### PR TITLE
netflix.com: Webpage scrolls when adjusting volume (VisionOS and iPad)

### DIFF
--- a/LayoutTests/pointerevents/ios/pointerdown-prevent-default-prevents-page-scrolling-expected.txt
+++ b/LayoutTests/pointerevents/ios/pointerdown-prevent-default-prevents-page-scrolling-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Calling preventDefault() on pointerdown prevents page scrolling when touch listeners are passive.
+

--- a/LayoutTests/pointerevents/ios/pointerdown-prevent-default-prevents-page-scrolling.html
+++ b/LayoutTests/pointerevents/ios/pointerdown-prevent-default-prevents-page-scrolling.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset=utf-8>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../utils.js"></script>
+<script>
+
+'use strict';
+
+target_test({ width: "200px", height: "200px" }, (target, test) => {
+    document.body.style.width = "2000px";
+    document.body.style.height = "2000px";
+
+    document.addEventListener("touchstart", () => {}, { passive: true });
+    target.addEventListener("pointerdown", event => event.preventDefault());
+
+    ui.swipe({ x: 100, y: 150 }, { x: 100, y: 50 }).then(() => {
+        assert_equals(window.pageYOffset, 0, "The page was not scrolled in the y-axis.");
+        test.done();
+    });
+}, "Calling preventDefault() on pointerdown prevents page scrolling when touch listeners are passive.");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/pointerevents/ios/pointerdown-without-prevent-default-allows-page-scrolling-expected.txt
+++ b/LayoutTests/pointerevents/ios/pointerdown-without-prevent-default-allows-page-scrolling-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Page scrolling is not blocked when pointerdown does not call preventDefault() with passive touch listeners.
+

--- a/LayoutTests/pointerevents/ios/pointerdown-without-prevent-default-allows-page-scrolling.html
+++ b/LayoutTests/pointerevents/ios/pointerdown-without-prevent-default-allows-page-scrolling.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset=utf-8>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../utils.js"></script>
+<script>
+
+'use strict';
+
+target_test({ width: "200px", height: "200px" }, (target, test) => {
+    document.body.style.width = "2000px";
+    document.body.style.height = "2000px";
+
+    document.addEventListener("touchstart", () => {}, { passive: true });
+    target.addEventListener("pointerdown", () => {});
+
+    ui.swipe({ x: 100, y: 150 }, { x: 100, y: 50 }).then(() => {
+        assert_not_equals(window.pageYOffset, 0, "The page was scrolled in the y-axis.");
+        test.done();
+    });
+}, "Page scrolling is not blocked when pointerdown does not call preventDefault() with passive touch listeners.");
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -532,8 +532,11 @@ void PointerCaptureController::pointerEventWasDispatched(const PointerEvent& eve
 
     // If the pointer event dispatched was pointerdown and the event was canceled, then set the PREVENT MOUSE EVENT flag for this pointerType.
     // https://www.w3.org/TR/pointerevents/#mapping-for-devices-that-support-hover
-    if (event.type() == eventNames().pointerdownEvent)
+    if (event.type() == eventNames().pointerdownEvent) {
         capturingData->preventsCompatibilityMouseEvents = event.defaultPrevented();
+        if (event.defaultPrevented())
+            m_pointerDownDefaultPreventedDuringCurrentHandling = true;
+    }
 }
 
 void PointerCaptureController::cancelPointer(PointerID pointerId, const IntPoint& documentPoint, PointerEvent* existingCancelEvent)

--- a/Source/WebCore/page/PointerCaptureController.h
+++ b/Source/WebCore/page/PointerCaptureController.h
@@ -73,6 +73,10 @@ public:
     void dispatchEvent(PointerEvent&, EventTarget*);
     WEBCORE_EXPORT void cancelPointer(PointerID, const IntPoint&, PointerEvent* existingCancelEvent = nullptr);
     void processPendingPointerCapture(PointerID);
+
+    void resetPointerDownDefaultPrevention() { m_pointerDownDefaultPreventedDuringCurrentHandling = false; }
+    bool wasPointerDownDefaultPrevented() const { return m_pointerDownDefaultPreventedDuringCurrentHandling; }
+
     // Used for mouse presses that trigger contextmenu, causing
     // the matching release to be suppressed.
     WEBCORE_EXPORT void clearUnmatchedMouseDown(PointerID);
@@ -132,6 +136,7 @@ private:
     PointerIdToCapturingDataMap m_activePointerIdsToCapturingData;
     bool m_processingPendingPointerCapture { false };
     bool m_haveAnyCapturingElement { false };
+    bool m_pointerDownDefaultPreventedDuringCurrentHandling { false };
 };
 
 inline void PointerCaptureController::elementWasRemoved(Element& element)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4943,10 +4943,14 @@ void WebPageProxy::sendUnpreventableTouchEvent(WebCore::FrameIdentifier frameID,
     if (event.isActivationTriggeringEvent())
         internals().lastActivationTimestamp = MonotonicTime::now();
 
-    sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::EventDispatcher::TouchEvent(webPageIDInProcess(processContainingFrame(frameID)), frameID, event), [protectedThis = Ref { *this }] (bool, std::optional<RemoteWebTouchEvent> remoteWebTouchEvent) mutable {
-        if (!remoteWebTouchEvent)
-            return;
-        protectedThis->sendUnpreventableTouchEvent(remoteWebTouchEvent->targetFrameID, remoteWebTouchEvent->transformedEvent);
+    sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::EventDispatcher::TouchEvent(webPageIDInProcess(processContainingFrame(frameID)), frameID, event), [protectedThis = Ref { *this }, event] (bool handled, std::optional<RemoteWebTouchEvent> remoteWebTouchEvent) mutable {
+        if (remoteWebTouchEvent)
+            return protectedThis->sendUnpreventableTouchEvent(remoteWebTouchEvent->targetFrameID, remoteWebTouchEvent->transformedEvent);
+
+        if (handled) {
+            if (RefPtr pageClient = protectedThis->pageClient())
+                pageClient->doneWithTouchEvent(event, handled);
+        }
     });
 }
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -2464,7 +2464,13 @@ static WebCore::FloatQuad inflateQuad(const WebCore::FloatQuad& quad, float infl
 #if ENABLE(TOUCH_EVENTS)
 - (void)_touchEvent:(const WebKit::WebTouchEvent&)touchEvent preventsNativeGestures:(BOOL)preventsNativeGesture
 {
-    if (!preventsNativeGesture || ![_touchEventGestureRecognizer isDispatchingTouchEvents])
+    if (!preventsNativeGesture)
+        return;
+
+    _preventsPanningInXAxis = YES;
+    _preventsPanningInYAxis = YES;
+
+    if (![_touchEventGestureRecognizer isDispatchingTouchEvents])
         return;
 
     _longPressCanClick = NO;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4053,7 +4053,16 @@ static Expected<bool, WebCore::RemoteFrameGeometryTransformer> handleTouchEvent(
     if (!localFrame || !localFrame->view())
         return false;
 
-    return localFrame->eventHandler().handleTouchEvent(platform(touchEvent));
+    WeakPtr weakPage = page;
+    if (weakPage)
+        weakPage->pointerCaptureController().resetPointerDownDefaultPrevention();
+
+    auto result = localFrame->eventHandler().handleTouchEvent(platform(touchEvent));
+
+    if (weakPage && !result.value_or(false) && weakPage->pointerCaptureController().wasPointerDownDefaultPrevented())
+        return true;
+
+    return result;
 }
 #endif
 


### PR DESCRIPTION
#### 9a30ed656c7f83a1af1139542cc828e41fcb7d32
<pre>
netflix.com: Webpage scrolls when adjusting volume (VisionOS and iPad)
<a href="https://bugs.webkit.org/show_bug.cgi?id=311217">https://bugs.webkit.org/show_bug.cgi?id=311217</a>
<a href="https://rdar.apple.com/173808616">rdar://173808616</a>

Reviewed by Brent Fulgham.

The problem: Netflix&apos;s volume slider calls preventDefault() on pointerdown
to stop the page from scrolling while dragging on the slider, but it was
ignored by WebKit. React has passive touch listeners, so WebKit classifies
it as TrackingType::Asynchronous, which routes the event to sendUnpreventableTouchEvent
instead of sendPreventableTouchEvent.

The fix: The unpreventable path&apos;s async reply was discarding the handled result
from the web process. Now when handled=true, it propagates the result back to
the UI process where the scrolling is blocked by panning prevention flags.

Tests: pointerevents/ios/pointerdown-prevent-default-prevents-page-scrolling.html
       pointerevents/ios/pointerdown-without-prevent-default-allows-page-scrolling.html

* LayoutTests/pointerevents/ios/pointerdown-prevent-default-prevents-page-scrolling-expected.txt: Added.
* LayoutTests/pointerevents/ios/pointerdown-prevent-default-prevents-page-scrolling.html: Added.
* LayoutTests/pointerevents/ios/pointerdown-without-prevent-default-allows-page-scrolling-expected.txt: Added.
* LayoutTests/pointerevents/ios/pointerdown-without-prevent-default-allows-page-scrolling.html: Added.
* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::PointerCaptureController::pointerEventWasDispatched):
* Source/WebCore/page/PointerCaptureController.h:
(WebCore::PointerCaptureController::resetPointerDownDefaultPrevention):
(WebCore::PointerCaptureController::wasPointerDownDefaultPrevented const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::sendUnpreventableTouchEvent):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _touchEvent:preventsNativeGestures:]):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::handleTouchEvent):

Canonical link: <a href="https://commits.webkit.org/310491@main">https://commits.webkit.org/310491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73befc3999f1bc4fcf7938c2ecfe7e2ac203da92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153953 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162705 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107419 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155826 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27061 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119055 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84173 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138246 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99756 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20407 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18371 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10538 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130064 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16098 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165178 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8325 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17699 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127146 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26540 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22405 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127300 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34544 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26546 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137892 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83256 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22199 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14680 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26154 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90462 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25846 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26011 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25908 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->