### PR TITLE
[Site Isolation] Console log is intentionally missing the full URL of a RemoteFrame for http/tests/security/block-top-level-navigations-by-sandboxed-iframe-with-propagated-user-gesture.html

### DIFF
--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -225,7 +225,6 @@ http/tests/security/XFrameOptions/x-frame-options-multiple-headers-sameorigin-de
 http/tests/security/XFrameOptions/x-frame-options-parent-same-origin-deny.html [ Failure ]
 http/tests/security/allow-top-level-navigations-by-third-party-iframes-with-previous-user-activation.html [ Failure ]
 http/tests/security/allow-top-level-navigations-by-third-party-iframes-with-user-activation.html [ Failure ]
-http/tests/security/block-top-level-navigations-by-sandboxed-iframe-with-propagated-user-gesture.html [ Failure ]
 http/tests/security/block-top-level-navigations-by-third-party-sandboxed-iframe.html [ Failure ]
 http/tests/security/contentSecurityPolicy/1.1/frame-ancestors/frame-ancestors-nested-cross-in-same-none-block.html [ Failure ]
 http/tests/security/contentSecurityPolicy/1.1/frame-ancestors/frame-ancestors-nested-cross-in-same-self-block.html [ Failure ]
@@ -442,10 +441,11 @@ fast/block/float/independent-align-positioning.html [ Missing ]
 ####################################
 # Tests with intentional text fail #
 ####################################
-# The following two tests have a different console log with Site Isolation enabled
+# The following tests have a different console log with Site Isolation enabled
 # vs disabled. The difference is that with Site Isolation enabled, the error message
 # only includes the protocol and origin of a RemoteFrame when with Site Isolation
 # is disabled the other frame is a LocalFrame which we log the URL with the
 # full path.
 http/tests/security/block-top-level-navigation-to-different-scheme-by-third-party-iframes.html [ Failure ]
+http/tests/security/block-top-level-navigations-by-sandboxed-iframe-with-propagated-user-gesture.html [ Failure ]
 http/tests/security/block-top-level-navigations-by-third-party-iframes.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -249,7 +249,6 @@ http/tests/security/XFrameOptions/x-frame-options-ancestors-same-origin-deny.htm
 http/tests/security/XFrameOptions/x-frame-options-ignore-deny-meta-tag-parent-same-origin-deny.html [ Failure ]
 http/tests/security/XFrameOptions/x-frame-options-multiple-headers-sameorigin-deny.html [ Failure ]
 http/tests/security/XFrameOptions/x-frame-options-parent-same-origin-deny.html [ Failure ]
-http/tests/security/block-top-level-navigations-by-sandboxed-iframe-with-propagated-user-gesture.html [ Failure ]
 http/tests/security/block-top-level-navigations-by-third-party-sandboxed-iframe.html [ Failure ]
 http/tests/security/contentSecurityPolicy/embed-redirect-allowed.html [ Failure ]
 http/tests/security/contentSecurityPolicy/embed-redirect-allowed2.html [ Failure ]
@@ -520,12 +519,13 @@ imported/w3c/web-platform-tests/cookies/third-party-cookies/third-party-cookies.
 ####################################
 # Tests with intentional text fail #
 ####################################
-# The following two tests have a different console log with Site Isolation enabled
+# The following tests have a different console log with Site Isolation enabled
 # vs disabled. The difference is that with Site Isolation enabled, the error message
 # only includes the protocol and origin of a RemoteFrame when with Site Isolation
 # is disabled the other frame is a LocalFrame which we log the URL with the
 # full path.
 http/tests/security/block-top-level-navigation-to-different-scheme-by-third-party-iframes.html [ Failure ]
+http/tests/security/block-top-level-navigations-by-sandboxed-iframe-with-propagated-user-gesture.html [ Failure ]
 http/tests/security/block-top-level-navigations-by-third-party-iframes.html [ Failure ]
 
 # This test has different output with site isolation enabled. A copy with site isolation enabled is


### PR DESCRIPTION
#### 80a2f83fa96b35052b2308ee781478d9dd9677bc
<pre>
[Site Isolation] Console log is intentionally missing the full URL of a RemoteFrame for http/tests/security/block-top-level-navigations-by-sandboxed-iframe-with-propagated-user-gesture.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=311286">https://bugs.webkit.org/show_bug.cgi?id=311286</a>
<a href="https://rdar.apple.com/173883912">rdar://173883912</a>

Reviewed by Sihui Liu.

In http/tests/security/block-top-level-navigations-by-sandboxed-iframe-with-propagated-user-gesture.html,
with site isolation enabled the console message logging
&quot;Unsafe JavaScript attempt to initiate navigation&quot; will
not contain the full URL (including resource path) of RemoteFrames.

This is the diff:
```
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Unsafe JavaScript attempt to initiate navigation for frame with URL &apos;<a href="http://127.0.0.1">http://127.0.0.1</a>:8000/security/block-top-level-navigations-by-sandboxed-iframe-with-propagated-user-gesture.html&apos; from frame with URL &apos;<a href="http://localhost">http://localhost</a>:8000/security/resources/navigate-top-level-frame-to-failure-page-via-message-handler.html&apos;. The frame attempting navigation of the top-level window is sandboxed, but the &apos;allow-top-navigation&apos; flag is not set.
+CONSOLE MESSAGE: Unsafe JavaScript attempt to initiate navigation for frame with URL &apos;<a href="http://127.0.0.1">http://127.0.0.1</a>:8000/&apos; from frame with URL &apos;<a href="http://localhost">http://localhost</a>:8000/security/resources/navigate-top-level-frame-to-failure-page-via-message-handler.html&apos;. The frame attempting navigation of the top-level window is sandboxed, but the &apos;allow-top-navigation&apos; flag is not set.

 CONSOLE MESSAGE: SecurityError: The operation is insecure.
 Test blocking of top-level navigations by an iframe with `sandbox=allow-top-navigation-by-user-activation` when the user gesture is propagated from another context.
```

This difference is thanks to <a href="https://commits.webkit.org/310093@main">https://commits.webkit.org/310093@main</a>
where we decided to prevent frames from fetching the full URL path of
remote frames in different processes.
http/tests/security/block-top-level-navigations-by-sandboxed-iframe-with-propagated-user-gesture.html
also has the same inconsistency in behavior with site isolation enabled vs disabled.

This patch moves the failing line in TestExpectations with the other intentional
failures from <a href="https://commits.webkit.org/310093@main">https://commits.webkit.org/310093@main</a>

* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/310523@main">https://commits.webkit.org/310523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e757cb11dcdbfd963840c137f399252f81823f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153749 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162500 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107209 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26855 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118874 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84057 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21134 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138058 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99584 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20213 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18171 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10332 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129862 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164970 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17511 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126951 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26330 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22202 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127118 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34569 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26332 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137712 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83010 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22029 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14494 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25949 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25640 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25800 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25700 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->