### PR TITLE
[GTK][WPE] Fix WTF_GUniquePtr.Basic and WTF_GUniquePtr.OutPtr test failures

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/glib/GUniquePtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/glib/GUniquePtr.cpp
@@ -40,11 +40,6 @@ inline std::string takeLogStr()
     return string;
 }
 
-static void (* _g_free)(void*) = g_free;
-#define g_free(x) \
-    log() << "g_free(" << ptr << ");"; \
-    _g_free(x);
-
 static void (* _g_error_free)(GError*) = g_error_free;
 #define g_error_free(x) \
     log() << "g_error_free(" << ptr << ");"; \
@@ -81,6 +76,23 @@ static void (* _g_key_file_free)(GKeyFile*) = g_key_file_free;
     _g_key_file_free(x);
 
 #include <wtf/glib/GUniquePtr.h>
+
+// The g_free macro trick doesn't work for GPtrDeleter<char>: the compiler
+// generates a copy in every file that uses GUniquePtr<char>, and the linker
+// keeps only one. It may keep a copy from a file where the macro wasn't
+// active, so the log stays empty. Defining our own specialization with
+// operator() outside the class body makes it a strong symbol the linker
+// always picks.
+namespace WTF {
+template<> struct GPtrDeleter<char> {
+    void operator()(char* ptr) const;
+};
+}
+void WTF::GPtrDeleter<char>::operator()(char* ptr) const
+{
+    log() << "g_free(" << ptr << ");";
+    g_free(ptr);
+}
 
 namespace TestWebKitAPI {
 


### PR DESCRIPTION
#### cb377b2d4e4132910163da40e679473df1cfc3da
<pre>
[GTK][WPE] Fix WTF_GUniquePtr.Basic and WTF_GUniquePtr.OutPtr test failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=311291">https://bugs.webkit.org/show_bug.cgi?id=311291</a>

Reviewed by Adrian Perez de Castro.

GPtrDeleter&lt;char&gt; uses the primary template, so its operator() is an
implicit instantiation emitted as a weak symbol. Since WTF is
statically linked into TestWTF, the linker may pick a version from
another translation unit where g_free was _not_ macro-intercepted,
causing the test&apos;s log to remain empty...

Provide an explicit specialization of GPtrDeleter&lt;char&gt; with the
operator() defined outside the class body, so it is not implicitly
inline and produces a strong symbol the linker always prefers.

The other deleter types (GError, GList, etc.) are unaffected because
they are already explicitly specialized in GUniquePtr.h via
WTF_DEFINE_GPTR_DELETER, and are not instantiated in other WTF
translation units linked into TestWTF.

* Tools/TestWebKitAPI/Tests/WTF/glib/GUniquePtr.cpp:
(WTF::GPtrDeleter&lt;char&gt;::operator const):

Canonical link: <a href="https://commits.webkit.org/310399@main">https://commits.webkit.org/310399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b411c0684065ce7457a369373e7f34414302db21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20153 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/162503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155625 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26858 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/162503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156711 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21139 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/138062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/162503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/10335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/15921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164973 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17515 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/126953 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/26333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/22205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127120 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34473 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137716 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/83013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22026 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/14499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25952 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/25643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/25803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/25703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->