### PR TITLE
REGRESSION(305392@main): Image with srcset and sizes containing calc(number / 0) is not displayed

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-display-none-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-display-none-expected.txt
@@ -167,4 +167,7 @@ PASS <img srcset="/images/green-1x1.png?f44 50w, /images/green-16x16.png?f44 51w
 PASS <img srcset="/images/green-1x1.png?f45 50w, /images/green-16x16.png?f45 51w" sizes="-1e0px"> ref sizes="100vw" (display:none)
 PASS <img srcset="/images/green-1x1.png?f46 50w, /images/green-16x16.png?f46 51w" sizes="1e1.5px"> ref sizes="100vw" (display:none)
 PASS <img srcset="/images/green-1x1.png?f47 50w, /images/green-16x16.png?f47 51w" style="--foo: 1px" sizes="var(--foo)"> ref sizes="100vw" (display:none)
+PASS <img srcset="/images/green-1x1.png?f50 50w, /images/green-16x16.png?f50 51w" sizes="calc(1px / 0)"> ref sizes="100vw" (display:none)
+PASS <img srcset="/images/green-1x1.png?f51 50w, /images/green-16x16.png?f51 51w" sizes="calc(0px / 0)"> ref sizes="100vw" (display:none)
+PASS <img srcset="/images/green-1x1.png?f52 50w, /images/green-16x16.png?f52 51w" sizes="calc(-1px / 0)"> ref sizes="100vw" (display:none)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-quirks-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-quirks-mode-expected.txt
@@ -167,4 +167,7 @@ PASS <img srcset="/images/green-1x1.png?f44 50w, /images/green-16x16.png?f44 51w
 PASS <img srcset="/images/green-1x1.png?f45 50w, /images/green-16x16.png?f45 51w" sizes="-1e0px"> ref sizes="100vw" (quirks mode)
 PASS <img srcset="/images/green-1x1.png?f46 50w, /images/green-16x16.png?f46 51w" sizes="1e1.5px"> ref sizes="100vw" (quirks mode)
 PASS <img srcset="/images/green-1x1.png?f47 50w, /images/green-16x16.png?f47 51w" style="--foo: 1px" sizes="var(--foo)"> ref sizes="100vw" (quirks mode)
+PASS <img srcset="/images/green-1x1.png?f50 50w, /images/green-16x16.png?f50 51w" sizes="calc(1px / 0)"> ref sizes="100vw" (quirks mode)
+PASS <img srcset="/images/green-1x1.png?f51 50w, /images/green-16x16.png?f51 51w" sizes="calc(0px / 0)"> ref sizes="100vw" (quirks mode)
+PASS <img srcset="/images/green-1x1.png?f52 50w, /images/green-16x16.png?f52 51w" sizes="calc(-1px / 0)"> ref sizes="100vw" (quirks mode)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-standards-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-standards-mode-expected.txt
@@ -167,4 +167,7 @@ PASS <img srcset="/images/green-1x1.png?f44 50w, /images/green-16x16.png?f44 51w
 PASS <img srcset="/images/green-1x1.png?f45 50w, /images/green-16x16.png?f45 51w" sizes="-1e0px"> ref sizes="100vw" (standards mode)
 PASS <img srcset="/images/green-1x1.png?f46 50w, /images/green-16x16.png?f46 51w" sizes="1e1.5px"> ref sizes="100vw" (standards mode)
 PASS <img srcset="/images/green-1x1.png?f47 50w, /images/green-16x16.png?f47 51w" style="--foo: 1px" sizes="var(--foo)"> ref sizes="100vw" (standards mode)
+PASS <img srcset="/images/green-1x1.png?f50 50w, /images/green-16x16.png?f50 51w" sizes="calc(1px / 0)"> ref sizes="100vw" (standards mode)
+PASS <img srcset="/images/green-1x1.png?f51 50w, /images/green-16x16.png?f51 51w" sizes="calc(0px / 0)"> ref sizes="100vw" (standards mode)
+PASS <img srcset="/images/green-1x1.png?f52 50w, /images/green-16x16.png?f52 51w" sizes="calc(-1px / 0)"> ref sizes="100vw" (standards mode)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-width-1000px-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-width-1000px-expected.txt
@@ -167,4 +167,7 @@ PASS <img srcset="/images/green-1x1.png?f44 50w, /images/green-16x16.png?f44 51w
 PASS <img srcset="/images/green-1x1.png?f45 50w, /images/green-16x16.png?f45 51w" sizes="-1e0px"> ref sizes="100vw" (width:1000px)
 PASS <img srcset="/images/green-1x1.png?f46 50w, /images/green-16x16.png?f46 51w" sizes="1e1.5px"> ref sizes="100vw" (width:1000px)
 PASS <img srcset="/images/green-1x1.png?f47 50w, /images/green-16x16.png?f47 51w" style="--foo: 1px" sizes="var(--foo)"> ref sizes="100vw" (width:1000px)
+PASS <img srcset="/images/green-1x1.png?f50 50w, /images/green-16x16.png?f50 51w" sizes="calc(1px / 0)"> ref sizes="100vw" (width:1000px)
+PASS <img srcset="/images/green-1x1.png?f51 50w, /images/green-16x16.png?f51 51w" sizes="calc(0px / 0)"> ref sizes="100vw" (width:1000px)
+PASS <img srcset="/images/green-1x1.png?f52 50w, /images/green-16x16.png?f52 51w" sizes="calc(-1px / 0)"> ref sizes="100vw" (width:1000px)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/support/sizes-iframed.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/support/sizes-iframed.sub.html
@@ -184,3 +184,6 @@
 <img srcset='/images/green-1x1.png?f45 50w, /images/green-16x16.png?f45 51w' sizes='-1e0px'>
 <img srcset='/images/green-1x1.png?f46 50w, /images/green-16x16.png?f46 51w' sizes='1e1.5px'>
 <img srcset='/images/green-1x1.png?f47 50w, /images/green-16x16.png?f47 51w' style='--foo: 1px' sizes='var(--foo)'>
+<img srcset='/images/green-1x1.png?f50 50w, /images/green-16x16.png?f50 51w' sizes='calc(1px / 0)'>
+<img srcset='/images/green-1x1.png?f51 50w, /images/green-16x16.png?f51 51w' sizes='calc(0px / 0)'>
+<img srcset='/images/green-1x1.png?f52 50w, /images/green-16x16.png?f52 51w' sizes='calc(-1px / 0)'>

--- a/Source/WebCore/css/parser/SizesAttributeParser.cpp
+++ b/Source/WebCore/css/parser/SizesAttributeParser.cpp
@@ -218,7 +218,16 @@ std::optional<float> SizesAttributeParser::parseFunction(CSSParserTokenRange tok
     auto result = CSSCalc::evaluateDouble(*tree, evaluationOptions);
     if (!result)
         return std::nullopt;
-    return CSS::clampToRange<range, float>(*result);
+
+    // https://drafts.csswg.org/css-values-4/#calc-ieee
+    // Infinities and NaN do not escape a top-level calculation. For the
+    // sizes attribute, treat these as invalid so the entry is skipped and
+    // the fallback/default size is used, matching other browsers.
+    auto value = *result;
+    if (std::isnan(value) || std::isinf(value))
+        return std::nullopt;
+
+    return CSS::clampToRange<range, float>(value);
 }
 
 std::optional<float> SizesAttributeParser::parseLength(CSSParserTokenRange tokens, const CSSParserContext& context)


### PR DESCRIPTION
#### e29e71d45d2511490d2d809dbd0691dbd9c21ad8
<pre>
REGRESSION(305392@main): Image with srcset and sizes containing calc(number / 0) is not displayed
<a href="https://bugs.webkit.org/show_bug.cgi?id=311238">https://bugs.webkit.org/show_bug.cgi?id=311238</a>
<a href="https://rdar.apple.com/173831217">rdar://173831217</a>

Reviewed by Simon Fraser.

When the sizes attribute contains a calc() expression that produces
infinity or NaN (e.g. calc(1px / 0)), SizesAttributeParser::parseFunction
would pass the result through to clampToRange, producing either an
enormous float or undefined behavior. This caused the srcset density
calculation to yield ~0 or infinity, rendering the image at 0x0 pixels.

Per <a href="https://drafts.csswg.org/css-values-4/#calc-ieee">https://drafts.csswg.org/css-values-4/#calc-ieee</a>, infinities and NaN
must not escape a top-level calculation. For the sizes attribute, treat
these as invalid so the entry is skipped and the default size (100vw) is
used, matching the behavior of Firefox and Chrome.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-display-none-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-quirks-mode-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-standards-mode-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-width-1000px-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/support/sizes-iframed.sub.html:
* Source/WebCore/css/parser/SizesAttributeParser.cpp:
(WebCore::SizesAttributeParser::parseFunction):

Canonical link: <a href="https://commits.webkit.org/310418@main">https://commits.webkit.org/310418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6913fe5894e3aac35dc9d9eb2150b2a7d0c10049

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162513 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107223 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bdf60702-1399-4b36-af4d-3f54984819af) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155635 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26868 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118885 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84064 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138059 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99595 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5e6d4ed7-ce09-4df1-a454-cb8384fa3e14) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20223 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18180 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10345 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129871 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15918 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164983 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8117 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17512 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126964 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26343 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22211 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127131 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34490 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137713 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83023 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22033 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14496 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25962 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90250 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25653 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25813 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25713 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->