### PR TITLE
Implement load and store for Memory64 in the OMG tier

### DIFF
--- a/JSTests/wasm/stress/memory64-load-and-store.js
+++ b/JSTests/wasm/stress/memory64-load-and-store.js
@@ -1,5 +1,5 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useOMGJIT=0")
+//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/stress/memory64-overflow.js
+++ b/JSTests/wasm/stress/memory64-overflow.js
@@ -1,5 +1,5 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("--useWasmMemory64=1", "--useOMGJIT=0")
+//@ runDefaultWasm("--useWasmMemory64=1")
 
 load("../spec-harness.js", "caller relative");
 

--- a/JSTests/wasm/stress/memory64-write-to-address-over-4-gigs.js
+++ b/JSTests/wasm/stress/memory64-write-to-address-over-4-gigs.js
@@ -1,5 +1,5 @@
 //@ skip if $addressBits <= 32
-//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useOMGJIT=0")
+//@ runDefaultWasm("-m", "--useWasmMemory64=1")
 import { instantiate } from "../wabt-wrapper.js";
 import * as assert from "../assert.js";
 

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -5885,7 +5885,7 @@ private:
             Tmp pointer = tmp(ptr);
 
             Arg ptrPlusImm = m_code.newTmp(GP);
-            append(Inst(Move32, value, pointer, ptrPlusImm));
+            append(Inst(moveForType(ptr->type()), value, pointer, ptrPlusImm));
             if (value->offset()) {
                 if (imm(value->offset()))
                     append(Add64, imm(value->offset()), ptrPlusImm);
@@ -5911,7 +5911,10 @@ private:
                 break;
             }
 
-            append(Inst(Air::WasmBoundsCheck, value, ptrPlusImm, limit));
+            if (value->offset())
+                append(Inst(Air::WasmBoundsCheck, value, ptrPlusImm, limit, pointer));
+            else
+                append(Inst(Air::WasmBoundsCheck, value, ptrPlusImm, limit));
             return;
         }
 

--- a/Source/JavaScriptCore/b3/B3Opcode.h
+++ b/Source/JavaScriptCore/b3/B3Opcode.h
@@ -356,10 +356,10 @@ enum Opcode : uint8_t {
     // WarmAny. It will not have an output constraint.
     Check,
 
-    // Special Wasm opcode that takes a Int32, a special pinned gpr and an offset. This node exists
-    // to allow us to CSE WasmBoundsChecks if both use the same pointer and one dominates the other.
-    // Without some such node B3 would not have enough information about the inner workings of wasm
-    // to be able to perform such optimizations.
+    // Special Wasm opcode that takes an Int32 or an Int64 in the memory64 case, a special pinned gpr and an
+    // offset. This node exists to allow us to CSE WasmBoundsChecks if both use the same pointer and one
+    // dominates the other. Without some such node B3 would not have enough information about the inner
+    // workings of wasm to be able to perform such optimizations.
     WasmBoundsCheck,
 
     WasmArrayGet,

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -841,7 +841,7 @@ public:
             case WasmBoundsCheck:
                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
                 VALIDATE(value->numChildren() == 1, ("At ", *value));
-                VALIDATE(value->child(0)->type() == Int32, ("At ", *value));
+                VALIDATE(value->child(0)->type() == Int32 || value->child(0)->type() == Int64, ("At ", *value));
                 switch (value->as<WasmBoundsCheckValue>()->boundsType()) {
                 case WasmBoundsCheckValue::Type::Pinned:
                     VALIDATE(m_procedure.code().isPinned(value->as<WasmBoundsCheckValue>()->bounds().pinnedSize), ("At ", *value));

--- a/Source/JavaScriptCore/b3/air/AirCustom.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCustom.cpp
@@ -208,23 +208,37 @@ MacroAssembler::Jump ShuffleCustom::generate(Inst& inst, CCallHelpers&, Generati
 
 bool WasmBoundsCheckCustom::isValidForm(Inst& inst)
 {
-    if (inst.args.size() != 2)
+    if (inst.args.size() < 2 || inst.args.size() > 3)
         return false;
+
     if (!inst.args[0].isTmp() && !inst.args[0].isSomeImm())
         return false;
 
-    return inst.args[1].isReg() || inst.args[1].isTmp() || inst.args[1].isSomeImm();
+    if (!(inst.args[1].isReg() || inst.args[1].isTmp() || inst.args[1].isSomeImm()))
+        return false;
+
+    if (inst.args.size() == 3)
+        return inst.args[2].isTmp() || inst.args[2].isReg();
+
+    return true;
 }
 
 MacroAssembler::Jump WasmBoundsCheckCustom::generate(Inst& inst, CCallHelpers& jit, GenerationContext& context)
 {
     WasmBoundsCheckValue* value = inst.origin->as<WasmBoundsCheckValue>();
+
+    MacroAssembler::Jump overflowOOB { };
+    if (inst.args.size() > 2)
+        overflowOOB = Inst((is32Bit() ? Air::Branch32 : Air::Branch64), value, Arg::relCond(MacroAssembler::Below), inst.args[0], inst.args[2]).generate(jit, context);
+
     MacroAssembler::Jump outOfBounds = Inst((is32Bit() ? Air::Branch32 : Air::Branch64), value, Arg::relCond(MacroAssembler::AboveOrEqual), inst.args[0], inst.args[1]).generate(jit, context);
 
     context.latePaths.append(std::tuple {
         value->origin(),
         createSharedTask<GenerationContext::LatePathFunction>(
-            [outOfBounds, value] (CCallHelpers& jit, Air::GenerationContext& context) {
+            [outOfBounds, overflowOOB, value] (CCallHelpers& jit, Air::GenerationContext& context) {
+                if (overflowOOB.isSet())
+                    overflowOOB.link(&jit);
                 outOfBounds.link(&jit);
                 switch (value->boundsType()) {
                 case WasmBoundsCheckValue::Type::Pinned:

--- a/Source/JavaScriptCore/b3/air/AirCustom.h
+++ b/Source/JavaScriptCore/b3/air/AirCustom.h
@@ -319,6 +319,8 @@ struct WasmBoundsCheckCustom : public CommonCustomBase<WasmBoundsCheckCustom> {
     {
         functor(inst.args[0], Arg::Use, GP, pointerWidth());
         functor(inst.args[1], Arg::Use, GP, pointerWidth());
+        if (inst.args.size() > 2)
+            functor(inst.args[2], Arg::Use, GP, pointerWidth());
     }
 
     template<typename... Arguments>

--- a/Source/JavaScriptCore/wasm/WasmAddressType.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAddressType.cpp
@@ -27,15 +27,14 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "B3Type.h"
 #include "WasmOps.h"
 
 namespace JSC { namespace Wasm {
 
-
 AddressType::AddressType(AddressType::Kind addressType) : m_type(addressType) { };
 
 AddressType::AddressType(bool is64Bit) : m_type(is64Bit ? AddressType::I64 : AddressType::I32) { };
-
 
 AddressType::AddressType(TypeKind typeKind)
 {
@@ -50,6 +49,22 @@ AddressType::AddressType(TypeKind typeKind)
         RELEASE_ASSERT_NOT_REACHED("Invalid Wasm Type to AddressType conversion");
     }
 }
+
+#if !PLATFORM(PLAYSTATION)
+AddressType::AddressType(B3::Type type)
+{
+    switch (type.kind()) {
+    case B3::TypeKind::Int32:
+        m_type = AddressType::I32;
+        break;
+    case B3::TypeKind::Int64:
+        m_type = AddressType::I64;
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED("Invalid Wasm Type to AddressType conversion");
+    }
+}
+#endif
 
 TypeKind AddressType::asTypeKind() const
 {

--- a/Source/JavaScriptCore/wasm/WasmAddressType.h
+++ b/Source/JavaScriptCore/wasm/WasmAddressType.h
@@ -26,7 +26,12 @@
 
 #if ENABLE(WEBASSEMBLY)
 
-namespace JSC { namespace Wasm {
+namespace JSC {
+namespace B3 {
+class Type;
+}
+
+namespace Wasm {
 enum class TypeKind : int8_t;
 
 class AddressType {
@@ -39,6 +44,9 @@ public:
     AddressType() = default;
     AddressType(TypeKind);
     AddressType(AddressType::Kind);
+#if !PLATFORM(PLAYSTATION)
+    AddressType(B3::Type);
+#endif
     explicit AddressType(bool is64bit);
 
     AddressType::Kind type() const { return m_type; }

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -87,6 +87,7 @@
 #include "WasmTypeDefinitionInlines.h"
 #include "WebAssemblyFunctionBase.h"
 #include <limits>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -733,8 +734,8 @@ public:
     [[nodiscard]] PartialResult setGlobal(uint32_t index, ExpressionType value);
 
     // Memory
-    [[nodiscard]] PartialResult load(LoadOpType, ExpressionType pointer, ExpressionType& result, uint32_t offset, uint8_t memoryIndex);
-    [[nodiscard]] PartialResult store(StoreOpType, ExpressionType pointer, ExpressionType value, uint32_t offset, uint8_t memoryIndex);
+    [[nodiscard]] PartialResult load(LoadOpType, ExpressionType pointer, ExpressionType& result, uint64_t offset, uint8_t memoryIndex);
+    [[nodiscard]] PartialResult store(StoreOpType, ExpressionType pointer, ExpressionType value, uint64_t offset, uint8_t memoryIndex);
     [[nodiscard]] PartialResult addGrowMemory(ExpressionType delta, ExpressionType& result, uint8_t memoryIndex);
     [[nodiscard]] PartialResult addCurrentMemory(ExpressionType& result, uint8_t memoryIndex);
     [[nodiscard]] PartialResult addMemoryFill(ExpressionType dstAddress, ExpressionType targetValue, ExpressionType count, uint8_t memoryIndex);
@@ -917,7 +918,7 @@ private:
 
     void emitWriteBarrierForJSWrapper();
     void emitWriteBarrier(Value* cell);
-    Value* emitCheckAndPreparePointer(Value* pointer, uint32_t offset, uint32_t sizeOfOp, uint8_t memoryIndex);
+    Value* emitCheckAndPreparePointer(Value* pointer, uint64_t offset, uint32_t sizeOfOp, uint8_t memoryIndex);
     B3::Kind memoryKind(B3::Opcode memoryOp);
     Value* emitLoadOp(LoadOpType, Value* pointer, uint32_t offset);
     void emitStoreOp(StoreOpType, Value* pointer, Value*, uint32_t offset);
@@ -2425,7 +2426,7 @@ inline void OMGIRGenerator::emitWriteBarrier(Value* cell)
     m_currentBlock = continuation;
 }
 
-inline Value* OMGIRGenerator::emitCheckAndPreparePointer(Value* pointer, uint32_t offset, uint32_t sizeOfOperation, uint8_t memoryIndex)
+inline Value* OMGIRGenerator::emitCheckAndPreparePointer(Value* pointer, uint64_t offset, uint32_t sizeOfOperation, uint8_t memoryIndex)
 {
     static_assert(GPRInfo::wasmBaseMemoryPointer != InvalidGPRReg);
 
@@ -2436,13 +2437,21 @@ inline Value* OMGIRGenerator::emitCheckAndPreparePointer(Value* pointer, uint32_
             // We're not using signal handling only when the memory is not shared.
             // Regardless of signaling, we must check that no memory access exceeds the current memory size.
             static_assert(GPRInfo::wasmBoundsCheckingSizeRegister != InvalidGPRReg);
-            uint64_t lastLoadedOffset = static_cast<uint64_t>(offset);
+            if (WTF::sumOverflows<uint64_t>(offset, sizeOfOperation)) {
+                B3::PatchpointValue* throwException = m_currentBlock->appendNew<B3::PatchpointValue>(m_proc, B3::Void, origin());
+                throwException->setGenerator([this, origin = this->origin()](CCallHelpers& jit, const B3::StackmapGenerationParams&) {
+                    this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsMemoryAccess);
+                });
+                break;
+            }
+            uint64_t lastLoadedOffset = offset;
             lastLoadedOffset += static_cast<uint64_t>(sizeOfOperation - 1);
             m_currentBlock->appendNew<WasmBoundsCheckValue>(m_proc, origin(), GPRInfo::wasmBoundsCheckingSizeRegister, pointer, lastLoadedOffset);
             break;
         }
 
         case MemoryMode::Signaling: {
+            RELEASE_ASSERT(!m_info.memory(memoryIndex).isMemory64());
             // We've virtually mapped 4GiB+redzone for this memory. Only the user-allocated pages are addressable, contiguously in range [0, current],
             // and everything above is mapped PROT_NONE. We don't need to perform any explicit bounds check in the 4GiB range because WebAssembly register
             // memory accesses are 32-bit. However WebAssembly register + offset accesses perform the addition in 64-bit which can push an access above
@@ -2463,13 +2472,18 @@ inline Value* OMGIRGenerator::emitCheckAndPreparePointer(Value* pointer, uint32_
         }
         }
 
-        pointer = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), pointer);
+        if (!m_info.memory(memoryIndex).isMemory64())
+            pointer = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), pointer);
         return m_currentBlock->appendNew<WasmAddressValue>(m_proc, origin(), pointer, GPRInfo::wasmBaseMemoryPointer);
     }
 
     // if memoryIndex != 0, force bounds checking
 
-    if (sumOverflows<uint32_t>(offset, sizeOfOperation)) {
+    bool offsetAndSizeOverflows = m_info.memory(memoryIndex).isMemory64()
+        ? sumOverflows<uint64_t>(offset, sizeOfOperation)
+        : sumOverflows<uint32_t>(offset, sizeOfOperation);
+
+    if (offsetAndSizeOverflows) [[unlikely]] {
         B3::PatchpointValue* throwException = m_currentBlock->appendNew<B3::PatchpointValue>(m_proc, B3::Void, origin());
         throwException->setGenerator([this, origin = this->origin()](CCallHelpers& jit, const B3::StackmapGenerationParams&) {
             this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsMemoryAccess);
@@ -2485,9 +2499,22 @@ inline Value* OMGIRGenerator::emitCheckAndPreparePointer(Value* pointer, uint32_
     uint64_t lastLoadedOffset = static_cast<uint64_t>(offset);
     lastLoadedOffset += static_cast<uint64_t>(sizeOfOperation - 1);
     auto boundsCheckOffset = constant(Int64, lastLoadedOffset);
-    pointer = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), pointer);
-    Value* outOfBounds = m_currentBlock->appendNew<Value>(m_proc, AboveEqual, origin(), m_currentBlock->appendNew<Value>(m_proc, Add, origin(), pointer, boundsCheckOffset), memorySize);
-    // FIXME: this should probably use a CheckAdd once memory64 is supported
+    if (!m_info.memory(memoryIndex).isMemory64())
+        pointer = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), pointer);
+
+    Value* sum;
+    if (m_info.memory(memoryIndex).isMemory64() && lastLoadedOffset) {
+        // FIXME: We should have an optional ResultCondition for CheckAdd (and friends)
+        sum = m_currentBlock->appendNew<Value>(m_proc, Add, origin(), pointer, boundsCheckOffset);
+        Value* overflowed = m_currentBlock->appendNew<Value>(m_proc, Below, origin(), sum, pointer);
+        CheckValue* overflowCheck = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(), overflowed);
+        overflowCheck->setGenerator([=, this, origin = this->origin()](CCallHelpers& jit, const B3::StackmapGenerationParams&) {
+            this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsMemoryAccess);
+        });
+    } else
+        sum = m_currentBlock->appendNew<Value>(m_proc, Add, origin(), pointer, boundsCheckOffset);
+
+    Value* outOfBounds = m_currentBlock->appendNew<Value>(m_proc, AboveEqual, origin(), sum, memorySize);
     CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(), outOfBounds);
     check->setGenerator([=, this, origin = this->origin()](CCallHelpers& jit, const B3::StackmapGenerationParams&) {
         this->emitExceptionCheck(jit, origin, ExceptionType::OutOfBoundsMemoryAccess);
@@ -2623,12 +2650,15 @@ inline Value* OMGIRGenerator::emitLoadOp(LoadOpType op, Value* pointer, uint32_t
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-auto OMGIRGenerator::load(LoadOpType op, ExpressionType pointerVar, ExpressionType& result, uint32_t offset, uint8_t memoryIndex) -> PartialResult
+auto OMGIRGenerator::load(LoadOpType op, ExpressionType pointerVar, ExpressionType& result, uint64_t offset, uint8_t memoryIndex) -> PartialResult
 {
     Value* pointer = get(pointerVar);
-    ASSERT(pointer->type() == Int32);
 
-    if (sumOverflows<uint32_t>(offset, sizeOfLoadOp(op))) [[unlikely]] {
+    bool offsetAndSizeOverflows = m_info.memory(memoryIndex).isMemory64()
+        ? sumOverflows<uint64_t>(offset, sizeOfLoadOp(op))
+        : sumOverflows<uint32_t>(offset, sizeOfLoadOp(op));
+
+    if (offsetAndSizeOverflows) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         B3::PatchpointValue* throwException = m_currentBlock->appendNew<B3::PatchpointValue>(m_proc, B3::Void, origin());
@@ -2729,13 +2759,16 @@ inline void OMGIRGenerator::emitStoreOp(StoreOpType op, Value* pointer, Value* v
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-auto OMGIRGenerator::store(StoreOpType op, ExpressionType pointerVar, ExpressionType valueVar, uint32_t offset, uint8_t memoryIndex) -> PartialResult
+auto OMGIRGenerator::store(StoreOpType op, ExpressionType pointerVar, ExpressionType valueVar, uint64_t offset, uint8_t memoryIndex) -> PartialResult
 {
     Value* pointer = get(pointerVar);
     Value* value = get(valueVar);
-    ASSERT(pointer->type() == Int32);
+    ASSERT(pointer->type() == m_info.memory(memoryIndex).addressType());
+    bool offsetAndSizeOverflows = m_info.memory(memoryIndex).isMemory64()
+        ? sumOverflows<uint64_t>(offset, sizeOfStoreOp(op))
+        : sumOverflows<uint32_t>(offset, sizeOfStoreOp(op));
 
-    if (sumOverflows<uint32_t>(offset, sizeOfStoreOp(op))) [[unlikely]] {
+    if (offsetAndSizeOverflows) [[unlikely]] {
         // FIXME: Even though this is provably out of bounds, it's not a validation error, so we have to handle it
         // as a runtime exception. However, this may change: https://bugs.webkit.org/show_bug.cgi?id=166435
         B3::PatchpointValue* throwException = m_currentBlock->appendNew<B3::PatchpointValue>(m_proc, B3::Void, origin());


### PR DESCRIPTION
#### f27f9013184da9287c39f8f6ee71f614bd2c2c18
<pre>
Implement load and store for Memory64 in the OMG tier
<a href="https://bugs.webkit.org/show_bug.cgi?id=311301">https://bugs.webkit.org/show_bug.cgi?id=311301</a>
<a href="https://rdar.apple.com/173894182">rdar://173894182</a>

Reviewed by Keith Miller.

This adds support for load and store in memory64
in the WebAssembly OMG tier.

* JSTests/wasm/stress/memory64-bulk-memory.js:
* JSTests/wasm/stress/memory64-grow-and-size.js:
* JSTests/wasm/stress/memory64-load-and-store.js:
* JSTests/wasm/stress/memory64-overflow.js:
* JSTests/wasm/stress/memory64-write-to-address-over-4-gigs.js:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitCheckAndPreparePointer):
(JSC::Wasm::OMGIRGenerator::load):
(JSC::Wasm::OMGIRGenerator::store):

Canonical link: <a href="https://commits.webkit.org/311362@main">https://commits.webkit.org/311362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8595499545d3b9b9cbf69a74bb7719e20f4c953

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156665 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23184 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165488 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110746 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30137 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30004 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121354 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85235 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23571 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140688 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102022 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22627 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20824 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13260 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148715 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132306 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18517 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167971 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17500 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12129 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129466 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29603 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129576 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35118 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140311 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87327 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24395 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17114 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188626 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29234 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93256 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48448 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28759 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28989 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28885 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->