### PR TITLE
[Navigation API] Fix handler promise completion timing to use microtask instead of task

### DIFF
--- a/LayoutTests/http/wpt/navigation-api/transition-promises.html
+++ b/LayoutTests/http/wpt/navigation-api/transition-promises.html
@@ -39,26 +39,31 @@ promise_test(async t => {
 
 promise_test(async t => {
     let transition_finished = false;
+    const expectedError = new Error("transition rejection test");
 
     navigation.onnavigate = t.step_func(e => {
         e.intercept({ handler: async () => {
-            throw new Error();
+            throw expectedError;
         }});
     });
 
     navigation.onnavigatesuccess = t.unreached_func('Navigation should not succeed');
 
     navigation.onnavigateerror = t.step_func(e => {
-        navigation.transition.finished.then(t.unreached_func('Transition should not be fullfilled'));
-        navigation.transition.finished.catch(() => {
-            // FIXME: Test error is the same as thrown.
-            transition_finished = true;
-        })
+        navigation.transition.finished.then(
+            t.unreached_func('Transition should not be fullfilled'),
+            (err) => {
+                assert_equals(err, expectedError, 'Rejection reason should be the thrown error');
+                transition_finished = true;
+            }
+        );
     });
 
-    await navigation.navigate("#1");
+    await navigation.navigate("#1").finished.catch((err) => {
+        assert_equals(err, expectedError, 'result.finished rejection reason should be the thrown error');
+    });
 
-    // The navigation resolves before the transition does.
+    // Wait for the transition.finished rejection chain (set up in navigateerror) to settle.
     await new Promise(resolve => t.step_timeout(resolve, 0));
 
     assert_true(transition_finished);

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-microtask-depth.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-microtask-depth.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name="variant" content="?no-currententrychange">
+<meta name="variant" content="?currententrychange">
+
+<script type="module">
+import { Recorder, hasVariant } from "./resources/helpers.mjs";
+
+// This test verifies that the "get a promise for waiting for all" algorithm
+// (https://webidl.spec.whatwg.org/#dfn-get-a-promise-for-waiting-for-all)
+// provides the correct microtask timing: navigatesuccess fires one microtask
+// deeper than the handler promise reactions, not deferred to a separate task.
+//
+// A single-level Promise.resolve().then() microtask should fire BEFORE
+// navigatesuccess, while a two-level chained microtask should fire AFTER it,
+// since both navigatesuccess and the double microtask are at the same depth
+// but navigatesuccess is queued first.
+
+promise_test(async t => {
+  // Wait for after the load event so that the navigation doesn't get converted
+  // into a replace navigation.
+  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+
+  const from = navigation.currentEntry;
+
+  const recorder = new Recorder({
+    skipCurrentChange: !hasVariant("currententrychange"),
+    finalExpectedEvent: "transition.finished fulfilled"
+  });
+
+  recorder.setUpNavigationAPIListeners();
+
+  navigation.addEventListener("navigate", e => {
+    e.intercept({ handler() { recorder.record("handler run"); } });
+  });
+
+  const result = navigation.navigate("#1");
+  recorder.setUpResultListeners(result);
+
+  Promise.resolve().then(() => recorder.record("promise microtask"));
+  Promise.resolve().then(() => {
+    Promise.resolve().then(() => recorder.record("double promise microtask"));
+  });
+
+  await recorder.readyToAssert;
+
+  recorder.assert([
+    /* event name, location.hash value, navigation.transition properties */
+    ["navigate", "", null],
+    ["currententrychange", "#1", { from, navigationType: "push" }],
+    ["handler run", "#1", { from, navigationType: "push" }],
+    ["committed fulfilled", "#1", { from, navigationType: "push" }],
+    ["transition.committed fulfilled", "#1", { from, navigationType: "push" }],
+    ["promise microtask", "#1", { from, navigationType: "push" }],
+    ["navigatesuccess", "#1", { from, navigationType: "push" }],
+    ["double promise microtask", "#1", null],
+    ["finished fulfilled", "#1", null],
+    ["transition.finished fulfilled", "#1", null],
+  ]);
+}, "navigatesuccess fires at the correct microtask depth relative to handler promise reactions");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-microtask-depth_currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-microtask-depth_currententrychange-expected.txt
@@ -1,0 +1,3 @@
+
+PASS navigatesuccess fires at the correct microtask depth relative to handler promise reactions
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-microtask-depth_no-currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-microtask-depth_no-currententrychange-expected.txt
@@ -1,0 +1,3 @@
+
+PASS navigatesuccess fires at the correct microtask depth relative to handler promise reactions
+

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -720,6 +720,11 @@ void NavigationScheduler::scheduleLocationChange(Document& initiatingDocument, S
         }
     }
 
+    // The frame's page may have been nulled if the navigate event handler
+    // detached the frame (e.g., iframe.remove() inside intercept handler).
+    if (!m_frame->page())
+        return completionHandler(ScheduleLocationChangeResult::Stopped);
+
     // Handle a location change of a page with no document as a special case.
     // This may happen when a frame changes the location of another frame.
     bool duringLoad = loader && !loader->stateMachine().committedFirstRealDocumentLoad();

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -297,7 +297,7 @@ enum EventTargetInterfaceType Navigation::eventTargetInterface() const
     return EventTargetInterfaceType::Navigation;
 }
 
-static RefPtr<DOMPromise> createDOMPromise(const DeferredPromise& deferredPromise)
+static Ref<DOMPromise> createDOMPromise(const DeferredPromise& deferredPromise)
 {
     Locker<JSC::JSLock> locker(commonVM().apiLock());
 
@@ -963,56 +963,90 @@ void Navigation::abortOngoingNavigation(NavigateEvent& event)
     }
 }
 
-struct AwaitingPromiseData : public RefCounted<AwaitingPromiseData> {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(AwaitingPromiseData);
-    Function<void()> fulfilledCallback;
-    Function<void(JSC::JSValue)> rejectionCallback;
-    size_t remainingPromises = 0;
-    bool rejected = false;
+class PromiseSettlementObserver : public RefCounted<PromiseSettlementObserver> {
+public:
 
-    AwaitingPromiseData() = delete;
-    AwaitingPromiseData(Function<void()>&& fulfilledCallback, Function<void(JSC::JSValue)>&& rejectionCallback, size_t remainingPromises)
-        : fulfilledCallback(WTF::move(fulfilledCallback))
-        , rejectionCallback(WTF::move(rejectionCallback))
-        , remainingPromises(remainingPromises)
+    static Ref<PromiseSettlementObserver> create(Document& document)
+    {
+        ASSERT(document.isFullyActive());
+        auto* globalObject = JSC::jsCast<JSDOMGlobalObject*>(document.globalObject());
+        JSC::JSLockHolder locker(globalObject->vm());
+        RefPtr wrapper = DeferredPromise::create(*globalObject, DeferredPromise::Mode::RetainPromiseOnResolve);
+        return adoptRef(*new PromiseSettlementObserver(wrapper.releaseNonNull()));
+    }
+
+    // https://webidl.spec.whatwg.org/#wait-for-all
+    Ref<DOMPromise> waitForAllPromises(const Vector<Ref<DOMPromise>>& promises)
+    {
+        ASSERT(!isSettled());
+        ASSERT(!m_totalPromises);
+
+        for (const auto& promise : promises) {
+            if (registerPromise(promise))
+                m_totalPromises++;
+        }
+
+        // Step 6.1 Queue a microtask to perform successSteps given « ».
+        if (!m_totalPromises) {
+            if (RefPtr context = m_wrapper->globalObject()->scriptExecutionContext()) {
+                protect(context->eventLoop())->queueMicrotask(context->vm(), [protectThis = Ref { *this }]() {
+                    protectThis->resolve();
+                });
+            }
+        }
+
+        return createDOMPromise(protect(*m_wrapper));
+    }
+
+private:
+    explicit PromiseSettlementObserver(Ref<DeferredPromise>&& wrapper)
+        : m_wrapper(WTF::move(wrapper))
     {
     }
-};
 
-// https://webidl.spec.whatwg.org/#wait-for-all
-static void waitForAllPromises(Document& document, const Vector<Ref<DOMPromise>>& promises, Function<void()>&& fulfilledCallback, Function<void(JSC::JSValue)>&& rejectionCallback)
-{
-    if (promises.isEmpty()) {
-        protect(document.eventLoop())->queueMicrotask(document.vm(), WTF::move(fulfilledCallback));
-        return;
-    }
+    bool isWaiting() const { return m_totalPromises > m_settledPromises; }
+    bool isSettled() const { return !m_wrapper; }
+    void resolve() { consumeWrapper()->resolve(); }
+    void reject(JSC::JSValue result) { consumeWrapper()->reject<IDLAny>(result); }
 
-    Ref awaitingData = adoptRef(*new AwaitingPromiseData(WTF::move(fulfilledCallback), WTF::move(rejectionCallback), promises.size()));
-
-    for (const auto& promise : promises) {
-        // At any point between promises the frame could have been detached.
-        // FIXME: There is possibly a better way to handle this rather than just never complete.
-        if (promise->isSuspended())
+    void handleResult(bool isFulfilled, JSC::JSValue result)
+    {
+        if (isSettled())
             return;
 
-        promise->whenSettledWithResult([awaitingData](auto* globalObject, bool isFulfilled, auto result) mutable {
+        ASSERT(isWaiting());
+        if (!isFulfilled)
+            return reject(result);
+
+        ++m_settledPromises;
+
+        if (!isWaiting())
+            resolve();
+    }
+
+    bool registerPromise(DOMPromise& promise)
+    {
+        auto handler = [protectThis = Ref { *this }](auto* globalObject, bool isFulfilled, auto result) mutable {
             RefPtr context = globalObject ? globalObject->scriptExecutionContext() : nullptr;
             if (!context || context->activeDOMObjectsAreSuspended() || context->activeDOMObjectsAreStopped())
                 return;
 
-            if (!isFulfilled) {
-                if (awaitingData->rejected)
-                    return;
-                awaitingData->rejected = true;
-                awaitingData->rejectionCallback(result);
-                return;
-            }
-            if (--awaitingData->remainingPromises > 0)
-                return;
-            awaitingData->fulfilledCallback();
-        });
+            protectThis->handleResult(isFulfilled, result);
+        };
+
+        return promise.whenSettledWithResult(WTF::move(handler)) == DOMPromise::IsCallbackRegistered::Yes;
     }
-}
+
+    Ref<DeferredPromise> consumeWrapper()
+    {
+        ASSERT(!isSettled());
+        return std::exchange(m_wrapper, nullptr).releaseNonNull();
+    }
+
+    RefPtr<DeferredPromise> m_wrapper;
+    unsigned m_totalPromises = 0;
+    unsigned m_settledPromises = 0;
+};
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#inner-navigate-event-firing-algorithm Step 32
 void Navigation::setupInterceptionState(NavigateEvent& event, NavigationNavigationType navigationType, NavigationDestination& destination, Document& document, SerializedScriptValue* classicHistoryAPIState)
@@ -1075,69 +1109,87 @@ std::optional<Navigation::DispatchResult> Navigation::handleSameDocumentNavigati
         }
     }
 
+    // A handler may have detached the document (e.g., by removing its iframe from the DOM).
+    if (!document.isFullyActive()) {
+        abortOngoingNavigation(event);
+        return DispatchResult::Aborted;
+    }
+
     // For intercepted traverse navigations, notify committed after handlers have been invoked but before
     // they complete. This ensures the correct event ordering.
     if (navigationType == NavigationNavigationType::Traverse && event.wasIntercepted() && apiMethodTracker && !apiMethodTracker->committedToEntry)
         notifyCommittedToEntry(apiMethodTracker, protect(currentEntry()).get(), navigationType);
 
-    // FIXME: this emulates the behavior of a Promise wrapped around waitForAll, but we may want the real
-    // thing if the ordering-and-transition tests show timing related issues related to this.
-    RefPtr scriptExecutionContext = this->scriptExecutionContext();
-    protect(scriptExecutionContext->eventLoop())->queueTask(TaskSource::DOMManipulation, [weakThis = WeakPtr { this }, promiseList, abortController = Ref { abortController }, document = Ref { document }, apiMethodTracker = RefPtr { apiMethodTracker }]() {
-        waitForAllPromises(document.get(), promiseList, [abortController, document, apiMethodTracker, weakThis]() mutable {
+    if (!event.wasIntercepted() && !apiMethodTracker) {
+        // For non-intercepted same-document navigations without a JS-initiated tracker
+        // (e.g., BFCache restorations, fragment navigations via link clicks), use a queued
+        // task instead of PromiseSettlementObserver. This avoids creating JS heap objects
+        // (DeferredPromise, DOMPromise) during commitProvisionalLoad, which can interfere
+        // with plugin initialization (e.g., UnifiedPDF during BFCache restoration).
+        RefPtr scriptExecutionContext = this->scriptExecutionContext();
+        protect(scriptExecutionContext->eventLoop())->queueTask(TaskSource::DOMManipulation, [weakThis = WeakPtr { this }, abortController = Ref { abortController }]() {
             RefPtr protectedThis = weakThis.get();
-            if (!protectedThis || abortController->signal().aborted() || !document->isFullyActive() || !protectedThis->m_ongoingNavigateEvent)
+            if (!protectedThis || abortController->signal().aborted())
+                return;
+            RefPtr document = dynamicDowncast<Document>(protectedThis->scriptExecutionContext());
+            if (!document || !document->isFullyActive() || !protectedThis->m_ongoingNavigateEvent)
                 return;
 
-            auto focusChanged = std::exchange(protectedThis->m_focusChangedDuringOngoingNavigation, FocusDidChange::No);
-            protect(protectedThis->ongoingNavigateEvent())->finish(document.get(), InterceptionHandlersDidFulfill::Yes, focusChanged);
             protectedThis->m_ongoingNavigateEvent = nullptr;
-
             protectedThis->dispatchEvent(Event::create(eventNames().navigatesuccessEvent, { }));
-
-            if (apiMethodTracker)
-                protectedThis->resolveFinishedPromise(apiMethodTracker.get());
-
-            if (RefPtr transition = std::exchange(protectedThis->m_transition, nullptr))
-                transition->resolvePromise();
-
-            protectedThis->m_ongoingNavigateEvent = nullptr;
-
-        }, [abortController, document, apiMethodTracker, weakThis](JSC::JSValue result) mutable {
+        });
+    } else {
+        // https://webidl.spec.whatwg.org/#wait-for-all
+        RefPtr wrapperPromise = PromiseSettlementObserver::create(document)->waitForAllPromises(promiseList);
+        wrapperPromise->whenSettledWithResult([weakThis = WeakPtr { this }, abortController = Ref { abortController }, document = Ref { document }, apiMethodTracker = RefPtr { apiMethodTracker }](JSDOMGlobalObject*, bool isFulfilled, JSC::JSValue result) mutable {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis || abortController->signal().aborted() || !document->isFullyActive() || !protectedThis->m_ongoingNavigateEvent)
                 return;
 
-            auto focusChanged = std::exchange(protectedThis->m_focusChangedDuringOngoingNavigation, FocusDidChange::No);
-            protect(protectedThis->ongoingNavigateEvent())->finish(document.get(), InterceptionHandlersDidFulfill::No, focusChanged);
+            if (isFulfilled) {
+                auto focusChanged = std::exchange(protectedThis->m_focusChangedDuringOngoingNavigation, FocusDidChange::No);
+                protect(protectedThis->ongoingNavigateEvent())->finish(document.get(), InterceptionHandlersDidFulfill::Yes, focusChanged);
+                protectedThis->m_ongoingNavigateEvent = nullptr;
 
-            abortController->signal().signalAbort(result);
+                protectedThis->dispatchEvent(Event::create(eventNames().navigatesuccessEvent, { }));
 
-            protectedThis->m_ongoingNavigateEvent = nullptr;
+                if (apiMethodTracker)
+                    protectedThis->resolveFinishedPromise(apiMethodTracker.get());
 
-            ErrorInformation errorInformation;
-            String errorMessage;
-            if (auto* errorInstance = jsDynamicCast<JSC::ErrorInstance*>(result)) {
-                if (auto result = extractErrorInformationFromErrorInstance(protect(protectedThis->scriptExecutionContext())->globalObject(), *errorInstance)) {
-                    errorInformation = WTF::move(*result);
-                    errorMessage = makeString("Uncaught "_s, errorInformation.errorTypeString, ": "_s, errorInformation.message);
+                if (RefPtr transition = std::exchange(protectedThis->m_transition, nullptr))
+                    transition->resolvePromise();
+            } else {
+                auto focusChanged = std::exchange(protectedThis->m_focusChangedDuringOngoingNavigation, FocusDidChange::No);
+                protect(protectedThis->ongoingNavigateEvent())->finish(document.get(), InterceptionHandlersDidFulfill::No, focusChanged);
+
+                abortController->signal().signalAbort(result);
+
+                protectedThis->m_ongoingNavigateEvent = nullptr;
+
+                ErrorInformation errorInformation;
+                String errorMessage;
+                if (auto* errorInstance = jsDynamicCast<JSC::ErrorInstance*>(result)) {
+                    if (auto result = extractErrorInformationFromErrorInstance(protect(protectedThis->scriptExecutionContext())->globalObject(), *errorInstance)) {
+                        errorInformation = WTF::move(*result);
+                        errorMessage = makeString("Uncaught "_s, errorInformation.errorTypeString, ": "_s, errorInformation.message);
+                    }
                 }
+
+                auto* navGlobalObject = protect(protectedThis->scriptExecutionContext())->globalObject();
+                protectedThis->dispatchEvent(ErrorEvent::create(*navGlobalObject, eventNames().navigateerrorEvent, errorMessage, errorInformation.sourceURL, errorInformation.line, errorInformation.column, { navGlobalObject->vm(), result }));
+
+                if (apiMethodTracker)
+                    Ref { apiMethodTracker->finishedPromise }->reject<IDLAny>(result, RejectAsHandled::Yes);
+
+                if (RefPtr transition = std::exchange(protectedThis->m_transition, nullptr))
+                    transition->rejectPromise(result);
             }
-
-            auto* navGlobalObject = protect(protectedThis->scriptExecutionContext())->globalObject();
-            protectedThis->dispatchEvent(ErrorEvent::create(*navGlobalObject, eventNames().navigateerrorEvent, errorMessage, errorInformation.sourceURL, errorInformation.line, errorInformation.column, { navGlobalObject->vm(), result }));
-
-            if (apiMethodTracker)
-                Ref { apiMethodTracker->finishedPromise }->reject<IDLAny>(result, RejectAsHandled::Yes);
-
-            if (RefPtr transition = std::exchange(protectedThis->m_transition, nullptr))
-                transition->rejectPromise(result);
         });
-    });
 
-    // If a new event has been dispatched in our event handler then we were aborted above.
-    if (m_ongoingNavigateEvent != &event)
-        return DispatchResult::Aborted;
+        // If a new event has been dispatched in our event handler then we were aborted above.
+        if (m_ongoingNavigateEvent != &event)
+            return DispatchResult::Aborted;
+    }
 
     return std::nullopt;
 }


### PR DESCRIPTION
#### 518a56e28159e7a05b0a2314d7bc69f4a468a93a
<pre>
[Navigation API] Fix handler promise completion timing to use microtask instead of task
<a href="https://bugs.webkit.org/show_bug.cgi?id=311298">https://bugs.webkit.org/show_bug.cgi?id=311298</a>
<a href="https://rdar.apple.com/173890874">rdar://173890874</a>

Reviewed by Anne van Kesteren.

The Navigation API&apos;s innerDispatchNavigateEvent() wrapped waitForAllPromises()
in queueTask(DOMManipulation) — a task. The spec&apos;s inner navigate event
firing algorithm uses &quot;wait for all&quot; which attaches reactions via
PerformPromiseThen (microtasks), meaning navigatesuccess/navigateerror should
fire within the same microtask checkpoint, not deferred to a separate task.

Replace the queueTask wrapper with a PromiseSettlementObserver class that
implements &quot;wait for all&quot; — creates a DeferredPromise wrapper, resolves/rejects
it when handler promises settle, and chains the navigation completion logic via
whenSettledWithResult on the wrapper promise. This fires
navigatesuccess/navigateerror at the correct microtask depth, matching Chrome&apos;s
behavior.

Also fix transition-promises.html to properly handle promise rejection chains
and verify error object identity.

Test: imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-microtask-depth.html
* LayoutTests/http/wpt/navigation-api/transition-promises.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-microtask-depth.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-microtask-depth_currententrychange-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-intercept-microtask-depth_no-currententrychange-expected.txt: Added.
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::NavigationScheduler::scheduleLocationChange):
* Source/WebCore/page/Navigation.cpp:
(WebCore::createDOMPromise):
(WebCore::PromiseSettlementObserver::create):
(WebCore::PromiseSettlementObserver::waitForAllPromises):
(WebCore::PromiseSettlementObserver::PromiseSettlementObserver):
(WebCore::PromiseSettlementObserver::isWaiting const):
(WebCore::PromiseSettlementObserver::isSettled const):
(WebCore::PromiseSettlementObserver::resolve):
(WebCore::PromiseSettlementObserver::reject):
(WebCore::PromiseSettlementObserver::handleResult):
(WebCore::PromiseSettlementObserver::registerPromise):
(WebCore::PromiseSettlementObserver::consumeWrapper):
(WebCore::Navigation::handleSameDocumentNavigation):
(WebCore::AwaitingPromiseData::AwaitingPromiseData): Deleted.
(WebCore::waitForAllPromises): Deleted.

Canonical link: <a href="https://commits.webkit.org/310748@main">https://commits.webkit.org/310748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6906e7f6a7d6adfd2b4dc249ceadc71ff0d41c24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163549 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cd05a730-0fc4-4103-b5c7-9752bb9daeba) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156662 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27897 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119739 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4bb7cbe4-ee3f-4242-868c-41fd82372617) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157748 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/22025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/139013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100432 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0378e0b4-8dc8-4db1-9c22-6e1f275a5a17) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11375 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/130772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166023 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/9298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/18466 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/127842 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/27593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/23173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127982 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34728 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27517 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138650 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/84222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22872 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27209 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/91311 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/26787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/27018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26860 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->