### PR TITLE
[Site Isolation] Fix http/tests/security/file-system-access-via-dataTransfer.html

### DIFF
--- a/LayoutTests/http/tests/security/file-system-access-via-dataTransfer-expected.txt
+++ b/LayoutTests/http/tests/security/file-system-access-via-dataTransfer-expected.txt
@@ -6,6 +6,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 PASS Should not receive file
 PASS Should not receive file
 PASS Should not receive file
+PASS Should not receive file
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/security/file-system-access-via-dataTransfer.html
+++ b/LayoutTests/http/tests/security/file-system-access-via-dataTransfer.html
@@ -31,21 +31,22 @@ function runTest() {
     input.files = dataTransfer.files;
 
     let resultCount = 0;
+    const expectedResultCount = 4;
 
     var functionOnSuccess = function (file)
     {
         testFailed("Received file");
-        if (resultCount == 2)
-            finishJSTest()
         resultCount++;
+        if (resultCount == expectedResultCount)
+            finishJSTest();
     }
 
     var functionOnError = function (value)
     {
         testPassed("Should not receive file");
-        if (resultCount == 2)
-            finishJSTest()
         resultCount++;
+        if (resultCount == expectedResultCount)
+            finishJSTest();
     }
 
     input.webkitEntries.forEach((entry) => {

--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -242,7 +242,6 @@ http/tests/security/contentSecurityPolicy/object-redirect-allowed.html [ Failure
 http/tests/security/contentSecurityPolicy/object-redirect-allowed2.html [ Failure ]
 http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/proper-nested-upgrades.html [ Failure ]
 http/tests/security/cross-origin-local-storage.html [ Failure ]
-http/tests/security/file-system-access-via-dataTransfer.html [ Failure ]
 http/tests/security/video-poster-cross-origin-crash2.html [ Failure ]
 http/tests/security/window-events-clear-domain.html [ Failure ]
 http/tests/security/xss-DENIED-iframe-src-alias.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -262,7 +262,6 @@ http/tests/security/contentSecurityPolicy/object-redirect-allowed2.html [ Failur
 http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/proper-nested-upgrades.html [ Failure ]
 http/tests/security/cross-origin-blob-transfer.html [ Failure ]
 http/tests/security/cross-origin-local-storage.html [ Failure ]
-http/tests/security/file-system-access-via-dataTransfer.html [ Failure ]
 http/tests/site-isolation/inspector/debugger/pause-in-cross-origin-iframe.html [ Pass ]
 http/tests/site-isolation/inspector/debugger/scriptParsed-frame-target.html [ Pass ]
 http/tests/site-isolation/inspector/debugger/setBreakpoint-cross-origin-iframe.html [ Pass ]


### PR DESCRIPTION
#### 5b1ce0d64d86f7877962a671ff822cc33eac1a67
<pre>
[Site Isolation] Fix http/tests/security/file-system-access-via-dataTransfer.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=311303">https://bugs.webkit.org/show_bug.cgi?id=311303</a>
<a href="https://rdar.apple.com/173894915">rdar://173894915</a>

Reviewed by Sihui Liu.

With site isolation enabled, this test printed
out a 4th instance of &quot;PASS Should not receive file&quot;
after &quot;TEST COMPLETE&quot;. This 4th log is not present
with site isolation disabled. I believe that it&apos;s
revelaing itself since finishJSTest is called
too early and the test running with site isolation
enabled is able to squeeze out an additional print.

Update the test so that with and without site isolation
enabled, this test prints 4 instances of
&quot;PASS Should not receive file&quot;.

* LayoutTests/http/tests/security/file-system-access-via-dataTransfer-expected.txt:
* LayoutTests/http/tests/security/file-system-access-via-dataTransfer.html:
* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/310534@main">https://commits.webkit.org/310534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d015ffc29be53ab016691b28ea538ad50e2eefac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162877 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27232 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119202 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ed1521f9-8308-4e96-bf31-c4e38244229f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21446 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138405 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99898 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/97508e0d-4c2c-4a18-a0aa-71d06f1889b0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18532 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10710 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/130196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165350 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17857 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127295 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26928 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22574 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127441 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26852 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138043 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/83445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23541 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22311 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14835 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26542 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26123 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26354 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26195 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->