### PR TITLE
[css-anchor-position-1] getComputedStyle() of inset: auto on layout-time anchor-positioned elements should be 0

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-getComputedStyle-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-getComputedStyle-004-expected.txt
@@ -1,4 +1,4 @@
 
 PASS position-area does not affect resolved inset properties
-FAIL 'auto' inset properties resolve to 0px when position-area is non-initial assert_equals: expected "0px" but got "50px"
+PASS 'auto' inset properties resolve to 0px when position-area is non-initial
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/auto-inset-margin-getComputedStyle-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/auto-inset-margin-getComputedStyle-expected.txt
@@ -1,8 +1,8 @@
 
 
-FAIL position-area with valid anchor sets insets to zero assert_equals: expected "0px" but got "40px"
-FAIL justify-self: anchor-center  with valid anchor sets insets to zero assert_equals: expected "0px" but got "20px"
-FAIL align-self: anchor-center  with valid anchor sets insets to zero assert_equals: expected "0px" but got "20px"
+PASS position-area with valid anchor sets insets to zero
+PASS justify-self: anchor-center  with valid anchor sets insets to zero
+PASS align-self: anchor-center  with valid anchor sets insets to zero
 PASS position-area with invalid anchor does not set insets to zero
 PASS justify-self: anchor-center with invalid anchor does not set insets to zero
 PASS align-self: anchor-center with invalid anchor does not set insets to zero

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -355,6 +355,13 @@ template<CSSPropertyID propertyID> struct InsetEdgeSharedAdaptor {
             // See http://www.w3.org/TR/CSS2/visuren.html#position-props
             //
             // Margins are included in offsetTop/offsetLeft so we need to remove them here.
+
+            // Per spec, when position-area or anchor-center is used, the used value
+            // of any auto inset properties and auto margin properties resolves to 0.
+            // See https://drafts.csswg.org/css-anchor-position-1/#position-area.
+            if (AnchorPositionEvaluator::isLayoutTimeAnchorPositioned(box.style()) && AnchorPositionEvaluator::defaultAnchorForBox(box)) [[unlikely]]
+                return LayoutUnit { };
+
             auto paddingBoxWidth = [&]() -> LayoutUnit {
                 if (CheckedPtr renderBlock = dynamicDowncast<RenderBlock>(container))
                     return renderBlock->paddingBoxWidth();


### PR DESCRIPTION
#### ad757582cef589ad4f4ca3e52d399fc9c740c322
<pre>
[css-anchor-position-1] getComputedStyle() of inset: auto on layout-time anchor-positioned elements should be 0
<a href="https://rdar.apple.com/173885561">rdar://173885561</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311289">https://bugs.webkit.org/show_bug.cgi?id=311289</a>

Reviewed by Antti Koivisto.

Per spec, getComputedStyle() returns the &quot;resolved value&quot;, which for inset/margin
properties is the &quot;used value&quot; [1]. The layout code doesn&apos;t keep track of the
inset/margin used values, so getComputedStyle() computes its own used value from
the box&apos;s geometry, as if the box is solely positioned using insets/margins.

This conflicts with position-area/anchor-center, which could position a box
anywhere depending on the anchor, even with 0 insets/margins. In fact, the
spec says that when an element uses position-area or anchor-center, the used
value of &apos;auto&apos; inset/margin properties is zero [2].

This issue doesn&apos;t affect layout code, as it ignores auto inset/margins if the box
uses position-area or anchor-center, but it does affects the value returned by
getComputedStyle(). This patches getComputedStyle() to return 0 for &apos;auto&apos; inset
properties if the box uses position-area/anchor-center and has a valid default anchor.
The computed margins in this case is already zero, so no changes needed there.

(for comparison, Chromium keeps track of the used inset/margin value and pipes it down
to getComputedStyle)

[1]: <a href="https://drafts.csswg.org/cssom/#resolved-values">https://drafts.csswg.org/cssom/#resolved-values</a>
[2]: <a href="https://drafts.csswg.org/css-anchor-position-1/#position-area">https://drafts.csswg.org/css-anchor-position-1/#position-area</a>

Tests: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-getComputedStyle-004.html
       imported/w3c/web-platform-tests/css/css-anchor-position/auto-inset-margin-getComputedStyle.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-getComputedStyle-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/auto-inset-margin-getComputedStyle-expected.txt:
* Source/WebCore/style/StyleExtractorCustom.h:
(WebCore::Style::InsetEdgeSharedAdaptor::computedValue const):

Canonical link: <a href="https://commits.webkit.org/311016@main">https://commits.webkit.org/311016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5b5009aabd3604aef1afc8c35e9f883e635a867

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164064 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109100 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd30f888-e21d-47ff-a5d1-6473e35655cd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157176 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120184 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84854 "1 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22409 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139476 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100875 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/96e28b3e-878b-4924-9f80-98394a9235b6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21495 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19574 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11890 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131163 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166542 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10703 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18919 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128292 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23608 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128423 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34906 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28031 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139102 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85416 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23284 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15899 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27725 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91828 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27302 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27532 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27375 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->