### PR TITLE
REGRESSION (307242@main): YouTube takes longer to load a page

### DIFF
--- a/Source/WebCore/platform/MediaStrategy.h
+++ b/Source/WebCore/platform/MediaStrategy.h
@@ -76,6 +76,7 @@ public:
 #if ENABLE(VIDEO)
     virtual void nativeImageFromVideoFrame(const VideoFrame&, CompletionHandler<void(std::optional<RefPtr<NativeImage>>&&)>&&);
     virtual bool canDecodeExtendedType(PlatformMediaDecodingType, const ContentType&) { return false; }
+    virtual void ensureCodecsSupportChecksInitialized() { }
 #endif
 
     virtual bool enableWebMMediaPlayer() const { return true; }

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
@@ -31,9 +31,12 @@
 #import "CMUtilities.h"
 #import "FourCC.h"
 #import "LibWebRTCProvider.h"
+#import "Logging.h"
+#import "MediaStrategy.h"
 #import "PlatformMediaCapabilitiesInfo.h"
 #import "PlatformMediaCapabilitiesVideoConfiguration.h"
 #import "PlatformScreen.h"
+#import "PlatformStrategies.h"
 #import "ScreenProperties.h"
 #import "SharedBuffer.h"
 #import "SystemBattery.h"
@@ -66,9 +69,9 @@ void VP9TestingOverrides::setHardwareDecoderDisabled(std::optional<bool>&& disab
         m_configurationChangedCallback(false);
 }
 
-void VP9TestingOverrides::setVP9HardwareDecoderEnabledOverride(std::optional<bool>&& disabled)
+void VP9TestingOverrides::setVP9HardwareDecoderEnabledOverride(std::optional<bool>&& enabled)
 {
-    m_vp9HardwareDecoderEnabledOverride = WTF::move(disabled);
+    m_vp9HardwareDecoderEnabledOverride = WTF::move(enabled);
     if (m_configurationChangedCallback)
         m_configurationChangedCallback(false);
 }
@@ -197,6 +200,11 @@ bool shouldEnableSWVP9Decoder()
     return isSWDecodersAlwaysEnabled() || (!vp9HardwareDecoderAvailable() && !systemHasBattery());
 }
 
+static bool isVP9HardwareDecoderAvailabilityKnown()
+{
+    return VP9TestingOverrides::singleton().hardwareDecoderDisabled() || VP9TestingOverrides::singleton().vp9HardwareDecoderEnabledOverride();
+}
+
 bool isVP9DecoderAvailable()
 {
     if (isSWDecodersAlwaysEnabled())
@@ -215,6 +223,13 @@ bool isVP8DecoderAvailable()
 
 bool vp9HardwareDecoderAvailable()
 {
+    // If the GPUP hasn't delivered VP9 hardware decoder capability yet,
+    // ensure it's initialized and re-check.
+    if (!isVP9HardwareDecoderAvailabilityKnown() && hasPlatformStrategies()) {
+        RELEASE_LOG_ERROR(Media, "SourceBufferParserWebM::isContentTypeSupported: VP9 availability unknown, ensuring codecs support is initialized");
+        platformStrategies()->mediaStrategy()->ensureCodecsSupportChecksInitialized();
+    }
+
     if (auto disabledForTesting = VP9TestingOverrides::singleton().hardwareDecoderDisabled())
         return !*disabledForTesting;
 

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
@@ -134,9 +134,10 @@ public:
     void addClient(const Client& client) { m_clients.add(client); }
 
     static constexpr Seconds defaultTimeout = 3_s;
+    bool waitForDidInitialize();
+
 private:
     GPUProcessConnection(Ref<IPC::Connection>&&);
-    bool waitForDidInitialize();
     void invalidate();
 
     // IPC::Connection::Client

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
@@ -84,17 +84,31 @@ static WorkQueue& webMediaStrategyQueueSingleton()
     return workQueue.get();
 }
 
+void WebMediaStrategy::ensureCodecsSupportChecksInitialized()
+{
+    callOnMainRunLoopAndWait([] {
+        protect(WebProcess::singleton().ensureGPUProcessConnection())->waitForDidInitialize();
+    });
+}
+
 bool WebMediaStrategy::canDecodeExtendedType(PlatformMediaDecodingType platformType, const ContentType& contentType)
 {
+    Ref connection = [&] {
+        RefPtr connection = WebProcess::singleton().existingGPUProcessConnection();
+        if (connection)
+            return connection.releaseNonNull();
+        callOnMainRunLoopAndWait([&] {
+            connection = &WebProcess::singleton().ensureGPUProcessConnection();
+        });
+        return connection.releaseNonNull();
+    }();
     std::atomic<bool> isSupported = false;
     BinarySemaphore semaphore;
-    webMediaStrategyQueueSingleton().dispatch([&] {
-        if (RefPtr connection = WebProcess::singleton().existingGPUProcessConnection()) {
-            connection->connection().sendWithAsyncReplyOnDispatcher(Messages::GPUConnectionToWebProcess::CanDecodeExtendedType(platformType, contentType), webMediaStrategyQueueSingleton(), [&semaphore, &isSupported](bool supported) {
-                isSupported = supported;
-                semaphore.signal();
-            });
-        }
+    webMediaStrategyQueueSingleton().dispatch([&, connection = WTF::move(connection)] {
+        connection->connection().sendWithAsyncReplyOnDispatcher(Messages::GPUConnectionToWebProcess::CanDecodeExtendedType(platformType, contentType), webMediaStrategyQueueSingleton(), [&semaphore, &isSupported](bool supported) {
+            isSupported = supported;
+            semaphore.signal();
+        });
     });
     semaphore.wait();
     return isSupported;

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
@@ -49,6 +49,7 @@ private:
 #if ENABLE(VIDEO) && ENABLE(GPU_PROCESS)
     RefPtr<WebCore::AudioVideoRenderer> createAudioVideoRenderer(LoggerHelper*, WebCore::HTMLMediaElementIdentifier, WebCore::MediaPlayerIdentifier) const final;
     bool canDecodeExtendedType(WebCore::PlatformMediaDecodingType, const WebCore::ContentType&) final;
+    void ensureCodecsSupportChecksInitialized() final;
 #endif
     std::unique_ptr<WebCore::NowPlayingManager> createNowPlayingManager() const final;
     bool hasThreadSafeMediaSourceSupport() const final;

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -236,11 +236,7 @@ void LibWebRTCCodecs::initializeIfNeeded()
     static std::once_flag doInitializationOnce;
     std::call_once(doInitializationOnce, [] {
         callOnMainRunLoopAndWait([] {
-#if HAVE(AUDIT_TOKEN)
-            protect(WebProcess::singleton().ensureGPUProcessConnection())->auditToken();
-#else
-            WebProcess::singleton().ensureGPUProcessConnection();
-#endif
+            protect(WebProcess::singleton().ensureGPUProcessConnection())->waitForDidInitialize();
         });
     });
 }


### PR DESCRIPTION
#### 4d9d9d1b5628b25af82d57f5b38fc0c82360f534
<pre>
REGRESSION (307242@main): YouTube takes longer to load a page
<a href="https://bugs.webkit.org/show_bug.cgi?id=311304">https://bugs.webkit.org/show_bug.cgi?id=311304</a>
<a href="https://rdar.apple.com/172104196">rdar://172104196</a>

Reviewed by Youenn Fablet.

A race condition in VP9 codec capability reporting caused a ~60% YouTube page load regression when
MediaContainmentEnabled was on.

Root cause: When a new WebContent process was created, YouTube&apos;s JS called MediaSource.isTypeSupported(&quot;video/webm;
codecs=vp9&quot;) before the GPU process had delivered its VP9 hardware decoder capability via
GPUProcessConnection::didInitialize. The WebContent process checked VTIsHardwareDecodeSupported(VP9) locally, which
returned false (VP9 hardware decoding is only available in the GPU process after supplemental decoder registration).
VP9 was incorrectly reported as unsupported, the result was cached, and YouTube fell back to H.264.

With MediaContainmentEnabled off, this didn&apos;t happen because the MSE pipeline ran in the GPU process where VP9 was
directly available.

The benchmark tools had content cached for mp4/h264 but didn&apos;t for webm/vp9 so we ended up comparing
two different things: one where the page had no video content of any kind, and one where the videos were loaded.

* Source/WebCore/platform/MediaStrategy.h: Added virtual void ensureCodecsSupportChecksInitialized()
* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h: Added isVP9HardwareDecoderAvailabilityKnown()
* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm:
(WebCore::vp9HardwareDecoderAvailable): Added fallback when VP9 availability is unknown, waiting for the GPU process initialisation as needed.
(WebCore::VP9TestingOverrides::setVP9HardwareDecoderEnabledOverride): rename argument, it was misnamed as disabled, when it meant the opposite.
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.h: Make waitForDidInitialize
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp:
(WebKit::WebMediaStrategy::ensureCodecsSupportChecksInitialized): we ensure the GPU connection
has been created and initialised. We follow the same pattern as LibWebRTCCodecs::initializeIfNeeded().
(WebKit::WebMediaStrategy::canDecodeExtendedType): Fly-By, if the method was called prior the GPU connection being available,
we would have exited early before signaling the semaphore, causing a deadlock
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h:
(WebKit::LibWebRTCCodecs::initializeIfNeeded): Make use of waitForDidInitialize, auditToken() was used as a workaround to access waitForDidInitialize.

Canonical link: <a href="https://commits.webkit.org/310474@main">https://commits.webkit.org/310474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60374958a101c297701240eab6c2df28aee6cb2b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153896 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26680 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162647 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107361 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e5686fe8-a185-46ef-8992-8679ca7fc711) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155769 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27002 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118994 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84138 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156855 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21264 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138190 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99704 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e97a18af-2079-467f-bc5b-c354eaa8c9ea) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20351 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18313 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10479 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130003 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16049 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165120 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8251 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17643 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127080 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22332 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127247 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34531 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26479 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137844 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83188 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22149 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14628 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26096 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90399 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25787 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25947 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25847 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->