### PR TITLE
[WebDriver] Fix element references after tab switch or close

### DIFF
--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -191,6 +191,71 @@ static JSValueRef isValidNodeIdentifier(JSContextRef context, JSObjectRef functi
     return JSValueMakeBoolean(context, isValidNodeHandle(nodeIdentifier->string()));
 }
 
+static JSValueRef isKnownReferenceCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
+{
+    // This is using the JSC C API so we cannot take a std::span in argument directly.
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
+
+    ASSERT(arguments.size() == 2);
+    ASSERT(JSValueIsNumber(context, arguments[0]));
+    ASSERT(JSValueIsString(context, arguments[1]));
+
+    if (arguments.size() != 2)
+        return JSValueMakeUndefined(context);
+
+    auto rawFrameID = JSValueToNumber(context, arguments[0], exception);
+    if (!ObjectIdentifier<WebCore::FrameIdentifierType>::isValidIdentifier(rawFrameID))
+        return JSValueMakeUndefined(context);
+    WebCore::FrameIdentifier currentFrameIdentifier(rawFrameID);
+    auto nodeIdentifier = adoptRef(JSValueToStringCopy(context, arguments[1], exception));
+
+    RefPtr automationSessionProxy = WebProcess::singleton().automationSessionProxy();
+    if (!automationSessionProxy)
+        return JSValueMakeUndefined(context);
+
+    return JSValueMakeBoolean(context, automationSessionProxy->isKnownReference(currentFrameIdentifier, nodeIdentifier->string()));
+}
+
+bool WebAutomationSessionProxy::isKnownReference(WebCore::FrameIdentifier frameID, const String& nodeHandle)
+{
+    auto findResult = m_knownReferences.find(frameID);
+    if (findResult != m_knownReferences.end())
+        return findResult->value.contains(nodeHandle);
+    return false;
+}
+
+static JSValueRef addKnownReferenceCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
+{
+    // This is using the JSC C API so we cannot take a std::span in argument directly.
+    auto arguments = unsafeMakeSpan(rawArguments, rawArgumentCount);
+
+    ASSERT(arguments.size() == 2);
+    ASSERT(JSValueIsNumber(context, arguments[0]));
+    ASSERT(JSValueIsString(context, arguments[1]));
+
+    if (arguments.size() != 2)
+        return JSValueMakeUndefined(context);
+
+    auto rawFrameID = JSValueToNumber(context, arguments[0], exception);
+    if (!ObjectIdentifier<WebCore::FrameIdentifierType>::isValidIdentifier(rawFrameID))
+        return JSValueMakeUndefined(context);
+    WebCore::FrameIdentifier currentFrameIdentifier(rawFrameID);
+    auto nodeIdentifier = adoptRef(JSValueToStringCopy(context, arguments[1], exception));
+
+    RefPtr automationSessionProxy = WebProcess::singleton().automationSessionProxy();
+    if (!automationSessionProxy)
+        return JSValueMakeUndefined(context);
+
+    automationSessionProxy->addKnownReference(currentFrameIdentifier, nodeIdentifier->string());
+    return JSValueMakeUndefined(context);
+}
+
+void WebAutomationSessionProxy::addKnownReference(WebCore::FrameIdentifier frameID, const String& nodeHandle)
+{
+    auto result = m_knownReferences.add(frameID, HashSet<String>());
+    result.iterator->value.add(nodeHandle);
+}
+
 static JSValueRef evaluate(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
 {
     ASSERT_ARG(argumentCount, argumentCount == 1);
@@ -206,6 +271,13 @@ static JSValueRef evaluate(JSContextRef context, JSObjectRef function, JSObjectR
 static JSValueRef createUUID(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
 {
     return toJSValue(context, createVersion4UUIDString().convertToASCIIUppercase());
+}
+
+String WebAutomationSessionProxy::errorTypeFromJavaScriptExceptionName(const String& exceptionName)
+{
+    auto errorType = Inspector::Protocol::AutomationHelpers::parseEnumValueFromString<Inspector::Protocol::Automation::ErrorMessage>(exceptionName)
+        .value_or(Inspector::Protocol::Automation::ErrorMessage::JavaScriptError);
+    return Inspector::Protocol::AutomationHelpers::getEnumConstantValue(errorType);
 }
 
 static JSValueRef evaluateJavaScriptCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t rawArgumentCount, const JSValueRef rawArguments[], JSValueRef* exception)
@@ -300,10 +372,13 @@ JSObjectRef WebAutomationSessionProxy::scriptObjectForFrame(WebFrame& frame)
     ASSERT(JSValueIsObject(context, scriptObjectFunction));
 
     JSValueRef sessionIdentifier = toJSValue(context, m_sessionIdentifier);
+    JSValueRef currentFrameIdentifier = JSValueMakeNumber(context, frame.frameID().toUInt64());
     JSObjectRef evaluateFunction = JSObjectMakeFunctionWithCallback(context, nullptr, evaluate);
     JSObjectRef createUUIDFunction = JSObjectMakeFunctionWithCallback(context, nullptr, createUUID);
     JSObjectRef isValidNodeIdentifierFunction = JSObjectMakeFunctionWithCallback(context, nullptr, isValidNodeIdentifier);
-    JSValueRef arguments[] = { sessionIdentifier, evaluateFunction, createUUIDFunction, isValidNodeIdentifierFunction };
+    JSObjectRef isKnownReferenceFunction = JSObjectMakeFunctionWithCallback(context, nullptr, isKnownReferenceCallback);
+    JSObjectRef addKnownReferenceFunction = JSObjectMakeFunctionWithCallback(context, nullptr, addKnownReferenceCallback);
+    JSValueRef arguments[] = { sessionIdentifier, currentFrameIdentifier, evaluateFunction, createUUIDFunction, isValidNodeIdentifierFunction, isKnownReferenceFunction, addKnownReferenceFunction };
     JSObjectRef scriptObject = const_cast<JSObjectRef>(JSObjectCallAsFunction(context, scriptObjectFunction, nullptr, std::size(arguments), arguments, &exception));
     ASSERT(JSValueIsObject(context, scriptObject));
 
@@ -311,30 +386,47 @@ JSObjectRef WebAutomationSessionProxy::scriptObjectForFrame(WebFrame& frame)
     return scriptObject;
 }
 
-WebCore::Element* WebAutomationSessionProxy::elementForNodeHandle(WebFrame& frame, const String& nodeHandle)
+Expected<Ref<Element>, String> WebAutomationSessionProxy::elementForNodeHandle(WebFrame& frame, const String& nodeHandle)
 {
     // Don't use scriptObjectForFrame() since we can assume if the script object
-    // does not exist, there are no nodes mapped to handles. Using scriptObjectForFrame()
-    // will make a new script object if it can't find one, preventing us from returning fast.
+    // does not exist, all known references came from previous documents and should
+    // be considered stale. Using scriptObjectForFrame() will make a new script
+    // object if it can't find one, preventing us from returning fast.
     JSGlobalContextRef context = frame.jsContext();
     auto* scriptObject = this->scriptObject(context);
-    if (!scriptObject)
-        return nullptr;
+    if (!scriptObject) {
+        if (isKnownReference(frame.frameID(), nodeHandle))
+            return makeUnexpected(Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::NodeNotFound));
+        return makeUnexpected(Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::InvalidNodeIdentifier));
+    }
 
     JSValueRef functionArguments[] = {
         toJSValue(context, nodeHandle)
     };
+    JSValueRef exception = nullptr;
 
-    JSValueRef result = callPropertyFunction(context, scriptObject, "nodeForIdentifier"_s, std::size(functionArguments), functionArguments, nullptr);
+    JSValueRef result = callPropertyFunction(context, scriptObject, "nodeForIdentifier"_s, std::size(functionArguments), functionArguments, &exception);
+
+    if (exception) {
+        String errorType = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::JavaScriptError);
+        if (JSValueIsObject(context, exception)) {
+            JSObjectRef exceptionObj = JSValueToObject(context, exception, nullptr);
+            JSValueRef nameValue = JSObjectGetProperty(context, exceptionObj, OpaqueJSString::tryCreate("name"_s).get(), nullptr);
+            String exceptionName = adoptRef(JSValueToStringCopy(context, nameValue, nullptr))->string();
+            errorType = errorTypeFromJavaScriptExceptionName(exceptionName);
+        }
+        return makeUnexpected(errorType);
+    }
+
     JSObjectRef element = JSValueToObject(context, result, nullptr);
     if (!element)
-        return nullptr;
+        return makeUnexpected(Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::InternalError));
 
     auto elementWrapper = JSC::jsDynamicCast<WebCore::JSElement*>(toJS(element));
     if (!elementWrapper)
-        return nullptr;
+        return makeUnexpected(Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::InvalidNodeIdentifier));
 
-    return &elementWrapper->wrapped();
+    return Ref { elementWrapper->wrapped() };
 }
 
 WebCore::AccessibilityObject* WebAutomationSessionProxy::getAccessibilityObjectForNode(WebCore::PageIdentifier pageID, std::optional<WebCore::FrameIdentifier> frameID, String nodeHandle, String& errorType)
@@ -356,11 +448,12 @@ WebCore::AccessibilityObject* WebAutomationSessionProxy::getAccessibilityObjectF
         return nullptr;
     }
 
-    RefPtr coreElement = elementForNodeHandle(*frame, nodeHandle);
-    if (!coreElement) {
-        errorType = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::NodeNotFound);
+    auto coreElementOrError = elementForNodeHandle(*frame, nodeHandle);
+    if (!coreElementOrError) {
+        errorType = coreElementOrError.error();
         return nullptr;
     }
+    Ref coreElement = WTF::move(*coreElementOrError);
 
     WebCore::AXObjectCache::enableAccessibility();
 
@@ -369,7 +462,7 @@ WebCore::AccessibilityObject* WebAutomationSessionProxy::getAccessibilityObjectF
         // the accessibility object for this element will not be created (because it doesn't yet have its renderer).
         axObjectCache->performDeferredCacheUpdate(ForceLayout::Yes);
 
-        if (auto* axObject = axObjectCache->exportedGetOrCreate(*coreElement))
+        if (auto* axObject = axObjectCache->exportedGetOrCreate(coreElement))
             return axObject;
     }
 
@@ -600,14 +693,13 @@ void WebAutomationSessionProxy::resolveChildFrameWithNodeHandle(WebCore::PageIde
         return;
     }
 
-    RefPtr coreElement = elementForNodeHandle(*frame, nodeHandle);
-    if (!coreElement) {
-        String nodeNotFoundErrorType = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::NodeNotFound);
-        completionHandler(nodeNotFoundErrorType, std::nullopt);
+    auto coreElementOrError = elementForNodeHandle(*frame, nodeHandle);
+    if (!coreElementOrError) {
+        completionHandler(coreElementOrError.error(), std::nullopt);
         return;
     }
 
-    RefPtr frameElementBase = dynamicDowncast<WebCore::HTMLFrameElementBase>(*coreElement);
+    RefPtr frameElementBase = dynamicDowncast<WebCore::HTMLFrameElementBase>(*coreElementOrError);
     if (!frameElementBase) {
         completionHandler(frameNotFoundErrorType, std::nullopt);
         return;
@@ -782,14 +874,14 @@ void WebAutomationSessionProxy::computeElementLayout(WebCore::PageIdentifier pag
         return;
     }
 
-    RefPtr coreElement = elementForNodeHandle(*frame, nodeHandle);
-    if (!coreElement) {
-        String nodeNotFoundErrorType = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::NodeNotFound);
-        completionHandler(nodeNotFoundErrorType, { }, std::nullopt, false);
+    auto coreElementOrError = elementForNodeHandle(*frame, nodeHandle);
+    if (!coreElementOrError) {
+        completionHandler(coreElementOrError.error(), { }, std::nullopt, false);
         return;
     }
+    Ref coreElement = WTF::move(*coreElementOrError);
 
-    RefPtr containerElement = containerElementForElement(*coreElement);
+    RefPtr containerElement = containerElementForElement(coreElement);
     if (scrollIntoViewIfNeeded && containerElement) {
         // §14.1 Element Click. Step 4. Scroll into view the element’s container.
         // https://w3c.github.io/webdriver/webdriver-spec.html#element-click
@@ -929,20 +1021,25 @@ void WebAutomationSessionProxy::selectOptionElement(WebCore::PageIdentifier page
         return;
     }
 
-    RefPtr coreElement = elementForNodeHandle(*frame, nodeHandle);
-    if (!coreElement || (!is<WebCore::HTMLOptionElement>(coreElement) && !is<WebCore::HTMLOptGroupElement>(coreElement))) {
+    auto coreElementOrError = elementForNodeHandle(*frame, nodeHandle);
+    if (!coreElementOrError) {
+        completionHandler(coreElementOrError.error());
+        return;
+    }
+
+    if (!is<HTMLOptionElement>(*coreElementOrError) && !is<HTMLOptGroupElement>(*coreElementOrError)) {
         String nodeNotFoundErrorType = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::NodeNotFound);
         completionHandler(nodeNotFoundErrorType);
         return;
     }
 
     String elementNotInteractableErrorType = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::ElementNotInteractable);
-    if (is<WebCore::HTMLOptGroupElement>(coreElement)) {
+    if (is<WebCore::HTMLOptGroupElement>(*coreElementOrError)) {
         completionHandler(elementNotInteractableErrorType);
         return;
     }
 
-    Ref optionElement = downcast<WebCore::HTMLOptionElement>(*coreElement);
+    Ref optionElement = downcast<WebCore::HTMLOptionElement>(*coreElementOrError);
     RefPtr selectElement = optionElement->ownerSelectElement();
     if (!selectElement) {
         completionHandler(elementNotInteractableErrorType);
@@ -974,7 +1071,12 @@ void WebAutomationSessionProxy::setFilesForInputFileUpload(WebCore::PageIdentifi
         return;
     }
 
-    RefPtr inputElement = dynamicDowncast<WebCore::HTMLInputElement>(elementForNodeHandle(*frame, nodeHandle));
+    auto coreElementOrError = elementForNodeHandle(*frame, nodeHandle);
+    if (!coreElementOrError) {
+        completionHandler(coreElementOrError.error());
+        return;
+    }
+    RefPtr inputElement = dynamicDowncast<WebCore::HTMLInputElement>(*coreElementOrError);
     if (!inputElement || !inputElement->isFileUpload()) {
         String nodeNotFoundErrorType = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::NodeNotFound);
         completionHandler(nodeNotFoundErrorType);
@@ -1064,12 +1166,12 @@ void WebAutomationSessionProxy::snapshotRectForScreenshot(WebCore::PageIdentifie
             return;
         }
 
-        coreElement = elementForNodeHandle(*frame, nodeHandle);
-        if (!coreElement) {
-            String nodeNotFoundErrorType = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::NodeNotFound);
-            completionHandler(nodeNotFoundErrorType, { });
+        auto coreElementOrError = elementForNodeHandle(*frame, nodeHandle);
+        if (!coreElementOrError) {
+            completionHandler(coreElementOrError.error(), { });
             return;
         }
+        coreElement = WTF::move(*coreElementOrError);
     }
 
     if (coreElement && scrollIntoViewIfNeeded)

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
@@ -78,13 +78,17 @@ public:
 
     void didEvaluateJavaScriptFunction(WebCore::FrameIdentifier, JSCallbackIdentifier, const String& result, const String& errorType);
 
+    bool isKnownReference(WebCore::FrameIdentifier, const String& nodeHandle);
+    void addKnownReference(WebCore::FrameIdentifier, const String&);
+
 private:
     explicit WebAutomationSessionProxy(const String& sessionIdentifier);
     JSObjectRef scriptObject(JSGlobalContextRef);
     void setScriptObject(JSGlobalContextRef, JSObjectRef);
     JSObjectRef scriptObjectForFrame(WebFrame&);
-    WebCore::Element* elementForNodeHandle(WebFrame&, const String&);
+    Expected<Ref<WebCore::Element>, String> elementForNodeHandle(WebFrame&, const String&);
     WebCore::AccessibilityObject* getAccessibilityObjectForNode(WebCore::PageIdentifier, std::optional<WebCore::FrameIdentifier>, String nodeHandle, String& error);
+    static String errorTypeFromJavaScriptExceptionName(const String& exceptionName);
 
     void ensureObserverForFrame(WebFrame&);
 
@@ -118,6 +122,7 @@ private:
 
     HashMap<WebCore::FrameIdentifier, HashMap<JSCallbackIdentifier, CompletionHandler<void(String&&, String&&)>>> m_webFramePendingEvaluateJavaScriptCallbacksMap;
     HashMap<WebCore::FrameIdentifier, Ref<WebAutomationDOMWindowObserver>> m_frameObservers;
+    HashMap<WebCore::FrameIdentifier, HashSet<String>> m_knownReferences;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.js
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.js
@@ -25,7 +25,7 @@
 
 //# sourceURL=__InjectedScript_WebAutomationSessionProxy.js
 
-(function (sessionIdentifier, evaluate, createUUID, isValidNodeIdentifier) {
+(function (sessionIdentifier, currentFrameIdentifier, evaluate, createUUID, isValidNodeIdentifier, isKnownReference, addKnownReference) {
 
 const sessionNodePropertyName = "session-node-" + sessionIdentifier;
 
@@ -56,11 +56,7 @@ let AutomationSessionProxy = class AutomationSessionProxy
     nodeForIdentifier(identifier)
     {
         this._clearStaleNodes();
-        try {
-            return this._nodeForIdentifier(identifier);
-        } catch (error) {
-            return null;
-        }
+        return this._nodeForIdentifier(identifier);
     }
 
     // Private
@@ -300,7 +296,11 @@ let AutomationSessionProxy = class AutomationSessionProxy
         let node = this._idToNodeMap.get(identifier);
         if (node)
             return node;
-        throw {name: "NodeNotFound", message: "Node with identifier '" + identifier + "' was not found"};
+
+        if (isKnownReference(currentFrameIdentifier, identifier))
+            throw {name: "NodeNotFound", message: "Stale element reference '" + identifier + "'"};
+
+        throw {name: "InvalidNodeIdentifier", message: "No such element with identifier '" + identifier + "'"};
     }
 
     _identifierForNode(node)
@@ -313,6 +313,7 @@ let AutomationSessionProxy = class AutomationSessionProxy
 
         this._nodeToIdMap.set(node, identifier);
         this._idToNodeMap.set(identifier, node);
+        addKnownReference(currentFrameIdentifier, identifier);
 
         return identifier;
     }


### PR DESCRIPTION
#### 060b7fdbde95a2945bd5c68b6ef1bc094bac9648
<pre>
[WebDriver] Fix element references after tab switch or close
<a href="https://bugs.webkit.org/show_bug.cgi?id=230612">https://bugs.webkit.org/show_bug.cgi?id=230612</a>

Reviewed by NOBODY (OOPS!).

When passing web Elements to clients, WebDriver maps each element to a
string reference, like &quot;node-$UUID&quot;. These references then can be passed
as arguments to other commands, like getElementTagName, or as attributes
to javascript functions. Inside the browser, these references are mapped
back to the original element they refer to, usually through the &quot;get a
known element&quot; algorithm at
<a href="https://w3c.github.io/webdriver/#dfn-get-a-known-element">https://w3c.github.io/webdriver/#dfn-get-a-known-element</a>

According to the spec, this process of resolving a reference might raise
two errors:

- &quot;stale element reference&quot; (NodeNotFound inside WebKit): When it&apos;s a
  known reference within the given context, but it&apos;s stale (e.g.
  disconnected)
- &quot;no such element&quot; (InvalidNodeIdentifier inside WebKit): When it&apos;s an
  unknown reference, or resolves to a node that&apos;s not an Element.

Currently, the reference mapping is done through the
`AutomationSessionProxy` class in the `WebAutomationSessionProxy.js`
helper script, alongside the C++
`WebAutomationSessionProxy::elementForNodeHandle` method. The JS class
is created as a helper script, associated with the current document. It
tracks the currently known references, clearing stale ones frequently.
This works relatively fine most of the time for &quot;no such elements&quot;, but
often leads to failure to raise &quot;stale element reference&quot;, as it has no
memory of the previously known references, alongside losing the
reference history when the helper script is destroyed.

On top of that, often callers of `elementForNodeHandle` assumed that, if
the returned element RefPtr is null, automatically they should raise &quot;no
such element&quot;, ignoring the &quot;stale element reference&quot; case, as the JS
nodeForIdentifier wrapper called by the former swallowed exceptions.

This commit addresses this issue by keeping track of known references
for a given frame on the C++ WebAutomationSessionProxy instance, using
it from the existing `elementForNodeHandle` and `nodeForIdentifier`, so
we can return both errors when needed, which in turn will be done by
returning `Expected&lt;Ref&lt;Element&gt;, String&gt;` instead of a plain
RefPtr&lt;Element&gt; in `elementForNodeHandle`.

The mentioned callers were also updated to address this new behavior,
forwarding the proper error when a reference can&apos;t be resolved.

Covered by existing tests. This fixes roughly 80 persistent failures,
gardened and ungardened.

* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::isKnownReferenceCallback): Added.
(WebKit::WebAutomationSessionProxy::isKnownReference): Added.
(WebKit::addKnownReferenceCallback): Added.
(WebKit::WebAutomationSessionProxy::addKnownReference): Added.
(WebKit::WebAutomationSessionProxy::errorTypeFromJavaScriptExceptionName): Added.
(WebKit::WebAutomationSessionProxy::scriptObjectForFrame): Expose new
callbacks and frame info to the script helper.
(WebKit::WebAutomationSessionProxy::elementForNodeHandle): Return the
right error type depending on the raised JS exception.
(WebKit::WebAutomationSessionProxy::getAccessibilityObjectForNode):
Forward exceptions from JS.
(WebKit::WebAutomationSessionProxy::resolveChildFrameWithNodeHandle):
Ditto.
(WebKit::WebAutomationSessionProxy::computeElementLayout): Ditto.
(WebKit::WebAutomationSessionProxy::selectOptionElement): Ditto.
(WebKit::WebAutomationSessionProxy::setFilesForInputFileUpload): Ditto.
(WebKit::WebAutomationSessionProxy::snapshotRectForScreenshot): Ditto.
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h: Added
  new methods.
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.js:
  Added new parameters.
(let.AutomationSessionProxy.prototype.nodeForIdentifier): Do not swallow
exceptions.
(let.AutomationSessionProxy.prototype._nodeForIdentifier): Check known
references through the new C++ helpers.
(let.AutomationSessionProxy.prototype._identifierForNode): Add new
references to the known references map.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/060b7fdbde95a2945bd5c68b6ef1bc094bac9648

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26672 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162639 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107351 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26994 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118987 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84133 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21258 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138177 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99697 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20347 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18303 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10471 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129999 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165112 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8243 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17630 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127073 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26469 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22322 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127240 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26471 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137831 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83170 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22138 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14615 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26088 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90395 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25779 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25939 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25839 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->