### PR TITLE
_AXSIsolatedTreeModeFunctionIsAvailable definition in UsageTrackingSoftLink.h is duplicative

### DIFF
--- a/Source/WTF/wtf/cocoa/SoftLinking.h
+++ b/Source/WTF/wtf/cocoa/SoftLinking.h
@@ -392,7 +392,7 @@ static void* lib##Library() \
     namespace functionNamespace { \
     extern void* lib##Library(bool isOptional = false); \
     bool is##lib##LibraryAvailable(); \
-    inline bool is##lib##LibaryAvailable() { \
+    inline bool is##lib##LibraryAvailable() { \
         return lib##Library(true) != nullptr; \
     } \
     }

--- a/Source/WebCore/PAL/pal/cocoa/UsageTrackingSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/UsageTrackingSoftLink.h
@@ -34,7 +34,6 @@
 SOFT_LINK_FRAMEWORK_FOR_HEADER(PAL, UsageTracking);
 
 SOFT_LINK_CLASS_FOR_HEADER(PAL, USVideoUsage);
-#define _AXSIsolatedTreeModeFunctionIsAvailable PAL::canLoad_libAccessibility__AXSIsolatedTreeMode
 
 SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(PAL, UsageTracking, USVideoMetadataKeyCanShowControlsManager, NSString *)
 #define USVideoMetadataKeyCanShowControlsManager PAL::get_UsageTracking_USVideoMetadataKeyCanShowControlsManagerSingleton()

--- a/Source/WebCore/PAL/pal/spi/cocoa/AccessibilitySupportSoftLink.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AccessibilitySupportSoftLink.h
@@ -35,7 +35,7 @@
 SOFT_LINK_LIBRARY_FOR_HEADER(PAL, libAccessibility)
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(PAL, libAccessibility, _AXSIsolatedTreeMode, AXSIsolatedTreeMode, (void), ())
 #define _AXSIsolatedTreeMode_Soft PAL::softLink_libAccessibility__AXSIsolatedTreeMode
-#define _AXSIsolatedTreeModeFunctionIsAvailable PAL::islibAccessibilityLibaryAvailable() && PAL::canLoad_libAccessibility__AXSIsolatedTreeMode
+#define _AXSIsolatedTreeModeFunctionIsAvailable() PAL::islibAccessibilityLibraryAvailable() && PAL::canLoad_libAccessibility__AXSIsolatedTreeMode()
 
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 


### PR DESCRIPTION
#### cc40c94564c8034f20645f41b3ea567a1802ff32
<pre>
_AXSIsolatedTreeModeFunctionIsAvailable definition in UsageTrackingSoftLink.h is duplicative
<a href="https://bugs.webkit.org/show_bug.cgi?id=311308">https://bugs.webkit.org/show_bug.cgi?id=311308</a>
<a href="https://rdar.apple.com/173901954">rdar://173901954</a>

Reviewed by Megan Gardner, Tyler Wilcock, and Lily Spiniolas.

The macro is defined in AccessibilitySupportSoftLink.h, which is a more
appropriate home for it. This patch removes the definition from
UsageTrackingSoftLink.h.

Furthermore, we fix the &quot;libary&quot; typo in the library softlinking macro.

Finally, _AXSIsolatedTreeModeFunctionIsAvailable is best expressed as a
function call, so we make it a function macro in this patch.

* Source/WTF/wtf/cocoa/SoftLinking.h:
* Source/WebCore/PAL/pal/cocoa/UsageTrackingSoftLink.h:
* Source/WebCore/PAL/pal/spi/cocoa/AccessibilitySupportSoftLink.h:

Canonical link: <a href="https://commits.webkit.org/310489@main">https://commits.webkit.org/310489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5930ab91e4787613868c200998ecffdf08bec95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20375 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162712 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107426 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d7702f93-67e3-4748-b59c-cdf27ec8782c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119059 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84179 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5602c421-7717-4d3b-ac63-5ffd00053f25) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138255 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99760 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20416 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18376 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10545 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146001 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130073 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165185 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14787 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8332 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17708 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127152 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26547 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127306 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34540 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26553 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137901 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83263 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22202 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14689 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185595 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26161 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90469 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47597 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25853 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26018 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25915 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->