### PR TITLE
cjk-kerning.html: Allow font-kerning: auto to enable kerning for CJK text

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/cjk-kerning-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/cjk-kerning-expected.txt
@@ -17,9 +17,9 @@ PASS expected match: .kernON .latin vs .paltOFFkernON .latin
 FAIL expected match: .kernON .latin vs .paltONkernON .latin assert_equals: expected 252 but got 235
 PASS expected match: .kernOFF .latin vs .paltONkernOFF .latin
 FAIL expected match: .kernON .cjk vs .paltONkernON .cjk assert_equals: expected 339 but got 385
-PASS expected match: .default .cjk vs .kernOFF .cjk
 PASS expected mismatch: .kernOFF .latin vs .kernON .latin
 FAIL expected mismatch: .kernOFF .cjk vs .kernON .cjk assert_not_equals: got disallowed value 385
 PASS expected mismatch: .paltOFFkernON .cjk vs .paltONkernON .cjk
 PASS .default .latin matches one of [.kernON .latin, .kernOFF .latin]
+PASS .default .cjk matches one of [.kernON .cjk, .kernOFF .cjk]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/cjk-kerning.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/cjk-kerning.html
@@ -83,7 +83,6 @@ const expectMatch = [
     [ ".kernON .latin",  ".paltONkernON .latin" ],
     [ ".kernOFF .latin", ".paltONkernOFF .latin" ],
     [ ".kernON .cjk",    ".paltONkernON .cjk" ],
-    [ ".default .cjk",   ".kernOFF .cjk" ],
 ];
 const expectMismatch = [
     [ ".kernOFF .latin",     ".kernON .latin" ],
@@ -92,6 +91,7 @@ const expectMismatch = [
 ];
 const expectMatchOneOf = [
     [ ".default .latin", [".kernON .latin", ".kernOFF .latin"] ],
+    [ ".default .cjk",   [".kernON .cjk",  ".kernOFF .cjk"] ],
 ];
 
 expectMatch.forEach((t) => {

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-fonts/cjk-kerning-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-fonts/cjk-kerning-expected.txt
@@ -17,9 +17,9 @@ PASS expected match: .kernON .latin vs .paltOFFkernON .latin
 PASS expected match: .kernON .latin vs .paltONkernON .latin
 PASS expected match: .kernOFF .latin vs .paltONkernOFF .latin
 PASS expected match: .kernON .cjk vs .paltONkernON .cjk
-FAIL expected match: .default .cjk vs .kernOFF .cjk assert_equals: expected 384 but got 385
 PASS expected mismatch: .kernOFF .latin vs .kernON .latin
 PASS expected mismatch: .kernOFF .cjk vs .kernON .cjk
 FAIL expected mismatch: .paltOFFkernON .cjk vs .paltONkernON .cjk assert_not_equals: got disallowed value 385
 PASS .default .latin matches one of [.kernON .latin, .kernOFF .latin]
+PASS .default .cjk matches one of [.kernON .cjk, .kernOFF .cjk]
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-fonts/cjk-kerning-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-fonts/cjk-kerning-expected.txt
@@ -17,9 +17,9 @@ PASS expected match: .kernON .latin vs .paltOFFkernON .latin
 FAIL expected match: .kernON .latin vs .paltONkernON .latin assert_equals: expected 245 but got 230
 PASS expected match: .kernOFF .latin vs .paltONkernOFF .latin
 FAIL expected match: .kernON .cjk vs .paltONkernON .cjk assert_equals: expected 337 but got 385
-PASS expected match: .default .cjk vs .kernOFF .cjk
 PASS expected mismatch: .kernOFF .latin vs .kernON .latin
 FAIL expected mismatch: .kernOFF .cjk vs .kernON .cjk assert_not_equals: got disallowed value 385
 PASS expected mismatch: .paltOFFkernON .cjk vs .paltONkernON .cjk
 PASS .default .latin matches one of [.kernON .latin, .kernOFF .latin]
+PASS .default .cjk matches one of [.kernON .cjk, .kernOFF .cjk]
 


### PR DESCRIPTION
#### 48c2ca7987d56236503cdf85d219ef349f1a5c2e
<pre>
cjk-kerning.html: Allow font-kerning: auto to enable kerning for CJK text
<a href="https://bugs.webkit.org/show_bug.cgi?id=311310">https://bugs.webkit.org/show_bug.cgi?id=311310</a>
<a href="https://rdar.apple.com/173437398">rdar://173437398</a>

Reviewed by Brent Fulgham.

The WPT test hardcoded .default .cjk (font-kerning: auto) to match
.kernOFF .cjk, but CSS Fonts 4 leaves auto behavior UA-defined. Move
this assertion to expectMatchOneOf so it passes whether the UA enables
or disables kerning by default for CJK text.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/cjk-kerning-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/cjk-kerning.html:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-fonts/cjk-kerning-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-fonts/cjk-kerning-expected.txt:

Canonical link: <a href="https://commits.webkit.org/310468@main">https://commits.webkit.org/310468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9055720ff8f5decf605458dca535b6522c8dcf7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162673 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107389 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b1c1cc6-9e65-4c65-bfb6-553e62a1a02c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27029 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119023 "Found 3 new test failures: fast/frames/frame-set-scaling-hit.html fast/mediastream/mediastream-gc.html media/video-src-empty.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84158 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/12e73f1c-1018-45f0-b689-3e2578fdaeb5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138221 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99728 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3c960c55-e972-40b9-a175-891007d72ce4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20383 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18345 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10505 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130025 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16075 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165146 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17674 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127114 "Found 1 new test failure: fast/repaint/select-option-background-color.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22368 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127274 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34526 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26510 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137869 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83220 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22170 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14655 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26123 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25814 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25978 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25874 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->