### PR TITLE
[WebTransport] Add headers and responseHeaders support

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/interfaces/webtransport.idl
+++ b/LayoutTests/imported/w3c/web-platform-tests/interfaces/webtransport.idl
@@ -31,8 +31,9 @@ interface WebTransport {
   readonly attribute Promise<undefined> ready;
   readonly attribute WebTransportReliabilityMode reliability;
   readonly attribute WebTransportCongestionControl congestionControl;
-  [EnforceRange] attribute unsigned short? anticipatedConcurrentIncomingUnidirectionalStreams;
-  [EnforceRange] attribute unsigned short? anticipatedConcurrentIncomingBidirectionalStreams;
+  attribute [EnforceRange] unsigned short? anticipatedConcurrentIncomingUnidirectionalStreams;
+  attribute [EnforceRange] unsigned short? anticipatedConcurrentIncomingBidirectionalStreams;
+  [SameObject] readonly attribute Headers? responseHeaders;
   readonly attribute DOMString protocol;
 
   readonly attribute Promise<WebTransportCloseInfo> closed;
@@ -62,19 +63,20 @@ enum WebTransportReliabilityMode {
 };
 
 dictionary WebTransportHash {
-  DOMString algorithm;
-  BufferSource value;
+  required DOMString algorithm;
+  required BufferSource value;
 };
 
 dictionary WebTransportOptions {
   boolean allowPooling = false;
   boolean requireUnreliable = false;
-  sequence<WebTransportHash> serverCertificateHashes;
+  HeadersInit headers = {};
+  sequence<WebTransportHash> serverCertificateHashes = [];
   WebTransportCongestionControl congestionControl = "default";
   [EnforceRange] unsigned short? anticipatedConcurrentIncomingUnidirectionalStreams = null;
   [EnforceRange] unsigned short? anticipatedConcurrentIncomingBidirectionalStreams = null;
   sequence<DOMString> protocols = [];
-  DatagramsReadableMode datagramsReadableMode;
+  ReadableStreamType datagramsReadableType;
 };
 
 enum WebTransportCongestionControl {
@@ -82,8 +84,6 @@ enum WebTransportCongestionControl {
   "throughput",
   "low-latency",
 };
-
-enum DatagramsReadableMode { "bytes" };
 
 dictionary WebTransportCloseInfo {
   unsigned long closeCode = 0;
@@ -100,25 +100,27 @@ dictionary WebTransportSendStreamOptions : WebTransportSendOptions {
 };
 
 dictionary WebTransportConnectionStats {
-  unsigned long long bytesSent = 0;
-  unsigned long long packetsSent = 0;
-  unsigned long long bytesLost = 0;
-  unsigned long long packetsLost = 0;
-  unsigned long long bytesReceived = 0;
-  unsigned long long packetsReceived = 0;
-  required DOMHighResTimeStamp smoothedRtt;
-  required DOMHighResTimeStamp rttVariation;
-  required DOMHighResTimeStamp minRtt;
+  unsigned long long bytesSent;
+  unsigned long long bytesSentOverhead;
+  unsigned long long bytesAcknowledged;
+  unsigned long long packetsSent;
+  unsigned long long bytesLost;
+  unsigned long long packetsLost;
+  unsigned long long bytesReceived;
+  unsigned long long packetsReceived;
+  DOMHighResTimeStamp smoothedRtt;
+  DOMHighResTimeStamp rttVariation;
+  DOMHighResTimeStamp minRtt;
   required WebTransportDatagramStats datagrams;
   unsigned long long? estimatedSendRate = null;
   boolean atSendCapacity = false;
 };
 
 dictionary WebTransportDatagramStats {
-  unsigned long long droppedIncoming = 0;
-  unsigned long long expiredIncoming = 0;
-  unsigned long long expiredOutgoing = 0;
-  unsigned long long lostOutgoing = 0;
+  unsigned long long droppedIncoming;
+  unsigned long long expiredIncoming;
+  unsigned long long expiredOutgoing;
+  unsigned long long lostOutgoing;
 };
 
 [Exposed=(Window,Worker), SecureContext, Transferable]
@@ -130,9 +132,9 @@ interface WebTransportSendStream : WritableStream {
 };
 
 dictionary WebTransportSendStreamStats {
-  unsigned long long bytesWritten = 0;
-  unsigned long long bytesSent = 0;
-  unsigned long long bytesAcknowledged = 0;
+  unsigned long long bytesWritten;
+  unsigned long long bytesSent;
+  unsigned long long bytesAcknowledged;
 };
 
 [Exposed=(Window,Worker), SecureContext]
@@ -146,8 +148,8 @@ interface WebTransportReceiveStream : ReadableStream {
 };
 
 dictionary WebTransportReceiveStreamStats {
-  unsigned long long bytesReceived = 0;
-  unsigned long long bytesRead = 0;
+  unsigned long long bytesReceived;
+  unsigned long long bytesRead;
 };
 
 [Exposed=(Window,Worker), SecureContext]

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/headers.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/headers.https.any-expected.txt
@@ -1,0 +1,21 @@
+
+PASS Setting wt-available-protocols header should throw TypeError
+PASS Setting wt-available-protocols header should throw TypeError (case-insensitive)
+PASS Setting wt-available-protocols header should throw TypeError (mixed case)
+PASS Forbidden request headers should be silently dropped
+PASS Empty headers object should be accepted
+PASS Custom headers should be accepted
+PASS Multiple custom headers should be accepted
+PASS Headers as sequence of sequences should be accepted
+PASS Duplicate header names in sequence form should be accepted
+PASS Header names should be lowercased
+PASS Mixed-case duplicate header names should be lowercased and preserved
+PASS Sequence with wrong inner length should throw TypeError
+PASS Invalid header name should throw TypeError
+PASS Header value with CR/LF should throw TypeError
+PASS responseHeaders is null before the connection is established
+PASS Custom request headers are received by the server
+PASS responseHeaders exposes headers from the server CONNECT response
+PASS Forbidden response header names are not exposed in responseHeaders
+PASS wt-protocol is stripped from responseHeaders
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/headers.https.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/headers.https.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/headers.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/headers.https.any.js
@@ -1,0 +1,163 @@
+// META: global=window,worker
+// META: script=resources/webtransport-test-helpers.sub.js
+// Tests for the WebTransportOptions headers option and the responseHeaders
+// attribute.
+// https://w3c.github.io/webtransport/#dom-webtransportoptions-headers
+//
+// The constructor tests validate constructor behavior only and do not require
+// a WebTransport server connection. They use https://localhost:0/ as
+// the URL to avoid triggering real connection attempts. The remaining tests
+// connect to the webtransport-h3 test server.
+
+const TEST_URL = 'https://localhost:0/';
+
+function createAndClose(url, options) {
+  const wt = new WebTransport(url, options);
+  wt.ready.catch(() => {});
+  wt.closed.catch(() => {});
+  wt.close();
+}
+
+test(() => {
+  assert_throws_js(TypeError, () => new WebTransport(
+    TEST_URL, { headers: { 'wt-available-protocols': 'test' } }));
+}, 'Setting wt-available-protocols header should throw TypeError');
+
+test(() => {
+  assert_throws_js(TypeError, () => new WebTransport(
+    TEST_URL, { headers: { 'WT-Available-Protocols': 'test' } }));
+}, 'Setting wt-available-protocols header should throw TypeError (case-insensitive)');
+
+test(() => {
+  assert_throws_js(TypeError, () => new WebTransport(
+    TEST_URL, { headers: { 'Wt-AVAILABLE-protocols': 'test' } }));
+}, 'Setting wt-available-protocols header should throw TypeError (mixed case)');
+
+test(() => {
+  createAndClose(TEST_URL,
+    { headers: { 'Host': 'evil.example.com' } });
+}, 'Forbidden request headers should be silently dropped');
+
+test(() => {
+  createAndClose(TEST_URL, { headers: {} });
+}, 'Empty headers object should be accepted');
+
+test(() => {
+  createAndClose(TEST_URL,
+    { headers: { 'x-custom-header': 'custom-value' } });
+}, 'Custom headers should be accepted');
+
+test(() => {
+  createAndClose(TEST_URL,
+    { headers: {
+        'x-grpc-method': '/service/Method',
+        'content-type': 'application/grpc+proto',
+        'x-custom': 'value'
+    } });
+}, 'Multiple custom headers should be accepted');
+
+test(() => {
+  createAndClose(TEST_URL,
+    { headers: [['x-foo', 'bar'], ['x-baz', 'qux']] });
+}, 'Headers as sequence of sequences should be accepted');
+
+test(() => {
+  createAndClose(TEST_URL,
+    { headers: [['x-dup', 'one'], ['x-dup', 'two']] });
+}, 'Duplicate header names in sequence form should be accepted');
+
+test(() => {
+  createAndClose(TEST_URL,
+    { headers: { 'X-Custom': 'value' } });
+}, 'Header names should be lowercased');
+
+test(() => {
+  createAndClose(TEST_URL,
+    { headers: [['foo', 'bar'], ['Foo', 'baz']] });
+}, 'Mixed-case duplicate header names should be lowercased and preserved');
+
+test(() => {
+  assert_throws_js(TypeError, () => new WebTransport(
+    TEST_URL, { headers: [['only-one-element']] }));
+}, 'Sequence with wrong inner length should throw TypeError');
+
+test(() => {
+  assert_throws_js(TypeError, () => new WebTransport(
+    TEST_URL, { headers: { 'bad name': 'value' } }));
+}, 'Invalid header name should throw TypeError');
+
+test(() => {
+  assert_throws_js(TypeError, () => new WebTransport(
+    TEST_URL, { headers: { 'x-custom': 'bad\r\nvalue' } }));
+}, 'Header value with CR/LF should throw TypeError');
+
+promise_test(async t => {
+  const wt = new WebTransport(webtransport_url('echo-request-headers.py'));
+  t.add_cleanup(() => wt.close());
+  assert_equals(wt.responseHeaders, null,
+    'responseHeaders is null synchronously after construction');
+  await wt.ready;
+}, 'responseHeaders is null before the connection is established');
+
+promise_test(async t => {
+  const wt = new WebTransport(webtransport_url('echo-request-headers.py'), {
+    headers: {
+      'X-Custom-Header': '  custom-value  ',
+      'x-other-header': 'other-value',
+      'Host': 'evil.example.com',
+    },
+  });
+  await wt.ready;
+
+  // Read incoming unidirectional stream for echoed request headers.
+  const streams = await wt.incomingUnidirectionalStreams;
+  const stream_reader = streams.getReader();
+  const { value: recv_stream } = await stream_reader.read();
+  stream_reader.releaseLock();
+  const request_headers = await read_stream_as_json(recv_stream);
+
+  assert_equals(request_headers['x-custom-header'], 'custom-value',
+    'header name should be lowercased and value trimmed');
+  assert_equals(request_headers['x-other-header'], 'other-value');
+  assert_equals(request_headers['host'], undefined,
+    'forbidden request headers should not be sent');
+}, 'Custom request headers are received by the server');
+
+promise_test(async t => {
+  const wt = new WebTransport(
+    webtransport_url('custom-response.py?x-custom-response=custom-response-value'));
+  await wt.ready;
+
+  assert_not_equals(wt.responseHeaders, null,
+    'responseHeaders should not be null after ready');
+  assert_true(wt.responseHeaders instanceof Headers);
+  assert_equals(wt.responseHeaders.get('x-custom-response'),
+    'custom-response-value');
+}, 'responseHeaders exposes headers from the server CONNECT response');
+
+promise_test(async t => {
+  const wt = new WebTransport(
+    webtransport_url('custom-response.py?set-cookie=a%3Db&x-safe-header=yes'));
+  await wt.ready;
+
+  assert_equals(wt.responseHeaders.get('x-safe-header'), 'yes',
+    'non-forbidden response headers should be exposed');
+  assert_equals(wt.responseHeaders.get('set-cookie'), null,
+    'forbidden response header names should not be exposed via get()');
+  const names = [...wt.responseHeaders.keys()];
+  assert_false(names.includes('set-cookie'),
+    'forbidden response header names should not be exposed via iteration');
+}, 'Forbidden response header names are not exposed in responseHeaders');
+
+promise_test(async t => {
+  const wt = new WebTransport(
+    webtransport_url('custom-response.py?wt-protocol=foo'));
+  t.add_cleanup(() => wt.close());
+  await wt.ready;
+
+  assert_false(wt.responseHeaders.has('wt-protocol'),
+    'wt-protocol must not be exposed via has()');
+  const names = [...wt.responseHeaders.keys()];
+  assert_false(names.includes('wt-protocol'),
+    'wt-protocol must not be exposed via iteration');
+}, 'wt-protocol is stripped from responseHeaders');

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/headers.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/headers.https.any.worker-expected.txt
@@ -1,0 +1,21 @@
+
+PASS Setting wt-available-protocols header should throw TypeError
+PASS Setting wt-available-protocols header should throw TypeError (case-insensitive)
+PASS Setting wt-available-protocols header should throw TypeError (mixed case)
+PASS Forbidden request headers should be silently dropped
+PASS Empty headers object should be accepted
+PASS Custom headers should be accepted
+PASS Multiple custom headers should be accepted
+PASS Headers as sequence of sequences should be accepted
+PASS Duplicate header names in sequence form should be accepted
+PASS Header names should be lowercased
+PASS Mixed-case duplicate header names should be lowercased and preserved
+PASS Sequence with wrong inner length should throw TypeError
+PASS Invalid header name should throw TypeError
+PASS Header value with CR/LF should throw TypeError
+PASS responseHeaders is null before the connection is established
+PASS Custom request headers are received by the server
+PASS responseHeaders exposes headers from the server CONNECT response
+PASS Forbidden response header names are not exposed in responseHeaders
+PASS wt-protocol is stripped from responseHeaders
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/headers.https.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/headers.https.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any-expected.txt
@@ -35,6 +35,7 @@ PASS WebTransport interface: attribute reliability
 PASS WebTransport interface: attribute congestionControl
 PASS WebTransport interface: attribute anticipatedConcurrentIncomingUnidirectionalStreams
 PASS WebTransport interface: attribute anticipatedConcurrentIncomingBidirectionalStreams
+PASS WebTransport interface: attribute responseHeaders
 PASS WebTransport interface: attribute protocol
 PASS WebTransport interface: attribute closed
 PASS WebTransport interface: attribute draining
@@ -56,6 +57,7 @@ PASS WebTransport interface: webTransport must inherit property "reliability" wi
 PASS WebTransport interface: webTransport must inherit property "congestionControl" with the proper type
 PASS WebTransport interface: webTransport must inherit property "anticipatedConcurrentIncomingUnidirectionalStreams" with the proper type
 PASS WebTransport interface: webTransport must inherit property "anticipatedConcurrentIncomingBidirectionalStreams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "responseHeaders" with the proper type
 PASS WebTransport interface: webTransport must inherit property "protocol" with the proper type
 PASS WebTransport interface: webTransport must inherit property "closed" with the proper type
 PASS WebTransport interface: webTransport must inherit property "draining" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker-expected.txt
@@ -35,6 +35,7 @@ PASS WebTransport interface: attribute reliability
 PASS WebTransport interface: attribute congestionControl
 PASS WebTransport interface: attribute anticipatedConcurrentIncomingUnidirectionalStreams
 PASS WebTransport interface: attribute anticipatedConcurrentIncomingBidirectionalStreams
+PASS WebTransport interface: attribute responseHeaders
 PASS WebTransport interface: attribute protocol
 PASS WebTransport interface: attribute closed
 PASS WebTransport interface: attribute draining
@@ -56,6 +57,7 @@ PASS WebTransport interface: webTransport must inherit property "reliability" wi
 PASS WebTransport interface: webTransport must inherit property "congestionControl" with the proper type
 PASS WebTransport interface: webTransport must inherit property "anticipatedConcurrentIncomingUnidirectionalStreams" with the proper type
 PASS WebTransport interface: webTransport must inherit property "anticipatedConcurrentIncomingBidirectionalStreams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "responseHeaders" with the proper type
 PASS WebTransport interface: webTransport must inherit property "protocol" with the proper type
 PASS WebTransport interface: webTransport must inherit property "closed" with the proper type
 PASS WebTransport interface: webTransport must inherit property "draining" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker-expected.txt
@@ -35,6 +35,7 @@ PASS WebTransport interface: attribute reliability
 PASS WebTransport interface: attribute congestionControl
 PASS WebTransport interface: attribute anticipatedConcurrentIncomingUnidirectionalStreams
 PASS WebTransport interface: attribute anticipatedConcurrentIncomingBidirectionalStreams
+PASS WebTransport interface: attribute responseHeaders
 PASS WebTransport interface: attribute protocol
 PASS WebTransport interface: attribute closed
 PASS WebTransport interface: attribute draining
@@ -56,6 +57,7 @@ PASS WebTransport interface: webTransport must inherit property "reliability" wi
 PASS WebTransport interface: webTransport must inherit property "congestionControl" with the proper type
 PASS WebTransport interface: webTransport must inherit property "anticipatedConcurrentIncomingUnidirectionalStreams" with the proper type
 PASS WebTransport interface: webTransport must inherit property "anticipatedConcurrentIncomingBidirectionalStreams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "responseHeaders" with the proper type
 PASS WebTransport interface: webTransport must inherit property "protocol" with the proper type
 PASS WebTransport interface: webTransport must inherit property "closed" with the proper type
 PASS WebTransport interface: webTransport must inherit property "draining" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker-expected.txt
@@ -35,6 +35,7 @@ PASS WebTransport interface: attribute reliability
 PASS WebTransport interface: attribute congestionControl
 PASS WebTransport interface: attribute anticipatedConcurrentIncomingUnidirectionalStreams
 PASS WebTransport interface: attribute anticipatedConcurrentIncomingBidirectionalStreams
+PASS WebTransport interface: attribute responseHeaders
 PASS WebTransport interface: attribute protocol
 PASS WebTransport interface: attribute closed
 PASS WebTransport interface: attribute draining
@@ -56,6 +57,7 @@ PASS WebTransport interface: webTransport must inherit property "reliability" wi
 PASS WebTransport interface: webTransport must inherit property "congestionControl" with the proper type
 PASS WebTransport interface: webTransport must inherit property "anticipatedConcurrentIncomingUnidirectionalStreams" with the proper type
 PASS WebTransport interface: webTransport must inherit property "anticipatedConcurrentIncomingBidirectionalStreams" with the proper type
+PASS WebTransport interface: webTransport must inherit property "responseHeaders" with the proper type
 PASS WebTransport interface: webTransport must inherit property "protocol" with the proper type
 PASS WebTransport interface: webTransport must inherit property "closed" with the proper type
 PASS WebTransport interface: webTransport must inherit property "draining" with the proper type

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8689,11 +8689,6 @@ imported/w3c/web-platform-tests/css/CSS2/css1/c5526-fltclr-000.xht [ ImageOnlyFa
 imported/w3c/web-platform-tests/css/CSS2/css1/c562-white-sp-000.xht [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/CSS2/css1/c62-percent-000.xht [ ImageOnlyFailure ]
 
-# webkit.org/b/321110 NEW TEST(317810@main): [iOS macOS]4 tests in imported/w3c/web-platform-tests/webtransport/idlharness are constant failure
-imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.html [ Failure ]
-imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker.html [ Failure ]
-imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker.html [ Failure ]
-imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker.html [ Failure ]
 
 # testdriver-vendor.js dispatches key actions through a UI script that references eventSender,
 # which does not exist in the UI-script context, and uiController has no leapForward equivalent,

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2448,11 +2448,6 @@ webkit.org/b/320326 imported/w3c/web-platform-tests/css/css-highlight-api/painti
 
 webkit.org/b/321103 [ Debug ] imported/w3c/web-platform-tests/uievents/textInput/enter-textarea-contenteditable.html [ Pass Failure ]
 
-# webkit.org/b/321110 NEW TEST(317810@main): [iOS macOS]4 tests in imported/w3c/web-platform-tests/webtransport/idlharness are constant failure
-imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.html [ Failure ]
-imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker.html [ Failure ]
-imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker.html [ Failure ]
-imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker.html [ Failure ]
 
 webkit.org/b/321185 [ Debug ] imported/w3c/web-platform-tests/wasm/core/float_exprs.wast.js.html [ Pass Timeout ]
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -814,6 +814,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/webtransport/WebTransportConnectionStats.h
     Modules/webtransport/WebTransportDatagramStats.h
     Modules/webtransport/WebTransportHash.h
+    Modules/webtransport/WebTransportHeaderValidation.h
     Modules/webtransport/WebTransportOptions.h
     Modules/webtransport/WebTransportReceiveStreamStats.h
     Modules/webtransport/WebTransportReliabilityMode.h

--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -35,7 +35,7 @@
 #include "DocumentInlines.h"
 #include "EmptyClients.h"
 #include "ExceptionOr.h"
-#include "HTTPParsers.h"
+#include "FetchHeaders.h"
 #include "JSDOMConvertDictionary.h"
 #include "JSDOMConvertInterface.h"
 #include "JSDOMException.h"
@@ -58,6 +58,7 @@
 #include "WebTransportDatagramDuplexStream.h"
 #include "WebTransportDatagramsWritable.h"
 #include "WebTransportError.h"
+#include "WebTransportHeaderValidation.h"
 #include "WebTransportOptions.h"
 #include "WebTransportReceiveStream.h"
 #include "WebTransportReceiveStreamByteSource.h"
@@ -99,6 +100,15 @@ ExceptionOr<Ref<WebTransport>> WebTransport::create(ScriptExecutionContext& cont
         escapedProtocols.append(WTF::move(*escapedProtocol));
     }
     options.protocols = WTF::move(escapedProtocols);
+
+    // https://w3c.github.io/webtransport/#dom-webtransportoptions-headers
+    Vector<KeyValuePair<String, String>> additionalHeaders;
+    if (options.headersInit) {
+        auto validatedHeaders = validateAndNormalizeWebTransportHeaders(*options.headersInit);
+        if (validatedHeaders.hasException())
+            return validatedHeaders.releaseException();
+        additionalHeaders = validatedHeaders.releaseReturnValue();
+    }
 
     auto* globalObject = context.globalObject();
     if (!globalObject) {
@@ -149,7 +159,7 @@ ExceptionOr<Ref<WebTransport>> WebTransport::create(ScriptExecutionContext& cont
 
     auto datagrams = WebTransportDatagramDuplexStream::create(incomingDatagrams.releaseNonNull());
 
-    Ref transport = adoptRef(*new WebTransport(context, domGlobalObject, incomingBidirectionalStreams.releaseReturnValue(), incomingUnidirectionalStreams.releaseReturnValue(), options, WTF::move(datagrams), datagramSource.releaseNonNull(), WTF::move(receiveStreamSource), WTF::move(bidirectionalStreamSource), WTF::move(parsedURL)));
+    Ref transport = adoptRef(*new WebTransport(context, domGlobalObject, incomingBidirectionalStreams.releaseReturnValue(), incomingUnidirectionalStreams.releaseReturnValue(), options, WTF::move(datagrams), datagramSource.releaseNonNull(), WTF::move(receiveStreamSource), WTF::move(bidirectionalStreamSource), WTF::move(parsedURL), WTF::move(additionalHeaders)));
     transport->suspendIfNeeded();
     return transport;
 }
@@ -163,7 +173,7 @@ static ClientOrigin clientOrigin(ScriptExecutionContext& context)
 
 // FIXME: Rename SocketProvider to NetworkProvider or something to reflect that it provides a little more than just simple sockets. SocketAndTransportProvider?
 
-WebTransport::WebTransport(ScriptExecutionContext& context, JSDOMGlobalObject& globalObject, Ref<ReadableStream>&& incomingBidirectionalStreams, Ref<ReadableStream>&& incomingUnidirectionalStreams, const WebTransportOptions& options, Ref<WebTransportDatagramDuplexStream>&& datagrams, Ref<DatagramSource>&& datagramSource, Ref<WebTransportReceiveStreamSource>&& receiveStreamSource, Ref<WebTransportBidirectionalStreamSource>&& bidirectionalStreamSource, URL&& url)
+WebTransport::WebTransport(ScriptExecutionContext& context, JSDOMGlobalObject& globalObject, Ref<ReadableStream>&& incomingBidirectionalStreams, Ref<ReadableStream>&& incomingUnidirectionalStreams, const WebTransportOptions& options, Ref<WebTransportDatagramDuplexStream>&& datagrams, Ref<DatagramSource>&& datagramSource, Ref<WebTransportReceiveStreamSource>&& receiveStreamSource, Ref<WebTransportBidirectionalStreamSource>&& bidirectionalStreamSource, URL&& url, Vector<KeyValuePair<String, String>>&& additionalHeaders)
     : ActiveDOMObject(&context)
     , m_incomingBidirectionalStreams(WTF::move(incomingBidirectionalStreams))
     , m_incomingUnidirectionalStreams(WTF::move(incomingUnidirectionalStreams))
@@ -181,7 +191,7 @@ WebTransport::WebTransport(ScriptExecutionContext& context, JSDOMGlobalObject& g
 {
     m_datagrams->attachTo(*this);
     m_datagramSource->setTransport(*this);
-    context.enqueueTaskWhenSettled(m_session->initialize(context, url, options, WebCore::clientOrigin(context)), WebCore::TaskSource::Networking, [weakThis = WeakPtr { *this }] (auto&& info) mutable {
+    context.enqueueTaskWhenSettled(m_session->initialize(context, url, options, additionalHeaders, WebCore::clientOrigin(context)), WebCore::TaskSource::Networking, [weakThis = WeakPtr { *this }] (auto&& info) mutable {
         RefPtr strongThis = weakThis.get();
         if (!strongThis)
             return;
@@ -191,6 +201,14 @@ WebTransport::WebTransport(ScriptExecutionContext& context, JSDOMGlobalObject& g
             return strongThis->cleanupWithSessionError();
         strongThis->m_protocol = WTF::move(info->protocol);
         strongThis->m_reliability = info->reliabilityMode;
+        HTTPHeaderMap headerMap;
+        for (auto& header : info->responseHeaders)
+            headerMap.add(header.key, header.value);
+        Ref responseHeaders = FetchHeaders::create(FetchHeaders::Guard::Immutable);
+        // Fill under a response guard so forbidden response header names are dropped.
+        // https://fetch.spec.whatwg.org/#forbidden-response-header-name
+        responseHeaders->filterAndFill(headerMap, FetchHeaders::Guard::Response);
+        strongThis->m_responseHeaders = WTF::move(responseHeaders);
         strongThis->m_state = State::Connected;
         protect(strongThis->m_ready.second)->resolve();
     });
@@ -434,6 +452,11 @@ void WebTransport::setAnticipatedConcurrentIncomingBidirectionalStreams(std::opt
 String& WebTransport::protocol()
 {
     return m_protocol;
+}
+
+FetchHeaders* WebTransport::responseHeaders()
+{
+    return m_responseHeaders.get();
 }
 
 bool WebTransport::supportsReliableOnly()

--- a/Source/WebCore/Modules/webtransport/WebTransport.h
+++ b/Source/WebCore/Modules/webtransport/WebTransport.h
@@ -47,6 +47,7 @@ class DOMPromise;
 class DatagramSource;
 class DeferredPromise;
 class Exception;
+class FetchHeaders;
 class JSDOMGlobalObject;
 class ReadableStream;
 class ReadableStreamSource;
@@ -92,6 +93,7 @@ public:
     std::optional<uint16_t> NODELETE anticipatedConcurrentIncomingBidirectionalStreams();
     void NODELETE setAnticipatedConcurrentIncomingBidirectionalStreams(std::optional<uint16_t>);
     String& NODELETE protocol();
+    FetchHeaders* NODELETE responseHeaders();
     DOMPromise& NODELETE closed();
     DOMPromise& NODELETE draining();
     void close(WebTransportCloseInfo&&);
@@ -111,7 +113,7 @@ public:
     void receiveStreamClosed(WebTransportStreamIdentifier);
 
 private:
-    WebTransport(ScriptExecutionContext&, JSDOMGlobalObject&, Ref<ReadableStream>&&, Ref<ReadableStream>&&, const WebTransportOptions&, Ref<WebTransportDatagramDuplexStream>&&, Ref<DatagramSource>&&, Ref<WebTransportReceiveStreamSource>&&, Ref<WebTransportBidirectionalStreamSource>&&, URL&&);
+    WebTransport(ScriptExecutionContext&, JSDOMGlobalObject&, Ref<ReadableStream>&&, Ref<ReadableStream>&&, const WebTransportOptions&, Ref<WebTransportDatagramDuplexStream>&&, Ref<DatagramSource>&&, Ref<WebTransportReceiveStreamSource>&&, Ref<WebTransportBidirectionalStreamSource>&&, URL&&, Vector<KeyValuePair<String, String>>&&);
 
     void cleanup(Ref<DOMException>&&, std::optional<WebTransportCloseInfo>&&);
     void cleanupWithSessionError();
@@ -151,6 +153,7 @@ private:
     std::optional<uint16_t> m_anticipatedConcurrentIncomingUnidirectionalStreams;
     std::optional<uint16_t> m_anticipatedConcurrentIncomingBidirectionalStreams;
     String m_protocol;
+    RefPtr<FetchHeaders> m_responseHeaders;
     const PromiseAndWrapper m_closed;
     const PromiseAndWrapper m_draining;
     const Ref<WebTransportDatagramDuplexStream> m_datagrams;

--- a/Source/WebCore/Modules/webtransport/WebTransport.idl
+++ b/Source/WebCore/Modules/webtransport/WebTransport.idl
@@ -39,6 +39,8 @@
     attribute unsigned short? anticipatedConcurrentIncomingUnidirectionalStreams;
     attribute unsigned short? anticipatedConcurrentIncomingBidirectionalStreams;
     readonly attribute DOMString protocol;
+    // The spec labels responseHeaders as [SameObject], but that is incorrect; omitting it matches Chromium.
+    readonly attribute FetchHeaders? responseHeaders;
     readonly attribute Promise<WebTransportCloseInfo> closed;
     readonly attribute Promise<undefined> draining;
     undefined close(optional WebTransportCloseInfo closeInfo = {});

--- a/Source/WebCore/Modules/webtransport/WebTransportHeaderValidation.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportHeaderValidation.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebTransportHeaderValidation.h"
+
+#include "ExceptionOr.h"
+#include "HTTPParsers.h"
+
+namespace WebCore {
+
+// https://fetch.spec.whatwg.org/#headers-validate with guard "request", plus the
+// wt-available-protocols step of https://w3c.github.io/webtransport/#webtransport-constructor.
+// Unlike the spec, this also normalizes name and value in place to the form sent over the wire,
+// so that receivers can verify a header list is already normalized.
+static ExceptionOr<bool> validateWebTransportHeader(String& name, String& value)
+{
+    if (!isValidHTTPToken(name))
+        return Exception { ExceptionCode::TypeError };
+    value = value.trim(isASCIIWhitespaceWithoutFF<char16_t>);
+    if (!isValidHTTPHeaderValue(value))
+        return Exception { ExceptionCode::TypeError };
+    name = name.convertToASCIILowercase();
+    if (name == "wt-available-protocols"_s)
+        return Exception { ExceptionCode::TypeError, "The 'wt-available-protocols' header cannot be set."_s };
+    if (isForbiddenHeader(name, value))
+        return false;
+    return true;
+}
+
+ExceptionOr<Vector<KeyValuePair<String, String>>> validateAndNormalizeWebTransportHeaders(const FetchHeaders::Init& init)
+{
+    Vector<KeyValuePair<String, String>> headers;
+    auto validateAndAppend = [&](String name, String value) -> ExceptionOr<void> {
+        auto result = validateWebTransportHeader(name, value);
+        if (result.hasException())
+            return result.releaseException();
+        if (result.returnValue())
+            headers.constructAndAppend(WTF::move(name), WTF::move(value));
+        return { };
+    };
+
+    if (std::holds_alternative<Vector<Vector<String>>>(init)) {
+        for (auto& header : std::get<Vector<Vector<String>>>(init)) {
+            if (header.size() != 2)
+                return Exception { ExceptionCode::TypeError, "Header sub-sequence must contain exactly two items"_s };
+            auto result = validateAndAppend(header[0], header[1]);
+            if (result.hasException())
+                return result.releaseException();
+        }
+    } else {
+        for (auto& header : std::get<Vector<KeyValuePair<String, String>>>(init)) {
+            auto result = validateAndAppend(header.key, header.value);
+            if (result.hasException())
+                return result.releaseException();
+        }
+    }
+    return headers;
+}
+
+bool areValidWebTransportHeaders(const Vector<KeyValuePair<String, String>>& headers)
+{
+    for (auto& header : headers) {
+        auto name = header.key;
+        auto value = header.value;
+        auto result = validateWebTransportHeader(name, value);
+        if (result.hasException() || !result.returnValue())
+            return false;
+        if (name != header.key || value != header.value)
+            return false;
+    }
+    return true;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/webtransport/WebTransportHeaderValidation.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportHeaderValidation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,26 +25,22 @@
 
 #pragma once
 
-#include <WebCore/WebTransportReliabilityMode.h>
+#include <WebCore/FetchHeaders.h>
+#include <wtf/KeyValuePair.h>
+#include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-struct WebTransportConnectionInfo {
-    String protocol;
-    WebTransportReliabilityMode reliabilityMode;
-    Vector<KeyValuePair<String, String>> responseHeaders;
+template<typename> class ExceptionOr;
 
-    WebTransportConnectionInfo isolatedCopy() const & {
-        return { protocol.isolatedCopy(), reliabilityMode, WTF::map(responseHeaders, [](auto& header) {
-            return KeyValuePair<String, String> { header.key.isolatedCopy(), header.value.isolatedCopy() };
-        }) };
-    }
-    WebTransportConnectionInfo isolatedCopy() && {
-        return { WTF::move(protocol).isolatedCopy(), reliabilityMode, WTF::map(WTF::move(responseHeaders), [](KeyValuePair<String, String>&& header) {
-            return KeyValuePair<String, String> { WTF::move(header.key).isolatedCopy(), WTF::move(header.value).isolatedCopy() };
-        }) };
-    }
-};
+// https://w3c.github.io/webtransport/#dom-webtransportoptions-headers
+WEBCORE_EXPORT ExceptionOr<Vector<KeyValuePair<String, String>>> validateAndNormalizeWebTransportHeaders(const FetchHeaders::Init&);
 
-}
+// Defense-in-depth re-validation of WebTransport request headers received by the NetworkProcess
+// over IPC from a WebContent process. The WebContent side already performs this validation in
+// validateAndNormalizeWebTransportHeaders; a compromised WebContent process could bypass
+// it, so the NetworkProcess must re-check before acting on the headers.
+WEBCORE_EXPORT bool areValidWebTransportHeaders(const Vector<KeyValuePair<String, String>>&);
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/webtransport/WebTransportOptions.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportOptions.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/FetchHeaders.h>
 #include <WebCore/ReadableStreamType.h>
 #include <WebCore/WebTransportCongestionControl.h>
 #include <WebCore/WebTransportHash.h>
@@ -40,6 +41,7 @@ struct WebTransportOptions {
     std::optional<uint16_t> anticipatedConcurrentIncomingBidirectionalStreams;
     Vector<String> protocols { };
     std::optional<ReadableStreamType> datagramsReadableType;
+    std::optional<FetchHeaders::Init> headersInit { };
 };
 
 }

--- a/Source/WebCore/Modules/webtransport/WebTransportOptions.idl
+++ b/Source/WebCore/Modules/webtransport/WebTransportOptions.idl
@@ -23,6 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+typedef (sequence<sequence<ByteString>> or record<ByteString, ByteString>) HeadersInit;
+
 // https://w3c.github.io/webtransport/#dictdef-webtransportoptions
 [
     EnabledBySetting=WebTransportEnabled,
@@ -35,4 +37,5 @@
     [EnforceRange] unsigned short? anticipatedConcurrentIncomingBidirectionalStreams = null;
     sequence<DOMString> protocols = [];
     ReadableStreamType datagramsReadableType;
+    [ImplementedAs=headersInit] HeadersInit headers;
 };

--- a/Source/WebCore/Modules/webtransport/WebTransportSession.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSession.h
@@ -27,8 +27,11 @@
 
 #include <span>
 #include <wtf/AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h>
+#include <wtf/KeyValuePair.h>
 #include <wtf/NativePromise.h>
 #include <wtf/ThreadSafeWeakPtr.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
@@ -65,7 +68,7 @@ class WEBCORE_EXPORT WebTransportSession : public AbstractThreadSafeRefCountedAn
 public:
     virtual ~WebTransportSession();
 
-    virtual Ref<WebTransportSessionInitializationPromise> initialize(ScriptExecutionContext&, const URL&, const WebTransportOptions&, const ClientOrigin&) = 0;
+    virtual Ref<WebTransportSessionInitializationPromise> initialize(ScriptExecutionContext&, const URL&, const WebTransportOptions&, const Vector<KeyValuePair<String, String>>& additionalHeaders, const ClientOrigin&) = 0;
     virtual Ref<WebTransportSendPromise> sendDatagram(std::optional<WebTransportSendGroupIdentifier>, std::span<const uint8_t>) = 0;
     virtual Ref<WebTransportStreamPromise> createOutgoingUnidirectionalStream() = 0;
     virtual Ref<WebTransportStreamPromise> createBidirectionalStream() = 0;

--- a/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp
+++ b/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp
@@ -146,11 +146,11 @@ void WorkerWebTransportSession::streamSendError(WebTransportStreamIdentifier ide
     });
 }
 
-Ref<WebTransportSessionInitializationPromise> WorkerWebTransportSession::initialize(ScriptExecutionContext& context, const URL& url, const WebTransportOptions& options, const ClientOrigin& origin)
+Ref<WebTransportSessionInitializationPromise> WorkerWebTransportSession::initialize(ScriptExecutionContext& context, const URL& url, const WebTransportOptions& options, const Vector<KeyValuePair<String, String>>& additionalHeaders, const ClientOrigin& origin)
 {
     ASSERT(!RunLoop::isMain());
     if (RefPtr session = m_session)
-        return session->initialize(context, url, options, origin);
+        return session->initialize(context, url, options, additionalHeaders, origin);
     return WebTransportSessionInitializationPromise::createAndReject();
 }
 

--- a/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h
+++ b/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h
@@ -54,7 +54,7 @@ private:
     void didFail(std::optional<uint32_t>&&, String&&) final;
     void didDrain() final;
 
-    Ref<WebTransportSessionInitializationPromise> initialize(ScriptExecutionContext&, const URL&, const WebTransportOptions&, const ClientOrigin&) final;
+    Ref<WebTransportSessionInitializationPromise> initialize(ScriptExecutionContext&, const URL&, const WebTransportOptions&, const Vector<KeyValuePair<String, String>>&, const ClientOrigin&) final;
     Ref<WebTransportSendPromise> sendDatagram(std::optional<WebTransportSendGroupIdentifier>, std::span<const uint8_t>) final;
     Ref<WebTransportStreamPromise> createOutgoingUnidirectionalStream() final;
     Ref<WebTransportStreamPromise> createBidirectionalStream() final;

--- a/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
@@ -144,6 +144,9 @@ void nw_connection_abort_writes(nw_connection_t, uint64_t);
 void nw_http_fields_access_value_by_name(nw_http_fields_t, const char*, NW_NOESCAPE nw_http_optional_string_accessor_t);
 OS_OBJECT_RETURNS_RETAINED sec_protocol_metadata_t nw_webtransport_metadata_copy_sec_protocol_metadata(nw_protocol_metadata_t);
 
+typedef bool (^nw_http_fields_enumerate_block_t)(const char* name, size_t nameLength, const char* value, size_t valueLength);
+bool nw_http_fields_enumerate(nw_http_fields_t, NW_NOESCAPE nw_http_fields_enumerate_block_t);
+
 WTF_EXTERN_C_END
 
 // ------------------------------------------------------------

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -587,6 +587,7 @@ Modules/webtransport/WebTransportBidirectionalStreamSource.cpp
 Modules/webtransport/WebTransportDatagramDuplexStream.cpp
 Modules/webtransport/WebTransportDatagramsWritable.cpp
 Modules/webtransport/WebTransportError.cpp
+Modules/webtransport/WebTransportHeaderValidation.cpp
 Modules/webtransport/WebTransportReceiveStream.cpp
 Modules/webtransport/WebTransportReceiveStreamByteSource.cpp
 Modules/webtransport/WebTransportReceiveStreamSource.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -7346,6 +7346,7 @@
 		FAC8498F2A9EA1CE00D407EF /* WebTransportSession.h in Headers */ = {isa = PBXBuildFile; fileRef = FAC8497A2A9E68E900D407EF /* WebTransportSession.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FAC849902A9EA1D900D407EF /* WebTransportSessionClient.h in Headers */ = {isa = PBXBuildFile; fileRef = FAC8497E2A9E6CEF00D407EF /* WebTransportSessionClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FACC82B02E8E093F00EBAFED /* WebTransportCongestionControl.h in Headers */ = {isa = PBXBuildFile; fileRef = FAC3C3F92A996703001E2EB8 /* WebTransportCongestionControl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CA7C3E0D2F31A94700AA1147 /* WebTransportHeaderValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = CA7C3E0B2F31A94700AA1147 /* WebTransportHeaderValidation.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FACC82B92E8EF2AF00EBAFED /* WebTransportOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = FAC3C3FB2A996704001E2EB8 /* WebTransportOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FACC82BA2E8EF33A00EBAFED /* WebTransportHash.h in Headers */ = {isa = PBXBuildFile; fileRef = FAC3C3FD2A996705001E2EB8 /* WebTransportHash.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FADAF3C92EA2FC80001ACE2E /* WebKitBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = FADAF3BE2EA1D011001ACE2E /* WebKitBuffer.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -23670,6 +23671,8 @@
 		FAC3C3FA2A996704001E2EB8 /* WebTransportDatagramDuplexStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebTransportDatagramDuplexStream.h; sourceTree = "<group>"; };
 		FAC3C3FB2A996704001E2EB8 /* WebTransportOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebTransportOptions.h; sourceTree = "<group>"; };
 		FAC3C3FD2A996705001E2EB8 /* WebTransportHash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebTransportHash.h; sourceTree = "<group>"; };
+		CA7C3E0C2F31A94700AA1147 /* WebTransportHeaderValidation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebTransportHeaderValidation.cpp; sourceTree = "<group>"; };
+		CA7C3E0B2F31A94700AA1147 /* WebTransportHeaderValidation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebTransportHeaderValidation.h; sourceTree = "<group>"; };
 		FAC3C3FF2A996705001E2EB8 /* WebTransportReceiveStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebTransportReceiveStream.h; sourceTree = "<group>"; };
 		FAC3C4002A996706001E2EB8 /* WebTransportError.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebTransportError.cpp; sourceTree = "<group>"; };
 		FAC3C4012A996706001E2EB8 /* WebTransportSendStream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebTransportSendStream.cpp; sourceTree = "<group>"; };
@@ -43487,6 +43490,8 @@
 				FAC3C3DF2A9960E0001E2EB8 /* WebTransportErrorSource.idl */,
 				FAC3C3FD2A996705001E2EB8 /* WebTransportHash.h */,
 				FAC3C3D02A9960DA001E2EB8 /* WebTransportHash.idl */,
+				CA7C3E0C2F31A94700AA1147 /* WebTransportHeaderValidation.cpp */,
+				CA7C3E0B2F31A94700AA1147 /* WebTransportHeaderValidation.h */,
 				FAC3C3FB2A996704001E2EB8 /* WebTransportOptions.h */,
 				FAC3C3D22A9960DB001E2EB8 /* WebTransportOptions.idl */,
 				FAC3C3EC2A9966FF001E2EB8 /* WebTransportReceiveStream.cpp */,
@@ -50268,6 +50273,7 @@
 				FA0B46D42E8CBF780073E9B3 /* WebTransportConnectionStats.h in Headers */,
 				FA0B46CE2E8C7FEB0073E9B3 /* WebTransportDatagramStats.h in Headers */,
 				FACC82BA2E8EF33A00EBAFED /* WebTransportHash.h in Headers */,
+				CA7C3E0D2F31A94700AA1147 /* WebTransportHeaderValidation.h in Headers */,
 				FACC82B92E8EF2AF00EBAFED /* WebTransportOptions.h in Headers */,
 				FA93D69F2AA40DD5006444FB /* WebTransportReceiveStreamStats.h in Headers */,
 				244447FB2ECD1F8E00EED177 /* WebTransportReliabilityMode.h in Headers */,

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -1242,7 +1242,7 @@ class EmptyWebTransportSession final : public WebTransportSession, public Thread
 public:
     WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
-    Ref<WebTransportSessionInitializationPromise> initialize(ScriptExecutionContext&, const URL&, const WebTransportOptions&, const ClientOrigin&) final { return WebTransportSessionInitializationPromise::createAndReject(); }
+    Ref<WebTransportSessionInitializationPromise> initialize(ScriptExecutionContext&, const URL&, const WebTransportOptions&, const Vector<KeyValuePair<String, String>>&, const ClientOrigin&) final { return WebTransportSessionInitializationPromise::createAndReject(); }
     Ref<WebTransportSendPromise> sendDatagram(std::optional<WebTransportSendGroupIdentifier>, std::span<const uint8_t>) final { return WebTransportSendPromise::createAndReject(); }
     Ref<WebTransportStreamPromise> createOutgoingUnidirectionalStream() final { return WebTransportStreamPromise::createAndReject(); }
     Ref<WebTransportStreamPromise> createBidirectionalStream() final { return WebTransportStreamPromise::createAndReject(); }

--- a/Source/WebCore/platform/network/HTTPParsers.h
+++ b/Source/WebCore/platform/network/HTTPParsers.h
@@ -81,13 +81,13 @@ enum class ClearSiteDataValue : uint8_t {
 enum class RangeAllowWhitespace : bool { No, Yes };
 
 bool NODELETE isValidReasonPhrase(const String&);
-bool NODELETE isValidHTTPHeaderValue(const String&);
+WEBCORE_EXPORT bool NODELETE isValidHTTPHeaderValue(const String&);
 bool NODELETE isValidAcceptHeaderValue(const String&);
 bool NODELETE isValidLanguageHeaderValue(const String&);
 #if USE(GLIB)
 WEBCORE_EXPORT bool isValidUserAgentHeaderValue(const String&);
 #endif
-bool NODELETE isValidHTTPToken(const String&);
+WEBCORE_EXPORT bool NODELETE isValidHTTPToken(const String&);
 bool isValidHTTPToken(StringView);
 std::optional<WallTime> parseHTTPDate(const String&);
 StringView filenameFromHTTPContentDisposition(StringView value LIFETIME_BOUND);
@@ -114,11 +114,11 @@ size_t parseHTTPRequestBody(std::span<const uint8_t> data, Vector<uint8_t>& body
 std::optional<uint64_t> parseContentLength(StringView);
 
 // HTTP Header routine as per https://fetch.spec.whatwg.org/#terminology-headers
-bool isForbiddenHeader(const String& name, StringView value);
+WEBCORE_EXPORT bool isForbiddenHeader(const String& name, StringView value);
 bool isForbiddenHeaderName(const String&);
 bool isNoCORSSafelistedRequestHeaderName(const String&);
 bool isPriviledgedNoCORSRequestHeaderName(const String&);
-bool isForbiddenResponseHeaderName(const String&);
+WEBCORE_EXPORT bool isForbiddenResponseHeaderName(const String&);
 bool isForbiddenMethod(StringView);
 bool isSimpleHeader(const String& name, const String& value);
 bool isCrossOriginSafeHeader(HTTPHeaderName, const HTTPHeaderSet&);

--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -94,6 +94,7 @@ symbols = [
     "nw_connection_abort_reads",
     "nw_connection_abort_writes",
     "nw_http_fields_access_value_by_name",
+    "nw_http_fields_enumerate",
     "nw_parameters_create_webtransport_http",
     "nw_protocol_copy_webtransport_definition",
     "nw_webtransport_create_options",

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -93,6 +93,7 @@
 #include <WebCore/SameSiteInfo.h>
 #include <WebCore/SecurityOriginData.h>
 #include <WebCore/SecurityPolicy.h>
+#include <WebCore/WebTransportHeaderValidation.h>
 #include <optional>
 #include <wtf/Borrow.h>
 #include <wtf/HashSet.h>
@@ -2005,7 +2006,7 @@ void NetworkConnectionToWebProcess::navigatorGetPushPermissionState(URL&& scopeU
 }
 #endif // ENABLE(DECLARATIVE_WEB_PUSH)
 
-void NetworkConnectionToWebProcess::initializeWebTransportSession(WebTransportSessionIdentifier identifier, URL&& url, WebCore::WebTransportOptions&& options, WebPageProxyIdentifier&& pageID, WebCore::ClientOrigin&& clientOrigin, CompletionHandler<void(std::optional<WebCore::WebTransportConnectionInfo>&&)>&& completionHandler)
+void NetworkConnectionToWebProcess::initializeWebTransportSession(WebTransportSessionIdentifier identifier, URL&& url, WebCore::WebTransportOptions&& options, Vector<KeyValuePair<String, String>>&& additionalHeaders, WebPageProxyIdentifier&& pageID, WebCore::ClientOrigin&& clientOrigin, CompletionHandler<void(std::optional<WebCore::WebTransportConnectionInfo>&&)>&& completionHandler)
 {
     if (!url.isValid()
         || !portAllowed(url)
@@ -2013,7 +2014,9 @@ void NetworkConnectionToWebProcess::initializeWebTransportSession(WebTransportSe
         || m_networkTransportSessions.contains(identifier))
         return completionHandler(std::nullopt);
 
-    RefPtr session = NetworkTransportSession::create(*this, identifier, WTF::move(url), WTF::move(options), WTF::move(pageID), WTF::move(clientOrigin));
+    MESSAGE_CHECK_COMPLETION(areValidWebTransportHeaders(additionalHeaders), completionHandler(std::nullopt));
+
+    RefPtr session = NetworkTransportSession::create(*this, identifier, WTF::move(url), WTF::move(options), WTF::move(additionalHeaders), WTF::move(pageID), WTF::move(clientOrigin));
     if (!session)
         return completionHandler(std::nullopt);
     session->initialize(WTF::move(completionHandler));

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -451,7 +451,7 @@ private:
     void navigatorGetPushPermissionState(URL&& scopeURL, CompletionHandler<void(Expected<uint8_t, WebCore::ExceptionData>&&)>&&);
 #endif
 
-    void initializeWebTransportSession(WebTransportSessionIdentifier, URL&&, WebCore::WebTransportOptions&&, WebPageProxyIdentifier&&, WebCore::ClientOrigin&&, CompletionHandler<void(std::optional<WebCore::WebTransportConnectionInfo>&&)>&&);
+    void initializeWebTransportSession(WebTransportSessionIdentifier, URL&&, WebCore::WebTransportOptions&&, Vector<KeyValuePair<String, String>>&&, WebPageProxyIdentifier&&, WebCore::ClientOrigin&&, CompletionHandler<void(std::optional<WebCore::WebTransportConnectionInfo>&&)>&&);
     void destroyWebTransportSession(WebTransportSessionIdentifier);
 
     struct ResourceNetworkActivityTracker {

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -146,7 +146,7 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
     NavigatorGetPushPermissionState(URL scopeURL) -> (Expected<uint8_t, WebCore::ExceptionData> result)
 #endif
 
-    [EnabledBy=WebTransportEnabled] InitializeWebTransportSession(WebKit::WebTransportSessionIdentifier identifier, URL url, struct WebCore::WebTransportOptions options, WebKit::WebPageProxyIdentifier pageID, struct WebCore::ClientOrigin clientOrigin) -> (struct std::optional<WebCore::WebTransportConnectionInfo> connectionInfo)
+    [EnabledBy=WebTransportEnabled] InitializeWebTransportSession(WebKit::WebTransportSessionIdentifier identifier, URL url, struct WebCore::WebTransportOptions options, Vector<KeyValuePair<String, String>> additionalHeaders, WebKit::WebPageProxyIdentifier pageID, struct WebCore::ClientOrigin clientOrigin) -> (struct std::optional<WebCore::WebTransportConnectionInfo> connectionInfo)
     [EnabledBy=WebTransportEnabled] DestroyWebTransportSession(WebKit::WebTransportSessionIdentifier identifier)
 
     ClearFrameLoadRecordsForStorageAccess(WebCore::FrameIdentifier frameID)

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp
@@ -222,7 +222,7 @@ void NetworkTransportSession::completeRequestsAfterInitialization(std::optional<
 }
 
 #if !HAVE(WEBTRANSPORT)
-RefPtr<NetworkTransportSession> NetworkTransportSession::create(NetworkConnectionToWebProcess&, WebTransportSessionIdentifier, URL&&, WebCore::WebTransportOptions&&, WebKit::WebPageProxyIdentifier&&, WebCore::ClientOrigin&&)
+RefPtr<NetworkTransportSession> NetworkTransportSession::create(NetworkConnectionToWebProcess&, WebTransportSessionIdentifier, URL&&, WebCore::WebTransportOptions&&, Vector<KeyValuePair<String, String>>&&, WebKit::WebPageProxyIdentifier&&, WebCore::ClientOrigin&&)
 {
     return nullptr;
 }

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -69,7 +69,7 @@ using WebTransportSessionIdentifier = AtomicObjectIdentifier<WebTransportSession
 class NetworkTransportSession : public RefCounted<NetworkTransportSession>, public IPC::MessageReceiver, public IPC::MessageSender {
     WTF_MAKE_TZONE_ALLOCATED(NetworkTransportSession);
 public:
-    static RefPtr<NetworkTransportSession> create(NetworkConnectionToWebProcess&, WebTransportSessionIdentifier, URL&&, WebCore::WebTransportOptions&&, WebKit::WebPageProxyIdentifier&&, WebCore::ClientOrigin&&);
+    static RefPtr<NetworkTransportSession> create(NetworkConnectionToWebProcess&, WebTransportSessionIdentifier, URL&&, WebCore::WebTransportOptions&&, Vector<KeyValuePair<String, String>>&&, WebKit::WebPageProxyIdentifier&&, WebCore::ClientOrigin&&);
 
     ~NetworkTransportSession();
 

--- a/Source/WebKit/NetworkProcess/webtransport/WebTransport.serialization.in
+++ b/Source/WebKit/NetworkProcess/webtransport/WebTransport.serialization.in
@@ -56,6 +56,7 @@ struct WebCore::WebTransportOptions {
     std::optional<uint16_t> anticipatedConcurrentIncomingBidirectionalStreams
     Vector<String> protocols
     std::optional<WebCore::ReadableStreamType> datagramsReadableType;
+    [NotSerialized] std::optional<WebCore::FetchHeaders::Init> headersInit;
 };
 
 enum class WebCore::WebTransportCongestionControl : uint8_t {
@@ -77,4 +78,5 @@ enum class WebCore::ReadableStreamType : uint8_t {
 struct WebCore::WebTransportConnectionInfo {
     String protocol
     WebCore::WebTransportReliabilityMode reliabilityMode
+    Vector<KeyValuePair<String, String>> responseHeaders
 };

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -41,6 +41,7 @@
 #import <WebCore/ClientOrigin.h>
 #import <WebCore/Exception.h>
 #import <WebCore/ExceptionCode.h>
+#import <WebCore/HTTPParsers.h>
 #import <WebCore/RFC8941.h>
 #import <WebCore/WebTransportConnectionInfo.h>
 #import <WebCore/WebTransportConnectionStats.h>
@@ -197,14 +198,15 @@ static String joinProtocolStrings(const Vector<String>& protocols)
     return builder.toString();
 }
 
-static RetainPtr<nw_parameters_t> createParameters(NetworkConnectionToWebProcess& connectionToWebProcess, URL&& url, WebCore::WebTransportOptions& options, WebKit::WebPageProxyIdentifier&& pageID, WebCore::ClientOrigin&& clientOrigin, RefPtr<NetworkTransportSession::SecurityProtocolMetadata> securityMetadata)
+static RetainPtr<nw_parameters_t> createParameters(NetworkConnectionToWebProcess& connectionToWebProcess, URL&& url, WebCore::WebTransportOptions& options, Vector<KeyValuePair<String, String>>&& additionalHeaders, WebKit::WebPageProxyIdentifier&& pageID, WebCore::ClientOrigin&& clientOrigin, RefPtr<NetworkTransportSession::SecurityProtocolMetadata> securityMetadata)
 {
     // https://www.w3.org/TR/webtransport/#web-transport-configuration
     auto configureWebTransport = [
         clientOrigin = clientOrigin.clientOrigin.toString(),
         maxStreamsUni = options.anticipatedConcurrentIncomingUnidirectionalStreams.value_or(100),
         maxStreamsBidi = options.anticipatedConcurrentIncomingBidirectionalStreams.value_or(100),
-        protocols = joinProtocolStrings(options.protocols)
+        protocols = joinProtocolStrings(options.protocols),
+        additionalHeaders = WTF::move(additionalHeaders)
     ](nw_protocol_options_t options) {
         nw_webtransport_options_set_is_unidirectional(options, false);
         nw_webtransport_options_set_is_datagram(options, true);
@@ -212,6 +214,8 @@ static RetainPtr<nw_parameters_t> createParameters(NetworkConnectionToWebProcess
         nw_webtransport_options_set_allow_joining_before_ready(options, true);
         nw_webtransport_options_set_initial_max_streams_uni(options, maxStreamsUni);
         nw_webtransport_options_set_initial_max_streams_bidi(options, maxStreamsBidi);
+        for (auto& header : additionalHeaders)
+            nw_webtransport_options_add_connect_request_header(options, header.key.latin1().data(), header.value.latin1().data());
         nw_webtransport_options_add_connect_request_header(options, "wt-available-protocols", protocols.utf8().data());
     };
 
@@ -258,7 +262,7 @@ static RetainPtr<nw_parameters_t> createParameters(NetworkConnectionToWebProcess
     return adoptNS(nw_parameters_create_webtransport_http(configureWebTransport, configureTLS, configureQUIC, configureTCP));
 }
 
-RefPtr<NetworkTransportSession> NetworkTransportSession::create(NetworkConnectionToWebProcess& connectionToWebProcess, WebTransportSessionIdentifier identifier, URL&& url, WebCore::WebTransportOptions&& options, WebKit::WebPageProxyIdentifier&& pageID, WebCore::ClientOrigin&& clientOrigin)
+RefPtr<NetworkTransportSession> NetworkTransportSession::create(NetworkConnectionToWebProcess& connectionToWebProcess, WebTransportSessionIdentifier identifier, URL&& url, WebCore::WebTransportOptions&& options, Vector<KeyValuePair<String, String>>&& additionalHeaders, WebKit::WebPageProxyIdentifier&& pageID, WebCore::ClientOrigin&& clientOrigin)
 {
     RetainPtr endpoint = adoptNS(nw_endpoint_create_url(url.string().utf8().data()));
     if (!endpoint) {
@@ -269,7 +273,7 @@ RefPtr<NetworkTransportSession> NetworkTransportSession::create(NetworkConnectio
     // FIXME: Remove SecurityProtocolMetadata once we no longer support platforms without nw_webtransport_metadata_copy_sec_protocol_metadata.
     RefPtr metadata = canLoad_Network_nw_webtransport_metadata_copy_sec_protocol_metadata() ? nullptr : SecurityProtocolMetadata::create();
 
-    RetainPtr parameters = createParameters(connectionToWebProcess, WTF::move(url), options, WTF::move(pageID), WTF::move(clientOrigin), metadata);
+    RetainPtr parameters = createParameters(connectionToWebProcess, WTF::move(url), options, WTF::move(additionalHeaders), WTF::move(pageID), WTF::move(clientOrigin), metadata);
     if (!parameters) {
         ASSERT_NOT_REACHED();
         return nullptr;
@@ -311,6 +315,7 @@ void NetworkTransportSession::initialize(CompletionHandler<void(std::optional<We
             return; // We will get another callback with another state change.
         case nw_connection_group_state_ready: {
             __block String protocol;
+            __block Vector<KeyValuePair<String, String>> responseHeaders;
             WebCore::WebTransportReliabilityMode reliabilityMode = WebCore::WebTransportReliabilityMode::Pending;
             if (RefPtr protectedThis = weakThis.get()) {
                 protectedThis->m_sessionMetadata = nw_connection_group_copy_protocol_metadata(protectedThis->m_connectionGroup.get(), adoptNS(nw_protocol_copy_webtransport_definition()).get());
@@ -330,6 +335,16 @@ void NetworkTransportSession::initialize(CompletionHandler<void(std::optional<We
                             }
                         }
                     });
+                    nw_http_fields_enumerate(response.get(), ^bool(const char *name, size_t nameLength, const char *value, size_t valueLength) {
+                        auto headerName = String(unsafeMakeSpan(name, nameLength)).convertToASCIILowercase();
+                        // Forbidden response header names must never reach WebContent.
+                        // https://fetch.spec.whatwg.org/#forbidden-response-header-name
+                        if (headerName != "wt-protocol"_s && !WebCore::isForbiddenResponseHeaderName(headerName)) {
+                            KeyValuePair<String, String> pair(WTF::move(headerName), String(unsafeMakeSpan(value, valueLength)));
+                            responseHeaders.append(WTF::move(pair));
+                        }
+                        return true;
+                    });
                     nw_webtransport_transport_mode_t transportMode = nw_webtransport_metadata_get_transport_mode(metadata.get());
                     if (transportMode == nw_webtransport_transport_mode_http3)
                         reliabilityMode = WebCore::WebTransportReliabilityMode::SupportsUnreliable;
@@ -337,7 +352,7 @@ void NetworkTransportSession::initialize(CompletionHandler<void(std::optional<We
                         reliabilityMode = WebCore::WebTransportReliabilityMode::ReliableOnly;
                 }
             }
-            return creationCompletionHandler(WebCore::WebTransportConnectionInfo { WTF::move(protocol), reliabilityMode });
+            return creationCompletionHandler(WebCore::WebTransportConnectionInfo { WTF::move(protocol), reliabilityMode, WTF::move(responseHeaders) });
         }
         case nw_connection_group_state_failed:
             if (RefPtr protectedThis = weakThis.get()) {

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
@@ -133,14 +133,14 @@ void WebTransportSession::didDrain()
         strongClient->didDrain();
 }
 
-Ref<WebCore::WebTransportSessionInitializationPromise> WebTransportSession::initialize(WebCore::ScriptExecutionContext& context, const URL& url, const WebCore::WebTransportOptions& options, const WebCore::ClientOrigin& origin)
+Ref<WebCore::WebTransportSessionInitializationPromise> WebTransportSession::initialize(WebCore::ScriptExecutionContext& context, const URL& url, const WebCore::WebTransportOptions& options, const Vector<KeyValuePair<String, String>>& additionalHeaders, const WebCore::ClientOrigin& origin)
 {
     std::optional<TextPosition> sourcePosition;
     if (RefPtr document = dynamicDowncast<WebCore::Document>(context))
         sourcePosition = document->currentParserSourcePosition();
     if (CheckedPtr csp = context.contentSecurityPolicy(); !csp || !csp->allowConnectToSource(url, WTF::move(sourcePosition)))
         return WebCore::WebTransportSessionInitializationPromise::createAndReject();
-    return sendWithPromisedReply(Messages::NetworkConnectionToWebProcess::InitializeWebTransportSession(m_identifier, url, options, m_pageID, origin))->whenSettled(RunLoop::mainSingleton(), [] (auto&& result) {
+    return sendWithPromisedReply(Messages::NetworkConnectionToWebProcess::InitializeWebTransportSession(m_identifier, url, options, additionalHeaders, m_pageID, origin))->whenSettled(RunLoop::mainSingleton(), [] (auto&& result) {
         if (result && *result)
             return WebCore::WebTransportSessionInitializationPromise::createAndResolve(WTF::move(**result));
         return WebCore::WebTransportSessionInitializationPromise::createAndReject();

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.h
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.h
@@ -85,7 +85,7 @@ private:
     WebTransportSession(Ref<IPC::Connection>&&, ThreadSafeWeakPtr<WebCore::WebTransportSessionClient>&&, WebTransportSessionIdentifier, WebPageProxyIdentifier);
 
     // WebTransportSession
-    Ref<WebCore::WebTransportSessionInitializationPromise> initialize(WebCore::ScriptExecutionContext&, const URL&, const WebCore::WebTransportOptions&, const WebCore::ClientOrigin&) final;
+    Ref<WebCore::WebTransportSessionInitializationPromise> initialize(WebCore::ScriptExecutionContext&, const URL&, const WebCore::WebTransportOptions&, const Vector<KeyValuePair<String, String>>&, const WebCore::ClientOrigin&) final;
     Ref<WebCore::WebTransportSendPromise> sendDatagram(std::optional<WebCore::WebTransportSendGroupIdentifier>, std::span<const uint8_t>) final;
     Ref<WebCore::WebTransportStreamPromise> createOutgoingUnidirectionalStream() final;
     Ref<WebCore::WebTransportStreamPromise> createBidirectionalStream() final;

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -276,6 +276,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/TransformationMatrix.cpp
         Tests/WebCore/URLParserTextEncoding.cpp
         Tests/WebCore/URLPatternTests.cpp
+        Tests/WebCore/WebTransportHeaderValidation.cpp
         Tests/WebCore/WritingModeTests.cpp
         Tests/WebCore/XRCompositionLayer.cpp
     )

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -827,6 +827,7 @@
 				WebCore/URLParserTextEncoding.cpp,
 				WebCore/UserAgentStringParser.cpp,
 				WebCore/WebGPUFramePacer.cpp,
+				WebCore/WebTransportHeaderValidation.cpp,
 				WebCore/WritingModeTests.cpp,
 				WebCore/XRCompositionLayer.cpp,
 				WebCore/YouTubePluginReplacement.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebCore/WebTransportHeaderValidation.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/WebTransportHeaderValidation.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Helpers/Test.h"
+#include <WebCore/WebTransportHeaderValidation.h>
+#include <wtf/KeyValuePair.h>
+#include <wtf/Vector.h>
+#include <wtf/text/StringBuilder.h>
+#include <wtf/text/WTFString.h>
+
+namespace TestWebKitAPI {
+
+using WebCore::areValidWebTransportHeaders;
+
+static Vector<KeyValuePair<String, String>> makeHeaders(std::initializer_list<std::pair<ASCIILiteral, ASCIILiteral>> pairs)
+{
+    Vector<KeyValuePair<String, String>> headers;
+    headers.reserveInitialCapacity(pairs.size());
+    for (auto& pair : pairs)
+        headers.constructAndAppend(String(pair.first), String(pair.second));
+    return headers;
+}
+
+TEST(WebTransportHeaderValidation, EmptyIsValid)
+{
+    EXPECT_TRUE(areValidWebTransportHeaders({ }));
+}
+
+TEST(WebTransportHeaderValidation, SimpleCustomHeaderIsValid)
+{
+    EXPECT_TRUE(areValidWebTransportHeaders(makeHeaders({ { "x-custom"_s, "value"_s } })));
+}
+
+TEST(WebTransportHeaderValidation, RejectsMixedCaseName)
+{
+    EXPECT_FALSE(areValidWebTransportHeaders(makeHeaders({ { "X-Custom"_s, "value"_s } })));
+}
+
+TEST(WebTransportHeaderValidation, RejectsInvalidHTTPToken)
+{
+    EXPECT_FALSE(areValidWebTransportHeaders(makeHeaders({ { "bad name"_s, "value"_s } })));
+}
+
+TEST(WebTransportHeaderValidation, RejectsWhenAnyHeaderInvalid)
+{
+    EXPECT_FALSE(areValidWebTransportHeaders(makeHeaders({
+        { "x-good"_s, "ok"_s },
+        { "cookie"_s, "oops"_s },
+    })));
+}
+
+TEST(WebTransportHeaderValidation, AcceptsHighByteValues)
+{
+    StringBuilder builder;
+    for (unsigned i = 0x80; i <= 0xFF; ++i)
+        builder.append(static_cast<char16_t>(i));
+    Vector<KeyValuePair<String, String>> headers;
+    headers.constructAndAppend("x-bytes"_s, builder.toString());
+    EXPECT_TRUE(areValidWebTransportHeaders(headers));
+}
+
+TEST(WebTransportHeaderValidation, RejectsUntrimmedValue)
+{
+    EXPECT_FALSE(areValidWebTransportHeaders(makeHeaders({ { "x-custom"_s, " value "_s } })));
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 89c464cce8ce7591d4a0d926d4e79f2b621136d4
<pre>
[WebTransport] Add headers and responseHeaders support
<a href="https://bugs.webkit.org/show_bug.cgi?id=311299">https://bugs.webkit.org/show_bug.cgi?id=311299</a>

Reviewed by Alex Christensen.

Implement the headers constructor option and responseHeaders attribute
from the WebTransport spec (<a href="https://github.com/w3c/webtransport/pull/713).">https://github.com/w3c/webtransport/pull/713).</a>

headers allows setting custom HTTP headers on the CONNECT request when
establishing a WebTransport session. responseHeaders exposes the
server&apos;s response headers as an immutable Headers object after the
session is established.

Tests: imported/w3c/web-platform-tests/webtransport/headers.https.any.html
       imported/w3c/web-platform-tests/webtransport/headers.https.any.worker.html
       Tools/TestWebKitAPI/Tests/WebCore/WebTransportHeaderValidation.cpp

* LayoutTests/imported/w3c/web-platform-tests/interfaces/webtransport.idl:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/headers.https.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/headers.https.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/headers.https.any.js: Added.
(createAndClose):
(test):
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/webtransport/headers.https.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/headers.https.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webtransport/idlharness.https.sub.any.worker-expected.txt:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::create):
(WebCore::WebTransport::WebTransport):
(WebCore::WebTransport::responseHeaders):
* Source/WebCore/Modules/webtransport/WebTransport.h:
* Source/WebCore/Modules/webtransport/WebTransport.idl:
* Source/WebCore/Modules/webtransport/WebTransportConnectionInfo.h:
(WebCore::WebTransportConnectionInfo::isolatedCopy const):
(WebCore::WebTransportConnectionInfo::isolatedCopy):
* Source/WebCore/Modules/webtransport/WebTransportHeaderValidation.cpp: Added.
(WebCore::validateWebTransportHeader):
(WebCore::validateAndNormalizeWebTransportHeaders):
(WebCore::areValidWebTransportHeaders):
* Source/WebCore/Modules/webtransport/WebTransportHeaderValidation.h: Copied from Source/WebCore/Modules/webtransport/WebTransportConnectionInfo.h.
* Source/WebCore/Modules/webtransport/WebTransportOptions.h:
* Source/WebCore/Modules/webtransport/WebTransportOptions.idl:
* Source/WebCore/Modules/webtransport/WebTransportSession.h:
* Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp:
(WebCore::WorkerWebTransportSession::initialize):
* Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h:
* Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/platform/network/HTTPParsers.h:
* Source/WebKit/Configurations/AllowedSPI.toml:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::initializeWebTransportSession):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.cpp:
(WebKit::NetworkTransportSession::create):
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
* Source/WebKit/NetworkProcess/webtransport/WebTransport.serialization.in:
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::createParameters):
(WebKit::NetworkTransportSession::create):
(WebKit::NetworkTransportSession::initialize):
* Source/WebKit/WebProcess/Network/WebTransportSession.cpp:
(WebKit::WebTransportSession::initialize):
* Source/WebKit/WebProcess/Network/WebTransportSession.h:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/WebTransportHeaderValidation.cpp: Added.
(TestWebKitAPI::makeHeaders):
(TestWebKitAPI::TEST(WebTransportHeaderValidation, EmptyIsValid)):
(TestWebKitAPI::TEST(WebTransportHeaderValidation, SimpleCustomHeaderIsValid)):
(TestWebKitAPI::TEST(WebTransportHeaderValidation, RejectsMixedCaseName)):
(TestWebKitAPI::TEST(WebTransportHeaderValidation, RejectsInvalidHTTPToken)):
(TestWebKitAPI::TEST(WebTransportHeaderValidation, RejectsWhenAnyHeaderInvalid)):
(TestWebKitAPI::TEST(WebTransportHeaderValidation, AcceptsHighByteValues)):
(TestWebKitAPI::TEST(WebTransportHeaderValidation, RejectsUntrimmedValue)):

Canonical link: <a href="https://commits.webkit.org/319182@main">https://commits.webkit.org/319182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05d788946519c60787551f66999091ea1fbefdbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48442 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190910 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145021 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182561 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55942 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54360 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140946 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44617 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/161714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121398 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/43290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/41573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153694 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41243 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2071 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47253 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/45828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192847 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54310 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161232 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150329 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54998 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/37861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150046 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27435 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44659 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/127263 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/122499 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53515 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16236 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52897 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53134 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52962 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->