### PR TITLE
[Android] Changed WPE code to use MemoryPressureHandlerGeneric

### DIFF
--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -68,7 +68,7 @@ static MemoryPressureHandler* memoryPressureHandlerIfExists()
 }
 
 MemoryPressureHandler::MemoryPressureHandler()
-#if OS(LINUX) || OS(FREEBSD) || OS(HAIKU) || OS(QNX)
+#if (OS(LINUX) || OS(FREEBSD) || OS(HAIKU) || OS(QNX)) && !OS(ANDROID)
     : m_holdOffTimer(RunLoop::mainSingleton(), "MemoryPressureHandler::HoldOffTimer"_s, this, &MemoryPressureHandler::holdOffTimerFired)
 #elif OS(WINDOWS)
     : m_windowsMeasurementTimer(RunLoop::mainSingleton(), "MemoryPressureHandler::WindowsMeasurementTimer"_s, this, &MemoryPressureHandler::windowsMeasurementTimerFired)

--- a/Source/WTF/wtf/MemoryPressureHandler.h
+++ b/Source/WTF/wtf/MemoryPressureHandler.h
@@ -269,7 +269,7 @@ private:
     Win32Handle m_lowMemoryHandle;
 #endif
 
-#if OS(LINUX) || OS(FREEBSD) || OS(HAIKU) || OS(QNX)
+#if (OS(LINUX) || OS(FREEBSD) || OS(HAIKU) || OS(QNX)) && !OS(ANDROID)
     RunLoop::Timer m_holdOffTimer;
     void holdOffTimerFired();
 #endif

--- a/Source/WTF/wtf/PlatformWPE.cmake
+++ b/Source/WTF/wtf/PlatformWPE.cmake
@@ -19,7 +19,6 @@ list(APPEND WTF_SOURCES
     glib/URLGLib.cpp
 
     linux/CurrentProcessMemoryStatus.cpp
-    linux/MemoryFootprintLinux.cpp
     linux/RealTimeThreads.cpp
 
     posix/CPUTimePOSIX.cpp
@@ -33,9 +32,21 @@ list(APPEND WTF_SOURCES
 
     unix/LanguageUnix.cpp
     unix/LoggingUnix.cpp
-    unix/MemoryPressureHandlerUnix.cpp
     unix/UniStdExtrasUnix.cpp
 )
+
+if (ANDROID)
+    list(APPEND WTF_SOURCES
+        generic/MemoryFootprintGeneric.cpp
+        generic/MemoryPressureHandlerGeneric.cpp
+    )
+else ()
+    list(APPEND WTF_SOURCES
+        linux/MemoryFootprintLinux.cpp
+
+        unix/MemoryPressureHandlerUnix.cpp
+    )
+endif ()
 
 list(APPEND WTF_PUBLIC_HEADERS
     android/RefPtrAndroid.h

--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -296,7 +296,7 @@ void AuxiliaryProcess::didReceiveInvalidMessage(IPC::Connection&, IPC::MessageNa
     CRASH();
 }
 
-#if OS(LINUX)
+#if OS(LINUX) && !OS(ANDROID)
 void AuxiliaryProcess::didReceiveMemoryPressureEvent(bool isCritical)
 {
     MemoryPressureHandler::singleton().triggerMemoryPressureEvent(isCritical);

--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -145,7 +145,7 @@ protected:
     bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
     bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
 
-#if OS(LINUX)
+#if OS(LINUX) && !OS(ANDROID)
     void didReceiveMemoryPressureEvent(bool isCritical);
 #endif
 

--- a/Source/WebKit/Shared/AuxiliaryProcess.messages.in
+++ b/Source/WebKit/Shared/AuxiliaryProcess.messages.in
@@ -35,7 +35,7 @@ messages -> AuxiliaryProcess WantsDispatchMessage {
     [DeferSendingIfSuspendedWithCoalescingKeys=(domain, key)] PreferenceDidUpdate(String domain, String key, std::optional<String> encodedValue)
 #endif
 
-#if OS(LINUX)
+#if OS(LINUX) && !OS(ANDROID)
     void DidReceiveMemoryPressureEvent(bool isCritical)
 #endif
 }

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -297,7 +297,7 @@ WebProcessPool::WebProcessPool(API::ProcessPoolConfiguration& configuration)
 
     platformInitialize(needsGlobalStaticInitialization);
 
-#if OS(LINUX)
+#if OS(LINUX) && !OS(ANDROID)
     if (!MemoryPressureMonitor::disabled())
         MemoryPressureMonitor::singleton().start();
 #endif
@@ -452,7 +452,7 @@ void WebProcessPool::fullKeyboardAccessModeChanged(bool fullKeyboardAccessEnable
     sendToAllProcesses(Messages::WebProcess::FullKeyboardAccessModeChanged(fullKeyboardAccessEnabled));
 }
 
-#if OS(LINUX)
+#if OS(LINUX) && !OS(ANDROID)
 void WebProcessPool::sendMemoryPressureEvent(bool isCritical)
 {
     sendToAllProcesses(Messages::AuxiliaryProcess::DidReceiveMemoryPressureEvent(isCritical));

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -381,7 +381,7 @@ public:
 #endif
 
     void fullKeyboardAccessModeChanged(bool fullKeyboardAccessEnabled);
-#if OS(LINUX)
+#if OS(LINUX) && !OS(ANDROID)
     void sendMemoryPressureEvent(bool isCritical);
 #endif
     void textCheckerStateChanged();

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -161,7 +161,7 @@ void WebProcessPool::platformInitialize(NeedsGlobalStaticInitialization)
     }
 #endif
 
-#if OS(LINUX)
+#if OS(LINUX) && !OS(ANDROID)
     if (!MemoryPressureMonitor::disabled())
         installMemoryPressureHandler();
 #endif
@@ -220,7 +220,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
     parameters.availableInputDevices = availableInputDevices();
     parameters.memoryCacheDisabled = m_memoryCacheDisabled || LegacyGlobalSettings::singleton().cacheModel() == CacheModel::DocumentViewer;
 
-#if OS(LINUX)
+#if OS(LINUX) && !OS(ANDROID)
     if (MemoryPressureMonitor::disabled())
         parameters.shouldSuppressMemoryPressureHandler = true;
 #endif

--- a/Source/WebKit/UIProcess/linux/MemoryPressureMonitor.cpp
+++ b/Source/WebKit/UIProcess/linux/MemoryPressureMonitor.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "MemoryPressureMonitor.h"
 
-#if OS(LINUX)
+#if OS(LINUX) && !OS(ANDROID)
 
 #include "WebProcessPool.h"
 #include <mutex>

--- a/Source/WebKit/UIProcess/linux/MemoryPressureMonitor.h
+++ b/Source/WebKit/UIProcess/linux/MemoryPressureMonitor.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if OS(LINUX)
+#if OS(LINUX) && !OS(ANDROID)
 
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Noncopyable.h>

--- a/Source/WebKit/UIProcess/soup/WebProcessPoolSoup.cpp
+++ b/Source/WebKit/UIProcess/soup/WebProcessPoolSoup.cpp
@@ -42,7 +42,7 @@ void WebProcessPool::platformInitializeNetworkProcess(NetworkProcessCreationPara
     parameters.languages = overrideLanguages().isEmpty() ? userPreferredLanguages() : overrideLanguages();
     parameters.memoryPressureHandlerConfiguration = s_networkProcessMemoryPressureHandlerConfiguration;
 
-#if OS(LINUX)
+#if OS(LINUX) && !OS(ANDROID)
     if (MemoryPressureMonitor::disabled())
         parameters.shouldSuppressMemoryPressureHandler = true;
 #endif // OS(LINUX)


### PR DESCRIPTION
#### f012b27a6c6ff5a744601787df584765f55807ca
<pre>
[Android] Changed WPE code to use MemoryPressureHandlerGeneric
<a href="https://bugs.webkit.org/show_bug.cgi?id=311311">https://bugs.webkit.org/show_bug.cgi?id=311311</a>

Reviewed by Adrian Perez de Castro.

Android has it own application memory management, so there is no need to use the MemoryPressureHandlerUnix with it.
Changed WPE code to use MemoryPressureHandlerGeneric and MemoryFootprintGeneric for OS ANDROID, then changed build conditionals as needed.

* Source/WTF/wtf/MemoryPressureHandler.cpp:
(WTF::MemoryPressureHandler::MemoryPressureHandler):
* Source/WTF/wtf/MemoryPressureHandler.h:
* Source/WTF/wtf/PlatformWPE.cmake:
* Source/WebKit/Shared/AuxiliaryProcess.cpp:
* Source/WebKit/Shared/AuxiliaryProcess.h:
* Source/WebKit/Shared/AuxiliaryProcess.messages.in:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::m_ipcTester):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::platformInitialize):
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/UIProcess/linux/MemoryPressureMonitor.cpp:
* Source/WebKit/UIProcess/linux/MemoryPressureMonitor.h:
* Source/WebKit/UIProcess/soup/WebProcessPoolSoup.cpp:
(WebKit::WebProcessPool::platformInitializeNetworkProcess):

Canonical link: <a href="https://commits.webkit.org/310425@main">https://commits.webkit.org/310425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee3a3831b84966495f666ae09c71a945ee0242fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162564 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26919 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118919 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156772 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138112 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99629 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20267 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10396 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145826 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129915 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15971 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165035 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14637 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8168 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17565 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127007 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26394 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22255 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127174 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34496 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26396 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137766 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/83074 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22073 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14550 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185449 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26013 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90301 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47567 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25704 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25864 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25764 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->