### PR TITLE
Cannot escape Id-value in SVG animation timing attributes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/syncbase-escaped-dots-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/syncbase-escaped-dots-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Single escaped dot in syncbase ID (begin="my\.anim.begin")
+PASS Multiple escaped dots in syncbase ID (begin="a\.b\.c.begin")
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/syncbase-escaped-dots.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/syncbase-escaped-dots.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<title>Escaped dots in syncbase timing ID references</title>
+<link rel="help" href="https://www.w3.org/TR/SMIL3/smil-timing.html#Timing-ParsingTimingSpecifiers">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=42871">
+<meta name="assert" content="Per SMIL3 § Parsing timing specifiers, the reverse solidus '\' must be used to escape full stop '.' characters within Id-values in timing attributes, so that dots in element IDs are not confused with the Id/event separator.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg>
+  <!-- Test 1: Single escaped dot -->
+  <rect width="10" height="10" fill="blue">
+    <animate attributeName="fill" from="yellow" to="red"
+             begin="indefinite" dur="10ms" id="my.anim" fill="freeze"/>
+  </rect>
+  <rect x="10" width="10" height="10" fill="blue">
+    <set attributeName="fill" to="green" begin="my\.anim.begin" id="dep1"/>
+  </rect>
+
+  <!-- Test 2: Multiple escaped dots -->
+  <rect x="20" width="10" height="10" fill="blue">
+    <animate attributeName="fill" from="yellow" to="red"
+             begin="indefinite" dur="10ms" id="a.b.c" fill="freeze"/>
+  </rect>
+  <rect x="30" width="10" height="10" fill="blue">
+    <set attributeName="fill" to="green" begin="a\.b\.c.begin" id="dep2"/>
+  </rect>
+
+</svg>
+
+<script>
+  async_test(t => {
+    const trigger = document.getElementById('my.anim');
+    const dep = document.getElementById('dep1');
+    dep.addEventListener('beginEvent', t.step_func_done(() => {
+        assert_equals(getComputedStyle(dep.parentElement).fill, 'rgb(0, 128, 0)');
+    }));
+    trigger.beginElement();
+  }, 'Single escaped dot in syncbase ID (begin="my\\.anim.begin")');
+
+  async_test(t => {
+    const trigger = document.getElementById('a.b.c');
+    const dep = document.getElementById('dep2');
+    dep.addEventListener('beginEvent', t.step_func_done(() => {
+        assert_equals(getComputedStyle(dep.parentElement).fill, 'rgb(0, 128, 0)');
+    }));
+    trigger.beginElement();
+  }, 'Multiple escaped dots in syncbase ID (begin="a\\.b\\.c.begin")');
+</script>

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -391,15 +391,24 @@ bool SVGSMILElement::parseCondition(StringView value, BeginOrEnd beginOrEnd)
     }
     if (conditionString.isEmpty())
         return false;
-    pos = conditionString.find('.');
-    
+
+    // Find the first dot not preceded by a backslash. Per the SMIL specification,
+    // dots in element IDs can be escaped with a backslash (e.g., "my\.anim.end").
+    size_t dotPosition = 0;
+    while (dotPosition != notFound) {
+        dotPosition = conditionString.find('.', dotPosition);
+        if (dotPosition == notFound || !dotPosition || conditionString[dotPosition - 1] != '\\')
+            break;
+        ++dotPosition;
+    }
+
     StringView baseID;
     StringView nameView;
-    if (pos == notFound)
+    if (dotPosition == notFound)
         nameView = conditionString;
     else {
-        baseID = conditionString.left(pos);
-        nameView = conditionString.substring(pos + 1);
+        baseID = conditionString.left(dotPosition);
+        nameView = conditionString.substring(dotPosition + 1);
     }
     if (nameView.isEmpty())
         return false;
@@ -430,7 +439,12 @@ bool SVGSMILElement::parseCondition(StringView value, BeginOrEnd beginOrEnd)
         nameString = nameView.toAtomString();
     }
     
-    m_conditions.append(Condition(type, beginOrEnd, baseID.toString(), WTF::move(nameString), offset, repeats));
+    // Remove backslash escapes from the element ID (e.g., "my\.anim" → "my.anim").
+    auto resolvedBaseID = baseID.toString();
+    if (resolvedBaseID.contains('\\'))
+        resolvedBaseID = resolvedBaseID.impl()->replace("\\."_s, "."_s);
+
+    m_conditions.append(Condition(type, beginOrEnd, WTF::move(resolvedBaseID), WTF::move(nameString), offset, repeats));
 
     if (type == Condition::EventBase && beginOrEnd == End)
         m_hasEndEventConditions = true;


### PR DESCRIPTION
#### ba227e713a9900f87222d60b19da70af868afee5
<pre>
Cannot escape Id-value in SVG animation timing attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=42871">https://bugs.webkit.org/show_bug.cgi?id=42871</a>
<a href="https://rdar.apple.com/94260935">rdar://94260935</a>

Reviewed by Antoine Quint.

The SMIL3 specification (§ Parsing timing specifiers) requires that
the reverse solidus character &apos;\&apos; be used to escape full stop &apos;.&apos;
characters within Id-values in timing attributes, so that dots in
element IDs are not confused with the Id/event separator.

For example, begin=&quot;my\.anim.end&quot; should reference an element with
id=&quot;my.anim&quot; and its &quot;end&quot; event. WebKit&apos;s parseCondition() used a
simple find(&apos;.&apos;) which matched the first dot regardless of escaping.

The fix finds the first unescaped dot (not preceded by &apos;\&apos;) when
splitting the condition string, then strips backslash escapes from
the resolved element ID before lookup.

The tests use only .begin events since parseCondition() handles
begin and end attributes through the same code path.

Spec: <a href="https://www.w3.org/TR/SMIL3/smil-timing.html#q22">https://www.w3.org/TR/SMIL3/smil-timing.html#q22</a>

Test: imported/w3c/web-platform-tests/svg/animations/syncbase-escaped-dots.html

* LayoutTests/imported/w3c/web-platform-tests/svg/animations/syncbase-escaped-dots-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/syncbase-escaped-dots.html: Added.
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::parseCondition):

Canonical link: <a href="https://commits.webkit.org/310805@main">https://commits.webkit.org/310805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae1e674de58ff9e9e68832384610c2a27854b442

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21363 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163704 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108415 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f709e63-46cf-43e4-80cb-ba92bbee5d52) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156817 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28052 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119876 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84731 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/009b32ff-89a6-47d7-8a58-d0dd25735aa1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157903 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139149 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100569 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/186bd817-926f-4046-b792-6bd63621adb0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21237 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19265 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11530 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130899 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16993 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166179 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/9776 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18602 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127978 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27748 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23304 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128117 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34779 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27672 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138786 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84381 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23001 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15581 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27364 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91468 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26942 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27173 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27015 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->