### PR TITLE
Improve `:lang()` matching: extend exact match fast path and fix singleton subtag handling

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2036,9 +2036,6 @@ webkit.org/b/185859 imported/w3c/web-platform-tests/css/selectors/focus-visible-
 webkit.org/b/217904 imported/w3c/web-platform-tests/css/selectors/is-where-visited.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/selectors/xml-class-selector.xml [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/selectors/case-insensitive-parent.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-017.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-018.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-020.html [ ImageOnlyFailure ]
 
 # This test is bit heavy for debug
 [ Debug ] imported/w3c/web-platform-tests/css/selectors/invalidation/has-complexity.html [ Skip ]

--- a/LayoutTests/fast/selectors/lang-extended-filtering-expected.txt
+++ b/LayoutTests/fast/selectors/lang-extended-filtering-expected.txt
@@ -44,15 +44,15 @@ PASS document.querySelectorAll(":lang(-en--)").length is 0
 PASS document.querySelectorAll(":lang(-en, -en-)").length is 0
 PASS document.querySelectorAll(":lang(-en-, -en--)").length is 0
 
-PASS document.querySelectorAll(":lang(fr-x)").length is 0
+PASS document.querySelectorAll(":lang(fr-x)").length is 2
 PASS document.querySelectorAll(":lang(fr-xenomorph)").length is 1
 
-PASS document.querySelectorAll(":lang(cocoa-1)").length is 0
-PASS document.querySelectorAll(":lang(cocoa-a)").length is 0
+PASS document.querySelectorAll(":lang(cocoa-1)").length is 1
+PASS document.querySelectorAll(":lang(cocoa-a)").length is 1
 PASS document.querySelectorAll(":lang(cocoa-bar)").length is 0
-PASS document.querySelectorAll(":lang(cocoa-1, cocoa-bar)").length is 0
-PASS document.querySelectorAll(":lang(cocoa-a, cocoa-bar)").length is 0
-PASS document.querySelectorAll(":lang(cocoa-1, cocoa-a)").length is 0
+PASS document.querySelectorAll(":lang(cocoa-1, cocoa-bar)").length is 1
+PASS document.querySelectorAll(":lang(cocoa-a, cocoa-bar)").length is 1
+PASS document.querySelectorAll(":lang(cocoa-1, cocoa-a)").length is 2
 
 PASS document.querySelectorAll(":lang(foo)").length is 1
 PASS document.querySelectorAll(":lang(foo-bar)").length is 1

--- a/LayoutTests/fast/selectors/lang-extended-filtering.html
+++ b/LayoutTests/fast/selectors/lang-extended-filtering.html
@@ -109,18 +109,18 @@
 
     debug(''); 
 
-    shouldBe('document.querySelectorAll(":lang(fr-x)").length', '0');
+    shouldBe('document.querySelectorAll(":lang(fr-x)").length', '2');
     shouldBe('document.querySelectorAll(":lang(fr-xenomorph)").length', '1');
 
     debug('');
 
-    shouldBe('document.querySelectorAll(":lang(cocoa-1)").length', '0');
-    shouldBe('document.querySelectorAll(":lang(cocoa-a)").length', '0');
+    shouldBe('document.querySelectorAll(":lang(cocoa-1)").length', '1');
+    shouldBe('document.querySelectorAll(":lang(cocoa-a)").length', '1');
     shouldBe('document.querySelectorAll(":lang(cocoa-bar)").length', '0');
 
-    shouldBe('document.querySelectorAll(":lang(cocoa-1, cocoa-bar)").length', '0');
-    shouldBe('document.querySelectorAll(":lang(cocoa-a, cocoa-bar)").length', '0');
-    shouldBe('document.querySelectorAll(":lang(cocoa-1, cocoa-a)").length', '0');
+    shouldBe('document.querySelectorAll(":lang(cocoa-1, cocoa-bar)").length', '1');
+    shouldBe('document.querySelectorAll(":lang(cocoa-a, cocoa-bar)").length', '1');
+    shouldBe('document.querySelectorAll(":lang(cocoa-1, cocoa-a)").length', '2');
 
     debug('');
 

--- a/LayoutTests/fast/selectors/lang-multiple-expected.txt
+++ b/LayoutTests/fast/selectors/lang-multiple-expected.txt
@@ -39,11 +39,11 @@ PASS document.querySelectorAll(":lang(-en-, -en-)").length is 0
 PASS document.querySelectorAll(":lang(-en, -en-)").length is 0
 PASS document.querySelectorAll(":lang(-en-, -en--)").length is 0
 
-PASS document.querySelectorAll(":lang(fr-x, fr-x)").length is 0
+PASS document.querySelectorAll(":lang(fr-x, fr-x)").length is 2
 PASS document.querySelectorAll(":lang(fr-xenomorph, fr-xenomorph)").length is 1
 
-PASS document.querySelectorAll(":lang(cocoa-1, cocoa-1)").length is 0
-PASS document.querySelectorAll(":lang(cocoa-a, cocoa-a)").length is 0
+PASS document.querySelectorAll(":lang(cocoa-1, cocoa-1)").length is 1
+PASS document.querySelectorAll(":lang(cocoa-a, cocoa-a)").length is 1
 PASS document.querySelectorAll(":lang(cocoa-bar, cocoa-bar)").length is 0
 
 PASS document.querySelectorAll(":lang(foo, foo)").length is 1

--- a/LayoutTests/fast/selectors/lang-multiple.html
+++ b/LayoutTests/fast/selectors/lang-multiple.html
@@ -91,13 +91,13 @@
 
     debug(''); 
 
-    shouldBe('document.querySelectorAll(":lang(fr-x, fr-x)").length', '0');
+    shouldBe('document.querySelectorAll(":lang(fr-x, fr-x)").length', '2');
     shouldBe('document.querySelectorAll(":lang(fr-xenomorph, fr-xenomorph)").length', '1');
 
     debug('');
 
-    shouldBe('document.querySelectorAll(":lang(cocoa-1, cocoa-1)").length', '0');
-    shouldBe('document.querySelectorAll(":lang(cocoa-a, cocoa-a)").length', '0');
+    shouldBe('document.querySelectorAll(":lang(cocoa-1, cocoa-1)").length', '1');
+    shouldBe('document.querySelectorAll(":lang(cocoa-a, cocoa-a)").length', '1');
     shouldBe('document.querySelectorAll(":lang(cocoa-bar, cocoa-bar)").length', '0');
 
     debug('');

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-020-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-020-expected.html
@@ -8,4 +8,4 @@
 div.test { color: green; }
 </style>
 
-<div class="test">This should be green</div>
+<div class="test"><span lang="iw-ase-jpan-basiceng">This should be green</span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-singleton-subtag-matching-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-singleton-subtag-matching-expected.txt
@@ -1,0 +1,11 @@
+
+PASS :lang(fr-x) matches lang="fr-x" and lang="fr-x-xenomorph" (singleton "x" matches)
+PASS :lang(fr-x) matches the correct elements
+PASS :lang(fr-xenomorph) only matches lang="fr-xenomorph" (not lang="fr-x-xenomorph")
+PASS :lang(cocoa-1) matches lang="cocoa-1-bar" (singleton "1" matches)
+PASS :lang(cocoa-a) matches lang="cocoa-a-bar" (singleton "a" matches)
+PASS :lang(cocoa-bar) does not match lang="cocoa-1-bar" (cannot skip past singleton "1")
+PASS :lang(en-x) matches lang="en-x-private" (private-use singleton)
+PASS :lang(zh-x) matches both lang="zh-x" and lang="zh-x-foobar"
+PASS :lang(en-private) does not match lang="en-x-private" (cannot skip past singleton "x")
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-singleton-subtag-matching.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-singleton-subtag-matching.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>CSS Selectors 4 - :lang extended filtering with singleton subtags</title>
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#the-lang-pseudo">
+<link rel="help" href="https://www.rfc-editor.org/rfc/rfc4647#section-3.4">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+
+<div lang="fr-x"></div>
+<div lang="fr-x-xenomorph"></div>
+<div lang="fr-xenomorph"></div>
+<div lang="cocoa-1-bar"></div>
+<div lang="cocoa-a-bar"></div>
+<div lang="en-x-private"></div>
+<div lang="zh-x"></div>
+<div lang="zh-x-foobar"></div>
+
+<script>
+// Per RFC 4647 Section 3.4, singleton subtags (single-character subtags) in the
+// language tag should block *skipping* during extended filtering (step 3D), but
+// should NOT prevent *matching* when the range subtag equals the tag subtag (step 3C).
+
+test(function() {
+    assert_equals(document.querySelectorAll(':lang(fr-x)').length, 2);
+}, ':lang(fr-x) matches lang="fr-x" and lang="fr-x-xenomorph" (singleton "x" matches)');
+
+test(function() {
+    assert_equals(document.querySelectorAll(':lang(fr-x)').length, 2);
+    var matched = document.querySelectorAll(':lang(fr-x)');
+    assert_equals(matched[0].getAttribute('lang'), 'fr-x');
+    assert_equals(matched[1].getAttribute('lang'), 'fr-x-xenomorph');
+}, ':lang(fr-x) matches the correct elements');
+
+test(function() {
+    assert_equals(document.querySelectorAll(':lang(fr-xenomorph)').length, 1);
+}, ':lang(fr-xenomorph) only matches lang="fr-xenomorph" (not lang="fr-x-xenomorph")');
+
+test(function() {
+    assert_equals(document.querySelectorAll(':lang(cocoa-1)').length, 1);
+    assert_equals(document.querySelectorAll(':lang(cocoa-1)')[0].getAttribute('lang'), 'cocoa-1-bar');
+}, ':lang(cocoa-1) matches lang="cocoa-1-bar" (singleton "1" matches)');
+
+test(function() {
+    assert_equals(document.querySelectorAll(':lang(cocoa-a)').length, 1);
+    assert_equals(document.querySelectorAll(':lang(cocoa-a)')[0].getAttribute('lang'), 'cocoa-a-bar');
+}, ':lang(cocoa-a) matches lang="cocoa-a-bar" (singleton "a" matches)');
+
+test(function() {
+    assert_equals(document.querySelectorAll(':lang(cocoa-bar)').length, 0);
+}, ':lang(cocoa-bar) does not match lang="cocoa-1-bar" (cannot skip past singleton "1")');
+
+test(function() {
+    assert_equals(document.querySelectorAll(':lang(en-x)').length, 1);
+    assert_equals(document.querySelectorAll(':lang(en-x)')[0].getAttribute('lang'), 'en-x-private');
+}, ':lang(en-x) matches lang="en-x-private" (private-use singleton)');
+
+test(function() {
+    assert_equals(document.querySelectorAll(':lang(zh-x)').length, 2);
+}, ':lang(zh-x) matches both lang="zh-x" and lang="zh-x-foobar"');
+
+test(function() {
+    assert_equals(document.querySelectorAll(':lang(en-private)').length, 0);
+}, ':lang(en-private) does not match lang="en-x-private" (cannot skip past singleton "x")');
+</script>
+
+<div id="log"></div>
+
+</body>
+</html>

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -198,8 +198,8 @@ ALWAYS_INLINE bool containslanguageSubtagMatchingRange(StringView language, Stri
 
         StringView languageSubtag = language.substring(languageSubtagsStartIndex, languageSubtagsEndIndex - languageSubtagsStartIndex);
         bool isEqual = equalIgnoringASCIICase(range, languageSubtag);
-        if (!isAsteriskRange) {
-            if ((!isEqual && !languageSubtagsStartIndex) || (languageSubtag.length() == 1 && languageSubtagsStartIndex > 0))
+        if (!isAsteriskRange && !isEqual) {
+            if (!languageSubtagsStartIndex || (languageSubtag.length() == 1 && languageSubtagsStartIndex > 0))
                 return false;
         }
         languageSubtagsStartIndex = languageSubtagsEndIndex;
@@ -234,7 +234,7 @@ ALWAYS_INLINE bool matchesLangPseudoClass(const Element& element, const FixedVec
             continue;
         if (rangeStringView == "*"_s)
             return true;
-        if (equalIgnoringASCIICase(languageStringView, rangeStringView) && !languageStringView.contains('-'))
+        if (equalIgnoringASCIICase(languageStringView, rangeStringView))
             return true;
 
         unsigned rangeLength = rangeStringView.length();


### PR DESCRIPTION
#### 3bc1891c635ddd7ba6bdc716cdbe23c59149952f
<pre>
Improve `:lang()` matching: extend exact match fast path and fix singleton subtag handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=311316">https://bugs.webkit.org/show_bug.cgi?id=311316</a>

Reviewed by Anne van Kesteren.

Two improvements to `:lang()` pseudo-class matching:

1. The exact match fast path in `matchesLangPseudoClass()` was gated on
   `!languageStringView.contains(&apos;-&apos;)`, limiting it to simple tags like
   &quot;en&quot;. Exact case-insensitive equality always implies a successful
   match under both RFC 4647 basic and extended filtering, so the
   `contains(&apos;-&apos;)` check was unnecessarily forcing hyphenated tags like
   &quot;en-US&quot; matching `:lang(en-US)` through the slower subtag-by-subtag
   comparison.

2. Fix a bug in `containslanguageSubtagMatchingRange()` where singleton
   subtags (single-character subtags like &quot;x&quot; in &quot;fr-x&quot;) in the language
   tag were unconditionally treated as match barriers, even when the
   range subtag was identical. Per RFC 4647 Section 3.4, singletons
   should only block *skipping* (step 3D) but not *matching* (step 3C).
   This aligns our behavior with Chromium. For example, `:lang(fr-x)`
   now correctly matches `lang=&quot;fr-x&quot;` and `lang=&quot;fr-x-xenomorph&quot;`.

* LayoutTests/TestExpectations:
Unskip the following WPT tests that are now passing in WebKit:
- imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-017.html
- imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-018.html
Those tests were already passing in both Firefox and Chrome.

* LayoutTests/fast/selectors/lang-extended-filtering-expected.txt:
* LayoutTests/fast/selectors/lang-extended-filtering.html:
* LayoutTests/fast/selectors/lang-multiple-expected.txt:
* LayoutTests/fast/selectors/lang-multiple.html:
Update tests to reflect behavior change. I have verified that our new behavior
on these tests matches Chrome.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-020-expected.html:
Fix pre-existing test failure. The test checks that `:lang(&quot;iw&quot;)` matches
`lang=&quot;iw-ase-jpan-basiceng&quot;` by verifying the text renders green. The
expected file had the text directly in a `&lt;div&gt;`, while the test wraps it
in a `&lt;span&gt;` with the `lang` attribute. On macOS, the Hebrew language tag
causes different font selection, making the pixel comparison fail even
though the color was correct. Fix by adding the same `&lt;span lang&gt;` wrapper
to the expected file so font metrics match.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-singleton-subtag-matching-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/selectors-4/lang-singleton-subtag-matching.html: Added.
Add WPT test coverage. Chrome is passing this test while Firefox is failing
some subtests.

* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::containslanguageSubtagMatchingRange):
(WebCore::matchesLangPseudoClass):

Canonical link: <a href="https://commits.webkit.org/310436@main">https://commits.webkit.org/310436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cf256f3bbe71244f125f868b6f02fc167c13e63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162618 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aa69c95b-29b1-4b21-a7fc-8eed543e9588) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155740 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26973 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118968 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4f3765cd-2345-471f-a09e-b935d9afb09a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156826 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138163 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99678 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/91dbf78a-0ac0-44a9-82d6-5e727e12cf42) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10450 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129963 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16022 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165091 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8222 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127053 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26448 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22304 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127220 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34505 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26450 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137817 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83131 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22120 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14601 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26067 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/90355 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25758 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25918 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25818 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->