### PR TITLE
Inserting image with srcset into dynamically created iframe results in invisible image

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset-natural-size-in-dynamic-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset-natural-size-in-dynamic-iframe-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Image with srcset inserted into a dynamic iframe should have non-zero natural dimensions
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset-natural-size-in-dynamic-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset-natural-size-in-dynamic-iframe.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<title>Image with srcset in dynamically created iframe should have non-zero natural dimensions</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+async_test(t => {
+    const iframe = document.createElement('iframe');
+
+    iframe.onload = t.step_func(() => {
+        const doc = iframe.contentDocument;
+
+        doc.body.innerHTML = '<img srcset="/images/green-256x256.png 256w">';
+
+        const image = doc.querySelector('img');
+
+        image.onload = t.step_func_done(() => {
+            assert_greater_than(image.naturalWidth, 0, 'naturalWidth should be greater than 0');
+            assert_greater_than(image.naturalHeight, 0, 'naturalHeight should be greater than 0');
+        });
+
+        image.onerror = t.unreached_func('Image should load successfully');
+    });
+
+    document.body.appendChild(iframe);
+}, 'Image with srcset inserted into a dynamic iframe should have non-zero natural dimensions');
+</script>
+</body>

--- a/Source/WebCore/css/parser/SizesAttributeParser.cpp
+++ b/Source/WebCore/css/parser/SizesAttributeParser.cpp
@@ -62,19 +62,22 @@ SizesAttributeParser::SizesAttributeParser(const String& attribute, const Docume
         m_result = parse(CSSTokenizer(attribute).tokenRange(), CSSParserContext(document));
 }
 
-float SizesAttributeParser::effectiveSize()
+std::optional<float> SizesAttributeParser::effectiveSize()
 {
     if (m_result)
         return *m_result;
     return effectiveSizeDefaultValue();
 }
 
-float SizesAttributeParser::effectiveSizeDefaultValue()
+std::optional<float> SizesAttributeParser::effectiveSizeDefaultValue()
 {
     auto conversionData = this->conversionData();
     if (!conversionData)
-        return 0;
-    return CSS::clampToRange<CSS::Nonnegative, float>(Style::computeNonCalcLengthDouble(100.0, CSS::LengthUnit::Vw, *conversionData));
+        return std::nullopt;
+    auto result = CSS::clampToRange<CSS::Nonnegative, float>(Style::computeNonCalcLengthDouble(100.0, CSS::LengthUnit::Vw, *conversionData));
+    if (!result)
+        return std::nullopt;
+    return result;
 }
 
 std::optional<float> SizesAttributeParser::parse(CSSParserTokenRange tokens, const CSSParserContext& context)

--- a/Source/WebCore/css/parser/SizesAttributeParser.h
+++ b/Source/WebCore/css/parser/SizesAttributeParser.h
@@ -46,7 +46,7 @@ class SizesAttributeParser {
 public:
     SizesAttributeParser(const String&, const Document&);
 
-    float effectiveSize();
+    std::optional<float> effectiveSize();
     bool isAuto() const { return m_isAuto; }
 
     const Vector<MQ::MediaQueryResult>& dynamicMediaQueryResults() const LIFETIME_BOUND { return m_dynamicMediaQueryResults; }
@@ -61,7 +61,7 @@ private:
 
     const Document& document() const { return m_document.get(); }
     std::optional<CSSToLengthConversionData> conversionData() const;
-    float effectiveSizeDefaultValue();
+    std::optional<float> effectiveSizeDefaultValue();
 
     WeakRef<const Document, WeakPtrImplWithEventTargetData> m_document;
     Vector<MQ::MediaQueryResult> m_dynamicMediaQueryResults;

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -314,14 +314,11 @@ ImageCandidate HTMLImageElement::bestFitSourceFromPictureElement()
 
         m_dynamicMediaQueryResults.appendVector(sizesParser.dynamicMediaQueryResults());
 
-        float sourceSize;
+        auto sourceSize = sizesParser.effectiveSize();
         if (sizesParser.isAuto() && isLazyLoadable()) {
             if (auto layoutWidth = autoSizesLayoutWidth())
-                sourceSize = *layoutWidth;
-            else
-                sourceSize = sizesParser.effectiveSize();
-        } else
-            sourceSize = sizesParser.effectiveSize();
+                sourceSize = std::optional<float>(*layoutWidth);
+        }
 
         candidate = bestFitSourceForImageAttributes(document->deviceScaleFactor(), nullAtom(), srcset, sourceSize, [&](auto& candidate) {
             return m_imageLoader->shouldIgnoreCandidateWhenLoadingFromArchive(candidate);
@@ -382,14 +379,11 @@ void HTMLImageElement::selectImageSource(RelevantMutation relevantMutation)
             // If we don't have a <picture> or didn't find a source, then we use our own attributes.
             SizesAttributeParser sizesParser(attributeWithoutSynchronization(sizesAttr).string(), document.get());
             m_dynamicMediaQueryResults.appendVector(sizesParser.dynamicMediaQueryResults());
-            float sourceSize;
+            auto sourceSize = sizesParser.effectiveSize();
             if (sizesParser.isAuto() && isLazyLoadable()) {
                 if (auto layoutWidth = autoSizesLayoutWidth())
-                    sourceSize = *layoutWidth;
-                else
-                    sourceSize = sizesParser.effectiveSize();
-            } else
-                sourceSize = sizesParser.effectiveSize();
+                    sourceSize = std::optional<float>(*layoutWidth);
+            }
             candidate = bestFitSourceForImageAttributes(document->deviceScaleFactor(), srcAttribute, srcsetAttribute, sourceSize, [&](auto& candidate) {
                 return m_imageLoader->shouldIgnoreCandidateWhenLoadingFromArchive(candidate);
             });

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
@@ -257,7 +257,7 @@ String replaceURLsInSrcsetAttribute(const Element& element, StringView attribute
     return result.toString();
 }
 
-static ImageCandidate pickBestImageCandidate(float deviceScaleFactor, Vector<ImageCandidate>& imageCandidates, float sourceSize)
+static ImageCandidate pickBestImageCandidate(float deviceScaleFactor, Vector<ImageCandidate>& imageCandidates, std::optional<float> sourceSize)
 {
     bool ignoreSrc = false;
     if (imageCandidates.isEmpty())
@@ -266,7 +266,9 @@ static ImageCandidate pickBestImageCandidate(float deviceScaleFactor, Vector<Ima
     // http://picture.responsiveimages.org/#normalize-source-densities
     for (auto& candidate : imageCandidates) {
         if (candidate.resourceWidth > 0) {
-            candidate.density = static_cast<float>(candidate.resourceWidth) / sourceSize;
+            candidate.density = sourceSize
+                ? static_cast<float>(candidate.resourceWidth) / *sourceSize
+                : DefaultDensityValue;
             ignoreSrc = true;
         } else if (candidate.density < 0)
             candidate.density = DefaultDensityValue;
@@ -295,7 +297,7 @@ static ImageCandidate pickBestImageCandidate(float deviceScaleFactor, Vector<Ima
     return imageCandidates[winner];
 }
 
-ImageCandidate bestFitSourceForImageAttributes(float deviceScaleFactor, const AtomString& srcAttribute, StringView srcsetAttribute, float sourceSize, NOESCAPE const Function<bool(const ImageCandidate&)>& shouldIgnoreCandidateCallback)
+ImageCandidate bestFitSourceForImageAttributes(float deviceScaleFactor, const AtomString& srcAttribute, StringView srcsetAttribute, std::optional<float> sourceSize, NOESCAPE const Function<bool(const ImageCandidate&)>& shouldIgnoreCandidateCallback)
 {
     if (srcsetAttribute.isNull()) {
         if (srcAttribute.isNull())

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.h
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.h
@@ -109,7 +109,7 @@ struct ImageCandidate {
     OriginAttribute originAttribute;
 };
 
-ImageCandidate bestFitSourceForImageAttributes(float deviceScaleFactor, const AtomString& srcAttribute, StringView srcsetAttribute, float sourceSize, NOESCAPE const Function<bool(const ImageCandidate&)>& shouldIgnoreCandidateCallback = { });
+ImageCandidate bestFitSourceForImageAttributes(float deviceScaleFactor, const AtomString& srcAttribute, StringView srcsetAttribute, std::optional<float> sourceSize, NOESCAPE const Function<bool(const ImageCandidate&)>& shouldIgnoreCandidateCallback = { });
 
 Vector<ImageCandidate> parseImageCandidatesFromSrcsetAttribute(StringView attribute);
 void getURLsFromSrcsetAttribute(const Element&, StringView attribute, ListHashSet<URL>&);


### PR DESCRIPTION
#### 08819349134185ddd637e4a9e9a0d24ba660e316
<pre>
Inserting image with srcset into dynamically created iframe results in invisible image
<a href="https://bugs.webkit.org/show_bug.cgi?id=215375">https://bugs.webkit.org/show_bug.cgi?id=215375</a>
<a href="https://rdar.apple.com/66849050">rdar://66849050</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

When an &lt;img&gt; with srcset using width descriptors but no sizes attribute
is inserted into a dynamically created iframe, effectiveSizeDefaultValue()
returns 0 because 100vw cannot be computed before layout. This flows into
pickBestImageCandidate() where density = resourceWidth / 0 = +inf, then
imageDevicePixelRatio = 1/+inf = 0, making naturalWidth() return 0.

Fix by changing effectiveSize() to return std::optional&lt;float&gt; so callers
can distinguish &quot;viewport unavailable&quot; from a valid size of 0. When the
source size is nullopt, pickBestImageCandidate() uses DefaultDensityValue
(1.0) instead of dividing by zero.

* Source/WebCore/css/parser/SizesAttributeParser.cpp:
(WebCore::SizesAttributeParser::effectiveSize):
(WebCore::SizesAttributeParser::effectiveSizeDefaultValue):
* Source/WebCore/css/parser/SizesAttributeParser.h:
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::bestFitSourceFromPictureElement):
(WebCore::HTMLImageElement::selectImageSource):
* Source/WebCore/html/parser/HTMLSrcsetParser.cpp:
(WebCore::pickBestImageCandidate):
(WebCore::bestFitSourceForImageAttributes):
* Source/WebCore/html/parser/HTMLSrcsetParser.h:
(WebCore::bestFitSourceForImageAttributes):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset-natural-size-in-dynamic-iframe-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset-natural-size-in-dynamic-iframe.html: Added.

Canonical link: <a href="https://commits.webkit.org/310446@main">https://commits.webkit.org/310446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2da53b8c29ae46ec4d194ff9a2854d4ac5d4f8ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162582 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107292 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a0878982-cd1a-483d-be31-144c6200b06d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155704 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118937 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84095 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156790 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21204 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138129 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request; run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99647 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6b4fc021-35c1-4d68-9d4a-7177900ae4db) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20284 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18243 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10414 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129932 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165054 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8186 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17582 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127023 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26412 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22272 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127190 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34515 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26414 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137783 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83092 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22090 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14567 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26031 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90319 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25722 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25882 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25782 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->