### PR TITLE
[Site Isolation] Wheel events do not work in cross-origin frames on iOS

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2190,7 +2190,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     auto event = WebKit::WebIOSEventFactory::createWebWheelEvent(update, _contentView.get(), overridePhase);
 
     _wheelEventCountInCurrentScrollGesture++;
-    _page->dispatchWheelEventWithoutScrolling(event, [weakSelf = WeakObjCPtr<WKWebView>(self), strongCompletion = makeBlockPtr(completion), isCancelable, isHandledByDefault](bool defaultPrevented) {
+    _page->handleWheelEventWithoutScrolling(event, [weakSelf = WeakObjCPtr<WKWebView>(self), strongCompletion = makeBlockPtr(completion), isCancelable, isHandledByDefault](bool defaultPrevented) {
         RetainPtr strongSelf = weakSelf.get();
         if (!strongSelf) {
             if (isCancelable)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4366,13 +4366,33 @@ void WebPageProxy::flushPendingKeyEventCallbacks()
 }
 
 #if PLATFORM(IOS_FAMILY)
-void WebPageProxy::dispatchWheelEventWithoutScrolling(const WebWheelEvent& event, CompletionHandler<void(bool)>&& completionHandler)
+void WebPageProxy::handleWheelEventWithoutScrolling(const WebWheelEvent& event, CompletionHandler<void(bool)>&& completionHandler)
 {
     if (!m_mainFrame) {
         completionHandler(false);
         return;
     }
-    sendWithAsyncReply(Messages::WebPage::DispatchWheelEventWithoutScrolling(m_mainFrame->frameID(), event), WTF::move(completionHandler));
+    sendWheelEventWithoutScrolling(m_mainFrame->frameID(), event, WTF::move(completionHandler));
+}
+
+void WebPageProxy::sendWheelEventWithoutScrolling(WebCore::FrameIdentifier frameID, const WebWheelEvent& event, CompletionHandler<void(bool)>&& completionHandler)
+{
+    sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::DispatchWheelEventWithoutScrolling(frameID, event), [weakThis = WeakPtr { *this }, event, completionHandler = WTF::move(completionHandler)](bool defaultPrevented, std::optional<RemoteUserInputEventData> remoteWheelEventData) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis) {
+            completionHandler(false);
+            return;
+        }
+
+        if (remoteWheelEventData) {
+            auto transformedEvent = event;
+            transformedEvent.setPosition(roundedIntPoint(remoteWheelEventData->transformedPoint));
+            protectedThis->sendWheelEventWithoutScrolling(remoteWheelEventData->targetFrameID, transformedEvent, WTF::move(completionHandler));
+            return;
+        }
+
+        completionHandler(defaultPrevented);
+    });
 }
 #endif
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2556,7 +2556,8 @@ public:
     bool isServiceWorkerPage() const { return m_isServiceWorkerPage; }
 
 #if PLATFORM(IOS_FAMILY)
-    void dispatchWheelEventWithoutScrolling(const WebWheelEvent&, CompletionHandler<void(bool)>&&);
+    void handleWheelEventWithoutScrolling(const WebWheelEvent&, CompletionHandler<void(bool)>&&);
+    void sendWheelEventWithoutScrolling(WebCore::FrameIdentifier, const WebWheelEvent&, CompletionHandler<void(bool)>&&);
 #endif
 
 #if ENABLE(CONTEXT_MENUS) && ENABLE(IMAGE_ANALYSIS)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3927,18 +3927,19 @@ std::pair<HandleUserInputEventResult, OptionSet<EventHandling>> WebPage::wheelEv
 }
 
 #if PLATFORM(IOS_FAMILY)
-void WebPage::dispatchWheelEventWithoutScrolling(FrameIdentifier frameID, const WebWheelEvent& wheelEvent, CompletionHandler<void(bool)>&& completionHandler)
+void WebPage::dispatchWheelEventWithoutScrolling(FrameIdentifier frameID, const WebWheelEvent& wheelEvent, CompletionHandler<void(bool, std::optional<RemoteUserInputEventData>)>&& completionHandler)
 {
 #if ENABLE(KINETIC_SCROLLING)
-    RefPtr localMainFrame = this->localMainFrame();
-    auto gestureState =  localMainFrame ? localMainFrame->eventHandler().wheelScrollGestureState() : std::nullopt;
+    RefPtr frame = WebProcess::singleton().webFrame(frameID);
+    RefPtr localFrame = frame ? frame->coreLocalFrame() : nullptr;
+    auto gestureState = localFrame ? localFrame->eventHandler().wheelScrollGestureState() : std::nullopt;
     bool isCancelable = !gestureState || gestureState == WheelScrollGestureState::Blocking || wheelEvent.phase() == WebWheelEvent::Phase::Began;
 #else
     bool isCancelable = true;
 #endif
     auto [result, handling] = this->wheelEvent(frameID, wheelEvent, { isCancelable ? WheelEventProcessingSteps::BlockingDOMEventDispatch : WheelEventProcessingSteps::NonBlockingDOMEventDispatch });
     // The caller of dispatchWheelEventWithoutScrolling never cares about DidReceiveEvent being sent back.
-    completionHandler(result.wasHandled() && handling.contains(EventHandling::DefaultPrevented));
+    completionHandler(result.wasHandled() && handling.contains(EventHandling::DefaultPrevented), result.remoteUserInputEventData());
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1984,7 +1984,7 @@ public:
     void didAddOrRemoveViewportConstrainedObjects();
 
 #if PLATFORM(IOS_FAMILY)
-    void dispatchWheelEventWithoutScrolling(WebCore::FrameIdentifier, const WebWheelEvent&, CompletionHandler<void(bool)>&&);
+    void dispatchWheelEventWithoutScrolling(WebCore::FrameIdentifier, const WebWheelEvent&, CompletionHandler<void(bool, std::optional<WebCore::RemoteUserInputEventData>)>&&);
 #endif
 
 #if ENABLE(PDF_PLUGIN)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -796,7 +796,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     HandleWheelEvent(WebCore::FrameIdentifier frameID, WebKit::WebWheelEvent event, OptionSet<WebCore::WheelEventProcessingSteps> processingSteps, std::optional<bool> willStartSwipe) -> (std::optional<WebCore::ScrollingNodeID> scrollingNodeID, enum:uint8_t std::optional<WebCore::WheelScrollGestureState> gestureState, bool handled, struct std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData)
 
 #if PLATFORM(IOS_FAMILY)
-    DispatchWheelEventWithoutScrolling(WebCore::FrameIdentifier frameID, WebKit::WebWheelEvent event) -> (bool defaultPrevented)
+    DispatchWheelEventWithoutScrolling(WebCore::FrameIdentifier frameID, WebKit::WebWheelEvent event) -> (bool defaultPrevented, struct std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData)
 #endif
 
     LastNavigationWasAppInitiated() -> (bool wasAppBound)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewTests.mm
@@ -29,8 +29,10 @@
 
 #import "InstanceMethodSwizzler.h"
 #import "Helpers/PlatformUtilities.h"
+#import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/cocoa/TestCocoa.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"
+#import "Helpers/cocoa/TestUIDelegate.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import "UIKitSPIForTesting.h"
 #import "Helpers/ios/UserInterfaceSwizzler.h"
@@ -38,12 +40,16 @@
 #import <WebCore/ColorCocoa.h>
 #import <WebCore/ColorSerialization.h>
 #import <WebCore/WebEvent.h>
+#import <WebKit/WKFrameInfoPrivate.h>
 #import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/WKWebViewPrivateForTestingIOS.h>
 #import <WebKit/_WKFeature.h>
+#import <WebKit/_WKFrameTreeNode.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/darwin/DispatchExtras.h>
 
 constexpr CGFloat blackColorComponents[4] = { 0, 0, 0, 1 };
@@ -471,6 +477,222 @@ TEST(WKScrollViewTests, WheelEventDispatchedToSubframe)
     [webView synchronouslyHandleScrollEventWithPhase:WKBEScrollViewScrollUpdatePhaseBegan location:CGPointMake(100, 100) delta:CGVectorMake(0, 10)];
 #endif
     EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"window.subframeHit"] intValue]);
+}
+
+TEST(WKScrollViewTests, WheelEventDispatchedToCrossOriginSubframeWithSiteIsolation)
+{
+    using namespace TestWebKitAPI;
+
+    static const char* mainHTML = R"PAGEDATA(
+        <!DOCTYPE html>
+        <html>
+        <body style='margin: 0'>
+            <iframe id='subframe' src='https://webkit.org/webkit' style='width: 200px; height: 200px; border: none;'></iframe>
+        </body>
+        </html>
+        )PAGEDATA";
+
+    static const char* iframeHTML = R"PAGEDATA(
+        <style>body { margin: 0; padding: 0; }</style>
+        <div id='overflow' style='position: absolute; left: 20px; top: 20px; width: 160px; height: 160px; overflow: scroll;'>
+            <div style='width: 300px; height: 300px;'></div>
+        </div>
+        <script>
+            var activeData = null;
+            var passiveData = null;
+            var activeHandler = null;
+            var passiveHandler = null;
+            var currentTarget = null;
+
+            function serialize(e) {
+                return JSON.stringify({
+                    cancelable: e.cancelable,
+                    deltaX: e.deltaX, deltaY: e.deltaY, deltaZ: e.deltaZ, deltaMode: e.deltaMode,
+                    wheelDelta: e.wheelDelta, wheelDeltaX: e.wheelDeltaX, wheelDeltaY: e.wheelDeltaY,
+                    clientX: e.clientX, clientY: e.clientY, pageX: e.pageX, pageY: e.pageY,
+                    screenX: e.screenX, screenY: e.screenY,
+                    offsetX: e.offsetX, offsetY: e.offsetY,
+                    layerX: e.layerX, layerY: e.layerY,
+                    movementX: e.movementX, movementY: e.movementY,
+                    x: e.x, y: e.y,
+                    button: e.button, buttons: e.buttons,
+                    altKey: e.altKey, ctrlKey: e.ctrlKey, shiftKey: e.shiftKey, metaKey: e.metaKey,
+                    defaultPrevented: e.defaultPrevented,
+                    webkitForce: e.webkitForce,
+                    relatedTarget: e.relatedTarget
+                });
+            }
+
+            function addListeners(name, mode) {
+                activeData = null;
+                passiveData = null;
+                var t = name === 'window' ? window : name === 'body' ? document.body : name === 'document' ? document : document.getElementById('overflow');
+                currentTarget = t;
+                if (mode === 'active') {
+                    activeHandler = function(e) { e.preventDefault(); activeData = serialize(e); };
+                    t.addEventListener('wheel', activeHandler, { passive: false });
+                } else if (mode === 'setup') {
+                    activeHandler = function(e) { };
+                    t.addEventListener('wheel', activeHandler, { passive: false });
+                } else {
+                    passiveHandler = function(e) { e.preventDefault(); passiveData = serialize(e); };
+                    t.addEventListener('wheel', passiveHandler, { passive: true });
+                }
+            }
+
+            function removeListeners() {
+                currentTarget.removeEventListener('wheel', activeHandler, { passive: false });
+                currentTarget.removeEventListener('wheel', passiveHandler, { passive: true });
+                currentTarget = null;
+                activeHandler = null;
+                passiveHandler = null;
+            }
+
+            alert('loaded');
+        </script>
+        )PAGEDATA";
+
+    HTTPServer server({
+        { "/example"_s, { String::fromUTF8(mainHTML) } },
+        { "/webkit"_s, { String::fromUTF8(iframeHTML) } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto captureAttributes = [&](bool enableSiteIsolation) -> RetainPtr<NSMutableDictionary> {
+        auto configuration = server.httpsProxyConfiguration();
+        if (enableSiteIsolation) {
+            for (_WKFeature *feature in [WKPreferences _features]) {
+                if ([feature.key isEqualToString:@"SiteIsolationEnabled"]) {
+                    [configuration.preferences _setEnabled:YES forFeature:feature];
+                    break;
+                }
+            }
+        }
+
+        RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+        RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+        [navigationDelegate allowAnyTLSCertificate];
+        RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200) configuration:configuration]);
+        [webView setNavigationDelegate:navigationDelegate.get()];
+        [webView setUIDelegate:uiDelegate.get()];
+
+        [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+        EXPECT_WK_STREQ([uiDelegate waitForAlert], "loaded");
+
+        RetainPtr childFrame = [webView firstChildFrame];
+        EXPECT_TRUE(childFrame.get() != nil);
+
+        RetainPtr allResults = adoptNS([NSMutableDictionary new]);
+
+        for (NSString *target in @[@"window", @"body", @"document", @"element"]) {
+            [webView objectByEvaluatingJavaScript:[NSString stringWithFormat:@"addListeners('%@', 'active')", target] inFrame:childFrame.get()];
+            [webView waitForNextPresentationUpdate];
+
+            [webView synchronouslyHandleScrollEventWithPhase:WKBEScrollViewScrollUpdatePhaseBegan location:CGPointMake(50, 50) delta:CGVectorMake(0, 10)];
+
+            id activeResult = [webView objectByEvaluatingJavaScript:@"activeData" inFrame:childFrame.get()];
+            EXPECT_TRUE(activeResult != nil);
+            if (activeResult)
+                [allResults setObject:activeResult forKey:[NSString stringWithFormat:@"active_%@", target]];
+
+            [webView objectByEvaluatingJavaScript:@"removeListeners()" inFrame:childFrame.get()];
+            [webView waitForNextPresentationUpdate];
+
+            [webView synchronouslyHandleScrollEventWithPhase:WKBEScrollViewScrollUpdatePhaseEnded location:CGPointMake(50, 50) delta:CGVectorMake(0, 0)];
+            [webView waitForNextPresentationUpdate];
+
+            // Establish a NonBlocking gesture with a non-passive, non-preventing listener
+            // so that subsequent Changed events are correctly non-cancelable.
+            [webView objectByEvaluatingJavaScript:[NSString stringWithFormat:@"addListeners('%@', 'setup')", target] inFrame:childFrame.get()];
+            [webView waitForNextPresentationUpdate];
+
+            [webView synchronouslyHandleScrollEventWithPhase:WKBEScrollViewScrollUpdatePhaseBegan location:CGPointMake(50, 50) delta:CGVectorMake(0, 10)];
+
+            [webView objectByEvaluatingJavaScript:@"removeListeners()" inFrame:childFrame.get()];
+            [webView waitForNextPresentationUpdate];
+
+            [webView objectByEvaluatingJavaScript:[NSString stringWithFormat:@"addListeners('%@', 'passive')", target] inFrame:childFrame.get()];
+            [webView waitForNextPresentationUpdate];
+
+            [webView synchronouslyHandleScrollEventWithPhase:WKBEScrollViewScrollUpdatePhaseChanged location:CGPointMake(50, 50) delta:CGVectorMake(0, 10)];
+            // With only passive listeners, the scroll event completion is synchronous
+            // (isCancelable is false), so the event hasn't been dispatched to the
+            // iframe's web process yet. Wait for the main frame to forward it.
+            [webView waitForNextPresentationUpdate];
+
+            id passiveResult = [webView objectByEvaluatingJavaScript:@"passiveData" inFrame:childFrame.get()];
+            EXPECT_TRUE(passiveResult != nil);
+            if (passiveResult)
+                [allResults setObject:passiveResult forKey:[NSString stringWithFormat:@"passive_%@", target]];
+
+            [webView objectByEvaluatingJavaScript:@"removeListeners()" inFrame:childFrame.get()];
+            [webView waitForNextPresentationUpdate];
+
+            [webView synchronouslyHandleScrollEventWithPhase:WKBEScrollViewScrollUpdatePhaseEnded location:CGPointMake(50, 50) delta:CGVectorMake(0, 0)];
+        }
+
+        return allResults;
+    };
+
+    auto withSiteIsolation = captureAttributes(true);
+    auto withoutSiteIsolation = captureAttributes(false);
+
+    auto parseJSON = [](id jsonString) -> RetainPtr<NSDictionary> {
+        if (![jsonString isKindOfClass:[NSString class]])
+            return nil;
+        return [NSJSONSerialization JSONObjectWithData:[jsonString dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil];
+    };
+
+    auto checkCommonAttributes = [](NSDictionary *data) {
+        EXPECT_EQ([data[@"deltaX"] intValue], 0);
+        EXPECT_EQ([data[@"deltaY"] intValue], -10);
+        EXPECT_EQ([data[@"deltaZ"] intValue], 0);
+        EXPECT_EQ([data[@"deltaMode"] intValue], 0);
+        EXPECT_EQ([data[@"wheelDelta"] intValue], 30);
+        EXPECT_EQ([data[@"wheelDeltaX"] intValue], 0);
+        EXPECT_EQ([data[@"wheelDeltaY"] intValue], 30);
+        EXPECT_EQ([data[@"clientX"] intValue], 50);
+        EXPECT_EQ([data[@"clientY"] intValue], 50);
+        EXPECT_EQ([data[@"pageX"] intValue], 50);
+        EXPECT_EQ([data[@"pageY"] intValue], 50);
+        EXPECT_EQ([data[@"screenX"] intValue], 50);
+        EXPECT_EQ([data[@"screenY"] intValue], 50);
+        EXPECT_EQ([data[@"offsetX"] intValue], 30);
+        EXPECT_EQ([data[@"offsetY"] intValue], 30);
+        EXPECT_EQ([data[@"layerX"] intValue], 30);
+        EXPECT_EQ([data[@"layerY"] intValue], 30);
+        EXPECT_EQ([data[@"movementX"] intValue], 0);
+        EXPECT_EQ([data[@"movementY"] intValue], 0);
+        EXPECT_EQ([data[@"x"] intValue], 50);
+        EXPECT_EQ([data[@"y"] intValue], 50);
+        EXPECT_EQ([data[@"button"] intValue], 0);
+        EXPECT_EQ([data[@"buttons"] intValue], 0);
+        EXPECT_FALSE([data[@"altKey"] boolValue]);
+        EXPECT_FALSE([data[@"ctrlKey"] boolValue]);
+        EXPECT_FALSE([data[@"shiftKey"] boolValue]);
+        EXPECT_FALSE([data[@"metaKey"] boolValue]);
+        EXPECT_EQ([data[@"webkitForce"] intValue], 0);
+        EXPECT_TRUE([data[@"relatedTarget"] isEqual:[NSNull null]]);
+    };
+
+    for (NSString *target in @[@"window", @"body", @"document", @"element"]) {
+        RetainPtr activeKey = [NSString stringWithFormat:@"active_%@", target];
+        RetainPtr passiveKey = [NSString stringWithFormat:@"passive_%@", target];
+
+        RetainPtr activeData = parseJSON([withoutSiteIsolation objectForKey:activeKey.get()]);
+        RetainPtr passiveData = parseJSON([withoutSiteIsolation objectForKey:passiveKey.get()]);
+
+        checkCommonAttributes(activeData.get());
+        EXPECT_TRUE([activeData.get()[@"cancelable"] boolValue]);
+        EXPECT_TRUE([activeData.get()[@"defaultPrevented"] boolValue]);
+
+        checkCommonAttributes(passiveData.get());
+        EXPECT_FALSE([passiveData.get()[@"cancelable"] boolValue]);
+        EXPECT_FALSE([passiveData.get()[@"defaultPrevented"] boolValue]);
+
+        // Site isolation should produce identical results.
+        EXPECT_WK_STREQ([withSiteIsolation objectForKey:activeKey.get()], [withoutSiteIsolation objectForKey:activeKey.get()]);
+        EXPECT_WK_STREQ([withSiteIsolation objectForKey:passiveKey.get()], [withoutSiteIsolation objectForKey:passiveKey.get()]);
+    }
 }
 
 #endif // HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)


### PR DESCRIPTION
#### 4cc552537d0efc96cb658312eae77b0e7c19c295
<pre>
[Site Isolation] Wheel events do not work in cross-origin frames on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=311318">https://bugs.webkit.org/show_bug.cgi?id=311318</a>
<a href="https://rdar.apple.com/165811136">rdar://165811136</a>

Reviewed by Aditya Keerthi.

Treat wheel events like we treat other gesture-related events such as mouse events:
send IPC between the UI process and web process until we find a frame which is not
out-of-process.

Rename dispatchWheelEventWithoutScrolling to handleWheelEventWithoutScrolling to
better match existing `handle*` and `send*` patterns.

To ensure the `cancelable` property of wheel events is correct in cross origin
frames, base the gesture state inside `WebPage::dispatchWheelEventWithoutScrolling`
off of the local frame instead of the local main frame.

Test: Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView scrollView:handleScrollUpdate:completion:]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::handleWheelEventWithoutScrolling):
(WebKit::WebPageProxy::sendWheelEventWithoutScrolling):
(WebKit::WebPageProxy::dispatchWheelEventWithoutScrolling): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::dispatchWheelEventWithoutScrolling):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm:

Canonical link: <a href="https://commits.webkit.org/310858@main">https://commits.webkit.org/310858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ad34c966ed4c588c91d8245b03536767ab0a99e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155056 "10 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21475 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163816 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108527 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dbf9581b-573f-4ad3-87ac-792dbabe5a0f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156929 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119963 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84771 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1efaaa00-63fd-4599-aa54-3dbc96cc1546) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22232 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139244 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100656 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/08f9a22c-60e6-451b-ab04-2f45995f8978) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21317 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19351 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11642 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130979 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17087 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166292 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10197 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18696 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128066 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23390 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128204 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138880 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84493 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23657 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23083 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15753 "Too many flaky failures: http/tests/media/clearkey/collect-webkit-media-session.html, http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html, http/tests/navigation/redirect-to-random-url-versus-memory-cache.html, http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.html, http/tests/security/canvas-cors-with-two-hosts.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/report-blocked-data-uri.py, http/tests/security/mixedContent/redirect-https-to-http-image-secure-cookies-UpgradeMixedContent.html, http/tests/site-isolation/iframe-top-level-navigation.html, http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss-ephemeral.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27476 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91580 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27055 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27285 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27127 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->