### PR TITLE
WebRTCVideoDecoderVTB should support decoded frame reordering for H264 and H265

### DIFF
--- a/Source/WebCore/platform/graphics/MediaReorderQueue.h
+++ b/Source/WebCore/platform/graphics/MediaReorderQueue.h
@@ -34,7 +34,10 @@ namespace WebCore {
 template <class T, class Compare = std::less_equal<T>>
 class MediaReorderQueue {
 public:
-    MediaReorderQueue() = default;
+    explicit MediaReorderQueue(size_t reorderSize = 0)
+        : m_reorderSize(reorderSize)
+    {
+    }
 
     using ContainerType = Deque<T>;
     ContainerType::iterator begin() LIFETIME_BOUND { return m_queue.begin(); }

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTB.h
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTB.h
@@ -33,20 +33,17 @@
 
 namespace WebCore {
 
+class WebRTCVideoDecoderVTBQueue;
+
 class WebRTCVideoDecoderVTB : public WebRTCVideoDecoder {
 public:
-    ~WebRTCVideoDecoderVTB() = default;
+    ~WebRTCVideoDecoderVTB();
 
 protected:
-    WebRTCVideoDecoderVTB(VideoDecoderVTB::CallbackMultiImage&& callback)
-        : m_callback(WTF::move(callback))
-    {
-    }
-
-    static BlockPtr<void(OSStatus, VTDecodeInfoFlags, CVImageBufferRef pixelBuffer, CMTaggedBufferGroupRef, CMTime presentationTime, CMTime)> createMultiImageCallback(WebRTCVideoDecoderCallback);
+    explicit WebRTCVideoDecoderVTB(WebRTCVideoDecoderCallback);
 
     int32_t decodeFrameInternal(int64_t timeStamp, std::span<const uint8_t> data);
-    void setVideoFormat(RetainPtr<CMVideoFormatDescriptionRef>&&);
+    void setVideoFormat(RetainPtr<CMVideoFormatDescriptionRef>&&, uint8_t reorderSize = 0);
 
     uint16_t width() const { return m_width; }
     uint16_t height() const { return m_height; }
@@ -56,11 +53,13 @@ private:
     void setFormat(std::span<const uint8_t>, uint16_t width, uint16_t height) override;
     void setFrameSize(uint16_t width, uint16_t height) final;
 
+    BlockPtr<void(CVPixelBufferRef, int64_t, int64_t, bool)> m_callback;
     RetainPtr<CMVideoFormatDescriptionRef> m_format;
     RefPtr<VideoDecoderVTB> m_decoder;
-    const VideoDecoderVTB::CallbackMultiImage m_callback;
+    RefPtr<WebRTCVideoDecoderVTBQueue> m_queue;
     uint16_t m_width { 0 };
     uint16_t m_height { 0 };
+    uint8_t m_reorderSize { 0 };
 };
 
 }

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTB.mm
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTB.mm
@@ -28,6 +28,7 @@
 
 #if USE(LIBWEBRTC)
 
+#import "MediaReorderQueue.h"
 #import <WebCore/CMUtilities.h>
 
 #import "CoreVideoSoftLink.h"
@@ -62,6 +63,67 @@ static RetainPtr<CFDictionaryRef> createPixelBufferAttributes(CMVideoFormatDescr
     return adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, attributesSize, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
 }
 
+class WebRTCVideoDecoderVTBQueue : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebRTCVideoDecoderVTBQueue> {
+public:
+    static Ref<WebRTCVideoDecoderVTBQueue> create(uint8_t reorderSize) { return adoptRef(*new WebRTCVideoDecoderVTBQueue(reorderSize)); }
+    void setReorderSize(uint8_t);
+    uint8_t reorderSize() const;
+
+    struct Buffer {
+        RetainPtr<CVPixelBufferRef> frame;
+        int64_t timeStamp { 0 };
+    };
+    void add(Buffer&&, WebRTCVideoDecoderCallback);
+    void flush(WebRTCVideoDecoderCallback);
+
+private:
+    explicit WebRTCVideoDecoderVTBQueue(uint8_t reorderSize)
+        : m_queue(reorderSize)
+    {
+    }
+
+    struct BufferComparator {
+        bool operator()(const Buffer& a, const Buffer& b) const { return a.timeStamp <= b.timeStamp; }
+    };
+
+    mutable Lock m_lock;
+    MediaReorderQueue<Buffer, BufferComparator> m_queue WTF_GUARDED_BY_LOCK(m_lock);
+};
+
+WebRTCVideoDecoderVTB::WebRTCVideoDecoderVTB(WebRTCVideoDecoderCallback callback)
+    : m_callback(makeBlockPtr(callback))
+{
+}
+
+WebRTCVideoDecoderVTB::~WebRTCVideoDecoderVTB() = default;
+
+static VideoDecoderVTB::CallbackMultiImage createMultiImageCallback(WebRTCVideoDecoderCallback callback, RefPtr<WebRTCVideoDecoderVTBQueue>&& queue, uint8_t reorderSize)
+{
+    return makeBlockPtr([callback = makeBlockPtr(callback), queue = WTF::move(queue), reorderSize](OSStatus, VTDecodeInfoFlags, CVImageBufferRef pixelBuffer, CMTaggedBufferGroupRef, CMTime presentationTime, CMTime) mutable {
+        UNUSED_PARAM(reorderSize);
+        if (!pixelBuffer) {
+            callback(nil, 0, 0, false);
+            return;
+        }
+
+        if (!queue) {
+            callback((CVPixelBufferRef)pixelBuffer, presentationTime.value, 0, false);
+            return;
+        }
+
+        if (reorderSize != queue->reorderSize()) {
+            queue->flush(callback.get());
+            queue->setReorderSize(reorderSize);
+        }
+
+        if (!reorderSize) {
+            callback((CVPixelBufferRef)pixelBuffer, presentationTime.value, 0, false);
+            return;
+        }
+        queue->add({ (CVPixelBufferRef)pixelBuffer, presentationTime.value }, callback.get());
+    });
+}
+
 int32_t WebRTCVideoDecoderVTB::decodeFrameInternal(int64_t timeStamp, std::span<const uint8_t> data)
 {
     if (!m_format)
@@ -79,18 +141,23 @@ int32_t WebRTCVideoDecoderVTB::decodeFrameInternal(int64_t timeStamp, std::span<
 
     PAL::CMSampleBufferSetOutputPresentationTimeStamp(sample.get(), PAL::CMTimeMake(timeStamp, 1));
     VTDecodeInfoFlags decodeInfoFlags = kVTDecodeFrame_EnableAsynchronousDecompression;
-    protect(m_decoder)->decodeMultiImageFrame(sample.get(), decodeInfoFlags, makeBlockPtr(m_callback.get()));
+    protect(m_decoder)->decodeMultiImageFrame(sample.get(), decodeInfoFlags, createMultiImageCallback(m_callback.get(), m_queue.get(), m_reorderSize));
     return 0;
 }
 
-void WebRTCVideoDecoderVTB::setVideoFormat(RetainPtr<CMVideoFormatDescriptionRef>&& format)
+void WebRTCVideoDecoderVTB::setVideoFormat(RetainPtr<CMVideoFormatDescriptionRef>&& format, uint8_t reorderSize)
 {
     m_format = WTF::move(format);
+    m_reorderSize = reorderSize;
+    if (reorderSize && !m_queue)
+        m_queue = WebRTCVideoDecoderVTBQueue::create(reorderSize);
 }
 
 void WebRTCVideoDecoderVTB::flush()
 {
     protect(m_decoder)->flush();
+    if (RefPtr queue = m_queue)
+        queue->flush(m_callback.get());
 }
 
 void WebRTCVideoDecoderVTB::setFormat(std::span<const uint8_t>, uint16_t width, uint16_t height)
@@ -104,16 +171,43 @@ void WebRTCVideoDecoderVTB::setFrameSize(uint16_t width, uint16_t height)
     m_height = height;
 }
 
-BlockPtr<void(OSStatus, VTDecodeInfoFlags, CVImageBufferRef pixelBuffer, CMTaggedBufferGroupRef, CMTime presentationTime, CMTime)> WebRTCVideoDecoderVTB::createMultiImageCallback(WebRTCVideoDecoderCallback callback)
+uint8_t WebRTCVideoDecoderVTBQueue::reorderSize() const
 {
-    return makeBlockPtr([callback = makeBlockPtr(callback)](OSStatus, VTDecodeInfoFlags, CVImageBufferRef pixelBuffer, CMTaggedBufferGroupRef, CMTime presentationTime, CMTime) mutable {
-        if (!pixelBuffer) {
-            callback(nil, 0, 0, false);
-            return;
-        }
+    Locker lock(m_lock);
+    return m_queue.reorderSize();
+}
 
-        callback((CVPixelBufferRef)pixelBuffer, presentationTime.value, 0, false);
-    });
+void WebRTCVideoDecoderVTBQueue::setReorderSize(uint8_t size)
+{
+    Locker lock(m_lock);
+    m_queue.setReorderSize(size);
+}
+
+void WebRTCVideoDecoderVTBQueue::add(Buffer&& buffer, WebRTCVideoDecoderCallback callback)
+{
+    Locker lock(m_lock);
+
+    m_queue.append(WTF::move(buffer));
+
+    bool hasCalledCallback = false;
+    bool moreFramesAvailable;
+    while (auto buffer = m_queue.takeIfAvailable(moreFramesAvailable)) {
+        hasCalledCallback = true;
+        callback(buffer->frame.get(), buffer->timeStamp, 0, moreFramesAvailable);
+    }
+
+    if (!hasCalledCallback)
+        callback(nil, 0, 0, true);
+}
+
+void WebRTCVideoDecoderVTBQueue::flush(WebRTCVideoDecoderCallback callback)
+{
+    Locker lock(m_lock);
+
+    while (!m_queue.isEmpty()) {
+        auto buffer = m_queue.takeFirst();
+        callback(buffer.frame.get(), buffer.timeStamp, 0, true);
+    }
 }
 
 }

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBAV1.mm
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBAV1.mm
@@ -59,7 +59,7 @@ static RetainPtr<CMVideoFormatDescriptionRef> computeAV1InputFormat(std::span<co
 }
 
 WebRTCVideoDecoderVTBAV1::WebRTCVideoDecoderVTBAV1(WebRTCVideoDecoderCallback callback)
-    : WebRTCVideoDecoderVTB(createMultiImageCallback(WTF::move(callback)))
+    : WebRTCVideoDecoderVTB(callback)
 {
 }
 

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBVP9.mm
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBVP9.mm
@@ -58,7 +58,7 @@ static RetainPtr<CMVideoFormatDescriptionRef> createVP9FormatDescriptionFromData
 }
 
 WebRTCVideoDecoderVTBVP9::WebRTCVideoDecoderVTBVP9(WebRTCVideoDecoderCallback callback)
-    : WebRTCVideoDecoderVTB(createMultiImageCallback(WTF::move(callback)))
+    : WebRTCVideoDecoderVTB(callback)
 {
 }
 


### PR DESCRIPTION
#### b123243404df9c06163c76ca2746d74e5b1d08bc
<pre>
WebRTCVideoDecoderVTB should support decoded frame reordering for H264 and H265
<a href="https://rdar.apple.com/173915678">rdar://173915678</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311324">https://bugs.webkit.org/show_bug.cgi?id=311324</a>

Reviewed by Eric Carlson.

We introduce WebRTCVideoDecoderVTBQueue that implements frames reordering based on timestamps.
The reorderSize should be given at the time the format is given.

WebRTCVideoDecoderVTB::m_queue is manipulated in the thread the API is called.
A ref to m_queue is taken in the VTB callback.
When the callback is called, frames will be added/sorted by the queue.

In case of flush, the queue is cleared after having cleared the VTB callback.
This queue will be used by H264/H265 decoders when implemented.
For existing decoders (AV1 and VP9), this is a no-op as reordering size is always 0.

Canonical link: <a href="https://commits.webkit.org/310508@main">https://commits.webkit.org/310508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/642f99a13fd34629969ec39d4a8d55f93790964c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154059 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/27315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162811 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155932 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/27447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27167 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119147 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157018 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/27447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138343 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99847 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/27447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10644 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/27447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165284 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/8484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17795 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127238 "Passed tests") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/26862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22505 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127390 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34557 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/26785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137988 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/83364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/26785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14776 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/26476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/90568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/26057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/26287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/26129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->