### PR TITLE
[JSC] Add `ArrayLengthStore` IC for `JSArray` length assignment

### DIFF
--- a/JSTests/microbenchmarks/array-length-reset.js
+++ b/JSTests/microbenchmarks/array-length-reset.js
@@ -1,0 +1,13 @@
+function test() {
+    let a = [];
+    for (let i = 0; i < 1e6; ++i) {
+        a.push(1);
+        a.push(2);
+        a.push(3);
+        a.length = 0;
+    }
+    return a.length;
+}
+noInline(test);
+for (let i = 0; i < 5; ++i)
+    test();

--- a/JSTests/stress/array-length-store-ic-alternating.js
+++ b/JSTests/stress/array-length-store-ic-alternating.js
@@ -1,0 +1,26 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = [1, 2, 3, 4, 5];
+    f(a, i & 1 ? 2 : 7);
+    if (i & 1) {
+        shouldBe(a.length, 2);
+        shouldBe(a[2], undefined);
+    } else {
+        shouldBe(a.length, 7);
+        shouldBe(a[4], 5);
+        shouldBe(a[5], undefined);
+    }
+}

--- a/JSTests/stress/array-length-store-ic-array-storage.js
+++ b/JSTests/stress/array-length-store-ic-array-storage.js
@@ -1,0 +1,21 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = [1, 2, 3];
+    a[1000] = 9;
+    f(a, 1);
+    shouldBe(a.length, 1);
+    shouldBe(a[1000], undefined);
+}

--- a/JSTests/stress/array-length-store-ic-by-val.js
+++ b/JSTests/stress/array-length-store-ic-by-val.js
@@ -1,0 +1,20 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, k, n) { a[k] = n; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = [1, 2, 3, 4, 5];
+    f(a, "length", 2);
+    shouldBe(a.length, 2);
+    shouldBe(a[2], undefined);
+}

--- a/JSTests/stress/array-length-store-ic-contiguous.js
+++ b/JSTests/stress/array-length-store-ic-contiguous.js
@@ -1,0 +1,21 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = ["x", {}, "y", null, true];
+    f(a, 1);
+    shouldBe(a.length, 1);
+    shouldBe(a[0], "x");
+    shouldBe(a[1], undefined);
+}

--- a/JSTests/stress/array-length-store-ic-cow.js
+++ b/JSTests/stress/array-length-store-ic-cow.js
@@ -1,0 +1,26 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function mk() { return [1, 2, 3, 4, 5]; }
+noInline(mk);
+function f(a, n) { a.length = n; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = mk();
+    let b = mk();
+    f(a, 1);
+    shouldBe(a.length, 1);
+    shouldBe(a[1], undefined);
+    shouldBe(b.length, 5);
+    shouldBe(b[1], 2);
+    shouldBe(b[4], 5);
+}

--- a/JSTests/stress/array-length-store-ic-derived.js
+++ b/JSTests/stress/array-length-store-ic-derived.js
@@ -1,0 +1,21 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+class A extends Array {}
+function f(a, n) { a.length = n; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = new A(1, 2, 3);
+    f(a, 1);
+    shouldBe(a.length, 1);
+    shouldBe(a[1], undefined);
+}

--- a/JSTests/stress/array-length-store-ic-double.js
+++ b/JSTests/stress/array-length-store-ic-double.js
@@ -1,0 +1,22 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = [1.5, 2.5, 3.5, 4.5];
+    f(a, 1);
+    shouldBe(a.length, 1);
+    shouldBe(a[0], 1.5);
+    shouldBe(a[1], undefined);
+    shouldBe(a[3], undefined);
+}

--- a/JSTests/stress/array-length-store-ic-enumerate.js
+++ b/JSTests/stress/array-length-store-ic-enumerate.js
@@ -1,0 +1,25 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = [1, 2, 3, 4, 5];
+    f(a, 2);
+    let keys = Object.keys(a);
+    shouldBe(keys.length, 2);
+    shouldBe(keys[0], "0");
+    shouldBe(keys[1], "1");
+    let count = 0;
+    for (let k in a) count++;
+    shouldBe(count, 2);
+}

--- a/JSTests/stress/array-length-store-ic-grow.js
+++ b/JSTests/stress/array-length-store-ic-grow.js
@@ -1,0 +1,21 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = [1, 2];
+    f(a, 10);
+    shouldBe(a.length, 10);
+    shouldBe(a[1], 2);
+    shouldBe(a[5], undefined);
+}

--- a/JSTests/stress/array-length-store-ic-int32-holey.js
+++ b/JSTests/stress/array-length-store-ic-int32-holey.js
@@ -1,0 +1,22 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = [1, , 3, , 5];
+    f(a, 3);
+    shouldBe(a.length, 3);
+    shouldBe(a[1], undefined);
+    shouldBe(a[2], 3);
+    shouldBe(a[3], undefined);
+}

--- a/JSTests/stress/array-length-store-ic-int32-zero.js
+++ b/JSTests/stress/array-length-store-ic-int32-zero.js
@@ -1,0 +1,22 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a) { a.length = 0; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = [];
+    for (let j = 0; j < 10; ++j) a.push(j);
+    f(a);
+    shouldBe(a.length, 0);
+    shouldBe(a[0], undefined);
+    shouldBe(a[9], undefined);
+}

--- a/JSTests/stress/array-length-store-ic-int32.js
+++ b/JSTests/stress/array-length-store-ic-int32.js
@@ -1,0 +1,23 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = [1, 2, 3, 4, 5];
+    f(a, 2);
+    shouldBe(a.length, 2);
+    shouldBe(a[0], 1);
+    shouldBe(a[1], 2);
+    shouldBe(a[2], undefined);
+    shouldBe(a[4], undefined);
+}

--- a/JSTests/stress/array-length-store-ic-large-shrink.js
+++ b/JSTests/stress/array-length-store-ic-large-shrink.js
@@ -1,0 +1,26 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = [];
+    for (let j = 0; j < 100; ++j) a.push(j);
+    f(a, 50);
+    shouldBe(a.length, 50);
+    shouldBe(a[49], 49);
+    shouldBe(a[50], undefined);
+    shouldBe(a[99], undefined);
+    a.push(777);
+    shouldBe(a[50], 777);
+    shouldBe(a.length, 51);
+}

--- a/JSTests/stress/array-length-store-ic-late-freeze.js
+++ b/JSTests/stress/array-length-store-ic-late-freeze.js
@@ -1,0 +1,33 @@
+"use strict";
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = [1, 2, 3, 4, 5];
+    f(a, 2);
+    shouldBe(a.length, 2);
+}
+
+let arr = [1, 2, 3];
+Object.defineProperty(arr, "length", { writable: false });
+shouldThrow(() => f(arr, 1), TypeError);
+shouldBe(arr.length, 3);
+shouldBe(arr[0], 1);
+shouldBe(arr[2], 3);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldThrow(() => f(arr, 1), TypeError);
+    shouldBe(arr.length, 3);
+}

--- a/JSTests/stress/array-length-store-ic-negative.js
+++ b/JSTests/stress/array-length-store-ic-negative.js
@@ -1,0 +1,20 @@
+"use strict";
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = [1, 2, 3];
+    shouldThrow(() => f(a, -1), RangeError);
+    shouldBe(a.length, 3);
+}

--- a/JSTests/stress/array-length-store-ic-non-integer.js
+++ b/JSTests/stress/array-length-store-ic-non-integer.js
@@ -1,0 +1,20 @@
+"use strict";
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = [1, 2, 3];
+    shouldThrow(() => f(a, 1.5), RangeError);
+    shouldBe(a.length, 3);
+}

--- a/JSTests/stress/array-length-store-ic-noop.js
+++ b/JSTests/stress/array-length-store-ic-noop.js
@@ -1,0 +1,20 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = [1, 2, 3];
+    f(a, 3);
+    shouldBe(a.length, 3);
+    shouldBe(a[2], 3);
+}

--- a/JSTests/stress/array-length-store-ic-polymorphic.js
+++ b/JSTests/stress/array-length-store-ic-polymorphic.js
@@ -1,0 +1,22 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n) { a.length = n; return a.length; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) f([1, 2, 3, 4, 5], 2);
+for (let i = 0; i < testLoopCount; ++i) {
+    let which = i & 3;
+    if (which === 0) shouldBe(f([1, 2, 3, 4, 5], 2), 2);
+    else if (which === 1) shouldBe(f([1.1, 2.2, 3.3], 1), 1);
+    else if (which === 2) shouldBe(f({ length: 9 }, 3), 3);
+    else { let a = [1, 2, 3]; a[100] = 7; shouldBe(f(a, 2), 2); }
+}

--- a/JSTests/stress/array-length-store-ic-proto.js
+++ b/JSTests/stress/array-length-store-ic-proto.js
@@ -1,0 +1,22 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(o, n) { o.length = n; }
+noInline(f);
+let proto = [1, 2, 3, 4, 5];
+for (let i = 0; i < testLoopCount; ++i) f([1, 2, 3], 1);
+for (let i = 0; i < testLoopCount; ++i) {
+    let o = Object.create(proto);
+    f(o, 2);
+    shouldBe(o.length, 2);
+    shouldBe(proto.length, 5);
+}

--- a/JSTests/stress/array-length-store-ic-push-reset-cycle.js
+++ b/JSTests/stress/array-length-store-ic-push-reset-cycle.js
@@ -1,0 +1,22 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a) { a.length = 0; }
+noInline(f);
+let a = [];
+for (let i = 0; i < testLoopCount; ++i) {
+    for (let j = 0; j < 8; ++j) a.push(j);
+    f(a);
+    shouldBe(a.length, 0);
+    shouldBe(a[0], undefined);
+    shouldBe(a[7], undefined);
+}

--- a/JSTests/stress/array-length-store-ic-reflect-receiver.js
+++ b/JSTests/stress/array-length-store-ic-reflect-receiver.js
@@ -1,0 +1,21 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n, r) { return Reflect.set(a, "length", n, r); }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = [1, 2, 3];
+    let r = {};
+    shouldBe(f(a, 1, r), true);
+    shouldBe(a.length, 3);
+    shouldBe(r.length, 1);
+}

--- a/JSTests/stress/array-length-store-ic-string-value.js
+++ b/JSTests/stress/array-length-store-ic-string-value.js
@@ -1,0 +1,20 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = [1, 2, 3];
+    f(a, "2");
+    shouldBe(a.length, 2);
+    shouldBe(a[2], undefined);
+}

--- a/JSTests/stress/array-length-store-ic-uint32max.js
+++ b/JSTests/stress/array-length-store-ic-uint32max.js
@@ -1,0 +1,22 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = [1, 2, 3];
+    f(a, 2);
+    shouldBe(a.length, 2);
+}
+let a = [1, 2, 3];
+f(a, 4294967295);
+shouldBe(a.length, 4294967295);

--- a/JSTests/stress/array-length-store-ic-undecided.js
+++ b/JSTests/stress/array-length-store-ic-undecided.js
@@ -1,0 +1,20 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = new Array(5);
+    f(a, 2);
+    shouldBe(a.length, 2);
+    shouldBe(a[0], undefined);
+}

--- a/JSTests/stress/array-length-store-ic-valueof.js
+++ b/JSTests/stress/array-length-store-ic-valueof.js
@@ -1,0 +1,22 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = [1, 2, 3, 4, 5];
+    let count = 0;
+    let obj = { valueOf() { count++; return 2; } };
+    f(a, obj);
+    shouldBe(a.length, 2);
+    shouldBe(count, 2);
+}

--- a/JSTests/stress/array-length-store-ic-very-large-shrink.js
+++ b/JSTests/stress/array-length-store-ic-very-large-shrink.js
@@ -1,0 +1,23 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = [];
+    for (let j = 0; j < 500; ++j) a.push(j);
+    f(a, 10);
+    shouldBe(a.length, 10);
+    shouldBe(a[9], 9);
+    shouldBe(a[10], undefined);
+    shouldBe(a[499], undefined);
+}

--- a/JSTests/stress/array-length-store-ic-warm-then-freeze-sloppy.js
+++ b/JSTests/stress/array-length-store-ic-warm-then-freeze-sloppy.js
@@ -1,0 +1,30 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+
+let arr = [10, 20, 30, 40, 50];
+for (let i = 0; i < testLoopCount; ++i) f(arr, 5);
+shouldBe(arr.length, 5);
+
+Object.defineProperty(arr, "length", { writable: false });
+
+f(arr, 1);
+shouldBe(arr.length, 5);
+shouldBe(arr[0], 10);
+shouldBe(arr[4], 50);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    f(arr, 1);
+    shouldBe(arr.length, 5);
+}

--- a/JSTests/stress/array-length-store-ic-warm-then-freeze-strict.js
+++ b/JSTests/stress/array-length-store-ic-warm-then-freeze-strict.js
@@ -1,0 +1,31 @@
+"use strict";
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = null;
+    try { func(); } catch (e) { threw = e; }
+    if (!threw || threw.constructor !== errorType)
+        throw new Error("expected " + errorType.name + ", got " + threw);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+
+let arr = [10, 20, 30, 40, 50];
+for (let i = 0; i < testLoopCount; ++i) f(arr, 5);
+shouldBe(arr.length, 5);
+
+Object.defineProperty(arr, "length", { writable: false });
+
+shouldThrow(() => f(arr, 1), TypeError);
+shouldBe(arr.length, 5);
+shouldBe(arr[0], 10);
+shouldBe(arr[4], 50);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldThrow(() => f(arr, 1), TypeError);
+    shouldBe(arr.length, 5);
+}

--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -81,6 +81,7 @@ Ref<AccessCase> AccessCase::create(VM& vm, JSCell* owner, AccessType type, Cache
     case ScopedArgumentsLength:
     case RegExpLastIndexLoad:
     case RegExpLastIndexStore:
+    case ArrayLengthStore:
     case ModuleNamespaceLoad:
     case Replace:
     case ProxyObjectIn:
@@ -383,6 +384,7 @@ bool AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck() const
     case ScopedArgumentsLength:
     case RegExpLastIndexLoad:
     case RegExpLastIndexStore:
+    case ArrayLengthStore:
     case ModuleNamespaceLoad:
     case ProxyObjectIn:
     case ProxyObjectLoad:
@@ -547,6 +549,7 @@ bool AccessCase::requiresIdentifierNameMatch() const
     case ScopedArgumentsLength:
     case RegExpLastIndexLoad:
     case RegExpLastIndexStore:
+    case ArrayLengthStore:
     case ModuleNamespaceLoad:
     case ProxyObjectIn:
     case ProxyObjectLoad:
@@ -693,6 +696,7 @@ bool AccessCase::requiresInt32PropertyCheck() const
     case ScopedArgumentsLength:
     case RegExpLastIndexLoad:
     case RegExpLastIndexStore:
+    case ArrayLengthStore:
     case ModuleNamespaceLoad:
     case ProxyObjectIn:
     case ProxyObjectLoad:
@@ -875,6 +879,7 @@ void AccessCase::forEachDependentCell(VM&, const Functor& functor) const
     case ScopedArgumentsLength:
     case RegExpLastIndexLoad:
     case RegExpLastIndexStore:
+    case ArrayLengthStore:
     case ProxyObjectIn:
     case ProxyObjectLoad:
     case ProxyObjectStore:
@@ -1034,6 +1039,7 @@ bool AccessCase::doesCalls(VM&) const
     case ScopedArgumentsLength:
     case RegExpLastIndexLoad:
     case RegExpLastIndexStore:
+    case ArrayLengthStore:
     case ModuleNamespaceLoad:
     case InstanceOfHit:
     case InstanceOfMiss:
@@ -1203,6 +1209,7 @@ bool AccessCase::canReplace(const AccessCase& other) const
     case ScopedArgumentsLength:
     case RegExpLastIndexLoad:
     case RegExpLastIndexStore:
+    case ArrayLengthStore:
     case IndexedScopedArgumentsLoad:
     case IndexedDirectArgumentsLoad:
     case IndexedTypedArrayInt8Load:
@@ -1472,6 +1479,7 @@ inline void AccessCase::runWithDowncast(const Func& func)
     case ScopedArgumentsLength:
     case RegExpLastIndexLoad:
     case RegExpLastIndexStore:
+    case ArrayLengthStore:
     case CheckPrivateBrand:
     case SetPrivateBrand:
     case IndexedMegamorphicLoad:
@@ -1674,6 +1682,7 @@ bool AccessCase::canBeShared(const AccessCase& lhs, const AccessCase& rhs)
     case ScopedArgumentsLength:
     case RegExpLastIndexLoad:
     case RegExpLastIndexStore:
+    case ArrayLengthStore:
     case CheckPrivateBrand:
     case SetPrivateBrand:
     case IndexedMegamorphicLoad:

--- a/Source/JavaScriptCore/bytecode/AccessCase.h
+++ b/Source/JavaScriptCore/bytecode/AccessCase.h
@@ -81,6 +81,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AccessCase);
     macro(ScopedArgumentsLength) \
     macro(RegExpLastIndexLoad) \
     macro(RegExpLastIndexStore) \
+    macro(ArrayLengthStore) \
     macro(ModuleNamespaceLoad) \
     macro(ProxyObjectIn) \
     macro(ProxyObjectLoad) \

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -260,6 +260,7 @@ static bool NODELETE needsScratchFPR(AccessCase::AccessType type)
     case AccessCase::ScopedArgumentsLength:
     case AccessCase::RegExpLastIndexLoad:
     case AccessCase::RegExpLastIndexStore:
+    case AccessCase::ArrayLengthStore:
     case AccessCase::ModuleNamespaceLoad:
     case AccessCase::ProxyObjectIn:
     case AccessCase::ProxyObjectLoad:
@@ -397,6 +398,7 @@ static bool NODELETE forInBy(AccessCase::AccessType type)
     case AccessCase::ScopedArgumentsLength:
     case AccessCase::RegExpLastIndexLoad:
     case AccessCase::RegExpLastIndexStore:
+    case AccessCase::ArrayLengthStore:
     case AccessCase::CheckPrivateBrand:
     case AccessCase::SetPrivateBrand:
     case AccessCase::IndexedMegamorphicLoad:
@@ -582,6 +584,7 @@ static bool NODELETE isStateless(AccessCase::AccessType type)
     case AccessCase::ScopedArgumentsLength:
     case AccessCase::RegExpLastIndexLoad:
     case AccessCase::RegExpLastIndexStore:
+    case AccessCase::ArrayLengthStore:
     case AccessCase::IndexedProxyObjectLoad:
     case AccessCase::IndexedMegamorphicLoad:
     case AccessCase::IndexedMegamorphicStore:
@@ -734,6 +737,7 @@ bool NODELETE doesJSCalls(AccessCase::AccessType type)
     case AccessCase::ScopedArgumentsLength:
     case AccessCase::RegExpLastIndexLoad:
     case AccessCase::RegExpLastIndexStore:
+    case AccessCase::ArrayLengthStore:
     case AccessCase::IndexedMegamorphicLoad:
     case AccessCase::IndexedMegamorphicStore:
     case AccessCase::IndexedInt32Load:
@@ -887,6 +891,7 @@ static bool NODELETE isMegamorphic(AccessCase::AccessType type)
     case AccessCase::ScopedArgumentsLength:
     case AccessCase::RegExpLastIndexLoad:
     case AccessCase::RegExpLastIndexStore:
+    case AccessCase::ArrayLengthStore:
     case AccessCase::IndexedInt32Load:
     case AccessCase::IndexedDoubleLoad:
     case AccessCase::IndexedContiguousLoad:
@@ -1030,6 +1035,7 @@ bool canBeViaGlobalProxy(AccessCase::AccessType type)
     case AccessCase::ScopedArgumentsLength:
     case AccessCase::RegExpLastIndexLoad:
     case AccessCase::RegExpLastIndexStore:
+    case AccessCase::ArrayLengthStore:
     case AccessCase::IndexedMegamorphicLoad:
     case AccessCase::IndexedMegamorphicStore:
     case AccessCase::IndexedInt32Load:
@@ -2020,6 +2026,49 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
         fallThrough.append(jit.branchIfNotType(baseGPR, RegExpObjectType));
         jit.loadValue(CCallHelpers::Address(baseGPR, RegExpObject::offsetOfLastIndex()), valueRegs);
         succeed();
+        return;
+    }
+
+    case AccessCase::ArrayLengthStore: {
+        ASSERT(!accessCase.viaGlobalProxy());
+
+        // FIXME: Support DoubleShape by clearing with PNaN instead of empty JSValue.
+        jit.load8(CCallHelpers::Address(baseGPR, JSCell::indexingTypeAndMiscOffset()), scratchGPR);
+        jit.and32(CCallHelpers::TrustedImm32(IndexingModeMask), scratchGPR);
+        auto isInt32 = jit.branch32(CCallHelpers::Equal, scratchGPR, CCallHelpers::TrustedImm32(IsArray | Int32Shape));
+        fallThrough.append(jit.branch32(CCallHelpers::NotEqual, scratchGPR, CCallHelpers::TrustedImm32(IsArray | ContiguousShape)));
+        isInt32.link(&jit);
+
+        m_failAndIgnore.append(jit.branchIfNotInt32(valueRegs));
+
+        auto allocator = makeDefaultScratchAllocator(scratchGPR);
+        GPRReg scratch2GPR = allocator.allocateScratchGPR();
+        ScratchRegisterAllocator::PreservedState preservedState = allocator.preserveReusedRegistersByPushing(jit, ScratchRegisterAllocator::ExtraStackSpace::NoExtraSpace);
+
+        CCallHelpers::JumpList failAndIgnore;
+
+        jit.loadPtr(CCallHelpers::Address(baseGPR, JSObject::butterflyOffset()), scratchGPR);
+        jit.load32(CCallHelpers::Address(scratchGPR, Butterfly::offsetOfPublicLength()), scratch2GPR);
+        failAndIgnore.append(jit.branch32(CCallHelpers::Above, valueRegs.payloadGPR(), scratch2GPR));
+
+        auto loopStart = jit.label();
+        auto loopDone = jit.branch32(CCallHelpers::BelowOrEqual, scratch2GPR, valueRegs.payloadGPR());
+        jit.sub32(CCallHelpers::TrustedImm32(1), scratch2GPR);
+        jit.storeTrustedValue(JSValue(), CCallHelpers::BaseIndex(scratchGPR, scratch2GPR, CCallHelpers::TimesEight));
+        jit.jump().linkTo(loopStart, &jit);
+        loopDone.link(&jit);
+
+        jit.store32(valueRegs.payloadGPR(), CCallHelpers::Address(scratchGPR, Butterfly::offsetOfPublicLength()));
+
+        allocator.restoreReusedRegistersByPopping(jit, preservedState);
+        succeed();
+
+        if (allocator.didReuseRegisters()) {
+            failAndIgnore.link(&jit);
+            allocator.restoreReusedRegistersByPopping(jit, preservedState);
+            m_failAndIgnore.append(jit.jump());
+        } else
+            m_failAndIgnore.append(failAndIgnore);
         return;
     }
 
@@ -3944,6 +3993,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
     case AccessCase::ScopedArgumentsLength:
     case AccessCase::RegExpLastIndexLoad:
     case AccessCase::RegExpLastIndexStore:
+    case AccessCase::ArrayLengthStore:
     case AccessCase::ModuleNamespaceLoad:
     case AccessCase::ProxyObjectIn:
     case AccessCase::ProxyObjectLoad:

--- a/Source/JavaScriptCore/bytecode/PutByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/PutByStatus.cpp
@@ -313,6 +313,7 @@ PutByStatus PutByStatus::computeForPropertyInlineCache
             case AccessCase::CustomValueSetter:
                 return PutByStatus(MakesCalls);
 
+            // FIXME: Handle ArrayLengthStore and RegExpLastIndexStore explicitly instead of falling through to default.
             default:
                 return PutByStatus(JSC::slowVersion(summary), *propertyCache);
             }

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -1053,8 +1053,18 @@ static InlineCacheAction tryCachePutBy(JSGlobalObject* globalObject, CodeBlock* 
 
         JSCell* baseCell = baseValue.asCell();
 
+        RefPtr<AccessCase> newCase;
+
+        if (propertyName == vm.propertyNames->length) {
+            if (baseCell->type() == ArrayType)
+                newCase = AccessCase::create(vm, codeBlock, AccessCase::ArrayLengthStore, propertyName);
+        } else if (propertyName == vm.propertyNames->lastIndex) {
+            if (jsDynamicCast<RegExpObject*>(baseCell))
+                newCase = AccessCase::create(vm, codeBlock, AccessCase::RegExpLastIndexStore, propertyName);
+        }
+
         bool isProxyObject = baseCell->type() == ProxyObjectType;
-        if (!isProxyObject) {
+        if (!newCase && !isProxyObject) {
             if (!slot.isCacheablePut() && !slot.isCacheableCustom() && !slot.isCacheableSetter())
                 return GiveUpOnCache;
 
@@ -1101,13 +1111,6 @@ static InlineCacheAction tryCachePutBy(JSGlobalObject* globalObject, CodeBlock* 
             case PutByKind::ByValDirectSloppy:
                 break;
             }
-        }
-
-        RefPtr<AccessCase> newCase;
-
-        if (propertyName == vm.propertyNames->lastIndex) {
-            if (jsDynamicCast<RegExpObject*>(baseCell))
-                newCase = AccessCase::create(vm, codeBlock, AccessCase::RegExpLastIndexStore, propertyName);
         }
 
         if (!newCase && slot.base() == baseValue && slot.isCacheablePut()) {
@@ -1209,7 +1212,7 @@ static InlineCacheAction tryCachePutBy(JSGlobalObject* globalObject, CodeBlock* 
 
                 newCase = AccessCase::createTransition(vm, codeBlock, propertyName, offset, oldStructure, newStructure, conditionSet, WTF::move(prototypeAccessChain), propertyCache);
             }
-        } else if (slot.isCacheableCustom() || slot.isCacheableSetter()) {
+        } else if (!newCase && (slot.isCacheableCustom() || slot.isCacheableSetter())) {
             if (slot.isCacheableCustom()) {
                 ObjectPropertyConditionSet conditionSet;
                 RefPtr<PolyProtoAccessChain> prototypeAccessChain;

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2330,6 +2330,8 @@ private:
                     speculateForBarrier(node->child2());
                     break;
                 }
+
+                // FIXME: Convert PutById(length) on Array to a dedicated node, similar to GetArrayLength.
             }
             
             fixEdge<CellUse>(node->child1());

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -259,7 +259,7 @@ bool JSArray::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName prope
         RETURN_IF_EXCEPTION(scope, false);
         double valueAsNumber = value.toNumber(globalObject);
         RETURN_IF_EXCEPTION(scope, false);
-        if (valueAsNumber != static_cast<double>(newLength)) {
+        if (valueAsNumber != static_cast<double>(newLength)) [[unlikely]] {
             throwException(globalObject, scope, createRangeError(globalObject, "Invalid array length"_s));
             return false;
         }


### PR DESCRIPTION
#### da43fc766f600451e7ea3e56c8491440e7635c18
<pre>
[JSC] Add `ArrayLengthStore` IC for `JSArray` length assignment
<a href="https://bugs.webkit.org/show_bug.cgi?id=311326">https://bugs.webkit.org/show_bug.cgi?id=311326</a>

Reviewed by Yusuke Suzuki.

JSArray::put left PutPropertySlot uncacheable when handling the length
property, so tryCachePutBy gave up immediately and every arr.length = N
went through operationPutByIdStrictGaveUp. This is hot in workloads that
reuse arrays via the push-then-reset idiom.

This patch marks the slot as a cacheable custom value and adds
AccessCase::ArrayLengthStore, which emits an inline stub that handles the
common shrink case (Int32Shape or ContiguousShape, non-negative int32
newLength &lt;= publicLength) by clearing the tail in place and updating
publicLength, with all other cases falling back to the slow path.

FTL:

                            TipOfTree                  Patched

array-length-reset       53.8298+-1.0723     ^     12.5104+-0.9437        ^ definitely 4.3028x faster

DFG:
                            TipOfTree                  Patched

array-length-reset       53.6773+-1.5016     ^     15.2961+-0.2704        ^ definitely 3.5092x faster

Baseline JIT:
                            TipOfTree                  Patched

array-length-reset      108.8065+-2.9597     ^     70.1085+-1.7622        ^ definitely 1.5520x faster

Tests: JSTests/microbenchmarks/array-length-reset.js
       JSTests/stress/array-length-store-ic-alternating.js
       JSTests/stress/array-length-store-ic-array-storage.js
       JSTests/stress/array-length-store-ic-by-val.js
       JSTests/stress/array-length-store-ic-contiguous.js
       JSTests/stress/array-length-store-ic-cow.js
       JSTests/stress/array-length-store-ic-derived.js
       JSTests/stress/array-length-store-ic-double.js
       JSTests/stress/array-length-store-ic-enumerate.js
       JSTests/stress/array-length-store-ic-frozen-sloppy.js
       JSTests/stress/array-length-store-ic-grow.js
       JSTests/stress/array-length-store-ic-int32-holey.js
       JSTests/stress/array-length-store-ic-int32-zero.js
       JSTests/stress/array-length-store-ic-int32.js
       JSTests/stress/array-length-store-ic-large-shrink.js
       JSTests/stress/array-length-store-ic-negative.js
       JSTests/stress/array-length-store-ic-non-integer.js
       JSTests/stress/array-length-store-ic-noop.js
       JSTests/stress/array-length-store-ic-polymorphic.js
       JSTests/stress/array-length-store-ic-proto.js
       JSTests/stress/array-length-store-ic-push-reset-cycle.js
       JSTests/stress/array-length-store-ic-reflect-receiver.js
       JSTests/stress/array-length-store-ic-string-value.js
       JSTests/stress/array-length-store-ic-uint32max.js
       JSTests/stress/array-length-store-ic-undecided.js
       JSTests/stress/array-length-store-ic-valueof.js
       JSTests/stress/array-length-store-ic-very-large-shrink.js
       JSTests/stress/array-length-store-ic-warm-then-freeze.js

* JSTests/microbenchmarks/array-length-reset.js: Added.
(test):
* JSTests/stress/array-length-store-ic-alternating.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-array-storage.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-by-val.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-contiguous.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-cow.js: Added.
(shouldBe):
(shouldThrow):
(mk):
(f):
* JSTests/stress/array-length-store-ic-derived.js: Added.
(shouldBe):
(shouldThrow):
(A):
(f):
* JSTests/stress/array-length-store-ic-double.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-enumerate.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-grow.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-int32-holey.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-int32-zero.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-int32.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-large-shrink.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-late-freeze.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-negative.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-non-integer.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-noop.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-polymorphic.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-proto.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-push-reset-cycle.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-reflect-receiver.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-string-value.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-uint32max.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-undecided.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-valueof.js: Added.
(shouldBe):
(shouldThrow):
(f):
(i.let.obj.valueOf):
* JSTests/stress/array-length-store-ic-very-large-shrink.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-warm-then-freeze-sloppy.js: Added.
(shouldBe):
(shouldThrow):
(f):
* JSTests/stress/array-length-store-ic-warm-then-freeze-strict.js: Added.
(shouldBe):
(shouldThrow):
(f):
* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::create):
(JSC::AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck const):
(JSC::AccessCase::requiresIdentifierNameMatch const):
(JSC::AccessCase::requiresInt32PropertyCheck const):
(JSC::AccessCase::forEachDependentCell const):
(JSC::AccessCase::doesCalls const):
(JSC::AccessCase::canReplace const):
(JSC::AccessCase::runWithDowncast):
(JSC::AccessCase::canBeShared):
* Source/JavaScriptCore/bytecode/AccessCase.h:
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::needsScratchFPR):
(JSC::forInBy):
(JSC::isStateless):
(JSC::doesJSCalls):
(JSC::isMegamorphic):
(JSC::canBeViaGlobalProxy):
(JSC::InlineCacheCompiler::generateWithGuard):
(JSC::InlineCacheCompiler::generateAccessCase):
* Source/JavaScriptCore/bytecode/PutByStatus.cpp:
(JSC::PutByStatus::computeForPropertyInlineCache):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::tryCachePutBy):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::setArrayLengthFromValue):
(JSC::JSC_DEFINE_CUSTOM_SETTER):
(JSC::JSArray::put):

Canonical link: <a href="https://commits.webkit.org/310895@main">https://commits.webkit.org/310895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f35b347d282a6cb72c2d02f33389cdab75a4067

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21346 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163687 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108397 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28035 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119864 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84725 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157886 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139134 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100557 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21222 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19252 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11513 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146977 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130884 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16978 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166162 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15758 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9718 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18587 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127966 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27731 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23291 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128105 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34832 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27655 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138771 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84363 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22984 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15566 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186714 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27347 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91451 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47841 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26925 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27156 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26998 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->