### PR TITLE
Cancel animations in display: none subtree so they restart

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-option-animation-reopens-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-option-animation-reopens-expected.txt
@@ -1,0 +1,6 @@
+
+one
+two
+
+PASS CSS animations on option elements restart when the base-select picker reopens.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-option-animation-reopens.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-option-animation-reopens.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<style>
+select, ::picker(select) {
+  appearance: base-select;
+}
+
+@keyframes fade-in {
+  from { opacity: 0 }
+  to { opacity: 1 }
+}
+
+option {
+  opacity: 0;
+  animation: fade-in 100s forwards;
+}
+</style>
+
+<select>
+  <option>one</option>
+  <option>two</option>
+</select>
+
+<script>
+const select = document.querySelector('select');
+const option = document.querySelector('option');
+
+promise_test(async () => {
+  // First open: animation should start.
+  await test_driver.click(select);
+
+  const animationsFirstOpen = option.getAnimations();
+  assert_equals(animationsFirstOpen.length, 1,
+    'Option should have one animation during first open.');
+  assert_equals(animationsFirstOpen[0].playState, 'running',
+    'Animation should be running during first open.');
+
+  // Close the picker.
+  await test_driver.click(select);
+
+  // Second open: animation should restart.
+  await test_driver.click(select);
+
+  const animationsSecondOpen = option.getAnimations();
+  assert_equals(animationsSecondOpen.length, 1,
+    'Option should have one animation during second open (animation restarted).');
+  assert_equals(animationsSecondOpen[0].playState, 'running',
+    'Animation should be running during second open.');
+}, 'CSS animations on option elements restart when the base-select picker reopens.');
+</script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -5793,6 +5793,7 @@ imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customiz
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-starting-style.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-pseudo-target-text.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-hr-listbox.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-option-animation-reopens.html [ Skip ]
 
 # Newly imported WPT tests that are timing out on iOS.
 imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-activate-keyup-prevented.html [ Skip ]

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -389,8 +389,11 @@ void Styleable::updateCSSAnimations(const RenderStyle* currentStyle, const Rende
 {
     auto& keyframeEffectStack = ensureKeyframeEffectStack();
 
-    // In case this element is newly getting a "display: none" we need to cancel all of its animations and disregard new ones.
-    if ((!currentStyle || currentStyle->display() != Style::DisplayType::None) && newStyle.display() == Style::DisplayType::None) {
+    // Cancel all animations and disregard new ones when this element is newly getting
+    // "display: none", or when it is in a display:none subtree due to an ancestor (so
+    // that animations restart when the subtree becomes visible again).
+    if (((!currentStyle || currentStyle->display() != Style::DisplayType::None) && newStyle.display() == Style::DisplayType::None)
+        || isInDisplayNoneTree == Style::IsInDisplayNoneTree::Yes) {
         for (auto& cssAnimation : animationsCreatedByMarkup())
             cssAnimation->cancelFromStyle();
         keyframeEffectStack.setCSSAnimationList(std::nullopt);


### PR DESCRIPTION
#### d39bde2caea58d8ff99e881f143b58fe215fa3d4
<pre>
Cancel animations in display: none subtree so they restart
<a href="https://bugs.webkit.org/show_bug.cgi?id=311329">https://bugs.webkit.org/show_bug.cgi?id=311329</a>
<a href="https://rdar.apple.com/171478911">rdar://171478911</a>

Reviewed by Antoine Quint.

If you open the select at <a href="https://codepen.io/mobalti/full/myPPmwL">https://codepen.io/mobalti/full/myPPmwL</a> a
second time, the options are no longer visible.

When a select picker closes, the popover gets display: none and render
tree teardown calls cancelStyleOriginatedAnimations() on the option
elements, clearing their cssAnimationList. However, the select/popover
close also triggers a style recalc (to verify the appearance value),
which causes the style resolver to re-visit the options while they&apos;re
still in the display: none subtree. updateCSSAnimations() is called
with isInDisplayNoneTree=Yes — it skips animation creation (correctly),
but setCSSAnimationList() at the end of the function re-populates
cssAnimationList. When the picker reopens, the early return in
updateCSSAnimations() sees previousAnimationList matches the new
animation list and returns without creating a new animation. The
animation never restarts.

The fix adds isInDisplayNoneTree == Yes to the existing cancellation
condition at the top of updateCSSAnimations(), so it cancels and
returns early before reaching setCSSAnimationList(). This is cheap (the
existing isInDisplayNoneTree == No guard already prevents animation
creation, so no useful work would happen past this point) and ensures
the animation state stays clean for when the subtree becomes visible
again.

Test: imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-option-animation-reopens.html

Upstream:
    <a href="https://github.com/web-platform-tests/wpt/pull/58941">https://github.com/web-platform-tests/wpt/pull/58941</a>
    <a href="https://github.com/web-platform-tests/wpt/pull/58979">https://github.com/web-platform-tests/wpt/pull/58979</a>

Canonical link: <a href="https://commits.webkit.org/310566@main">https://commits.webkit.org/310566@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc529a85e69d5e5ed4feb024c7fb138bb8e3bfcc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162880 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107595 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4f2f8ced-f129-4ad3-adfc-a934e56cca69) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156000 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27235 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119205 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84269 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9fc9841-3eb9-44c3-b347-841078d8bdea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157086 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21449 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138407 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99901 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20537 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18534 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10713 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130199 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16252 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165353 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8562 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17860 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127297 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22576 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127443 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26855 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138045 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83448 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23554 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22314 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14837 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26545 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90647 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26126 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26357 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26198 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->