### PR TITLE
[IndexedDB API] SQLiteMemoryIDBBackingStore is never used

### DIFF
--- a/LayoutTests/http/tests/IndexedDB/idbindex-getAllRecords-prev-private-expected.txt
+++ b/LayoutTests/http/tests/IndexedDB/idbindex-getAllRecords-prev-private-expected.txt
@@ -1,0 +1,30 @@
+Test IDBIndex.getAllRecords() with direction 'prev' in private browsing mode.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+indexedDB = self.indexedDB || self.webkitIndexedDB || self.mozIndexedDB || self.msIndexedDB || self.OIndexedDB;
+
+indexedDB.deleteDatabase(dbname)
+indexedDB.open(dbname)
+PASS records.length is 5
+PASS records[0].key is "E"
+PASS records[0].primaryKey is "e"
+PASS records[0].value.indexKey is "E"
+PASS records[0].value.value is "epsilon"
+PASS records[1].key is "D"
+PASS records[1].primaryKey is "d"
+PASS records[1].value.value is "delta"
+PASS records[2].key is "C"
+PASS records[2].primaryKey is "c"
+PASS records[2].value.value is "gamma"
+PASS records[3].key is "B"
+PASS records[3].primaryKey is "b"
+PASS records[3].value.value is "beta"
+PASS records[4].key is "A"
+PASS records[4].primaryKey is "a"
+PASS records[4].value.value is "alpha"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/IndexedDB/idbindex-getAllRecords-prev-private.html
+++ b/LayoutTests/http/tests/IndexedDB/idbindex-getAllRecords-prev-private.html
@@ -1,0 +1,68 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<html>
+<head>
+<script src="../resources/js-test-pre.js"></script>
+<script src="resources/shared.js"></script>
+</head>
+<body>
+<script>
+description("Test IDBIndex.getAllRecords() with direction 'prev' in private browsing mode.");
+
+function prepareDatabase()
+{
+    db = event.target.result;
+    var store = db.createObjectStore('store');
+    var index = store.createIndex('test_idx', 'indexKey');
+
+    store.put({indexKey: 'A', value: 'alpha'}, 'a');
+    store.put({indexKey: 'B', value: 'beta'}, 'b');
+    store.put({indexKey: 'C', value: 'gamma'}, 'c');
+    store.put({indexKey: 'D', value: 'delta'}, 'd');
+    store.put({indexKey: 'E', value: 'epsilon'}, 'e');
+}
+
+function verifyResults()
+{
+    db = event.target.result;
+    var transaction = db.transaction('store', 'readonly');
+    var store = transaction.objectStore('store');
+    var index = store.index('test_idx');
+
+    var request = index.getAllRecords({direction: 'prev'});
+    request.onerror = unexpectedErrorCallback;
+    request.onsuccess = function(event) {
+        records = event.target.result;
+
+        shouldBe("records.length", "5");
+
+        // Records should be in reverse index key order: E, D, C, B, A.
+        shouldBeEqualToString("records[0].key", "E");
+        shouldBeEqualToString("records[0].primaryKey", "e");
+        shouldBeEqualToString("records[0].value.indexKey", "E");
+        shouldBeEqualToString("records[0].value.value", "epsilon");
+
+        shouldBeEqualToString("records[1].key", "D");
+        shouldBeEqualToString("records[1].primaryKey", "d");
+        shouldBeEqualToString("records[1].value.value", "delta");
+
+        shouldBeEqualToString("records[2].key", "C");
+        shouldBeEqualToString("records[2].primaryKey", "c");
+        shouldBeEqualToString("records[2].value.value", "gamma");
+
+        shouldBeEqualToString("records[3].key", "B");
+        shouldBeEqualToString("records[3].primaryKey", "b");
+        shouldBeEqualToString("records[3].value.value", "beta");
+
+        shouldBeEqualToString("records[4].key", "A");
+        shouldBeEqualToString("records[4].primaryKey", "a");
+        shouldBeEqualToString("records[4].value.value", "alpha");
+
+        finishJSTest();
+    };
+}
+
+indexedDBTest(prepareDatabase, verifyResults);
+</script>
+<script src="../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -295,6 +295,10 @@ void NetworkStorageManager::startReceivingMessageFromConnection(IPC::Connection&
         ASSERT(!m_preferencesForConnections.contains(connection));
         m_preferencesForConnections.add(connection, preferences);
 
+        // Use SQLite in-memory backing store if any connection enables it.
+        if (preferences.indexedDBSQLiteMemoryBackingStoreEnabled)
+            m_useSQLiteMemoryBackingStore = true;
+
         RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis)] { });
     });
 
@@ -341,12 +345,13 @@ void NetworkStorageManager::updateSharedPreferencesForConnection(IPC::Connection
 
     workQueue().dispatch([this, protectedThis = Ref { *this }, connection = connection.uniqueID(), preferences]() mutable {
         assertIsCurrent(workQueue());
-        if (auto iter = m_preferencesForConnections.find(connection); iter != m_preferencesForConnections.end())
+        if (auto iter = m_preferencesForConnections.find(connection); iter != m_preferencesForConnections.end()) {
             iter->value = preferences;
 
-        // Use SQLite in-memory backing store if any connection enables it.
-        if (preferences.indexedDBSQLiteMemoryBackingStoreEnabled)
-            m_useSQLiteMemoryBackingStore = true;
+            // Use SQLite in-memory backing store if any connection enables it.
+            if (preferences.indexedDBSQLiteMemoryBackingStoreEnabled)
+                m_useSQLiteMemoryBackingStore = true;
+        }
 
         RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis)] { });
     });


### PR DESCRIPTION
#### 0b14bbfbe8eb9328030475669ced789fd2a0a5e7
<pre>
[IndexedDB API] SQLiteMemoryIDBBackingStore is never used
<a href="https://bugs.webkit.org/show_bug.cgi?id=311327">https://bugs.webkit.org/show_bug.cgi?id=311327</a>
<a href="https://rdar.apple.com/173917907">rdar://173917907</a>

Reviewed by Sihui Liu.

<a href="https://commits.webkit.org/307572@main">https://commits.webkit.org/307572@main</a> added SQLiteMemoryIDBBackingStore, which
uses SQLite&apos;s in-memory database (&quot;:memory:&quot;) for private browsing instead of
the custom MemoryIDBBackingStore.

It added the &apos;IndexedDBSQLiteMemoryBackingStoreEnabled&apos; preference to control
this and enabled it by default.

But in private mode in Safari, we&apos;re still using MemoryIDBBackingStore.

In private mode, IDBStorageManager::createBackingStore() decides which backing
store to use based on NetworkStorageManager::useSQLiteMemoryBackingStore(). This
returns true if m_useSQLiteMemoryBackingStore is true. This flag is only set to
true in one place: NetworkStorageManager::updateSharedPreferencesForConnection().

This function is only called when a preference is changed from false to true.

1. WebPageProxy::preferencesDidChange
2. WebProcessProxy::updateSharedPreferences
3. updateSharedPreferencesForWebProcess()
   * Only if preference changed from false to true, do we call:
4. WebProcessProxy::sharedPreferencesDidChange
5. NetworkProcess::sharedPreferencesForWebProcessDidChange
6. NetworkConnectionToWebProcess::updateSharedPreferencesForWebProcess
7. NetworkStorageManager::updateSharedPreferencesForConnection
   * Sets m_useSQLiteMemoryBackingStore

Since the preference is true by default, it never changes from false to true. So
m_useSQLiteMemoryBackingStore is never true and we continue using
MemoryIDBBackingStore.

To fix this, we ensure that the first time NetworkStorageManager is told of the
preferences, it sets m_useSQLiteMemoryBackingStore to true if the preference is
on. This happens in NetworkStorageManager::startReceivingMessageFromConnection().

Also, in NetworkStorageManager::updateSharedPreferencesForConnection(), we should
only set m_useSQLiteMemoryBackingStore to true if the connection for which these
new preferences have arrived actually exists.

This is covered by an IndexedDB test. We recently added support for
IDBIndex::getAllRecords(). This allows us to traverse the records in the backing
store in different directions (like reverse direction if direction is set to
&quot;prev&quot;). This functionality has been implemented in SQLiteIDBBackingStore but not
in MemoryIDBBackingStore because we expect to use SQLiteMemoryIDBBackingStore.
The test runs in private mode. If we&apos;re using SQLiteMemoryIDBBackingStore, it
should pass, if we&apos;re using MemoryIDBBackingStore, it will not.

* LayoutTests/http/tests/IndexedDB/idbindex-getAllRecords-prev-private-expected.txt: Added.
* LayoutTests/http/tests/IndexedDB/idbindex-getAllRecords-prev-private.html: Added.
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::startReceivingMessageFromConnection):
(WebKit::NetworkStorageManager::updateSharedPreferencesForConnection):

Canonical link: <a href="https://commits.webkit.org/310461@main">https://commits.webkit.org/310461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b87372b67b222a71b0a0e43ec1e314909d7d222e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153854 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26638 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20255 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162605 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107315 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4f795c64-929c-41fb-b624-a587d70dcc94) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26960 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118956 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84105 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7e8253cc-6df9-4268-b88a-99a9f6d2c309) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156813 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99666 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba3cb128-f29c-422e-a12e-10bfcdb05fa1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20301 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18264 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10437 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129949 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165077 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8209 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17604 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127044 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26435 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22293 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127211 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26437 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137805 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83115 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23514 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22105 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14589 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26054 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90342 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25745 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25905 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25805 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->