### PR TITLE
REGRESSION(309560@main): Newly added TestWebKitAPI.NavigationAPI.* tests timing out

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAPI.mm
@@ -39,8 +39,9 @@ TEST(NavigationAPI, PushStateUpdatesCurrentEntryKeyWithoutAllowPrivacySensitiveO
         { "/example"_s, { "example"_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
+    // This will also set a non-persistent data store on the configuration.
     RetainPtr configuration = server.httpsProxyConfiguration();
-    [configuration setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
+    EXPECT_FALSE([configuration.get().websiteDataStore isPersistent]);
     [configuration preferences]._allowPrivacySensitiveOperationsInNonPersistentDataStores = NO;
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 300) configuration:configuration.get()]);
@@ -65,8 +66,9 @@ TEST(NavigationAPI, ReplaceStateUpdatesCurrentEntryIDWithoutAllowPrivacySensitiv
         { "/example"_s, { "example"_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
+    // This will also set a non-persistent data store on the configuration.
     RetainPtr configuration = server.httpsProxyConfiguration();
-    [configuration setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
+    EXPECT_FALSE([configuration.get().websiteDataStore isPersistent]);
     [configuration preferences]._allowPrivacySensitiveOperationsInNonPersistentDataStores = NO;
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 300) configuration:configuration.get()]);


### PR DESCRIPTION
#### 05fc1c171c0bcaee5cfbb334a588603358f088a6
<pre>
REGRESSION(309560@main): Newly added TestWebKitAPI.NavigationAPI.* tests timing out
<a href="https://bugs.webkit.org/show_bug.cgi?id=311148">https://bugs.webkit.org/show_bug.cgi?id=311148</a>
<a href="https://rdar.apple.com/173733725">rdar://173733725</a>

Reviewed by Basuke Suzuki.

I am unable to reproduce the time out locally, but I believe this is the issue:

These tests rely on using a non-persistent data store. So they explicitly set one:
[configuration setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];

Right before they do this, they initially set up the WKWebViewConfiguration with:
RetainPtr configuration = server.httpsProxyConfiguration();

Turns out, HTTPServer::httpsProxyConfiguration() already sets up the
WKWebViewConfiguration with a non-persistent data store. It also sets this data
store up with the the HTTPSProxy that the test needs.

So when the test explicitly sets the freshly created non-persistent data store on
the WKWebViewConfiguration, it wipes out the data store that httpsProxyConfiguration
added which was aware of the HTTPSProxy.

This new data store is not set up with the proxy. It likely tries to actually go to
the network for its load instead of the proxy that is set up. The test likely times
out if the real server for example.com does not respond in time. Perhaps it responds
in time for me locally but not for the EWS bots.

We amend the test to use the data store set up by httpsProxyConfiguration and not
replace it with a fresh one.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAPI.mm:
(TestWebKitAPI::TEST(NavigationAPI, PushStateUpdatesCurrentEntryKeyWithoutAllowPrivacySensitiveOperationsInNonPersistentDataStores)):
(TestWebKitAPI::TEST(NavigationAPI, ReplaceStateUpdatesCurrentEntryIDWithoutAllowPrivacySensitiveOperationsInNonPersistentDataStores)):

Canonical link: <a href="https://commits.webkit.org/310530@main">https://commits.webkit.org/310530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d161edbee6c00c62a48d5e0a730b18228de58a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162699 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107415 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f1b00260-d830-45af-b015-3c2562b695f0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155822 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27055 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119052 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84171 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156908 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21314 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138248 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99753 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85367d6d-56d2-441f-812b-c9b22b4e0411) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20403 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18367 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10531 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130059 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165172 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17701 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127144 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26536 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22401 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127298 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26542 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137894 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83252 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23539 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22197 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14682 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26150 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25842 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26007 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25904 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->