### PR TITLE
Percent-decode fragments before using them for SVG references

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/percent-encoded-fragment-fill-stroke-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/percent-encoded-fragment-fill-stroke-expected.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>Percent-encoded fragment identifiers in SVG fill and stroke references (reference)</title>
+<style>svg { display: block; }</style>
+<p>The rects below should be filled/stroked with gradients, not black.</p>
+<svg width="200" height="120" viewBox="0 0 200 120">
+  <defs>
+    <linearGradient id="foo" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="green"/>
+      <stop offset="1" stop-color="green"/>
+    </linearGradient>
+    <linearGradient id="bar.baz" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="blue"/>
+      <stop offset="1" stop-color="blue"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Unencoded references (known to work) -->
+  <rect x="10" y="10" width="50" height="40" fill="url(#foo)"/>
+  <rect x="70" y="10" width="50" height="40" fill="url(#bar.baz)"/>
+  <rect x="130" y="10" width="50" height="40" fill="none"
+        stroke="url(#foo)" stroke-width="4"/>
+  <rect x="10" y="65" width="50" height="40" fill="url(#foo) red"/>
+  <rect x="70" y="65" width="50" height="40" fill="none"
+        stroke="url(#foo) red" stroke-width="4"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/percent-encoded-fragment-fill-stroke-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/percent-encoded-fragment-fill-stroke-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>Percent-encoded fragment identifiers in SVG fill and stroke references (reference)</title>
+<style>svg { display: block; }</style>
+<p>The rects below should be filled/stroked with gradients, not black.</p>
+<svg width="200" height="120" viewBox="0 0 200 120">
+  <defs>
+    <linearGradient id="foo" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="green"/>
+      <stop offset="1" stop-color="green"/>
+    </linearGradient>
+    <linearGradient id="bar.baz" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="blue"/>
+      <stop offset="1" stop-color="blue"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Unencoded references (known to work) -->
+  <rect x="10" y="10" width="50" height="40" fill="url(#foo)"/>
+  <rect x="70" y="10" width="50" height="40" fill="url(#bar.baz)"/>
+  <rect x="130" y="10" width="50" height="40" fill="none"
+        stroke="url(#foo)" stroke-width="4"/>
+  <rect x="10" y="65" width="50" height="40" fill="url(#foo) red"/>
+  <rect x="70" y="65" width="50" height="40" fill="none"
+        stroke="url(#foo) red" stroke-width="4"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/percent-encoded-fragment-fill-stroke.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/percent-encoded-fragment-fill-stroke.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>Percent-encoded fragment identifiers in SVG fill and stroke references</title>
+<link rel="help" href="https://url.spec.whatwg.org/#fragment-percent-encode-set">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=306387">
+<link rel="match" href="percent-encoded-fragment-fill-stroke-ref.html">
+<meta name="assert" content="Percent-encoded characters in SVG fill/stroke URL fragment references should be decoded before element ID lookup, rendering the same as unencoded references.">
+<style>svg { display: block; }</style>
+<p>The rects below should be filled/stroked with gradients, not black.</p>
+<svg width="200" height="120" viewBox="0 0 200 120">
+  <defs>
+    <linearGradient id="foo" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="green"/>
+      <stop offset="1" stop-color="green"/>
+    </linearGradient>
+    <linearGradient id="bar.baz" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="blue"/>
+      <stop offset="1" stop-color="blue"/>
+    </linearGradient>
+  </defs>
+
+  <!-- fill with %66%6f%6f = "foo" -->
+  <rect x="10" y="10" width="50" height="40" fill="url(#%66%6f%6f)"/>
+
+  <!-- fill with %62%61%72%2e%62%61%7a = "bar.baz" -->
+  <rect x="70" y="10" width="50" height="40" fill="url(#%62%61%72%2e%62%61%7a)"/>
+
+  <!-- stroke with %66%6f%6f = "foo" -->
+  <rect x="130" y="10" width="50" height="40" fill="none"
+        stroke="url(#%66%6f%6f)" stroke-width="4"/>
+
+  <!-- fill with fallback: %66%6f%6f = "foo", fallback red (should NOT be red) -->
+  <rect x="10" y="65" width="50" height="40" fill="url(#%66%6f%6f) red"/>
+
+  <!-- stroke with fallback: %66%6f%6f = "foo", fallback red -->
+  <rect x="70" y="65" width="50" height="40" fill="none"
+        stroke="url(#%66%6f%6f) red" stroke-width="4"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/percent-encoded-fragment-refs-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/percent-encoded-fragment-refs-expected.txt
@@ -1,0 +1,5 @@
+
+PASS clip-path: url(#%6d%79%20%63%6c%69%70) resolves to clipPath id="my clip"
+PASS filter: url(#%66%31) resolves to filter id="f1"
+PASS mask: url(#%6d%31) resolves to mask id="m1"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/percent-encoded-fragment-refs.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/percent-encoded-fragment-refs.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<title>Percent-encoded fragment identifiers in SVG clip-path, filter, and mask references</title>
+<link rel="help" href="https://url.spec.whatwg.org/#fragment-percent-encode-set">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=306387">
+<meta name="assert" content="Percent-encoded characters in SVG URL fragment references should be decoded before element ID lookup. For clip-path, filter, and mask, the computed style falls back to 'none' when the reference fails, providing a reliable signal.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg width="200" height="60">
+  <defs>
+    <clipPath id="my clip">
+      <rect width="200" height="200"/>
+    </clipPath>
+    <filter id="f1">
+      <feFlood flood-color="green" result="green"/>
+      <feMerge><feMergeNode in="green"/></feMerge>
+    </filter>
+    <mask id="m1">
+      <rect width="200" height="200" fill="white"/>
+    </mask>
+  </defs>
+
+  <!-- clip-path: %6d%79%20%63%6c%69%70 = "my clip" -->
+  <rect id="r1" x="0" y="0" width="40" height="40" fill="green"
+        clip-path="url(#%6d%79%20%63%6c%69%70)"/>
+
+  <!-- filter: %66%31 = "f1" -->
+  <rect id="r2" x="50" y="0" width="40" height="40" filter="url(#%66%31)"/>
+
+  <!-- mask: %6d%31 = "m1" -->
+  <rect id="r3" x="100" y="0" width="40" height="40" fill="green"
+        mask="url(#%6d%31)"/>
+</svg>
+
+<script>
+test(() => {
+  const style = getComputedStyle(document.getElementById('r1'));
+  assert_not_equals(style.clipPath, 'none',
+    'clip-path should resolve percent-encoded fragment');
+  assert_true(style.clipPath.includes('url('),
+    'clip-path computed value should contain the URL reference');
+}, 'clip-path: url(#%6d%79%20%63%6c%69%70) resolves to clipPath id="my clip"');
+
+test(() => {
+  const style = getComputedStyle(document.getElementById('r2'));
+  assert_not_equals(style.filter, 'none',
+    'filter should resolve percent-encoded fragment');
+  assert_true(style.filter.includes('url('),
+    'filter computed value should contain the URL reference');
+}, 'filter: url(#%66%31) resolves to filter id="f1"');
+
+test(() => {
+  const style = getComputedStyle(document.getElementById('r3'));
+  assert_not_equals(style.mask, 'none',
+    'mask should resolve percent-encoded fragment');
+  assert_true(style.mask.includes('url('),
+    'mask computed value should contain the URL reference');
+}, 'mask: url(#%6d%31) resolves to mask id="m1"');
+</script>

--- a/Source/WebCore/svg/SVGURIReference.cpp
+++ b/Source/WebCore/svg/SVGURIReference.cpp
@@ -31,6 +31,7 @@
 #include "SVGUseElement.h"
 #include "StyleSVGMarkerResource.h"
 #include "XLinkNames.h"
+#include <pal/text/TextEncoding.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 
@@ -76,13 +77,13 @@ AtomString SVGURIReference::fragmentIdentifierFromIRIString(const String& url, c
         return emptyAtom();
 
     if (!start)
-        return StringView(url).substring(1).toAtomString();
+        return AtomString(PAL::decodeURLEscapeSequences(StringView(url).substring(1)));
 
     URL base = URL(document.baseURL(), url.left(start));
     String fragmentIdentifier = url.substring(start);
     URL urlWithFragment(base, fragmentIdentifier);
     if (equalIgnoringFragmentIdentifier(urlWithFragment, document.url()))
-        return StringView(fragmentIdentifier).substring(1).toAtomString();
+        return AtomString(PAL::decodeURLEscapeSequences(StringView(fragmentIdentifier).substring(1)));
 
     // The url doesn't have any fragment identifier.
     return emptyAtom();
@@ -108,7 +109,8 @@ auto SVGURIReference::targetElementFromIRIString(const String& iri, const TreeSc
         return { };
 
     // Exclude the '#' character when determining the fragmentIdentifier.
-    auto id = StringView(iri).substring(startOfFragmentIdentifier + 1).toAtomString();
+    // Percent-decode the fragment so that url(#%66%6f%6f) resolves to id="foo".
+    auto id = AtomString(PAL::decodeURLEscapeSequences(StringView(iri).substring(startOfFragmentIdentifier + 1)));
     if (id.isEmpty())
         return { };
 


### PR DESCRIPTION
#### 2dc4421208744f093f919701bd88758bd1c8c017
<pre>
Percent-decode fragments before using them for SVG references
<a href="https://bugs.webkit.org/show_bug.cgi?id=306387">https://bugs.webkit.org/show_bug.cgi?id=306387</a>
<a href="https://rdar.apple.com/169582378">rdar://169582378</a>

Reviewed by Rob Buis.

SVG URL fragment references like fill=&quot;url(#%66%6f%6f)&quot; should resolve
to an element with id=&quot;foo&quot; after percent-decoding the fragment. WebKit
was using the raw percent-encoded string for element ID lookup, causing
the reference to fail. Chrome and Firefox both percent-decode correctly.

The fix adds PAL::decodeURLEscapeSequences() in three places where
fragment identifiers are extracted from URL strings:

- fragmentIdentifierFromIRIString() for bare fragment URLs (#fragment)
- fragmentIdentifierFromIRIString() for full URLs with fragments
- targetElementFromIRIString() for direct element lookup by IRI

Two complementary test strategies cover the fix:

1. A testharness test for clip-path, filter, and mask references.
These SVG resource types fall back to computed style &quot;none&quot; when
the reference fails to resolve, providing a reliable programmatic
assertion (assert_not_equals &quot;none&quot;).

2. A reftest for fill and stroke gradient references. The computed
style for fill/stroke preserves the raw url() string regardless
of whether the gradient resolved or not, making programmatic
assertion impossible. The reftest compares pixel output of
percent-encoded references against identical unencoded references.

Tests: imported/w3c/web-platform-tests/svg/pservers/reftests/percent-encoded-fragment-fill-stroke-ref.html
       imported/w3c/web-platform-tests/svg/pservers/reftests/percent-encoded-fragment-fill-stroke.html
       imported/w3c/web-platform-tests/svg/pservers/reftests/percent-encoded-fragment-refs.html

* LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/percent-encoded-fragment-fill-stroke-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/percent-encoded-fragment-fill-stroke-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/percent-encoded-fragment-fill-stroke.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/percent-encoded-fragment-refs-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/percent-encoded-fragment-refs.html: Added.
* Source/WebCore/svg/SVGURIReference.cpp:
(WebCore::SVGURIReference::fragmentIdentifierFromIRIString):
(WebCore::SVGURIReference::targetElementFromIRIString):

Canonical link: <a href="https://commits.webkit.org/310443@main">https://commits.webkit.org/310443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0dfc02732689314f66e3cbc0d5bf4abc27ae10b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153863 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26647 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162614 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107326 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/af46befa-719d-40f3-ac39-f1bb90ed5a74) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155736 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27176 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26969 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118964 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84112 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8dfb83b5-ba2d-429b-9695-2219557d72b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138157 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99674 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/daf7fdd1-0d37-4bd4-9a95-1d83cf87fc80) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20310 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18273 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10446 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129958 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16016 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165087 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8218 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17610 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127050 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127217 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26446 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137811 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83126 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23505 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22116 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14595 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26063 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90351 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25754 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25914 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25814 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->