### PR TITLE
WTF::Unexpected should be aliased to std::unexpected

### DIFF
--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -236,7 +236,6 @@ namespace std {
 namespace experimental {
 inline namespace fundamentals_v3 {
 template<class, class> class expected;
-template<class> class unexpected;
 }}} // namespace std::experimental::fundamentals_v3
 
 using WTF::SaSegmentedVector;
@@ -325,7 +324,6 @@ using WTF::WorkQueue;
 using WTF::makeUniqueRef;
 
 template<class T, class E> using Expected = std::experimental::expected<T, E>;
-template<class E> using Unexpected = std::experimental::unexpected<E>;
 
 // Sometimes an inline method simply forwards to another one and does nothing else. If it were
 // just a forward declaration of that method then you would only need a forward declaration of

--- a/Source/WTF/wtf/Unexpected.h
+++ b/Source/WTF/wtf/Unexpected.h
@@ -23,76 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// Implementation of Library Fundamentals v3's std::expected, as described here: http://wg21.link/p0323r4
-
 #pragma once
 
-/*
-    unexpected synopsis
-
-namespace std {
-namespace experimental {
-inline namespace fundamentals_v3 {
-    // ?.?.3, Unexpected object type
-    template <class E>
-      class unexpected;
-
-    // ?.?.4, Unexpected relational operators
-    template <class E>
-        constexpr bool
-        operator==(const unexpected<E>&, const unexpected<E>&);
-    template <class E>
-        constexpr bool
-        operator!=(const unexpected<E>&, const unexpected<E>&);
-
-    template <class E>
-    class unexpected {
-    public:
-        unexpected() = delete;
-        template <class U = E>
-          constexpr explicit unexpected(E&&);
-        constexpr const E& value() const &;
-        constexpr E& value() &;
-        constexpr E&& value() &&;
-        constexpr E const&& value() const&&;
-    private:
-        E val; // exposition only
-    };
-
-}}}
-
-*/
-
-#include <cstdlib>
+#include <expected>
+#include <type_traits>
 #include <utility>
-#include <wtf/FastMalloc.h>
-#include <wtf/StdLibExtras.h>
 
-namespace std {
-namespace experimental {
-inline namespace fundamentals_v3 {
-
-template<class E>
-class unexpected {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(unexpected);
-public:
-    unexpected() = delete;
-    template <class U = E>
-    constexpr explicit unexpected(U&& u) : val(std::forward<U>(u)) { }
-    constexpr const E& error() const & { return val; }
-    constexpr E& error() & { return val; }
-    constexpr E&& error() && { return WTF::move(val); }
-    constexpr const E&& error() const && { return WTF::move(val); }
-
-private:
-    E val;
-};
-
-template<class E> constexpr bool operator==(const unexpected<E>& lhs, const unexpected<E>& rhs) { return lhs.error() == rhs.error(); }
-
-}}} // namespace std::experimental::fundamentals_v3
-
-template<class E> using Unexpected = std::experimental::unexpected<E>;
-
-// Not in the std::expected spec, but useful to work around lack of C++17 deduction guides.
+template<class E> using Unexpected = std::unexpected<E>;
 template<class E> constexpr Unexpected<std::decay_t<E>> makeUnexpected(E&& v) { return Unexpected<typename std::decay<E>::type>(std::forward<E>(v)); }

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -197,6 +197,12 @@ if (COMPILER_IS_GCC_OR_CLANG)
     # FIXME: Remove once Clang 18 does no longer need to be supported for the GTK and WPE ports
     if ((CMAKE_CXX_COMPILER_ID STREQUAL Clang) AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19))
         WEBKIT_PREPEND_GLOBAL_CXX_FLAGS(-frelaxed-template-template-args)
+        # libstdc++'s <expected> is guarded behind __cpp_concepts >= 202002, even though
+        # Clang 18 is C++23 compliant. <https://webkit.org/b/311435>
+        add_compile_options(
+            $<$<COMPILE_LANGUAGE:CXX>:-D__cpp_concepts=202002>
+            $<$<COMPILE_LANGUAGE:CXX>:-Wno-builtin-macro-redefined>
+        )
     endif ()
 
     # GCC < 12.0 gives false warnings for mismatched-new-delete <https://webkit.org/b/241516>


### PR DESCRIPTION
#### 67dae37d84364c911c5d7da85f65dbfd753de284
<pre>
WTF::Unexpected should be aliased to std::unexpected
<a href="https://bugs.webkit.org/show_bug.cgi?id=311333">https://bugs.webkit.org/show_bug.cgi?id=311333</a>
<a href="https://rdar.apple.com/173923454">rdar://173923454</a>

Reviewed by Richard Robinson.

This patch follows up from webkit.org/b/311015. It is now possible to
establish this alias since WTF::Unexpected has a interface congruent
with its standard analogue&apos;s.

This patch is part of a series of changes that lead up to std::expected-
and-friends adoption within WebKit.

No new tests because there is no change in behavior.

* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/Unexpected.h:
(std::experimental::fundamentals_v3::unexpected::unexpected): Deleted.
(std::experimental::fundamentals_v3::unexpected::error const): Deleted.
(std::experimental::fundamentals_v3::unexpected::error): Deleted.
(std::experimental::fundamentals_v3::operator==): Deleted.
* Source/cmake/WebKitCompilerFlags.cmake:
  Drive-by workaround for GTK/WPE configurations still
  building against Clang 18.

Canonical link: <a href="https://commits.webkit.org/310588@main">https://commits.webkit.org/310588@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8f0ac2ca8abb9c9b31cb254d30c4e503a094d4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27495 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162992 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107706 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0934105e-b11f-4eb9-95f2-b91eec4f4beb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27346 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119291 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84325 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138517 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99987 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20639 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18641 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10824 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146287 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130301 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16362 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165464 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15069 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8673 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17971 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127387 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27042 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22683 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127532 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34607 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26966 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138155 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83566 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22417 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14947 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185873 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26656 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90759 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47664 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26237 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26468 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26309 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->