### PR TITLE
REGRESSION(310393@main): [GTK][WPE] WebGL context lost after dma-buf/EGLImage refactorization

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/DMABufBuffer.cpp
+++ b/Source/WebCore/platform/graphics/gbm/DMABufBuffer.cpp
@@ -157,11 +157,6 @@ static std::optional<Vector<EGLAttrib>> buildEGLAttributesForDMABuf(const DMABuf
     return eglAttributes;
 }
 
-EGLImage DMABufBuffer::createEGLImage(EGLDisplay eglDisplay) const
-{
-    return createEGLImage(eglDisplay, m_attributes);
-}
-
 EGLImage DMABufBuffer::createEGLImage(GLDisplay& display, const Attributes& dmaBufAttributes)
 {
     auto enableModifiers = display.extensions().EXT_image_dma_buf_import_modifiers
@@ -172,20 +167,14 @@ EGLImage DMABufBuffer::createEGLImage(GLDisplay& display, const Attributes& dmaB
     return display.createImage(EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, *eglAttributes);
 }
 
-EGLImage DMABufBuffer::createEGLImage(EGLDisplay eglDisplay, const Attributes& dmaBufAttributes)
+std::optional<Vector<EGLint>> DMABufBuffer::buildEGLImageAttributes(const Attributes& dmaBufAttributes, Attributes::EnableModifiers enableModifiers)
 {
-    auto eglAttributes = buildEGLAttributesForDMABuf(dmaBufAttributes, DMABufBuffer::Attributes::EnableModifiers::Yes);
-    if (!eglAttributes || eglDisplay == EGL_NO_DISPLAY)
-        return EGL_NO_IMAGE;
-
-    static PFNEGLCREATEIMAGEKHRPROC s_eglCreateImageKHR = reinterpret_cast<PFNEGLCREATEIMAGEKHRPROC>(eglGetProcAddress("eglCreateImageKHR"));
-    if (!s_eglCreateImageKHR)
-        return EGL_NO_IMAGE;
-
-    auto intAttributes = eglAttributes->map<Vector<EGLint>>([](EGLAttrib value) {
+    auto eglAttributes = buildEGLAttributesForDMABuf(dmaBufAttributes, enableModifiers);
+    if (!eglAttributes)
+        return std::nullopt;
+    return eglAttributes->map<Vector<EGLint>>([](EGLAttrib value) {
         return static_cast<EGLint>(value);
     });
-    return s_eglCreateImageKHR(eglDisplay, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, intAttributes.span().data());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gbm/DMABufBuffer.h
+++ b/Source/WebCore/platform/graphics/gbm/DMABufBuffer.h
@@ -29,7 +29,7 @@
 #include "DMABufBufferAttributes.h"
 #include <wtf/ThreadSafeRefCounted.h>
 
-typedef void* EGLDisplay;
+typedef int32_t EGLint;
 typedef void* EGLImage;
 
 namespace WebCore {
@@ -64,9 +64,8 @@ public:
     void setTransferFunction(TransferFunction transferFunction) { m_transferFunction = transferFunction; }
 
     EGLImage createEGLImage(GLDisplay&) const;
-    EGLImage createEGLImage(EGLDisplay) const;
     static EGLImage createEGLImage(GLDisplay&, const Attributes&);
-    static EGLImage createEGLImage(EGLDisplay, const Attributes&);
+    static std::optional<Vector<EGLint>> buildEGLImageAttributes(const Attributes&, Attributes::EnableModifiers = Attributes::EnableModifiers::Yes);
 
     CoordinatedPlatformLayerBuffer* buffer() const LIFETIME_BOUND { return m_buffer.get(); }
     void setBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&&);

--- a/Source/WebCore/platform/graphics/gbm/DMABufBufferAttributes.h
+++ b/Source/WebCore/platform/graphics/gbm/DMABufBufferAttributes.h
@@ -43,6 +43,8 @@ public:
     // EGL_EXT_image_dma_buf_import supports up to 4 planes (PLANE0..PLANE3).
     static constexpr unsigned maxPlaneCountForEGLImage = 4;
 
+    enum class EnableModifiers : bool { No, Yes };
+
     IntSize size;
     FourCC fourcc;
     Vector<WTF::UnixFileDescriptor> fds;
@@ -51,7 +53,6 @@ public:
     uint64_t modifier { 0 };
 
 #if USE(GBM)
-    enum class EnableModifiers : bool { No, Yes };
     static std::optional<DMABufBufferAttributes> fromGBMBufferObject(struct gbm_bo*, EnableModifiers = EnableModifiers::Yes);
 #endif
 };

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
@@ -140,9 +140,13 @@ GraphicsContextGLTextureMapperGBM::DrawingBuffer GraphicsContextGLTextureMapperG
     }
 
     Ref dmaBuf = DMABufBuffer::create(WTF::move(*dmaBufAttributes));
-    auto image = dmaBuf->createEGLImage(m_displayObj);
+    auto eglAttributes = DMABufBuffer::buildEGLImageAttributes(dmaBuf->attributes());
     gbm_bo_destroy(bo);
 
+    if (!eglAttributes)
+        return { };
+
+    auto image = EGL_CreateImageKHR(m_displayObj, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, eglAttributes->span().data());
     if (!image)
         return { };
 
@@ -260,7 +264,14 @@ GCGLExternalImage GraphicsContextGLTextureMapperGBM::createExternalImage(Externa
     }
 
     DMABufBufferAttributes dmaBufAttributes { imageSource.size, imageSource.fourcc, WTF::move(imageSource.fds), WTF::move(imageSource.offsets), WTF::move(imageSource.strides), imageSource.modifier };
-    auto eglImage = DMABufBuffer::createEGLImage(m_displayObj, dmaBufAttributes);
+    auto enableModifiers = PlatformDisplay::sharedDisplay().eglExtensions().EXT_image_dma_buf_import_modifiers
+        ? DMABufBufferAttributes::EnableModifiers::Yes : DMABufBufferAttributes::EnableModifiers::No;
+    auto eglAttributes = DMABufBuffer::buildEGLImageAttributes(dmaBufAttributes, enableModifiers);
+    if (!eglAttributes) {
+        addError(GCGLErrorCode::InvalidOperation);
+        return { };
+    }
+    auto eglImage = EGL_CreateImageKHR(m_displayObj, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, eglAttributes->span().data());
     if (!eglImage) {
         LOG(XR, "invalid operation importing the image %d", EGL_GetError());
         addError(GCGLErrorCode::InvalidOperation);


### PR DESCRIPTION
#### 6472f8c3a899dc8f69a968062978a289fb9a2030
<pre>
REGRESSION(310393@main): [GTK][WPE] WebGL context lost after dma-buf/EGLImage refactorization
<a href="https://bugs.webkit.org/show_bug.cgi?id=311335">https://bugs.webkit.org/show_bug.cgi?id=311335</a>

Reviewed by Sergio Villar Senin.

The consolidation patch moved EGLImage creation into DMABufBuffer::createEGLImage(EGLDisplay),
which resolved eglCreateImageKHR via system eglGetProcAddress. However, the WebGL call sites in
GraphicsContextGLTextureMapperGBM pass ANGLE&apos;s EGLDisplay (m_displayObj), which is not valid for
the system EGL — causing image creation to fail and the WebGL context to be lost.

Fix by replacing the EGLDisplay overloads with a buildEGLImageAttributes() helper that returns
the EGL attribute list without creating the image. The ANGLE call sites now build attributes via
this helper, then call ANGLE&apos;s EGL_CreateImageKHR directly (resolved through ANGLEHeaders.h).

Also restore the EXT_image_dma_buf_import_modifiers extension check for createExternalImage,
which was dropped in the consolidation. The original code only added modifier EGL attributes
when the extension was advertised; the shared helper was unconditionally adding them.

* Source/WebCore/platform/graphics/gbm/DMABufBuffer.cpp:
(WebCore::DMABufBuffer::buildEGLImageAttributes):
* Source/WebCore/platform/graphics/gbm/DMABufBuffer.h:
* Source/WebCore/platform/graphics/gbm/DMABufBufferAttributes.h:
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp:
(WebCore::GraphicsContextGLTextureMapperGBM::createDrawingBuffer const):
(WebCore::GraphicsContextGLTextureMapperGBM::createExternalImage):

Canonical link: <a href="https://commits.webkit.org/310506@main">https://commits.webkit.org/310506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/960ca33dc1b4c55fd1aa5f8dfdbb9d6acb892bda

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20272 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162622 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107334 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155744 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26977 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118972 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84118 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138165 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99682 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20319 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18294 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10454 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129967 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16024 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165095 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8226 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17618 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127059 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26452 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127226 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34555 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137819 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83136 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22124 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14603 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26071 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90359 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25762 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25922 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25822 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->