### PR TITLE
Exclude pseudo-elements from outline rect collection

### DIFF
--- a/LayoutTests/fast/css/focus-ring-list-item-expected.html
+++ b/LayoutTests/fast/css/focus-ring-list-item-expected.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body {
+    margin: 0;
+    overflow: hidden;
+}
+
+li {
+    margin-inline-start: 200px;
+    inline-size: 200px;
+    block-size: 30px;
+    list-style: none;
+    color: transparent;
+}
+</style>
+</head>
+<body>
+<li tabindex=0 id=target></li>
+<script>
+onload = () => target.focus();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/css/focus-ring-list-item.html
+++ b/LayoutTests/fast/css/focus-ring-list-item.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel=match href="focus-ring-list-item-expected.html">
+<style>
+body {
+    margin: 0;
+    overflow: hidden;
+}
+
+li {
+    margin-inline-start: 200px;
+    inline-size: 200px;
+    block-size: 30px;
+    color: transparent;
+}
+
+li::marker {
+    font-size: 100px;
+    color: transparent;
+}
+</style>
+</head>
+<body>
+<li tabindex=0 id=target></li>
+<script>
+onload = () => target.focus();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/css/focus-ring-pseudo-element-list-item-expected.html
+++ b/LayoutTests/fast/css/focus-ring-pseudo-element-list-item-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body {
+    margin: 0;
+    overflow: hidden;
+}
+
+div {
+    inline-size: 200px;
+    block-size: 30px;
+    color: transparent;
+}
+</style>
+</head>
+<body>
+<div tabindex=0 id=target></div>
+<script>
+onload = () => target.focus();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/css/focus-ring-pseudo-element-list-item.html
+++ b/LayoutTests/fast/css/focus-ring-pseudo-element-list-item.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel=match href="focus-ring-pseudo-element-list-item-expected.html">
+<style>
+body {
+    margin: 0;
+    overflow: hidden;
+}
+
+div {
+    inline-size: 200px;
+    block-size: 30px;
+    color: transparent;
+}
+
+div::before {
+    content: "";
+    display: list-item;
+    block-size: 100px;
+    color: transparent;
+}
+</style>
+</head>
+<body>
+<div tabindex=0 id=target></div>
+<script>
+onload = () => target.focus();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/select-base-select-focus-ring-shape-expected.html
+++ b/LayoutTests/fast/forms/select-base-select-focus-ring-shape-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+select {
+    appearance: base-select;
+    font-size: 30px;
+    inline-size: 250px;
+    block-size: 50px;
+    color: transparent;
+}
+
+select::picker-icon {
+    display: none;
+}
+</style>
+</head>
+<body>
+<select id="target">
+    <option>Option 1</option>
+</select>
+<script>
+    onload = () => target.focus();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/select-base-select-focus-ring-shape.html
+++ b/LayoutTests/fast/forms/select-base-select-focus-ring-shape.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel=match href="select-base-select-focus-ring-shape-expected.html">
+<style>
+select {
+    appearance: base-select;
+    font-size: 30px;
+    inline-size: 250px;
+    block-size: 50px;
+    color: transparent;
+}
+
+select::picker-icon {
+    color: transparent;
+    block-size: 80px;
+}
+</style>
+</head>
+<body>
+<select id="target">
+    <option>Option 1</option>
+</select>
+<script>
+    onload = () => target.focus();
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/OutlinePainter.cpp
+++ b/Source/WebCore/rendering/OutlinePainter.cpp
@@ -402,7 +402,7 @@ bool OutlinePainter::collectFocusRingRectsForBlock(const RenderBlock& renderer, 
 
 void OutlinePainter::collectFocusRingRectsForChildBox(const RenderBox& box, Vector<LayoutRect>& rects, const LayoutPoint& additionalOffset, const RenderLayerModelObject* paintContainer)
 {
-    if (box.isRenderListMarker() || box.isOutOfFlowPositioned())
+    if (box.style().pseudoElementType() || box.isOutOfFlowPositioned())
         return;
 
     FloatPoint pos;


### PR DESCRIPTION
#### 9fd740122600924ae7649e106c0b3262d1066996
<pre>
Exclude pseudo-elements from outline rect collection
<a href="https://bugs.webkit.org/show_bug.cgi?id=311337">https://bugs.webkit.org/show_bug.cgi?id=311337</a>

Reviewed by Tim Nguyen.

Including pseudo-elements in the outline calculation gives rather weird
looking results, e.g., on the select element of this demo:
<a href="https://codepen.io/mobalti/pen/myPPmwL">https://codepen.io/mobalti/pen/myPPmwL</a>

We already exclude markers, so let&apos;s make that more generic.

Tests: fast/css/focus-ring-list-item.html
       fast/css/focus-ring-pseudo-element-list-item.html
       fast/forms/select-base-select-focus-ring-shape.html

Canonical link: <a href="https://commits.webkit.org/310531@main">https://commits.webkit.org/310531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d12b15930fb966c0961fb3460dda2e62ac145278

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162823 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107537 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27460 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119157 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84236 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138354 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99857 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20488 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18479 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10656 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130136 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16205 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165296 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8496 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17806 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127247 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26874 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22515 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127399 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26797 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137999 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83376 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23540 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22266 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14787 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26488 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90580 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26069 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26299 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26141 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->