### PR TITLE
RenderText::previousCharacter() scans entire string to find last character

### DIFF
--- a/LayoutTests/fast/text/capitalize-after-surrogate-pair-expected.html
+++ b/LayoutTests/fast/text/capitalize-after-surrogate-pair-expected.html
@@ -1,0 +1,7 @@
+<meta charset="utf-8">
+<div>Hello 😀 World</div>
+<div>Test 🌍🌎🌏 Earth</div>
+<div>X😀Abc</div>
+<div>A 𐐀 Next</div>
+<div>Note 𝄞 Melody</div>
+<div>Emoji 😀 Smile</div>

--- a/LayoutTests/fast/text/capitalize-after-surrogate-pair.html
+++ b/LayoutTests/fast/text/capitalize-after-surrogate-pair.html
@@ -1,0 +1,21 @@
+<meta charset="utf-8">
+<!-- Tests that text-transform: capitalize works correctly when the previous
+     text node ends with a character outside the Basic Multilingual Plane
+     (i.e. a surrogate pair in UTF-16), such as emoji. The capitalize logic
+     needs to find the last character of the previous sibling text to determine
+     word boundaries. -->
+<style>
+div { text-transform: capitalize; }
+</style>
+<!-- Previous sibling text ends with a surrogate pair (emoji U+1F600 😀), next word should capitalize. -->
+<div><span>hello 😀</span> world</div>
+<!-- Multiple emoji (each is a surrogate pair). -->
+<div><span>test 🌍🌎🌏</span> earth</div>
+<!-- Surrogate pair character immediately before the span boundary, no space. -->
+<div><span>x😀</span>abc</div>
+<!-- Supplementary letter (U+10400 𐐀 Deseret Capital Long I) before a new word. -->
+<div><span>a 𐐀</span> next</div>
+<!-- Musical symbol (U+1D11E 𝄞) ending previous node. -->
+<div><span>note 𝄞</span> melody</div>
+<!-- Mix: BMP character after surrogate pair ending, verifying no over-read. -->
+<div><span>emoji 😀</span> <span>smile</span></div>

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1567,21 +1567,11 @@ Vector<char16_t> RenderText::previousCharacter() const
         if (previousString.is8Bit())
             previous.append(previousString[previousString.length() - 1]);
         else {
-            auto previousCharacterLength = [&] {
-                auto contentIterator = SurrogatePairAwareTextIterator { previousString.span16(), 0, previousString.length() };
-                unsigned characterLength = 0;
-                char32_t currentCharacter = 0;
-                while (contentIterator.consume(currentCharacter, characterLength))
-                    contentIterator.advance(characterLength);
-                return characterLength;
-            }();
-
-            if (previousCharacterLength > previousString.length()) {
-                ASSERT_NOT_REACHED();
-                return previous;
-            }
-            for (size_t i = previousString.length() - previousCharacterLength; i < previousString.length(); ++i)
-                previous.append(previousString[i]);
+            unsigned length = previousString.length();
+            bool hasSurrogatePair = length >= 2 && U_IS_LEAD(previousString[length - 2]) && U_IS_TRAIL(previousString[length - 1]);
+            if (hasSurrogatePair)
+                previous.append(previousString[length - 2]);
+            previous.append(previousString[length - 1]);
         }
     }
     return previous;


### PR DESCRIPTION
#### 7bdf5835b96547a88d2d94f657cdc9680171384b
<pre>
RenderText::previousCharacter() scans entire string to find last character
<a href="https://bugs.webkit.org/show_bug.cgi?id=311338">https://bugs.webkit.org/show_bug.cgi?id=311338</a>

Reviewed by Darin Adler and Alan Baradlay.

RenderText::previousCharacter() used a SurrogatePairAwareTextIterator to
scan from position 0 through the entire 16-bit string just to determine
the code-unit length of the last character. This is O(N) in the length
of the previous sibling&apos;s text.

Replace with an O(1) check: if the last two char16_t values form a
surrogate pair, take both; otherwise take just the last one.

There should be no behavior change but I added a layout test to make sure
we had test coverage for this change:
- fast/text/capitalize-after-surrogate-pair.html

* LayoutTests/fast/text/capitalize-after-surrogate-pair-expected.html: Added.
* LayoutTests/fast/text/capitalize-after-surrogate-pair.html: Added.
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::previousCharacter const):

Canonical link: <a href="https://commits.webkit.org/310458@main">https://commits.webkit.org/310458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c23e546e237c989da232b5dd7e3f1e85dc76279b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153886 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20287 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162637 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107349 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c3258046-5f36-483c-9a4b-dfd9fd97c94c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155759 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118985 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84135 "2 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff0e8419-7273-4b99-86d4-b284df5ca49d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21253 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138183 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99695 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f6cbc165-1c05-4c48-9227-d82f48cb07d1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20345 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18304 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10469 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129981 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16042 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165110 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8241 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17636 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127071 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26467 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127238 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34521 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26469 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137837 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83168 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22137 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14621 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26086 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90374 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25777 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25937 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25837 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->