### PR TITLE
HTMLFastPathParser fails to detect nested <li> elements when outer <li> is parsed via parseSpecificElements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/domparsing/innerhtml-li-autoclosing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domparsing/innerhtml-li-autoclosing-expected.txt
@@ -1,0 +1,9 @@
+
+PASS Adjacent empty li elements in ul produce siblings.
+PASS Adjacent empty li elements in ol produce siblings.
+PASS Adjacent li elements with text content produce siblings.
+PASS Three adjacent li elements produce siblings.
+PASS Legitimate li nesting through intervening ul is preserved.
+PASS Adjacent li elements produce siblings when ul is nested in div.
+PASS Adjacent li elements with attributes produce siblings.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/domparsing/innerhtml-li-autoclosing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/domparsing/innerhtml-li-autoclosing.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<title>innerHTML: li auto-closing behavior</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+// Per the HTML spec, an opening <li> tag implicitly closes any currently open
+// <li> in the same list scope. These tests verify that innerHTML parsing
+// produces sibling <li> elements (not nested) when adjacent <li> tags appear.
+
+test(function() {
+    var div = document.createElement("div");
+    div.innerHTML = "<ul><li><li></li></li></ul>";
+    var ul = div.querySelector("ul");
+    assert_equals(ul.children.length, 2, "ul should have 2 children");
+    assert_equals(ul.innerHTML, "<li></li><li></li>");
+}, "Adjacent empty li elements in ul produce siblings.");
+
+test(function() {
+    var div = document.createElement("div");
+    div.innerHTML = "<ol><li><li></li></li></ol>";
+    var ol = div.querySelector("ol");
+    assert_equals(ol.children.length, 2, "ol should have 2 children");
+    assert_equals(ol.innerHTML, "<li></li><li></li>");
+}, "Adjacent empty li elements in ol produce siblings.");
+
+test(function() {
+    var div = document.createElement("div");
+    div.innerHTML = "<ul><li>first<li>second</li></li></ul>";
+    var ul = div.querySelector("ul");
+    assert_equals(ul.children.length, 2, "ul should have 2 children");
+    assert_equals(ul.innerHTML, "<li>first</li><li>second</li>");
+}, "Adjacent li elements with text content produce siblings.");
+
+test(function() {
+    var div = document.createElement("div");
+    div.innerHTML = "<ul><li>a<li>b<li>c</li></li></li></ul>";
+    var ul = div.querySelector("ul");
+    assert_equals(ul.children.length, 3, "ul should have 3 children");
+    assert_equals(ul.innerHTML, "<li>a</li><li>b</li><li>c</li>");
+}, "Three adjacent li elements produce siblings.");
+
+test(function() {
+    var div = document.createElement("div");
+    div.innerHTML = "<ul><li><ul><li>nested</li></ul></li></ul>";
+    var outerUl = div.querySelector("ul");
+    assert_equals(outerUl.children.length, 1, "outer ul should have 1 child");
+    var innerUl = outerUl.querySelector("ul");
+    assert_equals(innerUl.children.length, 1, "inner ul should have 1 child");
+    assert_equals(innerUl.innerHTML, "<li>nested</li>");
+}, "Legitimate li nesting through intervening ul is preserved.");
+
+test(function() {
+    var div = document.createElement("div");
+    div.innerHTML = "<div><ul><li><li></li></li></ul></div>";
+    var ul = div.querySelector("ul");
+    assert_equals(ul.children.length, 2, "ul should have 2 children");
+}, "Adjacent li elements produce siblings when ul is nested in div.");
+
+test(function() {
+    var div = document.createElement("div");
+    div.innerHTML = '<ul><li class="a"><li class="b"></li></li></ul>';
+    var ul = div.querySelector("ul");
+    assert_equals(ul.children.length, 2, "ul should have 2 children");
+    assert_equals(ul.children[0].className, "a");
+    assert_equals(ul.children[1].className, "b");
+}, "Adjacent li elements with attributes produce siblings.");
+</script>

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -526,6 +526,15 @@ private:
         struct Li : ContainerTag<HTMLLIElement, PermittedParents::FlowContent> {
             static constexpr ElementName tagName = ElementNames::HTML::li;
             static constexpr std::array<CharacterType, 2> tagNameCharacters { 'l', 'i' };
+
+            static RefPtr<HTMLElement> parseChild(ContainerNode& parent, HTMLFastPathParser& self)
+            {
+                bool wasInsideOfTagLi = self.m_insideOfTagLi;
+                self.m_insideOfTagLi = true;
+                auto result = ContainerTag<HTMLLIElement, PermittedParents::FlowContent>::parseChild(parent, self);
+                self.m_insideOfTagLi = wasInsideOfTagLi;
+                return result;
+            }
         };
 
         struct Label : ContainsPhrasingContentTag<HTMLLabelElement, PermittedParents::PhrasingOrFlowContent> {


### PR DESCRIPTION
#### 2371382e387dabb8a8ac23c8bccb36b9fe175cc5
<pre>
HTMLFastPathParser fails to detect nested &lt;li&gt; elements when outer &lt;li&gt; is parsed via parseSpecificElements
<a href="https://bugs.webkit.org/show_bug.cgi?id=311342">https://bugs.webkit.org/show_bug.cgi?id=311342</a>

Reviewed by Ryosuke Niwa.

The m_insideOfTagLi guard that prevents nested &lt;li&gt; (which requires
auto-closing per the HTML spec) was only set in parseElement(). When
&lt;ul&gt;/&lt;ol&gt; parse their children via parseSpecificElements&lt;Li&gt;(), the
outer &lt;li&gt; bypasses parseElement() entirely, so m_insideOfTagLi is
never set. A subsequent &lt;li&gt; inside that outer &lt;li&gt; is then incorrectly
accepted as a nested child instead of causing the fast parser to bail
out.

For example, &quot;&lt;ul&gt;&lt;li&gt;&lt;li&gt;&lt;/li&gt;&lt;/li&gt;&lt;/ul&gt;&quot; produced nested &lt;li&gt;
elements instead of the spec-required sibling &lt;li&gt; elements.

Fix by adding a parseChild override to the Li tag struct that sets
m_insideOfTagLi while parsing children, mirroring the existing pattern
used by the A tag struct for m_insideOfTagA. Uses save/restore (rather
than unconditional set/clear) because &lt;li&gt; can legitimately nest
through intervening &lt;ul&gt;/&lt;ol&gt;.

Test: imported/w3c/web-platform-tests/domparsing/innerhtml-li-autoclosing.html

* LayoutTests/imported/w3c/web-platform-tests/domparsing/innerhtml-li-autoclosing-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/domparsing/innerhtml-li-autoclosing.html: Added.
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::TagInfo::Li::parseChild):

Canonical link: <a href="https://commits.webkit.org/310492@main">https://commits.webkit.org/310492@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/208c29f7cac9017e7e6c46659dc63130fc711171

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26665 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162632 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107344 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155754 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26987 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118981 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84130 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138174 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99691 "Passed tests") | | ⏳ 🛠 vision-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/153202 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20328 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18300 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10464 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/145894 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129976 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165105 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14705 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8236 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17627 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127068 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/153281 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26462 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22319 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127235 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34542 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137828 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83161 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22134 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14612 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26081 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90369 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25772 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25932 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25832 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->