### PR TITLE
Fetch Response should not allow resizable buffers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/allow-resizable-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/allow-resizable-expected.txt
@@ -1,6 +1,4 @@
 
-FAIL APIs without [AllowResizable] throw when passed resizable ArrayBuffers assert_throws_js: function "() => {
-    new Response(new Uint8Array(rab));
-  }" did not throw
+PASS APIs without [AllowResizable] throw when passed resizable ArrayBuffers
 PASS APIs with [AllowShared] but without [AllowResizable] throw when passed growable SharedArrayBuffers
 

--- a/Source/JavaScriptCore/runtime/JSArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/JSArrayBuffer.h
@@ -56,8 +56,10 @@ public:
     
     // This is the default DOM unwrapping. It calls toUnsharedArrayBuffer().
     static ArrayBuffer* toWrapped(VM&, JSValue);
+    static ArrayBuffer* toWrappedAllowResizable(VM&, JSValue);
     static ArrayBuffer* toWrappedAllowShared(VM&, JSValue);
-    
+    static ArrayBuffer* toWrappedAllowSharedAndResizable(VM&, JSValue);
+
 private:
     JSArrayBuffer(VM&, Structure*, RefPtr<ArrayBuffer>&&);
     void finishCreation(VM&, JSGlobalObject*);
@@ -91,12 +93,22 @@ inline ArrayBuffer* JSArrayBuffer::toWrapped(VM& vm, JSValue value)
     return result;
 }
 
+inline ArrayBuffer* JSArrayBuffer::toWrappedAllowResizable(VM& vm, JSValue value)
+{
+    return toUnsharedArrayBuffer(vm, value);
+}
+
 inline ArrayBuffer* JSArrayBuffer::toWrappedAllowShared(VM& vm, JSValue value)
 {
     auto result = toPossiblySharedArrayBuffer(vm, value);
     if (!result || result->isResizableOrGrowableShared())
         return nullptr;
     return result;
+}
+
+inline ArrayBuffer* JSArrayBuffer::toWrappedAllowSharedAndResizable(VM& vm, JSValue value)
+{
+    return toPossiblySharedArrayBuffer(vm, value);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.h
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.h
@@ -349,9 +349,11 @@ public:
     static constexpr ptrdiff_t offsetOfLength() { return OBJECT_OFFSETOF(JSArrayBufferView, m_length); }
     static constexpr ptrdiff_t offsetOfByteOffset() { return OBJECT_OFFSETOF(JSArrayBufferView, m_byteOffset); }
     static constexpr ptrdiff_t offsetOfMode() { return OBJECT_OFFSETOF(JSArrayBufferView, m_mode); }
-    
+
     static inline RefPtr<ArrayBufferView> toWrapped(VM&, JSValue);
+    static inline RefPtr<ArrayBufferView> toWrappedAllowResizable(VM&, JSValue);
     static inline RefPtr<ArrayBufferView> toWrappedAllowShared(VM&, JSValue);
+    static inline RefPtr<ArrayBufferView> toWrappedAllowSharedAndResizable(VM&, JSValue);
 
     bool isIteratorProtocolFastAndNonObservable();
 

--- a/Source/JavaScriptCore/runtime/JSArrayBufferViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferViewInlines.h
@@ -106,12 +106,29 @@ inline RefPtr<ArrayBufferView> JSArrayBufferView::toWrapped(VM&, JSValue value)
     return nullptr;
 }
 
+inline RefPtr<ArrayBufferView> JSArrayBufferView::toWrappedAllowResizable(VM&, JSValue value)
+{
+    if (JSArrayBufferView* view = jsDynamicCast<JSArrayBufferView*>(value)) {
+        if (view->isShared())
+            return nullptr;
+        return view->unsharedImpl();
+    }
+    return nullptr;
+}
+
 inline RefPtr<ArrayBufferView> JSArrayBufferView::toWrappedAllowShared(VM&, JSValue value)
 {
     if (JSArrayBufferView* view = jsDynamicCast<JSArrayBufferView*>(value)) {
         if (!view->isResizableOrGrowableShared())
             return view->possiblySharedImpl();
     }
+    return nullptr;
+}
+
+inline RefPtr<ArrayBufferView> JSArrayBufferView::toWrappedAllowSharedAndResizable(VM&, JSValue value)
+{
+    if (JSArrayBufferView* view = jsDynamicCast<JSArrayBufferView*>(value))
+        return view->possiblySharedImpl();
     return nullptr;
 }
 

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
@@ -154,9 +154,11 @@ public:
 
     // This is the default DOM unwrapping. It calls toUnsharedNativeTypedView().
     static inline RefPtr<typename Adaptor::ViewType> toWrapped(VM&, JSValue);
+    static inline RefPtr<typename Adaptor::ViewType> toWrappedAllowResizable(VM&, JSValue);
 
     // [AllowShared] annotation allows accepting TypedArray originated from SharedArrayBuffer.
     static inline RefPtr<typename Adaptor::ViewType> toWrappedAllowShared(VM&, JSValue);
+    static inline RefPtr<typename Adaptor::ViewType> toWrappedAllowSharedAndResizable(VM&, JSValue);
 
     inline void copyFromInt32ShapeArray(size_t offset, JSArray*, size_t objectOffset, size_t length);
     inline void copyFromDoubleShapeArray(size_t offset, JSArray*, size_t objectOffset, size_t length);

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -1002,12 +1002,22 @@ template<typename Adaptor> RefPtr<typename Adaptor::ViewType> JSGenericTypedArra
     return result;
 }
 
+template<typename Adaptor> RefPtr<typename Adaptor::ViewType> JSGenericTypedArrayView<Adaptor>::toWrappedAllowResizable(VM& vm, JSValue value)
+{
+    return JSC::toUnsharedNativeTypedView<Adaptor>(vm, value);
+}
+
 template<typename Adaptor> RefPtr<typename Adaptor::ViewType> JSGenericTypedArrayView<Adaptor>::toWrappedAllowShared(VM& vm, JSValue value)
 {
     auto result = JSC::toPossiblySharedNativeTypedView<Adaptor>(vm, value);
     if (!result || result->isResizableOrGrowableShared())
         return nullptr;
     return result;
+}
+
+template<typename Adaptor> RefPtr<typename Adaptor::ViewType> JSGenericTypedArrayView<Adaptor>::toWrappedAllowSharedAndResizable(VM& vm, JSValue value)
+{
+    return JSC::toPossiblySharedNativeTypedView<Adaptor>(vm, value);
 }
 
 template<typename PassedAdaptor> inline const ClassInfo* JSGenericResizableOrGrowableSharedTypedArrayView<PassedAdaptor>::info()

--- a/Source/WebCore/bindings/js/JSDOMConvertUnion.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertUnion.h
@@ -203,8 +203,12 @@ template<typename... T> struct Converter<IDLUnion<T...>> : DefaultConverter<IDLU
         //     2. If types includes object, then return the IDL value that is a reference to the object V.
         constexpr bool hasArrayBufferType = brigand::any<TypeList, IsIDLArrayBuffer<brigand::_1>>::value;
         if constexpr (hasArrayBufferType || hasObjectType) {
-            RefPtr arrayBuffer = (brigand::any<TypeList, IsIDLArrayBufferAllowShared<brigand::_1>>::value) ? JSC::JSArrayBuffer::toWrappedAllowShared(vm, value) : JSC::JSArrayBuffer::toWrapped(vm, value);
+            RefPtr arrayBuffer = (brigand::any<TypeList, IsIDLArrayBufferAllowShared<brigand::_1>>::value) ? JSC::JSArrayBuffer::toWrappedAllowSharedAndResizable(vm, value) : JSC::JSArrayBuffer::toWrappedAllowResizable(vm, value);
             if (arrayBuffer) {
+                if (arrayBuffer->isResizableOrGrowableShared()) {
+                    throwTypeError(&lexicalGlobalObject, scope, "ArrayBuffer cannot be resizable"_s);
+                    return functor(ConversionResultException());
+                }
                 if constexpr (hasArrayBufferType) {
                     return functor(arrayBuffer.releaseNonNull());
                 } else if constexpr (hasObjectType) {
@@ -216,8 +220,12 @@ template<typename... T> struct Converter<IDLUnion<T...>> : DefaultConverter<IDLU
 
         constexpr bool hasArrayBufferViewType = brigand::any<TypeList, IsIDLArrayBufferView<brigand::_1>>::value;
         if constexpr (hasArrayBufferViewType || hasObjectType) {
-            RefPtr arrayBufferView = (brigand::any<TypeList, IsIDLArrayBufferViewAllowShared<brigand::_1>>::value) ? JSC::JSArrayBufferView::toWrappedAllowShared(vm, value) : JSC::JSArrayBufferView::toWrapped(vm, value);
+            RefPtr arrayBufferView = (brigand::any<TypeList, IsIDLArrayBufferViewAllowShared<brigand::_1>>::value) ? JSC::JSArrayBufferView::toWrappedAllowSharedAndResizable(vm, value) : JSC::JSArrayBufferView::toWrappedAllowResizable(vm, value);
             if (arrayBufferView) {
+                if (arrayBufferView->isResizableOrGrowableShared()) {
+                    throwTypeError(&lexicalGlobalObject, scope, "ArrayBufferView cannot be resizable"_s);
+                    return functor(ConversionResultException());
+                }
                 if constexpr (hasArrayBufferViewType) {
                     return functor(arrayBufferView.releaseNonNull());
                 } else if constexpr (hasObjectType) {
@@ -238,8 +246,12 @@ template<typename... T> struct Converter<IDLUnion<T...>> : DefaultConverter<IDLU
         //     2. If types includes object, then return the IDL value that is a reference to the object V.
         constexpr bool hasDataViewType = brigand::any<TypeList, std::is_same<IDLDataView, brigand::_1>>::value;
         if constexpr (hasDataViewType || hasObjectType) {
-            RefPtr dataView = JSC::JSDataView::toWrapped(vm, value);
+            RefPtr dataView = JSC::JSDataView::toWrappedAllowResizable(vm, value);
             if (dataView) {
+                if (dataView->isResizableOrGrowableShared()) {
+                    throwTypeError(&lexicalGlobalObject, scope, "DataView cannot be resizable"_s);
+                    return functor(ConversionResultException());
+                }
                 if constexpr (hasDataViewType) {
                     return functor(dataView.releaseNonNull());
                 } else if constexpr (hasObjectType) {
@@ -262,10 +274,15 @@ template<typename... T> struct Converter<IDLUnion<T...>> : DefaultConverter<IDLU
 
                 using WrapperType = typename Converter<Type>::WrapperType;
 
-                RefPtr castedValue = (brigand::any<TypeList, IsIDLTypedArrayAllowShared<brigand::_1>>::value) ? WrapperType::toWrappedAllowShared(vm, value) : WrapperType::toWrapped(vm, value);
+                RefPtr castedValue = (brigand::any<TypeList, IsIDLTypedArrayAllowShared<brigand::_1>>::value) ? WrapperType::toWrappedAllowSharedAndResizable(vm, value) : WrapperType::toWrappedAllowResizable(vm, value);
                 if (!castedValue)
                     return;
 
+                if (castedValue->isResizableOrGrowableShared()) {
+                    throwTypeError(&lexicalGlobalObject, scope, "TypedArray cannot be resizable"_s);
+                    returnValue = functor(ConversionResultException());
+                    return;
+                }
                 returnValue = functor(ConversionResult<Type> { castedValue.releaseNonNull() });
             });
 


### PR DESCRIPTION
#### 76a1e3d281ca382c56bfd4ff0a7576c841dc71cf
<pre>
Fetch Response should not allow resizable buffers
<a href="https://rdar.apple.com/172196664">rdar://172196664</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311343">https://bugs.webkit.org/show_bug.cgi?id=311343</a>

Reviewed by Sam Weinig and Darin Adler.

When converting a union, we check whether the result of the conversion of array buffer (and friends) returns nullptr or not.
If returning nullptr, we go to the next union type.
In case of a array buffer value and union type having an array buffer type, we should check whether the array buffer is resizable,
and throw, except if conversion allows resizable. But the default conversion will return nullptr if the array buffer is resizable.

We add variants of toWrapped/toWrappedAllowShared which allow to get resizable array buffer.
We use those variants in the union convert routine and check explicitly whether the array buffer is resizable.
If so, instead of going to the next union type, we throw.

Covered by existing WPT tests.

Canonical link: <a href="https://commits.webkit.org/310920@main">https://commits.webkit.org/310920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7752cfff77632cd1aabc61a22bce44b4404adafc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164205 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9c14d0f5-c986-4f59-b327-37d6c2d4ea8c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157316 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28846 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120303 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/301cac28-06d2-443b-a76d-db1394cba3e6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158402 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22496 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139594 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100993 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/99451ad5-6e26-4e47-ba81-13613180225b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12034 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147493 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131251 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166683 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16274 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19036 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128413 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28247 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23721 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128549 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34852 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28171 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139219 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85608 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23386 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187328 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27865 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91968 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48025 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27442 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27672 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27515 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->