### PR TITLE
[css-values-5 attr()] Resolve namespaces

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4465,12 +4465,10 @@ imported/w3c/web-platform-tests/css/css-values/resolution-with-percentage-withou
 imported/w3c/web-platform-tests/css/css-values/viewport-units-scrollbars-scroll-vw-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/vh-update-and-transition-in-subframe.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-values/attr-universal-selector.html [ Pass Failure ]
-imported/w3c/web-platform-tests/css/css-values/attr-namespace-case-sensitivity.xhtml [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/calc-size/calc-size-flex-008.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/calc-size/calc-size-flex-009.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/viewport-units-scrollbars-dynamic-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/viewport-units-scrollbars-scroll-vw-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-values/attr-namespace-valid.xhtml [ ImageOnlyFailure ]
 
 # wpt css-sizing failures
 webkit.org/b/308648 imported/w3c/web-platform-tests/css/css-sizing/abspos-auto-sizing-fit-content-percentage-005.html [ ImageOnlyFailure ]

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1077,6 +1077,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/CSSGroupingRule.h
     css/CSSImportRule.h
     css/CSSMediaRule.h
+    css/CSSNamespacePrefixMap.h
     css/CSSPageDescriptors.h
     css/CSSPageRule.h
     css/CSSPrimitiveValue.h

--- a/Source/WebCore/css/CSSNamespacePrefixMap.h
+++ b/Source/WebCore/css/CSSNamespacePrefixMap.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/HashMap.h>
+#include <wtf/text/AtomString.h>
+#include <wtf/text/AtomStringHash.h>
+
+namespace WebCore {
+
+// Maps @namespace prefixes to URIs for resolving type selectors, attribute selectors, and attr(prefix|name).
+// An empty instance is essentially free (just a null HashMap pointer)
+// and this is almost always empty (only populated for stylesheets with prefixed @namespace rules),
+// so copying is preferred over refcounting.
+using CSSNamespacePrefixMap = HashMap<AtomString, AtomString>;
+
+} // namespace WebCore

--- a/Source/WebCore/css/CSSSubstitutionValue.cpp
+++ b/Source/WebCore/css/CSSSubstitutionValue.cpp
@@ -41,9 +41,17 @@ CSSSubstitutionValue::CSSSubstitutionValue(Ref<CSSVariableData>&& data)
     cacheSimpleReference();
 }
 
-Ref<CSSSubstitutionValue> CSSSubstitutionValue::create(const CSSParserTokenRange& range, const CSSParserContext& context)
+CSSSubstitutionValue::CSSSubstitutionValue(Ref<CSSVariableData>&& data, const CSSNamespacePrefixMap& namespacePrefixMap)
+    : CSSValue(ClassType::Substitution)
+    , m_data(WTF::move(data))
+    , m_namespacePrefixMap(namespacePrefixMap)
 {
-    return adoptRef(*new CSSSubstitutionValue(CSSVariableData::create(range, context)));
+    cacheSimpleReference();
+}
+
+Ref<CSSSubstitutionValue> CSSSubstitutionValue::create(const CSSParserTokenRange& range, const CSSNamespacePrefixMap& namespacePrefixMap, const CSSParserContext& context)
+{
+    return adoptRef(*new CSSSubstitutionValue(CSSVariableData::create(range, context), namespacePrefixMap));
 }
 
 Ref<CSSSubstitutionValue> CSSSubstitutionValue::create(Ref<CSSVariableData>&& data)

--- a/Source/WebCore/css/CSSSubstitutionValue.h
+++ b/Source/WebCore/css/CSSSubstitutionValue.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include <WebCore/CSSNamespacePrefixMap.h>
 #include <WebCore/CSSPropertyNames.h>
 #include <WebCore/CSSValue.h>
 #include <WebCore/CSSValueKeywords.h>
@@ -50,7 +51,7 @@ class SubstitutionResolver;
 // https://drafts.csswg.org/css-values-5/#arbitrary-substitution
 class CSSSubstitutionValue final : public CSSValue {
 public:
-    static Ref<CSSSubstitutionValue> create(const CSSParserTokenRange&, const CSSParserContext&);
+    static Ref<CSSSubstitutionValue> create(const CSSParserTokenRange&, const CSSNamespacePrefixMap&, const CSSParserContext&);
     static Ref<CSSSubstitutionValue> create(Ref<CSSVariableData>&&);
 
     bool equals(const CSSSubstitutionValue&) const;
@@ -64,10 +65,12 @@ private:
     friend class Style::SubstitutionResolver;
 
     explicit CSSSubstitutionValue(Ref<CSSVariableData>&&);
+    CSSSubstitutionValue(Ref<CSSVariableData>&&, const CSSNamespacePrefixMap&);
 
     void cacheSimpleReference();
 
     const Ref<CSSVariableData> m_data;
+    CSSNamespacePrefixMap m_namespacePrefixMap;
     mutable String m_stringValue;
 
     // For quickly resolving simple substitution functions.

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -88,7 +88,7 @@ StyleSheetContents::StyleSheetContents(const StyleSheetContents& o)
     , m_importRules(o.m_importRules.size())
     , m_namespaceRules(o.m_namespaceRules.size())
     , m_childRules(o.m_childRules.size())
-    , m_namespaces(o.m_namespaces)
+    , m_namespacePrefixMap(o.m_namespacePrefixMap)
     , m_defaultNamespace(o.m_defaultNamespace)
     , m_isUserStyleSheet(o.m_isUserStyleSheet)
     , m_loadCompleted(true)
@@ -386,16 +386,13 @@ void StyleSheetContents::parserAddNamespace(const AtomString& prefix, const Atom
         m_defaultNamespace = uri;
         return;
     }
-    PrefixNamespaceURIMap::AddResult result = m_namespaces.add(prefix, uri);
-    if (result.isNewEntry)
-        return;
-    result.iterator->value = uri;
+    m_namespacePrefixMap.set(prefix, uri);
 }
 
 const AtomString& StyleSheetContents::namespaceURIFromPrefix(const AtomString& prefix)
 {
-    PrefixNamespaceURIMap::const_iterator it = m_namespaces.find(prefix);
-    if (it == m_namespaces.end())
+    auto it = m_namespacePrefixMap.find(prefix);
+    if (it == m_namespacePrefixMap.end())
         return nullAtom();
     return it->value;
 }

--- a/Source/WebCore/css/StyleSheetContents.h
+++ b/Source/WebCore/css/StyleSheetContents.h
@@ -20,16 +20,15 @@
 
 #pragma once
 
+#include <WebCore/CSSNamespacePrefixMap.h>
 #include <WebCore/CSSParserContext.h>
 #include <optional>
 #include <wtf/CheckedRef.h>
 #include <wtf/Function.h>
-#include <wtf/HashMap.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
-#include <wtf/text/AtomStringHash.h>
 
 namespace WebCore {
 
@@ -68,6 +67,7 @@ public:
     
     const AtomString& defaultNamespace() LIFETIME_BOUND { return m_defaultNamespace; }
     const AtomString& NODELETE namespaceURIFromPrefix(const AtomString& prefix);
+    const CSSNamespacePrefixMap& namespacePrefixMap() const { return m_namespacePrefixMap; }
 
     bool parseAuthorStyleSheet(const CachedCSSStyleSheet*, const SecurityOrigin*);
     WEBCORE_EXPORT bool parseString(const String&);
@@ -180,8 +180,7 @@ private:
     Vector<Ref<StyleRuleImport>> m_importRules;
     Vector<Ref<StyleRuleNamespace>> m_namespaceRules;
     Vector<Ref<StyleRuleBase>> m_childRules;
-    typedef HashMap<AtomString, AtomString> PrefixNamespaceURIMap;
-    PrefixNamespaceURIMap m_namespaces;
+    CSSNamespacePrefixMap m_namespacePrefixMap;
     AtomString m_defaultNamespace;
 
     bool m_isUserStyleSheet;

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -1806,13 +1806,17 @@ void CSSParser::consumeCustomPropertyValue(CSSParserTokenRange range, const Atom
 {
     if (range.atEnd())
         topContext().m_parsedProperties.append(CSSProperty(CSSPropertyCustom, CSSCustomPropertyValue::createEmpty(variableName), important));
-    else if (auto value = CSSSubstitutionParser::parseDeclarationValue(variableName, range, m_context))
-        topContext().m_parsedProperties.append(CSSProperty(CSSPropertyCustom, value.releaseNonNull(), important));
+    else {
+        auto namespaceMap = m_styleSheet ? m_styleSheet->namespacePrefixMap() : CSSNamespacePrefixMap { };
+        if (auto value = CSSSubstitutionParser::parseDeclarationValue(variableName, range, m_context, namespaceMap))
+            topContext().m_parsedProperties.append(CSSProperty(CSSPropertyCustom, value.releaseNonNull(), important));
+    }
 }
 
 void CSSParser::consumeDeclarationValue(CSSParserTokenRange range, CSSPropertyID propertyID, IsImportant important, StyleRuleType ruleType)
 {
-    CSSPropertyParser::parseValue(propertyID, important, range, m_context, topContext().m_parsedProperties, ruleType);
+    auto namespaceMap = m_styleSheet ? m_styleSheet->namespacePrefixMap() : CSSNamespacePrefixMap { };
+    CSSPropertyParser::parseValue(propertyID, important, range, m_context, topContext().m_parsedProperties, ruleType, namespaceMap);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -87,7 +87,7 @@ static std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> 
 // MARK: - Root consumers
 
 // Style properties.
-static bool consumeStyleProperty(CSSParserTokenRange&, const CSSParserContext&, CSSPropertyID, IsImportant, StyleRuleType, CSS::PropertyParserResult&);
+static bool consumeStyleProperty(CSSParserTokenRange&, const CSSParserContext&, CSSPropertyID, IsImportant, StyleRuleType, CSS::PropertyParserResult&, const CSSNamespacePrefixMap& = { });
 
 // @font-face descriptors.
 static bool consumeFontFaceDescriptor(CSSParserTokenRange&, const CSSParserContext&, CSSPropertyID, CSS::PropertyParserResult&);
@@ -229,7 +229,7 @@ static std::optional<CSSWideKeyword> consumeCSSWideKeyword(CSSParserTokenRange& 
 
 using namespace CSSPropertyParserHelpers;
 
-bool CSSPropertyParser::parseValue(CSSPropertyID property, IsImportant important, CSSParserTokenRange range, const CSSParserContext& context, ParsedPropertyVector& parsedProperties, StyleRuleType ruleType)
+bool CSSPropertyParser::parseValue(CSSPropertyID property, IsImportant important, CSSParserTokenRange range, const CSSParserContext& context, ParsedPropertyVector& parsedProperties, StyleRuleType ruleType, const CSSNamespacePrefixMap& namespaceMap)
 {
     int initialParsedPropertiesSize = parsedProperties.size();
 
@@ -267,7 +267,7 @@ bool CSSPropertyParser::parseValue(CSSPropertyID property, IsImportant important
         parseSuccess = consumeFunctionDescriptor(range, context, property, result);
         break;
     default:
-        parseSuccess = consumeStyleProperty(range, context, property, important, ruleType, result);
+        parseSuccess = consumeStyleProperty(range, context, property, important, ruleType, result, namespaceMap);
         break;
     }
 
@@ -619,7 +619,7 @@ std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> consume
 
 // MARK: - Root consumers
 
-bool consumeStyleProperty(CSSParserTokenRange& range, const CSSParserContext& context, CSSPropertyID property, IsImportant important, StyleRuleType ruleType, CSS::PropertyParserResult& result)
+bool consumeStyleProperty(CSSParserTokenRange& range, const CSSParserContext& context, CSSPropertyID property, IsImportant important, StyleRuleType ruleType, CSS::PropertyParserResult& result, const CSSNamespacePrefixMap& namespaceMap)
 {
     if (CSSProperty::isDescriptorOnly(property))
         return false;
@@ -645,7 +645,7 @@ bool consumeStyleProperty(CSSParserTokenRange& range, const CSSParserContext& co
             return true;
 
         if (CSSSubstitutionParser::containsSubstitutionFunctions(originalRange, context)) {
-            result.addPropertyForAllLonghandsOfCurrentShorthand(state, CSSShorthandSubstitutionValue::create(property, CSSSubstitutionValue::create(originalRange, context)));
+            result.addPropertyForAllLonghandsOfCurrentShorthand(state, CSSShorthandSubstitutionValue::create(property, CSSSubstitutionValue::create(originalRange, namespaceMap, context)));
             return true;
         }
     } else {
@@ -665,7 +665,7 @@ bool consumeStyleProperty(CSSParserTokenRange& range, const CSSParserContext& co
         }
 
         if (CSSSubstitutionParser::containsSubstitutionFunctions(originalRange, context)) {
-            result.addProperty(state, property, CSSPropertyInvalid, CSSSubstitutionValue::create(originalRange, context), important);
+            result.addProperty(state, property, CSSPropertyInvalid, CSSSubstitutionValue::create(originalRange, namespaceMap, context), important);
             return true;
         }
     }

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <WebCore/CSSNamespacePrefixMap.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -53,7 +54,7 @@ enum class IsAttrTainted : bool;
 class CSSPropertyParser {
 public:
     // Parses any CSS property or descriptor. If successful, the result will be appended to the `result` Vector and the function will return true, otherwise, the function will return false and the `result` Vector will be unmodified.
-    static bool parseValue(CSSPropertyID, IsImportant, CSSParserTokenRange, const CSSParserContext&, Vector<CSSProperty, 256>& result, StyleRuleType);
+    static bool parseValue(CSSPropertyID, IsImportant, CSSParserTokenRange, const CSSParserContext&, Vector<CSSProperty, 256>& result, StyleRuleType, const CSSNamespacePrefixMap& = { });
 
     // Parses a longhand style property.
     static RefPtr<CSSValue> parseStylePropertyLonghand(CSSPropertyID, const String&, const CSSParserContext&);

--- a/Source/WebCore/css/parser/CSSSubstitutionParser.cpp
+++ b/Source/WebCore/css/parser/CSSSubstitutionParser.cpp
@@ -38,10 +38,12 @@
 #include "CSSParserTokenRange.h"
 #include "CSSPropertyParser.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
+#include "CSSSubstitutionValue.h"
 #include "CSSTokenizer.h"
 #include "CSSUnits.h"
 #include "CSSValueKeywords.h"
 #include "StyleCustomProperty.h"
+#include "StyleSheetContents.h"
 #include <stack>
 
 namespace WebCore {
@@ -305,7 +307,7 @@ bool CSSSubstitutionParser::containsSubstitutionFunctions(CSSParserTokenRange ra
     return type->classifyBlockResult.hasSubstitutionFunctions && !type->classifyBlockResult.hasTopLevelBraceBlockMixedWithOtherValues;
 }
 
-RefPtr<CSSCustomPropertyValue> CSSSubstitutionParser::parseDeclarationValue(const AtomString& variableName, CSSParserTokenRange range, const CSSParserContext& parserContext)
+RefPtr<CSSCustomPropertyValue> CSSSubstitutionParser::parseDeclarationValue(const AtomString& variableName, CSSParserTokenRange range, const CSSParserContext& parserContext, const CSSNamespacePrefixMap& namespaceMap)
 {
     auto type = classifyVariableRange(range, parserContext);
     if (!type)
@@ -315,7 +317,7 @@ RefPtr<CSSCustomPropertyValue> CSSSubstitutionParser::parseDeclarationValue(cons
         return CSSCustomPropertyValue::createWithCSSWideKeyword(variableName, *type->cssWideKeyword);
 
     if (type->classifyBlockResult.hasSubstitutionFunctions)
-        return CSSCustomPropertyValue::createUnresolved(variableName, CSSSubstitutionValue::create(range, parserContext));
+        return CSSCustomPropertyValue::createUnresolved(variableName, CSSSubstitutionValue::create(range, namespaceMap, parserContext));
 
     return CSSCustomPropertyValue::createSyntaxAll(variableName, CSSVariableData::create(range, parserContext));
 }

--- a/Source/WebCore/css/parser/CSSSubstitutionParser.h
+++ b/Source/WebCore/css/parser/CSSSubstitutionParser.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "CSSParserTokenRange.h"
+#include <WebCore/CSSNamespacePrefixMap.h>
 #include <wtf/RefPtr.h>
 #include <wtf/text/AtomString.h>
 
@@ -46,7 +47,7 @@ class CSSSubstitutionParser {
 public:
     static bool containsSubstitutionFunctions(CSSParserTokenRange, const CSSParserContext&);
 
-    static RefPtr<CSSCustomPropertyValue> parseDeclarationValue(const AtomString&, CSSParserTokenRange, const CSSParserContext&);
+    static RefPtr<CSSCustomPropertyValue> parseDeclarationValue(const AtomString&, CSSParserTokenRange, const CSSParserContext&, const CSSNamespacePrefixMap& = { });
     static RefPtr<const Style::CustomProperty> parseInitialValueForUniversalSyntax(const AtomString&, CSSParserTokenRange);
 
     static bool NODELETE isValidCustomPropertyName(const CSSParserToken&);

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -78,7 +78,7 @@ RefPtr<CSSStyleValue> CSSStyleValueFactory::constructStyleValueForShorthandSeria
     CSSTokenizer tokenizer(serialization);
     if (serialization.contains("var("_s))
         return CSSUnparsedValue::create(tokenizer.tokenRange());
-    return CSSStyleValue::create(CSSSubstitutionValue::create(tokenizer.tokenRange(), { document }));
+    return CSSStyleValue::create(CSSSubstitutionValue::create(tokenizer.tokenRange(), { }, { document }));
 }
 
 ExceptionOr<RefPtr<CSSValue>> CSSStyleValueFactory::extractCSSValue(Document& document, const CSSPropertyID& propertyID, const String& cssText)

--- a/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
@@ -156,7 +156,7 @@ ExceptionOr<CSSUnparsedSegment> CSSUnparsedValue::setItem(size_t index, CSSUnpar
 RefPtr<CSSValue> CSSUnparsedValue::toCSSValue() const
 {
     CSSTokenizer tokenizer(toString());
-    return CSSSubstitutionValue::create(tokenizer.tokenRange(), strictCSSParserContext());
+    return CSSSubstitutionValue::create(tokenizer.tokenRange(), { }, strictCSSParserContext());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -301,7 +301,13 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
     if (!element)
         return false;
 
-    auto& attributeValue = element->getAttribute(QualifiedName { nullAtom(), attributeName, nullAtom() });
+    // Resolve namespace prefix to URI.
+    auto namespaceURI = [&]() -> AtomString {
+        auto& prefix = parsedName->namespacePrefix;
+        if (prefix.isEmpty())
+            return nullAtom();
+        return m_substitutionValue->m_namespacePrefixMap.get(prefix);
+    }();
 
     // Check if this attribute is already being substituted (cycle detection).
     auto isInCycle = !m_styleBuilder.state().m_inProgressAttrAttributes.add(attributeName).isNewEntry;
@@ -333,6 +339,10 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
         return true;
     };
 
+    // If a non-empty prefix was given but couldn't be resolved, trigger fallback.
+    if (!parsedName->namespacePrefix.isEmpty() && namespaceURI.isNull())
+        return substituteFailure();
+
     if (isInCycle) {
         // Mark as in-cycle within attr() type() context for transitive detection.
         if (m_isInAttrTypeSyntax)
@@ -342,9 +352,7 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
         return substituteFailure();
     }
 
-    // FIXME: Resolve namespace prefixes using the stylesheet's @namespace rules instead of always triggering fallback.
-    if (!parsedName->namespacePrefix.isNull())
-        return substituteFailure();
+    auto& attributeValue = element->getAttribute(QualifiedName { nullAtom(), attributeName, namespaceURI });
 
     if (attributeValue.isNull())
         return substituteFailure();
@@ -559,6 +567,7 @@ RefPtr<CSSVariableData> SubstitutionResolver::substitute(const CSSSubstitutionVa
 {
     m_isAttrTainted = false;
     m_hasTaintedURL = false;
+    m_substitutionValue = &value;
 
     if (auto data = trySimpleSubstitution(value)) {
         propagateAttrTaint(data->isAttrTainted(), data->tokens());

--- a/Source/WebCore/style/StyleSubstitutionResolver.h
+++ b/Source/WebCore/style/StyleSubstitutionResolver.h
@@ -76,6 +76,7 @@ private:
     void propagateAttrTaint(IsAttrTainted, std::span<const CSSParserToken>);
 
     Builder& m_styleBuilder;
+    RefPtr<const CSSSubstitutionValue> m_substitutionValue;
     Vector<String> m_intermediateTokenStrings;
     unsigned m_urlContextDepth { 0 };
     bool m_isInAttrTypeSyntax { false };


### PR DESCRIPTION
#### 8bac746b3a579d8bf79c0a702bb7ccc5be893b3c
<pre>
[css-values-5 attr()] Resolve namespaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=311331">https://bugs.webkit.org/show_bug.cgi?id=311331</a>
<a href="https://rdar.apple.com/173920192">rdar://173920192</a>

Reviewed by Alan Baradlay.

@namespace foo &quot;some_url&quot;;
div { color: attr(foo|bar) }

For this we need to pass the namespace prefix map from the originating stylesheet to SubstitutionResolver.

* LayoutTests/TestExpectations:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSNamespacePrefixMap.h: Added.

Move the map to a header.
For simplicity we&apos;ll copy this map instead of say refcounting it as in practice
it is basically always empty and so just a nullptr.

* Source/WebCore/css/CSSSubstitutionValue.cpp:
(WebCore::CSSSubstitutionValue::CSSSubstitutionValue):
(WebCore::CSSSubstitutionValue::create):
* Source/WebCore/css/CSSSubstitutionValue.h:

Include the namespace map in subtitution value.

* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::StyleSheetContents):
(WebCore::StyleSheetContents::parserAddNamespace):
(WebCore::StyleSheetContents::namespaceURIFromPrefix):
(WebCore::StyleSheetContents::namespacePrefixMap const):
* Source/WebCore/css/StyleSheetContents.h:
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::consumeCustomPropertyValue):
(WebCore::CSSParser::consumeDeclarationValue):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::consumeStyleProperty):
(WebCore::CSSPropertyParser::parseValue):
* Source/WebCore/css/parser/CSSPropertyParser.h:
(WebCore::CSSPropertyParser::parseValue):
* Source/WebCore/css/parser/CSSSubstitutionParser.cpp:
(WebCore::CSSSubstitutionParser::parseDeclarationValue):
* Source/WebCore/css/parser/CSSSubstitutionParser.h:
(WebCore::CSSSubstitutionParser::parseDeclarationValue):
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
(WebCore::CSSStyleValueFactory::constructStyleValueForShorthandSerialization):
* Source/WebCore/css/typedom/CSSUnparsedValue.cpp:
(WebCore::CSSUnparsedValue::toCSSValue const):
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteAttrFunction):

Look up the namespace URL from the prefix map.

(WebCore::Style::SubstitutionResolver::substitute):
* Source/WebCore/style/StyleSubstitutionResolver.h:

Canonical link: <a href="https://commits.webkit.org/310459@main">https://commits.webkit.org/310459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f765896fd6c9d46b1015cc83059fd2c2ff61cb9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20303 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162653 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107367 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d274fcc6-3b6a-4a3f-b616-f2379862dceb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155775 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27215 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27008 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119005 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84140 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fdc56ac9-4619-4e5f-a7dc-b8bb9eb812a4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138202 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99715 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20360 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18322 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10485 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130012 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16055 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165126 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8257 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17655 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127088 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26483 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22341 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127255 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34522 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137850 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83200 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22152 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14634 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26102 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90402 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25793 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25953 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25853 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->