### PR TITLE
StabilityTracer: com.apple.WebKit.WebContent at WebCore:  WebCore::SharedMemory::createSendRight

### DIFF
--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -130,11 +130,15 @@ Ref<SharedBuffer> FragmentedSharedBuffer::makeContiguous() const
 
 auto FragmentedSharedBuffer::toIPCData() const -> IPCData
 {
-    if (useUnixDomainSockets || size() < minimumPageSize) {
+    auto segmentSpans = [&] {
         return WTF::map(m_segments, [](auto& segment) {
             return segment.segment->span();
         });
-    }
+    };
+
+    if (useUnixDomainSockets || size() < minimumPageSize)
+        return segmentSpans();
+
 #if PLATFORM(COCOA)
     if (m_segments.size() == 1) {
         Ref segment = m_segments[0].segment;
@@ -142,8 +146,9 @@ auto FragmentedSharedBuffer::toIPCData() const -> IPCData
             return SharedMemoryHandle::createVMShare(segment->span(), SharedMemory::Protection::ReadOnly);
     }
 #endif
-    RefPtr sharedMemoryBuffer = SharedMemory::copyBuffer(*this);
-    return sharedMemoryBuffer->createHandle(SharedMemory::Protection::ReadOnly);
+    if (RefPtr<SharedMemory> sharedMemoryBuffer = SharedMemory::copyBuffer(*this))
+        return sharedMemoryBuffer->createHandle(SharedMemory::Protection::ReadOnly);
+    return segmentSpans();
 }
 
 Vector<uint8_t> FragmentedSharedBuffer::copyData() const


### PR DESCRIPTION
#### 1c2cca8ce8690a4dcf0872e5a5a6ab68dfab499a
<pre>
StabilityTracer: com.apple.WebKit.WebContent at WebCore:  WebCore::SharedMemory::createSendRight
<a href="https://bugs.webkit.org/show_bug.cgi?id=311351">https://bugs.webkit.org/show_bug.cgi?id=311351</a>
<a href="https://rdar.apple.com/172419434">rdar://172419434</a>

Reviewed by Jer Noble.

Null-check the refptr returned by SharedMemory::copyBuffer inside the caller
FragmentedSharedBuffer::toIPCData(). In the case that the refptr is null, fall
back on the segment span copy path.

No new tests.

* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::FragmentedSharedBuffer::toIPCData const):

Canonical link: <a href="https://commits.webkit.org/310642@main">https://commits.webkit.org/310642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e31b2d1d1c1b185740288d9325c8edc0281b607b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27727 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163225 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107938 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/807de8d0-3708-44de-9e7d-cb31f5f57abf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156342 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27861 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119477 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84503 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ffcf96f-eb20-4c73-9f64-893ad9196fff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138734 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100174 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8e238aae-bab7-4246-87e6-e1f66c16f75e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20839 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18850 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11055 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130501 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16578 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165697 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8904 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18187 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127573 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27273 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22890 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127719 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34656 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138371 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83875 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22614 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15163 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26888 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90990 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26468 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26699 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26541 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->