### PR TITLE
AX: Update frame geometry after scrolling

### DIFF
--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -65,6 +65,7 @@ accessibility/textarea-insertion-point-line-number.html [ Failure ]
 accessibility/mac/html5-input-number.html [ Timeout ]
 
 # Regressions from ENABLE(ACCESSIBILITY_LOCAL_FRAME).
+accessibility/mac/iframe-position-after-scroll.html [ Failure ]
 accessibility/scroll-to-global-point-main-window.html [ Failure ]
 accessibility/scroll-to-make-visible-iframe-offscreen.html [ Timeout ]
 

--- a/LayoutTests/accessibility/mac/iframe-position-after-scroll-expected.txt
+++ b/LayoutTests/accessibility/mac/iframe-position-after-scroll-expected.txt
@@ -1,0 +1,8 @@
+This test verifies that scrolling the main page updates the screen position of elements inside an iframe.
+
+PASS: delta was equal or approximately equal to 300.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/iframe-position-after-scroll.html
+++ b/LayoutTests/accessibility/mac/iframe-position-after-scroll.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+body {
+    height: 5000px;
+    margin: 0;
+}
+#container {
+    position: absolute;
+    top: 200px;
+    left: 10px;
+}
+iframe {
+    width: 200px;
+    height: 100px;
+    border: none;
+}
+</style>
+</head>
+<body>
+
+<div id="container">
+    <iframe id="iframe" onload="runTest()" src="data:text/html,<body style='margin:0'><button id='target' style='width:80px;height:30px'>Click me</button></body>"></iframe>
+</div>
+
+<script>
+window.jsTestIsAsync = true;
+
+var output = "This test verifies that scrolling the main page updates the screen position of elements inside an iframe.\n\n";
+
+var target, initialY, scrolledY, delta;
+function runTest() {
+    if (!window.accessibilityController)
+        return;
+
+    setTimeout(async function() {
+        // Wait for the iframe's frame geometry to be initialized and the
+        // target element's position to stabilize.
+        var lastY;
+        await waitFor(() => {
+            var iframeContainer = accessibilityController.accessibleElementById("container");
+            if (!iframeContainer)
+                return false;
+            var iframeScrollView = iframeContainer.childAtIndex(0);
+            if (!iframeScrollView || !iframeScrollView.isFrameGeometryInitialized)
+                return false;
+            target = accessibilityController.accessibleElementById("target");
+            if (!target)
+                return false;
+            var stable = lastY === target.y;
+            lastY = target.y;
+            return stable;
+        });
+
+        initialY = target.y;
+
+        // Scroll the main page down by 300px.
+        window.scrollTo(0, 300);
+
+        // Wait for the element's absolute screen y to change after scroll.
+        await waitFor(() => {
+            target = accessibilityController.accessibleElementById("target");
+            return target && target.y !== initialY;
+        });
+
+        scrolledY = target.y;
+        delta = Math.abs(scrolledY - initialY);
+        output += expectNumber("delta", 300, /* Allowed variance */ 5);
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -315,6 +315,11 @@ void RemoteScrollingCoordinatorProxy::sendScrollingTreeNodeUpdate()
         webPageProxy->sendScrollUpdateForNode(m_scrollingTree->frameIDForScrollingNodeID(update.nodeID), update, isLastUpdate);
         m_waitingForDidScrollReply = true;
     }
+
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    if (!scrollUpdates.isEmpty())
+        webPageProxy->scheduleAccessibilityFrameGeometryUpdate();
+#endif
 }
 
 void RemoteScrollingCoordinatorProxy::scrollingThreadAddedPendingUpdate()


### PR DESCRIPTION
#### cfee00dedb536f3bcbf36a0b519eac428768d0e1
<pre>
AX: Update frame geometry after scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=290132">https://bugs.webkit.org/show_bug.cgi?id=290132</a>
<a href="https://rdar.apple.com/147531853">rdar://147531853</a>

Reviewed by Tyler Wilcock.

We didn&apos;t re-compute frame geometry when scrolling happened. Add a hook into our
coalescing FrameGeometry update mechanism when scroll finishes.

This newe test is flakey in ITM due to some bugs with FrameGeometry + scrolling,
which will be addressed in a follow-up PR.

Test: accessibility/mac/iframe-position-after-scroll.html

* LayoutTests/accessibility-isolated-tree/TestExpectations:
* LayoutTests/accessibility/mac/iframe-position-after-scroll-expected.txt: Added.
* LayoutTests/accessibility/mac/iframe-position-after-scroll.html: Added.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::sendScrollingTreeNodeUpdate):

Canonical link: <a href="https://commits.webkit.org/310499@main">https://commits.webkit.org/310499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ed1dc5e0d4b7b4b6851fa5295a32d2d7874f0ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26712 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162678 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107394 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a869ac46-54b5-45f5-895f-c34f54f232b7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27243 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27034 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119080 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84162 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/98a7da94-a10b-4974-bbdd-7e8ebe30cfdf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99731 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d3c4946a-ad6b-4fdb-8c22-df5da2a15d3e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20387 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18351 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10510 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130045 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16076 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165151 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8292 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17675 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127172 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26511 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22374 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127278 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34550 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26515 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137870 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83225 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22175 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14656 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26128 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90444 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25819 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25983 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25879 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->