### PR TITLE
AX: Presentational/hidden images shouldn't expose image overlay children

### DIFF
--- a/LayoutTests/accessibility/image-overlay-elements-presentational-expected.txt
+++ b/LayoutTests/accessibility/image-overlay-elements-presentational-expected.txt
@@ -1,0 +1,9 @@
+This test ensures image overlay elements are not exposed for presentational images.
+
+PASS: webArea.childrenCount === 0
+PASS: webArea.childrenCount > 0 === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/image-overlay-elements-presentational.html
+++ b/LayoutTests/accessibility/image-overlay-elements-presentational.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<img role="presentation" src="resources/green-400x400.png">
+
+<script>
+var output = "This test ensures image overlay elements are not exposed for presentational images.\n\n";
+var webArea;
+
+var overlayData = [
+    {
+        topLeft: new DOMPointReadOnly(0, 0),
+        topRight: new DOMPointReadOnly(1, 0),
+        bottomRight: new DOMPointReadOnly(1, 1),
+        bottomLeft: new DOMPointReadOnly(0, 1),
+        children: [
+            {
+                text: "overlay text",
+                topLeft: new DOMPointReadOnly(0, 0),
+                topRight: new DOMPointReadOnly(1, 0),
+                bottomRight: new DOMPointReadOnly(1, 1),
+                bottomLeft: new DOMPointReadOnly(0, 1),
+            }
+        ],
+    }
+];
+
+addEventListener("load", () => {
+    internals.installImageOverlay(document.querySelector("img"), overlayData);
+
+    if (window.accessibilityController) {
+        window.jsTestIsAsync = true;
+
+        webArea = accessibilityController.rootElement.childAtIndex(0);
+        output += expect("webArea.childrenCount", "0");
+
+        // Remove role="presentation" and verify overlay children become visible.
+        document.querySelector("img").removeAttribute("role");
+
+        setTimeout(async () => {
+            output += await expectAsync("webArea.childrenCount > 0", "true");
+            debug(output);
+            finishJSTest();
+        }, 0);
+    }
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -839,6 +839,9 @@ accessibility/clip-path-bounding-box.html [ Skip ]
 accessibility/first-letter-single-character.html [ Skip ]
 accessibility/table-cell-hit-test-not-column.html [ Skip ]
 
+# installImageOverlay is a no-op on platforms without IMAGE_ANALYSIS.
+accessibility/image-overlay-elements-presentational.html [ Skip ]
+
 accessibility/dynamic-expanded-text.html [ Failure ]
 
 accessibility/dynamic-content-visibility.html [ Skip ]

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -84,6 +84,7 @@
 #include "HitTestRequest.h"
 #include "HitTestResult.h"
 #include "Image.h"
+#include "ImageOverlay.h"
 #include "InlineIteratorBoxInlines.h"
 #include "InlineIteratorLogicalOrderTraversal.h"
 #include "InlineIteratorTextBoxInlines.h"
@@ -965,6 +966,12 @@ bool AccessibilityRenderObject::computeIsIgnored() const
         return true;
 
     if (role() == AccessibilityRole::Ignored)
+        return true;
+
+    // Image overlay children (text recognized in images) should be ignored if
+    // their host image is accessibility-ignored (e.g. role="presentation" or
+    // aria-hidden="true").
+    if (isInsideIgnoredImageOverlay())
         return true;
 
     // Needs to happen before the presentational role check, since we want to expose table cells if they are in an exposable table (even if within a presentational role).
@@ -2411,11 +2418,28 @@ AccessibilityRole AccessibilityRenderObject::determineAccessibilityRole()
     return AccessibilityRole::Unknown;
 }
 
+bool AccessibilityRenderObject::isInsideIgnoredImageOverlay() const
+{
+    RefPtr node = this->node();
+    if (!node || !ImageOverlay::isInsideOverlay(*node))
+        return false;
+
+    CheckedPtr cache = axObjectCache();
+    if (RefPtr hostObject = cache ? cache->getOrCreate(node->shadowHost()) : nullptr)
+        return hostObject->isIgnored();
+    return false;
+}
+
 std::optional<AXCoreObject::AccessibilityChildrenVector> AccessibilityRenderObject::imageOverlayElements()
 {
     AXTRACE("AccessibilityRenderObject::imageOverlayElements"_s);
 
     if (!m_renderer || !toSimpleImage(*m_renderer))
+        return std::nullopt;
+
+    // Don't expose image overlay elements for images that are accessibility-ignored
+    // (e.g. due to role="presentation" or aria-hidden="true").
+    if (isIgnored())
         return std::nullopt;
 
     const auto& children = this->unignoredChildren();

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.h
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.h
@@ -188,6 +188,7 @@ protected:
 private:
     bool isAccessibilityRenderObject() const final { return true; }
     bool isAllowedChildOfTree() const;
+    bool isInsideIgnoredImageOverlay() const;
     AccessibilityObject* containingTree() const;
     CharacterRange documentBasedSelectedTextRange() const;
     RefPtr<Element> rootEditableElementForPosition(const Position&) const;


### PR DESCRIPTION
#### 20193b191530c31847cb70759f7646d8cd805236
<pre>
AX: Presentational/hidden images shouldn&apos;t expose image overlay children
<a href="https://bugs.webkit.org/show_bug.cgi?id=311358">https://bugs.webkit.org/show_bug.cgi?id=311358</a>
<a href="https://rdar.apple.com/159304061">rdar://159304061</a>

Reviewed by Tyler Wilcock.

An image with role=&quot;presentation&quot; can have image overlay children (e.g., OCRed text). We
need to make sure that we don&apos;t expose those, or add them to the accessibility hierarchy
when they are descendants of an ignored image, as they are intrinsically tied.

Test: accessibility/image-overlay-elements-presentational.html
* LayoutTests/accessibility/image-overlay-elements-presentational-expected.txt: Added.
* LayoutTests/accessibility/image-overlay-elements-presentational.html: Added.
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::computeIsIgnored const):
(WebCore::AccessibilityRenderObject::isInsideIgnoredImageOverlay const):
(WebCore::AccessibilityRenderObject::imageOverlayElements):
* Source/WebCore/accessibility/AccessibilityRenderObject.h:

Canonical link: <a href="https://commits.webkit.org/310483@main">https://commits.webkit.org/310483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/616a07cefad4620b279a1dcd84661744b52ed65f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162696 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107412 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7a852eb7-15b9-4fa4-acbc-98827069c9f2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27052 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119050 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84169 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/90dcea79-ada9-4a2f-97ea-3b85be813c34) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21316 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138240 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99751 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/688e157e-e9c7-4899-91eb-5e3410a59c61) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20405 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18366 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10528 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130062 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16092 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165169 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8318 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17693 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127142 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26533 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22400 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127297 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34534 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26539 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137886 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83248 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22194 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14674 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26146 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90455 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25837 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26004 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25902 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->