### PR TITLE
[DFG] Prevent stale OSR exit hints for escaped heap allocations

### DIFF
--- a/viewport-fix/demo/index.html
+++ b/viewport-fix/demo/index.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <title>Modular Viewport Fix — Demo</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --color-bg: #0a0a0f;
+      --color-surface: #13131a;
+      --color-card: #1a1a26;
+      --color-border: #2a2a3d;
+      --color-primary: #7c6dfa;
+      --color-accent: #fa6d8f;
+      --color-success: #4ade80;
+      --color-warning: #fbbf24;
+      --color-text: #e4e4f0;
+      --color-muted: #7a7a9a;
+      --radius-md: 12px;
+      --radius-lg: 20px;
+      --font-sans: 'Inter', system-ui, sans-serif;
+      --font-mono: 'JetBrains Mono', monospace;
+    }
+
+    body {
+      font-family: var(--font-sans);
+      background: var(--color-bg);
+      color: var(--color-text);
+      margin: 0;
+      padding: 2rem 1.5rem;
+    }
+
+    .container {
+      max-width: 800px;
+      margin: 0 auto;
+    }
+
+    h1 { font-size: 2rem; margin-bottom: 2rem; text-align: center; }
+
+    /* Debug Panel */
+    .debug-panel {
+      background: var(--color-card);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-lg);
+      margin-bottom: 2rem;
+      overflow: hidden;
+    }
+    .debug-panel__header {
+      padding: 1rem 1.5rem;
+      background: rgba(124,109,250,0.05);
+      border-bottom: 1px solid var(--color-border);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .debug-panel__title { font-weight: 600; font-size: 0.9rem; }
+    .badge--ok { color: var(--color-success); font-size: 0.75rem; font-weight: 600; }
+    .badge--warn { color: var(--color-warning); font-size: 0.75rem; font-weight: 600; }
+    table { width: 100%; border-collapse: collapse; font-family: var(--font-mono); font-size: 0.8rem; }
+    td { padding: 0.75rem 1.5rem; border-bottom: 1px solid var(--color-border); }
+    td:first-child { color: var(--color-muted); }
+    td:last-child { color: var(--color-primary); font-weight: 600; text-align: right; }
+
+    /* Demo Grid */
+    .demo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 1rem;
+    }
+    .demo-card {
+      background: var(--color-card);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-md);
+      overflow: hidden;
+    }
+    .demo-card__label {
+      padding: 0.5rem 0.75rem;
+      border-bottom: 1px solid var(--color-border);
+      font-size: 0.65rem;
+      font-weight: 700;
+      color: var(--color-muted);
+      text-transform: uppercase;
+    }
+    .demo-card__box {
+      height: 120px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      position: relative;
+    }
+    .tick-bar {
+      position: absolute;
+      right: 8px;
+      top: 10px;
+      bottom: 10px;
+      width: 3px;
+      background: var(--color-border);
+      border-radius: 4px;
+    }
+    .tick-fill {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      border-radius: 4px;
+      background: linear-gradient(to top, var(--color-primary), var(--color-accent));
+      transition: height 0.3s;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Modular Viewport Fix</h1>
+    <div id="debug-panel-root"></div>
+    <div id="demo-boxes-root"></div>
+  </div>
+
+  <script type="module">
+    import { initViewportFix } from '../src/index.js';
+    import { DebugPanel } from '../src/components/DebugPanel.js';
+    import { DemoBoxes } from '../src/components/DemoBoxes.js';
+
+    const debugPanel = new DebugPanel(document.getElementById('debug-panel-root'));
+    const demoBoxes = new DemoBoxes(document.getElementById('demo-boxes-root'));
+
+    initViewportFix({
+      onMeasure: (m) => {
+        debugPanel.update(m);
+        demoBoxes.update(m);
+      }
+    });
+
+    console.info('[ViewportFix] ✅ Initialized modular version.');
+  </script>
+</body>
+</html>

--- a/viewport-fix/package.json
+++ b/viewport-fix/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "viewport-fix",
+  "version": "1.0.0",
+  "description": "Production-ready iOS Safari viewport height solution",
+  "main": "src/index.js",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "dev": "python -m http.server 7846"
+  },
+  "keywords": [
+    "viewport",
+    "ios",
+    "safari",
+    "vh",
+    "100vh",
+    "dvh",
+    "svh"
+  ],
+  "author": "Antigravity",
+  "license": "MIT"
+}

--- a/viewport-fix/src/components/DebugPanel.js
+++ b/viewport-fix/src/components/DebugPanel.js
@@ -1,0 +1,75 @@
+/**
+ * src/components/DebugPanel.js
+ * ─────────────────────────────────────────────────────────────
+ * Renders live viewport metrics into a <tbody> element.
+ * Completely optional — import only in development / demo builds.
+ *
+ * Usage:
+ *   import { DebugPanel } from './components/DebugPanel.js';
+ *   const panel = new DebugPanel(document.getElementById('debug-output'));
+ *   // then pass measurements to it:
+ *   panel.update(measurement);
+ */
+
+export class DebugPanel {
+  /**
+   * @param {HTMLElement} container - the element to render the panel into
+   */
+  constructor(container) {
+    if (!container) throw new Error('[DebugPanel] container is required');
+    
+    container.innerHTML = `
+      <div class="debug-panel">
+        <div class="debug-panel__header">
+          <span class="debug-panel__title">Live Viewport Metrics</span>
+          <span class="badge-target"></span>
+        </div>
+        <table>
+          <tbody class="output-target"></tbody>
+        </table>
+      </div>
+    `;
+
+    this._tbody = container.querySelector('.output-target');
+    this._badge = container.querySelector('.badge-target');
+  }
+
+  /**
+   * Re-render the panel with the latest measurement.
+   * @param {import('../core/measure.js').ViewportMeasurement} m
+   */
+  update(m) {
+    const vvp = window.visualViewport;
+
+    this._tbody.innerHTML = rows([
+      ['window.innerHeight',       `${window.innerHeight}px`],
+      ['visualViewport.height',    vvp ? `${vvp.height.toFixed(2)}px` : 'N/A'],
+      ['visualViewport.offsetTop', vvp ? `${vvp.offsetTop.toFixed(2)}px` : 'N/A'],
+      ['screen.height',            `${screen.height}px`],
+      ['--vh resolved (1%)',        `${(m.visual  / 100).toFixed(4)}px`],
+      ['--svh resolved (1%)',       `${(m.stable / 100).toFixed(4)}px`],
+      ['CSS svh support',          m.supportsSVH ? '✅ Yes' : '❌ No'],
+      ['CSS dvh support',          m.supportsDVH ? '✅ Yes' : '❌ No'],
+      ['visualViewport API',       m.hasVisualViewportAPI ? '✅ Yes' : '❌ No'],
+      ['Last updated',             new Date().toLocaleTimeString()],
+    ]);
+
+    if (this._badge) {
+      const allGood = m.supportsSVH && m.supportsDVH && m.hasVisualViewportAPI;
+      this._badge.innerHTML = allGood
+        ? '<span class="badge badge--ok">Full Support</span>'
+        : '<span class="badge badge--warn">Partial — JS active</span>';
+    }
+  }
+}
+
+// ─── helpers ────────────────────────────────────────────────
+
+function rows(pairs) {
+  return pairs.map(([label, value]) => `
+    <tr>
+      <td>${label}</td>
+      <td>${value}</td>
+    </tr>
+  `).join('');
+}

--- a/viewport-fix/src/components/DebugPanel.js
+++ b/viewport-fix/src/components/DebugPanel.js
@@ -1,23 +1,8 @@
-/**
- * src/components/DebugPanel.js
- * ─────────────────────────────────────────────────────────────
- * Renders live viewport metrics into a <tbody> element.
- * Completely optional — import only in development / demo builds.
- *
- * Usage:
- *   import { DebugPanel } from './components/DebugPanel.js';
- *   const panel = new DebugPanel(document.getElementById('debug-output'));
- *   // then pass measurements to it:
- *   panel.update(measurement);
- */
-
 export class DebugPanel {
-  /**
-   * @param {HTMLElement} container - the element to render the panel into
-   */
   constructor(container) {
     if (!container) throw new Error('[DebugPanel] container is required');
-    
+    this._container = container;
+
     container.innerHTML = `
       <div class="debug-panel">
         <div class="debug-panel__header">
@@ -32,44 +17,62 @@ export class DebugPanel {
 
     this._tbody = container.querySelector('.output-target');
     this._badge = container.querySelector('.badge-target');
+
+    this._valNodes = {};
+    const pairs = [
+      'window.innerHeight',
+      'visualViewport.height',
+      'visualViewport.offsetTop',
+      'screen.height',
+      '--vh resolved (1%)',
+      '--svh resolved (1%)',
+      'CSS svh support',
+      'CSS dvh support',
+      'visualViewport API',
+      'Last updated'
+    ];
+
+    for (const label of pairs) {
+      const tr = document.createElement('tr');
+      const td1 = document.createElement('td');
+      const td2 = document.createElement('td');
+      td1.textContent = label;
+      td2.textContent = '';
+      tr.appendChild(td1);
+      tr.appendChild(td2);
+      this._tbody.appendChild(tr);
+      this._valNodes[label] = td2;
+    }
+
+    this._badgeSpan = document.createElement('span');
+    if (this._badge) this._badge.appendChild(this._badgeSpan);
   }
 
-  /**
-   * Re-render the panel with the latest measurement.
-   * @param {import('../core/measure.js').ViewportMeasurement} m
-   */
   update(m) {
-    const vvp = window.visualViewport;
+    if (!this._container) return;
 
-    this._tbody.innerHTML = rows([
-      ['window.innerHeight',       `${window.innerHeight}px`],
-      ['visualViewport.height',    vvp ? `${vvp.height.toFixed(2)}px` : 'N/A'],
-      ['visualViewport.offsetTop', vvp ? `${vvp.offsetTop.toFixed(2)}px` : 'N/A'],
-      ['screen.height',            `${screen.height}px`],
-      ['--vh resolved (1%)',        `${(m.visual  / 100).toFixed(4)}px`],
-      ['--svh resolved (1%)',       `${(m.stable / 100).toFixed(4)}px`],
-      ['CSS svh support',          m.supportsSVH ? '✅ Yes' : '❌ No'],
-      ['CSS dvh support',          m.supportsDVH ? '✅ Yes' : '❌ No'],
-      ['visualViewport API',       m.hasVisualViewportAPI ? '✅ Yes' : '❌ No'],
-      ['Last updated',             new Date().toLocaleTimeString()],
-    ]);
+    this._valNodes['window.innerHeight'].textContent = `${m.stable}px`;
+    this._valNodes['visualViewport.height'].textContent = m.hasVisualViewportAPI ? `${m.visual.toFixed(2)}px` : 'N/A';
+    this._valNodes['visualViewport.offsetTop'].textContent = m.hasVisualViewportAPI ? `${m.offsetTop.toFixed(2)}px` : 'N/A';
+    this._valNodes['screen.height'].textContent = `${m.screen}px`;
+    this._valNodes['--vh resolved (1%)'].textContent = `${(m.visual / 100).toFixed(4)}px`;
+    this._valNodes['--svh resolved (1%)'].textContent = `${(m.stable / 100).toFixed(4)}px`;
+    this._valNodes['CSS svh support'].textContent = m.supportsSVH ? '✅ Yes' : '❌ No';
+    this._valNodes['CSS dvh support'].textContent = m.supportsDVH ? '✅ Yes' : '❌ No';
+    this._valNodes['visualViewport API'].textContent = m.hasVisualViewportAPI ? '✅ Yes' : '❌ No';
+    this._valNodes['Last updated'].textContent = new Date().toLocaleTimeString();
 
     if (this._badge) {
       const allGood = m.supportsSVH && m.supportsDVH && m.hasVisualViewportAPI;
-      this._badge.innerHTML = allGood
-        ? '<span class="badge badge--ok">Full Support</span>'
-        : '<span class="badge badge--warn">Partial — JS active</span>';
+      this._badgeSpan.className = allGood ? 'badge badge--ok' : 'badge badge--warn';
+      this._badgeSpan.textContent = allGood ? 'Full Support' : 'Partial — JS active';
     }
   }
-}
 
-// ─── helpers ────────────────────────────────────────────────
-
-function rows(pairs) {
-  return pairs.map(([label, value]) => `
-    <tr>
-      <td>${label}</td>
-      <td>${value}</td>
-    </tr>
-  `).join('');
+  destroy() {
+    if (this._container) this._container.innerHTML = '';
+    this._valNodes = {};
+    this._badgeSpan = null;
+    this._container = null;
+  }
 }

--- a/viewport-fix/src/components/DemoBoxes.js
+++ b/viewport-fix/src/components/DemoBoxes.js
@@ -1,19 +1,7 @@
-/**
- * src/components/DemoBoxes.js
- * ─────────────────────────────────────────────────────────────
- * Updates the visual height demo boxes and tick bars.
- * Uses a hidden probe element to measure CSS unit heights —
- * the probe is created once and cleaned up with destroy().
- */
-
 export class DemoBoxes {
-  /**
-   * @param {HTMLElement} container - the element to render the boxes into
-   */
   constructor(container) {
     if (!container) throw new Error('[DemoBoxes] container is required');
     this._container = container;
-    this._probe = null;
 
     this._container.innerHTML = `
       <div class="demo-grid">
@@ -28,65 +16,66 @@ export class DemoBoxes {
         `).join('')}
       </div>
     `;
+
+    this._els = {};
+    for (const id of ['vh', 'svh', 'dvh', 'js-svh', 'js-vh']) {
+      this._els[id] = {
+        val: this._container.querySelector(`#val-${id}`),
+        tick: this._container.querySelector(`#tick-${id}`),
+      };
+    }
+
+    this._probes = {
+      vh: this._createProbe('100vh'),
+      svh: this._createProbe('100svh'),
+      dvh: this._createProbe('100dvh'),
+    };
   }
 
-  /**
-   * Update all demo boxes based on the latest measurement.
-   * @param {import('../core/measure.js').ViewportMeasurement} m
-   */
+  _createProbe(cssValue) {
+    const probe = document.createElement('div');
+    Object.assign(probe.style, {
+      position: 'absolute',
+      top: '-9999px',
+      left: '-9999px',
+      visibility: 'hidden',
+      pointerEvents: 'none',
+      height: cssValue
+    });
+    const parent = document.body ?? document.documentElement;
+    parent.appendChild(probe);
+    return probe;
+  }
+
   update(m) {
-    const ref = screen.height;
+    if (!this._container) return;
+    const ref = m.screen;
 
     const entries = [
-      { id: 'vh',     h: this._probeUnit('100vh')  },
-      { id: 'svh',    h: this._probeUnit('100svh') },
-      { id: 'dvh',    h: this._probeUnit('100dvh') },
-      { id: 'js-svh', h: m.stable                  },
-      { id: 'js-vh',  h: m.visual                  },
+      { id: 'vh', h: this._probes.vh.getBoundingClientRect().height },
+      { id: 'svh', h: this._probes.svh.getBoundingClientRect().height },
+      { id: 'dvh', h: this._probes.dvh.getBoundingClientRect().height },
+      { id: 'js-svh', h: m.stable },
+      { id: 'js-vh', h: m.visual },
     ];
 
     for (const { id, h } of entries) {
-      const valEl  = this._container.querySelector(`#val-${id}`);
-      const tickEl = this._container.querySelector(`#tick-${id}`);
+      const { val: valEl, tick: tickEl } = this._els[id];
 
       const display = h > 0 ? `${Math.round(h)}px` : 'N/A';
 
-      if (valEl)  valEl.textContent = display;
-      if (tickEl) tickEl.style.height = h > 0
+      if (valEl) valEl.textContent = display;
+      if (tickEl) tickEl.style.height = (h > 0 && ref > 0)
         ? `${Math.min(100, (h / ref) * 100).toFixed(1)}%`
         : '0%';
     }
   }
 
-  /** Remove the probe element from the DOM. Call in cleanup(). */
   destroy() {
-    this._probe?.remove();
-    this._probe = null;
-  }
-
-  // ─── private ──────────────────────────────────────────────
-
-  /**
-   * Measure the rendered height of a CSS value using a hidden probe element.
-   * Returns 0 for unsupported units (e.g. svh on old browsers).
-   *
-   * @param {string} cssValue
-   * @returns {number}
-   */
-  _probeUnit(cssValue) {
-    if (!this._probe) {
-      this._probe = document.createElement('div');
-      Object.assign(this._probe.style, {
-        position:      'absolute',
-        top:           '-9999px',
-        left:          '-9999px',
-        visibility:    'hidden',
-        pointerEvents: 'none',
-      });
-      document.body.appendChild(this._probe);
-    }
-
-    this._probe.style.height = cssValue;
-    return this._probe.getBoundingClientRect().height;
+    Object.values(this._probes).forEach(p => p.remove());
+    if (this._container) this._container.innerHTML = '';
+    this._probes = {};
+    this._els = {};
+    this._container = null;
   }
 }

--- a/viewport-fix/src/components/DemoBoxes.js
+++ b/viewport-fix/src/components/DemoBoxes.js
@@ -1,0 +1,92 @@
+/**
+ * src/components/DemoBoxes.js
+ * ─────────────────────────────────────────────────────────────
+ * Updates the visual height demo boxes and tick bars.
+ * Uses a hidden probe element to measure CSS unit heights —
+ * the probe is created once and cleaned up with destroy().
+ */
+
+export class DemoBoxes {
+  /**
+   * @param {HTMLElement} container - the element to render the boxes into
+   */
+  constructor(container) {
+    if (!container) throw new Error('[DemoBoxes] container is required');
+    this._container = container;
+    this._probe = null;
+
+    this._container.innerHTML = `
+      <div class="demo-grid">
+        ${['vh', 'svh', 'dvh', 'js-svh', 'js-vh'].map(id => `
+          <div class="demo-card">
+            <div class="demo-card__label">${id.toUpperCase()}</div>
+            <div class="demo-card__box">
+              <div class="tick-bar"><div class="tick-fill" id="tick-${id}"></div></div>
+              <div class="val-display" id="val-${id}">—</div>
+            </div>
+          </div>
+        `).join('')}
+      </div>
+    `;
+  }
+
+  /**
+   * Update all demo boxes based on the latest measurement.
+   * @param {import('../core/measure.js').ViewportMeasurement} m
+   */
+  update(m) {
+    const ref = screen.height;
+
+    const entries = [
+      { id: 'vh',     h: this._probeUnit('100vh')  },
+      { id: 'svh',    h: this._probeUnit('100svh') },
+      { id: 'dvh',    h: this._probeUnit('100dvh') },
+      { id: 'js-svh', h: m.stable                  },
+      { id: 'js-vh',  h: m.visual                  },
+    ];
+
+    for (const { id, h } of entries) {
+      const valEl  = this._container.querySelector(`#val-${id}`);
+      const tickEl = this._container.querySelector(`#tick-${id}`);
+
+      const display = h > 0 ? `${Math.round(h)}px` : 'N/A';
+
+      if (valEl)  valEl.textContent = display;
+      if (tickEl) tickEl.style.height = h > 0
+        ? `${Math.min(100, (h / ref) * 100).toFixed(1)}%`
+        : '0%';
+    }
+  }
+
+  /** Remove the probe element from the DOM. Call in cleanup(). */
+  destroy() {
+    this._probe?.remove();
+    this._probe = null;
+  }
+
+  // ─── private ──────────────────────────────────────────────
+
+  /**
+   * Measure the rendered height of a CSS value using a hidden probe element.
+   * Returns 0 for unsupported units (e.g. svh on old browsers).
+   *
+   * @param {string} cssValue
+   * @returns {number}
+   */
+  _probeUnit(cssValue) {
+    if (!this._probe) {
+      this._probe = document.createElement('div');
+      Object.assign(this._probe.style, {
+        position:      'absolute',
+        top:           '-9999px',
+        left:          '-9999px',
+        visibility:    'hidden',
+        pointerEvents: 'none',
+      });
+      document.body.appendChild(this._probe);
+    }
+
+    this._probe.style.height = cssValue;
+    return this._probe.getBoundingClientRect().height;
+  }
+}

--- a/viewport-fix/src/core/cssVars.js
+++ b/viewport-fix/src/core/cssVars.js
@@ -1,42 +1,18 @@
-/**
- * src/core/cssVars.js
- * ─────────────────────────────────────────────────────────────
- * Writes viewport measurements as CSS custom properties.
- * Separated from measure.js so tests can verify writes independently.
- */
-
-/**
- * Write --vh and --svh onto a target element (defaults to :root).
- *
- * --vh  → 1% of the VISUAL viewport  (follows keyboard, toolbar animations)
- * --svh → 1% of the STABLE viewport  (innerHeight — does not animate)
- *
- * Usage in CSS:
- *   height: calc(var(--svh) * 100);   /* stable full-height shell *\/
- *   height: calc(var(--vh)  * 100);   /* keyboard-aware form container *\/
- *
- * @param {{ visual: number, stable: number }} measurement
- * @param {HTMLElement} [target=document.documentElement]
- */
-export function writeCSSVars(measurement, target = document.documentElement) {
+export function writeCSSVars(measurement, target) {
+  const el = target ?? (typeof document !== 'undefined' ? document.documentElement : null);
+  if (!el) return;
   const { visual, stable } = measurement;
-  target.style.setProperty('--vh',  px(visual  / 100));
-  target.style.setProperty('--svh', px(stable / 100));
+  el.style.setProperty('--vh', px(visual / 100));
+  el.style.setProperty('--svh', px(stable / 100));
 }
 
-/**
- * Remove the custom properties (e.g. for cleanup in tests or SSR).
- *
- * @param {HTMLElement} [target=document.documentElement]
- */
-export function clearCSSVars(target = document.documentElement) {
-  target.style.removeProperty('--vh');
-  target.style.removeProperty('--svh');
+export function clearCSSVars(target) {
+  const el = target ?? (typeof document !== 'undefined' ? document.documentElement : null);
+  if (!el) return;
+  el.style.removeProperty('--vh');
+  el.style.removeProperty('--svh');
 }
 
-// ─── helpers ────────────────────────────────────────────────
-
-/** Format a number as a CSS px value with 4 decimal places. */
 function px(n) {
   return `${n.toFixed(4)}px`;
 }

--- a/viewport-fix/src/core/cssVars.js
+++ b/viewport-fix/src/core/cssVars.js
@@ -1,0 +1,42 @@
+/**
+ * src/core/cssVars.js
+ * ─────────────────────────────────────────────────────────────
+ * Writes viewport measurements as CSS custom properties.
+ * Separated from measure.js so tests can verify writes independently.
+ */
+
+/**
+ * Write --vh and --svh onto a target element (defaults to :root).
+ *
+ * --vh  → 1% of the VISUAL viewport  (follows keyboard, toolbar animations)
+ * --svh → 1% of the STABLE viewport  (innerHeight — does not animate)
+ *
+ * Usage in CSS:
+ *   height: calc(var(--svh) * 100);   /* stable full-height shell *\/
+ *   height: calc(var(--vh)  * 100);   /* keyboard-aware form container *\/
+ *
+ * @param {{ visual: number, stable: number }} measurement
+ * @param {HTMLElement} [target=document.documentElement]
+ */
+export function writeCSSVars(measurement, target = document.documentElement) {
+  const { visual, stable } = measurement;
+  target.style.setProperty('--vh',  px(visual  / 100));
+  target.style.setProperty('--svh', px(stable / 100));
+}
+
+/**
+ * Remove the custom properties (e.g. for cleanup in tests or SSR).
+ *
+ * @param {HTMLElement} [target=document.documentElement]
+ */
+export function clearCSSVars(target = document.documentElement) {
+  target.style.removeProperty('--vh');
+  target.style.removeProperty('--svh');
+}
+
+// ─── helpers ────────────────────────────────────────────────
+
+/** Format a number as a CSS px value with 4 decimal places. */
+function px(n) {
+  return `${n.toFixed(4)}px`;
+}

--- a/viewport-fix/src/core/measure.js
+++ b/viewport-fix/src/core/measure.js
@@ -1,0 +1,54 @@
+/**
+ * src/core/measure.js
+ * ─────────────────────────────────────────────────────────────
+ * Raw viewport measurement — no side effects, no DOM writes.
+ * Returns a plain object so callers can decide what to do with it.
+ */
+
+/**
+ * @typedef {Object} ViewportMeasurement
+ * @property {number} visual  - visualViewport.height (tracks keyboard + toolbar)
+ * @property {number} stable  - window.innerHeight    (stable, ignores toolbar)
+ * @property {number} screen  - screen.height         (physical screen)
+ * @property {number} offsetTop - visualViewport.offsetTop (scroll offset)
+ * @property {boolean} hasVisualViewportAPI
+ * @property {boolean} supportsSVH  - CSS svh unit support
+ * @property {boolean} supportsDVH  - CSS dvh unit support
+ */
+
+/**
+ * Take a single snapshot of all viewport dimensions.
+ * Pure function — reads DOM but writes nothing.
+ *
+ * @returns {ViewportMeasurement}
+ */
+export function snapshot() {
+  const vvp = window.visualViewport;
+  const visual  = vvp ? vvp.height    : window.innerHeight;
+  const offsetTop = vvp ? vvp.offsetTop : 0;
+
+  return {
+    visual,
+    stable:   window.innerHeight,
+    screen:   screen.height,
+    offsetTop,
+    hasVisualViewportAPI: !!vvp,
+    supportsSVH: supportsUnit('1svh'),
+    supportsDVH: supportsUnit('1dvh'),
+  };
+}
+
+/**
+ * Probe whether the browser understands a given CSS unit string.
+ * Result is memoised — the answer never changes mid-session.
+ *
+ * @param {string} value  e.g. '1svh'
+ * @returns {boolean}
+ */
+const unitCache = new Map();
+function supportsUnit(value) {
+  if (unitCache.has(value)) return unitCache.get(value);
+  const result = typeof CSS !== 'undefined' && !!CSS.supports?.('height', value);
+  unitCache.set(value, result);
+  return result;
+}

--- a/viewport-fix/src/core/measure.js
+++ b/viewport-fix/src/core/measure.js
@@ -1,36 +1,24 @@
-/**
- * src/core/measure.js
- * ─────────────────────────────────────────────────────────────
- * Raw viewport measurement — no side effects, no DOM writes.
- * Returns a plain object so callers can decide what to do with it.
- */
+const unitCache = new Map();
 
-/**
- * @typedef {Object} ViewportMeasurement
- * @property {number} visual  - visualViewport.height (tracks keyboard + toolbar)
- * @property {number} stable  - window.innerHeight    (stable, ignores toolbar)
- * @property {number} screen  - screen.height         (physical screen)
- * @property {number} offsetTop - visualViewport.offsetTop (scroll offset)
- * @property {boolean} hasVisualViewportAPI
- * @property {boolean} supportsSVH  - CSS svh unit support
- * @property {boolean} supportsDVH  - CSS dvh unit support
- */
+function supportsUnit(value) {
+  if (unitCache.has(value)) return unitCache.get(value);
+  const result = typeof CSS !== 'undefined' && !!CSS.supports?.('height', value);
+  unitCache.set(value, result);
+  return result;
+}
 
-/**
- * Take a single snapshot of all viewport dimensions.
- * Pure function — reads DOM but writes nothing.
- *
- * @returns {ViewportMeasurement}
- */
 export function snapshot() {
-  const vvp = window.visualViewport;
-  const visual  = vvp ? vvp.height    : window.innerHeight;
+  const isBrowser = typeof window !== 'undefined';
+  const vvp = isBrowser ? window.visualViewport : null;
+  const innerHeight = isBrowser ? window.innerHeight : 0;
+
+  const visual = vvp ? vvp.height : innerHeight;
   const offsetTop = vvp ? vvp.offsetTop : 0;
 
   return {
     visual,
-    stable:   window.innerHeight,
-    screen:   screen.height,
+    stable: innerHeight,
+    screen: isBrowser && typeof screen !== 'undefined' ? screen.height : 0,
     offsetTop,
     hasVisualViewportAPI: !!vvp,
     supportsSVH: supportsUnit('1svh'),
@@ -38,17 +26,6 @@ export function snapshot() {
   };
 }
 
-/**
- * Probe whether the browser understands a given CSS unit string.
- * Result is memoised — the answer never changes mid-session.
- *
- * @param {string} value  e.g. '1svh'
- * @returns {boolean}
- */
-const unitCache = new Map();
-function supportsUnit(value) {
-  if (unitCache.has(value)) return unitCache.get(value);
-  const result = typeof CSS !== 'undefined' && !!CSS.supports?.('height', value);
-  unitCache.set(value, result);
-  return result;
+export function clearUnitCache() {
+  unitCache.clear();
 }

--- a/viewport-fix/src/index.js
+++ b/viewport-fix/src/index.js
@@ -1,0 +1,54 @@
+/**
+ * viewport-fix/src/index.js
+ * ─────────────────────────────────────────────────────────────
+ * Public API — this is the only file consumers import.
+ *
+ * Usage:
+ *   import { initViewportFix } from './src/index.js';
+ *   const cleanup = initViewportFix();
+ *   // later:
+ *   cleanup();
+ */
+
+import { snapshot }       from './core/measure.js';
+import { writeCSSVars, clearCSSVars } from './core/cssVars.js';
+import { createRAFScheduler, attachListeners } from './utils/scheduler.js';
+
+/**
+ * Initialise the viewport fix.
+ *
+ * 1. Takes an immediate measurement (no flash of wrong height).
+ * 2. Writes --vh and --svh to :root (or a custom target).
+ * 3. Attaches listeners that re-measure on resize / orientationchange.
+ * 4. Returns a cleanup function for use in React useEffect, Vue onUnmounted, etc.
+ *
+ * @param {{ target?: HTMLElement, onMeasure?: (m: import('./core/measure.js').ViewportMeasurement) => void }} [options]
+ * @returns {() => void} cleanup
+ */
+export function initViewportFix({ target, onMeasure } = {}) {
+  const el = target ?? document.documentElement;
+
+  const { schedule, cancel } = createRAFScheduler(() => {
+    const m = snapshot();
+    writeCSSVars(m, el);
+    onMeasure?.(m);
+  });
+
+  // Synchronous first run — must happen before first paint
+  const initial = snapshot();
+  writeCSSVars(initial, el);
+  onMeasure?.(initial);
+
+  // Wire up event listeners — returns a named cleanup fn
+  const removeListeners = attachListeners(schedule);
+
+  return function cleanup() {
+    cancel();
+    removeListeners();
+    clearCSSVars(el);
+  };
+}
+
+// Re-export primitives for advanced use (e.g. SSR, testing)
+export { snapshot } from './core/measure.js';
+export { writeCSSVars, clearCSSVars } from './core/cssVars.js';

--- a/viewport-fix/src/index.js
+++ b/viewport-fix/src/index.js
@@ -1,54 +1,50 @@
-/**
- * viewport-fix/src/index.js
- * ─────────────────────────────────────────────────────────────
- * Public API — this is the only file consumers import.
- *
- * Usage:
- *   import { initViewportFix } from './src/index.js';
- *   const cleanup = initViewportFix();
- *   // later:
- *   cleanup();
- */
-
-import { snapshot }       from './core/measure.js';
+import { snapshot } from './core/measure.js';
 import { writeCSSVars, clearCSSVars } from './core/cssVars.js';
 import { createRAFScheduler, attachListeners } from './utils/scheduler.js';
 
+let active = false;
+
 /**
- * Initialise the viewport fix.
- *
- * 1. Takes an immediate measurement (no flash of wrong height).
- * 2. Writes --vh and --svh to :root (or a custom target).
- * 3. Attaches listeners that re-measure on resize / orientationchange.
- * 4. Returns a cleanup function for use in React useEffect, Vue onUnmounted, etc.
- *
- * @param {{ target?: HTMLElement, onMeasure?: (m: import('./core/measure.js').ViewportMeasurement) => void }} [options]
- * @returns {() => void} cleanup
+ * Initialises the viewport fix, writing CSS custom properties on every resize.
+ * @param {{ target?: Element, onMeasure?: (m: object) => void }} [options]
+ * @returns {() => void} Cleanup function that removes all listeners and clears CSS vars.
+ *   Returns a no-op if called outside a browser environment, or if already initialised.
  */
 export function initViewportFix({ target, onMeasure } = {}) {
+  if (typeof window === 'undefined') return () => {};
+
+  if (active) {
+    console.warn('[viewport-fix] already initialised — call cleanup() before re-initialising');
+    return () => {};
+  }
+  active = true;
   const el = target ?? document.documentElement;
 
-  const { schedule, cancel } = createRAFScheduler(() => {
+  function measure() {
     const m = snapshot();
     writeCSSVars(m, el);
     onMeasure?.(m);
-  });
+  }
 
-  // Synchronous first run — must happen before first paint
-  const initial = snapshot();
-  writeCSSVars(initial, el);
-  onMeasure?.(initial);
+  const { schedule, cancel } = createRAFScheduler(measure);
 
-  // Wire up event listeners — returns a named cleanup fn
-  const removeListeners = attachListeners(schedule);
+  let removeListeners;
+  try {
+    measure();
+    removeListeners = attachListeners(schedule);
+  } catch (err) {
+    active = false;
+    cancel();
+    throw err;
+  }
 
   return function cleanup() {
+    active = false;
     cancel();
     removeListeners();
     clearCSSVars(el);
   };
 }
 
-// Re-export primitives for advanced use (e.g. SSR, testing)
 export { snapshot } from './core/measure.js';
 export { writeCSSVars, clearCSSVars } from './core/cssVars.js';

--- a/viewport-fix/src/utils/scheduler.js
+++ b/viewport-fix/src/utils/scheduler.js
@@ -1,21 +1,8 @@
-/**
- * src/utils/scheduler.js
- * ─────────────────────────────────────────────────────────────
- * RAF-based scheduler and event-listener helpers.
- * Returns cleanup functions so callers can tear down cleanly.
- */
-
-/**
- * Wrap a callback in requestAnimationFrame, cancelling any
- * pending frame before scheduling a new one.
- *
- * @param {() => void} callback
- * @returns {{ schedule: () => void, cancel: () => void }}
- */
 export function createRAFScheduler(callback) {
   let rafId = null;
 
   function schedule() {
+    if (typeof requestAnimationFrame === 'undefined') return;
     if (rafId !== null) cancelAnimationFrame(rafId);
     rafId = requestAnimationFrame(() => {
       callback();
@@ -33,41 +20,41 @@ export function createRAFScheduler(callback) {
   return { schedule, cancel };
 }
 
-/**
- * Attach all viewport-related event listeners.
- * Returns a single cleanup() function that removes every one.
- *
- * @param {() => void} handler  - the function to call on every change
- * @returns {() => void}         - call this to remove all listeners
- */
 export function attachListeners(handler) {
+  if (typeof window === 'undefined') return () => {};
   const opts = { passive: true };
+  let pendingOrientationTimer = null;
 
-  // Store named references so removeEventListener works correctly.
-  // Arrow functions passed inline cannot be removed — this was a bug
-  // in the original flat implementation.
-  const onResize            = () => handler();
-  const onOrientationChange = () => setTimeout(handler, 200);
-  // iOS fires orientationchange BEFORE the new dimensions are available,
-  // so a 200 ms delay lets the layout settle first.
+  const onResize = handler;
+
+  const onOrientationChange = () => {
+    if (pendingOrientationTimer !== null) clearTimeout(pendingOrientationTimer);
+    pendingOrientationTimer = setTimeout(() => {
+      handler();
+      pendingOrientationTimer = null;
+    }, 200);
+  };
 
   window.addEventListener('resize', onResize, opts);
   window.addEventListener('orientationchange', onOrientationChange, opts);
 
   let vvpCleanup = null;
-  if (window.visualViewport) {
-    const onVVPResize = () => handler();
-    const onVVPScroll = () => handler();
-    window.visualViewport.addEventListener('resize', onVVPResize, opts);
-    window.visualViewport.addEventListener('scroll', onVVPScroll, opts);
+  const vvp = window.visualViewport ?? null;
+  if (vvp) {
+    vvp.addEventListener('resize', handler, opts);
+    vvp.addEventListener('scroll', handler, opts);
 
     vvpCleanup = () => {
-      window.visualViewport.removeEventListener('resize', onVVPResize);
-      window.visualViewport.removeEventListener('scroll', onVVPScroll);
+      vvp.removeEventListener('resize', handler);
+      vvp.removeEventListener('scroll', handler);
     };
   }
 
   return function cleanup() {
+    if (pendingOrientationTimer !== null) {
+      clearTimeout(pendingOrientationTimer);
+      pendingOrientationTimer = null;
+    }
     window.removeEventListener('resize', onResize);
     window.removeEventListener('orientationchange', onOrientationChange);
     vvpCleanup?.();

--- a/viewport-fix/src/utils/scheduler.js
+++ b/viewport-fix/src/utils/scheduler.js
@@ -1,0 +1,75 @@
+/**
+ * src/utils/scheduler.js
+ * ─────────────────────────────────────────────────────────────
+ * RAF-based scheduler and event-listener helpers.
+ * Returns cleanup functions so callers can tear down cleanly.
+ */
+
+/**
+ * Wrap a callback in requestAnimationFrame, cancelling any
+ * pending frame before scheduling a new one.
+ *
+ * @param {() => void} callback
+ * @returns {{ schedule: () => void, cancel: () => void }}
+ */
+export function createRAFScheduler(callback) {
+  let rafId = null;
+
+  function schedule() {
+    if (rafId !== null) cancelAnimationFrame(rafId);
+    rafId = requestAnimationFrame(() => {
+      callback();
+      rafId = null;
+    });
+  }
+
+  function cancel() {
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+  }
+
+  return { schedule, cancel };
+}
+
+/**
+ * Attach all viewport-related event listeners.
+ * Returns a single cleanup() function that removes every one.
+ *
+ * @param {() => void} handler  - the function to call on every change
+ * @returns {() => void}         - call this to remove all listeners
+ */
+export function attachListeners(handler) {
+  const opts = { passive: true };
+
+  // Store named references so removeEventListener works correctly.
+  // Arrow functions passed inline cannot be removed — this was a bug
+  // in the original flat implementation.
+  const onResize            = () => handler();
+  const onOrientationChange = () => setTimeout(handler, 200);
+  // iOS fires orientationchange BEFORE the new dimensions are available,
+  // so a 200 ms delay lets the layout settle first.
+
+  window.addEventListener('resize', onResize, opts);
+  window.addEventListener('orientationchange', onOrientationChange, opts);
+
+  let vvpCleanup = null;
+  if (window.visualViewport) {
+    const onVVPResize = () => handler();
+    const onVVPScroll = () => handler();
+    window.visualViewport.addEventListener('resize', onVVPResize, opts);
+    window.visualViewport.addEventListener('scroll', onVVPScroll, opts);
+
+    vvpCleanup = () => {
+      window.visualViewport.removeEventListener('resize', onVVPResize);
+      window.visualViewport.removeEventListener('scroll', onVVPScroll);
+    };
+  }
+
+  return function cleanup() {
+    window.removeEventListener('resize', onResize);
+    window.removeEventListener('orientationchange', onOrientationChange);
+    vvpCleanup?.();
+  };
+}

--- a/viewport-fix/tests/viewport-fix.test.js
+++ b/viewport-fix/tests/viewport-fix.test.js
@@ -1,19 +1,11 @@
-/**
- * tests/viewport-fix.test.js
- * ─────────────────────────────────────────────────────────────
- * Unit tests for core modules.
- * Run with: npx vitest run
- */
 
 import { snapshot, clearUnitCache }       from '../src/core/measure.js';
 import { writeCSSVars, clearCSSVars }    from '../src/core/cssVars.js';
 import { createRAFScheduler, attachListeners } from '../src/utils/scheduler.js';
 import { initViewportFix }               from '../src/index.js';
 
-// ─── Mock browser globals ──────────────────────────────────────────────────
 
 beforeEach(() => {
-  // jsdom doesn't implement these — provide minimal stubs
   global.screen = { height: 844 };
 
   global.CSS = {
@@ -26,7 +18,6 @@ beforeEach(() => {
     value: 750,
   });
 
-  // Simulate visualViewport API
   global.window.visualViewport = {
     height:    740,
     offsetTop: 0,
@@ -34,7 +25,6 @@ beforeEach(() => {
     removeEventListener: vi.fn(),
   };
 
-  // RAF stub: execute callback asynchronously by default
   let rafId = 0;
   let pendingRAFs = new Map();
   global.requestAnimationFrame  = (cb) => { 
@@ -60,7 +50,6 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-// ─── snapshot() ────────────────────────────────────────────────────────────
 
 describe('snapshot()', () => {
   test('uses visualViewport.height for visual when API is present', () => {
@@ -93,7 +82,6 @@ describe('snapshot()', () => {
   });
 });
 
-// ─── writeCSSVars() ────────────────────────────────────────────────────────
 
 describe('writeCSSVars()', () => {
   test('sets --vh to visual / 100 as px string', () => {
@@ -115,7 +103,6 @@ describe('writeCSSVars()', () => {
   });
 });
 
-// ─── clearCSSVars() ────────────────────────────────────────────────────────
 
 describe('clearCSSVars()', () => {
   test('removes --vh and --svh from :root', () => {
@@ -126,7 +113,6 @@ describe('clearCSSVars()', () => {
   });
 });
 
-// ─── createRAFScheduler() ──────────────────────────────────────────────────
 
 describe('createRAFScheduler()', () => {
   test('calls callback after schedule() and runPendingRAF()', () => {
@@ -155,7 +141,6 @@ describe('createRAFScheduler()', () => {
   });
 });
 
-// ─── attachListeners() ─────────────────────────────────────────────────────
 
 describe('attachListeners()', () => {
   test('attaches listeners to window and visualViewport', () => {
@@ -188,7 +173,6 @@ describe('attachListeners()', () => {
   });
 });
 
-// ─── initViewportFix() ─────────────────────────────────────────────────────
 
 describe('initViewportFix()', () => {
   test('takes an immediate measurement and writes vars', () => {

--- a/viewport-fix/tests/viewport-fix.test.js
+++ b/viewport-fix/tests/viewport-fix.test.js
@@ -1,0 +1,148 @@
+/**
+ * tests/viewport-fix.test.js
+ * ─────────────────────────────────────────────────────────────
+ * Unit tests for core modules.
+ * Run with: node --experimental-vm-modules node_modules/.bin/jest
+ * Or:       npx vitest run
+ */
+
+import { snapshot }                  from '../src/core/measure.js';
+import { writeCSSVars, clearCSSVars } from '../src/core/cssVars.js';
+import { createRAFScheduler }         from '../src/utils/scheduler.js';
+
+// ─── Mock browser globals ──────────────────────────────────────────────────
+
+beforeEach(() => {
+  // jsdom doesn't implement these — provide minimal stubs
+  global.screen = { height: 844 };
+
+  global.CSS = {
+    supports: (prop, val) => ['1svh', '1dvh', '1lvh'].includes(val),
+  };
+
+  Object.defineProperty(window, 'innerHeight', {
+    writable: true,
+    configurable: true,
+    value: 750,
+  });
+
+  // Simulate visualViewport API
+  global.window.visualViewport = {
+    height:    740,
+    offsetTop: 0,
+    addEventListener:    jest.fn(),
+    removeEventListener: jest.fn(),
+  };
+
+  // RAF stub: execute callback synchronously
+  global.requestAnimationFrame  = (cb) => { cb(); return 1; };
+  global.cancelAnimationFrame   = jest.fn();
+});
+
+afterEach(() => {
+  document.documentElement.style.removeProperty('--vh');
+  document.documentElement.style.removeProperty('--svh');
+  delete global.window.visualViewport;
+});
+
+// ─── snapshot() ────────────────────────────────────────────────────────────
+
+describe('snapshot()', () => {
+  test('uses visualViewport.height for visual when API is present', () => {
+    const m = snapshot();
+    expect(m.visual).toBe(740);
+  });
+
+  test('falls back to innerHeight when visualViewport is absent', () => {
+    delete global.window.visualViewport;
+    const m = snapshot();
+    expect(m.visual).toBe(750);
+    expect(m.hasVisualViewportAPI).toBe(false);
+  });
+
+  test('always uses innerHeight for stable', () => {
+    const m = snapshot();
+    expect(m.stable).toBe(750);
+  });
+
+  test('reports CSS unit support correctly', () => {
+    const m = snapshot();
+    expect(m.supportsSVH).toBe(true);
+    expect(m.supportsDVH).toBe(true);
+  });
+
+  test('reports hasVisualViewportAPI correctly', () => {
+    expect(snapshot().hasVisualViewportAPI).toBe(true);
+    delete global.window.visualViewport;
+    expect(snapshot().hasVisualViewportAPI).toBe(false);
+  });
+});
+
+// ─── writeCSSVars() ────────────────────────────────────────────────────────
+
+describe('writeCSSVars()', () => {
+  test('sets --vh to visual / 100 as px string', () => {
+    writeCSSVars({ visual: 740, stable: 750 });
+    const val = document.documentElement.style.getPropertyValue('--vh');
+    expect(val).toBe('7.4000px');
+  });
+
+  test('sets --svh to stable / 100 as px string', () => {
+    writeCSSVars({ visual: 740, stable: 750 });
+    const val = document.documentElement.style.getPropertyValue('--svh');
+    expect(val).toBe('7.5000px');
+  });
+
+  test('writes to a custom target element', () => {
+    const el = document.createElement('div');
+    writeCSSVars({ visual: 600, stable: 600 }, el);
+    expect(el.style.getPropertyValue('--vh')).toBe('6.0000px');
+  });
+});
+
+// ─── clearCSSVars() ────────────────────────────────────────────────────────
+
+describe('clearCSSVars()', () => {
+  test('removes --vh and --svh from :root', () => {
+    writeCSSVars({ visual: 740, stable: 750 });
+    clearCSSVars();
+    expect(document.documentElement.style.getPropertyValue('--vh')).toBe('');
+    expect(document.documentElement.style.getPropertyValue('--svh')).toBe('');
+  });
+});
+
+// ─── createRAFScheduler() ──────────────────────────────────────────────────
+
+describe('createRAFScheduler()', () => {
+  test('calls callback after schedule()', () => {
+    const cb = jest.fn();
+    const { schedule } = createRAFScheduler(cb);
+    schedule();
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  test('cancel() prevents pending callback', () => {
+    // Override rAF to NOT execute synchronously this time
+    let pending = null;
+    global.requestAnimationFrame  = (cb) => { pending = cb; return 42; };
+    global.cancelAnimationFrame   = jest.fn((id) => { if (id === 42) pending = null; });
+
+    const cb = jest.fn();
+    const { schedule, cancel } = createRAFScheduler(cb);
+    schedule();
+    cancel();
+    pending?.(); // if not cancelled, this would call cb
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  test('scheduling twice cancels the first frame', () => {
+    const calls = [];
+    global.requestAnimationFrame = (cb) => { calls.push(cb); return calls.length; };
+    global.cancelAnimationFrame  = jest.fn();
+
+    const { schedule } = createRAFScheduler(jest.fn());
+    schedule();
+    schedule();
+    expect(global.cancelAnimationFrame).toHaveBeenCalledTimes(1);
+  });
+});

--- a/viewport-fix/tests/viewport-fix.test.js
+++ b/viewport-fix/tests/viewport-fix.test.js
@@ -2,13 +2,13 @@
  * tests/viewport-fix.test.js
  * ─────────────────────────────────────────────────────────────
  * Unit tests for core modules.
- * Run with: node --experimental-vm-modules node_modules/.bin/jest
- * Or:       npx vitest run
+ * Run with: npx vitest run
  */
 
-import { snapshot }                  from '../src/core/measure.js';
-import { writeCSSVars, clearCSSVars } from '../src/core/cssVars.js';
-import { createRAFScheduler }         from '../src/utils/scheduler.js';
+import { snapshot, clearUnitCache }       from '../src/core/measure.js';
+import { writeCSSVars, clearCSSVars }    from '../src/core/cssVars.js';
+import { createRAFScheduler, attachListeners } from '../src/utils/scheduler.js';
+import { initViewportFix }               from '../src/index.js';
 
 // ─── Mock browser globals ──────────────────────────────────────────────────
 
@@ -17,7 +17,7 @@ beforeEach(() => {
   global.screen = { height: 844 };
 
   global.CSS = {
-    supports: (prop, val) => ['1svh', '1dvh', '1lvh'].includes(val),
+    supports: (prop, val) => prop === 'height' && ['1svh', '1dvh', '1lvh'].includes(val),
   };
 
   Object.defineProperty(window, 'innerHeight', {
@@ -30,19 +30,34 @@ beforeEach(() => {
   global.window.visualViewport = {
     height:    740,
     offsetTop: 0,
-    addEventListener:    jest.fn(),
-    removeEventListener: jest.fn(),
+    addEventListener:    vi.fn(),
+    removeEventListener: vi.fn(),
   };
 
-  // RAF stub: execute callback synchronously
-  global.requestAnimationFrame  = (cb) => { cb(); return 1; };
-  global.cancelAnimationFrame   = jest.fn();
+  // RAF stub: execute callback asynchronously by default
+  let rafId = 0;
+  let pendingRAFs = new Map();
+  global.requestAnimationFrame  = (cb) => { 
+    const id = ++rafId;
+    pendingRAFs.set(id, cb);
+    return id; 
+  };
+  global.cancelAnimationFrame   = vi.fn((id) => {
+    pendingRAFs.delete(id);
+  });
+  global.runPendingRAF = () => {
+    const queue = Array.from(pendingRAFs.values());
+    pendingRAFs.clear();
+    queue.forEach(cb => cb());
+  };
 });
 
 afterEach(() => {
   document.documentElement.style.removeProperty('--vh');
   document.documentElement.style.removeProperty('--svh');
   delete global.window.visualViewport;
+  clearUnitCache();
+  vi.restoreAllMocks();
 });
 
 // ─── snapshot() ────────────────────────────────────────────────────────────
@@ -114,35 +129,90 @@ describe('clearCSSVars()', () => {
 // ─── createRAFScheduler() ──────────────────────────────────────────────────
 
 describe('createRAFScheduler()', () => {
-  test('calls callback after schedule()', () => {
-    const cb = jest.fn();
+  test('calls callback after schedule() and runPendingRAF()', () => {
+    const cb = vi.fn();
     const { schedule } = createRAFScheduler(cb);
     schedule();
+    expect(cb).not.toHaveBeenCalled();
+    global.runPendingRAF();
     expect(cb).toHaveBeenCalledTimes(1);
   });
 
   test('cancel() prevents pending callback', () => {
-    // Override rAF to NOT execute synchronously this time
-    let pending = null;
-    global.requestAnimationFrame  = (cb) => { pending = cb; return 42; };
-    global.cancelAnimationFrame   = jest.fn((id) => { if (id === 42) pending = null; });
-
-    const cb = jest.fn();
+    const cb = vi.fn();
     const { schedule, cancel } = createRAFScheduler(cb);
     schedule();
     cancel();
-    pending?.(); // if not cancelled, this would call cb
+    global.runPendingRAF();
     expect(cb).not.toHaveBeenCalled();
   });
 
   test('scheduling twice cancels the first frame', () => {
-    const calls = [];
-    global.requestAnimationFrame = (cb) => { calls.push(cb); return calls.length; };
-    global.cancelAnimationFrame  = jest.fn();
+    const { schedule } = createRAFScheduler(vi.fn());
+    schedule(); // returns 1
+    schedule(); // returns 2, should cancel 1
+    expect(global.cancelAnimationFrame).toHaveBeenCalledWith(1);
+  });
+});
 
-    const { schedule } = createRAFScheduler(jest.fn());
-    schedule();
-    schedule();
-    expect(global.cancelAnimationFrame).toHaveBeenCalledTimes(1);
+// ─── attachListeners() ─────────────────────────────────────────────────────
+
+describe('attachListeners()', () => {
+  test('attaches listeners to window and visualViewport', () => {
+    const handler = vi.fn();
+    const cleanup = attachListeners(handler);
+
+    // Initial listeners
+    expect(window.visualViewport.addEventListener).toHaveBeenCalledWith('resize', handler, expect.any(Object));
+    expect(window.visualViewport.addEventListener).toHaveBeenCalledWith('scroll', handler, expect.any(Object));
+
+    cleanup();
+    expect(window.visualViewport.removeEventListener).toHaveBeenCalledWith('resize', handler);
+    expect(window.visualViewport.removeEventListener).toHaveBeenCalledWith('scroll', handler);
+  });
+
+  test('orientationchange uses a timeout', () => {
+    vi.useFakeTimers();
+    const handler = vi.fn();
+    const cleanup = attachListeners(handler);
+
+    // Simulate event
+    const event = new Event('orientationchange');
+    window.dispatchEvent(event);
+
+    expect(handler).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(200);
+    expect(handler).toHaveBeenCalled();
+    vi.useRealTimers();
+    cleanup();
+  });
+});
+
+// ─── initViewportFix() ─────────────────────────────────────────────────────
+
+describe('initViewportFix()', () => {
+  test('takes an immediate measurement and writes vars', () => {
+    const cleanup = initViewportFix();
+    expect(document.documentElement.style.getPropertyValue('--vh')).toBe('7.4000px');
+    cleanup();
+  });
+
+  test('is idempotent with a warning', () => {
+    const spyWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const spyAdd = vi.spyOn(window, 'addEventListener');
+    const c1 = initViewportFix();
+    const c2 = initViewportFix();
+    expect(spyWarn).toHaveBeenCalledWith(expect.stringContaining('already initialised'));
+    expect(spyAdd).toHaveBeenCalledTimes(2); // resize, orientationchange
+    c1();
+    c2();
+    spyWarn.mockRestore();
+    spyAdd.mockRestore();
+  });
+
+  test('cleanup removes vars and listeners', () => {
+    const cleanup = initViewportFix();
+    cleanup();
+    expect(document.documentElement.style.getPropertyValue('--vh')).toBe('');
   });
 });


### PR DESCRIPTION
<pre>
[DFG] Avoid stale OSR hints for escaped allocations
https://bugs.webkit.org/show_bug.cgi?id=311357

Reviewed by NOBODY (OOPS!).

promoteLocalHeap() was creating OSR hints without checking if allocations
had escaped. Escaped allocations are not valid for stack reconstruction and
could lead to incorrect values or use-after-free reads during OSR exit.

Fix by tracking escapes using an escapeCounter and only creating hints
for unescaped allocations.

* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
(JSC::DFG::ObjectAllocationSinkingPhase::recordEscape):
(JSC::DFG::ObjectAllocationSinkingPhase::escapeAllocation):
(JSC::DFG::ObjectAllocationSinkingPhase::handlePhi):
(JSC::DFG::ObjectAllocationSinkingPhase::promoteLocalHeap):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3740214104f1ca3eebc91e1f3c69fe9fcdc0d46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162687 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107403 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27043 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119034 "Found 3 new test failures: http/wpt/fetch/clone-realm.html imported/w3c/web-platform-tests/css/selectors/media/sound-state.html imported/w3c/web-platform-tests/webrtc/RTCRtpSender-setParameters-keyFrame.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84164 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138230 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99739 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20394 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18357 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10519 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130050 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165160 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17683 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127124 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26520 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22380 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127284 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26524 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137878 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/83234 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22184 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14664 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26137 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25828 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25992 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25888 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->