### PR TITLE
[Site Isolation] Cross-site redirect in <object> subframe causes parent page to complete prematurely

### DIFF
--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -238,8 +238,6 @@ http/tests/security/contentSecurityPolicy/iframe-redirect-allowed-by-child-src.h
 http/tests/security/contentSecurityPolicy/iframe-redirect-allowed-by-child-src2.html [ Failure ]
 http/tests/security/contentSecurityPolicy/iframe-redirect-allowed-by-frame-src.html [ Failure ]
 http/tests/security/contentSecurityPolicy/iframe-redirect-allowed-by-frame-src2.html [ Failure ]
-http/tests/security/contentSecurityPolicy/object-redirect-allowed.html [ Failure ]
-http/tests/security/contentSecurityPolicy/object-redirect-allowed2.html [ Failure ]
 http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/proper-nested-upgrades.html [ Failure ]
 http/tests/security/cross-origin-local-storage.html [ Failure ]
 http/tests/security/video-poster-cross-origin-crash2.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -257,8 +257,6 @@ http/tests/security/contentSecurityPolicy/iframe-redirect-allowed-by-child-src.h
 http/tests/security/contentSecurityPolicy/iframe-redirect-allowed-by-child-src2.html [ Failure ]
 http/tests/security/contentSecurityPolicy/iframe-redirect-allowed-by-frame-src.html [ Failure ]
 http/tests/security/contentSecurityPolicy/iframe-redirect-allowed-by-frame-src2.html [ Failure ]
-http/tests/security/contentSecurityPolicy/object-redirect-allowed.html [ Failure ]
-http/tests/security/contentSecurityPolicy/object-redirect-allowed2.html [ Failure ]
 http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/proper-nested-upgrades.html [ Failure ]
 http/tests/security/cross-origin-blob-transfer.html [ Failure ]
 http/tests/security/cross-origin-local-storage.html [ Failure ]

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2379,7 +2379,7 @@ void DocumentLoader::cancelMainResourceLoad(const ResourceError& resourceError, 
 
     clearMainResource();
 
-    mainReceivedError(error);
+    mainReceivedError(error, loadWillContinueInAnotherProcess);
 }
 
 void DocumentLoader::willContinueMainResourceLoadAfterRedirect(const ResourceRequest& newRequest)

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3749,7 +3749,7 @@ void FrameLoader::receivedMainResourceError(const ResourceError& error, LoadWill
     // FIXME: Don't want to do this if an entirely new load is going, so should check
     // that both data sources on the frame are either this or nil.
     stop();
-    if (m_client->shouldFallBack(error)) {
+    if (loadWillContinueInAnotherProcess == LoadWillContinueInAnotherProcess::No && m_client->shouldFallBack(error)) {
         if (RefPtr owner = dynamicDowncast<HTMLObjectElement>(frame->ownerElement()))
             owner->renderFallbackContent();
     }
@@ -3772,7 +3772,12 @@ void FrameLoader::receivedMainResourceError(const ResourceError& error, LoadWill
             clientRedirectCancelledOrFinished(NewLoadInProgress::No);
     }
 
-    checkCompleted();
+    if (frame->isMainFrame() || loadWillContinueInAnotherProcess == LoadWillContinueInAnotherProcess::No)
+        checkCompleted();
+    else if (loadWillContinueInAnotherProcess == LoadWillContinueInAnotherProcess::Yes) {
+        ASSERT(frame->settings().siteIsolationEnabled());
+        m_provisionalLoadHappeningInAnotherProcess = true;
+    }
     if (frame->page())
         checkLoadComplete(loadWillContinueInAnotherProcess);
 }


### PR DESCRIPTION
#### 534d9836c83d92de540b54e0517ac2927694c978
<pre>
[Site Isolation] Cross-site redirect in &lt;object&gt; subframe causes parent page to complete prematurely
<a href="https://bugs.webkit.org/show_bug.cgi?id=311362">https://bugs.webkit.org/show_bug.cgi?id=311362</a>
<a href="https://rdar.apple.com/173954545">rdar://173954545</a>

Reviewed by Sihui Liu.

 When an &lt;object type=&quot;text/html&quot;&gt; element&apos;s load is redirected to a different site with site
isolation enabled, the parent page fires its load event before the redirected content loads in
the new process. The child frame&apos;s error handling path does not distinguish between a real
failure and a process-swap cancellation, so the child frame is marked complete and the &lt;object&gt;
element renders fallback content instead of waiting for the cross-process load to finish.

Forward the LoadWillContinueInAnotherProcess flag from cancelMainResourceLoad to
mainReceivedError, and use it in receivedMainResourceError to skip fallback rendering and set
m_provisionalLoadHappeningInAnotherProcess so the parent waits for the cross-process load.

Tested by enabling:
LayoutTests/http/tests/security/contentSecurityPolicy/object-redirect-allowed.html
LayoutTests/http/tests/security/contentSecurityPolicy/object-redirect-allowed2.html

* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::cancelMainResourceLoad):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::receivedMainResourceError):

Canonical link: <a href="https://commits.webkit.org/310557@main">https://commits.webkit.org/310557@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abf42d73f4393a8b037ee0233a2b51e7746494b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162693 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107409 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f505ed35-9cd7-4f91-8b37-a7584546872a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155816 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27049 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119047 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84168 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7a498ffc-58f3-4bc4-aa4c-ad2be53e604e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21317 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138243 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99744 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/41ba0930-5e75-4460-a65b-b1c7a95b270b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20406 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18363 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10525 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130063 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16095 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165166 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8315 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17696 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127349 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26530 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22397 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127288 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34592 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26536 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137889 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83245 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22192 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14677 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26143 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90452 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25834 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26001 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25894 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->