### PR TITLE
Fix some correctness issues for a few TestWebKitAPI tests

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/VisibleContentRect.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/VisibleContentRect.mm
@@ -37,7 +37,7 @@
 @end
 
 @interface TestWKWebViewWithEnclosingView : TestWKWebView
-@property (nonatomic, assign) UIView *test_enclosingViewForExposedRectComputation;
+@property (nonatomic, weak) UIView *test_enclosingViewForExposedRectComputation;
 @end
 
 @implementation TestWKWebViewWithEnclosingView

--- a/Tools/TestWebKitAPI/Tests/mac/WKWebViewMacEditingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/WKWebViewMacEditingTests.mm
@@ -256,24 +256,6 @@ TEST(WKWebViewMacEditingTests, DoubleClickDoesNotSelectTrailingSpace)
     EXPECT_STREQ("Hello", selectedText.UTF8String);
 }
 
-TEST(WKWebViewMacEditingTests, DoNotCrashWhenCallingTextInputClientMethodsWhileDeallocatingView)
-{
-    NSString *textContent = @"This test should not cause us to dereference null.";
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
-    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<p>%@</p>", textContent]];
-    [webView removeFromSuperview];
-
-    __unsafe_unretained id <NSTextInputClient_Async> inputClient = (id <NSTextInputClient_Async>)webView.get();
-    [inputClient hasMarkedTextWithCompletionHandler:^(BOOL) {
-        [inputClient selectedRangeWithCompletionHandler:^(NSRange) {
-            [inputClient markedRangeWithCompletionHandler:^(NSRange) { }];
-        }];
-    }];
-
-    EXPECT_WK_STREQ(textContent, [webView stringByEvaluatingJavaScript:@"document.body.textContent"]);
-}
-
 TEST(WKWebViewMacEditingTests, KeyDownFiresBeforeCompositionEvent)
 {
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);


### PR DESCRIPTION
#### 595acc3c1f77e0d712990df8daf7c08f7e9839da
<pre>
Fix some correctness issues for a few TestWebKitAPI tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=311366">https://bugs.webkit.org/show_bug.cgi?id=311366</a>
<a href="https://rdar.apple.com/173964365">rdar://173964365</a>

Reviewed by Tim Horton.

Both tests were always technically crashing because they were accessing non-weak properties/variables,
but accidentally were passing because the test runner exited before the crash actually happened.

Address `DoNotCrashWhenCallingTextInputClientMethodsWhileDeallocatingView` by deleting it entirely, since it
is an invalid test that relied on accidental behavior of the test runner itself.

Fix the other test by using `weak`.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/VisibleContentRect.mm:
* Tools/TestWebKitAPI/Tests/mac/WKWebViewMacEditingTests.mm:
(TestWebKitAPI::TEST(WKWebViewMacEditingTests, DoNotCrashWhenCallingTextInputClientMethodsWhileDeallocatingView)):

Canonical link: <a href="https://commits.webkit.org/310493@main">https://commits.webkit.org/310493@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4927dd866be0d3dc99ee8c76b97eb3c0ce338f15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20387 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162724 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107438 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/08a30cb7-9005-4d27-a19f-e3240d97e528) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155845 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119072 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84181 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6d3c7ca3-d051-423f-8410-64474d9a8710) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138273 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99773 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1fd71d1d-89a2-4e52-95ea-bbcc083e39fc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20421 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18390 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10557 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130078 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16125 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165197 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17726 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127164 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26559 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22424 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127318 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26565 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137919 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83276 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23528 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22209 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14707 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26173 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25865 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26030 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25927 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->