### PR TITLE
[JSC] GreedyRegAlloc: Fix trySplitAroundClobbers cost model and exit early

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -61,12 +61,16 @@ static_assert(unspillableCost > fastTmpSpillCost);
 static_assert(unspillableCost > maxSpillableSpillCost);
 
 // Phase constants used for the PhaseInsertionSet. Ensures that the fixup and spill/fill instructions
-// inserted in a particular gap ends up in the correct order.
+// inserted in a particular gap end up in the correct order.
+// "MoveTo" = value flows toward the original tmp (or its spill slot).
+// "MoveFrom" = value flows away from the original tmp (or its spill slot).
 enum InsertionPhase : unsigned {
-    SpillStore,
-    SplitMoveTo,
-    SplitMoveFrom,
-    SpillLoad,
+    SpillMoveTo,
+    ClobberMoveTo,
+    IntraBlockMoveTo,
+    IntraBlockMoveFrom,
+    ClobberMoveFrom,
+    SpillMoveFrom,
 };
 
 static bool NODELETE verbose() { return Options::airGreedyRegAllocVerbose(); }
@@ -2139,6 +2143,8 @@ private:
                 case Stage::Spill:
                     doStageSpill<bank>(tmp, tmpData);
                     continue;
+                case Stage::Replaced:
+                    continue; // Split tmp no longer needed; skip stale queue entry.
                 default:
                     dataLogLn("Invalid stage tmp = ", tmp, " tmpData = ", tmpData);
                     // Tmps in these stages should not have been enqueued.
@@ -2372,16 +2378,19 @@ private:
             });
             return result;
         };
+        ASSERT(tmpData.spillCost() != unspillableCost); // Should have evicted.
 
         Reg bestSplitReg;
-        float minSplitCost = unspillableCost;
+        constexpr float invalidSplitCost = std::numeric_limits<float>::infinity();
+        const float splitMultiplier = Options::airGreedyRegAllocSplitMultiplier();
+        const float splitCostLimit = splitMultiplier > 0.0 ? tmpData.useDefCost / splitMultiplier : invalidSplitCost;
+        float minSplitCost = splitCostLimit;
         Width width = widthForConflicts<bank>(tmp);
         for (Reg r : m_allowedRegistersInPriorityOrder[bank]) {
             float splitCost = 0.0f;
             m_regRanges[r].forEachConflict(tmpData.liveRange, width,
                 [&](auto& conflict) -> IterationStatus {
                     if (conflict.tmp.isReg() && conflict.interval.distance() == 1) {
-                        // Block freq * rare block penalty
                         BasicBlock* block = findBlockContainingPoint(conflict.interval.begin());
                         unsigned instIndex = this->instIndex(positionOfHead(block), conflict.interval.begin());
                         Inst& inst = block->at(instIndex);
@@ -2390,15 +2399,17 @@ private:
                             // can't split the tmp around this clobber.
                             // FIXME: could allow uses, but then we'd have to make split tmp conflict with any
                             // spill tmps used by this instruction, so unclear if that's better.
-                            splitCost = unspillableCost;
+                            splitCost = invalidSplitCost;
                             return IterationStatus::Done;
                         }
                         // Times 2 for 'MOV tmp, gapTmp' and 'MOV gapTmp, tmp'
                         splitCost += adjustedBlockFrequency(block) * 2;
+                        if (splitCost >= minSplitCost)
+                            return IterationStatus::Done; // Not the best or already over limit, exit early.
                         return IterationStatus::Continue;
                     }
                     // Conflicts with another Tmp already assigned to this register so splitting around the clobbers won't help.
-                    splitCost = unspillableCost;
+                    splitCost = invalidSplitCost;
                     return IterationStatus::Done;
                 });
             if (splitCost < minSplitCost) {
@@ -2406,13 +2417,9 @@ private:
                 bestSplitReg = r;
             }
         }
-        ASSERT(tmpData.spillCost() != unspillableCost); // Should have evicted.
-        if (minSplitCost >= unspillableCost)
-            return false; // Other conflicts exist, so splitting is not productive
-        // Multiplier of 0 means split around clobbers at every opportunity. The higher the multiplier,
-        // the less often the split will be applied (i.e. treats splitting as more costly).
-        if (minSplitCost * Options::airGreedyRegAllocSplitMultiplier() >= tmpData.spillCost())
-            return false; // Better to spill than to split
+        if (minSplitCost >= splitCostLimit)
+            return false; // No register found or better to spill than to split
+        ASSERT(bestSplitReg);
 
         LiveRange holeRange;
         m_regRanges[bestSplitReg].forEachConflict(tmpData.liveRange, width,
@@ -2835,7 +2842,7 @@ private:
                     // when there are back-to-back Move spill-spill-scratch instructions (scratch is early-def, late-use).
                     // See https://bugs.webkit.org/show_bug.cgi?id=163548#c2 for more info.
                     // FIXME: reconsider this, https://bugs.webkit.org/show_bug.cgi?id=288122
-                    m_insertionSets[block].insert(instIndex, SpillLoad, Nop, inst.origin);
+                    m_insertionSets[block].insert(instIndex, SpillMoveFrom, Nop, inst.origin);
                     continue;
                 }
 
@@ -2873,13 +2880,13 @@ private:
                             if constexpr (bank == GP) {
                                 int64_t value = m_useCounts.constant<bank>(tmpIndex);
                                 if (Arg::isValidImmForm(value) && isValidForm(Move, Arg::Imm, Arg::Tmp)) {
-                                    m_insertionSets[block].insert(instIndex, SpillLoad, Move, inst.origin, Arg::imm(value), tmp);
+                                    m_insertionSets[block].insert(instIndex, SpillMoveFrom, Move, inst.origin, Arg::imm(value), tmp);
                                     m_stats[bank].numRematerializeConst++;
                                     dataLogLnIf(verbose(), "Rematerialized (imm) BB", *block, " ", originalTmp, ": ", tmp, " <- ", WTF::RawHex(value));
                                     return true;
                                 }
                                 RELEASE_ASSERT(isValidForm(Move, Arg::BigImm, Arg::Tmp));
-                                m_insertionSets[block].insert(instIndex, SpillLoad, Move, inst.origin, Arg::bigImm(value), tmp);
+                                m_insertionSets[block].insert(instIndex, SpillMoveFrom, Move, inst.origin, Arg::bigImm(value), tmp);
                                 m_stats[bank].numRematerializeConst++;
                                 dataLogLnIf(verbose(), "Rematerialized (bigImm) BB", *block, " ", originalTmp, ": ", tmp, " <- ", WTF::RawHex(value));
                                 return true;
@@ -2909,7 +2916,7 @@ private:
                                 }
 
                                 if (imm && isValidForm(constMove, imm.kind(), Arg::Tmp)) {
-                                    m_insertionSets[block].insert(instIndex, SpillLoad, constMove, inst.origin, imm, tmp);
+                                    m_insertionSets[block].insert(instIndex, SpillMoveFrom, constMove, inst.origin, imm, tmp);
                                     m_stats[bank].numRematerializeConst++;
                                     dataLogLnIf(verbose(), "Rematerialized (FP) BB", *block, " ", originalTmp, ": ", tmp);
                                     return true;
@@ -2920,7 +2927,7 @@ private:
                         };
 
                         if (!tryRematerialize()) {
-                            m_insertionSets[block].insert(instIndex, SpillLoad, move, inst.origin, arg, tmp);
+                            m_insertionSets[block].insert(instIndex, SpillMoveFrom, move, inst.origin, arg, tmp);
                             m_stats[bank].numLoadSpill++;
                         }
                     }
@@ -2934,7 +2941,7 @@ private:
                             dataLogLnIf(verbose(), "Rematerialized BB", *block, " removing def inst: ", inst);
                         } else {
                             ASSERT(!doKillInst);
-                            m_insertionSets[block].insert(instIndex + 1, SpillStore, move, inst.origin, tmp, arg);
+                            m_insertionSets[block].insert(instIndex + 1, SpillMoveTo, move, inst.origin, tmp, arg);
                             m_stats[bank].numStoreSpill++;
                         }
                     }
@@ -2989,8 +2996,8 @@ private:
                 if (spilled)
                     arg = Arg::stack(spilled);
                 Opcode move = moveOpcode(gapTmp);
-                m_insertionSets[block].insert(instIndex, SplitMoveFrom, move, inst.origin, metadata.originalTmp, arg);
-                m_insertionSets[block].insert(instIndex + 1, SplitMoveTo, move, inst.origin, arg, metadata.originalTmp);
+                m_insertionSets[block].insert(instIndex, ClobberMoveFrom, move, inst.origin, metadata.originalTmp, arg);
+                m_insertionSets[block].insert(instIndex + 1, ClobberMoveTo, move, inst.origin, arg, metadata.originalTmp);
                 dataLogLnIf(verbose(), "Inserted Moves around clobber tmp=", metadata.originalTmp, " gapTmp=", gapTmp, " gapReg = ", assignedReg(gapTmp), " block=", *block, " index=", instIndex, " inst = ", inst);
             }
         }
@@ -3015,16 +3022,17 @@ private:
             }
 
             LiveRange& clusterRange = m_map[clusterTmp].liveRange;
-            ASSERT(clusterRange.intervals().size() == 1);
-            const Interval& clusterInterval = clusterRange.intervals().first();
+            // Cluster tmp may have multiple intervals if it was also split around clobbers,
+            // but the first interval will still coincide with the beginning of the cluster.
+            Point clusterBegin = clusterRange.intervals().first().begin();
 
-            BasicBlock* block = findBlockContainingPoint(clusterInterval.begin());
+            BasicBlock* block = findBlockContainingPoint(clusterBegin);
             Point positionOfHead = this->positionOfHead(block);
 
             // trySplitIntraBlock includes the Pre point in the cluster interval iff the original Tmp is live into the cluster.
-            if (pointAtOffset(clusterInterval.begin(), PointOffsets::Pre) == clusterInterval.begin()) {
-                unsigned instIndex = this->instIndex(positionOfHead, clusterInterval.begin());
-                m_insertionSets[block].insert(instIndex, SplitMoveFrom, move, block->at(instIndex).origin, Arg::stack(spilled), clusterTmp);
+            if (pointAtOffset(clusterBegin, PointOffsets::Pre) == clusterBegin) {
+                unsigned instIndex = this->instIndex(positionOfHead, clusterBegin);
+                m_insertionSets[block].insert(instIndex, IntraBlockMoveFrom, move, block->at(instIndex).origin, Arg::stack(spilled), clusterTmp);
                 m_stats[bank].numSplitIntraBlockLoad++;
             } else
                 ASSERT(split.lastDefPoint);
@@ -3032,7 +3040,7 @@ private:
             // Need to store back into the original Tmp's spill slot only if the cluster def'ed the Tmp
             if (split.lastDefPoint) {
                 unsigned instIndex = this->instIndex(positionOfHead, split.lastDefPoint);
-                m_insertionSets[block].insert(instIndex + 1, SplitMoveTo, move, block->at(instIndex).origin, clusterTmp, Arg::stack(spilled));
+                m_insertionSets[block].insert(instIndex + 1, IntraBlockMoveTo, move, block->at(instIndex).origin, clusterTmp, Arg::stack(spilled));
                 m_stats[bank].numSplitIntraBlockStore++;
             }
         }


### PR DESCRIPTION
#### b0ca3d39ab0b6cae0bde1400b5559e7b5fdd48a6
<pre>
[JSC] GreedyRegAlloc: Fix trySplitAroundClobbers cost model and exit early
<a href="https://bugs.webkit.org/show_bug.cgi?id=311372">https://bugs.webkit.org/show_bug.cgi?id=311372</a>
<a href="https://rdar.apple.com/173970443">rdar://173970443</a>

Reviewed by Keith Miller.

The cost comparison used spillCost() (which had become useDefCost
normalized by range size) instead of useDefCost directly. Since splitCost
is an absolute frequency-weighted instruction count, comparing it against
range-normalized spillCost always favored spilling. Changed to compare
against useDefCost so both sides are in the same units.

Handle Replaced stage in the main allocation loop since gap tmps whose
original was spilled can be in the queue and should be skipped.

Additionally, exit the search early if splitCost becomes too high such
that it&apos;s guaranteed it won&apos;t beat the best min so far, and initialize
the min to the value required to succeed the split.

Also remove an ASSERT in insertSplitIntraBlockFixupCode that is no longer
valid now that split types can compose. The code was doing the right
thing still, but rewrite it slightly to clarify.

Finally, renamed InsertionPhase values for clarity and added IntraBlockMoveFrom/
IntraBlockMoveTo phases to ensure correct ordering when clobber and
intra-block splits compose on the same tmp. Sharing the phase was okay
since the two split types wouldn&apos;t try to insert in the same slot, but
it&apos;s easier to reason about if they use distinct phases.

* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::GreedyAllocator::allocateRegisters):
(JSC::B3::Air::Greedy::GreedyAllocator::trySplitAroundClobbers):
(JSC::B3::Air::Greedy::GreedyAllocator::emitSpillCodeAndEnqueueNewTmps):
(JSC::B3::Air::Greedy::GreedyAllocator::insertSplitAroundClobbersFixupCode):
(JSC::B3::Air::Greedy::GreedyAllocator::insertSplitIntraBlockFixupCode):

Canonical link: <a href="https://commits.webkit.org/310551@main">https://commits.webkit.org/310551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37ef702358c6375ace3b7c66af0e27536345b93e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154102 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162854 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107568 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aa1b7a17-f78f-40d3-89ee-6842fa82710a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27491 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27210 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119180 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84257 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5fc025f6-3d2c-4409-8fc2-b290e8bd6223) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21418 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138378 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99880 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/afa2ce8e-1302-4d55-a35b-4a4f2cca28d3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20514 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18504 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10687 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146151 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130176 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16229 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165327 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14930 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8539 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17830 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127272 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26905 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22542 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127423 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138023 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83415 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23545 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22289 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14811 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185737 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26520 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90624 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47634 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26100 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26330 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26172 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->