### PR TITLE
Render gradients formed of solid stripes with FillRect to avoid dithering

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4055,8 +4055,6 @@ imported/w3c/web-platform-tests/html/browsers/windows/auxiliary-browsing-context
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_escaping-2.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_nonescaping-2.html [ Skip ]
 
-imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-conic.html [ ImageOnlyFailure ]
-
 webkit.org/b/187773 http/tests/webAPIStatistics [ Skip ]
 
 # This is fallout from turning Web Animations on.
@@ -4331,7 +4329,6 @@ imported/w3c/web-platform-tests/css/css-images/gradient/gradient-eval-predefined
 imported/w3c/web-platform-tests/css/css-images/gradient/gradient-infinity-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-images/gradient/gradient-infinity-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-images/gradient/gradient-infinity-003.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-images/gradient/gradient-single-stop-none-interpolation.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-border-image.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-exif-png-3.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-none-cross-origin-canvas.html [ ImageOnlyFailure ]
@@ -6708,7 +6705,6 @@ webkit.org/b/274091 imported/w3c/web-platform-tests/mediacapture-streams/idlharn
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-fixed-inside-transform-1.html [ ImageOnlyFailure ]
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-local-hidden.html [ ImageOnlyFailure ]
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/background-image-gradient-currentcolor-visited.html [ ImageOnlyFailure ]
-webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/background-image-table-cells-straddling-no-repeat.html
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/background-margin-iframe-root.html [ ImageOnlyFailure ]
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/background-margin-transformed-root.html [ ImageOnlyFailure ]
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/background-margin-will-change-root.html [ ImageOnlyFailure ]
@@ -6722,14 +6718,9 @@ webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/box-shad
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow-radius-001.html [ ImageOnlyFailure ]
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/slice-inline-fragmentation-001.html [ ImageOnlyFailure ]
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/slice-inline-fragmentation-002.html [ ImageOnlyFailure ]
-webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-fixed-block-002.html [ ImageOnlyFailure ]
-webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-fixed-inline-002.html [ ImageOnlyFailure ]
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-fixed-inline-scrolled.html [ ImageOnlyFailure ]
-webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-local-block-002.html [ ImageOnlyFailure ]
-webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-local-inline-002.html [ ImageOnlyFailure ]
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-animated-text.html [ ImageOnlyFailure ]
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/background-gradient-interpolation-003.html [ ImageOnlyFailure ]
-webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/background-rounded-image-clip-002.html [ ImageOnlyFailure ]
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-borders/border-radius-greater-than-width.html [ ImageOnlyFailure ]
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-borders/tentative/border-radius-side-shorthands/border-radius-side-shorthands-001.html [ ImageOnlyFailure ]
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-borders/tentative/border-radius-side-shorthands/border-radius-side-shorthands-002.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/backgrounds/background-blend-mode-difference.html
+++ b/LayoutTests/fast/backgrounds/background-blend-mode-difference.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=2; totalPixels=84000-102000" />
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-102000" />
 <style>
     .checkboard {
         background-blend-mode: difference;

--- a/LayoutTests/http/tests/css/css-masking/mask-external-svg-fragment.html
+++ b/LayoutTests/http/tests/css/css-masking/mask-external-svg-fragment.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8263" />
+<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8360" />
 <style>
     .container {
         display: inline-block;

--- a/LayoutTests/http/tests/css/css-masking/mask-external-svg-image.html
+++ b/LayoutTests/http/tests/css/css-masking/mask-external-svg-image.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8263" />
+<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8360" />
 <style>
     .container {
         display: inline-block;

--- a/LayoutTests/http/tests/css/css-masking/mask-external-svg-mask.html
+++ b/LayoutTests/http/tests/css/css-masking/mask-external-svg-mask.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8263" />
+<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8360" />
 <style>
     .container {
         display: inline-block;

--- a/LayoutTests/http/tests/css/css-masking/mask-inline-svg-image.html
+++ b/LayoutTests/http/tests/css/css-masking/mask-inline-svg-image.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8263" />
+<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8360" />
 <style>
     .container {
         display: inline-block;

--- a/LayoutTests/http/tests/css/css-masking/mask-inline-svg-mask.html
+++ b/LayoutTests/http/tests/css/css-masking/mask-inline-svg-mask.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8263" />
+<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8360" />
 <style>
     .container {
         display: inline-block;

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -243,8 +243,6 @@ fast/events/drag-customData.html
 # Need to implement WebGeolocationRequest::cancelPermissionRequest on mac.
 webkit.org/b/55944 fast/dom/Geolocation/page-reload-cancel-permission-requests.html [ Failure Timeout ]
 
-webkit.org/b/103435 fast/backgrounds/background-opaque-images-over-color.html [ ImageOnlyFailure ]
-
 webkit.org/b/56685 webarchive/test-link-rel-icon.html [ Failure ]
 
 # Quota API is not supported.
@@ -2078,8 +2076,6 @@ imported/w3c/web-platform-tests/svg/animations/reinserting-svg-into-document.htm
 imported/w3c/web-platform-tests/svg/animations/use-animate-display-none-symbol-2.html [ Pass Failure ]
 
 webkit.org/b/266996 imported/w3c/web-platform-tests/css/css-writing-modes/mongolian-orientation-002.html [ ImageOnlyFailure ]
-
-fast/gradients/conic-stop-with-offset-zero-in-middle.html [ ImageOnlyFailure ]
 
 # Requires (ACCESSIBILITY_NON_BLINKING_CURSOR)
 accessibility/mac/prefers-non-blinking-cursor.html [ Skip ]

--- a/Source/WebCore/platform/graphics/Gradient.cpp
+++ b/Source/WebCore/platform/graphics/Gradient.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2007 Alp Toker <alp@atoker.com>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "Gradient.h"
 
+#include "ColorSpace.h"
 #include "FloatRect.h"
 #include <wtf/HashFunctions.h>
 #include <wtf/Hasher.h>
@@ -37,6 +38,20 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Gradient);
+
+// Compare two colors as equal if they resolve to the same value after replacing
+// CSS 'none' (NaN) components with zero. This is conservative: per the CSS spec
+// 'none' takes the neighbor's value, but substituting zero is sufficient to detect
+// the common case (e.g., color(srgb none 1 none) vs rgb(0 255 0)) and will never
+// incorrectly identify a real gradient as solid.
+bool Gradient::resolvedColorsMatch(const Color& a, const Color& b)
+{
+    if (a == b)
+        return true;
+    auto [csA, compA] = a.colorSpaceAndResolvedColorComponents();
+    auto [csB, compB] = b.colorSpaceAndResolvedColorComponents();
+    return csA == csB && compA == compB;
+}
 
 Ref<Gradient> Gradient::create(Data&& data, ColorInterpolationMethod colorInterpolationMethod, GradientSpreadMethod spreadMethod, GradientColorStops&& stops, bool isTransient)
 {
@@ -107,6 +122,7 @@ void Gradient::addColorStop(GradientColorStop&& stop)
 {
     m_stops.addColorStop(WTF::move(stop));
     m_cachedHash = 0;
+    m_cachedSolidBands = std::nullopt;
     stopsChanged();
 }
 
@@ -130,6 +146,64 @@ unsigned Gradient::hash() const
     if (!m_cachedHash)
         m_cachedHash = computeHash(m_data, m_colorInterpolationMethod, m_spreadMethod, m_stops.sorted());
     return m_cachedHash;
+}
+
+Vector<Gradient::SolidBand> Gradient::extractSolidBands(const GradientColorStops& sortedStops)
+{
+    auto& stops = sortedStops.stops();
+    if (stops.isEmpty())
+        return { };
+
+    // Resolve CSS 'none' (NaN) components to zero before storing in bands,
+    // so that platform color conversions at draw time produce correct results
+    // (e.g., oklch with hue=NaN must become hue=0 before converting to sRGB).
+    auto resolvedColor = [](const Color& c) -> Color {
+        auto [colorSpace, components] = c.colorSpaceAndResolvedColorComponents();
+        return callWithColorType(components, colorSpace, [](const auto& typedColor) {
+            return Color(typedColor);
+        });
+    };
+
+    if (stops.size() == 1)
+        return { { 0, 1, resolvedColor(stops[0].color) } };
+
+    size_t bandBoundaryCount = 0;
+    for (size_t i = 1; i < stops.size(); ++i) {
+        if (stops[i].offset != stops[i - 1].offset) {
+            if (!resolvedColorsMatch(stops[i].color, stops[i - 1].color))
+                return { };
+        } else if (!resolvedColorsMatch(stops[i].color, stops[i - 1].color))
+            ++bandBoundaryCount;
+    }
+
+    // When all stops resolve to the same color, return a single band so that the fill is rendered
+    // with fillRect instead of through the default gradient renderer, which can still dither a
+    // single-color gradient and produce pixel differences against a solid fill.
+    if (!bandBoundaryCount)
+        return { { stops.first().offset, stops.last().offset, resolvedColor(stops[0].color) } };
+
+    Vector<SolidBand> solidBands;
+    solidBands.reserveInitialCapacity(bandBoundaryCount + 1);
+    Color currentColor = stops[0].color;
+    float currentStart = stops[0].offset;
+
+    for (size_t i = 1; i < stops.size(); ++i) {
+        if (stops[i].offset == stops[i - 1].offset && !resolvedColorsMatch(stops[i].color, currentColor)) {
+            solidBands.append({ currentStart, stops[i].offset, resolvedColor(currentColor) });
+            currentColor = stops[i].color;
+            currentStart = stops[i].offset;
+        }
+    }
+
+    solidBands.append({ currentStart, stops.last().offset, resolvedColor(currentColor) });
+    return solidBands;
+}
+
+const Vector<Gradient::SolidBand>& Gradient::solidBands() const
+{
+    if (!m_cachedSolidBands)
+        m_cachedSolidBands = extractSolidBands(m_stops.sorted());
+    return *m_cachedSolidBands;
 }
 
 TextStream& operator<<(TextStream& ts, const Gradient& gradient)

--- a/Source/WebCore/platform/graphics/Gradient.h
+++ b/Source/WebCore/platform/graphics/Gradient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2007 Alp Toker <alp@atoker.com>
  * Copyright (C) 2008 Torch Mobile, Inc.
  *
@@ -89,6 +89,12 @@ public:
 
     using Data = Variant<LinearData, RadialData, ConicData>;
 
+    struct SolidBand {
+        float startOffset;
+        float endOffset;
+        Color color;
+    };
+
     // isTransient may affect backend rendering implementation caching decisions.
     // Transient instances may be assumed to be drawn only few times or seldomly and as such the backend
     // may not persist caches related to the instance.
@@ -138,6 +144,13 @@ private:
     GradientSpreadMethod m_spreadMethod;
     GradientColorStops m_stops;
     mutable unsigned m_cachedHash { 0 };
+
+    const Vector<SolidBand>& solidBands() const;
+    mutable std::optional<Vector<SolidBand>> m_cachedSolidBands;
+
+    static bool resolvedColorsMatch(const Color& a, const Color& b);
+
+    static Vector<SolidBand> extractSolidBands(const GradientColorStops& sortedStops);
 
 #if USE(CG)
     std::optional<GradientRendererCG> m_platformRenderer;

--- a/Source/WebCore/platform/graphics/cairo/GradientCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GradientCairo.cpp
@@ -268,7 +268,6 @@ void Gradient::fill(GraphicsContext& context, const FloatRect& rect)
 
     ASSERT(context.hasPlatformContext());
     auto& platformContext = *context.platformContext();
-
     platformContext.save();
     Cairo::fillRect(platformContext, rect, pattern.get());
     platformContext.restore();

--- a/Source/WebCore/platform/graphics/cg/GradientCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GradientCG.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2007 Alp Toker <alp@atoker.com>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,10 +31,113 @@
 
 #include "GradientRendererCG.h"
 #include "GraphicsContextCG.h"
+#include <numbers>
 #include <pal/spi/cg/CoreGraphicsSPI.h>
+#include <span>
 #include <wtf/MathExtras.h>
 
 namespace WebCore {
+
+static void fillSolidBandsCG(CGContextRef context, CGFloat left, CGFloat length, const FloatRect& clipBounds, std::span<const Gradient::SolidBand> bands)
+{
+    for (auto& band : bands) {
+        CGFloat bandStart = left + band.startOffset * length;
+        CGFloat bandEnd = left + band.endOffset * length;
+        if (bandStart > bandEnd)
+            std::swap(bandStart, bandEnd);
+        bandStart = std::max<CGFloat>(bandStart, clipBounds.x());
+        bandEnd = std::min<CGFloat>(bandEnd, clipBounds.maxX());
+        if (bandStart >= bandEnd)
+            continue;
+        CGContextSetFillColorWithColor(context, cachedCGColor(band.color).get());
+        CGContextFillRect(context, CGRectMake(bandStart, clipBounds.y(), bandEnd - bandStart, clipBounds.height()));
+    }
+}
+
+static void paintLinearSolidBands(CGContextRef context, FloatPoint point0, FloatPoint point1, const Vector<Gradient::SolidBand>& bands)
+{
+    if (bands.isEmpty())
+        return;
+
+    CGContextStateSaver stateSaver(context);
+
+    // Disable anti-aliasing so rectangle edges at band boundaries are pixel-sharp.
+    CGContextSetShouldAntialias(context, false);
+
+    FloatSize gradientVector = point1 - point0;
+    float gradientLength = gradientVector.diagonalLength();
+
+    CGContextTranslateCTM(context, point0.x(), point0.y());
+    if (gradientLength > 0)
+        CGContextRotateCTM(context, FloatPoint(gradientVector).slopeAngleRadians());
+
+    FloatRect clipBounds = CGContextGetClipBoundingBox(context);
+    if (clipBounds.isInfinite() || clipBounds.isEmpty())
+        return;
+
+    float padStart = gradientLength > 0 ? clipBounds.x() / gradientLength : 0;
+    float padEnd = gradientLength > 0 ? clipBounds.maxX() / gradientLength : 1;
+    padStart = std::min(padStart, bands.first().startOffset);
+    padEnd = std::max(padEnd, bands.last().endOffset);
+
+    if (padStart < bands.first().startOffset) {
+        Gradient::SolidBand leadingPad { padStart, bands.first().startOffset, bands.first().color };
+        fillSolidBandsCG(context, 0, gradientLength, clipBounds, { &leadingPad, 1 });
+    }
+
+    fillSolidBandsCG(context, 0, gradientLength, clipBounds, bands);
+
+    if (padEnd > bands.last().endOffset) {
+        Gradient::SolidBand trailingPad { bands.last().endOffset, padEnd, bands.last().color };
+        fillSolidBandsCG(context, 0, gradientLength, clipBounds, { &trailingPad, 1 });
+    }
+}
+
+static void fillConicSector(CGContextRef context, FloatPoint center, float radius, float startAngle, float endAngle, const Color& color, bool flipArcDirection)
+{
+    CGContextBeginPath(context);
+    CGContextMoveToPoint(context, center.x(), center.y());
+    CGContextAddArc(context, center.x(), center.y(), radius, startAngle, endAngle, flipArcDirection);
+    CGContextClosePath(context);
+    CGContextSetFillColorWithColor(context, cachedCGColor(color).get());
+    CGContextFillPath(context);
+}
+
+static void paintConicSolidBands(CGContextRef context, FloatPoint center, float startAngleRadians, const Vector<Gradient::SolidBand>& bands)
+{
+    if (bands.isEmpty())
+        return;
+
+    CGContextSetShouldAntialias(context, false);
+
+    FloatRect clipBounds = CGContextGetClipBoundingBox(context);
+    if (clipBounds.isInfinite() || clipBounds.isEmpty())
+        return;
+
+    float dx = std::max(std::abs(clipBounds.x() - center.x()), std::abs(clipBounds.maxX() - center.x()));
+    float dy = std::max(std::abs(clipBounds.y() - center.y()), std::abs(clipBounds.maxY() - center.y()));
+    float radius = std::hypot(dx, dy);
+
+    // On iOS the native coordinate system has a flipped y-axis relative to
+    // macOS, which reverses the arc sweep direction. Detect this and flip.
+#if PLATFORM(IOS_FAMILY)
+    CGAffineTransform ctm = CGContextGetCTM(context);
+    bool flipArcDirection = ctm.a * ctm.d - ctm.b * ctm.c < 0;
+#else
+    constexpr bool flipArcDirection = false;
+#endif
+
+    constexpr float twoPi = 2 * static_cast<float>(std::numbers::pi);
+
+    if (bands.first().startOffset > 0)
+        fillConicSector(context, center, radius, startAngleRadians, startAngleRadians + bands.first().startOffset * twoPi, bands.first().color, flipArcDirection);
+
+    for (auto& band : bands)
+        fillConicSector(context, center, radius, startAngleRadians + band.startOffset * twoPi, startAngleRadians + band.endOffset * twoPi, band.color, flipArcDirection);
+
+    if (bands.last().endOffset < 1)
+        fillConicSector(context, center, radius, startAngleRadians + bands.last().endOffset * twoPi, startAngleRadians + twoPi, bands.last().color, flipArcDirection);
+}
 
 void Gradient::stopsChanged()
 {
@@ -59,16 +162,28 @@ void Gradient::paint(CGContextRef platformContext)
 
     WTF::switchOn(m_data,
         [&] (const LinearData& data) {
+            const FloatSize gradientVector = data.point1 - data.point0;
+            // Check axis-alignment in screen space by transforming the gradient
+            // direction through the CTM's linear part (ignoring translation).
+            CGAffineTransform ctm = CGContextGetCTM(platformContext);
+            CGFloat screenX = ctm.a * gradientVector.width() + ctm.c * gradientVector.height();
+            CGFloat screenY = ctm.b * gradientVector.width() + ctm.d * gradientVector.height();
+            bool isAxisAligned = !screenX || !screenY;
+            const auto& bands = solidBands();
+            bool useSolidBands = isAxisAligned && !bands.isEmpty();
+
             switch (m_spreadMethod) {
             case GradientSpreadMethod::Repeat:
             case GradientSpreadMethod::Reflect: {
                 CGContextStateSaver saveState(platformContext);
-                CGGradientDrawingOptions extendOptions = 0;
 
-                FloatPoint gradientVectorNorm(data.point1 - data.point0);
+                FloatPoint gradientVectorNorm(gradientVector);
                 gradientVectorNorm.normalize();
                 CGFloat angle = gradientVectorNorm.isZero() ? 0 : atan2(gradientVectorNorm.y(), gradientVectorNorm.x());
                 CGContextRotateCTM(platformContext, angle);
+
+                if (useSolidBands)
+                    CGContextSetShouldAntialias(platformContext, false);
 
                 CGRect boundingBox = CGContextGetClipBoundingBox(platformContext);
                 if (CGRectIsInfinite(boundingBox) || CGRectIsEmpty(boundingBox))
@@ -84,10 +199,16 @@ void Gradient::paint(CGContextRef platformContext)
                     dx = dx < 0 ? -pixelSize : pixelSize;
 
                 auto drawLinearGradient = [&](CGFloat start, CGFloat end, bool flip) {
-                    CGPoint left = CGPointMake(flip ? end : start, 0);
-                    CGPoint right = CGPointMake(flip ? start : end, 0);
+                    CGFloat left = flip ? end : start;
+                    CGFloat right = flip ? start : end;
 
-                    m_platformRenderer->drawLinearGradient(platformContext, left, right, extendOptions);
+                    if (useSolidBands) {
+                        fillSolidBandsCG(platformContext, left, right - left, FloatRect(boundingBox), bands);
+                        return;
+                    }
+
+                    CGGradientDrawingOptions extendOptions = 0;
+                    m_platformRenderer->drawLinearGradient(platformContext, CGPointMake(left, 0), CGPointMake(right, 0), extendOptions);
                 };
 
                 auto isLeftOf = [](CGFloat start, CGFloat end, CGRect boundingBox) -> bool {
@@ -136,6 +257,10 @@ void Gradient::paint(CGContextRef platformContext)
                 break;
             }
             case GradientSpreadMethod::Pad: {
+                if (useSolidBands) {
+                    paintLinearSolidBands(platformContext, data.point0, data.point1, bands);
+                    break;
+                }
                 CGGradientDrawingOptions extendOptions = kCGGradientDrawsBeforeStartLocation | kCGGradientDrawsAfterEndLocation;
                 m_platformRenderer->drawLinearGradient(platformContext, data.point0, data.point1, extendOptions);
                 break;
@@ -161,12 +286,17 @@ void Gradient::paint(CGContextRef platformContext)
                 CGContextRestoreGState(platformContext);
         },
         [&] (const ConicData& data) {
-            CGContextSaveGState(platformContext);
+            CGContextStateSaver stateSaver(platformContext);
             CGContextTranslateCTM(platformContext, data.point0.x(), data.point0.y());
             CGContextRotateCTM(platformContext, (CGFloat)-piOverTwoDouble);
             CGContextTranslateCTM(platformContext, -data.point0.x(), -data.point0.y());
+
+            const auto& bands = solidBands();
+            if (!bands.isEmpty()) {
+                paintConicSolidBands(platformContext, data.point0, data.angleRadians, bands);
+                return;
+            }
             m_platformRenderer->drawConicGradient(platformContext, data.point0, data.angleRadians);
-            CGContextRestoreGState(platformContext);
         }
     );
 }

--- a/Source/WebCore/platform/graphics/skia/GradientSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GradientSkia.cpp
@@ -32,16 +32,141 @@
 #include "GradientColorStops.h"
 #include "GraphicsContextSkia.h"
 #include "NotImplemented.h"
+#include <numbers>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColor.h>
+#include <skia/core/SkPathBuilder.h>
 #include <skia/core/SkScalar.h>
 #include <skia/effects/SkGradient.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#include <span>
 
 namespace WebCore {
 
 void Gradient::stopsChanged()
 {
+}
+
+static void fillSolidBandsSkia(SkCanvas& canvas, float left, float length, const SkRect& clipBounds, std::span<const Gradient::SolidBand> bands, float globalAlpha)
+{
+    SkPaint paint;
+    paint.setAntiAlias(false);
+    paint.setStyle(SkPaint::kFill_Style);
+
+    for (auto& band : bands) {
+        float bandStart = left + band.startOffset * length;
+        float bandEnd = left + band.endOffset * length;
+        if (bandStart > bandEnd)
+            std::swap(bandStart, bandEnd);
+        bandStart = std::max(bandStart, clipBounds.fLeft);
+        bandEnd = std::min(bandEnd, clipBounds.fRight);
+        if (bandStart >= bandEnd)
+            continue;
+        SkColor4f color = static_cast<SkColor4f>(band.color);
+        color.fA *= globalAlpha;
+        paint.setColor4f(color);
+        canvas.drawRect(SkRect::MakeLTRB(bandStart, clipBounds.fTop, bandEnd, clipBounds.fBottom), paint);
+    }
+}
+
+static bool paintLinearSolidBands(SkCanvas& canvas, FloatPoint point0, FloatPoint point1, const Vector<Gradient::SolidBand>& bands, float globalAlpha)
+{
+    if (bands.isEmpty())
+        return false;
+
+    FloatSize gradientVector = point1 - point0;
+    // Check axis-alignment in screen space by transforming the gradient vector through the CTM.
+    SkMatrix ctm = canvas.getTotalMatrix();
+    SkPoint screenVector = ctm.mapVector(gradientVector.width(), gradientVector.height());
+    bool isAxisAligned = !screenVector.fX || !screenVector.fY;
+    if (!isAxisAligned)
+        return false;
+
+    canvas.save();
+
+    float gradientLength = gradientVector.diagonalLength();
+    canvas.translate(point0.x(), point0.y());
+    if (gradientLength > 0)
+        canvas.rotate(SkRadiansToDegrees(FloatPoint(gradientVector).slopeAngleRadians()));
+
+    SkRect clipBounds;
+    if (!canvas.getLocalClipBounds(&clipBounds) || clipBounds.isEmpty()) {
+        canvas.restore();
+        return true;
+    }
+
+    float padStart = gradientLength > 0 ? clipBounds.fLeft / gradientLength : 0;
+    float padEnd = gradientLength > 0 ? clipBounds.fRight / gradientLength : 1;
+    padStart = std::min(padStart, bands.first().startOffset);
+    padEnd = std::max(padEnd, bands.last().endOffset);
+
+    if (padStart < bands.first().startOffset) {
+        Gradient::SolidBand leadingPad { padStart, bands.first().startOffset, bands.first().color };
+        fillSolidBandsSkia(canvas, 0, gradientLength, clipBounds, { &leadingPad, 1 }, globalAlpha);
+    }
+
+    fillSolidBandsSkia(canvas, 0, gradientLength, clipBounds, bands, globalAlpha);
+
+    if (padEnd > bands.last().endOffset) {
+        Gradient::SolidBand trailingPad { bands.last().endOffset, padEnd, bands.last().color };
+        fillSolidBandsSkia(canvas, 0, gradientLength, clipBounds, { &trailingPad, 1 }, globalAlpha);
+    }
+
+    canvas.restore();
+    return true;
+}
+
+static bool paintConicSolidBands(SkCanvas& canvas, const Gradient::ConicData& data, const Vector<Gradient::SolidBand>& bands, float globalAlpha)
+{
+    if (bands.isEmpty())
+        return false;
+
+    canvas.save();
+
+    SkRect clipBounds;
+    if (!canvas.getLocalClipBounds(&clipBounds) || clipBounds.isEmpty()) {
+        canvas.restore();
+        return true;
+    }
+
+    float dx = std::max(std::abs(clipBounds.fLeft - data.point0.x()), std::abs(clipBounds.fRight - data.point0.x()));
+    float dy = std::max(std::abs(clipBounds.fTop - data.point0.y()), std::abs(clipBounds.fBottom - data.point0.y()));
+    float radius = std::hypot(dx, dy);
+
+    SkPaint paint;
+    paint.setAntiAlias(false);
+    paint.setStyle(SkPaint::kFill_Style);
+
+    float startDegrees = SkRadiansToDegrees(data.angleRadians) - 90.0f;
+    SkRect oval = SkRect::MakeLTRB(
+        data.point0.x() - radius, data.point0.y() - radius,
+        data.point0.x() + radius, data.point0.y() + radius);
+
+    auto drawSector = [&](float startOffset, float endOffset, const Color& bandColor) {
+        float startAngle = startDegrees + startOffset * 360.0f;
+        float sweepAngle = (endOffset - startOffset) * 360.0f;
+        SkColor4f color = static_cast<SkColor4f>(bandColor);
+        color.fA *= globalAlpha;
+        paint.setColor4f(color);
+
+        SkPathBuilder pathBuilder;
+        pathBuilder.moveTo(data.point0.x(), data.point0.y());
+        pathBuilder.arcTo(oval, startAngle, sweepAngle, false);
+        pathBuilder.close();
+        canvas.drawPath(pathBuilder.detach(), paint);
+    };
+
+    if (bands.first().startOffset > 0)
+        drawSector(0, bands.first().startOffset, bands.first().color);
+
+    for (auto& band : bands)
+        drawSector(band.startOffset, band.endOffset, band.color);
+
+    if (bands.last().endOffset < 1)
+        drawSector(bands.last().endOffset, 1, bands.last().color);
+
+    canvas.restore();
+    return true;
 }
 
 inline SkScalar webCoreDoubleToSkScalar(double d)
@@ -207,9 +332,36 @@ sk_sp<SkShader> Gradient::shader(float globalAlpha, const AffineTransform& gradi
 
 void Gradient::fill(GraphicsContext& context, const FloatRect& rect)
 {
+    SkCanvas* canvas = context.platformContext();
+
+    const auto& bands = solidBands();
+    if (!bands.isEmpty()) {
+        bool handled = WTF::switchOn(m_data,
+            [&] (const LinearData& data) {
+                if (m_spreadMethod != GradientSpreadMethod::Pad)
+                    return false;
+                canvas->save();
+                canvas->clipRect(rect);
+                bool result = paintLinearSolidBands(*canvas, data.point0, data.point1, bands, context.alpha());
+                canvas->restore();
+                return result;
+            },
+            [&] (const ConicData& data) {
+                canvas->save();
+                canvas->clipRect(rect);
+                bool result = paintConicSolidBands(*canvas, data, bands, context.alpha());
+                canvas->restore();
+                return result;
+            },
+            [&] (const RadialData&) { return false; }
+        );
+        if (handled)
+            return;
+    }
+
     auto paint = static_cast<GraphicsContextSkia*>(&context)->createFillPaint();
     paint.setShader(shader(context.alpha(), context.fillGradientSpaceTransform()));
-    context.platformContext()->drawRect(rect, paint);
+    canvas->drawRect(rect, paint);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### d497e3cf924e88bae48130b326a96cc9a48388e6
<pre>
Render gradients formed of solid stripes with FillRect to avoid dithering
<a href="https://bugs.webkit.org/show_bug.cgi?id=310678">https://bugs.webkit.org/show_bug.cgi?id=310678</a>
<a href="https://rdar.apple.com/173279381">rdar://173279381</a>

Reviewed by NOBODY (OOPS!).

Gradient noise is a problem for both our own automated tests and for WPT, given many
reftests assume that a single-color gradient matches a solid color, or matches another
single-color gradient.

Gradients composed entirely of hard color stops (where adjacent stops share the same
offset) resolve to discrete solid color regions, but CoreGraphics still applies gradient
dithering at stop boundaries, producing artifacts that cause pixel differences compared
to test expectations.

This patch does the following:
(1) Detect this pattern in a new method extractSolidBands() that detects when a linear
    gradient style results in solid color bands.
(2) Adds new methods to paint solid color bands as filled rectangles covering both the
    Pad spread and Repeat/Reflect spread styles.
(3) Adds a new method to paint solid color arc sectors for conic gradients
(4) Disables anti-aliasing at band boundaries to ensure pixel-sharp edges.

The Pad optimization is restricted to axis-aligned gradients to avoid sub-pixel gaps from
rasterization of rotated rectangles in the graphics backend.

I had to increase the noise tolerance for five css-masking SVG tests because of this
change, but I believe this is correct. Before this change, CG gradient dithering was
introducing noise along the color boundary, and some edge pixels would &quot;accidentally&quot;
match between the mask and clip-path renderings. With clean CGContextFillRect fills, the
solid regions are now perfectly flat, which more consistently exposes the systematic
anti-aliasing difference between masking and clipping at shape edges.

Tests: fast/backgrounds/background-opaque-images-over-color.html
       fast/gradients/conic-stop-with-offset-zero-in-middle.html
       imported/w3c/web-platform-tests/css/css-backgrounds/background-image-table-cells-straddling-no-repeat.html
       imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-fixed-block-002.html
       imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-fixed-inline-002.html
       imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-local-block-002.html
       imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-local-inline-002.html
       imported/w3c/web-platform-tests/css/css-backgrounds/background-rounded-image-clip-002.html
       imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-conic.html
       imported/w3c/web-platform-tests/css/css-images/gradient/gradient-single-stop-none-interpolation.html

* LayoutTests/TestExpectations:
* LayoutTests/fast/backgrounds/background-blend-mode-difference.html:
* LayoutTests/http/tests/css/css-masking/mask-external-svg-fragment.html:
* LayoutTests/http/tests/css/css-masking/mask-external-svg-image.html:
* LayoutTests/http/tests/css/css-masking/mask-external-svg-mask.html:
* LayoutTests/http/tests/css/css-masking/mask-inline-svg-image.html:
* LayoutTests/http/tests/css/css-masking/mask-inline-svg-mask.html:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/platform/graphics/Gradient.cpp:
(WebCore::Gradient::resolvedColorsMatch):
(WebCore::Gradient::addColorStop):
(WebCore::Gradient::extractSolidBands):
(WebCore::Gradient::solidBands const):
* Source/WebCore/platform/graphics/Gradient.h:
* Source/WebCore/platform/graphics/cairo/GradientCairo.cpp:
(WebCore::Gradient::fill):
* Source/WebCore/platform/graphics/cg/GradientCG.cpp:
(WebCore::fillSolidBandsCG):
(WebCore::paintLinearSolidBands):
(WebCore::fillConicSector):
(WebCore::paintConicSolidBands):
(WebCore::Gradient::paint):
* Source/WebCore/platform/graphics/skia/GradientSkia.cpp:
(WebCore::fillSolidBandsSkia):
(WebCore::paintLinearSolidBands):
(WebCore::paintConicSolidBands):
(WebCore::Gradient::fill):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d497e3cf924e88bae48130b326a96cc9a48388e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27987 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21146 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163488 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108197 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156601 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27836 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119691 "Found 11 new test failures: css3/blending/background-blend-mode-body-transparent-color-and-image.html imported/w3c/web-platform-tests/css/css-images/gradient/gradient-single-stop-006.html imported/w3c/web-platform-tests/css/css-images/gradient/gradient-single-stop-007.html imported/w3c/web-platform-tests/css/css-images/gradient/gradient-single-stop-008.html imported/w3c/web-platform-tests/css/css-images/normalization-conic-2.html imported/w3c/web-platform-tests/css/css-images/normalization-conic-degenerate.html imported/w3c/web-platform-tests/css/css-images/normalization-conic.html imported/w3c/web-platform-tests/css/css-lists/list-style-image-gradients-dynamic.html imported/w3c/web-platform-tests/css/css-lists/list-style-image-gradients.html imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-composite-1d.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84638 "1 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157687 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22000 "Found 16 new test failures: fast/canvas/canvas-conic-gradient-angle.html fast/canvas/canvas-conic-gradient-center.html fast/gradients/conic-center-outside-box.html fast/gradients/conic-from-angle.html fast/gradients/conic-off-center.html fast/gradients/conic-repeating.html fast/gradients/conic-stop-with-offset-zero-in-middle.html fast/gradients/conic-two-hints.html fast/gradients/conic.html http/tests/css/css-masking/mask-external-svg-fragment.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138961 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100385 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/847bfcf6-91f6-4b99-881c-1198486ff5a7) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21064 "Found 60 new test failures: imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-fixed-block-002.html imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-fixed-inline-002.html imported/w3c/web-platform-tests/css/css-images/gradient/gradient-analogous-missing-components-002.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-conic.html imported/w3c/web-platform-tests/css/css-transforms/document-styles/svg-document-styles-002.html imported/w3c/web-platform-tests/css/css-transforms/document-styles/svg-document-styles-005.html imported/w3c/web-platform-tests/css/css-transforms/document-styles/svg-document-styles-006.html imported/w3c/web-platform-tests/css/css-transforms/document-styles/svg-document-styles-007.html imported/w3c/web-platform-tests/css/css-transforms/document-styles/svg-document-styles-009.html imported/w3c/web-platform-tests/css/css-transforms/document-styles/svg-document-styles-010.html ... (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19083 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11314 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130726 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16805 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165962 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9185 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18414 "Found 60 new test failures: compositing/repaint/foreground-layer-change.html fast/scrolling/mac/stateless-user-scroll-scrollend.html http/tests/iframe-monitor/workers/service-worker-not-count-twice.html http/tests/performance/performance-resource-timing-cross-origin-media.html imported/w3c/web-platform-tests/css/css-images/gradient/gradient-analogous-missing-components-002.html imported/w3c/web-platform-tests/css/css-transforms/document-styles/svg-document-styles-002.html imported/w3c/web-platform-tests/css/css-transforms/document-styles/svg-document-styles-005.html imported/w3c/web-platform-tests/css/css-transforms/document-styles/svg-document-styles-006.html imported/w3c/web-platform-tests/css/css-transforms/document-styles/svg-document-styles-007.html imported/w3c/web-platform-tests/css/css-transforms/document-styles/svg-document-styles-009.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127792 "Found 13 new test failures: css3/blending/background-blend-mode-body-transparent-color-and-image.html imported/w3c/web-platform-tests/css/css-images/gradient/gradient-single-stop-006.html imported/w3c/web-platform-tests/css/css-images/gradient/gradient-single-stop-007.html imported/w3c/web-platform-tests/css/css-images/gradient/gradient-single-stop-008.html imported/w3c/web-platform-tests/css/css-images/normalization-conic-2.html imported/w3c/web-platform-tests/css/css-images/normalization-conic-degenerate.html imported/w3c/web-platform-tests/css/css-images/normalization-conic.html imported/w3c/web-platform-tests/css/css-lists/list-style-image-gradients-dynamic.html imported/w3c/web-platform-tests/css/css-lists/list-style-image-gradients.html imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-composite-1d.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27532 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23123 "Found 60 new test failures: accessibility/mac/stale-textmarker-crash.html http/tests/navigation/redirect-to-random-url-versus-memory-cache.html imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.serviceworker.html imported/w3c/web-platform-tests/css/css-images/gradient/gradient-analogous-missing-components-002.html imported/w3c/web-platform-tests/css/css-transforms/document-styles/svg-document-styles-002.html imported/w3c/web-platform-tests/css/css-transforms/document-styles/svg-document-styles-005.html imported/w3c/web-platform-tests/css/css-transforms/document-styles/svg-document-styles-006.html imported/w3c/web-platform-tests/css/css-transforms/document-styles/svg-document-styles-007.html imported/w3c/web-platform-tests/css/css-transforms/document-styles/svg-document-styles-009.html imported/w3c/web-platform-tests/css/css-transforms/document-styles/svg-document-styles-010.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127931 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138598 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84161 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22827 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15392 "Found 60 new test failures: fast/canvas/canvas-conic-gradient-angle.html fast/canvas/canvas-conic-gradient-center.html fast/css-custom-paint/simple-hidpi.html fast/gradients/conic-repeating.html fast/gradients/conic-stop-with-offset-zero-in-middle.html fast/gradients/conic-two-hints.html fast/gradients/conic.html imported/w3c/web-platform-tests/css/css-images/gradient/gradient-analogous-missing-components-002.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-conic.html imported/w3c/web-platform-tests/css/css-transforms/document-styles/svg-document-styles-002.html ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27148 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91250 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26726 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26957 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26799 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->