### PR TITLE
Skip variant dispatch for touch-action: auto elements during event region unification

### DIFF
--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -471,7 +471,10 @@ void EventRegion::unite(const Region& region, const RenderObject& renderer, cons
     m_region.unite(region);
 
 #if ENABLE(TOUCH_ACTION_REGIONS)
-    uniteTouchActions(region, Style::toPlatform(style.usedTouchAction()));
+    if (auto touchAction = style.usedTouchAction(); !touchAction.isAuto())
+        uniteTouchActions(region, Style::toPlatform(touchAction));
+    else if (!m_touchActionRegions.isEmpty())
+        subtractAutoFromTouchActions(region);
 #endif
 
     uniteEventListeners(region, style.eventListenerRegionTypes());
@@ -580,6 +583,12 @@ void EventRegion::uniteTouchActions(const Region& touchRegion, OptionSet<TouchAc
             LOG_WITH_STREAM(EventRegions, stream << " subtracting for TouchAction " << regionTouchAction);
         }
     }
+}
+
+void EventRegion::subtractAutoFromTouchActions(const Region& region)
+{
+    for (auto& regionEntry : m_touchActionRegions)
+        regionEntry.subtract(region);
 }
 
 const Region* EventRegion::regionForTouchAction(TouchAction action) const

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -174,6 +174,7 @@ private:
     friend struct IPC::ArgumentCoder<EventRegion>;
 #if ENABLE(TOUCH_ACTION_REGIONS)
     void uniteTouchActions(const Region&, OptionSet<TouchAction>);
+    void subtractAutoFromTouchActions(const Region&);
 #endif
     void uniteEventListeners(const Region&, OptionSet<EventListenerRegionType>);
 


### PR DESCRIPTION
#### fcca4de2925ff7785635fbd6bd744087a5b0534f
<pre>
Skip variant dispatch for touch-action: auto elements during event region unification
<a href="https://rdar.apple.com/173455838">rdar://173455838</a>

Reviewed by NOBODY (OOPS!).

When `ENABLE_TOUCH_ACTION_REGIONS` is on, EventRegion::unite() calls
uniteTouchActions() unconditionally for every element, which requires a
Style::toPlatform() variant dispatch, even for the overwhelming majority
of elements with touch-action: auto.

As an optimization opportunity, we check isAuto() first (a single integer
comparison on the variant index) and skip the toPlatform() conversion
entirely when possible. If m_touchActionRegions is empty, meaning no
non-auto region has been found yet, we can skip uniteTouchActions()
altogether. When non-empty, we just use a helper dedicated to subtract
from the existing regions for touch-action: auto, again avoiding the
toPlatform conversion.

* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegion::unite):
(WebCore::EventRegion::subtractAutoFromTouchActions):
* Source/WebCore/rendering/EventRegion.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcca4de2925ff7785635fbd6bd744087a5b0534f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162756 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107470 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155877 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27112 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119099 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84197 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f6e99b6-148e-48bb-8652-178886bf0098) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138296 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99799 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/29f3d6d4-0de7-4f48-a5ad-f10b3baa7c01) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20449 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18422 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10589 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130106 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16148 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165229 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8425 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17749 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127190 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26806 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22456 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127343 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26730 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137942 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83309 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22237 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14730 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26421 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90513 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26002 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26232 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26074 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->