### PR TITLE
Fix availability versions for 26.4 releases

### DIFF
--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h
@@ -53,9 +53,9 @@ WK_CLASS_AVAILABLE(macos(10.12), ios(16.0))
 @property (nonatomic, readonly, copy) NSString *linkLabel;
 @property (nonatomic, readonly, copy) NSString *linkTitle;
 @property (nonatomic, readonly, copy) NSString *linkSuggestedFilename WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
-@property (nonatomic, readonly) BOOL linkHasTargetFrame WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-@property (nonatomic, readonly) BOOL linkTargetFrameIsSameAsLinkFrame WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-@property (nonatomic, readonly) BOOL linkTargetFrameIsInDifferentWebView WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, readonly) BOOL linkHasTargetFrame WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
+@property (nonatomic, readonly) BOOL linkTargetFrameIsSameAsLinkFrame WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
+@property (nonatomic, readonly) BOOL linkTargetFrameIsInDifferentWebView WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 @property (nonatomic, readonly, copy) NSString *imageSuggestedFilename WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
 @property (nonatomic, readonly, copy) NSString *lookupText;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfoPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfoPrivate.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) CGSize _visibleContentSizeExcludingScrollbars WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 @property (nonatomic, readonly, nullable) SecTrustRef _serverTrust WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 
-- (BOOL)_isSameFrame:(WKFrameInfo *)frame WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (BOOL)_isSameFrame:(WKFrameInfo *)frame WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 NS_ASSUME_NONNULL_END
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -38,9 +38,9 @@ typedef NS_OPTIONS(NSUInteger, _WKDebugOverlayRegions) {
     _WKTouchActionRegion = 1 << 2,
     _WKEditableElementRegion = 1 << 3,
     _WKInteractionRegion WK_API_AVAILABLE(macos(13.0), ios(16.0)) = 1 << 4,
-    _WKSiteIsolationRegion WK_API_DEPRECATED_WITH_REPLACEMENT("ShowFrameProcessBordersEnabled", macos(15.0, WK_MAC_TBA), ios(18.0, WK_IOS_TBA), visionos(2.0, WK_XROS_TBA)) = 1 << 5,
-    _WKEnhancedSecurityRegion WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) = 1 << 6,
-    _WKTouchEventRegion WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) = 1 << 7,
+    _WKSiteIsolationRegion WK_API_DEPRECATED_WITH_REPLACEMENT("ShowFrameProcessBordersEnabled", macos(15.0, 26.4), ios(18.0, 26.4), visionos(2.0, 26.4)) = 1 << 5,
+    _WKEnhancedSecurityRegion WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4)) = 1 << 6,
+    _WKTouchEventRegion WK_API_AVAILABLE(ios(26.4), visionos(26.4)) = 1 << 7,
 } WK_API_AVAILABLE(macos(10.11), ios(9.0));
 
 typedef NS_OPTIONS(NSUInteger, _WKJavaScriptRuntimeFlags) {
@@ -126,7 +126,7 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 @property (nonatomic, setter=_setEnumeratingAllNetworkInterfacesEnabled:) BOOL _enumeratingAllNetworkInterfacesEnabled WK_API_AVAILABLE(macos(10.13), ios(11.0));
 @property (nonatomic, setter=_setICECandidateFilteringEnabled:) BOOL _iceCandidateFilteringEnabled WK_API_AVAILABLE(macos(10.13.4), ios(11.3));
 @property (nonatomic, setter=_setInactiveMediaCaptureStreamRepromptIntervalInMinutes:) double _inactiveMediaCaptureStreamRepromptIntervalInMinutes WK_API_AVAILABLE(macos(10.13.4), ios(11.3));
-@property (nonatomic, setter=_setInactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes:) double _inactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, setter=_setInactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes:) double _inactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes WK_API_AVAILABLE(macos(26.4), ios(26.4));
 @property (nonatomic, setter=_setInterruptAudioOnPageVisibilityChangeEnabled:) BOOL _interruptAudioOnPageVisibilityChangeEnabled WK_API_AVAILABLE(macos(10.15), ios(13.0));
 
 @property (nonatomic, setter=_setJavaScriptCanAccessClipboard:) BOOL _javaScriptCanAccessClipboard WK_API_AVAILABLE(macos(10.13), ios(11.0));
@@ -204,7 +204,7 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 @property (nonatomic, setter=_setModelElementEnabled:) BOOL _modelElementEnabled WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 @property (nonatomic, setter=_setModelProcessEnabled:) BOOL _modelProcessEnabled WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 @property (nonatomic, setter=_setModelNoPortalAttributeEnabled:) BOOL _modelNoPortalAttributeEnabled WK_API_AVAILABLE(visionos(2.4));
-@property (nonatomic, setter=_setUpdateSceneGeometryEnabled:) BOOL _updateSceneGeometryEnabled WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+@property (nonatomic, setter=_setUpdateSceneGeometryEnabled:) BOOL _updateSceneGeometryEnabled WK_API_AVAILABLE(visionos(26.4));
 @property (nonatomic, setter=_setRequiresPageVisibilityForVideoToBeNowPlayingForTesting:) BOOL _requiresPageVisibilityForVideoToBeNowPlayingForTesting WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 @property (nonatomic, setter=_setSiteIsolationEnabled:) BOOL _siteIsolationEnabled WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 
@@ -263,7 +263,7 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 #endif
 @property (nonatomic, setter=_setDisplayListDrawingEnabled:) BOOL _displayListDrawingEnabled WK_API_DEPRECATED("Display list drawing is no longer supported", macos(10.12, 14.4), ios(10.0, 17.4), visionos(1.0, 1.1));
 // FIXME: We should remove this property.
-@property (nonatomic, setter=_setOfflineApplicationCacheIsEnabled:) BOOL _offlineApplicationCacheIsEnabled WK_API_DEPRECATED("OfflineApplicationCache is no longer supported", macos(10.10, WK_MAC_TBA), ios(8.0, WK_IOS_TBA));
+@property (nonatomic, setter=_setOfflineApplicationCacheIsEnabled:) BOOL _offlineApplicationCacheIsEnabled WK_API_DEPRECATED("OfflineApplicationCache is no longer supported", macos(10.10, 26.4), ios(8.0, 26.4));
 @property (nonatomic, setter=_setMediaStreamEnabled:) BOOL _mediaStreamEnabled WK_API_DEPRECATED("Media stream preference is no longer supported", macos(10.14, 15.4));
 @property (nonatomic, setter=_setClientBadgeEnabled:) BOOL _clientBadgeEnabled WK_API_DEPRECATED("Client badge is no longer supported", macos(13.3, 26.0), ios(16.4, 26.0));
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
@@ -130,8 +130,8 @@ WK_CLASS_AVAILABLE(macos(14.5), ios(17.5), visionos(1.2))
 - (void)_terminateServiceWorkers WK_API_AVAILABLE(macos(10.14), ios(12.0));
 
 // Test only.
-- (NSSet<NSNumber *> *)_prewarmedProcessIdentifiersForTesting WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
-- (void)_countWebPagesInAllProcessesForTesting:(void(^)(unsigned))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+- (NSSet<NSNumber *> *)_prewarmedProcessIdentifiersForTesting WK_API_AVAILABLE(macos(26.4), ios(26.4));
+- (void)_countWebPagesInAllProcessesForTesting:(void(^)(unsigned))completionHandler WK_API_AVAILABLE(macos(26.4), ios(26.4));
 
 - (void)_terminateAllWebContentProcesses;
 
@@ -149,7 +149,7 @@ WK_CLASS_AVAILABLE(macos(14.5), ios(17.5), visionos(1.2))
 - (NSUInteger)_processCacheCapacity WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
 - (NSUInteger)_processCacheSize WK_API_AVAILABLE(macos(10.15), ios(13.0));
 - (void)_clearWebProcessCache WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
-- (void)_setCachedProcessLifetimeForTesting:(NSTimeInterval)lifetime WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+- (void)_setCachedProcessLifetimeForTesting:(NSTimeInterval)lifetime WK_API_AVAILABLE(macos(26.4), ios(26.4));
 - (void)_setUseSeparateServiceWorkerProcess:(BOOL)forceServiceWorkerProcess WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 - (pid_t)_gpuProcessIdentifier WK_API_AVAILABLE(macos(12.0), ios(15.0));
 - (BOOL)_hasAudibleMediaActivity WK_API_AVAILABLE(macos(13.0), ios(16.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
@@ -159,7 +159,7 @@ struct UIEdgeInsets;
 - (void)_webView:(WKWebView *)webView hasVideoInPictureInPictureDidChange:(BOOL)hasVideoInPictureInPicture WK_API_AVAILABLE(macos(10.13), ios(11.0));
 - (void)_webView:(WKWebView *)webView shouldAllowPDFAtURL:(NSURL *)fileURL toOpenFromFrame:(WKFrameInfo *)frame completionHandler:(void (^)(BOOL))completionHandler WK_API_AVAILABLE(macos(11.0), ios(14.0));
 
-- (void)_webView:(WKWebView *)webView didReceiveConsoleLogForTesting:(NSString *)log WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_webView:(WKWebView *)webView didReceiveConsoleLogForTesting:(NSString *)log WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 - (void)_webView:(WKWebView *)webView imageOrMediaDocumentSizeChanged:(CGSize)size WK_API_AVAILABLE(macos(10.12), ios(10.0));
 - (NSDictionary *)_dataDetectionContextForWebView:(WKWebView *)webView WK_API_AVAILABLE(macos(10.12), ios(10.0));
@@ -228,7 +228,7 @@ struct UIEdgeInsets;
 - (void)_webView:(WKWebView *)webView setRecentlyAccessedGamepads:(BOOL)recentlyAccessedGamepads WK_API_AVAILABLE(visionos(2.0));
 - (void)_webView:(WKWebView *)webView gamepadsConnectedStateDidChange:(BOOL)gamepadsConnected WK_API_AVAILABLE(visionos(2.0));
 
-- (void)_webViewWillPresentModalUI:(WKWebView *)webView WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+- (void)_webViewWillPresentModalUI:(WKWebView *)webView WK_API_AVAILABLE(visionos(26.4));
 #endif
 
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentControllerPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentControllerPrivate.h
@@ -46,8 +46,8 @@
 - (void)_removeAllUserContentFilters WK_API_AVAILABLE(macos(10.11), ios(9.0));
 - (void)_addContentRuleList:(WKContentRuleList *)contentRuleList extensionBaseURL:(NSURL *)extensionBaseURL WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
-- (void)_addBuffer:(_WKJSBuffer *)buffer contentWorld:(WKContentWorld *)world name:(NSString *)name WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-- (void)_removeBufferWithName:(NSString *)name contentWorld:(WKContentWorld *)world WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_addBuffer:(_WKJSBuffer *)buffer contentWorld:(WKContentWorld *)world name:(NSString *)name WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
+- (void)_removeBufferWithName:(NSString *)name contentWorld:(WKContentWorld *)world WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 @property (nonatomic, readonly, copy) NSArray<_WKUserStyleSheet *> *_userStyleSheets WK_API_AVAILABLE(macos(10.12), ios(10.0));
 - (void)_addUserStyleSheet:(_WKUserStyleSheet *)userStyleSheet WK_API_AVAILABLE(macos(10.12), ios(10.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
@@ -96,8 +96,8 @@ typedef NS_ENUM(NSUInteger, _WKContentSecurityPolicyModeForExtension) {
 @property (nonatomic, setter=_setDrawsBackground:) BOOL _drawsBackground WK_API_AVAILABLE(macos(10.14), ios(12.0));
 @property (nonatomic, setter=_setShouldDeferAsynchronousScriptsUntilAfterDocumentLoad:) BOOL _shouldDeferAsynchronousScriptsUntilAfterDocumentLoad WK_API_AVAILABLE(macos(10.14), ios(12.0));
 @property (nonatomic, setter=_setShowsSystemScreenTimeBlockingView:) BOOL _showsSystemScreenTimeBlockingView WK_API_AVAILABLE(macos(26.0), ios(26.0)) WK_API_UNAVAILABLE(visionos);
-@property (nonatomic, setter=_setAllowPostingLegacySynchronousMessages:) BOOL _allowPostingLegacySynchronousMessages WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
-@property (nonatomic, setter=_setShouldSendConsoleLogsToUIProcessForTesting:) BOOL _shouldSendConsoleLogsToUIProcessForTesting WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, setter=_setAllowPostingLegacySynchronousMessages:) BOOL _allowPostingLegacySynchronousMessages WK_API_AVAILABLE(macos(26.4), ios(26.4));
+@property (nonatomic, setter=_setShouldSendConsoleLogsToUIProcessForTesting:) BOOL _shouldSendConsoleLogsToUIProcessForTesting WK_API_AVAILABLE(macos(26.4), ios(26.4));
 @property (nonatomic, readonly) WKWebsiteDataStore *_websiteDataStoreIfExists WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 @property (nonatomic, copy, setter=_setCORSDisablingPatterns:) NSArray<NSString *> *_corsDisablingPatterns WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 @property (nonatomic, copy, setter=_setMaskedURLSchemes:) NSSet<NSString *> *_maskedURLSchemes WK_API_AVAILABLE(macos(13.0), ios(16.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -192,7 +192,7 @@ typedef NS_ENUM(NSInteger, _WKImmediateActionType) {
 @property (nonatomic, readonly) NSURL *_resourceDirectoryURL WK_API_AVAILABLE(macos(10.15), ios(13.0));
 
 - (void)_loadAlternateHTMLString:(NSString *)string baseURL:(NSURL *)baseURL forUnreachableURL:(NSURL *)unreachableURL;
-- (void)_loadAlternateHTMLString:(NSString *)string baseURL:(NSURL *)baseURL forUnreachableURL:(NSURL *)unreachableURL withWebpagePreferences:(WKWebpagePreferences *)preferences WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_loadAlternateHTMLString:(NSString *)string baseURL:(NSURL *)baseURL forUnreachableURL:(NSURL *)unreachableURL withWebpagePreferences:(WKWebpagePreferences *)preferences WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 - (WKNavigation *)_loadData:(NSData *)data MIMEType:(NSString *)MIMEType characterEncodingName:(NSString *)characterEncodingName baseURL:(NSURL *)baseURL userData:(id)userData WK_API_AVAILABLE(macos(10.12), ios(10.0));
 - (WKNavigation *)_loadRequest:(NSURLRequest *)request shouldOpenExternalURLs:(BOOL)shouldOpenExternalURLs WK_API_AVAILABLE(macos(10.13), ios(11.0));
 - (WKNavigation *)_loadRequest:(NSURLRequest *)request shouldOpenExternalURLsPolicy:(_WKShouldOpenExternalURLsPolicy)shouldOpenExternalURLsPolicy WK_API_AVAILABLE(macos(12.0), ios(15.0));
@@ -327,7 +327,7 @@ for this property.
 - (void)_executeEditCommand:(NSString *)command argument:(NSString *)argument completion:(void (^)(BOOL))completion WK_API_AVAILABLE(macos(10.13.4), ios(11.3));
 
 - (void)_isJITEnabled:(void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
-- (void)_isEnhancedSecurityEnabled:(void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_isEnhancedSecurityEnabled:(void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 - (void)_removeDataDetectedLinks:(dispatch_block_t)completion WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
 
 - (IBAction)_alignCenter:(id)sender WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
@@ -362,8 +362,8 @@ for this property.
 - (void)_archiveWithConfiguration:(_WKArchiveConfiguration*)configuration completionHandler:(void (^)(NSError *error))completionHandler WK_API_AVAILABLE(macos(14.4), ios(17.4), visionos(1.1));
 - (void)_getMainResourceDataWithCompletionHandler:(void (^)(NSData *, NSError *))completionHandler;
 - (void)_getWebArchiveDataWithCompletionHandler:(void (^)(NSData *, NSError *))completionHandler;
-- (void)_createWebArchiveForFrame:(WKFrameInfo *)frame completionHandler:(void (^)(NSData *, NSError *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-- (void)_createWebArchiveForFrames:(NSArray<WKFrameInfo *> *)frames rootFrame:(WKFrameInfo *)rootFrame completionHandler:(void (^)(NSData *, NSError *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_createWebArchiveForFrame:(WKFrameInfo *)frame completionHandler:(void (^)(NSData *, NSError *))completionHandler WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
+- (void)_createWebArchiveForFrames:(NSArray<WKFrameInfo *> *)frames rootFrame:(WKFrameInfo *)rootFrame completionHandler:(void (^)(NSData *, NSError *))completionHandler WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 - (void)_getContentsAsStringWithCompletionHandler:(void (^)(NSString *, NSError *))completionHandler WK_API_AVAILABLE(macos(10.13), ios(11.0));
 - (void)_getContentsAsStringWithCompletionHandlerKeepIPCConnectionAliveForTesting:(void (^)(NSString *, NSError *))completionHandler;
 - (void)_getContentsOfAllFramesAsStringWithCompletionHandler:(void (^)(NSString *))completionHandler WK_API_AVAILABLE(macos(11.0), ios(14.0));
@@ -446,15 +446,15 @@ for this property.
 - (void)_convertPoint:(CGPoint)point fromFrame:(WKFrameInfo *)frame toMainFrameCoordinates:(void (^)(CGPoint, NSError *error))completionHandler WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 - (void)_convertRect:(CGRect)rect fromFrame:(WKFrameInfo *)frame toMainFrameCoordinates:(void (^)(CGRect, NSError *error))completionHandler WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 
-@property (nonatomic, setter=_setStatusBarIsVisible:) BOOL _statusBarIsVisible WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-@property (nonatomic, setter=_setMenuBarIsVisible:) BOOL _menuBarIsVisible WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-@property (nonatomic, setter=_setToolbarsAreVisible:) BOOL _toolbarsAreVisible WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, setter=_setStatusBarIsVisible:) BOOL _statusBarIsVisible WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
+@property (nonatomic, setter=_setMenuBarIsVisible:) BOOL _menuBarIsVisible WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
+@property (nonatomic, setter=_setToolbarsAreVisible:) BOOL _toolbarsAreVisible WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 // If frame is nil, the main frame will be used if there is a main frame.
 // If frame is non-nil, not only will frame's coordinate space be used, but frame's subtree will be searched,
 // so a node from a parent node won't be returned, even if point is outside frame's rect.
 // The result frame info is the frame that contains the hit node.
-- (void)_hitTestAtPoint:(CGPoint)point inFrameCoordinateSpace:(WKFrameInfo *)frame completionHandler:(void (^)(_WKJSHandle *, NSError *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_hitTestAtPoint:(CGPoint)point inFrameCoordinateSpace:(WKFrameInfo *)frame completionHandler:(void (^)(_WKJSHandle *, NSError *))completionHandler WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 - (void)_takePDFSnapshotWithConfiguration:(WKSnapshotConfiguration *)snapshotConfiguration completionHandler:(void (^)(NSData *pdfSnapshotData, NSError *error))completionHandler WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 - (void)_getPDFFirstPageSizeInFrame:(_WKFrameHandle *)frame completionHandler:(void(^)(CGSize))completionHandler WK_API_AVAILABLE(macos(12.0), ios(15.0));
@@ -494,8 +494,8 @@ for this property.
 
 @property (nonatomic, readonly) _WKSpatialBackdropSource *_spatialBackdropSource WK_API_AVAILABLE(visionos(26.0));
 
-@property (nonatomic, weak, setter=_setImmersiveEnvironmentDelegate:) id <_WKImmersiveEnvironmentDelegate> _immersiveEnvironmentDelegate WK_API_AVAILABLE(visionos(WK_XROS_TBA));
-- (void)_exitImmersive WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+@property (nonatomic, weak, setter=_setImmersiveEnvironmentDelegate:) id <_WKImmersiveEnvironmentDelegate> _immersiveEnvironmentDelegate WK_API_AVAILABLE(visionos(26.4));
+- (void)_exitImmersive WK_API_AVAILABLE(visionos(26.4));
 
 - (void)_grantAccessToAssetServices WK_API_AVAILABLE(macos(12.0), ios(14.0));
 - (void)_revokeAccessToAssetServices WK_API_AVAILABLE(macos(12.0), ios(14.0));
@@ -656,17 +656,17 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 #endif
 
 #if TARGET_OS_IPHONE
-- (void)_takeSnapshotOfNode:(_WKJSHandle *)node completionHandler:(WK_SWIFT_UI_ACTOR void (^)(UIImage *, NSError *))completionHandler WK_SWIFT_ASYNC_NAME(_takeSnapshotOfNode(_:)) WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_takeSnapshotOfNode:(_WKJSHandle *)node completionHandler:(WK_SWIFT_UI_ACTOR void (^)(UIImage *, NSError *))completionHandler WK_SWIFT_ASYNC_NAME(_takeSnapshotOfNode(_:)) WK_API_AVAILABLE(ios(26.4), visionos(26.4));
 #else
-- (void)_takeSnapshotOfNode:(_WKJSHandle *)node completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSImage *, NSError *))completionHandler WK_SWIFT_ASYNC_NAME(_takeSnapshotOfNode(_:)) WK_API_AVAILABLE(macos(WK_MAC_TBA));
+- (void)_takeSnapshotOfNode:(_WKJSHandle *)node completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSImage *, NSError *))completionHandler WK_SWIFT_ASYNC_NAME(_takeSnapshotOfNode(_:)) WK_API_AVAILABLE(macos(26.4));
 #endif
 
-- (void)_getSelectorPathDataForNode:(_WKJSHandle *)node completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSData *))completionHandler WK_SWIFT_ASYNC_NAME(_getSelectorPathDataForNode(_:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-- (void)_getNodeForSelectorPathData:(NSData *)data completionHandler:(WK_SWIFT_UI_ACTOR void (^)(_WKJSHandle *))completionHandler WK_SWIFT_ASYNC_NAME(_getNodeForSelectorPathData(_:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_getSelectorPathDataForNode:(_WKJSHandle *)node completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSData *))completionHandler WK_SWIFT_ASYNC_NAME(_getSelectorPathDataForNode(_:)) WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
+- (void)_getNodeForSelectorPathData:(NSData *)data completionHandler:(WK_SWIFT_UI_ACTOR void (^)(_WKJSHandle *))completionHandler WK_SWIFT_ASYNC_NAME(_getNodeForSelectorPathData(_:)) WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
-- (void)_debugTextWithConfiguration:(_WKTextExtractionConfiguration *)configuration completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSString *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) NS_SWIFT_NAME(_debugText(with:completionHandler:));
-- (void)_extractDebugTextWithConfiguration:(_WKTextExtractionConfiguration *)configuration completionHandler:(WK_SWIFT_UI_ACTOR void(^)(_WKTextExtractionResult *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) NS_SWIFT_NAME(_extractDebugText(with:completionHandler:));
-- (void)_performInteraction:(_WKTextExtractionInteraction *)interaction completionHandler:(WK_SWIFT_UI_ACTOR void(^)(_WKTextExtractionInteractionResult *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) NS_SWIFT_NAME(_performInteraction(_:completionHandler:));
+- (void)_debugTextWithConfiguration:(_WKTextExtractionConfiguration *)configuration completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSString *))completionHandler WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4)) NS_SWIFT_NAME(_debugText(with:completionHandler:));
+- (void)_extractDebugTextWithConfiguration:(_WKTextExtractionConfiguration *)configuration completionHandler:(WK_SWIFT_UI_ACTOR void(^)(_WKTextExtractionResult *))completionHandler WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4)) NS_SWIFT_NAME(_extractDebugText(with:completionHandler:));
+- (void)_performInteraction:(_WKTextExtractionInteraction *)interaction completionHandler:(WK_SWIFT_UI_ACTOR void(^)(_WKTextExtractionInteractionResult *))completionHandler WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4)) NS_SWIFT_NAME(_performInteraction(_:completionHandler:));
 
 - (void)_addWritingToolsPreservedNodes:(NSArray<_WKJSHandle *> *)nodes WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
@@ -724,7 +724,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 
 // Indicates if the page uses touch-action to disallow panning.
 // Whether or not a pan will actually occur depends on many other factors.
-- (BOOL)_allowsTouchPanningAtPoint:(CGPoint)point WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (BOOL)_allowsTouchPanningAtPoint:(CGPoint)point WK_API_AVAILABLE(ios(26.4), visionos(26.4));
 
 // An ancestor view whose bounds will be intersected with those of this WKWebView to determine the visible region of content to render.
 @property (nonatomic, readonly) UIView *_enclosingViewForExposedRectComputation WK_API_AVAILABLE(ios(11.0));
@@ -765,7 +765,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 - (void)didStartFormControlInteraction WK_API_AVAILABLE(ios(10.3));
 - (void)didEndFormControlInteraction WK_API_AVAILABLE(ios(10.3));
 
-- (void)didEnsurePositionInformationIsUpToDate WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)didEnsurePositionInformationIsUpToDate WK_API_AVAILABLE(ios(26.4), visionos(26.4));
 
 - (void)_beginInteractiveObscuredInsetsChange;
 - (void)_endInteractiveObscuredInsetsChange;
@@ -951,17 +951,17 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= 260000
 @property (nonatomic, readonly) NSScrollPocket *_topScrollPocket WK_API_AVAILABLE(macos(26.0));
-@property (nonatomic, setter=_setPrefersSolidColorHardScrollPocket:) BOOL _prefersSolidColorHardScrollPocket WK_API_AVAILABLE(macos(WK_MAC_TBA));
+@property (nonatomic, setter=_setPrefersSolidColorHardScrollPocket:) BOOL _prefersSolidColorHardScrollPocket WK_API_AVAILABLE(macos(26.4));
 #endif
 
 - (void)_showWritingTools WK_API_AVAILABLE(macos(15.2));
 
-- (BOOL)_isSmartListsEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA));
-- (void)_setSmartListsEnabled:(BOOL)flag WK_API_AVAILABLE(macos(WK_MAC_TBA));
-- (void)_toggleSmartLists:(id)sender WK_API_AVAILABLE(macos(WK_MAC_TBA));
+- (BOOL)_isSmartListsEnabled WK_API_AVAILABLE(macos(26.4));
+- (void)_setSmartListsEnabled:(BOOL)flag WK_API_AVAILABLE(macos(26.4));
+- (void)_toggleSmartLists:(id)sender WK_API_AVAILABLE(macos(26.4));
 
-- (void)_storePrivateClickMeasurementWithSourceID:(uint8_t)sourceID destinationURL:(NSURL *)destinationURL reportEndpoint:(NSURL *)reportEndpoint WK_API_AVAILABLE(macos(WK_MAC_TBA));
-- (void)_storeSimulatedPrivateClickMeasurementConversionWithPriority:(uint8_t)priority triggerData:(uint8_t)triggerData sourceURL:(NSURL *)sourceURL destinationURL:(NSURL *)destinationURL WK_API_AVAILABLE(macos(WK_MAC_TBA));
+- (void)_storePrivateClickMeasurementWithSourceID:(uint8_t)sourceID destinationURL:(NSURL *)destinationURL reportEndpoint:(NSURL *)reportEndpoint WK_API_AVAILABLE(macos(26.4));
+- (void)_storeSimulatedPrivateClickMeasurementConversionWithPriority:(uint8_t)priority triggerData:(uint8_t)triggerData sourceURL:(NSURL *)sourceURL destinationURL:(NSURL *)destinationURL WK_API_AVAILABLE(macos(26.4));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -112,7 +112,7 @@ typedef NSVisualEffectView _WKPlatformVisualEffectView;
 - (STWebpageController *)_screenTimeWebpageController;
 - (_WKPlatformVisualEffectView *)_screenTimeBlurredSnapshot;
 
-- (void)_getRenderTreeAsStringWithCompletionHandler:(NS_SWIFT_UI_ACTOR void (^)(NSString * NS_NULLABLE_RESULT, NSError * _Nullable error))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_getRenderTreeAsStringWithCompletionHandler:(NS_SWIFT_UI_ACTOR void (^)(NSString * NS_NULLABLE_RESULT, NSError * _Nullable error))completionHandler WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 @property (nonatomic, setter=_setScrollingUpdatesDisabledForTesting:) BOOL _scrollingUpdatesDisabledForTesting;
 @property (nonatomic, readonly) NSString *_scrollingTreeAsText;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h
@@ -69,7 +69,7 @@ typedef NS_ENUM(NSInteger, WKSecurityRestrictionMode) {
     WKSecurityRestrictionModeNone,
     WKSecurityRestrictionModeMaximizeCompatibility,
     WKSecurityRestrictionModeLockdown
-} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+} WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 /*! A WKWebpagePreferences object is a collection of properties that
  determine the preferences to use when loading and rendering a page.
@@ -126,7 +126,7 @@ WK_CLASS_AVAILABLE(macos(10.15), ios(13.0))
  When the system has chosen WKSecurityRestrictionModeLockdown (e.g., in Lockdown Mode), attempts to set a less restrictive mode will fail silently.
  The default value is WKSecurityRestrictionModeNone.
  */
-@property (nonatomic) WKSecurityRestrictionMode securityRestrictionMode WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic) WKSecurityRestrictionMode securityRestrictionMode WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 /* @abstract Used to make changes to the network request that will be used for this navigation's main resource load.
 */

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
@@ -125,7 +125,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteNetworkConnectionIntegrityPolicy) {
 @property (nonatomic, copy, setter=_setVisibilityAdjustmentSelectorsIncludingShadowHosts:) NSArray<NSArray<NSSet<NSString *> *> *> *_visibilityAdjustmentSelectorsIncludingShadowHosts WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
 @property (nonatomic, copy, setter=_setVisibilityAdjustmentSelectors:) NSSet<NSString *> *_visibilityAdjustmentSelectors WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
 
-@property (nonatomic, setter=_setAllowSharedProcess:) BOOL _allowSharedProcess WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, setter=_setAllowSharedProcess:) BOOL _allowSharedProcess WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 - (void)_setContentRuleListsEnabled:(BOOL)enabled exceptions:(NSSet<NSString *> *)exceptions WK_API_AVAILABLE(macos(14.0), ios(17.0));
 
@@ -133,9 +133,9 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteNetworkConnectionIntegrityPolicy) {
 
 @property (nonatomic, setter=setAlternateRequest:) NSURLRequest *_alternateRequest WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
-@property (nonatomic, setter=_setAllowsJSHandleCreationInPageWorld:) BOOL _allowsJSHandleCreationInPageWorld WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, setter=_setAllowsJSHandleCreationInPageWorld:) BOOL _allowsJSHandleCreationInPageWorld WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
-@property (nonatomic, setter=_setEnhancedSecurityEnabled:) BOOL _enhancedSecurityEnabled WK_API_DEPRECATED_WITH_REPLACEMENT("securityRestrictionMode", macos(WK_MAC_TBA, WK_MAC_TBA), ios(WK_IOS_TBA, WK_IOS_TBA), visionos(WK_XROS_TBA, WK_XROS_TBA));
+@property (nonatomic, setter=_setEnhancedSecurityEnabled:) BOOL _enhancedSecurityEnabled WK_API_DEPRECATED_WITH_REPLACEMENT("securityRestrictionMode", macos(26.4, 26.4), ios(26.4, 26.4), visionos(26.4, 26.4));
 
 @property (nonatomic, setter=setOverrideReferrer:) NSString *_overrideReferrerForAllRequests WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h
@@ -39,7 +39,7 @@ WK_EXTERN NSString * const _WKWebsiteDataTypeAdClickAttributions WK_API_AVAILABL
 WK_EXTERN NSString * const _WKWebsiteDataTypePrivateClickMeasurements WK_API_AVAILABLE(macos(12.0), ios(15.0));
 WK_EXTERN NSString * const _WKWebsiteDataTypeAlternativeServices WK_API_AVAILABLE(macos(11.0), ios(14.0));
 WK_EXTERN NSString * const _WKWebsiteDataTypeFileSystem WK_API_DEPRECATED_WITH_REPLACEMENT("WKWebsiteDataTypeFileSystem", macos(13.0, 14.0), ios(16.0, 17.0));
-WK_EXTERN NSString * const _WKWebsiteDataTypeEnhancedSecurityRecord WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+WK_EXTERN NSString * const _WKWebsiteDataTypeEnhancedSecurityRecord WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 @interface WKWebsiteDataRecord (WKPrivate)
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
@@ -161,7 +161,7 @@ typedef NS_ENUM(uint8_t, _WKRestrictedOpenerType) {
 - (void)_fetchDataOfTypes:(NSSet<NSString *> *)dataTypes completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSData *))completionHandler WK_API_DEPRECATED_WITH_REPLACEMENT("-fetchDataOfTypes:completionHandler:", macos(15.4, WK_MAC_TBA), ios(18.4, WK_IOS_TBA), visionos(2.4, WK_XROS_TBA));
 - (void)_restoreData:(NSData *)data completionHandler:(WK_SWIFT_UI_ACTOR void(^)(BOOL))completionHandler WK_API_DEPRECATED_WITH_REPLACEMENT("-restoreData:completionHandler:", macos(15.4, WK_MAC_TBA), ios(18.4, WK_IOS_TBA), visionos(2.4, WK_XROS_TBA));
 
-- (void)_isStorageSuspendedForTesting:(WK_SWIFT_UI_ACTOR void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_isStorageSuspendedForTesting:(WK_SWIFT_UI_ACTOR void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.h
@@ -44,13 +44,13 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 // Concrete classes that conform to staging protocols
-WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_CLASS_AVAILABLE(macos(26.4), ios(26.4))
 @interface _WKAuthenticationPRFInputValues : NSObject <_WKAuthenticationPRFInputValuesStaging>
 @property (nullable, nonatomic, copy) NSData *prfSalt1;
 @property (nullable, nonatomic, copy) NSData *prfSalt2;
 @end
 
-WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_CLASS_AVAILABLE(macos(26.4), ios(26.4))
 @interface _WKAuthenticationExtensionsLargeBlobInputs : NSObject <_WKAuthenticationExtensionsLargeBlobInputsStaging>
 @property (nullable, nonatomic, copy) NSString *support;
 @property (nonatomic) BOOL read;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h
@@ -53,10 +53,10 @@ WK_CLASS_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4))
 @property (nonatomic) BOOL disableLegacyBuiltinOverrides;
 
 /*! @abstract A boolean indicating whether window.webkit.createJSHandle is available. */
-@property (nonatomic) BOOL allowJSHandleCreation WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic) BOOL allowJSHandleCreation WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 /*! @abstract A boolean indicating whether window.webkit.serializeNode is available. */
-@property (nonatomic) BOOL allowNodeSerialization WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic) BOOL allowNodeSerialization WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKImmersiveEnvironmentDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKImmersiveEnvironmentDelegate.h
@@ -31,13 +31,13 @@ NS_ASSUME_NONNULL_BEGIN
 // FIXME: This SPI should become an API - rdar://problem/164244457
 
 WK_SWIFT_UI_ACTOR
-WK_API_AVAILABLE(visionos(WK_XROS_TBA))
+WK_API_AVAILABLE(visionos(26.4))
 @protocol _WKImmersiveEnvironmentDelegate <NSObject>
 
 #if (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
-- (void)webView:(WKWebView *)webView allowImmersiveEnvironmentFromURL:(NSURL *)url completion:(void (^)(bool allow))completion NS_SWIFT_ASYNC_NAME(webView(_:allowImmersiveEnvironmentFromURL:)) WK_API_AVAILABLE(visionos(WK_XROS_TBA));
-- (void)webView:(WKWebView *)webView presentImmersiveEnvironment:(UIView *)environmentView completion:(void (^)(NSError * _Nullable error))completion NS_SWIFT_ASYNC_NAME(webView(_:presentImmersiveEnvironment:)) WK_API_AVAILABLE(visionos(WK_XROS_TBA));
-- (void)webView:(WKWebView *)webView dismissImmersiveEnvironment:(void (^)(void))completion NS_SWIFT_ASYNC_NAME(webViewDismissImmersiveEnvironment(_:)) WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+- (void)webView:(WKWebView *)webView allowImmersiveEnvironmentFromURL:(NSURL *)url completion:(void (^)(bool allow))completion NS_SWIFT_ASYNC_NAME(webView(_:allowImmersiveEnvironmentFromURL:)) WK_API_AVAILABLE(visionos(26.4));
+- (void)webView:(WKWebView *)webView presentImmersiveEnvironment:(UIView *)environmentView completion:(void (^)(NSError * _Nullable error))completion NS_SWIFT_ASYNC_NAME(webView(_:presentImmersiveEnvironment:)) WK_API_AVAILABLE(visionos(26.4));
+- (void)webView:(WKWebView *)webView dismissImmersiveEnvironment:(void (^)(void))completion NS_SWIFT_ASYNC_NAME(webViewDismissImmersiveEnvironment(_:)) WK_API_AVAILABLE(visionos(26.4));
 #endif
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInputDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInputDelegate.h
@@ -47,8 +47,8 @@ typedef NS_ENUM(NSInteger, _WKFocusStartsInputSessionPolicy) {
 
 - (void)_webView:(WKWebView *)webView didStartInputSession:(id <_WKFormInputSession>)inputSession;
 - (void)_webView:(WKWebView *)webView willSubmitFormValues:(NSDictionary *)values userObject:(NSObject <NSSecureCoding> *)userObject submissionHandler:(void (^)(void))submissionHandler;
-- (void)_webView:(WKWebView *)webView willSubmitFormValues:(NSDictionary *)values frameInfo:(WKFrameInfo *)frameInfo sourceFrameInfo:(WKFrameInfo *)sourceFrameInfo userObject:(NSObject <NSSecureCoding> *)userObject submissionHandler:(void (^)(void))submissionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-- (void)_webView:(WKWebView *)webView willSubmitFormValues:(NSDictionary *)values frameInfo:(WKFrameInfo *)frameInfo sourceFrameInfo:(WKFrameInfo *)sourceFrameInfo userObject:(NSObject <NSSecureCoding> *)userObject requestURL:(NSURL *)requestURL method:(NSString *)method submissionHandler:(void (^)(void))submissionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_webView:(WKWebView *)webView willSubmitFormValues:(NSDictionary *)values frameInfo:(WKFrameInfo *)frameInfo sourceFrameInfo:(WKFrameInfo *)sourceFrameInfo userObject:(NSObject <NSSecureCoding> *)userObject submissionHandler:(void (^)(void))submissionHandler WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
+- (void)_webView:(WKWebView *)webView willSubmitFormValues:(NSDictionary *)values frameInfo:(WKFrameInfo *)frameInfo sourceFrameInfo:(WKFrameInfo *)sourceFrameInfo userObject:(NSObject <NSSecureCoding> *)userObject requestURL:(NSURL *)requestURL method:(NSString *)method submissionHandler:(void (^)(void))submissionHandler WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 #if TARGET_OS_IPHONE
 - (BOOL)_webView:(WKWebView *)webView focusShouldStartInputSession:(id <_WKFocusedElementInfo>)info;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorDebuggableInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorDebuggableInfo.h
@@ -38,7 +38,7 @@ typedef NS_ENUM(NSInteger, _WKInspectorDebuggableType) {
     _WKInspectorDebuggableTypeServiceWorker,
     _WKInspectorDebuggableTypePage,
     _WKInspectorDebuggableTypeWebPage,
-    _WKInspectorDebuggableTypeWasmDebugger WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA)),
+    _WKInspectorDebuggableTypeWasmDebugger WK_API_AVAILABLE(macos(26.4), ios(26.4)),
 } WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 
 WK_CLASS_AVAILABLE(macos(10.15.4), ios(13.4))

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKJSBuffer.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKJSBuffer.h
@@ -27,7 +27,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_CLASS_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4))
 @interface _WKJSBuffer : WKJSScriptingBuffer
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.h
@@ -28,7 +28,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 // Note: NSSecureCoding should not be made public API.
-WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_CLASS_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4))
 @interface _WKJSHandle : WKJSHandle<NSSecureCoding>
 - (void)windowFrameInfo:(void (^)(WKFrameInfo * _Nullable))completionHandler;
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKNSStringExtras.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKNSStringExtras.h
@@ -27,6 +27,6 @@
 
 @interface NSString (WKExtras)
 
-- (NSString *)_wk_decodeHostName WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (NSString *)_wk_decodeHostName WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKNSURLExtras.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKNSURLExtras.h
@@ -27,6 +27,6 @@
 
 @interface NSURL (WKExtras)
 
-- (NSString *)_wk_userVisibleString WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (NSString *)_wk_userVisibleString WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h
@@ -83,7 +83,7 @@ WK_EXTERN WK_API_DEPRECATED("Creating and using multiple instances of WKProcessP
 
 @property (nonatomic) BOOL suspendsWebProcessesAggressivelyOnMemoryPressure WK_API_AVAILABLE(macos(15.4));
 
-@property (nonatomic) unsigned prewarmedProcessCountLimitForTesting WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic) unsigned prewarmedProcessCountLimitForTesting WK_API_AVAILABLE(macos(26.4), ios(26.4));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKSerializedNode.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKSerializedNode.h
@@ -27,7 +27,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_CLASS_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4))
 @interface _WKSerializedNode : WKJSSerializedNode
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKSessionState.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKSessionState.h
@@ -31,7 +31,7 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 @interface _WKSessionState : NSObject
 
 - (instancetype)initWithData:(NSData *)data;
-- (BOOL)isEqualForTesting:(_WKSessionState *)other WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (BOOL)isEqualForTesting:(_WKSessionState *)other WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 @property (nonatomic, readonly, copy) NSData *data;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -39,22 +39,22 @@ typedef NS_OPTIONS(NSUInteger, _WKTextExtractionFilterOptions) {
     _WKTextExtractionFilterClassifier = 1 << 1,
     _WKTextExtractionFilterRules = 1 << 2,
     _WKTextExtractionFilterAll = NSUIntegerMax,
-} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+} WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 typedef NS_ENUM(NSInteger, _WKTextExtractionNodeIdentifierInclusion) {
     _WKTextExtractionNodeIdentifierInclusionNone = 0,
     _WKTextExtractionNodeIdentifierInclusionEditableOnly,
     _WKTextExtractionNodeIdentifierInclusionInteractive,
     _WKTextExtractionNodeIdentifierInclusionAllContainers,
-} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+} WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 typedef NS_ENUM(NSInteger, _WKTextExtractionOutputFormat) {
     _WKTextExtractionOutputFormatTextTree = 0,
     _WKTextExtractionOutputFormatHTML,
     _WKTextExtractionOutputFormatMarkdown,
     _WKTextExtractionOutputFormatJSON,
-    _WKTextExtractionOutputFormatPlainText,
-} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+    _WKTextExtractionOutputFormatPlainText WK_API_AVAILABLE(mac(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)),
+} WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 #define WK_TEXT_EXTRACTION_HAS_EVENT_LISTENER_CATEGORIES 1
 
@@ -84,7 +84,7 @@ typedef NS_ENUM(NSInteger, _WKTextExtractionWordLimitPolicy) {
     _WKTextExtractionWordLimitPolicyDiscretionary,
 } WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
-WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_CLASS_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4))
 @interface _WKTextExtractionConfiguration : NSObject
 
 @property (nonatomic, class, copy, readonly) _WKTextExtractionConfiguration *configurationForVisibleTextOnly WK_API_DEPRECATED_WITH_REPLACEMENT("_WKTextExtractionOutputFormatPlainText", macos(WK_MAC_TBA, WK_MAC_TBA), ios(WK_IOS_TBA, WK_IOS_TBA), visionos(WK_XROS_TBA, WK_XROS_TBA)) NS_SWIFT_NAME(visibleTextOnly);
@@ -238,7 +238,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 
 @end
 
-WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_CLASS_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4))
 @interface _WKTextExtractionResult : NSObject
 
 @property (nonatomic, readonly) NSString *textContent;
@@ -297,11 +297,11 @@ typedef NS_ENUM(NSInteger, _WKTextExtractionAction) {
     _WKTextExtractionActionTextInput,
     _WKTextExtractionActionKeyPress,
     _WKTextExtractionActionHighlightText,
-    _WKTextExtractionActionScroll,
+    _WKTextExtractionActionScroll WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)),
     _WKTextExtractionActionScrollBy = _WKTextExtractionActionScroll,
-} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+} WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
-WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_CLASS_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4))
 WK_SWIFT_UI_ACTOR
 NS_REQUIRES_PROPERTY_DEFINITIONS
 @interface _WKTextExtractionInteraction : NSObject
@@ -325,7 +325,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
 @end
 
-WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_CLASS_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4))
 WK_SWIFT_UI_ACTOR
 NS_REQUIRES_PROPERTY_DEFINITIONS
 @interface _WKTextExtractionInteractionResult : NSObject

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionBookmarks.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionBookmarks.h
@@ -18,7 +18,7 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 typedef NS_ENUM(NSInteger, _WKWebExtensionBookmarkType) {
     _WKWebExtensionBookmarkTypeBookmark,
     _WKWebExtensionBookmarkTypeFolder,
-} NS_SWIFT_NAME(_WKWebExtension.BookmarkType) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+} NS_SWIFT_NAME(_WKWebExtension.BookmarkType) WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 /*! @abstract A class conforming to the ``_WKWebExtensionBookmark`` protocol represents a single bookmark node (a bookmark or folder) to web extensions. */
 WK_SWIFT_UI_ACTOR

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
@@ -82,8 +82,8 @@ WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
 @property (nonatomic) BOOL serviceWorkerProcessTerminationDelayEnabled WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 @property (nonatomic, nullable, copy) NSURL *networkCacheDirectory WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 @property (nonatomic, nullable, copy) NSURL *deviceIdHashSaltsStorageDirectory WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
-@property (nonatomic, nullable, copy) NSURL *applicationCacheDirectory WK_API_DEPRECATED("ApplicationCache is no longer supported", macos(10.15.4, WK_MAC_TBA), ios(13.4, WK_IOS_TBA));
-@property (nonatomic, nullable, copy) NSString *applicationCacheFlatFileSubdirectoryName WK_API_DEPRECATED("ApplicationCache is no longer supported", macos(10.4, WK_MAC_TBA), ios(13.4, WK_IOS_TBA));
+@property (nonatomic, nullable, copy) NSURL *applicationCacheDirectory WK_API_DEPRECATED("ApplicationCache is no longer supported", macos(10.15.4, 26.4), ios(13.4, 26.4));
+@property (nonatomic, nullable, copy) NSString *applicationCacheFlatFileSubdirectoryName WK_API_DEPRECATED("ApplicationCache is no longer supported", macos(10.4, 26.4), ios(13.4, 26.4));
 @property (nonatomic, nullable, copy) NSURL *mediaCacheDirectory WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 @property (nonatomic, nullable, copy) NSURL *mediaKeysStorageDirectory WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 @property (nonatomic) NSUInteger testSpeedMultiplier WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
@@ -109,7 +109,7 @@ WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
 // Testing only.
 @property (nonatomic) BOOL allLoadsBlockedByDeviceManagementRestrictionsForTesting WK_API_AVAILABLE(macos(10.15), ios(13.0));
 
-@property (nonatomic, nullable, copy) NSString *additionalDomainsWithUserInteractionForTesting WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, nullable, copy) NSString *additionalDomainsWithUserInteractionForTesting WK_API_AVAILABLE(macos(26.4), ios(26.4));
 
 @end
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.h
@@ -38,6 +38,6 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 - (void)clearWrappers;
 - (void)makeAllShadowRootsOpen WK_API_AVAILABLE(macos(10.12), ios(10.0));
 - (void)disableOverrideBuiltinsBehavior WK_API_AVAILABLE(macos(10.14), ios(12.0));
-- (void)allowJSHandleCreation WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+- (void)allowJSHandleCreation WK_API_AVAILABLE(macos(26.4), ios(26.4));
 
 @end


### PR DESCRIPTION
#### db97d9b4646e9fb217c5e517aa38f4ffc13728d0
<pre>
Fix availability versions for 26.4 releases
<a href="https://bugs.webkit.org/show_bug.cgi?id=311379">https://bugs.webkit.org/show_bug.cgi?id=311379</a>
<a href="https://rdar.apple.com/171621941">rdar://171621941</a>

Reviewed by Richard Robinson.

Mechanically replace TBA macros with release versions, for API changes
that shipped in these releases.

One declaration in Swift sources (WebPage+NavigationPreferences.swift)
is not fixed yet, because we need a way to suppress Swift availabilities
in downlevel builds &lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=294412">https://bugs.webkit.org/show_bug.cgi?id=294412</a>&gt;.

* Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h:
* Source/WebKit/UIProcess/API/Cocoa/WKFrameInfoPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentControllerPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKImmersiveEnvironmentDelegate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKInputDelegate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorDebuggableInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKJSBuffer.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKNSStringExtras.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKNSURLExtras.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKSerializedNode.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKSessionState.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionBookmarks.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h:
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.h:

Canonical link: <a href="https://commits.webkit.org/310735@main">https://commits.webkit.org/310735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba0d74af80db7d7803973356617ccbeae66084f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163263 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107975 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/034d7ade-06cc-44ab-9400-76eef4f3a99f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27614 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119508 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84526 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/14c27912-d589-4edf-b522-4fcd65fe07eb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21788 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100205 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20874 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18884 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11092 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130536 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165734 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8941 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18216 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127604 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22924 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127748 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34724 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27234 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138400 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83917 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22650 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15192 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26925 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91027 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26505 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26736 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26578 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->