### PR TITLE
Treat system-ui like other generic font families

### DIFF
--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -293,14 +293,10 @@ static std::optional<CSSValueID> consumeGenericFamilyUnresolved(CSSParserTokenRa
     return consumeIdentRaw<CSSValueSerif, CSSValueSansSerif, CSSValueCursive, CSSValueFantasy, CSSValueMonospace, CSSValueWebkitBody, CSSValueWebkitPictograph, CSSValueSystemUi, CSSValueMath>(range);
 }
 
-static RefPtr<CSSValue> consumeGenericFamily(CSSParserTokenRange& range, CSS::PropertyParserState& state)
+static RefPtr<CSSValue> consumeGenericFamily(CSSParserTokenRange& range)
 {
-    if (auto familyName = consumeGenericFamilyUnresolved(range)) {
-        // FIXME: Remove special case for system-ui.
-        if (*familyName == CSSValueSystemUi)
-            return state.pool.createFontFamilyValue(nameString(*familyName));
+    if (auto familyName = consumeGenericFamilyUnresolved(range))
         return CSSPrimitiveValue::create(*familyName);
-    }
     return nullptr;
 }
 
@@ -339,7 +335,7 @@ RefPtr<CSSValue> consumeFontFamily(CSSParserTokenRange& range, CSS::PropertyPars
     // https://drafts.csswg.org/css-fonts-4/#font-family-prop
 
     return consumeListSeparatedBy<',', OneOrMore>(range, [&](auto& range) -> RefPtr<CSSValue> {
-        if (auto parsedValue = consumeGenericFamily(range, state))
+        if (auto parsedValue = consumeGenericFamily(range))
             return parsedValue;
         return consumeFamilyName(range, state);
     });

--- a/Source/WebCore/platform/graphics/cocoa/FontDescriptionCocoa.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontDescriptionCocoa.cpp
@@ -30,6 +30,15 @@
 
 namespace WebCore {
 
+static std::optional<SystemFontKind> matchSystemFontUseForFamily(const FontFamily& family)
+{
+    if (auto use = SystemFontDatabaseCoreText::forCurrentThread().matchSystemFontUse(family.name))
+        return use;
+    if (family.isGeneric() && equalLettersIgnoringASCIICase(family.name, "-webkit-system-ui"_s))
+        return SystemFontKind::SystemUI;
+    return std::nullopt;
+}
+
 static inline Vector<RetainPtr<CTFontDescriptorRef>> systemFontCascadeList(const FontDescription& description, const AtomString& cssFamily, SystemFontKind systemFontKind, AllowUserInstalledFonts allowUserInstalledFonts)
 {
     return SystemFontDatabaseCoreText::forCurrentThread().cascadeList(description, cssFamily, systemFontKind, allowUserInstalledFonts);
@@ -41,7 +50,7 @@ unsigned FontCascadeDescription::effectiveFamilyCount() const
     unsigned result = 0;
     for (unsigned i = 0; i < familyCount(); ++i) {
         const auto& family = familyAt(i);
-        if (auto use = SystemFontDatabaseCoreText::forCurrentThread().matchSystemFontUse(family.name))
+        if (auto use = matchSystemFontUseForFamily(family))
             result += systemFontCascadeList(*this, family.name, *use, shouldAllowUserInstalledFonts()).size();
         else
             ++result;
@@ -59,7 +68,7 @@ FontFamilySpecification FontCascadeDescription::effectiveFamilyAt(unsigned index
     // These two behaviors should be unified, which would hopefully allow us to delete this duplicate code.
     for (unsigned i = 0; i < familyCount(); ++i) {
         const auto& family = familyAt(i);
-        if (auto use = SystemFontDatabaseCoreText::forCurrentThread().matchSystemFontUse(family.name)) {
+        if (auto use = matchSystemFontUseForFamily(family)) {
             auto cascadeList = systemFontCascadeList(*this, family.name, *use, shouldAllowUserInstalledFonts());
             if (index < cascadeList.size())
                 return FontFamilySpecification(cascadeList[index].get());

--- a/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
@@ -215,7 +215,9 @@ static String getFamilyNameStringFromFamily(const String& family)
         return "math"_s;
 
 #if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
-    if (family == *familyNamesData->at(FamilyNamesIndex::SystemUiFamily) || family == "-webkit-system-font"_s)
+    if (family == *familyNamesData->at(FamilyNamesIndex::SystemUiFamily))
+        return "system-ui"_s;
+    if (family == "-webkit-system-font"_s)
         return SystemSettings::singleton().defaultSystemFont();
 #endif
 

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -321,12 +321,8 @@ static ResolvedFontFamily fontFamilyFromUnresolvedFontFamily(const CSSPropertyPa
     auto families = WTF::compactMap(unresolvedFamily, [&](auto& item) -> std::optional<WebCore::FontFamily> {
         auto [familyName, isGenericFamily] = switchOn(item,
             [&](CSSValueID ident) -> std::pair<AtomString, bool> {
-                if (ident != CSSValueWebkitBody) {
-                    // FIXME: Treat system-ui like other generic font families
-                    if (ident == CSSValueSystemUi)
-                        return { nameString(CSSValueSystemUi), true };
+                if (ident != CSSValueWebkitBody)
                     return { *familyNamesData->at(CSSPropertyParserHelpers::genericFontFamilyIndex(ident)), true };
-                }
                 return { AtomString(context->settingsValues().fontGenericFamilies.standardFontFamily()), false };
             },
             [&](const AtomString& familyString) -> std::pair<AtomString, bool> {


### PR DESCRIPTION
#### f40755b6839493e35c771d2474cb092ebafdd1df
<pre>
Treat system-ui like other generic font families
<a href="https://bugs.webkit.org/show_bug.cgi?id=311380">https://bugs.webkit.org/show_bug.cgi?id=311380</a>
<a href="https://rdar.apple.com/173977467">rdar://173977467</a>

Reviewed by NOBODY (OOPS!).

system-ui was special-cased in both the CSS parser and style resolution
to bypass the normal generic font family pipeline. Remove both special
cases so system-ui flows through the same CSSValueID → -webkit-* name
path as serif, sans-serif, and the other generics. The platform font
cache implementations already handle -webkit-system-ui natively
(Cocoa via effectiveFamilyAt cascade list expansion, GTK/WPE via
getFamilyNameStringFromFamily), so FontGenericFamilies does not need
to resolve it. On Cocoa, a new matchSystemFontUseForFamily helper
recognizes generic -webkit-system-ui for cascade list expansion while
leaving the plain string unresolved. On GTK/WPE, split the SystemUiFamily
and -webkit-system-font cases in getFamilyNameStringFromFamily so that
system-ui maps to &quot;system-ui&quot; (for fontconfig) rather than the concrete
default system font name.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
(WebCore::CSSPropertyParserHelpers::consumeGenericFamily):
* Source/WebCore/platform/graphics/cocoa/FontDescriptionCocoa.cpp:
(WebCore::matchSystemFontUseForFamily):
(WebCore::FontCascadeDescription::effectiveFamilyCount const):
(WebCore::FontCascadeDescription::effectiveFamilyAt const):
* Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp:
(WebCore::getFamilyNameStringFromFamily):
* Source/WebCore/style/StyleResolveForFont.cpp:
(WebCore::Style::fontFamilyFromUnresolvedFontFamily):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f40755b6839493e35c771d2474cb092ebafdd1df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154121 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162874 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107589 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27229 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119200 "Found 5 new test failures: fast/forms/placeholder-content-center.html fast/forms/placeholder-content-line-height.html fast/text/design-system-ui-sans-serif.html fast/text/system-font-features.html fast/text/system-font-legacy-name.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84266 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cdb1f97f-57f6-46de-8dda-38775581d258) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21448 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138403 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99896 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a69a9849-fc9d-4875-bbae-01e8894ba74f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20536 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18531 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10707 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130198 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165347 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8556 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17855 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127293 "Found 3 new test failures: fast/text/design-system-ui-sans-serif.html fast/text/system-font-features.html fast/text/system-font-legacy-name.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127439 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138041 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83442 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22309 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14833 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26539 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90641 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26119 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26349 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26191 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->