### PR TITLE
[Quirk] extend the ceac.state.gov quirk to cover more cases

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -138,6 +138,27 @@ static constexpr auto nbaSeekBarFixScript = R"js(if (!window.__nbaSeekFix) {
 })js"_s;
 #endif
 
+// ceac.state.gov rdar://170258502
+static constexpr auto ceacBeforeUnloadFixScript = R"js((function() {
+    if (window.__ceacBeforeUnloadFix) return;
+    window.__ceacBeforeUnloadFix = true;
+    var origAEL = window.addEventListener;
+    window.addEventListener = function(type, fn, opts) {
+        if (type === 'beforeunload') {
+            return origAEL.call(this, type, function(e) {
+                var ae = document.activeElement;
+                if (ae && ae.tagName === 'INPUT') {
+                    var t = (ae.type || '').toLowerCase();
+                    if (t === 'radio' || t === 'checkbox' || t === 'submit' || t === 'button')
+                        return;
+                }
+                if (typeof fn === 'function') fn.call(this, e);
+            }, opts);
+        }
+        return origAEL.apply(this, arguments);
+    };
+})();)js"_s;
+
 static inline OptionSet<AutoplayQuirk> NODELETE allowedAutoplayQuirks(Document& document)
 {
     auto* loader = document.loader();
@@ -2002,6 +2023,10 @@ String Quirks::scriptToEvaluateBeforeRunningScriptFromURL(const URL& scriptURL)
 #endif
 #endif
 
+    // ceac.state.gov rdar://170258502
+    if (m_quirksData.isCEAC && scriptURL.lastPathComponent() == "CheckBrowserClose.js"_s) [[unlikely]]
+        return ceacBeforeUnloadFixScript;
+
     return { };
 }
 
@@ -2732,16 +2757,21 @@ static void handleTMobileQuirks(QuirksData& quirksData, const URL& quirksURL, co
     });
 }
 
-#if PLATFORM(MAC)
 static void handleCEACStateGovQuirks(QuirksData& quirksData, const URL& quirksURL, const String& /* quirksDomainString */, const URL&  /* documentURL */)
 {
     auto topDocumentHost = quirksURL.host();
     if (topDocumentHost == "ceac.state.gov"_s || topDocumentHost.endsWith(".ceac.state.gov"_s)) {
+        quirksData.isCEAC = true;
+#if PLATFORM(MAC)
         // ceac.state.gov https://bugs.webkit.org/show_bug.cgi?id=193478
         quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsFormControlToBeMouseFocusableQuirk);
+#endif
+        // ceac.state.gov https://bugs.webkit.org/show_bug.cgi?id=311383
+        quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsScriptToEvaluateBeforeRunningScriptFromURLQuirk);
     }
 }
 
+#if PLATFORM(MAC)
 static void handleMadisonCityK12Quirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL& /* documentURL */)
 {
     QUIRKS_EARLY_RETURN_IF_NOT_DOMAIN("madisoncity.k12.al.us"_s);
@@ -3693,9 +3723,7 @@ void Quirks::determineRelevantQuirks()
         { "soylent"_s, &handleSoylentQuirks },
 #endif
         { "spotify"_s, &handleSpotifyQuirks },
-#if PLATFORM(MAC)
         { "state"_s, &handleCEACStateGovQuirks },
-#endif
 #if PLATFORM(IOS_FAMILY)
         { "theguardian"_s, &handleGuardianQuirks },
         { "thesaurus"_s, &handleScriptToEvaluateBeforeRunningScriptFromURLQuirk },

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -35,6 +35,7 @@ struct QuirksData {
     bool isBankOfAmerica : 1 { false };
     bool isBing : 1 { false };
     bool isCBSSports : 1 { false };
+    bool isCEAC : 1 { false };
     bool isDictionary : 1 { false };
     bool isEA : 1 { false };
     bool isESPN : 1 { false };


### PR DESCRIPTION
#### 10b8cd7a0d3972ef8574b589681506f6944d322f
<pre>
[Quirk] extend the ceac.state.gov quirk to cover more cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=311383">https://bugs.webkit.org/show_bug.cgi?id=311383</a>
<a href="https://rdar.apple.com/170258502">rdar://170258502</a>

Reviewed by Brent Fulgham.

The US visa application site ceac.state.gov uses CheckBrowserClose.js
which registers a beforeunload handler (ClearSession) that inspects
document.activeElement to decide if navigation is intentional. When it
decides navigation is not intentional, it sets an ExpiredSession cookie
and blocks navigation, killing the user&apos;s session.

The existing NeedsFormControlToBeMouseFocusableQuirk (bug 193478)
ensures form controls gain focus on mouse click so
document.activeElement is set correctly. However, two bugs in the
site&apos;s JavaScript still cause session loss even when focus works:

1. An operator precedence bug at line 232 of CheckBrowserClose.js:

    (A &amp;&amp; B &amp;&amp; HTMLBodyElement) || HTMLInputElement

    The || is not grouped with the &amp;&amp; chain, so ANY focused &lt;input&gt;
    element (including properly focused submit buttons, radio buttons,
    and text fields) triggers validNavigation = false.

2. Radio buttons are not recognized by the valid-navigation checks
    at lines 67-80. The site checks for id.indexOf(&quot;Radio&quot;) but
    ASP.NET RadioButtonList generates IDs with &quot;rbl&quot; prefix, not
    &quot;Radio&quot;. Radio buttons fall through all checks and hit the
    catch-all at line 232.

The fix adds a script injection quirk that runs before
CheckBrowserClose.js loads. The injected script wraps
window.addEventListener to intercept the beforeunload registration.
When beforeunload fires, if document.activeElement is a form input
(radio, checkbox, submit, or button), the original ClearSession is
skipped entirely, allowing navigation to proceed.

Both quirks work together at different points in the pipeline:
- Quirk 1 (focus, Mac only): at click time, ensures
document.activeElement is set to the clicked element
- Quirk 2 (script injection, all platforms): at beforeunload time,
bypasses the site&apos;s broken ClearSession logic when activeElement
is a form input

The handler is moved outside #if PLATFORM(MAC) so the script
injection quirk applies on all platforms. The mouse focus quirk
remains Mac-only inside the handler since it addresses mouse-specific
focus behavior.

* Source/WebCore/page/Quirks.cpp:
(CompletionHandler&lt;void): Deleted.
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/310699@main">https://commits.webkit.org/310699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c39f57abe307b79f10da00ab1a0949395424560c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154018 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162770 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107484 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155891 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27126 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119109 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84204 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138306 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99809 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20451 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18431 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10603 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130108 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16158 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165243 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8443 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17759 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127200 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26820 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22465 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127353 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26744 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137952 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83323 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23596 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22238 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14740 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26435 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90527 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26016 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26246 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26088 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->