### PR TITLE
[YARR] Reset `firstCharacterAdditionalReadSize` at `BodyAlternativeNext` reentry

### DIFF
--- a/JSTests/stress/regexp-jit-non-bmp-first-character-additional-read-size-reset.js
+++ b/JSTests/stress/regexp-jit-non-bmp-first-character-additional-read-size-reset.js
@@ -1,0 +1,47 @@
+/*
+ * Regression test for non-BMP first-character optimization stale register.
+ *
+ * BodyAlternativeNext / once-through-End reentry labels did not reset
+ * m_regs.firstCharacterAdditionalReadSize. After a prior alternative read a
+ * surrogate-pair character (setting the register to 1), the body loop would
+ * incorrectly advance the index by an extra unit, skipping valid match
+ * positions in subsequent alternatives.
+ *
+ * Triggered when m_useFirstNonBMPCharacterOptimization is enabled
+ * (decodeSurrogatePairs && !inlineTest && !multiline && !containsBOL
+ * && !containsLookbehinds && !containsModifiers).
+ */
+
+function shouldBe(actual, expected) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error("bad value: actual=" + JSON.stringify(actual) + " expected=" + JSON.stringify(expected));
+}
+
+for (var i = 0; i < 1e4; ++i) {
+    // Two alternatives: alt1 reads non-BMP, alt2 should match later position.
+    shouldBe("\u{10400}ZY".match(/\u{10400}X|Y/u), ["Y"]);
+    shouldBe("\u{1F600}Xc".match(/\u{1F600}b|c/u), ["c"]);
+
+    // Same shape with leading prefix forcing alt1 to consume non-BMP first.
+    shouldBe("a\u{1F600}X".match(/a\u{1F600}b|\u{1F600}/u), ["\u{1F600}"]);
+
+    // CharacterClass containing a non-BMP code point with a quantifier.
+    shouldBe("a\u{1F600}X".match(/a[\u{1F600}]+b|\u{1F600}/u), ["\u{1F600}"]);
+
+    // Mixed-width character class repeated, then second alternative.
+    shouldBe("\u{10400}\u{10400}ZY".match(/[\u{10400}a]{2}X|Y/u), ["Y"]);
+
+    // leftmost-first invariant: when both alternatives can match, the
+    // earliest position must win. Bug version returned the longer alt at
+    // a later index because the loop over-advanced.
+    var m = "a\u{1F600}Xa\u{1F600}b".match(/a\u{1F600}b|\u{1F600}/u);
+    shouldBe(m[0], "\u{1F600}");
+    shouldBe(m.index, 1);
+
+    // Sanity: with /m the optimization is disabled, behaviour must match.
+    shouldBe("\u{10400}ZY".match(/\u{10400}X|Y/um), ["Y"]);
+
+    // Body loop iterates: prior alt reads non-BMP, body advances by one,
+    // alt2 must find the match at the next code unit.
+    shouldBe("ZZ\u{1F600}aXY".match(/\u{1F600}aZ|XY/u), ["XY"]);
+}

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -3671,6 +3671,13 @@ class YarrGenerator final : public YarrJITInfo {
                     // PRIOR alteranative, and we will only check input availability if we
                     // need to progress it forwards.
                     defineReentryLabel(op);
+#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
+                    // Reset on reentry: a prior alternative may have read a non-BMP codepoint
+                    // and left this register set to 1. The next alternative starts a fresh
+                    // first-character read.
+                    if (m_useFirstNonBMPCharacterOptimization)
+                        m_jit.move(MacroAssembler::TrustedImm32(0), m_regs.firstCharacterAdditionalReadSize);
+#endif
                     if (shouldRecordSubpatterns() && priorAlternative->needToCleanupCaptures()) {
                         for (unsigned subpattern = priorAlternative->firstCleanupSubpatternId(); subpattern <= priorAlternative->m_lastSubpatternId; subpattern++)
                             clearSubpattern(subpattern);
@@ -3684,6 +3691,11 @@ class YarrGenerator final : public YarrJITInfo {
                     // This is the reentry point for the End of 'once through' alternatives,
                     // jumped to when the last alternative fails to match.
                     defineReentryLabel(op);
+#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
+                    // Reset on reentry: see BodyAlternativeNext above.
+                    if (m_useFirstNonBMPCharacterOptimization)
+                        m_jit.move(MacroAssembler::TrustedImm32(0), m_regs.firstCharacterAdditionalReadSize);
+#endif
                     m_jit.sub32(MacroAssembler::Imm32(priorAlternative->m_minimumSize), m_regs.index);
                 }
                 break;


### PR DESCRIPTION
#### 8c10428db1b842eaf9531fc53e619f56e3062c79
<pre>
[YARR] Reset `firstCharacterAdditionalReadSize` at `BodyAlternativeNext` reentry
<a href="https://bugs.webkit.org/show_bug.cgi?id=311388">https://bugs.webkit.org/show_bug.cgi?id=311388</a>

Reviewed by Yusuke Suzuki.

The non-BMP first-character optimization sets
firstCharacterAdditionalReadSize to 1 when tryReadUnicodeChar reads a
surrogate pair, and the BodyAlternativeEnd trampoline reads it back to
advance the index past the pair on the next iteration.

BodyAlternativeBegin resets the register at its reentry label;
BodyAlternativeNext did not. After a prior alternative read a surrogate
pair, the register stayed at 1 across the alt boundary, and if the next
alternative short-circuited without its own tryReadUnicodeChar call,
the trampoline added the stale 1 and skipped a valid match position.

Mirror the BodyAlternativeBegin reset at BodyAlternativeNext, and add
the same defensive reset at the once-through BodyAlternativeEnd reentry.

Test: JSTests/stress/regexp-jit-non-bmp-first-character-additional-read-size-reset.js

* JSTests/stress/regexp-jit-non-bmp-first-character-additional-read-size-reset.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/310677@main">https://commits.webkit.org/310677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f503ef926751608ec95310951b772c6f6e2b4e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27281 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162778 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107492 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27134 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119117 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84207 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21364 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99817 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20453 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18438 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10611 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146097 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130110 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16161 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165251 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14853 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8451 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17762 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127208 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22473 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127361 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34677 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26752 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137955 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83331 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22236 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14743 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185661 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26443 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90535 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47610 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26024 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26254 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26096 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->