### PR TITLE
Resync `the-img-element` from WPT Upstream

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2280,6 +2280,7 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode-path-changes.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/decode/image-decode.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/invalid-src.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset/srcset-w-reselect-on-resize.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-object-element/object-events.html [ Skip ]
 
 # These tests time out (fail) because they only work in engines that support Ogg Vorbis video.
@@ -8270,3 +8271,5 @@ imported/w3c/web-platform-tests/css/selectors/invalidation/media-loading-pseudo-
 imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open_fires_resize.tentative.html [ Skip ] # timeout
 
 webkit.org/b/311207 imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared.html [ Pass Failure ]
+
+imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-dynamic-attributes.html [ Failure Pass ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/WEB_FEATURES.yml
@@ -1,20 +1,54 @@
 features:
+- name: img
+  files:
+  - "*"
+  # Exclude `data-urls`. Keep in sync with `data-urls` mappings below.
+  - "!data-url.html"
+  # Exclude `loading-lazy`. Keep in sync with `loading-lazy` mappings below.
+  - "!*loading-lazy*"
+  - "!image-loading-subpixel-clip.html"
+  - "!move-element-and-scroll.html"
+  - "!relevant-mutations-lazy.html"
+  - "!remove-element-and-scroll.html"
+  - "!scrolling-below-viewport-image-lazy-loading-in-iframe.html"
+  # Exclude `base`. Keep in sync with `base` mappings below.
+  - "!document-adopt-base-url.html"
+  - "!document-base-url.html"
+  - "!image-base-url.html"
+  # Exclude `srcset`. Keep in sync with `srcset` mappings below.
+  - "!responsive-image-select-print.html"
+  - "!update-the-source-set.html"
+  - "!null-image-source.html"
+  # Exclude `image-maps`. Keep in sync with `image-maps` mappings below.
+  - "!usemap-casing.html"
 - name: loading-lazy
   files:
+  # Keep in sync with `img` mappings.
   - "*loading-lazy*"
   - image-loading-subpixel-clip.html
   - move-element-and-scroll.html
   - relevant-mutations-lazy.html
   - remove-element-and-scroll.html
   - scrolling-below-viewport-image-lazy-loading-in-iframe.html
+  - "!image-loading-lazy-base-url.html"
 - name: base
   files:
+  # Keep in sync with `img` mappings.
   - document-adopt-base-url.html
   - document-base-url.html
   - image-base-url.html
   - image-loading-lazy-base-url.html
 - name: srcset
   files:
+  # Keep in sync with `img` mappings.
   - responsive-image-select-print.html
   - update-the-source-set.html
   - null-image-source.html
+- name: image-maps
+  files:
+  # Keep in sync with `img` mappings.
+  - usemap-casing.html
+- name: data-urls
+  files:
+  # Keep in sync with `img` mappings.
+  - data-url.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-alternate-no-store.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-alternate-no-store.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Reassigning the same src value should not trigger an extra image fetch
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-alternate-no-store.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-alternate-no-store.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-alternate-no-store.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-alternate-no-store.window.js
@@ -1,0 +1,18 @@
+// https://html.spec.whatwg.org/multipage/images.html#updating-the-image-data
+// Under Step 27, after fetch, step 3: Add the image to the list of available
+// images using the key key, with the ignore higher-layer caching flag set.
+//
+// Step 7.4: If the list of available images contains an entry for key, then:
+// Step 7.4.4: Set the current request to a new image request whose image data
+// is that of the entry and whose state is completely available.
+
+promise_test(async () => {
+  const img = document.createElement("img");
+  img.src = "resources/image-alternate-no-store.py";
+  await img.decode();
+  let width = img.naturalWidth;
+
+  img.src = img.src;
+  await img.decode();
+  assert_equals(width, img.naturalWidth, "The image size should be the same");
+}, "Reassigning the same src value should not trigger an extra image fetch");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/img.complete-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/img.complete-expected.txt
@@ -17,4 +17,6 @@ PASS async src removal test
 PASS async srcset removal test
 PASS async src available image lookup test
 PASS async pending request test
+PASS not loadable
+PASS invalid URL
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/img.complete.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/img.complete.html
@@ -197,4 +197,20 @@
       assert_false(img.complete, "Should not be complete because we have started a new load");
     });
   }, "async pending request test");
+
+  async_test(t => {
+    var img = document.createElement("img");
+    img.src = `about:error`;
+    img.onerror = t.step_func_done(function() {
+      assert_true(img.complete);
+    });
+  }, "not loadable");
+
+  async_test(t => {
+    var img = document.createElement("img");
+    img.src = `http://`;
+    img.onerror = t.step_func_done(function() {
+      assert_true(img.complete);
+    });
+  }, "invalid URL");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/ismap/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/ismap/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: image-maps
+  files: '**'

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/ismap/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/ismap/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/ismap/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/ismap/img-ismap-coordinates-iframe-after.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/ismap/img-ismap-coordinates-iframe-before.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/ismap/img-ismap-coordinates-iframe-inside.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/resources/image-alternate-no-store.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/resources/image-alternate-no-store.py
@@ -1,0 +1,18 @@
+import os
+
+from wptserve.utils import isomorphic_decode
+
+STASH_ID = "882e0112-2a43-4ff1-9503-658b1a2a8e67"
+
+def main(request, response):
+  # Alternate between blue-10.png and green.png on each request
+  switch = request.server.stash.take(STASH_ID)
+  request.server.stash.put(STASH_ID, not switch)
+
+  image = "blue-10.png" if switch else "green.png"
+  response_headers = [
+      (b"Content-Type", b"image/png"),
+      (b"Cache-Control", b"no-store")
+  ]
+  image_path = os.path.join(os.path.dirname(isomorphic_decode(__file__)), image)
+  return (200, response_headers, open(image_path, mode='rb').read())

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/resources/w3c-import.log
@@ -19,6 +19,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/resources/blue-10.png
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/resources/cat.jpg
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/resources/green.png
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/resources/image-alternate-no-store.py
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/resources/image-and-stash.py
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/resources/image-loading-lazy-below-viewport.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/resources/image-loading-lazy-in-viewport.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/responsive-image-select-print-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/responsive-image-select-print-ref.html
@@ -3,6 +3,10 @@
   :root {
     print-color-adjust: exact;
   }
+  @page {
+    size: 300px;
+    margin: 0;
+  }
 </style>
 <body>
   <div style="width: 200px; height: 200px; background-color: green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/responsive-image-select-print.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/responsive-image-select-print.html
@@ -4,6 +4,15 @@
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1803094">
 <link rel="author" href="https://mozilla.org" title="Mozilla">
 <link rel="match" href="responsive-image-select-print-ref.html">
+<style>
+  :root {
+    print-color-adjust: exact;
+  }
+  @page {
+    size: 300px;
+    margin: 0;
+  }
+</style>
 <body>
   <picture>
     <source width="200" srcset="./resources/red.png 1w, ./resources/green.png 200w">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/WEB_FEATURES.yml
@@ -1,3 +1,8 @@
 features:
 - name: srcset
-  files: "**"
+  files:
+  - "*"
+  - "!sizes-auto*"
+- name: sizes-auto
+  files:
+  - "sizes-auto*"

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-dynamic-attributes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-dynamic-attributes-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS sizes=auto→500px: prior sizes=auto must not override new sizes value
+FAIL loading=lazy removed: prior loading=lazy must not override 100vw fallback for loading=eager assert_true: initial (got: http://web-platform.test:8800/images/green-16x16.png?a) expected true got false
+FAIL picture source removal: new selector must not fall back to 100vw assert_true: initial (got: http://web-platform.test:8800/images/green-16x16.png?a) expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-dynamic-attributes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-dynamic-attributes.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>sizes=auto: size used for source selection changes when image sizes/source/loading changes</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/images.html#allows-auto-sizes">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1819581">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  /* 10px width ensures auto-sizes picks 50w; height keeps lazy images in viewport */
+  img { width: 10px; height: 10px; }
+</style>
+<div id="container"></div>
+<div id="log"></div>
+<script>
+"use strict";
+
+const container = document.getElementById('container');
+
+function waitLoad(img) {
+  return new Promise((resolve, reject) => {
+    img.addEventListener('load', resolve, {once: true});
+    img.onerror = reject;
+  });
+}
+
+function assertSmall(img, msg) {
+  assert_true(img.currentSrc.includes('red-16x16'), msg + ' (got: ' + img.currentSrc + ')');
+}
+
+function assertLarge(img, msg) {
+  assert_true(img.currentSrc.includes('green-16x16'), msg + ' (got: ' + img.currentSrc + ')');
+}
+
+const kSrcset = '/images/red-16x16.png?a 50w, /images/green-16x16.png?a 51w';
+
+async function makeAutoImg(parent = container, srcset = kSrcset) {
+  const img = document.createElement('img');
+  img.id = 'img';
+  img.setAttribute('loading', 'lazy');
+  img.setAttribute('sizes', 'auto');
+  if (srcset) { img.srcset = srcset; }
+  parent.appendChild(img);
+  await waitLoad(img);
+  assertSmall(img, 'initial');
+  return img;
+}
+
+// Changing sizes from "auto" to a concrete value should use that value, not the stale
+// auto-width.
+promise_test(async () => {
+  const img = await makeAutoImg();
+  img.setAttribute('sizes', '500px');
+  img.srcset = '/images/red-16x16.png?b 50w, /images/green-16x16.png?b 51w';
+  await waitLoad(img);
+  assertLarge(img, 'after sizes→500px');
+}, 'sizes=auto→500px: prior sizes=auto must not override new sizes value');
+
+// Removing lazy loading should make sizes=auto fall back to 100vw, not use the stale
+// auto-width.
+promise_test(async () => {
+  const img = await makeAutoImg();
+  img.setAttribute('loading', 'eager');
+  img.srcset = '/images/red-16x16.png?b 50w, /images/green-16x16.png?b 51w';
+  await waitLoad(img);
+  assertLarge(img, 'after loading→eager: sizes=auto falls back to 100vw');
+}, 'loading=lazy removed: prior loading=lazy must not override 100vw fallback for loading=eager');
+
+// When a <picture> source is removed and the img gains its own srcset, the
+// element's actual 10px width should be used, instead of falling back to 100vw.
+promise_test(async () => {
+  const picture = document.createElement('picture');
+  const source = document.createElement('source');
+  source.srcset = kSrcset;
+  picture.append(source);
+  container.appendChild(picture);
+  const img = await makeAutoImg(picture, null)
+
+  picture.removeChild(source);
+  img.srcset = kSrcset;
+  await waitLoad(img);
+  assertSmall(img, 'after source removal: new selector should use element width, not 100vw');
+}, 'picture source removal: new selector must not fall back to 100vw');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-expected.txt
@@ -67,6 +67,12 @@ PASS <img loading="lazy" sizes="auto" style="width: calc(5px + 5px)" data-ref="r
 PASS <picture><source srcset="/images/green-1x1.png?picture33 50w, /images/green-16x16.png?picture33 51w"><img loading="lazy" sizes="auto" style="width: calc(5px + 5px)" data-ref="ref1"></picture>
 PASS <img loading="lazy" sizes="auto" style="position: absolute; left: 50%; right: 49%" data-ref="ref2" srcset="/images/green-1x1.png?img34 50w, /images/green-16x16.png?img34 51w">
 PASS <picture><source srcset="/images/green-1x1.png?picture34 50w, /images/green-16x16.png?picture34 51w"><img loading="lazy" sizes="auto" style="position: absolute; left: 50%; right: 49%" data-ref="ref2"></picture>
+PASS <img loading="lazy" sizes="(max-width: 0px) 10px, auto" style="width: 10px" data-ref="ref2" srcset="/images/green-1x1.png?img35 50w, /images/green-16x16.png?img35 51w">
+PASS <picture><source sizes="(max-width: 0px) 10px, auto" srcset="/images/green-1x1.png?picture35 50w, /images/green-16x16.png?picture35 51w"><img loading="lazy" style="width: 10px" data-ref="ref2"></picture>
+PASS <img loading="lazy" sizes="(min-width: 0px) auto" style="width: 10px" data-ref="ref2" srcset="/images/green-1x1.png?img36 50w, /images/green-16x16.png?img36 51w">
+PASS <picture><source sizes="(min-width: 0px) auto" srcset="/images/green-1x1.png?picture36 50w, /images/green-16x16.png?picture36 51w"><img loading="lazy" style="width: 10px" data-ref="ref2"></picture>
+PASS <img loading="lazy" sizes="(min-width: 0px) 100vw, auto" style="width: 10px" data-ref="ref2" srcset="/images/green-1x1.png?img37 50w, /images/green-16x16.png?img37 51w">
+PASS <picture><source sizes="(min-width: 0px) 100vw, auto" srcset="/images/green-1x1.png?picture37 50w, /images/green-16x16.png?picture37 51w"><img loading="lazy" style="width: 10px" data-ref="ref2"></picture>
 
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto.html
@@ -92,6 +92,10 @@ const tests = [
   {loading: 'lazy', sizes: 'auto', style: '--my-width: 10px; width: var(--my-width)', 'data-ref': 'ref1'},
   {loading: 'lazy', sizes: 'auto', style: 'width: calc(5px + 5px)', 'data-ref': 'ref1'},
   {loading: 'lazy', sizes: 'auto', style: 'position: absolute; left: 50%; right: 49%', 'data-ref': 'ref2'}, // replaced elements don't get the width resolved from 'left'/'right' per https://drafts.csswg.org/css2/#abs-replaced-width
+  // img allows auto-sizes only if sizes starts with auto
+  {loading: 'lazy', sizes: '(max-width: 0px) 10px, auto', style: 'width: 10px', 'data-ref': 'ref2'},
+  {loading: 'lazy', sizes: '(min-width: 0px) auto', style: 'width: 10px', 'data-ref': 'ref2'},
+  {loading: 'lazy', sizes: '(min-width: 0px) 100vw, auto', style: 'width: 10px', 'data-ref': 'ref2'},
 ];
 
 function test_img(obj, i) {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/w3c-import.log
@@ -20,6 +20,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-quirks-mode.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-standards-mode.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-width-1000px.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-dynamic-attributes.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-rendering-2-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-rendering-2.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-rendering-3-expected.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset/srcset-w-reselect-on-resize-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset/srcset-w-reselect-on-resize-expected.txt
@@ -1,0 +1,5 @@
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT srcset w-descriptor: narrow to wide selects higher-density candidate Test timed out
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset/srcset-w-reselect-on-resize.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset/srcset-w-reselect-on-resize.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<title>srcset w-descriptor reselects on viewport resize</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/images.html#reacting-to-environment-changes">
+<link rel="help" href="https://crbug.com/41385706">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<div id=log></div>
+<script>
+// Tests that an <img> with srcset w-descriptors correctly re-selects the
+// image source when the viewport (iframe) is resized.
+
+function resolveUrl(url) {
+  const a = document.createElement('a');
+  a.href = url;
+  return a.href;
+}
+
+function createIframe(width) {
+  const id = token();
+  return new Promise(resolvePromise => {
+    const iframe = document.createElement('iframe');
+    iframe.style.width = width + 'px';
+    iframe.srcdoc = `<!doctype html>
+                     <img srcset="/images/green-1x1.png?200w-${id} 200w,
+                                  /images/green-2x2.png?800w-${id} 800w"
+                          sizes="100vw">`;
+    iframe.onload = () => resolvePromise({iframe, id});
+    document.body.appendChild(iframe);
+  });
+}
+
+promise_test(async t => {
+  const {iframe, id} = await createIframe(100);
+  const img = iframe.contentDocument.querySelector('img');
+  const narrow = resolveUrl(`/images/green-1x1.png?200w-${id}`);
+  const wide = resolveUrl(`/images/green-2x2.png?800w-${id}`);
+
+  assert_equals(img.currentSrc, narrow, 'narrow viewport should select 200w');
+
+  // Set up load listener before resizing so we catch the re-selection.
+  const loaded = new Promise(resolve =>
+      img.addEventListener('load', resolve, {once: true}));
+  iframe.style.width = '1000px';
+  await loaded;
+  assert_equals(img.currentSrc, wide, 'after widening should select 800w');
+}, 'srcset w-descriptor: narrow to wide selects higher-density candidate');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset/w3c-import.log
@@ -20,3 +20,4 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset/parse-a-srcset-attribute.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset/select-an-image-source.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset/srcset-media-dynamic.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset/srcset-w-reselect-on-resize.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/w3c-import.log
@@ -52,6 +52,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/empty-src-no-current-request.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/historical-progress-event.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-1.jpg
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-alternate-no-store.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-base-url.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-compositing-change-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-compositing-change-ref.html
@@ -141,6 +142,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/scrolling-below-viewport-image-lazy-loading-in-iframe.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/source-media-outside-doc.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/source-relevant-mutations.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset-natural-size-in-dynamic-iframe.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/svg-for-content-type-with-parameters.svg
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/svg-for-content-type-with-parameters.svg.headers
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/svg-img-with-external-stylesheet-expected.html

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-expected.txt
@@ -67,6 +67,12 @@ PASS <img loading="lazy" sizes="auto" style="width: calc(5px + 5px)" data-ref="r
 PASS <picture><source srcset="/images/green-1x1.png?picture33 50w, /images/green-16x16.png?picture33 51w"><img loading="lazy" sizes="auto" style="width: calc(5px + 5px)" data-ref="ref1"></picture>
 PASS <img loading="lazy" sizes="auto" style="position: absolute; left: 50%; right: 49%" data-ref="ref2" srcset="/images/green-1x1.png?img34 50w, /images/green-16x16.png?img34 51w">
 PASS <picture><source srcset="/images/green-1x1.png?picture34 50w, /images/green-16x16.png?picture34 51w"><img loading="lazy" sizes="auto" style="position: absolute; left: 50%; right: 49%" data-ref="ref2"></picture>
+PASS <img loading="lazy" sizes="(max-width: 0px) 10px, auto" style="width: 10px" data-ref="ref2" srcset="/images/green-1x1.png?img35 50w, /images/green-16x16.png?img35 51w">
+PASS <picture><source sizes="(max-width: 0px) 10px, auto" srcset="/images/green-1x1.png?picture35 50w, /images/green-16x16.png?picture35 51w"><img loading="lazy" style="width: 10px" data-ref="ref2"></picture>
+PASS <img loading="lazy" sizes="(min-width: 0px) auto" style="width: 10px" data-ref="ref2" srcset="/images/green-1x1.png?img36 50w, /images/green-16x16.png?img36 51w">
+PASS <picture><source sizes="(min-width: 0px) auto" srcset="/images/green-1x1.png?picture36 50w, /images/green-16x16.png?picture36 51w"><img loading="lazy" style="width: 10px" data-ref="ref2"></picture>
+PASS <img loading="lazy" sizes="(min-width: 0px) 100vw, auto" style="width: 10px" data-ref="ref2" srcset="/images/green-1x1.png?img37 50w, /images/green-16x16.png?img37 51w">
+PASS <picture><source sizes="(min-width: 0px) 100vw, auto" srcset="/images/green-1x1.png?picture37 50w, /images/green-16x16.png?picture37 51w"><img loading="lazy" style="width: 10px" data-ref="ref2"></picture>
 
 
 


### PR DESCRIPTION
#### 2f93b2087a3fcabda135f97abf1633a48f6beaba
<pre>
Resync `the-img-element` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=311391">https://bugs.webkit.org/show_bug.cgi?id=311391</a>
<a href="https://rdar.apple.com/173985712">rdar://173985712</a>

Reviewed by Abrar Rahman Protyasha.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/d1bf16a5383b29e7bc7845cef5f5aa4775936613">https://github.com/web-platform-tests/wpt/commit/d1bf16a5383b29e7bc7845cef5f5aa4775936613</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-alternate-no-store.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-alternate-no-store.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-alternate-no-store.window.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/img.complete-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/img.complete.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/ismap/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/ismap/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/resources/image-alternate-no-store.py: Added.
(main):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/responsive-image-select-print-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/responsive-image-select-print.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-dynamic-attributes-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-dynamic-attributes.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/w3c-import.log:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset/srcset-w-reselect-on-resize.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/srcset/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/w3c-import.log:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-expected.txt:

Canonical link: <a href="https://commits.webkit.org/310565@main">https://commits.webkit.org/310565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1b862ecff122f23de92eed7d622755743d84185

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20641 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162977 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e8cbe6d6-8010-435a-817c-21e6557aa0a8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27613 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27331 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119271 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/48bc5278-79c8-4724-9478-aaecf36e2a11) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21538 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138501 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99967 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/32ba4111-21fc-4cfd-95cf-916b45365d83) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20626 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18627 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10809 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130288 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16346 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165449 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17955 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127368 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27027 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127513 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34596 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26951 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138139 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83544 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22403 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14931 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26641 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26222 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26453 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26294 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->