### PR TITLE
[JSC][WASM][Debugger] Notify LLDB when a new WebAssembly module is dynamically instantiated

### DIFF
--- a/JSTests/wasm/debugger/resources/swift-wasm/build.sh
+++ b/JSTests/wasm/debugger/resources/swift-wasm/build.sh
@@ -30,20 +30,41 @@ FOLDER="$1"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 if [ -d "$SCRIPT_DIR/$FOLDER" ]; then
-    # Build Swift WASM with Swiftly https://www.swift.org/documentation/articles/wasm-getting-started.html
-    echo "Building Swift WebAssembly $FOLDER..."
-    cd "$SCRIPT_DIR/$FOLDER"
-    "$SWIFT" build --swift-sdk "$SDK" --configuration release
+    FOLDER_DIR="$SCRIPT_DIR/$FOLDER"
 
-    # Move compiled WASM beside main.js
-    echo "Moving $FOLDER.wasm..."
-    mv ".build/wasm32-unknown-wasip1/release/$FOLDER.wasm" "./$FOLDER.wasm"
+    # Detect whether the folder contains multiple Swift sub-packages (no top-level
+    # Package.swift, but sub-directories that each have their own Package.swift).
+    if [ ! -f "$FOLDER_DIR/Package.swift" ] && ls "$FOLDER_DIR"/*/Package.swift &>/dev/null; then
+        echo "Building Swift WebAssembly $FOLDER (multi-package)..."
+        for pkg_dir in "$FOLDER_DIR"/*/; do
+            pkg_name="$(basename "$pkg_dir")"
+            if [ ! -f "$pkg_dir/Package.swift" ]; then
+                continue
+            fi
+            echo "  Building $pkg_name..."
+            cd "$pkg_dir"
+            "$SWIFT" build --swift-sdk "$SDK" --configuration release
+            mv ".build/wasm32-unknown-wasip1/release/$pkg_name.wasm" "$FOLDER_DIR/$pkg_name.wasm"
+            rm -rf .build
+            echo "  $pkg_name.wasm ready."
+        done
+        echo "Done! All .wasm files for $FOLDER are ready for testing."
+    else
+        # Single-package folder: standard build.
+        echo "Building Swift WebAssembly $FOLDER..."
+        cd "$FOLDER_DIR"
+        "$SWIFT" build --swift-sdk "$SDK" --configuration release
 
-    # Clean up build artifacts
-    echo "Cleaning up..."
-    rm -rf .build
+        # Move compiled WASM beside main.js
+        echo "Moving $FOLDER.wasm..."
+        mv ".build/wasm32-unknown-wasip1/release/$FOLDER.wasm" "./$FOLDER.wasm"
 
-    echo "Done! $FOLDER.wasm is ready for testing."
+        # Clean up build artifacts
+        echo "Cleaning up..."
+        rm -rf .build
+
+        echo "Done! $FOLDER.wasm is ready for testing."
+    fi
 else
     echo "Creating new Swift WASM test folder '$FOLDER'..."
     cd "$SCRIPT_DIR"

--- a/JSTests/wasm/debugger/resources/swift-wasm/dynamic-module-load/func-a/Package.swift
+++ b/JSTests/wasm/debugger/resources/swift-wasm/dynamic-module-load/func-a/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "func-a",
+    targets: [
+        .executableTarget(
+            name: "func-a",
+            path: "Sources/func-a",
+            linkerSettings: [
+                .unsafeFlags(["-Xlinker", "--export=func_a"])
+            ]
+        )
+    ]
+)

--- a/JSTests/wasm/debugger/resources/swift-wasm/dynamic-module-load/func-a/Sources/func-a/func-a.swift
+++ b/JSTests/wasm/debugger/resources/swift-wasm/dynamic-module-load/func-a/Sources/func-a/func-a.swift
@@ -1,0 +1,12 @@
+@_cdecl("func_a")
+public func funcA(_ x: Int32) -> Int32 {
+    let doubled = x * 2
+    return doubled + 1
+}
+
+@main
+struct FuncA {
+    static func main() {
+        _ = funcA
+    }
+}

--- a/JSTests/wasm/debugger/resources/swift-wasm/dynamic-module-load/func-b/Package.swift
+++ b/JSTests/wasm/debugger/resources/swift-wasm/dynamic-module-load/func-b/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "func-b",
+    targets: [
+        .executableTarget(
+            name: "func-b",
+            path: "Sources/func-b",
+            linkerSettings: [
+                .unsafeFlags(["-Xlinker", "--export=func_b"])
+            ]
+        )
+    ]
+)

--- a/JSTests/wasm/debugger/resources/swift-wasm/dynamic-module-load/func-b/Sources/func-b/func-b.swift
+++ b/JSTests/wasm/debugger/resources/swift-wasm/dynamic-module-load/func-b/Sources/func-b/func-b.swift
@@ -1,0 +1,12 @@
+@_cdecl("func_b")
+public func funcB(_ x: Int32) -> Int32 {
+    let incremented = x + 1
+    return incremented * 2
+}
+
+@main
+struct FuncB {
+    static func main() {
+        _ = funcB
+    }
+}

--- a/JSTests/wasm/debugger/resources/swift-wasm/dynamic-module-load/main.js
+++ b/JSTests/wasm/debugger/resources/swift-wasm/dynamic-module-load/main.js
@@ -1,0 +1,38 @@
+var imports = {
+    wasi_snapshot_preview1: {
+        proc_exit: function (code) {
+            print("Program exited with code:", code);
+        },
+        args_get: function () { return 0; },
+        args_sizes_get: function () { return 0; },
+        environ_get: function () { return 0; },
+        environ_sizes_get: function () { return 0; },
+        fd_write: function () { return 0; },
+        fd_read: function () { return 0; },
+        fd_close: function () { return 0; },
+        fd_seek: function () { return 0; },
+        fd_fdstat_get: function () { return 0; },
+        fd_prestat_get: function () { return 8; },
+        fd_prestat_dir_name: function () { return 8; },
+        path_open: function () { return 8; },
+        random_get: function () { return 0; },
+        clock_time_get: function () { return 0; }
+    }
+};
+
+var moduleA = new WebAssembly.Module(read('func-a.wasm', 'binary'));
+var instance1 = new WebAssembly.Instance(moduleA, imports);
+print("Module A (func_a) loaded");
+
+print("Waiting for debugger — attach LLDB and type 'c' to continue.");
+while (!$vm.hasDebuggerContinued()) { }
+print("Debugger continued");
+
+instance1.exports.func_a(1);
+
+var moduleB = new WebAssembly.Module(read('func-b.wasm', 'binary'));
+var instance2 = new WebAssembly.Instance(moduleB, imports);
+print("Module B (func_b) loaded");
+
+instance2.exports.func_b(1);
+print("Done.");

--- a/JSTests/wasm/debugger/resources/wasm/dynamic-module-load.js
+++ b/JSTests/wasm/debugger/resources/wasm/dynamic-module-load.js
@@ -1,0 +1,76 @@
+var wasm1 = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic: \0asm
+    0x01, 0x00, 0x00, 0x00, // version: 1
+
+    // [0x08] Type section: 1 type
+    0x01, 0x04,             // section id=1, size=4
+    0x01,                   // 1 type
+    0x60, 0x00, 0x00,       // Type 0: (func [] -> [])
+
+    // [0x0e] Function section: 1 function
+    0x03, 0x02,             // section id=3, size=2
+    0x01,                   // 1 function
+    0x00,                   // function 0: type 0
+
+    // [0x12] Export section: export function 0 as "func_a"
+    0x07, 0x0a,             // section id=7, size=10
+    0x01,                   // 1 export
+    0x06, 0x66, 0x75, 0x6e, 0x63, 0x5f, 0x61, // name "func_a" (length=6)
+    0x00,                   // export kind: function
+    0x00,                   // function index 0
+
+    // [0x1e] Code section: 1 function body
+    0x0a, 0x04,             // section id=10, size=4
+    0x01,                   // 1 function body
+
+    // [0x21] func_a body
+    0x02,                   // body size=2
+    0x00,                   // 0 local declarations
+    0x0b,                   // [0x23] end
+]);
+var inst1 = new WebAssembly.Instance(new WebAssembly.Module(wasm1));
+print("Module1 loaded");
+
+print("Waiting for debugger — attach LLDB and type 'c' to continue.");
+while (!$vm.hasDebuggerContinued()) { }
+print("Debugger continued");
+
+inst1.exports.func_a();
+
+var wasm2 = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic: \0asm
+    0x01, 0x00, 0x00, 0x00, // version: 1
+
+    // [0x08] Type section: 1 type
+    0x01, 0x04,             // section id=1, size=4
+    0x01,                   // 1 type
+    0x60, 0x00, 0x00,       // Type 0: (func [] -> [])
+
+    // [0x0e] Function section: 1 function
+    0x03, 0x02,             // section id=3, size=2
+    0x01,                   // 1 function
+    0x00,                   // function 0: type 0
+
+    // [0x12] Export section: export function 0 as "func_b"
+    0x07, 0x0a,             // section id=7, size=10
+    0x01,                   // 1 export
+    0x06, 0x66, 0x75, 0x6e, 0x63, 0x5f, 0x62, // name "func_b" (length=6)
+    0x00,                   // export kind: function
+    0x00,                   // function index 0
+
+    // [0x1e] Code section: 1 function body
+    0x0a, 0x04,             // section id=10, size=4
+    0x01,                   // 1 function body
+
+    // [0x21] func_b body
+    0x02,                   // body size=2
+    0x00,                   // 0 local declarations
+    0x0b,                   // [0x23] end
+]);
+var inst2 = new WebAssembly.Instance(new WebAssembly.Module(wasm2));
+print("Module2 loaded");
+
+inst2.exports.func_b();
+print("Done.");

--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -1968,3 +1968,73 @@ class WasmOobMemoryTrapTestCase(BaseTestCase):
                 "frame #1: 0xc000000000000000",
             ]
         )
+
+
+class DynamicModuleLoadTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/dynamic-module-load.js", extra_jsc_options=["--useDollarVM=1"])
+
+        try:
+            self.test()
+
+        except Exception as e:
+            raise Exception(f"Test failed: {e}")
+
+    def test(self):
+        # Set a breakpoint at the 'end' instruction of func_a in module 1 (virtual address
+        # 0x4000000000000023).  Module 1 is already loaded, so the breakpoint resolves immediately.
+        self.send_lldb_command_or_raise("b 0x4000000000000023", patterns=["Breakpoint 1"])
+
+        # Resume: stops at the func_a breakpoint in module 1.
+        # Disassembly confirms the stopped instruction is 'end' at the expected address.
+        self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped", "->  0x4000000000000023: end"])
+
+        # Resume: stops for the module-load notification (library:; T-packet) when module 2 is
+        # instantiated.  LLDB re-queries qXfer:libraries:read and loads module 2.
+        self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped", "new wasm module loaded"])
+
+        # Set a breakpoint at the 'end' instruction of func_b in module 2 (virtual address
+        # 0x4000000100000023).  Module 2 is now loaded, so the breakpoint resolves immediately.
+        self.send_lldb_command_or_raise("b 0x4000000100000023", patterns=["Breakpoint 2"])
+
+        # Resume: stops at the func_b breakpoint in module 2.
+        # Disassembly confirms the stopped instruction is 'end' at the expected address.
+        self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped", "->  0x4000000100000023: end"])
+
+
+class SwiftWasmDynamicModuleLoadTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/swift-wasm/dynamic-module-load/main.js", extra_jsc_options=["--useDollarVM=1"])
+
+        try:
+            self.test()
+
+        except Exception as e:
+            raise Exception(f"Test failed: {e}")
+
+    def test(self):
+        # Module A is loaded at the start, so this breakpoint is resolved immediately.
+        self.send_lldb_command_or_raise("b func_a", patterns=["Breakpoint 1", "func_a"])
+
+        # Module B is loaded dynamically later, so this breakpoint is pending at the start.
+        self.send_lldb_command_or_raise("b func_b", patterns=["pending"])
+
+        # Resume: stops at the func_a breakpoint (module A), confirming that the breakpoint is set and hit correctly.
+        self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped", "func_a"])
+
+        # Resume: stops at when Module B is loaded and the associated instance is created. This stop trigger
+        # LLDB re-querying debug info and resolving the pending breakpoint for func_b, confirming that dynamic
+        # module load triggers pending breakpoint resolution.
+        self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped", "new wasm module loaded"])
+        self.send_lldb_command_or_raise("br list", patterns=["func_a", "func_b"])
+
+        # Resume: stops at the func_b breakpoint (module B) on the first call, confirming that the pending breakpoint was resolved via debug info.
+        self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped", "func_b"])

--- a/Source/JavaScriptCore/runtime/StopTheWorldCallback.h
+++ b/Source/JavaScriptCore/runtime/StopTheWorldCallback.h
@@ -45,12 +45,21 @@ using StopTheWorldStatus = std::pair<IterationStatus, VM*>;
 #define STW_RESUME() StopTheWorldStatus(IterationStatus::Done, nullptr)
 
 enum class StopTheWorldEvent : uint8_t {
+    // Common STW events.
+    //
+    // The WASM debugger treats all three as interrupt stops.
     VMCreated,
     VMActivated,
     VMStopped,
-    BreakpointHit,
-    TrapHit,
-    StepIntoSiteReached,
+
+    // WASM-debugger-only events below.
+    //
+    // The WASM program itself triggered a stop (breakpoint hit, trap, or dynamic module load).
+    WasmProgramStop,
+    // Not a real stop: fired when the mutator reaches a call/throw site during step-into.
+    // Signals the debugger thread to check whether a callee entry breakpoint was installed;
+    // the mutator does not pause and wait for a debugger command.
+    WasmStepIntoSiteReached,
 };
 
 // The VMManager Stop the World (STW) mechanism will call handlers of this shape once the world

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -596,7 +596,7 @@ VM::~VM()
 #if ENABLE(WEBASSEMBLY_DEBUGGER)
     if (Options::enableWasmDebugger()) [[unlikely]] {
         auto& debugServer = Wasm::DebugServer::singleton();
-        if (debugServer.isConnected())
+        if (debugServer.hasDebugger())
             debugServer.execution().notifyVMDestruction(this);
     }
 #endif

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -95,6 +95,10 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #include "WasmStreamingParser.h"
 #endif
 
+#if ENABLE(WEBASSEMBLY_DEBUGGER)
+#include "WasmDebugServer.h"
+#endif
+
 #if PLATFORM(COCOA)
 #include <wtf/cocoa/CrashReporter.h>
 #endif
@@ -2165,6 +2169,9 @@ static JSC_DECLARE_HOST_FUNCTION(functionCreateWasmStreamingParser);
 static JSC_DECLARE_HOST_FUNCTION(functionCreateWasmStreamingCompilerForCompile);
 static JSC_DECLARE_HOST_FUNCTION(functionCreateWasmStreamingCompilerForInstantiate);
 #endif
+#if ENABLE(WEBASSEMBLY_DEBUGGER)
+static JSC_DECLARE_HOST_FUNCTION(functionHasDebuggerContinued);
+#endif
 static JSC_DECLARE_HOST_FUNCTION(functionCreateStaticCustomAccessor);
 static JSC_DECLARE_HOST_FUNCTION(functionCreateStaticCustomValue);
 static JSC_DECLARE_HOST_FUNCTION(functionCreateStaticDontDeleteDontEnum);
@@ -2407,6 +2414,13 @@ JSC_DEFINE_HOST_FUNCTION(functionOMGTrue, (JSGlobalObject* globalObject, CallFra
 
     return JSValue::encode(jsNumber(2));
 }
+
+#if ENABLE(WEBASSEMBLY_DEBUGGER)
+JSC_DEFINE_HOST_FUNCTION(functionHasDebuggerContinued, (JSGlobalObject*, CallFrame*))
+{
+    return JSValue::encode(jsBoolean(Wasm::DebugServer::singleton().hasContinued()));
+}
+#endif // ENABLE(WEBASSEMBLY_DEBUGGER)
 
 JSC_DEFINE_HOST_FUNCTION(functionCpuMfence, (JSGlobalObject*, CallFrame*))
 {
@@ -4415,6 +4429,9 @@ void JSDollarVM::finishCreation(VM& vm)
     addFunction(vm, "createWasmStreamingParser"_s, functionCreateWasmStreamingParser, 0);
     addFunction(vm, "createWasmStreamingCompilerForCompile"_s, functionCreateWasmStreamingCompilerForCompile, 0);
     addFunction(vm, "createWasmStreamingCompilerForInstantiate"_s, functionCreateWasmStreamingCompilerForInstantiate, 0);
+#endif
+#if ENABLE(WEBASSEMBLY_DEBUGGER)
+    addFunction(vm, "hasDebuggerContinued"_s, functionHasDebuggerContinued, 0);
 #endif
     addFunction(vm, "createStaticCustomAccessor"_s, functionCreateStaticCustomAccessor, 0);
     addFunction(vm, "createStaticCustomValue"_s, functionCreateStaticCustomValue, 0);

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -77,7 +77,7 @@ namespace JSC { namespace IPInt {
 #define IPINT_HANDLE_STEP_INTO_CALL(callerVM, boxedCallee, calleeInstance) do { \
         if (Options::enableWasmDebugger()) [[unlikely]] { \
             Wasm::DebugServer& debugServer = Wasm::DebugServer::singleton(); \
-            if (debugServer.isConnected()) \
+            if (debugServer.hasDebugger()) \
                 debugServer.execution().setStepIntoBreakpointForCall((callerVM), (boxedCallee), (calleeInstance)); \
         } \
     } while (false)
@@ -87,7 +87,7 @@ namespace JSC { namespace IPInt {
 #define IPINT_HANDLE_STEP_INTO_THROW(throwVM) do { \
         if (Options::enableWasmDebugger()) [[unlikely]] { \
             Wasm::DebugServer& debugServer = Wasm::DebugServer::singleton(); \
-            if (debugServer.isConnected()) \
+            if (debugServer.hasDebugger()) \
                 debugServer.execution().setStepIntoBreakpointForThrow((throwVM)); \
         } \
     } while (false)
@@ -1341,7 +1341,7 @@ WASM_IPINT_EXTERN_CPP_DECL(handle_debugger_trap_if_needed, CallFrame* callFrame,
 #if ENABLE(WEBASSEMBLY_DEBUGGER)
     if (Options::enableWasmDebugger()) [[unlikely]] {
         Wasm::DebugServer& debugServer = Wasm::DebugServer::singleton();
-        if (debugServer.isConnected()) {
+        if (debugServer.hasDebugger()) {
             uint8_t* pc = static_cast<uint8_t*>(sp[2].pointer());
             uint8_t* mc = static_cast<uint8_t*>(sp[3].pointer());
             IPIntLocal* pl = static_cast<IPIntLocal*>(sp[0].pointer());

--- a/Source/JavaScriptCore/wasm/debugger/Debugger-Mutator-Protocol.md
+++ b/Source/JavaScriptCore/wasm/debugger/Debugger-Mutator-Protocol.md
@@ -182,7 +182,7 @@ step()                             │   │
       │                      │             ├─ Set breakpoint at callee or exception handler   
       │                      │             └─ stopTheWorld()           
       │                      │                 └─ notifyVMStop()
-      │                      │                     ├─ stopCode(StepIntoSiteReached)
+      │                      │                     ├─ stopCode(WasmStepIntoSiteReached)
       │                      │                     ├─ Check state -> StepRequested                 
       │                      └─────────────────────┼─ notifyOne(debuggerCV)
       │                           ┌──────────────> ├─ wait(debuggeeCV)

--- a/Source/JavaScriptCore/wasm/debugger/README.md
+++ b/Source/JavaScriptCore/wasm/debugger/README.md
@@ -196,12 +196,6 @@ See [RWI_ARCHITECTURE.md](./RWI_ARCHITECTURE.md) for complete setup instructions
 - **Location**: `WasmDebugServer.cpp:348-349`
 - **Solution**: Introduce various stop states and proper termination handling
 
-### Dynamic Module Notifications
-
-- **Issue**: LLDB is not notified when new modules are loaded or unloaded
-- **Location**: `WasmDebugServer.cpp:472, 484`
-- **Solution**: Implement proper LLDB notifications for dynamic module loading/unloading
-
 ### Multi-Thread Display in LLDB
 
 - **Issue**: Thread select and stop reply protocol handlers need improvement to correctly display multi-VM data in LLDB

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
@@ -297,6 +297,8 @@ void DebugServer::reset()
 {
     // Reset to the init state without stopping the debug server.
     m_executionHandler->reset();
+    m_isDebuggerReady.store(false, std::memory_order_release);
+    m_hasContinued.store(false, std::memory_order_release);
     closeSocket(m_clientSocket);
     m_noAckMode = false;
     m_packetParser.reset();
@@ -403,24 +405,19 @@ void DebugServer::handlePacket(StringView packet)
         m_memoryHandler->write(packet);
         break;
     case 'c':
+    case 'C':
+        // 'C' is ContinueWithSignal — LLDB sends C<sig> instead of 'c' when resuming from a
+        // signal stop (e.g. T05/SIGTRAP). Signal re-delivery is a ptrace concept; we have no
+        // OS-level signal injection so the signal number is irrelevant — treat identically to 'c'.
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Routing continue packet to ExecutionHandler");
         m_executionHandler->resume();
-        break;
-    case 'C':
-        // ContinueWithSignal: LLDB sends C<sig> instead of 'c' when resuming from a signal
-        // stop (e.g. T05/SIGTRAP). Signal re-delivery is a ptrace concept; we have no OS-level
-        // signal injection so the signal number is irrelevant — just resume.
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Routing ContinueWithSignal packet to ExecutionHandler (signal ignored)");
-        m_executionHandler->resume();
+        m_hasContinued.store(true, std::memory_order_release);
         break;
     case 's':
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Routing legacy step packet to ExecutionHandler");
-        m_executionHandler->step();
-        break;
     case 'S':
-        // StepWithSignal: same reasoning as 'C' above — signal re-delivery does not apply
-        // to our WASM VM, so ignore the signal number and treat it as a plain step.
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Routing StepWithSignal packet to ExecutionHandler (signal ignored)");
+        // 'S' is StepWithSignal — same reasoning as 'C': signal re-delivery does not apply
+        // to our WASM VM, so ignore the signal number and treat identically to plain 's'.
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Routing step packet to ExecutionHandler");
         m_executionHandler->step();
         break;
     case 'Z':
@@ -438,10 +435,6 @@ void DebugServer::handlePacket(StringView packet)
     case '?':
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Routing halt reason query to ExecutionHandler");
         m_executionHandler->interrupt();
-        // After the initial interrupt is handled and the stop reply is sent, the debugger has
-        // established a known VM state. Any trap encountered in future execution
-        // (after the user sends 'c') will be properly intercepted.
-        m_executionHandler->setTrapHandlingEnabled(true);
         break;
     case 'k':
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Kill request");
@@ -537,11 +530,18 @@ void DebugServer::trackInstance(JSWebAssemblyInstance* instance)
     if (!m_moduleManager)
         return;
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Tracking WebAssembly instance: ", RawPointer(instance));
-    uint32_t instanceId = m_moduleManager->registerInstance(instance);
-    if (isConnected()) {
-        UNUSED_VARIABLE(instanceId);
-        // FIXME: Should notify LLDB with new module library.
-    }
+    // Notify the debugger here (trackInstance) rather than in trackModule for two reasons:
+    // 1. Module::create covers both the synchronous and streaming-async compilation paths.
+    //    In the async path the JS thread is not at a JS safepoint when the module is created,
+    //    so a stop-the-world request would only fire at the next safepoint — too late for the
+    //    debugger to intercept the load. By the time trackInstance is called the JS thread is
+    //    back at a safepoint and we can stop immediately.
+    // 2. A Module can be compiled speculatively without ever being instantiated (e.g. via
+    //    WebAssembly.compile). Only when a JSWebAssemblyInstance is created do we know the
+    //    module will actually be used, making this the right moment to notify LLDB.
+    m_moduleManager->registerInstance(instance);
+    if (isDebuggerReady() && m_moduleManager->needsNewModuleNotification(instance))
+        m_executionHandler->notifyDebuggerOfNewModule(instance->vm());
 }
 
 void DebugServer::trackModule(Module& module)
@@ -549,11 +549,7 @@ void DebugServer::trackModule(Module& module)
     if (!m_moduleManager)
         return;
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Tracking WebAssembly module: ", RawPointer(&module));
-    uint32_t moduleId = m_moduleManager->registerModule(module);
-    if (isConnected()) {
-        UNUSED_VARIABLE(moduleId);
-        // FIXME: Should notify LLDB with new module library.
-    }
+    m_moduleManager->registerModule(module);
 }
 
 void DebugServer::untrackModule(Module& module)
@@ -564,7 +560,7 @@ void DebugServer::untrackModule(Module& module)
     m_moduleManager->unregisterModule(module);
 }
 
-bool DebugServer::isConnected() const
+bool DebugServer::hasDebugger() const
 {
     if (!isState(State::Running))
         return false;
@@ -573,6 +569,12 @@ bool DebugServer::isConnected() const
         return true;
 #endif
     return isSocketValid(m_clientSocket);
+}
+
+ModuleManager& DebugServer::moduleManager() const
+{
+    RELEASE_ASSERT(m_moduleManager);
+    return *m_moduleManager;
 }
 
 }

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
@@ -116,7 +116,23 @@ public:
 
     void setPort(uint64_t port) { m_port = port; }
 
-    JS_EXPORT_PRIVATE bool NODELETE isConnected() const;
+    // Returns true when a GDB remote client is present at the transport layer — either a TCP
+    // socket has been accepted or an RWI handler has been registered. This is a wire-level check
+    // only: the debugger may not have completed its startup sequence yet.
+    JS_EXPORT_PRIVATE bool NODELETE hasDebugger() const;
+
+    // Non-blocking check: returns true once the debugger has sent its first 'c' (continue).
+    // This is used for test only.
+    bool hasContinued() const { return m_hasContinued.load(std::memory_order_acquire); }
+
+    // True once the debugger has completed its startup exchange ('?' + first qXfer:libraries:read),
+    // which is the point at which we consider the debugger fully ready to handle breakpoints, traps, and new module loads.
+    bool isDebuggerReady() const
+    {
+        bool ready = m_isDebuggerReady.load(std::memory_order_acquire);
+        RELEASE_ASSERT(!ready || hasDebugger());
+        return ready;
+    }
 
     JS_EXPORT_PRIVATE void handlePacket(StringView packet);
 
@@ -126,11 +142,7 @@ public:
         return *m_executionHandler;
     }
 
-    JS_EXPORT_PRIVATE ModuleManager& moduleManager() const
-    {
-        RELEASE_ASSERT(m_moduleManager);
-        return *m_moduleManager;
-    }
+    JS_EXPORT_PRIVATE ModuleManager& moduleManager() const;
 
 private:
     void reset();
@@ -168,6 +180,8 @@ private:
     friend class ExecutionHandler;
 
     std::atomic<State> m_state { State::Stopped };
+    std::atomic<bool> m_hasContinued { false };
+    std::atomic<bool> m_isDebuggerReady { false };
     uint16_t m_port { defaultPort };
     SocketType m_serverSocket { invalidSocketValue };
     SocketType m_clientSocket { invalidSocketValue };

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp
@@ -340,19 +340,15 @@ Vector<FrameInfo> collectCallStack(VirtualAddress stopAddress, CallFrame* startF
 }
 
 StopData::StopData(IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame)
-    : code(Code::Stop)
-    , location(Location::Prologue)
-    , address(VirtualAddress::toVirtual(instance, callee->functionIndex(), callee->bytecode()))
+    : address(VirtualAddress::toVirtual(instance, callee->functionIndex(), callee->bytecode()))
     , callee(callee)
     , instance(instance)
     , callFrame(callFrame)
 {
 }
 
-StopData::StopData(Location location, Code code, VirtualAddress address, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack, IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame)
-    : code(code)
-    , location(location)
-    , address(address)
+StopData::StopData(VirtualAddress address, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack, IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame)
+    : address(address)
     , originalBytecode(originalBytecode)
     , pc(pc)
     , mc(mc)
@@ -364,27 +360,8 @@ StopData::StopData(Location location, Code code, VirtualAddress address, uint8_t
 {
 }
 
-static StopData::Code codeForBreakpointType(Breakpoint::Type type)
-{
-    switch (type) {
-    case Breakpoint::Type::Interrupt:
-        return StopData::Code::Stop;
-    case Breakpoint::Type::Step:
-        return StopData::Code::Trace;
-    case Breakpoint::Type::Regular:
-        return StopData::Code::Breakpoint;
-    default:
-        return StopData::Code::Unknown;
-    }
-}
-
-StopData::StopData(Breakpoint::Type type, VirtualAddress address, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack, IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame)
-    : StopData(Location::Breakpoint, codeForBreakpointType(type), address, originalBytecode, pc, mc, locals, stack, callee, instance, callFrame)
-{
-}
-
 StopData::StopData(IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack, Wasm::ExceptionType type)
-    : StopData(Location::Trap, Code::Trap, VirtualAddress::toVirtual(instance, callee->functionIndex(), pc), 0, pc, mc, locals, stack, callee, instance, callFrame)
+    : StopData(VirtualAddress::toVirtual(instance, callee->functionIndex(), pc), 0, pc, mc, locals, stack, callee, instance, callFrame)
 {
     wasmTrapType = type;
 }
@@ -393,9 +370,7 @@ StopData::~StopData() = default;
 
 void StopData::dump(PrintStream& out) const
 {
-    out.print("StopData(Code:", code);
-    out.print(", location:", location);
-    out.print(", address:", address);
+    out.print("StopData(address:", address);
     out.print(", originalBytecode:", originalBytecode);
     out.print(", pc:", RawPointer(pc));
     out.print(", mc:", RawPointer(mc));

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
@@ -103,8 +103,7 @@ struct Breakpoint {
         Regular = 0,
 
         // One-time breakpoint (auto-removed after each stop)
-        Interrupt = 1,
-        Step = 2,
+        Step = 1,
     };
 
     Breakpoint() = default;
@@ -133,39 +132,21 @@ struct Breakpoint {
     uint8_t originalBytecode { 0 };
 };
 
-// Immutable snapshot of VM state when stopped at a debugging event (interrupt/breakpoint/step).
-// Captures stop reason, location, PC/MC, and execution state for debugger inspection.
+// WASM execution context snapshot captured when stopped at a debugging event.
+// Present for Breakpoint/Step/Trap stops; null for Interrupted stops (no WASM execution context).
 struct StopData {
     WTF_MAKE_STRUCT_TZONE_ALLOCATED(StopData);
 
-    // GDB Remote Protocol stop reason codes mapped to GDB Remote Protocol semantics
-    // Reference: https://sourceware.org/gdb/onlinedocs/gdb/Stop-Reply-Packets.html
-    enum class Code : uint8_t {
-        Unknown = 0,
-        Stop, // SIGSTOP - Debugger interrupt (uncatchable stop) - reason:signal
-        Trace, // SIGTRAP - Single step/trace completion - reason:trace
-        Breakpoint, // SIGTRAP - Breakpoint hit - reason:breakpoint (distinct from trace)
-        Trap, // SIGTRAP - Wasm trap (unreachable instruction) - reason:signal
-    };
+    StopData(VirtualAddress, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal*, IPInt::IPIntStackEntry*, IPIntCallee*, JSWebAssemblyInstance*, CallFrame*);
 
-    enum class Location : uint8_t {
-        Prologue = 0,
-        Breakpoint,
-        Trap, // Stopped at a Wasm unreachable trap
-    };
+    StopData(IPIntCallee*, JSWebAssemblyInstance*, CallFrame*); // Prologue: no pc/mc
 
-    StopData(Breakpoint::Type, VirtualAddress, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal*, IPInt::IPIntStackEntry*, IPIntCallee*, JSWebAssemblyInstance*, CallFrame*);
-
-    StopData(IPIntCallee*, JSWebAssemblyInstance*, CallFrame*);
-
-    StopData(IPIntCallee*, JSWebAssemblyInstance*, CallFrame*, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal*, IPInt::IPIntStackEntry*, Wasm::ExceptionType);
+    StopData(IPIntCallee*, JSWebAssemblyInstance*, CallFrame*, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal*, IPInt::IPIntStackEntry*, Wasm::ExceptionType); // Trap
 
     ~StopData();
 
     void dump(PrintStream&) const;
 
-    Code code { Code::Unknown };
-    Location location;
     VirtualAddress address;
     uint8_t originalBytecode { 0 };
     uint8_t* pc { nullptr };
@@ -176,53 +157,95 @@ struct StopData {
     JSWebAssemblyInstance* instance { nullptr };
     CallFrame* callFrame { nullptr };
     std::optional<Wasm::ExceptionType> wasmTrapType;
-
-private:
-    StopData(Location, Code, VirtualAddress, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal*, IPInt::IPIntStackEntry*, IPIntCallee*, JSWebAssemblyInstance*, CallFrame*);
 };
 
-// Per-VM debugging state machine (Running/Stopped) with current stop information.
-// Owns stopData snapshot while stopped, tracks step-into events across function boundaries.
+// Per-VM debugging state machine with current stop information.
 // Created on-demand via VM::debugState(), accessed only when VM is stopped.
 struct DebugState {
     WTF_MAKE_STRUCT_TZONE_ALLOCATED(DebugState);
 
-    enum class State : uint8_t {
-        Running,
-        Stopped,
+    // Why the VM stopped. Always set when isStopped(). Drives GDB wire protocol signal and reason.
+    enum class Reason : uint8_t {
+        // Debugger-imposed stop: passive VM (no WASM context) or WASM function prologue.
+        // Also used for new module load stops (isNewModuleLoad flag is set in that case).
+        Interrupted,
+        Breakpoint, // A user-set breakpoint was hit (reason:breakpoint)
+        Step, // A step breakpoint was hit (reason:trace)
+        WasmTrap, // Wasm trap / exception
     };
 
     DebugState() = default;
 
     void setPrologueStopData(JSWebAssemblyInstance* instance, IPIntCallee* callee, CallFrame* callFrame)
     {
+        stopReason = Reason::Interrupted;
         stopData = makeUnique<StopData>(callee, instance, callFrame);
     }
 
     void setBreakpointStopData(Breakpoint::Type type, VirtualAddress address, uint8_t originalBytecode, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack, IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame)
     {
-        stopData = makeUnique<StopData>(type, address, originalBytecode, pc, mc, locals, stack, callee, instance, callFrame);
+        switch (type) {
+        case Breakpoint::Type::Step:
+            stopReason = Reason::Step;
+            break;
+        case Breakpoint::Type::Regular:
+            stopReason = Reason::Breakpoint;
+            break;
+        }
+        stopData = makeUnique<StopData>(address, originalBytecode, pc, mc, locals, stack, callee, instance, callFrame);
     }
 
     void setTrapStopData(IPIntCallee* callee, JSWebAssemblyInstance* instance, CallFrame* callFrame, uint8_t* pc, uint8_t* mc, IPInt::IPIntLocal* locals, IPInt::IPIntStackEntry* stack, Wasm::ExceptionType wasmTrapType)
     {
+        stopReason = Reason::WasmTrap;
         stopData = makeUnique<StopData>(callee, instance, callFrame, pc, mc, locals, stack, wasmTrapType);
     }
 
-    bool atSystemCall() const { return !stopData; }
-    bool atPrologue() const { return !!stopData && stopData->location == StopData::Location::Prologue; }
-    bool atBreakpoint() const { return !!stopData && stopData->location == StopData::Location::Breakpoint; }
-    bool isWasmTrap() const { return !!stopData && stopData->wasmTrapType.has_value(); }
+    // WHERE-based helpers — determined by stopData presence and pc:
+    bool isStoppedAtSystemCall() const
+    {
+        bool result = !stopData;
+        if (result)
+            RELEASE_ASSERT(stopReason == Reason::Interrupted);
+        return result;
+    }
+    bool isStoppedAtPrologue() const
+    {
+        bool result = stopData && !stopData->pc;
+        if (result)
+            RELEASE_ASSERT(stopReason == Reason::Interrupted || stopReason == Reason::WasmTrap);
+        return result;
+    }
+    bool isStoppedAtBytecode() const
+    {
+        bool result = stopData && stopData->pc;
+        if (result)
+            RELEASE_ASSERT(stopReason == Reason::Breakpoint || stopReason == Reason::Step || stopReason == Reason::WasmTrap);
+        return result;
+    }
+
+    // WHY-based helpers — determined by stopReason:
+    bool isStoppedDueToWasmTrap() const
+    {
+        return stopReason == Reason::WasmTrap;
+    }
 
     void clearStop()
     {
-        state = State::Running;
+        stopReason = std::nullopt;
+        isNewModuleLoad = false;
         stopData = nullptr;
     }
 
-    void setStopped() { state = State::Stopped; }
-    bool isStopped() const { return state == State::Stopped; }
-    bool isRunning() const { return state == State::Running; }
+    // No-op for the debuggee VM (stopReason already set); sets Interrupted on VMs with no stop reason.
+    void setStopped()
+    {
+        if (!stopReason.has_value())
+            stopReason = Reason::Interrupted;
+    }
+
+    bool isStopped() const { return stopReason.has_value(); }
+    bool isRunning() const { return !stopReason.has_value(); }
 
     bool hasStepIntoEvent() { return stepIntoEvent.hasAny(); }
     void setStepIntoCall() { stepIntoEvent.set(StepIntoEvent::StepIntoCall); }
@@ -230,7 +253,8 @@ struct DebugState {
     void setStepIntoThrow() { stepIntoEvent.set(StepIntoEvent::StepIntoThrow); }
     bool takeStepIntoThrow() { return stepIntoEvent.take(StepIntoEvent::StepIntoThrow); }
 
-    State state { State::Running };
+    std::optional<Reason> stopReason;
+    bool isNewModuleLoad { false };
     std::unique_ptr<StopData> stopData { nullptr };
 
     // Step-into tracking (for step debugging behavior)

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
@@ -78,21 +78,22 @@ static String signalStopString(int signo)
     return makeString('T', hex(signo, 2, WTF::Uppercase));
 }
 
-static inline StopReasonInfo stopReasonCodeToInfo(StopData::Code code)
+// Maps DebugState::Reason to GDB RSP T-packet signal and reason suffix.
+// Reference: https://sourceware.org/gdb/current/onlinedocs/gdb/Stop-Reply-Packets.html
+static inline StopReasonInfo stopReasonToInfo(const DebugState& state)
 {
-    switch (code) {
-    case StopData::Code::Stop:
+    RELEASE_ASSERT(state.stopReason.has_value());
+    switch (*state.stopReason) {
+    case DebugState::Reason::Interrupted:
         return { signalStopString(SIGSTOP), "signal"_s };
-    case StopData::Code::Trace:
-        return { signalStopString(SIGTRAP), "trace"_s };
-    case StopData::Code::Breakpoint:
+    case DebugState::Reason::Breakpoint:
         return { signalStopString(SIGTRAP), "breakpoint"_s };
-    case StopData::Code::Trap:
+    case DebugState::Reason::Step:
+        return { signalStopString(SIGTRAP), "trace"_s };
+    case DebugState::Reason::WasmTrap:
         return { signalStopString(SIGTRAP), "exception"_s };
-    default:
-        RELEASE_ASSERT_NOT_REACHED();
-        return { String(), "trace"_s };
     }
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 ExecutionHandler::ExecutionHandler(DebugServer& debugServer, ModuleManager& instanceManager)
@@ -111,12 +112,11 @@ void ExecutionHandler::stopTheWorld(VM& debuggee, StopTheWorldEvent event)
         Locker locker { m_lock };
 
         switch (event) {
-        case StopTheWorldEvent::StepIntoSiteReached:
+        case StopTheWorldEvent::WasmStepIntoSiteReached:
             RELEASE_ASSERT(Thread::currentSingleton().uid() == threadId(*m_debuggee));
             RELEASE_ASSERT(m_debuggee == info.targetVM && info.worldMode == VMManager::Mode::RunOne);
             break;
-        case StopTheWorldEvent::BreakpointHit:
-        case StopTheWorldEvent::TrapHit:
+        case StopTheWorldEvent::WasmProgramStop:
             RELEASE_ASSERT(info.worldMode != VMManager::Mode::Stopped);
             break;
         default:
@@ -142,22 +142,24 @@ DebuggerTrapStatus ExecutionHandler::handleDebuggerTrapIfNeeded(CallFrame* callF
         if (auto* breakpoint = m_breakpointManager->findBreakpoint(address)) {
             debuggee.debugState()->setBreakpointStopData(breakpoint->type, address, breakpoint->originalBytecode, pc, mc, locals, stack, callee, instance, callFrame);
             dataLogLnIf(Options::verboseWasmDebugger(), "[Code][handleDebuggerTrapIfNeeded] Breakpoint at ", *breakpoint, " with ", *debuggee.debugState()->stopData);
-            stopTheWorld(debuggee, StopTheWorldEvent::BreakpointHit);
+            stopTheWorld(debuggee, StopTheWorldEvent::WasmProgramStop);
             return DebuggerTrapStatus::ResolvedByDebugger; // Don't throw; resume execution at this breakpoint
         }
     }
 
-    if (!isTrapHandlingEnabled())
+    if (!m_debugServer.isDebuggerReady())
         return DebuggerTrapStatus::NotResolvedByDebugger; // Throw; no debugger connected
 
     if (exceptionType == Wasm::ExceptionType::StackOverflow || exceptionType == Wasm::ExceptionType::Termination) {
-        RELEASE_ASSERT(debuggee.debugState()->atPrologue());
-        debuggee.debugState()->stopData->code = StopData::Code::Trap;
+        // Fires during the prologue stack check — stopData already set as prologue context.
+        // Upgrade reason to Trap and add trap type; keep existing callee/instance/address.
+        RELEASE_ASSERT(debuggee.debugState()->isStoppedAtPrologue());
+        debuggee.debugState()->stopReason = DebugState::Reason::WasmTrap;
         debuggee.debugState()->stopData->wasmTrapType = exceptionType;
     } else
         debuggee.debugState()->setTrapStopData(callee, instance, callFrame, pc, mc, locals, stack, exceptionType);
     dataLogLnIf(Options::verboseWasmDebugger(), "[Code][handleDebuggerTrapIfNeeded] Wasm trap at ", *debuggee.debugState()->stopData);
-    stopTheWorld(debuggee, StopTheWorldEvent::TrapHit);
+    stopTheWorld(debuggee, StopTheWorldEvent::WasmProgramStop);
     return DebuggerTrapStatus::NotResolvedByDebugger; // Throw; trap was reported, now propagate it
 }
 
@@ -183,15 +185,19 @@ ExecutionHandler::ResumeMode ExecutionHandler::stopCode(Locker<Lock>& locker, St
     case StopTheWorldEvent::VMCreated:
     case StopTheWorldEvent::VMActivated:
         RELEASE_ASSERT(m_debuggerState == DebuggerState::InterruptRequested || m_debuggerState == DebuggerState::SwitchRequested);
-        notifyDebuggerOfStop();
-        break;
-    case StopTheWorldEvent::BreakpointHit:
-    case StopTheWorldEvent::TrapHit:
-        RELEASE_ASSERT(m_debuggerState == DebuggerState::StepRequested || m_debuggerState == DebuggerState::ContinueRequested || m_debuggerState == DebuggerState::SwitchRequested);
         m_breakpointManager->clearAllOneTimeBreakpoints();
         notifyDebuggerOfStop();
         break;
-    case StopTheWorldEvent::StepIntoSiteReached:
+    case StopTheWorldEvent::WasmProgramStop:
+        RELEASE_ASSERT(m_debuggerState == DebuggerState::StepRequested || m_debuggerState == DebuggerState::ContinueRequested || m_debuggerState == DebuggerState::SwitchRequested);
+        // FIXME: For module-load stops (isNewModuleLoad), step breakpoints should be preserved
+        // so the in-progress step can complete after LLDB resumes. Clearing them here silently
+        // cancels any active step. This also affects future LLDB expression evaluation, which can
+        // trigger module loads internally and should not interrupt a step.
+        m_breakpointManager->clearAllOneTimeBreakpoints();
+        notifyDebuggerOfStop();
+        break;
+    case StopTheWorldEvent::WasmStepIntoSiteReached:
         RELEASE_ASSERT(m_debuggerState == DebuggerState::StepRequested);
         m_debuggerContinue.notifyOne(); // Notify that breakpoint is set.
         break;
@@ -258,7 +264,7 @@ void ExecutionHandler::selectDebuggeeIfNeeded(VM& fallbackVM) WTF_REQUIRES_LOCK(
     VM* selectedVM = nullptr;
     VMManager::forEachVM([&](VM& vm) {
         auto* debugState = vm.debugState();
-        if (vm.debugState()->isStopped() && debugState->atPrologue()) {
+        if (vm.debugState()->isStopped() && debugState->isStoppedAtPrologue()) {
             selectedVM = &vm;
             return IterationStatus::Done;
         }
@@ -275,7 +281,7 @@ StopTheWorldStatus wasmDebuggerOnStopCallback(VM& debuggee, StopTheWorldEvent ev
 {
     dataLogLnIf(Options::verboseWasmDebugger(), "[STW] Callback invoked with event:", event);
     auto& server = DebugServer::singleton();
-    if (!server.isConnected()) {
+    if (!server.hasDebugger()) {
         dataLogLnIf(Options::verboseWasmDebugger(), "[STW] Not connected, resuming all");
         return STW_RESUME_ALL();
     }
@@ -299,7 +305,7 @@ void ExecutionHandler::handlePostResume()
 void wasmDebuggerOnResumeCallback()
 {
     auto& server = DebugServer::singleton();
-    if (!server.isConnected()) {
+    if (!server.hasDebugger()) {
         dataLogLnIf(Options::verboseWasmDebugger(), "[STW][PostResume] Not connected, resuming all");
         return;
     }
@@ -326,6 +332,12 @@ void ExecutionHandler::resumeImpl(Locker<Lock>& locker)
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Continue] Notified code to continue and waiting...");
     m_debuggerContinue.wait(locker); // Wait for resume to complete.
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Continue] Confirmed that code is running...");
+}
+
+void ExecutionHandler::notifyDebuggerOfNewModule(VM& vm)
+{
+    vm.debugState()->isNewModuleLoad = true;
+    stopTheWorld(vm, StopTheWorldEvent::WasmProgramStop);
 }
 
 static inline VM* findVM(uint64_t threadId)
@@ -400,16 +412,15 @@ void ExecutionHandler::step()
     RELEASE_ASSERT(m_debuggerState == DebuggerState::Replied && state->isStopped());
 
     bool resumeAll = false;
-    if (state->atSystemCall() || state->isWasmTrap()) {
+    if (state->isStoppedAtSystemCall() || state->isStoppedDueToWasmTrap()) {
         // There is no valid next WASM instruction to step to in either case.
         // For traps (including StackOverflow at prologue), execution unwinds back to JS —
         // resuming all is the right behavior.
         resumeAll = true;
-    }
-    else if (state->atBreakpoint())
+    } else if (state->isStoppedAtBytecode())
         resumeAll = stepAtBreakpoint(locker, state);
     else {
-        RELEASE_ASSERT(state->atPrologue());
+        RELEASE_ASSERT(state->isStoppedAtPrologue());
         setBreakpointAtEntry(state->stopData->instance, state->stopData->callee.get(), Breakpoint::Type::Step);
     }
 
@@ -430,7 +441,7 @@ void ExecutionHandler::step()
 
 bool ExecutionHandler::stepAtBreakpoint(Locker<Lock>& locker, DebugState* state)
 {
-    RELEASE_ASSERT(state->atBreakpoint());
+    RELEASE_ASSERT(state->isStoppedAtBytecode());
     auto& stopData = *state->stopData;
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Step] Start with ", stopData);
 
@@ -544,7 +555,7 @@ void ExecutionHandler::setStepIntoBreakpointForCall(VM& callerVM, CalleeBits box
         setBreakpointAtEntry(calleeInstance, downcast<IPIntCallee>(wasmCallee.get()), Breakpoint::Type::Step);
     }();
 
-    stopTheWorld(callerVM, StopTheWorldEvent::StepIntoSiteReached);
+    stopTheWorld(callerVM, StopTheWorldEvent::WasmStepIntoSiteReached);
 }
 
 void ExecutionHandler::setStepIntoBreakpointForThrow(VM& throwVM)
@@ -587,7 +598,7 @@ void ExecutionHandler::setStepIntoBreakpointForThrow(VM& throwVM)
         setBreakpointAtPC(catchInstance, catchCallee->functionIndex(), Breakpoint::Type::Step, handlerPC);
     }();
 
-    stopTheWorld(throwVM, StopTheWorldEvent::StepIntoSiteReached);
+    stopTheWorld(throwVM, StopTheWorldEvent::WasmStepIntoSiteReached);
 }
 
 void ExecutionHandler::setBreakpointAtEntry(JSWebAssemblyInstance* instance, IPIntCallee* callee, Breakpoint::Type type)
@@ -714,7 +725,7 @@ void ExecutionHandler::handleThreadStopInfo(StringView packet)
 
 static uint64_t NODELETE getStopPC(const DebugState& state)
 {
-    if (state.atSystemCall())
+    if (state.isStoppedAtSystemCall())
         return VirtualAddress(VirtualAddress::INVALID_BASE).value();
     RELEASE_ASSERT(state.stopData);
     return state.stopData->address;
@@ -723,12 +734,12 @@ static uint64_t NODELETE getStopPC(const DebugState& state)
 static String getThreadName(const DebugState& state, uint64_t threadId)
 {
     StringView stateName;
-    if (state.atPrologue())
+    if (state.isStoppedAtPrologue())
         stateName = "wasm-prologue"_s;
-    else if (state.atBreakpoint() || state.isWasmTrap())
+    else if (state.isStoppedAtBytecode())
         stateName = "wasm-call"_s;
     else {
-        RELEASE_ASSERT(state.atSystemCall());
+        RELEASE_ASSERT(state.isStoppedAtSystemCall());
         stateName = "system-call"_s;
     }
     return makeString(stateName, " tid:0x"_s, hex(threadId, Lowercase));
@@ -750,8 +761,7 @@ static Vector<ThreadInfo> collectAllStoppedThreads()
             return IterationStatus::Continue;
 
         uint64_t threadId = ExecutionHandler::threadId(vm);
-        StopData::Code code = state->atSystemCall() ? StopData::Code::Stop : state->stopData->code;
-        auto stopInfo = stopReasonCodeToInfo(code);
+        auto stopInfo = stopReasonToInfo(*state);
         threads.append({ threadId, getStopPC(*state), getThreadName(*state, threadId), stopInfo.reasonSuffix });
         return IterationStatus::Continue;
     });
@@ -779,8 +789,7 @@ void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t t
     Vector<ThreadInfo> allThreads = collectAllStoppedThreads();
 
     // FIXME: Report different stop reasons for active vs passive threads (currently all use same code).
-    StopData::Code code = state->atSystemCall() ? StopData::Code::Stop : state->stopData->code;
-    auto stopInfo = stopReasonCodeToInfo(code);
+    auto stopInfo = stopReasonToInfo(*state);
 
     // Build packet with target thread
     StringBuilder reply;
@@ -809,9 +818,21 @@ void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t t
     reply.append("00:"_s, toNativeEndianHex(getStopPC(*state)), ';');
     reply.append("reason:"_s, stopInfo.reasonSuffix, ';');
 
-    // For trap stops, include a hex-encoded description matching WAMR convention so LLDB
-    // can display the trap reason to the user.
-    if (code == StopData::Code::Trap) {
+    // For new module load stops, append library:; to prompt LLDB to re-query qXfer:libraries:read,
+    // which causes LLDB to load debug info for the new module and resolve any pending breakpoints
+    // that target symbols in it. Also append a description so LLDB can display a human-readable
+    // stop reason in the UI.
+    if (state->isNewModuleLoad) {
+        RELEASE_ASSERT(state->isStoppedAtSystemCall());
+        reply.append("library:;"_s);
+        reply.append("description:"_s);
+        for (UChar c : StringView("new wasm module loaded"_s).codeUnits())
+            reply.append(hex(static_cast<uint8_t>(c), 2, Lowercase));
+        reply.append(';');
+    }
+
+    // For trap stops, include a hex-encoded description so LLDB can display the trap reason.
+    if (state->isStoppedDueToWasmTrap()) {
         reply.append("description:"_s);
         for (UChar c : StringView(Wasm::errorMessageForExceptionType(*state->stopData->wasmTrapType)).codeUnits())
             reply.append(hex(static_cast<uint8_t>(c), 2, Lowercase));
@@ -868,7 +889,6 @@ void ExecutionHandler::reset()
 
     m_breakpointManager->clearAllBreakpoints();
     m_debuggerState = DebuggerState::Replied;
-    setTrapHandlingEnabled(false);
     takeAwaitingResumeNotification();
     m_debuggee = nullptr;
 }
@@ -885,7 +905,7 @@ uint64_t ExecutionHandler::threadId(const VM& vm)
 
 DebugState* ExecutionHandler::debuggeeState() const { return m_debuggee->debugState(); }
 
-DebugState* ExecutionHandler::debuggeeStateSafe() const
+DebugState* ExecutionHandler::debuggeeStateForTest() const
 {
     Locker locker { m_lock };
     RELEASE_ASSERT(m_debuggee);

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
@@ -83,6 +83,7 @@ public:
     JS_EXPORT_PRIVATE void resume();
     JS_EXPORT_PRIVATE void step();
     JS_EXPORT_PRIVATE void interrupt();
+    void notifyDebuggerOfNewModule(VM&);
     void handleThreadStopInfo(StringView packet);
     String callStackStringFor(uint64_t threadId);
     JS_EXPORT_PRIVATE void reset();
@@ -107,7 +108,7 @@ public:
     void setDebugServerThreadId(uint64_t threadId) { m_debugServerThreadId = threadId; }
 
     JS_EXPORT_PRIVATE DebugState* debuggeeState() const WTF_REQUIRES_LOCK(m_lock);
-    JS_EXPORT_PRIVATE DebugState* debuggeeStateSafe() const; // FIXME: Should be used for test only
+    JS_EXPORT_PRIVATE DebugState* debuggeeStateForTest() const; // FIXME: Should be used for test only
 
     VM* debuggeeVM() const // Used for test only
     {
@@ -127,7 +128,6 @@ public:
     StopTheWorldStatus handleStopTheWorld(VM&, StopTheWorldEvent);
     void handlePostResume();
     bool takeAwaitingResumeNotification() WTF_REQUIRES_LOCK(m_lock) { return std::exchange(m_awaitingResumeNotification, false); }
-    void setTrapHandlingEnabled(bool enabled) { m_trapHandlingEnabled.store(enabled, std::memory_order_release); }
 
 private:
     friend class DebugServer;
@@ -148,8 +148,6 @@ private:
     void sendErrorReply(ProtocolError);
 
     void selectDebuggeeIfNeeded(VM& fallbackVM) WTF_REQUIRES_LOCK(m_lock);
-
-    bool isTrapHandlingEnabled() const { return m_trapHandlingEnabled.load(std::memory_order_acquire); }
 
     bool requiresStopConfirmation() const WTF_REQUIRES_LOCK(m_lock)
     {
@@ -172,7 +170,6 @@ private:
     Condition m_debuggeeContinue;
     DebuggerState m_debuggerState WTF_GUARDED_BY_LOCK(m_lock) { DebuggerState::Replied };
     bool m_awaitingResumeNotification WTF_GUARDED_BY_LOCK(m_lock) { false };
-    std::atomic<bool> m_trapHandlingEnabled { false };
     VM* m_debuggee WTF_GUARDED_BY_LOCK(m_lock) { nullptr };
     std::optional<uint64_t> m_debugServerThreadId;
 };

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.cpp
@@ -59,6 +59,7 @@ uint32_t ModuleManager::registerModule(Module& module)
     m_moduleIdToModule.set(moduleId, &module);
     const auto& moduleInfo = module.moduleInformation();
     moduleInfo.debugInfo->id = moduleId;
+    m_unnotifiedModuleIds.add(moduleId);
     dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][registerModule] - registered module with ID: ", moduleId, " size: ", moduleInfo.debugInfo->source.size(), " bytes");
     return moduleId;
 }
@@ -68,6 +69,7 @@ void ModuleManager::unregisterModule(Module& module)
     Locker locker { m_lock };
     uint32_t moduleId = module.debugId();
     m_moduleIdToModule.remove(moduleId);
+    m_unnotifiedModuleIds.remove(moduleId);
     dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][unregisterModule] - unregistered module with debug ID: ", moduleId);
 }
 
@@ -85,6 +87,19 @@ uint32_t ModuleManager::registerInstance(JSWebAssemblyInstance* jsInstance)
     jsInstance->setDebugId(instanceId);
     dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][registerInstance] - registered instance with ID: ", instanceId, " for module ID: ", jsInstance->module().debugId());
     return instanceId;
+}
+
+bool ModuleManager::needsNewModuleNotification(JSWebAssemblyInstance* jsInstance)
+{
+    Locker locker { m_lock };
+    uint32_t moduleId = jsInstance->module().debugId();
+    return m_unnotifiedModuleIds.contains(moduleId);
+}
+
+void ModuleManager::markAllModulesAsNotified()
+{
+    Locker locker { m_lock };
+    m_unnotifiedModuleIds.clear();
 }
 
 Module* ModuleManager::module(uint32_t moduleId) const

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.h
@@ -31,6 +31,7 @@
 #include "WasmModule.h"
 #include "WasmVirtualAddress.h"
 #include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Vector.h>
@@ -60,14 +61,18 @@ public:
     Module* module(uint32_t moduleId) const;
 
     uint32_t registerInstance(JSWebAssemblyInstance*);
+    bool needsNewModuleNotification(JSWebAssemblyInstance*);
     JSWebAssemblyInstance* jsInstance(uint32_t instanceId);
     uint32_t nextInstanceId() const;
 
     String generateLibrariesXML() const;
 
+    void markAllModulesAsNotified();
+
 private:
     using IdToModule = UncheckedKeyHashMap<uint32_t, Module*, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
     using IdToInstance = UncheckedKeyHashMap<uint32_t, ThreadSafeWeakPtr<Wasm::InstanceAnchor>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+    using ModuleIdSet = HashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 
     // Amortized cleanup mechanism (matches ThreadSafeWeakHashSet behavior).
     void amortizedCleanupIfNeeded() WTF_REQUIRES_LOCK(m_lock);
@@ -76,6 +81,7 @@ private:
     mutable Lock m_lock;
     IdToModule m_moduleIdToModule WTF_GUARDED_BY_LOCK(m_lock);
     IdToInstance m_instanceIdToInstance WTF_GUARDED_BY_LOCK(m_lock);
+    ModuleIdSet m_unnotifiedModuleIds WTF_GUARDED_BY_LOCK(m_lock); // Module IDs not yet seen by LLDB; cleared by markAllModulesAsNotified() after each qXfer:libraries:read reply
 
     uint32_t m_nextModuleId WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     uint32_t m_nextInstanceId WTF_GUARDED_BY_LOCK(m_lock) { 0 };

--- a/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
@@ -288,6 +288,11 @@ void QueryHandler::handleLibrariesRead(StringView packet)
     if (handleChunkedLibrariesResponse(offset, maxSize, response)) {
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Sending library list chunk: offset=", offset, ", maxSize=", maxSize);
         m_debugServer.sendReply(response);
+        // Only mark modules notified and signal debugger-ready on the final chunk ('l' prefix).
+        if (response[0] == 'l') {
+            m_debugServer.m_isDebuggerReady.store(true, std::memory_order_release);
+            m_debugServer.moduleManager().markAllModulesAsNotified();
+        }
     } else {
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Failed to generate library list chunk");
         m_debugServer.sendErrorReply(ProtocolError::MemoryError);
@@ -354,8 +359,8 @@ void QueryHandler::handleWasmLocal(StringView packet)
 
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] qWasmLocal frame=", frameIndex, ", variable=", localIndex);
 
-    auto* state = m_debugServer.execution().debuggeeStateSafe();
-    if (state->atSystemCall() || state->atPrologue()) {
+    auto* state = m_debugServer.execution().debuggeeStateForTest();
+    if (state->isStoppedAtSystemCall() || state->isStoppedAtPrologue()) {
         m_debugServer.sendErrorReply(ProtocolError::UnknownCommand);
         return;
     }
@@ -436,8 +441,8 @@ void QueryHandler::handleWasmGlobal(StringView packet)
 
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] qWasmGlobal frame=", frameIndex, ", global=", globalIndex);
 
-    auto* state = m_debugServer.execution().debuggeeStateSafe();
-    if (state->atSystemCall()) {
+    auto* state = m_debugServer.execution().debuggeeStateForTest();
+    if (state->isStoppedAtSystemCall()) {
         m_debugServer.sendErrorReply(ProtocolError::UnknownCommand);
         return;
     }

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
@@ -230,8 +230,8 @@ static void testBreakpointContinueCycles()
             return getReplyCount() == expectedReplyCount;
         });
 
-        DebugState* state = executionHandler->debuggeeStateSafe();
-        CHECK(state->atBreakpoint(), "Should stop at a breakpoint");
+        DebugState* state = executionHandler->debuggeeStateForTest();
+        CHECK(state->isStoppedAtBytecode(), "Should stop at a breakpoint");
         VLOG("  Stopped at breakpoint in vm:", RawPointer(executionHandler->debuggeeVM()));
     }
 
@@ -261,11 +261,11 @@ static void testBreakpointSingleStepping()
         bool stopped = getReplyCount() == expectedReplyCount;
         if (!stopped)
             return false;
-        return executionHandler->debuggeeStateSafe()->atBreakpoint();
+        return executionHandler->debuggeeStateForTest()->isStoppedAtBytecode();
     });
 
-    DebugState* state = executionHandler->debuggeeStateSafe();
-    CHECK(state->atBreakpoint(), "Should be at breakpoint");
+    DebugState* state = executionHandler->debuggeeStateForTest();
+    CHECK(state->isStoppedAtBytecode(), "Should be at breakpoint");
 
     // Record initial virtual address
     CHECK(state->stopData, "Should have stopData");
@@ -298,8 +298,8 @@ static void testBreakpointSingleStepping()
         if (breakpoint)
             executionHandler->breakpointManager()->setBreakpoint(beforeStepAddress, WTF::move(breakpointCopy));
 
-        state = executionHandler->debuggeeStateSafe();
-        CHECK(state->atBreakpoint(), "Should be at breakpoint after step");
+        state = executionHandler->debuggeeStateForTest();
+        CHECK(state->isStoppedAtBytecode(), "Should be at breakpoint after step");
 
         JSC::Wasm::VirtualAddress afterStepAddress = state->stopData->address;
         VLOG("  After step: ", afterStepAddress);

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.cpp
@@ -272,7 +272,7 @@ void setupTestEnvironment(DebugServer*& debugServer, ExecutionHandler*& executio
     });
 
     RELEASE_ASSERT(started, "Failed to start DebugServer in RWI mode");
-    RELEASE_ASSERT(debugServer->isConnected(), "DebugServer not connected");
+    RELEASE_ASSERT(debugServer->hasDebugger(), "DebugServer has no debug client after RWI start");
 
     executionHandler = &debugServer->execution();
     executionHandler->setDebugServerThreadId(Thread::currentSingleton().uid());

--- a/Source/WebKit/WebProcess/Inspector/WasmDebuggerDispatcher.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WasmDebuggerDispatcher.cpp
@@ -70,8 +70,8 @@ void WasmDebuggerDispatcher::dispatchMessage(const String& message)
     // Safe to call even when main thread is blocked in infinite loop.
     JSC::Wasm::DebugServer& debugServer = JSC::Wasm::DebugServer::singleton();
 
-    if (!debugServer.isConnected()) {
-        RELEASE_LOG_ERROR(Inspector, "WasmDebugServer not connected");
+    if (!debugServer.hasDebugger()) {
+        RELEASE_LOG_ERROR(Inspector, "WasmDebugServer has no debug client");
         return;
     }
 


### PR DESCRIPTION
#### 348694c4bfd2fcd01336a7cb42eba72392d058c5
<pre>
[JSC][WASM][Debugger] Notify LLDB when a new WebAssembly module is dynamically instantiated
<a href="https://bugs.webkit.org/show_bug.cgi?id=311390">https://bugs.webkit.org/show_bug.cgi?id=311390</a>
<a href="https://rdar.apple.com/173985480">rdar://173985480</a>

Reviewed by Mark Lam (OOPS\!).

In native C++ debugging, dlopen triggers _dyld_debugger_notification which LLDB
intercepts to transparently resolve pending breakpoints in newly loaded libraries.
No equivalent mechanism exists for WASM: LLDB only queries qXfer:libraries:read
once at attach via DynamicLoaderWasmDYLD, then goes silent. As a result, pending
breakpoints targeting symbols in dynamically loaded WASM modules are never resolved
— the user sets &quot;b func_b&quot; before the module loads, and the breakpoint is silently
missed when func_b is eventually called.

To fix this, when a WebAssembly.Instance is created for a module that LLDB has not
yet seen, JSC stops all VMs via the existing STW mechanism and sends a T-packet
with library:; This causes LLDB to re-query qXfer:libraries:read, load debug info
for the new module, and resolve any pending breakpoints that target symbols in it.

Key design points:
- Notification fires at trackInstance (not trackModule) so the JS thread is at a
  safepoint and the stop is immediate. Modules compiled speculatively without
  instantiation (WebAssembly.compile) do not generate spurious stops.
- ModuleManager tracks a set of unnotified module IDs (m_unnotifiedModuleIds).
  Multiple modules compiled before any instance is created are batched: the first
  instance creation triggers one stop and LLDB picks up all pending modules in a
  single qXfer:libraries:read response, after which markModulesNotified() clears the set.
- isDebuggerReady() gates module-load notifications on the debugger having
  completed its startup exchange (&apos;?&apos; + first qXfer:libraries:read), replacing
  the old m_trapHandlingEnabled flag with a cleaner readiness concept.

As a prerequisite cleanup:
- StopData::Code and StopData::Location are removed; DebugState::Reason is the
  single source of truth for why the VM stopped. NewModuleLoad is represented as
  Reason::Interrupted with isNewModuleLoad flag rather than a separate enum value.
- BreakpointHit and TrapHit StopTheWorldEvents are merged into WasmProgramStop.
- isConnected() is renamed hasDebugger() to better reflect that it is a
  transport-level check, not a protocol-readiness check.
- $vm.hasDebuggerContinued() is added to JSDollarVM for test synchronization.

Tests:
* JSTests/wasm/debugger/tests/tests.py:
(DynamicModuleLoadTestCase):
(SwiftWasmDynamicModuleLoadTestCase):

Canonical link: <a href="https://commits.webkit.org/310825@main">https://commits.webkit.org/310825@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd01fcb5a3475a67867dbdddb013ada21f0aeacc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155133 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28393 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163893 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba00a741-a2fa-4bff-bb8d-3de52e9600ec) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28533 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28241 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120030 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22285 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/139309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100723 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11719 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147183 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/17151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166371 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15964 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18760 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128133 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27937 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/23458 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128271 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34790 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27861 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138944 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/84570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23137 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186920 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27554 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/91657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/47896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/27132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/27362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27205 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->