### PR TITLE
[YARR] Clear captures when backtracking out of ParenContext FixedCount and negative lookahead in JIT

### DIFF
--- a/JSTests/stress/regexp-jit-negative-lookahead-clear-captures-on-backtrack.js
+++ b/JSTests/stress/regexp-jit-negative-lookahead-clear-captures-on-backtrack.js
@@ -1,0 +1,14 @@
+
+function shouldBe(actual, expected) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error("bad value: actual=" + JSON.stringify(actual) + " expected=" + JSON.stringify(expected));
+}
+
+for (var i = 0; i < 1e4; ++i) {
+    shouldBe(/(?!(a){2})./.exec("ab"), ["a", undefined]);
+    shouldBe(/(?!(ab){2})./.exec("abc"), ["a", undefined]);
+    shouldBe(/(?!(?<n>a){2})./.exec("ab"), ["a", undefined]);
+    var m = /(?!(?<n>a){2})./.exec("ab");
+    shouldBe(m.groups.n, undefined);
+    shouldBe(/(?!(a)(b))./.exec("abc"), ["b", undefined, undefined]);
+}

--- a/JSTests/stress/regexp-jit-paren-context-fixedcount-clear-captures-on-no-context-backtrack.js
+++ b/JSTests/stress/regexp-jit-paren-context-fixedcount-clear-captures-on-no-context-backtrack.js
@@ -1,0 +1,15 @@
+
+function shouldBe(actual, expected) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error("bad value: actual=" + JSON.stringify(actual) + " expected=" + JSON.stringify(expected));
+}
+
+for (var i = 0; i < 1e4; ++i) {
+    shouldBe(/(?:(a+){2}|.)/.exec("ax"), ["a", undefined]);
+    shouldBe(/(?:(ab){3}|.)/.exec("ababx"), ["a", undefined]);
+    shouldBe(/(?:(a){2}x|.)/.exec("aab"), ["a", undefined]);
+    shouldBe(/(?:(?<n>a+){2}|.)/.exec("ax"), ["a", undefined]);
+    var m = /(?:(?<n>a+){2}|.)/.exec("ax");
+    shouldBe(m.groups.n, undefined);
+    shouldBe(/(?:(?:(a)b){2}|.)/.exec("abx"), ["a", undefined]);
+}

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -5080,6 +5080,10 @@ class YarrGenerator final : public YarrJITInfo {
 
                     // No context available - propagate failure
                     noContext.link(&m_jit);
+                    if (shouldRecordSubpatterns() && term->containsAnyCaptures()) {
+                        for (unsigned subpattern = term->parentheses.subpatternId; subpattern <= term->parentheses.lastSubpatternId; subpattern++)
+                            clearSubpattern(subpattern);
+                    }
                     storeToFrame(MacroAssembler::TrustedImm32(-1), parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
                     m_backtrackingState.fallthrough();
                     break;
@@ -5226,8 +5230,13 @@ class YarrGenerator final : public YarrJITInfo {
                     // is treated as a successful match - jump to the end of the
                     // subpattern. We already have adjusted the input position
                     // back to that before the assertion, which is correct.
-                    if (term->invert())
+                    if (term->invert()) {
+                        if (shouldRecordSubpatterns() && term->containsAnyCaptures()) {
+                            for (unsigned subpattern = term->parentheses.subpatternId; subpattern <= term->parentheses.lastSubpatternId; subpattern++)
+                                clearSubpattern(subpattern);
+                        }
                         m_jit.jump(endOp.m_reentry);
+                    }
 
                     m_backtrackingState.fallthrough();
                 }


### PR DESCRIPTION
#### 036d2c0c8216c36906ac3d3d2a861442f64ed0ad
<pre>
[YARR] Clear captures when backtracking out of ParenContext FixedCount and negative lookahead in JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=311392">https://bugs.webkit.org/show_bug.cgi?id=311392</a>

Reviewed by Yusuke Suzuki.

Two backtrack paths skipped the capture-clearing step their siblings
already perform, leaving stale captures from failed inner alternatives
visible to the surrounding pattern.

ParenContext FixedCount Begin backtrack (noContext path): when no
usable context remains, control falls through to propagate failure
without clearing inner subpatterns. The Simple FixedCount sibling
already clears them; mirror the loop here.
  /(?:(a+){2}|.)/.exec(&quot;ax&quot;) -&gt; JIT [&quot;a&quot;,&quot;a&quot;], correct [&quot;a&quot;,null]

ParentheticalAssertionBegin backtrack (inverted): when the inner
fails, the negative lookahead succeeds and jumps to End.reentry,
bypassing ParentheticalAssertionEnd&apos;s capture-clearing. Per spec,
captures inside a successful negative lookahead must be undefined.
  /(?!(a){2})./.exec(&quot;ab&quot;) -&gt; JIT [&quot;a&quot;,&quot;a&quot;], correct [&quot;a&quot;,null]

Tests: JSTests/stress/regexp-jit-negative-lookahead-clear-captures-on-backtrack.js
       JSTests/stress/regexp-jit-paren-context-fixedcount-clear-captures-on-no-context-backtrack.js

* JSTests/stress/regexp-jit-negative-lookahead-clear-captures-on-backtrack.js: Added.
(shouldBe):
(i.shouldBe):
(i.m):
* JSTests/stress/regexp-jit-paren-context-fixedcount-clear-captures-on-no-context-backtrack.js: Added.
(shouldBe):
(i.shouldBe):
(i.m):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/310679@main">https://commits.webkit.org/310679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/580db9692f4f1b17df35f8f93f8e3aef79488d75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20448 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107499 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27141 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119121 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84213 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156992 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21368 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138319 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99821 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20457 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18444 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10618 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146079 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130114 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16171 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165258 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14860 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8458 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127213 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26836 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22479 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127366 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34678 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26759 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137965 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83338 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22241 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14753 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185668 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26450 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90542 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47614 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26031 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26261 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26103 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->