### PR TITLE
text-transform: capitalize should handle supplementary Unicode characters

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-capitalize-supplementary-char-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-capitalize-supplementary-char-expected.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Test Reference: ::first-letter with text-transform:capitalize after supplementary character</title>
+  <style>
+  .ref {
+    font-size: 36px;
+  }
+  </style>
+</head>
+<body>
+  <div class="ref"><span style="color: green">&#x1D400;</span>bc Def</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-capitalize-supplementary-char.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-capitalize-supplementary-char.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Test: ::first-letter with text-transform:capitalize after supplementary character</title>
+  <link rel="author" title="Chris Dumez" href="mailto:cdumez@apple.com">
+  <link rel="match" href="first-letter-capitalize-supplementary-char-expected.html">
+  <link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#first-letter-styling">
+  <link rel="help" href="https://drafts.csswg.org/css-text-3/#text-transform-property">
+  <meta name="assert" content="When ::first-letter captures a supplementary Unicode character (surrogate pair), text-transform:capitalize on the remaining text must correctly identify the previous character for word boundary detection.">
+  <style>
+  .test {
+    font-size: 36px;
+    text-transform: capitalize;
+  }
+  .test::first-letter {
+    color: green;
+  }
+  </style>
+</head>
+<body>
+  <!-- U+1D400 (MATHEMATICAL BOLD CAPITAL A) is a supplementary character (surrogate pair in UTF-16).
+       "bc" continues the same word, so capitalize should NOT uppercase "b".
+       "def" is a new word, so capitalize SHOULD uppercase "d". -->
+  <div class="test">&#x1D400;bc def</div>
+</body>
+</html>

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -86,6 +86,7 @@ public:
     char16_t characterAt(unsigned index) const;
     char16_t operator[](unsigned index) const;
     char32_t characterStartingAt(unsigned index) const;
+    char32_t codePointBefore(unsigned index) const;
 
     class CodeUnits;
     CodeUnits codeUnits() const;
@@ -623,6 +624,15 @@ inline char32_t StringView::characterStartingAt(unsigned index) const
     if (index + 1 < length() && U16_IS_LEAD(characters[index]) && U16_IS_TRAIL(characters[index + 1]))
         return U16_GET_SUPPLEMENTARY(characters[index], characters[index + 1]);
     return characters[index];
+}
+
+inline char32_t StringView::codePointBefore(unsigned index) const
+{
+    ASSERT(index > 0 && index <= length());
+    unsigned offset = index;
+    char32_t codePoint;
+    U16_PREV(*this, 0, offset, codePoint);
+    return codePoint;
 }
 
 inline bool StringView::contains(char16_t character) const

--- a/Source/WebCore/editing/ICUSearcher.cpp
+++ b/Source/WebCore/editing/ICUSearcher.cpp
@@ -168,8 +168,7 @@ bool isWordStartMatch(std::span<const char16_t> buffer, size_t start, size_t len
     U16_GET(buffer, 0, offset, size, firstCharacter);
 
     if (options.contains(FindOption::TreatMedialCapitalAsWordStart)) {
-        char32_t previousCharacter;
-        U16_PREV(buffer, 0, offset, previousCharacter);
+        char32_t previousCharacter = StringView(buffer).codePointBefore(offset);
 
         if (isSeparator(firstCharacter)) {
             // The start of a separator run is a word start (".org" in "webkit.org").

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -238,11 +238,11 @@ String capitalize(const String& string, char32_t previousCharacter)
     // Replace NO BREAK SPACE with a normal spaces since ICU does not treat it as a word separator.
     std::array<char16_t, 2> previousCharacterUTF16;
     int32_t previousCharacterLength = 0;
-    U16_APPEND_UNSAFE(previousCharacterUTF16, previousCharacterLength, convertNoBreakSpaceToSpace(previousCharacter));
+    U16_APPEND_UNSAFE(previousCharacterUTF16, previousCharacterLength, previousCharacter);
 
     Vector<char16_t> stringWithPrevious(previousCharacterLength + length);
     for (int32_t i = 0; i < previousCharacterLength; ++i)
-        stringWithPrevious[i] = previousCharacterUTF16[i];
+        stringWithPrevious[i] = convertNoBreakSpaceToSpace(previousCharacterUTF16[i]);
     for (int32_t i = previousCharacterLength; i < length + previousCharacterLength; ++i)
         stringWithPrevious[i] = convertNoBreakSpaceToSpace(stringImpl[i - previousCharacterLength]);
 
@@ -1567,12 +1567,7 @@ char32_t RenderText::previousCharacter() const
     unsigned length = previousString.length();
     if (!length)
         return ' ';
-    if (previousString.is8Bit())
-        return previousString[length - 1];
-    unsigned offset = length;
-    char32_t codePoint;
-    U16_PREV(previousString, 0, offset, codePoint);
-    return codePoint;
+    return StringView(previousString).codePointBefore(length);
 }
 
 static String convertToFullSizeKana(const String& string)

--- a/Source/WebCore/rendering/RenderTextFragment.cpp
+++ b/Source/WebCore/rendering/RenderTextFragment.cpp
@@ -91,8 +91,8 @@ char32_t RenderTextFragment::previousCharacter() const
 {
     if (start()) {
         String original = textNode() ? textNode()->data() : contentString();
-        if (!original.isNull() && start() <= original.length())
-            return original[start() - 1];
+        if (start() <= original.length())
+            return StringView(original).codePointBefore(start());
     }
     return RenderText::previousCharacter();
 }


### PR DESCRIPTION
#### f05a4503950fc1e7ab2a9a010c12cb2c7407c0cf
<pre>
text-transform: capitalize should handle supplementary Unicode characters
<a href="https://bugs.webkit.org/show_bug.cgi?id=311394">https://bugs.webkit.org/show_bug.cgi?id=311394</a>

Reviewed by Darin Adler.

Fix two issues with text-transform:capitalize when the previous character
is a supplementary Unicode character (encoded as a surrogate pair in UTF-16):

1. RenderTextFragment::previousCharacter() used operator[] to get the last
   character before the fragment start, which returns a single char16_t.
   When the previous character is supplementary (e.g. U+1D400), this returns
   a lone trailing surrogate instead of the full code point. Fix by adding
   a new StringView::codePointBefore() helper that properly decodes
   surrogate pairs using ICU&apos;s U16_PREV macro. Adopt the new helper in
   RenderText::previousCharacter(), RenderTextFragment::previousCharacter(),
   and ICUSearcher&apos;s isWordStartMatch().

2. capitalize() passed the char32_t previous character through
   convertNoBreakSpaceToSpace() before U16_APPEND_UNSAFE, which silently
   truncated supplementary characters (U+1D400 became U+D400). This caused
   U16_APPEND_UNSAFE to write a single wrong code unit instead of a
   surrogate pair, so ICU&apos;s word break iterator saw a different character
   and inserted a spurious word boundary. Fix by moving the
   convertNoBreakSpaceToSpace() call into the loop over the resulting
   char16_t code units, and narrowing its type to char16_t since it now
   only operates on code units.

Test: imported/w3c/web-platform-tests/css/css-pseudo/first-letter-capitalize-supplementary-char.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-capitalize-supplementary-char-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/first-letter-capitalize-supplementary-char.html: Added.
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::characterStartingAt const):
(WTF::StringView::codePointBefore const):
* Source/WebCore/editing/ICUSearcher.cpp:
(WebCore::isWordStartMatch):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::capitalize):
(WebCore::RenderText::previousCharacter const):
* Source/WebCore/rendering/RenderTextFragment.cpp:
(WebCore::RenderTextFragment::previousCharacter const):

Canonical link: <a href="https://commits.webkit.org/310597@main">https://commits.webkit.org/310597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23f9b2ec4aeb20fbee70ac33d2b4b66c7cba5149

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20715 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163051 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107766 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/45611cbb-bd70-4d87-b413-60d15b57bf41) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27405 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119332 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84365 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/554da95f-b1aa-490b-a6e4-6a251626fcda) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157256 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21596 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138571 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100028 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/937363f9-3646-4afe-b9aa-24d8e767a752) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20684 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18691 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10883 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146346 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130346 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165523 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15128 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8732 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18025 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127427 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27101 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22733 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127572 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34620 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27025 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138209 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83645 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22460 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15001 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185932 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26715 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90818 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47680 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26296 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26527 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26369 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->