### PR TITLE
Use std::isfinite instead of manual !isnan && !isinf checks in WebAudio

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
@@ -602,7 +602,7 @@ double AudioBufferSourceNode::totalPitchRate()
 
     totalRate = std::clamp(totalRate, -MaxRate, MaxRate);
     
-    bool isTotalRateValid = !std::isnan(totalRate) && !std::isinf(totalRate);
+    bool isTotalRateValid = std::isfinite(totalRate);
     ASSERT(isTotalRateValid);
     if (!isTotalRateValid)
         totalRate = 1.0;

--- a/Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp
@@ -128,12 +128,12 @@ ExceptionOr<void> AudioParamTimeline::setValueCurveAtTime(Vector<float>&& curve,
 
 static bool NODELETE isValidNumber(float x)
 {
-    return !std::isnan(x) && !std::isinf(x);
+    return std::isfinite(x);
 }
 
 static bool NODELETE isValidNumber(Seconds s)
 {
-    return !std::isnan(s.value()) && !std::isinf(s.value());
+    return std::isfinite(s.value());
 }
 
 ExceptionOr<void> AudioParamTimeline::insertEvent(ParamEvent&& event)


### PR DESCRIPTION
#### 2ec44a1d32e25df03fec224594a2f614f9ea6135
<pre>
Use std::isfinite instead of manual !isnan &amp;&amp; !isinf checks in WebAudio
<a href="https://bugs.webkit.org/show_bug.cgi?id=311399">https://bugs.webkit.org/show_bug.cgi?id=311399</a>
<a href="https://rdar.apple.com/173992658">rdar://173992658</a>

Reviewed by Chris Dumez.

Replace `!std::isnan(x) &amp;&amp; !std::isinf(x)` with the equivalent
`std::isfinite(x)` [1] in WebAudio code.

[1] <a href="https://en.cppreference.com/w/cpp/numeric/math/isfinite">https://en.cppreference.com/w/cpp/numeric/math/isfinite</a>

* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp:
(WebCore::AudioBufferSourceNode::totalPitchRate):
* Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp:
(WebCore::isValidNumber):

Canonical link: <a href="https://commits.webkit.org/310517@main">https://commits.webkit.org/310517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ab5bd62203cdbc8a358363ab5919a83eeb46c84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162802 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107516 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155923 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119137 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84223 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21374 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138326 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99837 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20463 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18458 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10635 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130120 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16178 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165275 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8475 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17779 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127233 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26853 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22494 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127380 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34562 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26776 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137972 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83355 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22251 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14760 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26467 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90559 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26048 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26278 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26120 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->