### PR TITLE
Use C++20 <bit> header functions in WebCore

### DIFF
--- a/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
+++ b/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
@@ -61,10 +61,7 @@ bool RealtimeAnalyser::setFftSize(size_t size)
     ASSERT(isMainThread());
 
     // Only allow powers of two.
-    unsigned log2size = static_cast<unsigned>(log2(size));
-    bool isPOT(1UL << log2size == size);
-
-    if (!isPOT || size > MaxFFTSize || size < MinFFTSize)
+    if (!isPowerOfTwo(size) || size > MaxFFTSize || size < MinFFTSize)
         return false;
 
     if (m_fftSize != size) {

--- a/Source/WebCore/platform/audio/HRTFKernel.cpp
+++ b/Source/WebCore/platform/audio/HRTFKernel.cpp
@@ -56,7 +56,7 @@ static float extractAverageGroupDelay(AudioChannel* channel, size_t analysisFFTS
         return 0;
     
     // Check for power-of-2.
-    ASSERT(1UL << static_cast<unsigned>(log2(analysisFFTSize)) == analysisFFTSize);
+    ASSERT(isPowerOfTwo(analysisFFTSize));
 
     FFTFrame estimationFrame(analysisFFTSize);
     estimationFrame.doFFT(impulseP);

--- a/Source/WebCore/platform/audio/HRTFPanner.cpp
+++ b/Source/WebCore/platform/audio/HRTFPanner.cpp
@@ -79,7 +79,7 @@ size_t HRTFPanner::fftSizeForSampleRate(float sampleRate)
 
     // This is the size used for analysis frames in the HRTF kernel. The
     // convolvers used by the kernel are twice this size.
-    int analysisFFTSize = 1 << static_cast<unsigned>(log2(resampledLength));
+    int analysisFFTSize = std::bit_floor(static_cast<unsigned>(resampledLength));
 
     // Don't let the analysis size be smaller than the supported size
     analysisFFTSize = std::max(analysisFFTSize, FFTFrame::minFFTSize());
@@ -209,7 +209,7 @@ void HRTFPanner::pan(double desiredAzimuth, double elevation, const AudioBus& in
     }
 
     // This algorithm currently requires that we process in power-of-two size chunks at least AudioUtilities::renderQuantumSize.
-    ASSERT(1UL << static_cast<int>(log2(framesToProcess)) == framesToProcess);
+    ASSERT(isPowerOfTwo(framesToProcess));
     ASSERT(framesToProcess >= AudioUtilities::renderQuantumSize);
 
     const unsigned framesPerSegment = AudioUtilities::renderQuantumSize;

--- a/Source/WebCore/platform/audio/cocoa/FFTFrameCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/FFTFrameCocoa.cpp
@@ -61,7 +61,7 @@ FFTFrame::FFTFrame(unsigned fftSize)
     , m_imagData(fftSize)
 {
     m_FFTSize = fftSize;
-    m_log2FFTSize = static_cast<unsigned>(log2(fftSize));
+    m_log2FFTSize = std::bit_width(fftSize) - 1;
 
     // We only allow power of two
     ASSERT(1UL << m_log2FFTSize == m_FFTSize);
@@ -133,7 +133,7 @@ void FFTFrame::doInverseFFT(std::span<float> data)
 
 FFTSetup FFTFrame::fftSetupForSize(unsigned fftSize)
 {
-    auto pow2size = static_cast<size_t>(log2(fftSize));
+    auto pow2size = static_cast<size_t>(std::bit_width(fftSize) - 1);
     ASSERT(pow2size < kMaxFFTPow2Size);
 
     Locker locker { fftSetupsLock };


### PR DESCRIPTION
#### ae620cf03592ffbe246918ad67439e1d71c570e9
<pre>
Use C++20 &lt;bit&gt; header functions in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=311406">https://bugs.webkit.org/show_bug.cgi?id=311406</a>
<a href="https://rdar.apple.com/174003269">rdar://174003269</a>

Reviewed by Darin Adler.

Replace manual bit manipulation with C++20 &lt;bit&gt; functions:
- std::bit_floor replaces hand-rolled roundDownToPowerOfTwo
- std::bit_width replaces manual integralLog2 loop and floating-point log2() on integers
- WTF::isPowerOfTwo replaces verbose 1UL &lt;&lt; log2(x) == x power-of-2 checks

* Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp:
(WebCore::RealtimeAnalyser::setFftSize):
* Source/WebCore/platform/audio/HRTFKernel.cpp:
(WebCore::extractAverageGroupDelay):
* Source/WebCore/platform/audio/HRTFPanner.cpp:
(WebCore::HRTFPanner::fftSizeForSampleRate):
(WebCore::HRTFPanner::pan):
* Source/WebCore/platform/audio/cocoa/FFTFrameCocoa.cpp:
(WebCore::FFTFrame::FFTFrame):
(WebCore::FFTFrame::fftSetupForSize):

Canonical link: <a href="https://commits.webkit.org/310710@main">https://commits.webkit.org/310710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7b9464b562cf75f6192b0898e117922c3332a6b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27874 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163373 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108084 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5b2a75ad-6d44-49a0-a53b-763b72dca080) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156488 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28007 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27723 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119592 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84579 "3 flakes 1 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/83bbd475-b27f-4af0-b565-2c7944dec1a9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21880 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138862 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100289 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20965 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18982 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11201 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130628 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16706 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165845 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9050 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127695 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27419 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127838 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34704 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27343 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138499 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84025 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22733 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15293 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27035 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91137 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26613 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26844 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26686 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->