### PR TITLE
WebRTC VP9 encoders should propagate frame colorspace

### DIFF
--- a/LayoutTests/http/wpt/mediastream/webrtc-vp9-colorspace-expected.txt
+++ b/LayoutTests/http/wpt/mediastream/webrtc-vp9-colorspace-expected.txt
@@ -1,0 +1,4 @@
+
+PASS WebRTC VP9 encoder should preserve color space through WebRTC - bt709
+PASS WebRTC VP9 encoder should preserve color space through WebRTC - smpte170m
+

--- a/LayoutTests/http/wpt/mediastream/webrtc-vp9-colorspace.html
+++ b/LayoutTests/http/wpt/mediastream/webrtc-vp9-colorspace.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>WebRTC VP9 encoder color space preservation</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/webrtc/RTCPeerConnection-helper.js"></script>
+</head>
+<body>
+<script>
+async function getLocalTrack(test, colorPrimaries)
+{
+    const generatorWorkerCode = `
+        function makeVideoFrameFromBuffer(width, height, colorSpace) {
+            // Create I420 buffer (YUV 4:2:0 planar format)
+            const yPlaneSize = width * height;
+            const uvPlaneSize = (width / 2) * (height / 2);
+            const totalSize = yPlaneSize + 2 * uvPlaneSize;
+
+            const buffer = new Uint8Array(totalSize);
+
+            for (let y = 0; y < height; y++) {
+                for (let x = 0; x < width; x++) {
+                    const index = y * width + x;
+                    // Create a simple pattern
+                    buffer[index] = ((x + y) % 256);
+                }
+            }
+
+            const uOffset = yPlaneSize;
+            for (let y = 0; y < height / 2; y++) {
+                for (let x = 0; x < width / 2; x++) {
+                    const index = uOffset + y * (width / 2) + x;
+                    buffer[index] = 128 + (x % 64);
+                }
+            }
+
+            const vOffset = yPlaneSize + uvPlaneSize;
+            for (let y = 0; y < height / 2; y++) {
+                for (let x = 0; x < width / 2; x++) {
+                    const index = vOffset + y * (width / 2) + x;
+                    buffer[index] = 128 + (y % 64);
+                }
+            }
+
+            return new VideoFrame(buffer, {
+                format: 'I420',
+                codedWidth: width,
+                codedHeight: height,
+                timestamp: performance.now() * 1000,
+                colorSpace: colorSpace
+            });
+        }
+
+        let frameInterval = null;
+        let writer = null;
+        let generator = null;
+
+        self.onmessage = async (event) => {
+            if (event.data.type === 'start') {
+                generator = new VideoTrackGenerator();
+                writer = generator.writable.getWriter();
+
+                const colorSpace = {
+                    primaries: "${colorPrimaries}"
+                };
+
+                frameInterval = setInterval(() => {
+                    const frame = makeVideoFrameFromBuffer(320, 240, colorSpace);
+                    writer.write(frame).catch(() => {});
+                }, 100);
+
+                const processor = new MediaStreamTrackProcessor({ track: generator.track });
+                const reader = processor.readable.getReader();
+
+                const result = await reader.read();
+                const frame = result.value;
+
+                const colorSpaceInfo = {
+                    primaries: frame.colorSpace.primaries,
+                    transfer: frame.colorSpace.transfer,
+                    matrix: frame.colorSpace.matrix
+                };
+
+                frame.close();
+                reader.releaseLock();
+
+                self.postMessage({
+                    type: 'track',
+                    track: generator.track,
+                    colorSpace: colorSpaceInfo
+                }, [generator.track]);
+            } else if (event.data.type === 'stop') {
+                if (frameInterval)
+                    clearInterval(frameInterval);
+                if (writer)
+                    writer.close().catch(() => {});
+            }
+        };
+    `;
+
+    const generatorBlob = new Blob([generatorWorkerCode], { type: 'application/javascript' });
+    const generatorWorkerUrl = URL.createObjectURL(generatorBlob);
+    const generatorWorker = new Worker(generatorWorkerUrl);
+
+    test.add_cleanup(() => {
+        generatorWorker.postMessage({ type: 'stop' });
+        generatorWorker.terminate();
+        URL.revokeObjectURL(generatorWorkerUrl);
+    });
+
+    const { localTrack, localColorSpace } = await new Promise((resolve) => {
+        generatorWorker.onmessage = (event) => {
+            if (event.data.type === 'track')
+                resolve({
+                    localTrack: event.data.track,
+                    localColorSpace: event.data.colorSpace
+                });
+        };
+        generatorWorker.postMessage({ type: 'start' });
+    });
+
+    test.add_cleanup(() => {
+        localTrack.stop();
+    });
+
+    assert_equals(localColorSpace.primaries, colorPrimaries, "Local frame primaries should be " + colorPrimaries);
+
+    return localTrack;
+}
+
+async function sendTrackWithVP9(test, localTrack)
+{
+    const pc1 = new RTCPeerConnection();
+    const pc2 = new RTCPeerConnection();
+
+    test.add_cleanup(() => {
+        pc1.close();
+        pc2.close();
+    });
+
+    const sender = pc1.addTrack(localTrack);
+    const transceiver = pc1.getTransceivers().find(t => t.sender === sender);
+
+    const capabilities = RTCRtpSender.getCapabilities('video');
+    const vp9Codecs = capabilities.codecs.filter(codec => codec.mimeType === 'video/VP9');
+    assert_true(vp9Codecs.length > 0, "VP9 codec should be supported");
+    transceiver.setCodecPreferences(vp9Codecs);
+
+    const remoteTrackPromise = new Promise((resolve) => {
+        pc2.ontrack = (event) => {
+            resolve(event.track);
+        };
+    });
+
+    pc1.onicecandidate = (event) => {
+        if (event.candidate)
+            pc2.addIceCandidate(event.candidate);
+    };
+
+    pc2.onicecandidate = (event) => {
+        if (event.candidate)
+            pc1.addIceCandidate(event.candidate);
+    };
+
+    const offer = await pc1.createOffer();
+    await pc1.setLocalDescription(offer);
+    await pc2.setRemoteDescription(offer);
+
+    const answer = await pc2.createAnswer();
+    await pc2.setLocalDescription(answer);
+    await pc1.setRemoteDescription(answer);
+
+    return remoteTrackPromise;
+}
+
+function getRemoteTrackColor(test, remoteTrack) {
+    const remoteVerifyWorkerCode = `
+        self.onmessage = async (event) => {
+            if (event.data.type === 'verify') {
+                const track = event.data.track;
+                const processor = new MediaStreamTrackProcessor({ track: track });
+                const reader = processor.readable.getReader();
+
+                const result = await reader.read();
+                const frame = result.value;
+                self.postMessage({ type: 'result', primaries:frame.colorSpace.primaries });
+                frame.close();
+                reader.releaseLock();
+            }
+        };
+    `;
+
+    const remoteVerifyBlob = new Blob([remoteVerifyWorkerCode], { type: 'application/javascript' });
+    const remoteVerifyWorkerUrl = URL.createObjectURL(remoteVerifyBlob);
+    const remoteVerifyWorker = new Worker(remoteVerifyWorkerUrl);
+
+    test.add_cleanup(() => {
+        remoteVerifyWorker.terminate();
+        URL.revokeObjectURL(remoteVerifyWorkerUrl);
+    });
+
+    const frameColorPromise = new Promise((resolve) => {
+        remoteVerifyWorker.onmessage = (event) => {
+            if (event.data.type === 'result')
+                resolve(event.data.primaries);
+        };
+    });
+    remoteVerifyWorker.postMessage({ type: 'verify', track: remoteTrack }, [remoteTrack]);
+    return frameColorPromise;
+}
+
+function doTest(colorPrimaries) {
+    promise_test(async (test) => {
+        const localTrack = await getLocalTrack(test, colorPrimaries);
+        const remoteTrack = await sendTrackWithVP9(test, localTrack);
+        const frameColor = await getRemoteTrackColor(test, remoteTrack);
+        assert_equals(frameColor, colorPrimaries,  "At least one remote frame should have the expected color space primaries");
+    }, "WebRTC VP9 encoder should preserve color space through WebRTC - " + colorPrimaries);
+}
+
+doTest("bt709");
+doTest("smpte170m");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2786,6 +2786,8 @@ webkit.org/b/265865 imported/w3c/web-platform-tests/webrtc-stats/rtp-stats-creat
 
 fast/mediastream/video-rotation2.html [ Failure Pass Timeout ]
 
+http/wpt/mediastream/webrtc-vp9-colorspace.html [ Failure ]
+
 # Regressions introduced by https://commits.webkit.org/263750@main
 fast/mediastream/apply-constraints-advanced.html [ Failure ]
 fast/mediastream/apply-constraints-video.html [ Failure ]

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.cpp
@@ -31,6 +31,7 @@
 
 #if USE(LIBWEBRTC)
 
+#include "LibWebRTCVideoFrameUtilities.h"
 #include "Logging.h"
 
 ALLOW_UNUSED_PARAMETERS_BEGIN
@@ -259,15 +260,19 @@ void RealtimeOutgoingVideoSource::sendBlackFramesIfNeeded()
 void RealtimeOutgoingVideoSource::sendOneBlackFrame()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    sendFrame(webrtc::scoped_refptr { m_blackFrame.get() });
+    sendFrame(webrtc::scoped_refptr { m_blackFrame.get() }, { });
 }
 
-void RealtimeOutgoingVideoSource::sendFrame(webrtc::scoped_refptr<webrtc::VideoFrameBuffer>&& buffer)
+void RealtimeOutgoingVideoSource::sendFrame(webrtc::scoped_refptr<webrtc::VideoFrameBuffer>&& buffer, const PlatformVideoColorSpace& colorSpace)
 {
+
     MonotonicTime timestamp = MonotonicTime::now();
     webrtc::VideoFrame frame(buffer, m_isApplyingRotation ? webrtc::kVideoRotation_0 : m_currentRotation, static_cast<int64_t>(timestamp.secondsSinceEpoch().microseconds()));
 
-    // FIXME: set color space based on VideoFrame.
+    if (colorSpace.isValid()) {
+        if (auto webrtColorSpace = toWebRTCColorSpace(colorSpace))
+            frame.set_color_space(*webrtColorSpace);
+    }
 
 #if !RELEASE_LOG_DISABLED
     ++m_frameCount;

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
@@ -40,6 +40,8 @@
 
 namespace WebCore {
 
+struct PlatformVideoColorSpace;
+
 class RealtimeOutgoingVideoSource
     : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeOutgoingVideoSource, WTF::DestructionThread::Main>
     , public webrtc::VideoTrackSourceInterface
@@ -74,7 +76,7 @@ public:
 protected:
     explicit RealtimeOutgoingVideoSource(Ref<MediaStreamTrackPrivate>&&);
 
-    void sendFrame(webrtc::scoped_refptr<webrtc::VideoFrameBuffer>&&);
+    void sendFrame(webrtc::scoped_refptr<webrtc::VideoFrameBuffer>&&, const PlatformVideoColorSpace&);
     bool isSilenced() const { return m_muted || !m_enabled; }
 
     virtual webrtc::scoped_refptr<webrtc::VideoFrameBuffer> createBlackFrame(size_t width, size_t height) = 0;

--- a/Source/WebCore/platform/mediastream/cocoa/RealtimeOutgoingVideoSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/RealtimeOutgoingVideoSourceCocoa.cpp
@@ -89,6 +89,14 @@ void RealtimeOutgoingVideoSourceCocoa::videoFrameAvailable(VideoFrame& videoFram
         break;
     }
 
+    auto colorSpace = [&] {
+        if (auto pixelFormat = convertVideoFramePixelFormat(videoFrame.pixelFormat(), true)) {
+            if (isRGBVideoPixelFormat(*pixelFormat))
+                return PlatformVideoColorSpace { PlatformVideoColorPrimaries::Bt709, PlatformVideoTransferCharacteristics::Bt709, PlatformVideoMatrixCoefficients::Bt709, false };
+        }
+        return videoFrame.colorSpace();
+    }();
+
     auto videoFrameScaling = this->videoFrameScaling();
     bool isApplyingRotation = m_isApplyingRotation && m_currentRotation != webrtc::kVideoRotation_0;
     if (!isApplyingRotation) {
@@ -98,14 +106,14 @@ void RealtimeOutgoingVideoSourceCocoa::videoFrameAvailable(VideoFrame& videoFram
             sendFrame(webrtc::toWebRTCVideoFrameBuffer(&remoteVideoFrame.leakRef(),
                 [](auto* pointer) { return static_cast<VideoFrame*>(pointer)->pixelBuffer(); },
                 [](auto* pointer) { static_cast<VideoFrame*>(pointer)->deref(); },
-                static_cast<int>(size.width() * videoFrameScaling), static_cast<int>(size.height() * videoFrameScaling)));
+                static_cast<int>(size.width() * videoFrameScaling), static_cast<int>(size.height() * videoFrameScaling)), colorSpace);
             return;
         }
         if (auto* webrtcVideoFrame = dynamicDowncast<VideoFrameLibWebRTC>(videoFrame)) {
             auto webrtcBuffer = webrtcVideoFrame->buffer();
             if (videoFrameScaling != 1)
                 webrtcBuffer = webrtcBuffer->Scale(webrtcBuffer->width() * videoFrameScaling, webrtcBuffer->height() * videoFrameScaling);
-            sendFrame(WTF::move(webrtcBuffer));
+            sendFrame(WTF::move(webrtcBuffer), colorSpace);
             return;
         }
     }
@@ -128,7 +136,7 @@ void RealtimeOutgoingVideoSourceCocoa::videoFrameAvailable(VideoFrame& videoFram
     if (videoFrameScaling != 1)
         webrtcBuffer = webrtcBuffer->Scale(webrtcBuffer->width() * videoFrameScaling, webrtcBuffer->height() * videoFrameScaling);
 
-    sendFrame(WTF::move(webrtcBuffer));
+    sendFrame(WTF::move(webrtcBuffer), colorSpace);
 }
 
 webrtc::scoped_refptr<webrtc::VideoFrameBuffer> RealtimeOutgoingVideoSourceCocoa::createBlackFrame(size_t  width, size_t  height)

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingVideoSourceLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingVideoSourceLibWebRTC.cpp
@@ -75,7 +75,7 @@ void RealtimeOutgoingVideoSourceLibWebRTC::videoFrameAvailable(VideoFrame& video
     }
 
     GST_TRACE("Sending video frame");
-    sendFrame(GStreamerVideoFrameLibWebRTC::create(GRefPtr(static_cast<VideoFrameGStreamer&>(videoFrame).sample())));
+    sendFrame(GStreamerVideoFrameLibWebRTC::create(GRefPtr(static_cast<VideoFrameGStreamer&>(videoFrame).sample())), videoFrame.colorSpace());
 }
 
 webrtc::scoped_refptr<webrtc::VideoFrameBuffer> RealtimeOutgoingVideoSourceLibWebRTC::createBlackFrame(size_t  width, size_t  height)


### PR DESCRIPTION
#### 10e34010e28d267aeb51d1ab926244f6c91187b5
<pre>
WebRTC VP9 encoders should propagate frame colorspace
<a href="https://rdar.apple.com/174008548">rdar://174008548</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311410">https://bugs.webkit.org/show_bug.cgi?id=311410</a>

Reviewed by Eric Carlson.

When sending a WebCore VideoFrame in RealtimeOutgoingVideoSource::sendFrame, we make sure to populate the webrtc color space.
It is then up to each encoder to encode the color space so that the remote side will get the propoer information.
The VP9 encoder is supporting this, we add a test to validate this.
Other encoders, like H264/H265 might need updates to support this.
Like done for LibWebRTCVPXInternalVideoEncoder::encode, when encoding RGB frames, we use a BT709 color space as the encoder will do a conversion to YUV.
Covered by added test.

Canonical link: <a href="https://commits.webkit.org/311065@main">https://commits.webkit.org/311065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbe084868ff62d53285b8f9627c8f4d1060f5c70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163957 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108897 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157070 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28305 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120083 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84826 "2 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22342 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139372 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100778 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21428 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19478 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11783 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131092 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166435 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10588 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128188 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28001 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23513 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128325 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34936 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139003 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84634 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23193 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15799 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27618 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91722 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27196 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27426 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27269 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->