### PR TITLE
Avoid ref-counting churn in JSElementCustom.cpp and JSNodeCustom.cpp

### DIFF
--- a/Source/WebCore/bindings/js/JSElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSElementCustom.cpp
@@ -56,13 +56,13 @@ using namespace HTMLNames;
 
 static JSValue createNewElementWrapper(JSDOMGlobalObject* globalObject, Ref<Element>&& element)
 {
-    if (auto* htmlElement = dynamicDowncast<HTMLElement>(element.get()))
-        return createJSHTMLWrapper(globalObject, *htmlElement);
-    if (auto* svgElement = dynamicDowncast<SVGElement>(element.get()))
-        return createJSSVGWrapper(globalObject, *svgElement);
+    if (is<HTMLElement>(element))
+        return createJSHTMLWrapper(globalObject, uncheckedDowncast<HTMLElement>(WTF::move(element)));
+    if (is<SVGElement>(element))
+        return createJSSVGWrapper(globalObject, uncheckedDowncast<SVGElement>(WTF::move(element)));
 #if ENABLE(MATHML)
-    if (auto* mathmlElement = dynamicDowncast<MathMLElement>(element.get()))
-        return createJSMathMLWrapper(globalObject, *mathmlElement);
+    if (is<MathMLElement>(element))
+        return createJSMathMLWrapper(globalObject, uncheckedDowncast<MathMLElement>(WTF::move(element)));
 #endif
     return createWrapper<Element>(globalObject, WTF::move(element));
 }

--- a/Source/WebCore/bindings/js/JSNodeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNodeCustom.cpp
@@ -99,13 +99,13 @@ static ALWAYS_INLINE JSValue createWrapperInline(JSGlobalObject* lexicalGlobalOb
     JSDOMObject* wrapper;    
     switch (node->nodeType()) {
     case NodeType::Element:
-        if (auto* htmlElement = dynamicDowncast<HTMLElement>(node.get()))
-            wrapper = createJSHTMLWrapper(globalObject, *htmlElement);
-        else if (auto* svgElement = dynamicDowncast<SVGElement>(node.get()))
-            wrapper = createJSSVGWrapper(globalObject, *svgElement);
+        if (is<HTMLElement>(node))
+            wrapper = createJSHTMLWrapper(globalObject, uncheckedDowncast<HTMLElement>(WTF::move(node)));
+        else if (is<SVGElement>(node))
+            wrapper = createJSSVGWrapper(globalObject, uncheckedDowncast<SVGElement>(WTF::move(node)));
 #if ENABLE(MATHML)
-        else if (auto* mathmlElement = dynamicDowncast<MathMLElement>(node.get()))
-            wrapper = createJSMathMLWrapper(globalObject, *mathmlElement);
+        else if (is<MathMLElement>(node))
+            wrapper = createJSMathMLWrapper(globalObject, uncheckedDowncast<MathMLElement>(WTF::move(node)));
 #endif
         else
             wrapper = createWrapper<Element>(globalObject, WTF::move(node));


### PR DESCRIPTION
#### 12e7b01211e294de6f757c05659184bf63f8b070
<pre>
Avoid ref-counting churn in JSElementCustom.cpp and JSNodeCustom.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=311412">https://bugs.webkit.org/show_bug.cgi?id=311412</a>

Reviewed by Anne van Kesteren.

We have a Ref and the createJS*Wrapper() functions take in a Ref&amp;&amp;.
WTF::move() our ref directly into the createJS*Wrapper() to avoid
ref-counting churn.

* Source/WebCore/bindings/js/JSElementCustom.cpp:
(WebCore::createNewElementWrapper):
* Source/WebCore/bindings/js/JSNodeCustom.cpp:
(WebCore::createWrapperInline):

Canonical link: <a href="https://commits.webkit.org/310515@main">https://commits.webkit.org/310515@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe2cf4b328ac19c24d901c580fcf691163089da0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162832 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107546 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff99f5d5-6b6f-4f29-a79a-7b49c92af28a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119164 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84246 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e667d32-2596-48b7-aaad-3ad866a5c169) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21401 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138361 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99864 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b6dc4bda-315e-4abf-841f-52e338c9abac) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18486 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10665 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/130147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165305 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/8505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17813 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127255 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127407 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34561 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26806 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138006 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83390 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22274 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14794 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26497 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90589 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26078 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26308 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26150 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->