### PR TITLE
Avoid temporary String allocations in CSSParserToken::serialize()

### DIFF
--- a/Source/WebCore/css/CSSContainerRule.cpp
+++ b/Source/WebCore/css/CSSContainerRule.cpp
@@ -71,7 +71,7 @@ String CSSContainerRule::containerName() const
 
     auto name = styleRuleContainer().containerQuery().name;
     if (!name.isEmpty())
-        serializeIdentifier(name, builder);
+        serializeIdentifier(builder, name);
 
     return builder.toString();
 }

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
@@ -387,9 +387,9 @@ String CSSCounterStyleDescriptors::Symbol::cssText() const
 {
     StringBuilder builder;
     if (isCustomIdent)
-        serializeIdentifier(text, builder);
+        serializeIdentifier(builder, text);
     else
-        serializeString(text, builder);
+        serializeString(builder, text);
     return builder.toString();
 }
 

--- a/Source/WebCore/css/CSSCounterValue.cpp
+++ b/Source/WebCore/css/CSSCounterValue.cpp
@@ -61,7 +61,7 @@ String CSSCounterValue::customCSSText(const CSS::SerializationContext&) const
         return makeString("counter("_s, m_identifier, styleSeparator, styleLiteral, ')');
     StringBuilder result;
     result.append("counters("_s, m_identifier, ", "_s);
-    serializeString(m_separator, result);
+    serializeString(result, m_separator);
     result.append(styleSeparator, styleLiteral, ')');
     return result.toString();
 }

--- a/Source/WebCore/css/CSSFontFeatureValuesRule.cpp
+++ b/Source/WebCore/css/CSSFontFeatureValuesRule.cpp
@@ -57,7 +57,7 @@ String CSSFontFeatureValuesRule::cssText() const
         if (!tags.isEmpty()) {
             builder.append('@', variantName, " { "_s);
             for (auto tag : tags) {
-                serializeIdentifier(tag.key, builder);
+                serializeIdentifier(builder, tag.key);
                 builder.append(':');
                 for (auto integer : tag.value)
                     builder.append(' ', integer);

--- a/Source/WebCore/css/CSSFunctionRule.cpp
+++ b/Source/WebCore/css/CSSFunctionRule.cpp
@@ -71,13 +71,13 @@ String CSSFunctionRule::cssText() const
 {
     StringBuilder builder;
     builder.append("@function "_s);
-    serializeIdentifier(name(), builder);
+    serializeIdentifier(builder, name());
     builder.append('(');
 
     auto separator = ""_s;
     for (auto& parameter : styleRuleFunction().parameters()) {
         builder.append(separator);
-        serializeIdentifier(parameter.name, builder);
+        serializeIdentifier(builder, parameter.name);
         // FIXME: Serialize the type.
 
         if (RefPtr defaultValue = parameter.defaultValue)

--- a/Source/WebCore/css/CSSGridLineNamesValue.cpp
+++ b/Source/WebCore/css/CSSGridLineNamesValue.cpp
@@ -44,7 +44,7 @@ String CSSGridLineNamesValue::customCSSText(const CSS::SerializationContext&) co
     for (auto& name : m_names) {
         if (!std::exchange(first, false))
             result.append(' ');
-        serializeIdentifier(name, result);
+        serializeIdentifier(result, name);
     }
     result.append(']');
     return result.toString();

--- a/Source/WebCore/css/CSSLayerBlockRule.cpp
+++ b/Source/WebCore/css/CSSLayerBlockRule.cpp
@@ -73,7 +73,7 @@ String stringFromCascadeLayerName(const CascadeLayerName& name)
 {
     StringBuilder result;
     for (auto& segment : name) {
-        serializeIdentifier(segment, result);
+        serializeIdentifier(result, segment);
         if (&segment != &name.last())
             result.append('.');
     }

--- a/Source/WebCore/css/CSSMarkup.cpp
+++ b/Source/WebCore/css/CSSMarkup.cpp
@@ -53,7 +53,7 @@ static inline bool NODELETE isCSSTokenizerIdentifier(std::span<const CharacterTy
 }
 
 // "ident" from the CSS tokenizer, minus backslash-escape sequences
-static bool NODELETE isCSSTokenizerIdentifier(const String& string)
+static bool NODELETE isCSSTokenizerIdentifier(StringView string)
 {
     if (string.isEmpty())
         return false;
@@ -63,19 +63,19 @@ static bool NODELETE isCSSTokenizerIdentifier(const String& string)
     return isCSSTokenizerIdentifier(string.span16());
 }
 
-static void serializeCharacter(char32_t c, StringBuilder& appendTo)
+static void serializeCharacter(StringBuilder& appendTo, char32_t c)
 {
     appendTo.append('\\', c);
 }
 
-static void serializeCharacterAsCodePoint(char32_t c, StringBuilder& appendTo)
+static void serializeCharacterAsCodePoint(StringBuilder& appendTo, char32_t c)
 {
     appendTo.append('\\', hex(c, Lowercase), ' ');
 }
 
-void serializeIdentifier(const String& identifier, StringBuilder& appendTo, bool skipStartChecks)
+void serializeIdentifier(StringBuilder& appendTo, StringView identifier, ShouldSkipStartChecks skipStartChecks)
 {
-    bool isFirst = !skipStartChecks;
+    bool isFirst = skipStartChecks == ShouldSkipStartChecks::No;
     bool isSecond = false;
     bool isFirstCharHyphen = false;
     unsigned index = 0;
@@ -87,13 +87,13 @@ void serializeIdentifier(const String& identifier, StringBuilder& appendTo, bool
         if (!c)
             appendTo.append(replacementCharacter);
         else if (c <= 0x1f || c == deleteCharacter || (0x30 <= c && c <= 0x39 && (isFirst || (isSecond && isFirstCharHyphen))))
-            serializeCharacterAsCodePoint(c, appendTo);
+            serializeCharacterAsCodePoint(appendTo, c);
         else if (c == hyphenMinus && isFirst && index == identifier.length())
-            serializeCharacter(c, appendTo);
+            serializeCharacter(appendTo, c);
         else if (0x80 <= c || c == hyphenMinus || c == lowLine || (0x30 <= c && c <= 0x39) || (0x41 <= c && c <= 0x5a) || (0x61 <= c && c <= 0x7a))
             appendTo.append(c);
         else
-            serializeCharacter(c, appendTo);
+            serializeCharacter(appendTo, c);
 
         if (isFirst) {
             isFirst = false;
@@ -104,7 +104,7 @@ void serializeIdentifier(const String& identifier, StringBuilder& appendTo, bool
     }
 }
 
-void serializeString(const String& string, StringBuilder& appendTo)
+void serializeString(StringBuilder& appendTo, StringView string)
 {
     appendTo.append('"');
 
@@ -114,9 +114,9 @@ void serializeString(const String& string, StringBuilder& appendTo)
         index += U16_LENGTH(c);
 
         if (c <= 0x1f || c == deleteCharacter)
-            serializeCharacterAsCodePoint(c, appendTo);
+            serializeCharacterAsCodePoint(appendTo, c);
         else if (c == quotationMark || c == reverseSolidus)
-            serializeCharacter(c, appendTo);
+            serializeCharacter(appendTo, c);
         else
             appendTo.append(c);
     }
@@ -124,18 +124,18 @@ void serializeString(const String& string, StringBuilder& appendTo)
     appendTo.append('"');
 }
 
-String serializeString(const String& string)
+String serializeString(StringView string)
 {
     StringBuilder builder;
-    serializeString(string, builder);
+    serializeString(builder, string);
     return builder.toString();
 }
 
-String serializeURL(const String& string)
+String serializeURL(StringView string)
 {
     StringBuilder builder;
     builder.append("url("_s);
-    serializeString(string, builder);
+    serializeString(builder, string);
     builder.append(')');
     return builder.toString();
 }

--- a/Source/WebCore/css/CSSMarkup.h
+++ b/Source/WebCore/css/CSSMarkup.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <wtf/text/StringView.h>
 #include <wtf/text/WTFString.h>
 
 // Helper functions for converting from CSSValues to text.
@@ -29,10 +30,11 @@
 namespace WebCore {
 
 // Common serializing methods. See: http://dev.w3.org/csswg/cssom/#common-serializing-idioms
-void serializeIdentifier(const String& identifier, StringBuilder& appendTo, bool skipStartChecks = false);
-void serializeString(const String&, StringBuilder& appendTo);
-String serializeString(const String&);
-String serializeURL(const String&);
+enum class ShouldSkipStartChecks : bool { No, Yes };
+void serializeIdentifier(StringBuilder& appendTo, StringView identifier, ShouldSkipStartChecks = ShouldSkipStartChecks::No);
+void serializeString(StringBuilder& appendTo, StringView);
+String serializeString(StringView);
+String serializeURL(StringView);
 String serializeFontFamily(const String&);
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSNamespaceRule.cpp
+++ b/Source/WebCore/css/CSSNamespaceRule.cpp
@@ -55,7 +55,7 @@ String CSSNamespaceRule::cssText() const
     auto prefix = this->prefix();
     StringBuilder result;
     result.append("@namespace "_s);
-    serializeIdentifier(prefix, result);
+    serializeIdentifier(result, prefix);
     result.append(prefix.isEmpty() ? ""_s : " "_s, "url("_s, serializeString(namespaceURI()), ");"_s);
     return result.toString();
 }

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -1025,7 +1025,7 @@ ALWAYS_INLINE String CSSPrimitiveValue::serializeInternal(const CSS::Serializati
         return serializeString(m_value.string);
     case CSSUnitType::CustomIdent: {
         StringBuilder builder;
-        serializeIdentifier(m_value.string, builder);
+        serializeIdentifier(builder, m_value.string);
         return builder.toString();
     }
 

--- a/Source/WebCore/css/CSSPropertyRule.cpp
+++ b/Source/WebCore/css/CSSPropertyRule.cpp
@@ -77,12 +77,12 @@ String CSSPropertyRule::cssText() const
     auto& descriptor = m_propertyRule->descriptor();
 
     builder.append("@property "_s);
-    serializeIdentifier(descriptor.name, builder);
+    serializeIdentifier(builder, descriptor.name);
     builder.append(" { "_s);
 
     if (!descriptor.syntax.isNull()) {
         builder.append("syntax: "_s);
-        serializeString(syntax(), builder);
+        serializeString(builder, syntax());
         builder.append("; "_s);
     }
 

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -418,9 +418,9 @@ static void appendPseudoClassFunctionTail(StringBuilder& builder, const CSSSelec
 static void appendPossiblyQuotedIdentifier(StringBuilder& builder, const PossiblyQuotedIdentifier& identifier)
 {
     if (!identifier.wasQuoted)
-        serializeIdentifier(identifier.identifier, builder);
+        serializeIdentifier(builder, identifier.identifier);
     else
-        serializeString(identifier.identifier, builder);
+        serializeString(builder, identifier.identifier);
 }
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, PossiblyQuotedIdentifier identifier)
@@ -477,7 +477,7 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
         if (identifier == starAtom())
             builder.append('*');
         else
-            serializeIdentifier(identifier, builder);
+            serializeIdentifier(builder, identifier);
     };
 
     StringBuilder builder;
@@ -499,12 +499,12 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
         }
         if (selector->match() == Match::Id) {
             builder.append('#');
-            serializeIdentifier(selector->serializingValue(), builder);
+            serializeIdentifier(builder, selector->serializingValue());
         } else if (selector->match() == Match::NestingParent) {
             builder.append('&');
         } else if (selector->match() == Match::Class) {
             builder.append('.');
-            serializeIdentifier(selector->serializingValue(), builder);
+            serializeIdentifier(builder, selector->serializingValue());
         } else if (selector->match() == Match::ForgivingUnknown || selector->match() == Match::ForgivingUnknownNestContaining) {
             builder.append(selector->value());
         } else if (selector->match() == Match::HasScope) {
@@ -556,7 +556,7 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
             }
             case PseudoClass::State:
                 builder.append('(');
-                serializeIdentifier(selector->argument(), builder);
+                serializeIdentifier(builder, selector->argument());
                 builder.append(')');
                 break;
             case PseudoClass::Heading:
@@ -573,7 +573,7 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
 
                 builder.append("("_s,
                     interleave(*selector->stringList(), [&](auto& builder, auto& partName) {
-                        serializeIdentifier(partName, builder);
+                        serializeIdentifier(builder, partName);
                     }, ", "_s),
                 ')');
                 break;
@@ -607,7 +607,7 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
 
                 builder.append("::part("_s,
                     interleave(*selector->stringList(), [&](auto& builder, auto& partName) {
-                        serializeIdentifier(partName, builder);
+                        serializeIdentifier(builder, partName);
                     }, ' '),
                 ')');
                 break;
@@ -629,7 +629,7 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
             default:
                 ASSERT(!pseudoElementMayHaveArgument(selector->pseudoElement()), "Missing serialization for pseudo-element argument");
                 builder.append("::"_s);
-                serializeIdentifier(selector->serializingValue(), builder);
+                serializeIdentifier(builder, selector->serializingValue());
                 break;
             }
         } else if (selector->isAttributeSelector()) {
@@ -666,7 +666,7 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
                 break;
             }
             if (selector->match() != Match::Set) {
-                serializeString(selector->serializingValue(), builder);
+                serializeString(builder, selector->serializingValue());
                 if (selector->attributeValueMatchingIsCaseInsensitive())
                     builder.append(" i]"_s);
                 else

--- a/Source/WebCore/css/DOMCSSNamespace.cpp
+++ b/Source/WebCore/css/DOMCSSNamespace.cpp
@@ -84,7 +84,7 @@ bool DOMCSSNamespace::supports(Document& document, const String& conditionText)
 String DOMCSSNamespace::escape(const String& ident)
 {
     StringBuilder builder;
-    serializeIdentifier(ident, builder);
+    serializeIdentifier(builder, ident);
     return builder.toString();
 }
 

--- a/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
@@ -415,7 +415,7 @@ void serializeMathFunctionArguments(StringBuilder& builder, const IndirectNode<R
 void serializeMathFunctionArguments(StringBuilder& builder, const IndirectNode<Anchor>& anchor, SerializationState& state)
 {
     if (!anchor->elementName.isNull()) {
-        serializeIdentifier(anchor->elementName, builder);
+        serializeIdentifier(builder, anchor->elementName);
         builder.append(' ');
     }
 
@@ -464,7 +464,7 @@ void serializeMathFunctionArguments(StringBuilder& builder, const IndirectNode<A
     bool hasElementName = !anchorSize->elementName.isNull();
 
     if (hasElementName)
-        serializeIdentifier(anchorSize->elementName, builder);
+        serializeIdentifier(builder, anchorSize->elementName);
 
     if (anchorSize->dimension) {
         if (hasElementName)
@@ -494,7 +494,7 @@ template<typename Op> void serializeMathFunctionArguments(StringBuilder& builder
         [&](const AtomString& root) {
             if (!root.isNull()) {
                 builder.append(std::exchange(separator, ", "_s));
-                serializeIdentifier(root, builder);
+                serializeIdentifier(builder, root);
             }
         },
         [&](const auto& root) {

--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -635,26 +635,26 @@ void CSSParserToken::serialize(StringBuilder& builder, const CSSParserToken* nex
 
     switch (type()) {
     case IdentToken:
-        serializeIdentifier(value().toString(), builder);
+        serializeIdentifier(builder, value());
         appendCommentIfNeeded({ IdentToken, FunctionToken, UrlToken, BadUrlToken, NumberToken, PercentageToken, DimensionToken, CDCToken, LeftParenthesisToken }, '-');
         break;
     case FunctionToken:
-        serializeIdentifier(value().toString(), builder);
+        serializeIdentifier(builder, value());
         builder.append('(');
         break;
     case AtKeywordToken:
         builder.append('@');
-        serializeIdentifier(value().toString(), builder);
+        serializeIdentifier(builder, value());
         appendCommentIfNeeded({ IdentToken, FunctionToken, UrlToken, BadUrlToken, NumberToken, PercentageToken, DimensionToken, CDCToken }, '-');
         break;
     case HashToken:
         builder.append('#');
-        serializeIdentifier(value().toString(), builder, (getHashTokenType() == HashTokenUnrestricted));
+        serializeIdentifier(builder, value(), (getHashTokenType() == HashTokenUnrestricted) ? ShouldSkipStartChecks::Yes : ShouldSkipStartChecks::No);
         appendCommentIfNeeded({ IdentToken, FunctionToken, UrlToken, BadUrlToken, NumberToken, PercentageToken, DimensionToken, CDCToken }, '-');
         break;
     case UrlToken:
         builder.append("url("_s);
-        serializeIdentifier(value().toString(), builder);
+        serializeIdentifier(builder, value());
         builder.append(')');
         break;
     case DelimiterToken:
@@ -713,12 +713,12 @@ void CSSParserToken::serialize(StringBuilder& builder, const CSSParserToken* nex
             builder.append(originalText());
         else {
             builder.append(numericValue());
-            serializeIdentifier(unitString().toString(), builder);
+            serializeIdentifier(builder, unitString());
         }
         appendCommentIfNeeded({ IdentToken, FunctionToken, UrlToken, BadUrlToken, NumberToken, PercentageToken, DimensionToken, CDCToken }, '-');
         break;
     case StringToken:
-        serializeString(value().toString(), builder);
+        serializeString(builder, value());
         break;
 
     case IncludeMatchToken:

--- a/Source/WebCore/css/query/ContainerQuery.cpp
+++ b/Source/WebCore/css/query/ContainerQuery.cpp
@@ -54,7 +54,7 @@ void serialize(StringBuilder& builder, const ContainerQuery& query)
 {
     auto name = query.name;
     if (!name.isEmpty()) {
-        serializeIdentifier(name, builder);
+        serializeIdentifier(builder, name);
         builder.append(' ');
     }
 

--- a/Source/WebCore/css/query/GenericMediaQuerySerialization.cpp
+++ b/Source/WebCore/css/query/GenericMediaQuerySerialization.cpp
@@ -89,7 +89,7 @@ void serialize(StringBuilder& builder, const Feature& feature)
 
     switch (feature.syntax) {
     case Syntax::Boolean:
-        serializeIdentifier(feature.name, builder);
+        serializeIdentifier(builder, feature.name);
         break;
 
     case Syntax::Plain:
@@ -107,7 +107,7 @@ void serialize(StringBuilder& builder, const Feature& feature)
             ASSERT_NOT_REACHED();
             break;
         }
-        serializeIdentifier(feature.name, builder);
+        serializeIdentifier(builder, feature.name);
 
         builder.append(": "_s, protect(feature.rightComparison->value)->cssText(CSS::defaultSerializationContext()));
         break;
@@ -118,7 +118,7 @@ void serialize(StringBuilder& builder, const Feature& feature)
             serializeRangeComparisonOperator(feature.leftComparison->op);
         }
 
-        serializeIdentifier(feature.name, builder);
+        serializeIdentifier(builder, feature.name);
 
         if (feature.rightComparison) {
             serializeRangeComparisonOperator(feature.rightComparison->op);

--- a/Source/WebCore/css/query/MediaQueryParser.cpp
+++ b/Source/WebCore/css/query/MediaQueryParser.cpp
@@ -206,7 +206,7 @@ void serialize(StringBuilder& builder, const MediaQuery& query)
     }
 
     if (!query.mediaType.isEmpty() && (!query.condition || query.prefix || query.mediaType != allAtom())) {
-        serializeIdentifier(query.mediaType, builder);
+        serializeIdentifier(builder, query.mediaType);
         if (query.condition)
             builder.append(" and "_s);
     }

--- a/Source/WebCore/css/typedom/CSSKeywordValue.cpp
+++ b/Source/WebCore/css/typedom/CSSKeywordValue.cpp
@@ -74,7 +74,7 @@ ExceptionOr<void> CSSKeywordValue::setValue(const String& value)
 void CSSKeywordValue::serialize(StringBuilder& builder, OptionSet<SerializationArguments>) const
 {
     // https://drafts.css-houdini.org/css-typed-om/#keywordvalue-serialization
-    serializeIdentifier(m_value, builder);
+    serializeIdentifier(builder, m_value);
 }
 
 RefPtr<CSSValue> CSSKeywordValue::toCSSValue() const

--- a/Source/WebCore/css/values/CSSValueTypes.cpp
+++ b/Source/WebCore/css/values/CSSValueTypes.cpp
@@ -38,7 +38,7 @@ namespace CSS {
 
 void serializationForCSSCustomIdentifier(StringBuilder& builder, const SerializationContext&, const CustomIdentifier& value)
 {
-    WebCore::serializeIdentifier(value.value, builder);
+    WebCore::serializeIdentifier(builder, value.value);
 }
 
 void serializationForCSSPropertyIdentifier(StringBuilder& builder, const SerializationContext&, const PropertyIdentifier& value)
@@ -48,12 +48,12 @@ void serializationForCSSPropertyIdentifier(StringBuilder& builder, const Seriali
 
 void serializationForCSSString(StringBuilder& builder, const SerializationContext&, const WTF::AtomString& value)
 {
-    WebCore::serializeString(value, builder);
+    WebCore::serializeString(builder, value);
 }
 
 void serializationForCSSString(StringBuilder& builder, const SerializationContext&, const WTF::String& value)
 {
-    WebCore::serializeString(value, builder);
+    WebCore::serializeString(builder, value);
 }
 
 Ref<CSSValue> makePrimitiveCSSValue(CSSValueID value)

--- a/Source/WebCore/css/values/primitives/CSSURL.cpp
+++ b/Source/WebCore/css/values/primitives/CSSURL.cpp
@@ -43,13 +43,13 @@ void Serialize<URL>::operator()(StringBuilder& builder, const SerializationConte
 
     if (!value.resolved.isNull()) {
         if (auto replacementURLString = context.replacementURLStrings.get(value.resolved.string()); !replacementURLString.isEmpty())
-            serializeString(replacementURLString, builder);
+            serializeString(builder, replacementURLString);
         else if (context.shouldUseResolvedURLInCSSText)
-            serializeString(value.resolved.string(), builder);
+            serializeString(builder, value.resolved.string());
         else
-            serializeString(value.specified, builder);
+            serializeString(builder, value.specified);
     } else
-        serializeString(value.specified, builder);
+        serializeString(builder, value.specified);
 
     if (value.modifiers.crossOrigin) {
         builder.append(' ');

--- a/Source/WebCore/css/values/shapes/CSSPathFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSPathFunction.cpp
@@ -46,7 +46,7 @@ void Serialize<Path>::operator()(StringBuilder& builder, const SerializationCont
     // FIXME: Add version of `buildStringFromByteStream` that takes a `StringBuilder`.
     String pathString;
     buildStringFromByteStream(value.data.byteStream, pathString, UnalteredParsing);
-    serializeString(pathString, builder);
+    serializeString(builder, pathString);
 }
 
 void ComputedStyleDependenciesCollector<Path::Data>::operator()(ComputedStyleDependencies&, const Path::Data&)


### PR DESCRIPTION
#### 512f1e7a44f950c674b251e66cc533d550e4f0a6
<pre>
Avoid temporary String allocations in CSSParserToken::serialize()
<a href="https://bugs.webkit.org/show_bug.cgi?id=311413">https://bugs.webkit.org/show_bug.cgi?id=311413</a>

Reviewed by Darin Adler.

serializeIdentifier() and serializeString() in CSSMarkup only iterate
characters; they don&apos;t need an owning String. Change them to accept
StringView so callers can pass StringView directly instead of
materializing a temporary String via toString().

This eliminates 7 unnecessary String allocations per
CSSParserToken::serialize() call, which is used for custom property
serialization and @supports CSSOM.

* Source/WebCore/css/CSSContainerRule.cpp:
(WebCore::CSSContainerRule::containerName const):
* Source/WebCore/css/CSSCounterStyleDescriptors.cpp:
(WebCore::CSSCounterStyleDescriptors::Symbol::cssText const):
* Source/WebCore/css/CSSCounterValue.cpp:
(WebCore::CSSCounterValue::customCSSText const):
* Source/WebCore/css/CSSFontFeatureValuesRule.cpp:
(WebCore::CSSFontFeatureValuesRule::cssText const):
* Source/WebCore/css/CSSFunctionRule.cpp:
(WebCore::CSSFunctionRule::cssText const):
* Source/WebCore/css/CSSGridLineNamesValue.cpp:
(WebCore::CSSGridLineNamesValue::customCSSText const):
* Source/WebCore/css/CSSLayerBlockRule.cpp:
(WebCore::stringFromCascadeLayerName):
* Source/WebCore/css/CSSMarkup.cpp:
(WebCore::isCSSTokenizerIdentifier):
(WebCore::serializeCharacter):
(WebCore::serializeCharacterAsCodePoint):
(WebCore::serializeIdentifier):
(WebCore::serializeString):
(WebCore::serializeURL):
* Source/WebCore/css/CSSMarkup.h:
* Source/WebCore/css/CSSNamespaceRule.cpp:
(WebCore::CSSNamespaceRule::cssText const):
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::serializeInternal const):
* Source/WebCore/css/CSSPropertyRule.cpp:
(WebCore::CSSPropertyRule::cssText const):
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::appendPossiblyQuotedIdentifier):
(WebCore::CSSSelector::selectorText const):
* Source/WebCore/css/DOMCSSNamespace.cpp:
(WebCore::DOMCSSNamespace::escape):
* Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp:
(WebCore::CSSCalc::serializeMathFunctionArguments):
* Source/WebCore/css/parser/CSSParserToken.cpp:
(WebCore::CSSParserToken::serialize const):
* Source/WebCore/css/query/ContainerQuery.cpp:
(WebCore::CQ::serialize):
* Source/WebCore/css/query/GenericMediaQuerySerialization.cpp:
(WebCore::MQ::serialize):
* Source/WebCore/css/query/MediaQueryParser.cpp:
(WebCore::MQ::serialize):
* Source/WebCore/css/typedom/CSSKeywordValue.cpp:
(WebCore::CSSKeywordValue::serialize const):
* Source/WebCore/css/values/CSSValueTypes.cpp:
(WebCore::CSS::serializationForCSSCustomIdentifier):
(WebCore::CSS::serializationForCSSString):
* Source/WebCore/css/values/primitives/CSSURL.cpp:
(WebCore::CSS::Serialize&lt;URL&gt;::operator):
* Source/WebCore/css/values/shapes/CSSPathFunction.cpp:
(WebCore::CSS::Serialize&lt;Path&gt;::operator):

Canonical link: <a href="https://commits.webkit.org/310602@main">https://commits.webkit.org/310602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5d95bfc19ab9882d8587fad2af85d78ed4b9051

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154319 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20737 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163073 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107788 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f0a49847-29ec-4754-abcd-2a3adedfda91) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156192 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27427 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119348 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84384 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/52905618-359c-4cb0-a956-986493fa4b5b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157278 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21620 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138591 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100044 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0990592d-0dac-4b22-8682-f1c40d654c83) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20708 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18711 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10905 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130370 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16436 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165545 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8754 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18045 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127444 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27123 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127589 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34625 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27047 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138229 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83676 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22481 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15021 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26737 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90840 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26318 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26549 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26391 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->