### PR TITLE
Fix url() token serialization in custom properties

### DIFF
--- a/LayoutTests/fast/css/attr-parsing-expected.txt
+++ b/LayoutTests/fast/css/attr-parsing-expected.txt
@@ -13,7 +13,7 @@ Rules from the stylesheet:
 #j { content: attr(-k); }
 #l { content: attr(0m); }
 #n { content: attr(-0p); }
-#q { content: attr(url(http\:\/\/webkit\.org)); }
+#q { content: attr(url(http://webkit.org)); }
 #r { content: attr(U/**/+0020); }
 #s { content: attr(U/**/+0020/**/-00FF); }
 #t { content: attr(#123456); }
@@ -31,7 +31,7 @@ Expected result:
 #j { content: attr(-k); }
 #l { content: attr(0m); }
 #n { content: attr(-0p); }
-#q { content: attr(url(http\:\/\/webkit\.org)); }
+#q { content: attr(url(http://webkit.org)); }
 #r { content: attr(U/**/+0020); }
 #s { content: attr(U/**/+0020/**/-00FF); }
 #t { content: attr(#123456); }

--- a/LayoutTests/fast/css/attr-parsing.html
+++ b/LayoutTests/fast/css/attr-parsing.html
@@ -36,7 +36,7 @@
 #j { content: attr(-k); }
 #l { content: attr(0m); }
 #n { content: attr(-0p); }
-#q { content: attr(url(http\:\/\/webkit\.org)); }
+#q { content: attr(url(http://webkit.org)); }
 #r { content: attr(U/**/+0020); }
 #s { content: attr(U/**/+0020/**/-00FF); }
 #t { content: attr(#123456); }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-security-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-security-expected.txt
@@ -46,8 +46,8 @@ FAIL 'background-image: image-set(if(style(--true): url(https://does-not-exist.t
                             else: url(https://does-not-exist.test/404.png);))' with data-foo="attr(data-foo type(*))" assert_equals: expected "image-set(url(\"https://does-not-exist.test/404.png\") 1dppx)" but got "none"
 PASS 'background-image: image-set(
                 if(style(--condition-val: if(style(--true): attr(data-foo type(*));)): url(https://does-not-exist.test/404.png);))' with data-foo="3"
-FAIL '--x: image-set(if(style(--condition-val: if(style(--true): attr(data-foo type(*));)): url(https://does-not-exist.test/404.png);))' with data-foo="3" assert_equals: expected "image-set(url(https://does-not-exist.test/404.png))" but got "image-set(if(style(--condition-val: if(style(--true): 3;)): url(https\\:\\/\\/does-not-exist\\.test\\/404\\.png);))"
-FAIL '--x: image-set(if(style(--condition-val >= attr(data-foo type(*))): url(https://does-not-exist.test/404.png);))' with data-foo="3" assert_equals: expected "image-set(url(https://does-not-exist.test/404.png))" but got "image-set(if(style(--condition-val >= 3): url(https\\:\\/\\/does-not-exist\\.test\\/404\\.png);))"
+FAIL '--x: image-set(if(style(--condition-val: if(style(--true): attr(data-foo type(*));)): url(https://does-not-exist.test/404.png);))' with data-foo="3" assert_equals: expected "image-set(url(https://does-not-exist.test/404.png))" but got "image-set(if(style(--condition-val: if(style(--true): 3;)): url(https://does-not-exist.test/404.png);))"
+FAIL '--x: image-set(if(style(--condition-val >= attr(data-foo type(*))): url(https://does-not-exist.test/404.png);))' with data-foo="3" assert_equals: expected "image-set(url(https://does-not-exist.test/404.png))" but got "image-set(if(style(--condition-val >= 3): url(https://does-not-exist.test/404.png);))"
 PASS 'background-image: image-set(
                 if(style(--condition-val >= attr(data-foo type(*))): url(https://does-not-exist.test/404.png);))' with data-foo="3"
 PASS 'background-image: image-set(

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/url-token-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/url-token-serialization-expected.txt
@@ -1,0 +1,8 @@
+
+PASS Period in url() token must not be escaped
+PASS Slashes and periods in url() token must not be escaped
+PASS Colons, slashes, periods, question marks, equals, ampersands, and hash in url() token must not be escaped
+PASS Tilde, plus, and exclamation mark in url() token must not be escaped
+PASS Escaped space in url() token must be serialized as an escape
+PASS Escaped tab in url() token must be serialized as an escape
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/url-token-serialization.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/url-token-serialization.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Variables: url() token serialization in custom properties</title>
+<link rel="help" href="https://drafts.csswg.org/css-variables-2/#serializing-custom-props">
+<link rel="help" href="https://drafts.csswg.org/css-syntax-3/#serialization">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="target"></div>
+<script>
+// "Specified values of custom properties must be serialized exactly as
+// specified by the author. Simplifications that might occur in other
+// properties, such as dropping comments, normalizing whitespace,
+// reserializing numeric tokens from their value, etc., must not occur."
+//
+// The url() token value should not have its contents escaped using CSS
+// identifier serialization rules. Characters like "." and "/" are valid
+// in url() tokens and must not be backslash-escaped.
+
+function test_url_roundtrip(input, description) {
+    test(function() {
+        var target = document.getElementById('target');
+        target.style.setProperty('--test', input);
+        var result = target.style.getPropertyValue('--test');
+        target.style.removeProperty('--test');
+        assert_equals(result, input);
+    }, description);
+}
+
+function test_url_serialization(input, expected, description) {
+    test(function() {
+        var target = document.getElementById('target');
+        target.style.setProperty('--test', input);
+        var result = target.style.getPropertyValue('--test');
+        target.style.removeProperty('--test');
+        assert_equals(result, expected);
+    }, description);
+}
+
+test_url_roundtrip(
+    'url(image.png)',
+    'Period in url() token must not be escaped'
+);
+
+test_url_roundtrip(
+    'url(path/to/image.png)',
+    'Slashes and periods in url() token must not be escaped'
+);
+
+test_url_roundtrip(
+    'url(https://example.com/image.png?q=1&v=2#frag)',
+    'Colons, slashes, periods, question marks, equals, ampersands, and hash in url() token must not be escaped'
+);
+
+test_url_roundtrip(
+    'url(~icons+set!v2)',
+    'Tilde, plus, and exclamation mark in url() token must not be escaped'
+);
+
+test_url_serialization(
+    'url(foo\\ bar)',
+    'url(foo\\ bar)',
+    'Escaped space in url() token must be serialized as an escape'
+);
+
+test_url_serialization(
+    'url(foo\\\tbar)',
+    'url(foo\\\tbar)',
+    'Escaped tab in url() token must be serialized as an escape'
+);
+</script>

--- a/Source/WebCore/css/CSSImportRule.cpp
+++ b/Source/WebCore/css/CSSImportRule.cpp
@@ -23,9 +23,10 @@
 #include "CSSImportRule.h"
 
 #include "CSSLayerBlockRule.h"
-#include "CSSMarkup.h"
 #include "CSSSerializationContext.h"
 #include "CSSStyleSheet.h"
+#include "CSSURL.h"
+#include "CSSValueTypes.h"
 #include "CachedCSSStyleSheet.h"
 #include "MediaList.h"
 #include "MediaQueryParser.h"
@@ -75,10 +76,11 @@ String CSSImportRule::supportsText() const
     return m_importRule->supportsText();
 }
 
-String CSSImportRule::cssTextInternal(const String& urlString) const
+String CSSImportRule::cssTextInternal(const String& urlString, const CSS::SerializationContext& context) const
 {
     StringBuilder builder;
-    builder.append("@import "_s, serializeURL(urlString));
+    builder.append("@import "_s);
+    CSS::serializationForCSS(builder, context, CSS::URL { .specified = urlString, .resolved = { }, .modifiers = { } });
 
     if (auto layerName = this->layerName(); !layerName.isNull()) {
         if (layerName.isEmpty())
@@ -102,7 +104,7 @@ String CSSImportRule::cssTextInternal(const String& urlString) const
 
 String CSSImportRule::cssText() const
 {
-    return cssTextInternal(m_importRule->href());
+    return cssTextInternal(m_importRule->href(), CSS::defaultSerializationContext());
 }
 
 String CSSImportRule::cssText(const CSS::SerializationContext& context) const
@@ -110,12 +112,12 @@ String CSSImportRule::cssText(const CSS::SerializationContext& context) const
     if (RefPtr sheet = styleSheet()) {
         auto urlString = context.replacementURLStringsForCSSStyleSheet.get(*sheet);
         if (!urlString.isEmpty())
-            return cssTextInternal(urlString);
+            return cssTextInternal(urlString, context);
     }
 
     auto urlString = m_importRule->href();
     auto replacementURLString = context.replacementURLStrings.get(urlString);
-    return replacementURLString.isEmpty() ? cssTextInternal(urlString) : cssTextInternal(replacementURLString);
+    return cssTextInternal(replacementURLString.isEmpty() ? urlString : replacementURLString, context);
 }
 
 CSSStyleSheet* CSSImportRule::styleSheet() const

--- a/Source/WebCore/css/CSSImportRule.h
+++ b/Source/WebCore/css/CSSImportRule.h
@@ -56,7 +56,7 @@ private:
     void NODELETE reattach(StyleRuleBase&) final;
     void getChildStyleSheets(HashSet<Ref<CSSStyleSheet>>&) final;
 
-    String cssTextInternal(const String& urlString) const;
+    String cssTextInternal(const String& urlString, const CSS::SerializationContext&) const;
     const MQ::MediaQueryList& NODELETE mediaQueries() const;
     void setMediaQueries(MQ::MediaQueryList&&);
 

--- a/Source/WebCore/css/CSSMarkup.cpp
+++ b/Source/WebCore/css/CSSMarkup.cpp
@@ -63,12 +63,18 @@ static bool NODELETE isCSSTokenizerIdentifier(StringView string)
     return isCSSTokenizerIdentifier(string.span16());
 }
 
+// https://drafts.csswg.org/css-syntax-3/#non-printable-code-point
+static bool isNonPrintableCodePoint(char32_t c)
+{
+    return c <= 0x08 || c == 0x0b || (c >= 0x0e && c <= 0x1f) || c == deleteCharacter;
+}
+
 static void serializeCharacter(StringBuilder& appendTo, char32_t c)
 {
     appendTo.append('\\', c);
 }
 
-static void serializeCharacterAsCodePoint(StringBuilder& appendTo, char32_t c)
+static void serializeCharacterAsEscapeSequence(StringBuilder& appendTo, char32_t c)
 {
     appendTo.append('\\', hex(c, Lowercase), ' ');
 }
@@ -87,7 +93,7 @@ void serializeIdentifier(StringBuilder& appendTo, StringView identifier, ShouldS
         if (!c)
             appendTo.append(replacementCharacter);
         else if (c <= 0x1f || c == deleteCharacter || (0x30 <= c && c <= 0x39 && (isFirst || (isSecond && isFirstCharHyphen))))
-            serializeCharacterAsCodePoint(appendTo, c);
+            serializeCharacterAsEscapeSequence(appendTo, c);
         else if (c == hyphenMinus && isFirst && index == identifier.length())
             serializeCharacter(appendTo, c);
         else if (0x80 <= c || c == hyphenMinus || c == lowLine || (0x30 <= c && c <= 0x39) || (0x41 <= c && c <= 0x5a) || (0x61 <= c && c <= 0x7a))
@@ -114,7 +120,7 @@ void serializeString(StringBuilder& appendTo, StringView string)
         index += U16_LENGTH(c);
 
         if (c <= 0x1f || c == deleteCharacter)
-            serializeCharacterAsCodePoint(appendTo, c);
+            serializeCharacterAsEscapeSequence(appendTo, c);
         else if (c == quotationMark || c == reverseSolidus)
             serializeCharacter(appendTo, c);
         else
@@ -124,19 +130,25 @@ void serializeString(StringBuilder& appendTo, StringView string)
     appendTo.append('"');
 }
 
+// https://drafts.csswg.org/css-syntax-3/#consume-url-token
+void serializeURLTokenValue(StringBuilder& appendTo, StringView string)
+{
+    for (auto c : string.codePoints()) {
+        if (!c)
+            appendTo.append(replacementCharacter);
+        else if (isNonPrintableCodePoint(c) || isCSSNewline(c))
+            serializeCharacterAsEscapeSequence(appendTo, c);
+        else if (c == '"' || c == '\'' || c == '(' || c == ')' || c == reverseSolidus || isASCIIWhitespace(c))
+            serializeCharacter(appendTo, c);
+        else
+            appendTo.append(c);
+    }
+}
+
 String serializeString(StringView string)
 {
     StringBuilder builder;
     serializeString(builder, string);
-    return builder.toString();
-}
-
-String serializeURL(StringView string)
-{
-    StringBuilder builder;
-    builder.append("url("_s);
-    serializeString(builder, string);
-    builder.append(')');
     return builder.toString();
 }
 

--- a/Source/WebCore/css/CSSMarkup.h
+++ b/Source/WebCore/css/CSSMarkup.h
@@ -34,7 +34,7 @@ enum class ShouldSkipStartChecks : bool { No, Yes };
 void serializeIdentifier(StringBuilder& appendTo, StringView identifier, ShouldSkipStartChecks = ShouldSkipStartChecks::No);
 void serializeString(StringBuilder& appendTo, StringView);
 String serializeString(StringView);
-String serializeURL(StringView);
+void serializeURLTokenValue(StringBuilder& appendTo, StringView);
 String serializeFontFamily(const String&);
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSParserIdioms.h
+++ b/Source/WebCore/css/parser/CSSParserIdioms.h
@@ -47,6 +47,13 @@ inline bool isCSSSpace(CharacterType c)
     return c == ' ' || c == '\t' || c == '\n';
 }
 
+// https://drafts.csswg.org/css-syntax-3/#newline
+template<typename CharacterType>
+inline bool isCSSNewline(CharacterType c)
+{
+    return c == '\n' || c == '\r' || c == '\f';
+}
+
 // http://dev.w3.org/csswg/css-syntax/#name-start-code-point
 template <typename CharacterType>
 bool isNameStartCodePoint(CharacterType c)

--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -654,7 +654,7 @@ void CSSParserToken::serialize(StringBuilder& builder, const CSSParserToken* nex
         break;
     case UrlToken:
         builder.append("url("_s);
-        serializeIdentifier(builder, value());
+        serializeURLTokenValue(builder, value());
         builder.append(')');
         break;
     case DelimiterToken:

--- a/Source/WebCore/css/parser/CSSTokenizer.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizer.cpp
@@ -45,7 +45,7 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSTokenizer);
 String CSSTokenizer::preprocessString(const String& string)
 {
     // We don't replace '\r' and '\f' with '\n' as the specification suggests, instead
-    // we treat them all the same in the isNewline function below.
+    // we treat them all the same in the isCSSNewline() function from CSSParserIdioms.h.
     StringImpl* oldImpl = string.impl();
     String replaced = makeStringByReplacingAll(string, '\0', replacementCharacter);
     replaced = replaceUnpairedSurrogatesWithReplacementCharacter(WTF::move(replaced));
@@ -144,12 +144,6 @@ bool CSSTokenizer::isWhitespace(CSSParserTokenType type)
     return type == NonNewlineWhitespaceToken || type == NewlineToken;
 }
 
-bool CSSTokenizer::isNewline(char16_t cc)
-{
-    // We check \r and \f here, since we have no preprocessing stage
-    return (cc == '\r' || cc == '\n' || cc == '\f');
-}
-
 CSSParserToken CSSTokenizer::newline(char16_t)
 {
     return CSSParserToken(NewlineToken);
@@ -158,7 +152,7 @@ CSSParserToken CSSTokenizer::newline(char16_t)
 // http://dev.w3.org/csswg/css-syntax/#check-if-two-code-points-are-a-valid-escape
 static bool NODELETE twoCharsAreValidEscape(char16_t first, char16_t second)
 {
-    return first == '\\' && !CSSTokenizer::isNewline(second);
+    return first == '\\' && !isCSSNewline(second);
 }
 
 void CSSTokenizer::reconsume(char16_t c)
@@ -630,7 +624,7 @@ CSSParserToken CSSTokenizer::consumeStringTokenUntil(char16_t endingCodePoint)
             m_input.advance(size + 1);
             return CSSParserToken(StringToken, m_input.rangeAt(startOffset, size));
         }
-        if (isNewline(cc)) {
+        if (isCSSNewline(cc)) {
             m_input.advance(size);
             return CSSParserToken(BadStringToken);
         }
@@ -643,14 +637,14 @@ CSSParserToken CSSTokenizer::consumeStringTokenUntil(char16_t endingCodePoint)
         char16_t cc = consume();
         if (cc == endingCodePoint || cc == kEndOfFileMarker)
             return CSSParserToken(StringToken, registerString(output.toString()));
-        if (isNewline(cc)) {
+        if (isCSSNewline(cc)) {
             reconsume(cc);
             return CSSParserToken(BadStringToken);
         }
         if (cc == '\\') {
             if (m_input.nextInputChar() == kEndOfFileMarker)
                 continue;
-            if (isNewline(m_input.peek(0)))
+            if (isCSSNewline(m_input.peek(0)))
                 consumeSingleWhitespaceIfNext(); // This handles \r\n for us
             else
                 output.append(consumeEscape());
@@ -804,7 +798,7 @@ StringView CSSTokenizer::consumeName()
 char32_t CSSTokenizer::consumeEscape()
 {
     char16_t cc = consume();
-    ASSERT(!isNewline(cc));
+    ASSERT(!isCSSNewline(cc));
     if (isASCIIHexDigit(cc)) {
         uint32_t codePoint = toASCIIHexValue(cc);
         unsigned consumedHexDigits = 1;

--- a/Source/WebCore/css/parser/CSSTokenizer.h
+++ b/Source/WebCore/css/parser/CSSTokenizer.h
@@ -56,7 +56,6 @@ public:
     unsigned NODELETE tokenCount();
 
     static bool NODELETE isWhitespace(CSSParserTokenType);
-    static bool NODELETE isNewline(char16_t);
 
     Vector<String>&& escapedStringsForAdoption() { return WTF::move(m_stringPool); }
 

--- a/Source/WebCore/css/parser/CSSTokenizerInputStream.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizerInputStream.cpp
@@ -30,7 +30,7 @@
 #include "config.h"
 #include "CSSTokenizerInputStream.h"
 
-#include "CSSTokenizer.h"
+#include "CSSParserIdioms.h"
 
 #include <wtf/NeverDestroyed.h>
 
@@ -62,7 +62,7 @@ void CSSTokenizerInputStream::advanceUntilNewlineOrNonWhitespace()
 {
     auto advance = [this](auto characters) {
         while (m_offset < m_stringLength && isASCIIWhitespace(characters[m_offset])) {
-            if (CSSTokenizer::isNewline(characters[m_offset]))
+            if (isCSSNewline(characters[m_offset]))
                 return;
             ++m_offset;
         }


### PR DESCRIPTION
#### 8df46ae128e21639fa2613d4bb78d35a6c7bb5cf
<pre>
Fix url() token serialization in custom properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=311414">https://bugs.webkit.org/show_bug.cgi?id=311414</a>

Reviewed by Sam Weinig and Darin Adler.

CSSParserToken::serialize() was using serializeIdentifier() for
&lt;url-token&gt; values, which applies CSS identifier escaping rules.
This incorrectly escapes characters like &quot;.&quot;, &quot;/&quot;, &quot;:&quot;, &quot;?&quot;, and &quot;#&quot;
that are perfectly valid in URL tokens. For example, url(image.png)
would round-trip as url(image\.png).

This violates the CSS custom property serialization requirement that
specified values be serialized exactly as specified by the author.
 <a href="https://drafts.csswg.org/css-variables-2/#serializing-custom-props">https://drafts.csswg.org/css-variables-2/#serializing-custom-props</a>

Fix this by adding serializeURLTokenValue() which implements
&lt;url-token&gt; serialization that only escapes non-printable code points,
quotes, parentheses, and backslashes -- the characters that the CSS
tokenizer rejects in unquoted URL values.
<a href="https://drafts.csswg.org/css-syntax-3/#consume-url-token">https://drafts.csswg.org/css-syntax-3/#consume-url-token</a>

Test: imported/w3c/web-platform-tests/css/css-variables/url-token-serialization.html

* LayoutTests/fast/css/attr-parsing-expected.txt:
* LayoutTests/fast/css/attr-parsing.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-security-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/url-token-serialization-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/url-token-serialization.html: Added.
* Source/WebCore/css/CSSImportRule.cpp:
(WebCore::CSSImportRule::cssTextInternal const):
(WebCore::CSSImportRule::cssText const):
* Source/WebCore/css/CSSImportRule.h:
* Source/WebCore/css/CSSMarkup.cpp:
(WebCore::isNonPrintableCodePoint):
(WebCore::serializeCharacterAsEscapeSequence):
(WebCore::serializeIdentifier):
(WebCore::serializeString):
(WebCore::serializeURLTokenValue):
(WebCore::serializeCharacterAsCodePoint): Deleted.
(WebCore::serializeURL): Deleted.
* Source/WebCore/css/CSSMarkup.h:
* Source/WebCore/css/parser/CSSParserIdioms.h:
(WebCore::isCSSNewline):
* Source/WebCore/css/parser/CSSParserToken.cpp:
(WebCore::CSSParserToken::serialize const):
* Source/WebCore/css/parser/CSSTokenizer.cpp:
(WebCore::CSSTokenizer::preprocessString):
(WebCore::twoCharsAreValidEscape):
(WebCore::CSSTokenizer::consumeStringTokenUntil):
(WebCore::CSSTokenizer::consumeEscape):
(WebCore::CSSTokenizer::isNewline): Deleted.
* Source/WebCore/css/parser/CSSTokenizer.h:
* Source/WebCore/css/parser/CSSTokenizerInputStream.cpp:
(WebCore::CSSTokenizerInputStream::advanceUntilNewlineOrNonWhitespace):

Canonical link: <a href="https://commits.webkit.org/310628@main">https://commits.webkit.org/310628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e9d3ceaec0c7fc570c96dceebaacfb3aeaecfc5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154441 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163196 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107910 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4560b3e8-6fb5-4c38-95bf-9c34b2d0cc73) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156314 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27549 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119453 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84478 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/08a76f35-c6b3-40a2-ac3e-5cd496c742b1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157400 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21730 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138704 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100150 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1b3d91d3-3c46-47a7-ba8d-d1b7a40bd6b2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20817 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18824 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11027 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/130479 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165667 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8876 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18157 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/127550 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27245 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22864 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/127694 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34643 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27169 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138341 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83831 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22589 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15133 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26859 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90962 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26440 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26671 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26513 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->