### PR TITLE
Fix event.target not being set after dispatching in shadow tree with no listeners

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/event-post-dispatch-no-listeners-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/event-post-dispatch-no-listeners-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Event properties post dispatch with an open ShadowRoot and no listeners (composed: true)
+PASS Event properties post dispatch with an open ShadowRoot and no listeners (composed: false)
+PASS Event properties post dispatch with a closed ShadowRoot and no listeners (composed: true)
+PASS Event properties post dispatch with nested open ShadowRoots and no listeners (composed: true)
+PASS Event properties post dispatch with a disabled element in shadow tree and no listeners (composed: true)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/event-post-dispatch-no-listeners.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/event-post-dispatch-no-listeners.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<title>Shadow DOM: Event properties post dispatch when there are no event listeners</title>
+<meta name="author" title="Chris Dumez" href="mailto:cdumez@apple.com">
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-event-dispatch">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/shadow-dom.js"></script>
+
+<div id="test1">
+  <div id="host">
+    <template id="sr" data-mode="open">
+      <div id="target"></div>
+    </template>
+  </div>
+</div>
+<script>
+test(() => {
+  const nodes = createTestTree(test1);
+  document.body.appendChild(nodes.test1);
+
+  // Use a unique event type with no listeners registered anywhere in the document.
+  const event = new Event('unheard-event', { bubbles: true, composed: true });
+  nodes.target.dispatchEvent(event);
+
+  // The event target should be retargeted to the host since the original target
+  // is inside the shadow tree and the event is composed.
+  assert_equals(event.target, nodes.host,
+    'event.target should be the shadow host (retargeted) after dispatch');
+  assert_equals(event.eventPhase, 0);
+  assert_equals(event.currentTarget, null);
+  assert_array_equals(event.composedPath(), []);
+
+  nodes.test1.remove();
+}, 'Event properties post dispatch with an open ShadowRoot and no listeners (composed: true)');
+</script>
+
+<div id="test2">
+  <div id="host">
+    <template id="sr" data-mode="open">
+      <div id="target"></div>
+    </template>
+  </div>
+</div>
+<script>
+test(() => {
+  const nodes = createTestTree(test2);
+  document.body.appendChild(nodes.test2);
+
+  const event = new Event('unheard-event-2', { bubbles: true, composed: false });
+  nodes.target.dispatchEvent(event);
+
+  // Non-composed event stays inside the shadow tree; target should be cleared
+  // post dispatch since the target's root is a shadow root.
+  assert_equals(event.target, null,
+    'event.target should be null for non-composed event inside shadow tree');
+  assert_equals(event.eventPhase, 0);
+  assert_equals(event.currentTarget, null);
+  assert_array_equals(event.composedPath(), []);
+
+  nodes.test2.remove();
+}, 'Event properties post dispatch with an open ShadowRoot and no listeners (composed: false)');
+</script>
+
+<div id="test3">
+  <div id="host">
+    <template id="sr" data-mode="closed">
+      <div id="target"></div>
+    </template>
+  </div>
+</div>
+<script>
+test(() => {
+  const nodes = createTestTree(test3);
+  document.body.appendChild(nodes.test3);
+
+  const event = new Event('unheard-event-3', { bubbles: true, composed: true });
+  nodes.target.dispatchEvent(event);
+
+  assert_equals(event.target, nodes.host,
+    'event.target should be the shadow host (retargeted) after dispatch');
+  assert_equals(event.eventPhase, 0);
+  assert_equals(event.currentTarget, null);
+  assert_array_equals(event.composedPath(), []);
+
+  nodes.test3.remove();
+}, 'Event properties post dispatch with a closed ShadowRoot and no listeners (composed: true)');
+</script>
+
+<div id="test4">
+  <div id="host1">
+    <template id="sr1" data-mode="open">
+      <div id="host2">
+        <template id="sr2" data-mode="open">
+          <div id="target"></div>
+        </template>
+      </div>
+    </template>
+  </div>
+</div>
+<script>
+test(() => {
+  const nodes = createTestTree(test4);
+  document.body.appendChild(nodes.test4);
+
+  const event = new Event('unheard-event-4', { bubbles: true, composed: true });
+  nodes.target.dispatchEvent(event);
+
+  assert_equals(event.target, nodes.host1,
+    'event.target should be the outermost shadow host after dispatch');
+  assert_equals(event.eventPhase, 0);
+  assert_equals(event.currentTarget, null);
+  assert_array_equals(event.composedPath(), []);
+
+  nodes.test4.remove();
+}, 'Event properties post dispatch with nested open ShadowRoots and no listeners (composed: true)');
+</script>
+
+<div id="test5">
+  <div id="host">
+    <template id="sr" data-mode="open">
+      <input id="target" disabled>
+    </template>
+  </div>
+</div>
+<script>
+test(() => {
+  const nodes = createTestTree(test5);
+  document.body.appendChild(nodes.test5);
+
+  const event = new Event('unheard-event-5', { bubbles: true, composed: true });
+  nodes.target.dispatchEvent(event);
+
+  assert_equals(event.target, nodes.host,
+    'event.target should be the shadow host (retargeted) after dispatch');
+  assert_equals(event.eventPhase, 0);
+  assert_equals(event.currentTarget, null);
+  assert_array_equals(event.composedPath(), []);
+
+  nodes.test5.remove();
+}, 'Event properties post dispatch with a disabled element in shadow tree and no listeners (composed: true)');
+</script>

--- a/Source/WebCore/dom/EventDispatcher.cpp
+++ b/Source/WebCore/dom/EventDispatcher.cpp
@@ -226,8 +226,15 @@ void EventDispatcher::dispatchEvent(Node& node, Event& event)
     }
 
     if (hasNoEventListenerOrDefaultEventHandler) {
-        if (shouldClearTargetsAfterDispatch)
-            resetAfterDispatchInShadowTree(event);
+        event.resetBeforeDispatch();
+        // Use the retargeted target from the outermost event path context,
+        // since the EventPath applies retargeting across shadow boundaries.
+        // The path may be empty if adjustForDisabledFormControl() truncated it.
+        if (!eventPath.isEmpty()) {
+            event.setTarget(RefPtr { eventPath.last().target() });
+            if (shouldClearTargetsAfterDispatch)
+                resetAfterDispatchInShadowTree(event);
+        }
         return;
     }
 

--- a/Source/WebCore/dom/EventPath.h
+++ b/Source/WebCore/dom/EventPath.h
@@ -51,6 +51,8 @@ public:
     size_t size() const { return m_path.size(); }
     const EventContext& contextAt(size_t i) const { return m_path[i]; }
     EventContext& contextAt(size_t i) { return m_path[i]; }
+    const EventContext& last() const { return m_path.last(); }
+    EventContext& last() { return m_path.last(); }
 
     void adjustForDisabledFormControl();
 


### PR DESCRIPTION
#### 6029b693424e1779c8827ea9004083e82f7ffb7a
<pre>
Fix event.target not being set after dispatching in shadow tree with no listeners
<a href="https://bugs.webkit.org/show_bug.cgi?id=311415">https://bugs.webkit.org/show_bug.cgi?id=311415</a>

Reviewed by Anne van Kesteren.

When dispatching an event on a node inside a shadow tree and there are
no event listeners for that event type in the document, the early-exit
path in EventDispatcher::dispatchEvent failed to call resetBeforeDispatch()
and setTarget(). This left event.target stale (or null) instead of being
set to the retargeted shadow host.

The fix uses the retargeted target from the outermost EventPath context,
which correctly reflects the target after shadow DOM retargeting.

Test: imported/w3c/web-platform-tests/shadow-dom/event-post-dispatch-no-listeners.html

* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/event-post-dispatch-no-listeners-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/event-post-dispatch-no-listeners.html: Added.
* Source/WebCore/dom/EventDispatcher.cpp:
(WebCore::EventDispatcher::dispatchEvent):
* Source/WebCore/dom/EventPath.h:
(WebCore::EventPath::last const):
(WebCore::EventPath::last):

Canonical link: <a href="https://commits.webkit.org/310621@main">https://commits.webkit.org/310621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4f56e5e3570a9331fc56a6bf33e41cde73ab5b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20820 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163157 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107871 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156275 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27510 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119420 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84451 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1af0fb67-0afb-4e74-819e-c82008b4b4a4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138663 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100117 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/43d38e25-3f29-49e1-b987-990ed808aff2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20775 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18786 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10988 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130437 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16507 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165628 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8837 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18116 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127515 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27206 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22828 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127659 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34638 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27130 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138300 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83787 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22552 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15092 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26820 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90923 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26401 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26632 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26474 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->