### PR TITLE
m_isFocusingWithValidationMessage breaks bit packing in ValidatedFormListedElement

### DIFF
--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -53,7 +53,7 @@
 #include "ValidationMessage.h"
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <wtf/Ref.h>
-#include <wtf/SetForScope.h>
+#include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/MakeString.h>
@@ -167,7 +167,9 @@ RefPtr<HTMLElement> ValidatedFormListedElement::focusableValidationAnchorElement
 void ValidatedFormListedElement::focusAndShowValidationMessage(Ref<HTMLElement> validationAnchor)
 {
     Ref protectedThis { *this };
-    SetForScope isFocusingWithValidationMessageScope(m_isFocusingWithValidationMessage, true);
+    bool previousIsFocusingWithValidationMessage = m_isFocusingWithValidationMessage;
+    m_isFocusingWithValidationMessage = true;
+    auto scopeExit = makeScopeExit([&] { m_isFocusingWithValidationMessage = previousIsFocusingWithValidationMessage; });
 
     // Calling focus() will scroll the element into view.
     validationAnchor->focus();

--- a/Source/WebCore/html/ValidatedFormListedElement.h
+++ b/Source/WebCore/html/ValidatedFormListedElement.h
@@ -146,7 +146,7 @@ private:
     bool m_hasReadOnlyAttribute : 1 { false };
     bool m_wasInteractedWithSinceLastFormSubmitEvent : 1 { false };
     bool m_belongsToFormThatIsBeingDestroyed : 1 { false };
-    bool m_isFocusingWithValidationMessage { false };
+    bool m_isFocusingWithValidationMessage : 1 { false };
 
     mutable TriState m_isInsideDataList : 2 { TriState::Indeterminate };
 


### PR DESCRIPTION
#### 0d55646bbb0ea841f7539fd74ab04e051ceb0eaf
<pre>
m_isFocusingWithValidationMessage breaks bit packing in ValidatedFormListedElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=311416">https://bugs.webkit.org/show_bug.cgi?id=311416</a>

Reviewed by Anne van Kesteren.

Every other bool member uses : 1. This one does not, breaking the bit
field packing. It forces the compiler to end the bitfield, allocate a
separate byte for this bool, then potentially pad before
`m_isInsideDataList : 2`.

Bit-fields can&apos;t bind to non-const references, so SetForScope doesn&apos;t
work with them directly. I thus had to use another pattern in
focusAndShowValidationMessage().

* Source/WebCore/html/ValidatedFormListedElement.cpp:
(WebCore::ValidatedFormListedElement::focusAndShowValidationMessage):
* Source/WebCore/html/ValidatedFormListedElement.h:

Canonical link: <a href="https://commits.webkit.org/310563@main">https://commits.webkit.org/310563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca2924d1dc18e4c5164ff5be021f6f5160fbb1ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154192 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162946 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107660 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/56e2d553-4b49-4c74-8505-0313609afce9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27300 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119250 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84301 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21512 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138469 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99946 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/38146128-7e47-4730-84e7-dd44f301e964) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20600 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18598 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10778 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130262 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165418 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8627 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127344 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22640 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127490 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34595 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26920 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138107 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83513 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22380 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14899 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26610 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90713 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26191 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26422 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26263 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->