### PR TITLE
REGRESSION(309850@main): [GTK][JSC] build-webkit --gtk --debug reports "ASSERTION FAILED: i64_load_mem" while generating WebKit-6.0.gir

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
@@ -800,10 +800,11 @@ FOR_EACH_IPINT_UINT_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 
 namespace JSC { namespace IPInt {
 
-#if LLINT_TRACING
+#if LLINT_TRACING || ASSERT_ENABLED
 // When LLINT_TRACING is enabled, each ipintOp handler has a trace prologue injected,
 // which can push the largest handlers past 256 bytes. Double the slot size in tracing
 // builds so the dispatch table stays valid.
+// Debug builds can have larger jump instructions without linker optimizations too.
 constexpr uint64_t alignIPInt = 512;
 #else
 constexpr uint64_t alignIPInt = 256;


### PR DESCRIPTION
#### 157104dcbd6b32bc8dd5aa9b955e487ba6d3647d
<pre>
REGRESSION(<a href="https://commits.webkit.org/309850@main">309850@main</a>): [GTK][JSC] build-webkit --gtk --debug reports &quot;ASSERTION FAILED: i64_load_mem&quot; while generating WebKit-6.0.gir
<a href="https://bugs.webkit.org/show_bug.cgi?id=310768">https://bugs.webkit.org/show_bug.cgi?id=310768</a>

Reviewed by NOBODY (OOPS!).

On linux x86_64 debug builds, the linker can emit rel32 jumps instead
of rel16, causing IPInt instructions to get too big. For these
non-production builds, we increase the max size of ipint instructions.
This will probably also come in handy if we ever add more debug checks
in the future.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/157104dcbd6b32bc8dd5aa9b955e487ba6d3647d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162840 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107554 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27196 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119170 "Found 56 new test failures: imported/w3c/web-platform-tests/wasm/core/bulk.wast.js.html imported/w3c/web-platform-tests/wasm/core/conversions.wast.js.html imported/w3c/web-platform-tests/wasm/core/memory_copy.wast.js.html imported/w3c/web-platform-tests/wasm/core/memory_fill.wast.js.html imported/w3c/web-platform-tests/wasm/core/memory_init.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_address.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_align.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_bit_shift.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_bitwise.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_boolean.wast.js.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84250 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157047 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21408 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99870 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18492 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10673 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/146137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130166 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165313 "Built successfully") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/14915 "Found 1 new JSC stress test failure: Too many failures: 2793 jsc tests failed (failure)") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8535 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17817 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127261 "Found 52 new test failures: imported/w3c/web-platform-tests/wasm/core/bulk.wast.js.html imported/w3c/web-platform-tests/wasm/core/conversions.wast.js.html imported/w3c/web-platform-tests/wasm/core/memory_copy.wast.js.html imported/w3c/web-platform-tests/wasm/core/memory_fill.wast.js.html imported/w3c/web-platform-tests/wasm/core/memory_init.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_address.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_align.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_bit_shift.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_bitwise.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_f32x4.wast.js.html ... (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26891 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22562 "Found 60 new test failures: imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.worker.html imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-implicit.html imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-a-bitrate.html imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-av-framesize.html imported/w3c/web-platform-tests/wasm/core/bulk.wast.js.html imported/w3c/web-platform-tests/wasm/core/conversions.wast.js.html imported/w3c/web-platform-tests/wasm/core/elem.wast.js.html imported/w3c/web-platform-tests/wasm/core/memory_copy.wast.js.html imported/w3c/web-platform-tests/wasm/core/memory_fill.wast.js.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127413 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26814 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138010 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83401 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22280 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14798 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185723 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26505 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90597 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47628 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26086 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26316 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26158 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->