### PR TITLE
[JSC] GreedyRegAlloc: split disjoint defs

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -752,7 +752,6 @@ public:
         , m_spillSlotTable(FillWith { }, 1, nullptr) // Sacrifice index 0.
         , m_regRanges(Reg::maxIndex() + 1)
         , m_insertionSets(code.size())
-        , m_useCounts(m_code)
         , m_tmpWidth(m_code)
     {
     }
@@ -767,6 +766,9 @@ public:
         buildRegisterSets();
         buildIndices();
         buildLiveRanges();
+        splitDisconnectedDefs<GP>();
+        splitDisconnectedDefs<FP>();
+        m_useCounts = UseCounts(m_code);
         initSpillCosts<GP>();
         initSpillCosts<FP>();
         coalesceWithPinnedRegisters();
@@ -2455,6 +2457,185 @@ private:
         m_splitMetadata.append(WTF::move(metadata));
         m_stats[bank].numSplitAroundClobbers++;
         return true;
+    }
+
+    // Split tmps whose live range intervals form disconnected components in the CFG.
+    // Each component becomes its own tmp with a smaller live range. This is pure renaming
+    // — no fixup code (loads/stores) is needed since the components are disconnected.
+    template<Bank bank>
+    void splitDisconnectedDefs()
+    {
+        if (!Options::airGreedyRegAllocSplitDisconnectedDefs())
+            return;
+
+        // forEachTmp snapshots numTmps before iterating, so newly-created tmps won't be visited.
+        m_code.forEachTmp<bank>([&](Tmp tmp) {
+            if (m_map.get<bank>(tmp).liveRange.intervals().size() <= 1)
+                return;
+            splitDisconnectedDefsForTmp<bank>(tmp);
+        });
+    }
+
+    template<Bank bank>
+    void splitDisconnectedDefsForTmp(Tmp tmp)
+    {
+        // Phase 1: Copy intervals into a stable Vector (addTmpImpl invalidates TmpData refs).
+        const auto& liveRangeIntervals = m_map.get<bank>(tmp).liveRange.intervals();
+        unsigned numIntervals = liveRangeIntervals.size();
+        ASSERT(numIntervals > 1);
+
+        Vector<Interval, 8> intervals;
+        intervals.reserveInitialCapacity(numIntervals);
+        for (const auto& interval : liveRangeIntervals)
+            intervals.append(interval);
+
+        // Phase 2: Build connectivity via union-find on interval indices.
+        // Two intervals are connected when one is live-out of a block and the other
+        // is live-in to a CFG successor.
+        Vector<unsigned, 8> parent(numIntervals);
+        Vector<unsigned, 8> rank;
+        rank.fill(0, numIntervals);
+        for (unsigned i = 0; i < numIntervals; i++)
+            parent[i] = i;
+
+        auto find = [&](unsigned x) -> unsigned {
+            while (parent[x] != x) {
+                parent[x] = parent[parent[x]]; // path halving
+                x = parent[x];
+            }
+            return x;
+        };
+
+        auto unite = [&](unsigned a, unsigned b) {
+            a = find(a);
+            b = find(b);
+            if (a == b)
+                return;
+            if (rank[a] < rank[b])
+                std::swap(a, b);
+            parent[b] = a;
+            if (rank[a] == rank[b])
+                rank[a]++;
+        };
+
+        // For each block, which interval is live-in (interval covers positionOfHead(block)).
+        HashMap<BasicBlock*, unsigned> liveInToBlock;
+        // (block, intervalIdx) pairs where the interval is live-out of the block.
+        Vector<std::pair<BasicBlock*, unsigned>> liveOuts;
+
+        for (unsigned idx = 0; idx < numIntervals; idx++) {
+            Interval interval = intervals[idx];
+            BasicBlock* firstBlock = findBlockContainingPoint(interval.begin());
+            BasicBlock* lastBlock = findBlockContainingPoint(interval.end() - 1);
+
+            for (unsigned blockIdx = firstBlock->index(); blockIdx <= lastBlock->index(); blockIdx++) {
+                BasicBlock* block = m_code[blockIdx];
+                if (!block)
+                    continue;
+                Point head = positionOfHead(block);
+                Point tail = positionOfTail(block);
+                if (tail < interval.begin() || head >= interval.end())
+                    continue;
+
+                bool isLiveIn = interval.begin() <= head;
+                bool isLiveOut = interval.end() > tail;
+
+                if (isLiveIn)
+                    liveInToBlock.add(block, idx);
+                if (isLiveOut)
+                    liveOuts.append({ block, idx });
+            }
+        }
+
+        // Unite intervals connected via CFG edges.
+        for (auto& [block, outIdx] : liveOuts) {
+            for (auto& successor : block->successors()) {
+                auto it = liveInToBlock.find(successor.block());
+                if (it != liveInToBlock.end())
+                    unite(outIdx, it->value);
+            }
+        }
+
+        // Phase 3: Count distinct components. Component 0 = first interval's root.
+        // Map root interval index -> component ID. Use a Vector since roots are in [0, numIntervals).
+        constexpr unsigned noComponent = std::numeric_limits<unsigned>::max();
+        Vector<unsigned, 8> rootToComponent;
+        rootToComponent.fill(noComponent, numIntervals);
+        unsigned numComponents = 0;
+        Vector<unsigned, 8> intervalToComponent(numIntervals);
+
+        unsigned firstRoot = find(0);
+        rootToComponent[firstRoot] = 0;
+        numComponents = 1;
+
+        for (unsigned i = 0; i < numIntervals; i++) {
+            unsigned root = find(i);
+            if (rootToComponent[root] == noComponent)
+                rootToComponent[root] = numComponents++;
+            intervalToComponent[i] = rootToComponent[root];
+        }
+
+        if (numComponents <= 1)
+            return;
+
+        dataLogLnIf(verbose(), "splitDisconnectedDefs: ", tmp, " has ", numComponents, " components across ", numIntervals, " intervals");
+
+        // Phase 4: Build per-component live ranges.
+        Vector<LiveRange> componentLRs(numComponents);
+        for (unsigned i = 0; i < numIntervals; i++)
+            componentLRs[intervalToComponent[i]].append(intervals[i]);
+
+        // Phase 5: Create new tmps for non-primary components.
+        Vector<Tmp> componentTmp(numComponents);
+        componentTmp[0] = tmp;
+        for (unsigned comp = 1; comp < numComponents; comp++) {
+            Tmp newTmp = addTmpImpl(tmp, 0, { });
+            m_map.get<bank>(newTmp).liveRange = WTF::move(componentLRs[comp]);
+            componentTmp[comp] = newTmp;
+        }
+
+        // Update original tmp's live range to component 0 only.
+        m_map.get<bank>(tmp).liveRange = WTF::move(componentLRs[0]);
+
+        // Phase 6: Replace tmp refs in instructions for non-primary components.
+        for (unsigned comp = 1; comp < numComponents; comp++) {
+            Tmp newTmp = componentTmp[comp];
+            const auto& newIntervals = m_map.get<bank>(newTmp).liveRange.intervals();
+
+            for (const auto& interval : newIntervals) {
+                BasicBlock* firstBlock = findBlockContainingPoint(interval.begin());
+                BasicBlock* lastBlock = findBlockContainingPoint(interval.end() - 1);
+
+                for (unsigned blockIdx = firstBlock->index(); blockIdx <= lastBlock->index(); blockIdx++) {
+                    BasicBlock* block = m_code[blockIdx];
+                    if (!block)
+                        continue;
+                    Point head = positionOfHead(block);
+                    Point tail = positionOfTail(block);
+                    if (tail < interval.begin() || head >= interval.end())
+                        continue;
+
+                    unsigned firstInst = 0;
+                    if (interval.begin() > head)
+                        firstInst = instIndex(head, interval.begin());
+                    unsigned lastInst = block->size() - 1;
+                    if (interval.end() <= tail)
+                        lastInst = instIndex(head, interval.end() - 1);
+
+                    for (unsigned ii = firstInst; ii <= lastInst; ii++) {
+                        block->at(ii).forEachTmpFast([&](Tmp& t) {
+                            if (t == tmp)
+                                t = newTmp;
+                        });
+                    }
+                }
+            }
+        }
+
+        // Phase 7: Clear stale coalescables and update stats.
+        m_map.get<bank>(tmp).coalescables = Coalescables();
+        m_stats[bank].numSplitDisconnectedDefs++;
+        m_stats[bank].numSplitDisconnectedDefsComponents += numComponents;
     }
 
     // Note that the use/def lists are computed only once and not kept up to date.

--- a/Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h
+++ b/Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h
@@ -65,6 +65,8 @@ namespace JSC { namespace B3 { namespace Air {
     macro(numGroupMovesCoalesced)               \
     macro(numGroupConstDefMerged)               \
     macro(maxGroupSize)                         \
+    macro(numSplitDisconnectedDefs)             \
+    macro(numSplitDisconnectedDefsComponents)   \
     macro(numInsts)                             \
 
 class AirAllocateRegistersStats {

--- a/Source/JavaScriptCore/b3/air/AirUseCounts.h
+++ b/Source/JavaScriptCore/b3/air/AirUseCounts.h
@@ -43,6 +43,8 @@ class Code;
 // that are only reachable by rare edges is scaled by Options::rareBlockPenalty().
 class UseCounts {
 public:
+    UseCounts() = default;
+
     UseCounts(Code& code)
     {
         // Find non-rare blocks.

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -510,6 +510,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, airUseGreedyRegAlloc, true, Normal, nullptr) \
     v(Double, airGreedyRegAllocSplitMultiplier, 2.0, Normal, nullptr) \
     v(Bool, airGreedyRegAllocSpillsEverything, false, Normal, nullptr) \
+    v(Bool, airGreedyRegAllocSplitDisconnectedDefs, true, Normal, nullptr) \
     v(Bool, airDumpPhaseStats, false, Normal, nullptr) \
     v(Bool, airValidateGreedRegAlloc, ASSERT_ENABLED, Normal, nullptr) \
     v(Bool, airRandomizeRegs, false, Normal, nullptr) \


### PR DESCRIPTION
#### 80c91a238e74bb240203df074eff3b5cc73e007d
<pre>
[JSC] GreedyRegAlloc: split disjoint defs
<a href="https://bugs.webkit.org/show_bug.cgi?id=311422">https://bugs.webkit.org/show_bug.cgi?id=311422</a>
<a href="https://rdar.apple.com/174022649">rdar://174022649</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).

* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::GreedyAllocator::run):
(JSC::B3::Air::Greedy::GreedyAllocator::splitDisconnectedDefs):
(JSC::B3::Air::Greedy::GreedyAllocator::splitDisconnectedDefsForTmp):
* Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h:
* Source/JavaScriptCore/b3/air/AirUseCounts.h:
* Source/JavaScriptCore/runtime/OptionsList.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80c91a238e74bb240203df074eff3b5cc73e007d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162862 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27218 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/119188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157069 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/21434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/138391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/99888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10695 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/146159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/130192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/16243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165335 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/14938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/8545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/17843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/127284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26913 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/22551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/127435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26836 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/138036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/83423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/22302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/14824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185745 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26528 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/90631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/47639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/26108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26338 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26180 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->