### PR TITLE
Use "= default" for destructor in WebCore code

### DIFF
--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -54,9 +54,7 @@ ScrollingTreeScrollingNodeDelegateMac::ScrollingTreeScrollingNodeDelegateMac(Scr
 #endif
 }
 
-ScrollingTreeScrollingNodeDelegateMac::~ScrollingTreeScrollingNodeDelegateMac()
-{
-}
+ScrollingTreeScrollingNodeDelegateMac::~ScrollingTreeScrollingNodeDelegateMac() = default;
 
 void ScrollingTreeScrollingNodeDelegateMac::nodeWillBeDestroyed()
 {

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleDataConverter.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleDataConverter.mm
@@ -43,9 +43,7 @@ AudioSampleDataConverter::AudioSampleDataConverter()
 {
 }
 
-AudioSampleDataConverter::~AudioSampleDataConverter()
-{
-}
+AudioSampleDataConverter::~AudioSampleDataConverter() = default;
 
 OSStatus AudioSampleDataConverter::setFormats(const CAAudioStreamDescription& inputDescription, const CAAudioStreamDescription& outputDescription)
 {

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm
@@ -62,9 +62,7 @@ AudioSampleDataSource::AudioSampleDataSource(size_t maximumSampleCount, LoggerHe
 #endif
 }
 
-AudioSampleDataSource::~AudioSampleDataSource()
-{
-}
+AudioSampleDataSource::~AudioSampleDataSource() = default;
 
 OSStatus AudioSampleDataSource::setupConverter()
 {

--- a/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
@@ -284,9 +284,7 @@ PlatformSpeechSynthesizer::PlatformSpeechSynthesizer(PlatformSpeechSynthesizerCl
 {
 }
 
-PlatformSpeechSynthesizer::~PlatformSpeechSynthesizer()
-{
-}
+PlatformSpeechSynthesizer::~PlatformSpeechSynthesizer() = default;
 
 void PlatformSpeechSynthesizer::appendVoices(NSArray *voices)
 {

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -65,9 +65,7 @@ PlaybackSessionModelMediaElement::PlaybackSessionModelMediaElement()
 {
 }
 
-PlaybackSessionModelMediaElement::~PlaybackSessionModelMediaElement()
-{
-}
+PlaybackSessionModelMediaElement::~PlaybackSessionModelMediaElement() = default;
 
 void PlaybackSessionModelMediaElement::setMediaElement(HTMLMediaElement* mediaElement)
 {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm
@@ -55,9 +55,7 @@ VideoLayerManagerObjC::VideoLayerManagerObjC(const Logger& logger, uint64_t logI
 }
 #endif
 
-VideoLayerManagerObjC::~VideoLayerManagerObjC()
-{
-}
+VideoLayerManagerObjC::~VideoLayerManagerObjC() = default;
 
 PlatformLayer* VideoLayerManagerObjC::videoInlineLayer() const
 {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
@@ -327,9 +327,7 @@ WebCoreAVFResourceLoader::WebCoreAVFResourceLoader(MediaPlayerPrivateAVFoundatio
 {
 }
 
-WebCoreAVFResourceLoader::~WebCoreAVFResourceLoader()
-{
-}
+WebCoreAVFResourceLoader::~WebCoreAVFResourceLoader() = default;
 
 void WebCoreAVFResourceLoader::startLoading()
 {

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
@@ -199,9 +199,7 @@ PlatformCAAnimationCocoa::PlatformCAAnimationCocoa(PlatformAnimationRef animatio
     m_animation = caAnimation;
 }
 
-PlatformCAAnimationCocoa::~PlatformCAAnimationCocoa()
-{
-}
+PlatformCAAnimationCocoa::~PlatformCAAnimationCocoa() = default;
 
 Ref<PlatformCAAnimation> PlatformCAAnimationCocoa::copy() const
 {

--- a/Source/WebCore/platform/graphics/cocoa/IconCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IconCocoa.mm
@@ -39,9 +39,7 @@ Icon::Icon(CocoaImage *image)
 {
 }
 
-Icon::~Icon()
-{
-}
+Icon::~Icon() = default;
 
 RefPtr<Icon> Icon::create(CocoaImage *image)
 {

--- a/Source/WebCore/platform/ios/DeviceMotionClientIOS.mm
+++ b/Source/WebCore/platform/ios/DeviceMotionClientIOS.mm
@@ -42,9 +42,7 @@ DeviceMotionClientIOS::DeviceMotionClientIOS(RefPtr<DeviceOrientationUpdateProvi
 {
 }
 
-DeviceMotionClientIOS::~DeviceMotionClientIOS()
-{
-}
+DeviceMotionClientIOS::~DeviceMotionClientIOS() = default;
 
 void DeviceMotionClientIOS::setController(DeviceMotionController* controller)
 {

--- a/Source/WebCore/platform/ios/DeviceOrientationClientIOS.mm
+++ b/Source/WebCore/platform/ios/DeviceOrientationClientIOS.mm
@@ -42,9 +42,7 @@ DeviceOrientationClientIOS::DeviceOrientationClientIOS(RefPtr<DeviceOrientationU
 {
 }
 
-DeviceOrientationClientIOS::~DeviceOrientationClientIOS()
-{
-}
+DeviceOrientationClientIOS::~DeviceOrientationClientIOS() = default;
 
 void DeviceOrientationClientIOS::setController(DeviceOrientationController* controller)
 {

--- a/Source/WebCore/platform/ios/ScrollAnimatorIOS.mm
+++ b/Source/WebCore/platform/ios/ScrollAnimatorIOS.mm
@@ -52,9 +52,7 @@ ScrollAnimatorIOS::ScrollAnimatorIOS(ScrollableArea& scrollableArea)
 {
 }
 
-ScrollAnimatorIOS::~ScrollAnimatorIOS()
-{
-}
+ScrollAnimatorIOS::~ScrollAnimatorIOS() = default;
 
 #if ENABLE(TOUCH_EVENTS)
 bool ScrollAnimatorIOS::handleTouchEvent(const PlatformTouchEvent& touchEvent)

--- a/Source/WebCore/platform/ios/ScrollbarThemeIOS.mm
+++ b/Source/WebCore/platform/ios/ScrollbarThemeIOS.mm
@@ -55,9 +55,7 @@ ScrollbarThemeIOS::ScrollbarThemeIOS()
 {
 }
 
-ScrollbarThemeIOS::~ScrollbarThemeIOS()
-{
-}
+ScrollbarThemeIOS::~ScrollbarThemeIOS() = default;
 
 void ScrollbarThemeIOS::preferencesChanged()
 {

--- a/Source/WebCore/platform/ios/WebSQLiteDatabaseTrackerClient.mm
+++ b/Source/WebCore/platform/ios/WebSQLiteDatabaseTrackerClient.mm
@@ -56,9 +56,7 @@ WebSQLiteDatabaseTrackerClient::WebSQLiteDatabaseTrackerClient()
     ASSERT(pthread_main_np());
 }
 
-WebSQLiteDatabaseTrackerClient::~WebSQLiteDatabaseTrackerClient()
-{
-}
+WebSQLiteDatabaseTrackerClient::~WebSQLiteDatabaseTrackerClient() = default;
 
 void WebSQLiteDatabaseTrackerClient::willBeginFirstTransaction()
 {

--- a/Source/WebCore/platform/ios/WidgetIOS.mm
+++ b/Source/WebCore/platform/ios/WidgetIOS.mm
@@ -65,9 +65,7 @@ Widget::Widget(NSView* view)
     init(view);
 }
 
-Widget::~Widget()
-{
-}
+Widget::~Widget() = default;
 
 // FIXME: Should move this to Chrome; bad layering that this knows about Frame.
 void Widget::setFocus(bool focused)

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
@@ -210,9 +210,7 @@ ScrollbarThemeMac::ScrollbarThemeMac()
     }
 }
 
-ScrollbarThemeMac::~ScrollbarThemeMac()
-{
-}
+ScrollbarThemeMac::~ScrollbarThemeMac() = default;
 
 void ScrollbarThemeMac::preferencesChanged()
 {

--- a/Source/WebCore/platform/mac/WidgetMac.mm
+++ b/Source/WebCore/platform/mac/WidgetMac.mm
@@ -81,9 +81,7 @@ Widget::Widget(NSView *view)
     init(view);
 }
 
-Widget::~Widget()
-{
-}
+Widget::~Widget() = default;
 
 // FIXME: Should move this to Chrome; bad layering that this knows about Frame.
 void Widget::setFocus(bool focused)

--- a/Source/WebCore/platform/network/cocoa/ResourceHandleCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceHandleCocoa.mm
@@ -82,9 +82,7 @@ static NSOperationQueue *operationQueueForAsyncClients()
     return queue.get().get();
 }
 
-ResourceHandleInternal::~ResourceHandleInternal()
-{
-}
+ResourceHandleInternal::~ResourceHandleInternal() = default;
 
 ResourceHandle::~ResourceHandle()
 {

--- a/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
+++ b/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
@@ -83,9 +83,7 @@ LocaleCocoa::LocaleCocoa(const AtomString& locale)
     [m_gregorianCalendar setLocale:m_locale];
 }
 
-LocaleCocoa::~LocaleCocoa()
-{
-}
+LocaleCocoa::~LocaleCocoa() = default;
 
 RetainPtr<NSDateFormatter> LocaleCocoa::shortDateFormatter()
 {


### PR DESCRIPTION
#### b58109b70bd3b70d4150878ac16d5a318bac9968
<pre>
Use &quot;= default&quot; for destructor in WebCore code
<a href="https://bugs.webkit.org/show_bug.cgi?id=311423">https://bugs.webkit.org/show_bug.cgi?id=311423</a>
<a href="https://rdar.apple.com/174024173">rdar://174024173</a>

Reviewed by Anne van Kesteren.

This extends our &quot;= default&quot; usage across few leftover empty destructors
in WebCore code.

* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::~ScrollingTreeScrollingNodeDelegateMac): Deleted.
* Source/WebCore/platform/audio/cocoa/AudioSampleDataConverter.mm:
(WebCore::AudioSampleDataConverter::~AudioSampleDataConverter): Deleted.
* Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm:
(WebCore::AudioSampleDataSource::~AudioSampleDataSource): Deleted.
* Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm:
(WebCore::PlatformSpeechSynthesizer::~PlatformSpeechSynthesizer): Deleted.
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
(WebCore::PlaybackSessionModelMediaElement::~PlaybackSessionModelMediaElement): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm:
(WebCore::VideoLayerManagerObjC::~VideoLayerManagerObjC): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm:
(WebCore::WebCoreAVFResourceLoader::~WebCoreAVFResourceLoader): Deleted.
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm:
(WebCore::PlatformCAAnimationCocoa::~PlatformCAAnimationCocoa): Deleted.
* Source/WebCore/platform/graphics/cocoa/IconCocoa.mm:
(WebCore::Icon::~Icon): Deleted.
* Source/WebCore/platform/ios/DeviceMotionClientIOS.mm:
(WebCore::DeviceMotionClientIOS::~DeviceMotionClientIOS): Deleted.
* Source/WebCore/platform/ios/DeviceOrientationClientIOS.mm:
(WebCore::DeviceOrientationClientIOS::~DeviceOrientationClientIOS): Deleted.
* Source/WebCore/platform/ios/ScrollAnimatorIOS.mm:
(WebCore::ScrollAnimatorIOS::~ScrollAnimatorIOS): Deleted.
* Source/WebCore/platform/ios/ScrollbarThemeIOS.mm:
(WebCore::ScrollbarThemeIOS::~ScrollbarThemeIOS): Deleted.
* Source/WebCore/platform/ios/WebSQLiteDatabaseTrackerClient.mm:
(WebCore::WebSQLiteDatabaseTrackerClient::~WebSQLiteDatabaseTrackerClient): Deleted.
* Source/WebCore/platform/ios/WidgetIOS.mm:
(WebCore::Widget::~Widget): Deleted.
* Source/WebCore/platform/mac/ScrollbarThemeMac.mm:
(WebCore::ScrollbarThemeMac::~ScrollbarThemeMac): Deleted.
* Source/WebCore/platform/mac/WidgetMac.mm:
(WebCore::Widget::~Widget): Deleted.
* Source/WebCore/platform/network/cocoa/ResourceHandleCocoa.mm:
(WebCore::ResourceHandleInternal::~ResourceHandleInternal): Deleted.
* Source/WebCore/platform/text/cocoa/LocaleCocoa.mm:
(WebCore::LocaleCocoa::~LocaleCocoa): Deleted.

Canonical link: <a href="https://commits.webkit.org/310548@main">https://commits.webkit.org/310548@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9657948efd9273bf1abe2b585f699fcf8deec91b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154136 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27393 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20554 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162890 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107604 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27244 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119211 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84273 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157095 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138418 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99907 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20548 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18544 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10722 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130210 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16263 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165362 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8571 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17871 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127305 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26940 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22586 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127451 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34588 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26864 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138056 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/83457 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22324 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14848 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26554 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90656 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26135 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26366 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26207 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->