### PR TITLE
[AutoFill Debugging] Adjust extraction heuristics to include form elements around password fields

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-offscreen-password-fields-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-offscreen-password-fields-expected.txt
@@ -1,0 +1,49 @@
+-- texttree
+
+root
+    scrollable,scrollPosition=(0,0),contentSize=[…]
+        section
+            article
+                'Article Title'
+                'This is some visible content.'
+        form,autocomplete='on',name='login'
+            'Log in to your account'
+            input,'text',placeholder='Username',name='username',required
+            input,'password',placeholder='Password',name='password',required,secure
+            input,'password',placeholder='Confirm Password',name='confirm-password',required,secure
+            button,'Log in'
+        'Enter access code'
+        input,'password',placeholder='Access Code',name='access-code',secure
+        form,autocomplete='on'
+            'Create account'
+            input,'text',placeholder='User',name='user',required
+        input,'password',placeholder='Password',name='pass',required,secure
+
+-- html
+
+<body>
+    <main>
+        <section>
+            <article>
+                Article Title
+                This is some visible content.
+            </article>
+        </section>
+        <form autocomplete='on' name='login'>
+            Log in to your account
+            <input type='text' placeholder='Username' name='username' required>
+            <input type='password' placeholder='Password' name='password' required>
+            <input type='password' placeholder='Confirm Password' name='confirm-password' required>
+            <button>Log in</button>
+        </form>
+        Enter access code
+        <input type='password' placeholder='Access Code' name='access-code'>
+        <form autocomplete='on'>
+            Create account
+            <input type='text' placeholder='User' name='user' required>
+        </form>
+        <input type='password' placeholder='Password' name='pass' required>
+    </main>
+</body>
+
+

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-offscreen-password-fields.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-offscreen-password-fields.html
@@ -1,0 +1,124 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+<style>
+.text-representation {
+    white-space: pre-wrap;
+}
+
+.tall {
+    width: 1px;
+    height: 150vh;
+}
+
+form {
+    width: 390px;
+    height: 350px;
+    border-radius: 1em;
+    border: 1px solid black;
+    padding: 1em;
+}
+
+h4 {
+    margin: auto;
+}
+
+main {
+    position: fixed;
+    inset: 0;
+    overflow-y: scroll;
+}
+
+.password-wrapper {
+    width: 300px;
+    height: 250px;
+    border: 1px solid gray;
+    padding: 0.5em;
+}
+
+.standalone-container {
+    width: 390px;
+    height: 350px;
+    border: 1px solid gray;
+    padding: 1em;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<main role="main">
+    <section aria-label="Visible content">
+        <article role="article">
+            <header>
+                <h3>Article Title</h3>
+            </header>
+            <p>This is some visible content.</p>
+        </article>
+    </section>
+    <div class="tall"></div>
+    <section aria-label="Login section">
+        <form name="login" autocomplete="on">
+            <h4>Log in to your account</h4>
+            <input name="username" placeholder="Username" required />
+            <div class="password-wrapper">
+                <input name="password" placeholder="Password" type="password" required />
+                <input name="confirm-password" placeholder="Confirm Password" type="password" required />
+            </div>
+            <button type="submit">Log in</button>
+        </form>
+    </section>
+    <section aria-label="Standalone password">
+        <div class="standalone-container">
+            <h4>Enter access code</h4>
+            <input name="access-code" placeholder="Access Code" type="password" />
+        </div>
+    </section>
+    <section aria-label="Distant form">
+        <form id="distant-form" autocomplete="on">
+            <h4>Create account</h4>
+            <input name="user" placeholder="User" required />
+        </form>
+        <div class="password-wrapper">
+            <input name="pass" placeholder="Password" type="password" form="distant-form" required />
+        </div>
+    </section>
+</main>
+<script>
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    const results = [];
+    for (let outputFormat of ["texttree", "html"]) {
+        const heading = document.createElement("h1");
+        heading.textContent = `-- ${outputFormat}`;
+
+        const container = document.createElement("pre");
+        container.classList.add("text-representation");
+        let textContent = await UIHelper.requestDebugText({
+            normalize: true,
+            includeRects: false,
+            includeURLs: false,
+            includeOffscreenPasswordFields: true,
+            clipToBounds: true,
+            outputFormat,
+        });
+
+        container.textContent = textContent;
+        results.push(heading);
+        results.push(container);
+        results.push(document.createElement("br"));
+    }
+
+    document.body.replaceChildren(...results);
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -1243,15 +1243,22 @@ Result extractItem(Request&& request, LocalFrame& frame)
         WeakHashSet<Node, WeakPtrImplWithEventTargetData> additionalContainersToCollect;
         RefPtr extractionRoot = dynamicDowncast<ContainerNode>(*extractionRootNode);
         if (extractionRoot && request.includeOffscreenPasswordFields && request.collectionRectInRootView) {
-            Vector<Ref<HTMLInputElement>> passwordFields;
+            ListHashSet<Ref<HTMLElement>> targetedElements;
             for (Ref input : descendantsOfType<HTMLInputElement>(*extractionRoot)) {
-                if (input->isPasswordField())
-                    passwordFields.append(input);
+                if (!input->isPasswordField())
+                    continue;
+
+                RefPtr form = input->form();
+                if (!form || !input->isShadowIncludingDescendantOf(*form))
+                    targetedElements.add(input);
+
+                if (form)
+                    targetedElements.add(form.releaseNonNull());
             }
 
-            for (Ref passwordField : passwordFields) {
+            for (Ref element : targetedElements) {
                 static constexpr FloatSize minimumSize { 280, 200 };
-                if (RefPtr container = findLargeContainerAboveNode(passwordField, minimumSize)) {
+                if (RefPtr container = findLargeContainerAboveNode(element, minimumSize)) {
                     addBoxShadowIfNeeded(*container, "#cb30e0"_s);
                     additionalContainersToCollect.add(container.releaseNonNull());
                 }


### PR DESCRIPTION
#### 84f3aa4aa3a4fc9056ddde8fcb2dcab295188600
<pre>
[AutoFill Debugging] Adjust extraction heuristics to include form elements around password fields
<a href="https://bugs.webkit.org/show_bug.cgi?id=311425">https://bugs.webkit.org/show_bug.cgi?id=311425</a>
<a href="https://rdar.apple.com/173252294">rdar://173252294</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

When the `includeOffscreenPasswordFields` flag is set, make sure we encompass forms that contain all
the password fields (not just the &quot;large container&quot; above each password field).

Test: fast/text-extraction/debug-text-extraction-offscreen-password-fields.html

* LayoutTests/fast/text-extraction/debug-text-extraction-offscreen-password-fields-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-offscreen-password-fields.html: Added.
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItem):

Canonical link: <a href="https://commits.webkit.org/310537@main">https://commits.webkit.org/310537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44eb75fcfc031d2bbe5b04ea3686d104a48c41d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162891 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/42144887-e065-43a8-86e4-dc5b369d63ba) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27245 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119213 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e864b295-826d-4c1f-8f50-d3305dc7adff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21461 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138419 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99909 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10723 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/130211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16264 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165363 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/8572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17872 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127308 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26941 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22588 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127454 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34577 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26865 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138057 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83458 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22323 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14849 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26555 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/90657 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26136 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26367 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26208 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->