### PR TITLE
Use std::lerp instead of custom linearInterpolation helpers in WebCore

### DIFF
--- a/Source/WebCore/platform/ScrollAnimationSmooth.cpp
+++ b/Source/WebCore/platform/ScrollAnimationSmooth.cpp
@@ -106,11 +106,6 @@ Seconds ScrollAnimationSmooth::durationFromDistance(const FloatSize& delta) cons
     return std::min(Seconds(distance / animationSpeed), maxAnimationDuration);
 }
 
-inline float NODELETE linearInterpolation(float progress, float a, float b)
-{
-    return a + progress * (b - a);
-}
-
 void ScrollAnimationSmooth::serviceAnimation(MonotonicTime currentTime)
 {
     bool animationActive = animateScroll(currentTime);
@@ -125,11 +120,11 @@ bool ScrollAnimationSmooth::animateScroll(MonotonicTime currentTime)
     currentTime = std::min(currentTime, endTime);
 
     double fractionComplete = (currentTime - m_startTime) / m_duration;
-    double progress = m_timingFunction->transformProgress(fractionComplete, m_duration.value());
+    float progress = m_timingFunction->transformProgress(fractionComplete, m_duration.value());
 
     m_currentOffset = {
-        linearInterpolation(progress, m_startOffset.x(), m_destinationOffset.x()),
-        linearInterpolation(progress, m_startOffset.y(), m_destinationOffset.y()),
+        std::lerp(m_startOffset.x(), m_destinationOffset.x(), progress),
+        std::lerp(m_startOffset.y(), m_destinationOffset.y(), progress),
     };
 
     return currentTime < endTime;

--- a/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
@@ -230,7 +230,7 @@ ColorComponents<float, 4> FETurbulenceSoftwareApplier::noise2D(const PaintingDat
         q = paintingData.gradient[channel][b10];
         float v = (noiseX.fraction - 1) * q[0] + noiseY.fraction * q[1];
         // a = lerp(sx, u, v);
-        float a = linearInterpolation(sx, u, v);
+        float a = std::lerp(u, v, sx);
 
         // b01 = uLatticeSelector[i + by1];
         int b01 = paintingData.latticeSelector[latticeIndex + noiseY.nextIndex];
@@ -245,10 +245,10 @@ ColorComponents<float, 4> FETurbulenceSoftwareApplier::noise2D(const PaintingDat
         q = paintingData.gradient[channel][b11];
         v = (noiseX.fraction - 1) * q[0] + (noiseY.fraction - 1) * q[1];
         // b = lerp(sx, u, v);
-        float b = linearInterpolation(sx, u, v);
+        float b = std::lerp(u, v, sx);
 
         // return lerp(sy, a, b);
-        return linearInterpolation(sy, a, b);
+        return std::lerp(a, b, sy);
     };
 
     return {

--- a/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.h
@@ -88,7 +88,6 @@ private:
     static long NODELETE random(long& seed);
 
     static inline float smoothCurve(float t) { return t * t * (3 - 2 * t); }
-    static inline float linearInterpolation(float t, float a, float b) { return a + t * (b - a); }
 
     static ColorComponents<float, 4> noise2D(const PaintingData&, const StitchData&, const FloatPoint& noiseVector);
     static ColorComponents<uint8_t, 4> toIntBasedColorComponents(const ColorComponents<float, 4>& floatComponents);


### PR DESCRIPTION
#### a03165eb7c18a4621681c6580155cb0f1d8009ef
<pre>
Use std::lerp instead of custom linearInterpolation helpers in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=311426">https://bugs.webkit.org/show_bug.cgi?id=311426</a>
<a href="https://rdar.apple.com/174024669">rdar://174024669</a>

Reviewed by Simon Fraser.

Replace two custom linearInterpolation(t, a, b) helper functions with
C++20 std::lerp(a, b, t), removing the now-unused helpers.

* Source/WebCore/platform/ScrollAnimationSmooth.cpp:
(WebCore::ScrollAnimationSmooth::animateScroll): Make `progress` float as well.
(WebCore::linearInterpolation): Deleted.
* Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp:
(WebCore::FETurbulenceSoftwareApplier::noise2D):
* Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.h:

Canonical link: <a href="https://commits.webkit.org/310709@main">https://commits.webkit.org/310709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/256025722e1e0a87287671f52ff65f6b7b63e346

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154607 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21025 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163365 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108076 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/423a317d-0add-4eaa-94cb-63a78312983a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156480 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27999 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27715 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119584 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84574 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/641fc75e-7453-48a8-a8a0-3db66706c274) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21872 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138853 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100281 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aea96856-f83b-46e3-9563-bef13e7aa6e7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20957 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18974 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11193 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130620 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16697 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165837 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9042 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18306 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127685 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23014 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127828 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34702 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138490 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84017 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22724 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15283 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27027 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91129 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26605 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26836 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26678 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->