### PR TITLE
Use "= default" for destructor in WebKit code

### DIFF
--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -98,9 +98,7 @@ GPUProcess::GPUProcess()
 #endif
 }
 
-GPUProcess::~GPUProcess()
-{
-}
+GPUProcess::~GPUProcess() = default;
 
 GPUProcess& GPUProcess::singleton()
 {

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
@@ -52,9 +52,7 @@ RemoteCDMInstanceSessionProxy::RemoteCDMInstanceSessionProxy(WeakPtr<RemoteCDMPr
 {
 }
 
-RemoteCDMInstanceSessionProxy::~RemoteCDMInstanceSessionProxy()
-{
-}
+RemoteCDMInstanceSessionProxy::~RemoteCDMInstanceSessionProxy() = default;
 
 void RemoteCDMInstanceSessionProxy::setLogIdentifier(uint64_t logIdentifier)
 {

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm
@@ -91,9 +91,7 @@ void RemoteSampleBufferDisplayLayer::setLogIdentifier(uint64_t identifier)
 }
 #endif
 
-RemoteSampleBufferDisplayLayer::~RemoteSampleBufferDisplayLayer()
-{
-}
+RemoteSampleBufferDisplayLayer::~RemoteSampleBufferDisplayLayer() = default;
 
 CGRect RemoteSampleBufferDisplayLayer::bounds() const
 {

--- a/Source/WebKit/NetworkProcess/NetworkActivityTracker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkActivityTracker.cpp
@@ -34,9 +34,7 @@ NetworkActivityTracker::NetworkActivityTracker(Label, Domain)
 {
 }
 
-NetworkActivityTracker::~NetworkActivityTracker()
-{
-}
+NetworkActivityTracker::~NetworkActivityTracker() = default;
 
 void NetworkActivityTracker::setParent(NetworkActivityTracker&)
 {

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -149,9 +149,7 @@ Cache::Cache(NetworkProcess& networkProcess, const String& storageDirectory, Ref
     }
 }
 
-Cache::~Cache()
-{
-}
+Cache::~Cache() = default;
 
 size_t Cache::capacity() const
 {

--- a/Source/WebKit/NetworkProcess/cache/PrefetchCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/PrefetchCache.cpp
@@ -50,9 +50,7 @@ PrefetchCache::PrefetchCache()
 {
 }
 
-PrefetchCache::~PrefetchCache()
-{
-}
+PrefetchCache::~PrefetchCache() = default;
 
 void PrefetchCache::clear()
 {

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkActivityTrackerCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkActivityTrackerCocoa.mm
@@ -37,9 +37,7 @@ NetworkActivityTracker::NetworkActivityTracker(Label label, Domain domain)
 {
 }
 
-NetworkActivityTracker::~NetworkActivityTracker()
-{
-}
+NetworkActivityTracker::~NetworkActivityTracker() = default;
 
 void NetworkActivityTracker::setParent(NetworkActivityTracker& parent)
 {

--- a/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp
@@ -55,10 +55,7 @@ NetworkSessionCurl::NetworkSessionCurl(NetworkProcess& networkProcess, const Net
     setTrackingPreventionEnabled(parameters.resourceLoadStatisticsParameters.enabled);
 }
 
-NetworkSessionCurl::~NetworkSessionCurl()
-{
-
-}
+NetworkSessionCurl::~NetworkSessionCurl() = default;
 
 void NetworkSessionCurl::clearAlternativeServices(WallTime)
 {

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp
@@ -54,9 +54,7 @@ BackgroundFetchStoreImpl::BackgroundFetchStoreImpl(ThreadSafeWeakPtr<NetworkStor
 {
 }
 
-BackgroundFetchStoreImpl::~BackgroundFetchStoreImpl()
-{
-}
+BackgroundFetchStoreImpl::~BackgroundFetchStoreImpl() = default;
 
 String BackgroundFetchStoreImpl::getFilename(const ServiceWorkerRegistrationKey& key, const String& identifier)
 {

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp
@@ -67,9 +67,7 @@ BackgroundFetchStoreManager::BackgroundFetchStoreManager(const String& path, Ref
     });
 }
 
-BackgroundFetchStoreManager::~BackgroundFetchStoreManager()
-{
-}
+BackgroundFetchStoreManager::~BackgroundFetchStoreManager() = default;
 
 void BackgroundFetchStoreManager::initializeFetches(InitializeCallback&& callback)
 {

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
@@ -129,9 +129,7 @@ NetworkRTCUDPSocketCocoa::NetworkRTCUDPSocketCocoa(WebCore::LibWebRTCSocketIdent
 {
 }
 
-NetworkRTCUDPSocketCocoa::~NetworkRTCUDPSocketCocoa()
-{
-}
+NetworkRTCUDPSocketCocoa::~NetworkRTCUDPSocketCocoa() = default;
 
 void NetworkRTCUDPSocketCocoa::close()
 {

--- a/Source/WebKit/Platform/IPC/MessageReceiverMap.cpp
+++ b/Source/WebKit/Platform/IPC/MessageReceiverMap.cpp
@@ -35,9 +35,7 @@ MessageReceiverMap::MessageReceiverMap()
 {
 }
 
-MessageReceiverMap::~MessageReceiverMap()
-{
-}
+MessageReceiverMap::~MessageReceiverMap() = default;
 
 void MessageReceiverMap::addMessageReceiver(ReceiverName messageReceiverName, MessageReceiver& messageReceiver)
 {

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -74,9 +74,7 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(VideoPresentationInterfaceLMK);
 
-VideoPresentationInterfaceLMK::~VideoPresentationInterfaceLMK()
-{
-}
+VideoPresentationInterfaceLMK::~VideoPresentationInterfaceLMK() = default;
 
 Ref<VideoPresentationInterfaceLMK> VideoPresentationInterfaceLMK::create(WebCore::PlaybackSessionInterfaceIOS& playbackSessionInterface)
 {

--- a/Source/WebKit/Shared/APIWebArchive.mm
+++ b/Source/WebKit/Shared/APIWebArchive.mm
@@ -92,9 +92,7 @@ WebArchive::WebArchive(RefPtr<LegacyWebArchive>&& legacyWebArchive)
 {
 }
 
-WebArchive::~WebArchive()
-{
-}
+WebArchive::~WebArchive() = default;
 
 WebArchiveResource* WebArchive::mainResource()
 {

--- a/Source/WebKit/Shared/BlobDataFileReferenceWithSandboxExtension.cpp
+++ b/Source/WebKit/Shared/BlobDataFileReferenceWithSandboxExtension.cpp
@@ -36,9 +36,7 @@ BlobDataFileReferenceWithSandboxExtension::BlobDataFileReferenceWithSandboxExten
 {
 }
 
-BlobDataFileReferenceWithSandboxExtension::~BlobDataFileReferenceWithSandboxExtension()
-{
-}
+BlobDataFileReferenceWithSandboxExtension::~BlobDataFileReferenceWithSandboxExtension() = default;
 
 void BlobDataFileReferenceWithSandboxExtension::prepareForFileAccess()
 {

--- a/Source/WebKit/Shared/HangDetectionDisabler.h
+++ b/Source/WebKit/Shared/HangDetectionDisabler.h
@@ -44,9 +44,7 @@ inline HangDetectionDisabler::HangDetectionDisabler()
 {
 }
 
-inline HangDetectionDisabler::~HangDetectionDisabler()
-{
-}
+inline HangDetectionDisabler::~HangDetectionDisabler() = default;
 #endif
 
 }

--- a/Source/WebKit/Shared/SandboxExtension.h
+++ b/Source/WebKit/Shared/SandboxExtension.h
@@ -160,7 +160,7 @@ String resolveAndCreateReadWriteDirectoryForSandboxExtension(StringView path);
 
 inline SandboxExtensionHandle::SandboxExtensionHandle() { }
 inline SandboxExtensionHandle::SandboxExtensionHandle(const SandboxExtensionHandle&) { }
-inline SandboxExtensionHandle::~SandboxExtensionHandle() { }
+inline SandboxExtensionHandle::~SandboxExtensionHandle() = default;
 inline RefPtr<SandboxExtension> SandboxExtension::create(Handle&&) { return nullptr; }
 inline auto SandboxExtension::createHandle(StringView, Type) -> std::optional<Handle> { return Handle { }; }
 inline auto SandboxExtension::createReadOnlyHandlesForFiles(ASCIILiteral, const Vector<String>&) -> Vector<Handle> { return { }; }
@@ -168,7 +168,7 @@ inline auto SandboxExtension::createHandleWithoutResolvingPath(StringView, Type)
 inline auto SandboxExtension::createHandleForReadWriteDirectory(StringView) -> std::optional<Handle> { return Handle { }; }
 inline auto SandboxExtension::createHandleForTemporaryFile(StringView, Type) -> std::optional<std::pair<Handle, String>> { return std::pair<Handle, String> { }; }
 inline auto SandboxExtension::createHandleForGenericExtension(ASCIILiteral) -> std::optional<Handle> { return Handle { }; }
-inline SandboxExtension::~SandboxExtension() { }
+inline SandboxExtension::~SandboxExtension() = default;
 inline bool SandboxExtension::revoke() { return true; }
 inline bool SandboxExtension::consume() { return true; }
 inline bool SandboxExtension::consumePermanently() { return true; }

--- a/Source/WebKit/Shared/SandboxInitializationParameters.h
+++ b/Source/WebKit/Shared/SandboxInitializationParameters.h
@@ -107,9 +107,7 @@ SandboxInitializationParameters::SandboxInitializationParameters()
 {
 }
 
-SandboxInitializationParameters::~SandboxInitializationParameters()
-{
-}
+SandboxInitializationParameters::~SandboxInitializationParameters() = default;
 #endif
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/SharedStringHashTable.cpp
+++ b/Source/WebKit/Shared/SharedStringHashTable.cpp
@@ -37,9 +37,7 @@ SharedStringHashTable::SharedStringHashTable()
 {
 }
 
-SharedStringHashTable::~SharedStringHashTable()
-{
-}
+SharedStringHashTable::~SharedStringHashTable() = default;
 
 bool SharedStringHashTable::add(SharedStringHash sharedStringHash)
 {

--- a/Source/WebKit/Shared/WebCompiledContentRuleList.cpp
+++ b/Source/WebKit/Shared/WebCompiledContentRuleList.cpp
@@ -42,9 +42,7 @@ WebCompiledContentRuleList::WebCompiledContentRuleList(WebCompiledContentRuleLis
 {
 }
 
-WebCompiledContentRuleList::~WebCompiledContentRuleList()
-{
-}
+WebCompiledContentRuleList::~WebCompiledContentRuleList() = default;
 
 std::span<const uint8_t> WebCompiledContentRuleList::urlFiltersBytecode() const
 {

--- a/Source/WebKit/Shared/WebGeolocationPosition.cpp
+++ b/Source/WebKit/Shared/WebGeolocationPosition.cpp
@@ -37,8 +37,6 @@ Ref<WebGeolocationPosition> WebGeolocationPosition::create(GeolocationPositionDa
     return adoptRef(*new WebGeolocationPosition(WTF::move(geolocationPosition)));
 }
 
-WebGeolocationPosition::~WebGeolocationPosition()
-{
-}
+WebGeolocationPosition::~WebGeolocationPosition() = default;
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebHitTestResultData.cpp
+++ b/Source/WebKit/Shared/WebHitTestResultData.cpp
@@ -198,9 +198,7 @@ WebHitTestResultData::WebHitTestResultData(const String& absoluteImageURL, const
         imageSharedMemory = WebCore::SharedMemory::map(WTF::move(*imageHandle), WebCore::SharedMemory::Protection::ReadOnly);
 }
 
-WebHitTestResultData::~WebHitTestResultData()
-{
-}
+WebHitTestResultData::~WebHitTestResultData() = default;
 
 IntRect WebHitTestResultData::elementBoundingBoxInWindowCoordinates(const WebCore::HitTestResult& hitTestResult)
 {

--- a/Source/WebKit/Shared/WebKeyboardEvent.cpp
+++ b/Source/WebKit/Shared/WebKeyboardEvent.cpp
@@ -137,9 +137,7 @@ WebKeyboardEvent::WebKeyboardEvent(WebEvent&& event, const String& text, const S
 
 #endif
 
-WebKeyboardEvent::~WebKeyboardEvent()
-{
-}
+WebKeyboardEvent::~WebKeyboardEvent() = default;
 
 bool WebKeyboardEvent::isKeyboardEventType(WebEventType type)
 {

--- a/Source/WebKit/Shared/glib/WebContextMenuItemGlib.cpp
+++ b/Source/WebKit/Shared/glib/WebContextMenuItemGlib.cpp
@@ -94,9 +94,7 @@ WebContextMenuItemGlib::WebContextMenuItemGlib(GtkAction* action)
 ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 
-WebContextMenuItemGlib::~WebContextMenuItemGlib()
-{
-}
+WebContextMenuItemGlib::~WebContextMenuItemGlib() = default;
 
 void WebContextMenuItemGlib::createActionIfNeeded()
 {

--- a/Source/WebKit/UIProcess/API/APIAttachment.cpp
+++ b/Source/WebKit/UIProcess/API/APIAttachment.cpp
@@ -46,9 +46,7 @@ Attachment::Attachment(const WTF::String& identifier, WebKit::WebPageProxy& webP
 {
 }
 
-Attachment::~Attachment()
-{
-}
+Attachment::~Attachment() = default;
 
 void Attachment::updateAttributes(CompletionHandler<void()>&& callback)
 {

--- a/Source/WebKit/UIProcess/API/APIContentRuleList.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleList.cpp
@@ -41,9 +41,7 @@ ContentRuleList::ContentRuleList(Ref<WebKit::WebCompiledContentRuleList>&& conte
 {
 }
 
-ContentRuleList::~ContentRuleList()
-{
-}
+ContentRuleList::~ContentRuleList() = default;
 
 const WTF::String& ContentRuleList::name() const
 {

--- a/Source/WebKit/UIProcess/API/APIFormInfo.cpp
+++ b/Source/WebKit/UIProcess/API/APIFormInfo.cpp
@@ -39,9 +39,7 @@ FormInfo::FormInfo(API::FrameInfo& frame, API::FrameInfo& sourceFrame, const WTF
 {
 }
 
-FormInfo::~FormInfo()
-{
-}
+FormInfo::~FormInfo() = default;
 
 API::FrameInfo* FormInfo::targetFrame() const
 {

--- a/Source/WebKit/UIProcess/API/APINavigation.cpp
+++ b/Source/WebKit/UIProcess/API/APINavigation.cpp
@@ -96,9 +96,7 @@ Navigation::Navigation(WebCore::ProcessIdentifier processID, WebCore::ResourceRe
     m_substituteData = WTF::move(substituteData);
 }
 
-Navigation::~Navigation()
-{
-}
+Navigation::~Navigation() = default;
 
 void Navigation::resetRequestStart()
 {

--- a/Source/WebKit/UIProcess/API/APINavigationData.cpp
+++ b/Source/WebKit/UIProcess/API/APINavigationData.cpp
@@ -33,8 +33,6 @@ NavigationData::NavigationData(const WebKit::WebNavigationDataStore& store)
 {
 }
 
-NavigationData::~NavigationData()
-{
-}
+NavigationData::~NavigationData() = default;
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/APIOpenPanelParameters.cpp
+++ b/Source/WebKit/UIProcess/API/APIOpenPanelParameters.cpp
@@ -45,9 +45,7 @@ OpenPanelParameters::OpenPanelParameters(const FileChooserSettings& settings)
 {
 }
 
-OpenPanelParameters::~OpenPanelParameters()
-{
-}
+OpenPanelParameters::~OpenPanelParameters() = default;
 
 Ref<API::Array> OpenPanelParameters::acceptMIMETypes() const
 {

--- a/Source/WebKit/UIProcess/API/APISessionState.cpp
+++ b/Source/WebKit/UIProcess/API/APISessionState.cpp
@@ -38,8 +38,6 @@ SessionState::SessionState(WebKit::SessionState sessionState)
 {
 }
 
-SessionState::~SessionState()
-{
-}
+SessionState::~SessionState() = default;
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APIWebsiteDataRecord.cpp
+++ b/Source/WebKit/UIProcess/API/APIWebsiteDataRecord.cpp
@@ -38,8 +38,6 @@ WebsiteDataRecord::WebsiteDataRecord(WebKit::WebsiteDataRecord&& websiteDataReco
 {
 }
 
-WebsiteDataRecord::~WebsiteDataRecord()
-{
-}
+WebsiteDataRecord::~WebsiteDataRecord() = default;
 
 }

--- a/Source/WebKit/UIProcess/API/APIWindowFeatures.cpp
+++ b/Source/WebKit/UIProcess/API/APIWindowFeatures.cpp
@@ -38,8 +38,6 @@ WindowFeatures::WindowFeatures(const WebCore::WindowFeatures& windowFeatures)
 {
 }
 
-WindowFeatures::~WindowFeatures()
-{
-}
+WindowFeatures::~WindowFeatures() = default;
 
 }

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewLoadRequest.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewLoadRequest.cpp
@@ -40,9 +40,7 @@ WPEQtViewLoadRequest::WPEQtViewLoadRequest(const QUrl& url, WPEQtView::LoadStatu
 {
 }
 
-WPEQtViewLoadRequest::~WPEQtViewLoadRequest()
-{
-}
+WPEQtViewLoadRequest::~WPEQtViewLoadRequest() = default;
 
 bool WPEQtViewLoadRequest::event(QEvent* ev)
 {

--- a/Source/WebKit/UIProcess/Authentication/WebCredential.cpp
+++ b/Source/WebKit/UIProcess/Authentication/WebCredential.cpp
@@ -33,9 +33,7 @@ WebCredential::WebCredential(const WebCore::Credential& credential)
 {
 }
 
-WebCredential::~WebCredential()
-{
-}
+WebCredential::~WebCredential() = default;
 
 const WebCore::Credential& WebCredential::credential()
 {

--- a/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.cpp
+++ b/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.cpp
@@ -44,9 +44,7 @@ BackgroundProcessResponsivenessTimer::BackgroundProcessResponsivenessTimer(WebPr
 {
 }
 
-BackgroundProcessResponsivenessTimer::~BackgroundProcessResponsivenessTimer()
-{
-}
+BackgroundProcessResponsivenessTimer::~BackgroundProcessResponsivenessTimer() = default;
 
 void BackgroundProcessResponsivenessTimer::updateState()
 {

--- a/Source/WebKit/UIProcess/Cocoa/DisplayCaptureSessionManager.mm
+++ b/Source/WebKit/UIProcess/Cocoa/DisplayCaptureSessionManager.mm
@@ -164,9 +164,7 @@ DisplayCaptureSessionManager::DisplayCaptureSessionManager()
 {
 }
 
-DisplayCaptureSessionManager::~DisplayCaptureSessionManager()
-{
-}
+DisplayCaptureSessionManager::~DisplayCaptureSessionManager() = default;
 
 bool DisplayCaptureSessionManager::canRequestDisplayCapturePermission()
 {

--- a/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.mm
@@ -42,9 +42,7 @@ IconLoadingDelegate::IconLoadingDelegate(WKWebView *webView)
 {
 }
 
-IconLoadingDelegate::~IconLoadingDelegate()
-{
-}
+IconLoadingDelegate::~IconLoadingDelegate() = default;
 
 std::unique_ptr<API::IconLoadingClient> IconLoadingDelegate::createIconLoadingClient()
 {
@@ -68,9 +66,7 @@ IconLoadingDelegate::IconLoadingClient::IconLoadingClient(IconLoadingDelegate& i
 {
 }
 
-IconLoadingDelegate::IconLoadingClient::~IconLoadingClient()
-{
-}
+IconLoadingDelegate::IconLoadingClient::~IconLoadingClient() = default;
 
 typedef void (^IconLoadCompletionHandler)(NSData*);
 

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -369,9 +369,7 @@ NavigationState::NavigationClient::NavigationClient(NavigationState& navigationS
 {
 }
 
-NavigationState::NavigationClient::~NavigationClient()
-{
-}
+NavigationState::NavigationClient::~NavigationClient() = default;
 
 bool NavigationState::NavigationClient::didChangeBackForwardList(WebPageProxy&, WebBackForwardListItem* added, const Vector<Ref<WebBackForwardListItem>>& removed)
 {
@@ -1502,9 +1500,7 @@ NavigationState::HistoryClient::HistoryClient(NavigationState& navigationState)
 {
 }
 
-NavigationState::HistoryClient::~HistoryClient()
-{
-}
+NavigationState::HistoryClient::~HistoryClient() = default;
 
 void NavigationState::HistoryClient::didNavigateWithNavigationData(WebPageProxy&, const WebNavigationDataStore& navigationDataStore)
 {

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -273,9 +273,7 @@ UIDelegate::ContextMenuClient::ContextMenuClient(UIDelegate& uiDelegate)
 {
 }
 
-UIDelegate::ContextMenuClient::~ContextMenuClient()
-{
-}
+UIDelegate::ContextMenuClient::~ContextMenuClient() = default;
 
 void UIDelegate::ContextMenuClient::menuFromProposedMenu(WebPageProxy& page, NSMenu *menu, const ContextMenuContextData& data, API::Object* userInfo, CompletionHandler<void(RetainPtr<NSMenu>&&)>&& completionHandler)
 {

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestProxyCocoa.mm
@@ -43,9 +43,7 @@ UserMediaPermissionRequestProxyCocoa::UserMediaPermissionRequestProxyCocoa(UserM
 {
 }
 
-UserMediaPermissionRequestProxyCocoa::~UserMediaPermissionRequestProxyCocoa()
-{
-}
+UserMediaPermissionRequestProxyCocoa::~UserMediaPermissionRequestProxyCocoa() = default;
 
 void UserMediaPermissionRequestProxyCocoa::invalidate()
 {

--- a/Source/WebKit/UIProcess/FrameLoadState.cpp
+++ b/Source/WebKit/UIProcess/FrameLoadState.cpp
@@ -28,9 +28,7 @@
 
 namespace WebKit {
 
-FrameLoadState::~FrameLoadState()
-{
-}
+FrameLoadState::~FrameLoadState() = default;
 
 void FrameLoadState::addObserver(FrameLoadStateObserver& observer)
 {

--- a/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm
+++ b/Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm
@@ -66,9 +66,7 @@ InspectorExtensionDelegate::InspectorExtensionClient::InspectorExtensionClient(I
 {
 }
 
-InspectorExtensionDelegate::InspectorExtensionClient::~InspectorExtensionClient()
-{
-}
+InspectorExtensionDelegate::InspectorExtensionClient::~InspectorExtensionClient() = default;
 
 void InspectorExtensionDelegate::InspectorExtensionClient::didShowExtensionTab(const Inspector::ExtensionTabID& extensionTabID, WebCore::FrameIdentifier frameID)
 {

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
@@ -84,9 +84,7 @@ WebInspectorUIProxy::WebInspectorUIProxy(WebPageProxy& inspectedPage)
     protect(inspectedPage.legacyMainFrameProcess())->addMessageReceiver(Messages::WebInspectorBackendProxy::messageReceiverName(), m_inspectedPage->webPageIDInMainFrameProcess(), m_backend.get());
 }
 
-WebInspectorUIProxy::~WebInspectorUIProxy()
-{
-}
+WebInspectorUIProxy::~WebInspectorUIProxy() = default;
 
 void WebInspectorUIProxy::setInspectorClient(std::unique_ptr<API::InspectorClient>&& inspectorClient)
 {

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp
@@ -121,9 +121,7 @@ RemoteInspectorClient::RemoteInspectorClient(URL url, RemoteInspectorObserver& o
     startInitialCommunication();
 }
 
-RemoteInspectorClient::~RemoteInspectorClient()
-{
-}
+RemoteInspectorClient::~RemoteInspectorClient() = default;
 
 void RemoteInspectorClient::sendWebInspectorEvent(const String& event)
 {

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp
@@ -48,9 +48,7 @@ RemoteMediaSessionProxy::RemoteMediaSessionProxy(const RemoteMediaSessionState& 
     setMediaSessionIdentifier(state.sessionIdentifier);
 }
 
-RemoteMediaSessionProxy::~RemoteMediaSessionProxy()
-{
-}
+RemoteMediaSessionProxy::~RemoteMediaSessionProxy() = default;
 
 void RemoteMediaSessionProxy::updateState(const RemoteMediaSessionState& remoteState)
 {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm
@@ -45,9 +45,7 @@ RemoteLayerTreeScrollingPerformanceData::RemoteLayerTreeScrollingPerformanceData
 {
 }
 
-RemoteLayerTreeScrollingPerformanceData::~RemoteLayerTreeScrollingPerformanceData()
-{
-}
+RemoteLayerTreeScrollingPerformanceData::~RemoteLayerTreeScrollingPerformanceData() = default;
 
 void RemoteLayerTreeScrollingPerformanceData::didCommitLayerTree(const FloatRect& visibleRect)
 {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm
@@ -58,9 +58,7 @@ ScrollingTreeFrameScrollingNodeRemoteIOS::ScrollingTreeFrameScrollingNodeRemoteI
 {
 }
 
-ScrollingTreeFrameScrollingNodeRemoteIOS::~ScrollingTreeFrameScrollingNodeRemoteIOS()
-{
-}
+ScrollingTreeFrameScrollingNodeRemoteIOS::~ScrollingTreeFrameScrollingNodeRemoteIOS() = default;
 
 ScrollingTreeScrollingNodeDelegateIOS* ScrollingTreeFrameScrollingNodeRemoteIOS::delegate() const
 {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.mm
@@ -51,9 +51,7 @@ ScrollingTreeOverflowScrollingNodeIOS::ScrollingTreeOverflowScrollingNodeIOS(Web
     m_delegate = makeUnique<ScrollingTreeScrollingNodeDelegateIOS>(*this);
 }
 
-ScrollingTreeOverflowScrollingNodeIOS::~ScrollingTreeOverflowScrollingNodeIOS()
-{
-}
+ScrollingTreeOverflowScrollingNodeIOS::~ScrollingTreeOverflowScrollingNodeIOS() = default;
 
 ScrollingTreeScrollingNodeDelegateIOS& ScrollingTreeOverflowScrollingNodeIOS::delegate() const
 {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.mm
@@ -46,9 +46,7 @@ ScrollingTreePluginScrollingNodeIOS::ScrollingTreePluginScrollingNodeIOS(WebCore
     m_delegate = makeUnique<ScrollingTreeScrollingNodeDelegateIOS>(*this);
 }
 
-ScrollingTreePluginScrollingNodeIOS::~ScrollingTreePluginScrollingNodeIOS()
-{
-}
+ScrollingTreePluginScrollingNodeIOS::~ScrollingTreePluginScrollingNodeIOS() = default;
 
 ScrollingTreeScrollingNodeDelegateIOS& ScrollingTreePluginScrollingNodeIOS::delegate() const
 {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
@@ -43,9 +43,7 @@ ScrollingTreeFrameScrollingNodeRemoteMac::ScrollingTreeFrameScrollingNodeRemoteM
     m_delegate->initScrollbars();
 }
 
-ScrollingTreeFrameScrollingNodeRemoteMac::~ScrollingTreeFrameScrollingNodeRemoteMac()
-{
-}
+ScrollingTreeFrameScrollingNodeRemoteMac::~ScrollingTreeFrameScrollingNodeRemoteMac() = default;
 
 Ref<ScrollingTreeFrameScrollingNodeRemoteMac> ScrollingTreeFrameScrollingNodeRemoteMac::create(ScrollingTree& tree, ScrollingNodeType nodeType, ScrollingNodeID nodeID)
 {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
@@ -46,9 +46,7 @@ ScrollingTreeOverflowScrollingNodeRemoteMac::ScrollingTreeOverflowScrollingNodeR
     m_delegate->initScrollbars();
 }
 
-ScrollingTreeOverflowScrollingNodeRemoteMac::~ScrollingTreeOverflowScrollingNodeRemoteMac()
-{
-}
+ScrollingTreeOverflowScrollingNodeRemoteMac::~ScrollingTreeOverflowScrollingNodeRemoteMac() = default;
 
 void ScrollingTreeOverflowScrollingNodeRemoteMac::repositionRelatedLayers()
 {

--- a/Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.cpp
@@ -42,8 +42,6 @@ WebScriptMessageHandler::WebScriptMessageHandler(std::unique_ptr<Client> client,
 {
 }
 
-WebScriptMessageHandler::~WebScriptMessageHandler()
-{
-}
+WebScriptMessageHandler::~WebScriptMessageHandler() = default;
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -815,9 +815,7 @@ WebBackForwardListWrapper::WebBackForwardListWrapper(WebPageProxy& webPageProxy)
 {
 }
 
-WebBackForwardListWrapper::~WebBackForwardListWrapper()
-{
-}
+WebBackForwardListWrapper::~WebBackForwardListWrapper() = default;
 
 WebBackForwardListItem* WebBackForwardListWrapper::currentItem() const
 {

--- a/Source/WebKit/UIProcess/WebColorPicker.cpp
+++ b/Source/WebKit/UIProcess/WebColorPicker.cpp
@@ -35,9 +35,7 @@ WebColorPicker::WebColorPicker(Client* client, std::optional<WebCore::FrameIdent
 {
 }
 
-WebColorPicker::~WebColorPicker()
-{
-}
+WebColorPicker::~WebColorPicker() = default;
 
 void WebColorPicker::endPicker()
 {

--- a/Source/WebKit/UIProcess/WebDataListSuggestionsDropdown.cpp
+++ b/Source/WebKit/UIProcess/WebDataListSuggestionsDropdown.cpp
@@ -35,9 +35,7 @@ WebDataListSuggestionsDropdown::WebDataListSuggestionsDropdown(WebPageProxy& pag
 {
 }
 
-WebDataListSuggestionsDropdown::~WebDataListSuggestionsDropdown()
-{
-}
+WebDataListSuggestionsDropdown::~WebDataListSuggestionsDropdown() = default;
 
 void WebDataListSuggestionsDropdown::show(WebCore::DataListSuggestionInformation&& information)
 {

--- a/Source/WebKit/UIProcess/WebDateTimePicker.cpp
+++ b/Source/WebKit/UIProcess/WebDateTimePicker.cpp
@@ -36,9 +36,7 @@ WebDateTimePicker::WebDateTimePicker(WebPageProxy& page)
 {
 }
 
-WebDateTimePicker::~WebDateTimePicker()
-{
-}
+WebDateTimePicker::~WebDateTimePicker() = default;
 
 void WebDateTimePicker::showDateTimePicker(WebCore::DateTimeChooserParameters&& params)
 {

--- a/Source/WebKit/UIProcess/WebNavigationState.cpp
+++ b/Source/WebKit/UIProcess/WebNavigationState.cpp
@@ -41,9 +41,7 @@ WebNavigationState::WebNavigationState(WebPageProxy& page)
 {
 }
 
-WebNavigationState::~WebNavigationState()
-{
-}
+WebNavigationState::~WebNavigationState() = default;
 
 Ref<API::Navigation> WebNavigationState::createLoadRequestNavigation(WebCore::ProcessIdentifier processID, ResourceRequest&& request, RefPtr<WebBackForwardListItem>&& currentItem)
 {

--- a/Source/WebKit/UIProcess/WebViewportAttributes.cpp
+++ b/Source/WebKit/UIProcess/WebViewportAttributes.cpp
@@ -33,8 +33,6 @@ WebViewportAttributes::WebViewportAttributes(const WebCore::ViewportAttributes& 
 {
 }
 
-WebViewportAttributes::~WebViewportAttributes()
-{
-}
+WebViewportAttributes::~WebViewportAttributes() = default;
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp
+++ b/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp
@@ -64,9 +64,7 @@ BackingStore::BackingStore(const IntSize& size, float deviceScaleFactor)
 {
 }
 
-BackingStore::~BackingStore()
-{
-}
+BackingStore::~BackingStore() = default;
 
 void BackingStore::paint(PlatformPaintContextPtr cr, const IntRect& rect)
 {

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -118,9 +118,7 @@ PageClientImpl::PageClientImpl(WKContentView *contentView, WKWebView *webView)
 {
 }
 
-PageClientImpl::~PageClientImpl()
-{
-}
+PageClientImpl::~PageClientImpl() = default;
 
 Ref<DrawingAreaProxy> PageClientImpl::createDrawingAreaProxy(WebProcessProxy& webProcessProxy)
 {

--- a/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
@@ -74,7 +74,7 @@ Ref<WebDataListSuggestionsDropdownMac> WebDataListSuggestionsDropdownMac::create
     return adoptRef(*new WebDataListSuggestionsDropdownMac(page, view));
 }
 
-WebDataListSuggestionsDropdownMac::~WebDataListSuggestionsDropdownMac() { }
+WebDataListSuggestionsDropdownMac::~WebDataListSuggestionsDropdownMac() = default;
 
 WebDataListSuggestionsDropdownMac::WebDataListSuggestionsDropdownMac(WebPageProxy& page, NSView *view)
     : WebDataListSuggestionsDropdown(page)

--- a/Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp
+++ b/Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp
@@ -82,9 +82,7 @@ PlayStationWebView::PlayStationWebView(const API::PageConfiguration& conf)
 
 #endif // USE(WPE_BACKEND_PLAYSTATION)
 
-PlayStationWebView::~PlayStationWebView()
-{
-}
+PlayStationWebView::~PlayStationWebView() = default;
 
 void PlayStationWebView::setClient(std::unique_ptr<API::ViewClient>&& client)
 {

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursor.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursor.cpp
@@ -45,9 +45,7 @@ Cursor::Cursor(std::unique_ptr<Plane>&& plane, struct gbm_device* device, uint32
 {
 }
 
-Cursor::~Cursor()
-{
-}
+Cursor::~Cursor() = default;
 
 bool Cursor::tryEnsureBuffer()
 {

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursorTheme.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursorTheme.cpp
@@ -59,9 +59,7 @@ CursorTheme::CursorTheme(std::unique_ptr<WPE::CursorTheme>&& theme)
 {
 }
 
-CursorTheme::~CursorTheme()
-{
-}
+CursorTheme::~CursorTheme() = default;
 
 const Vector<CursorTheme::Image>& CursorTheme::cursor(const char* name, double scale, std::optional<uint32_t> maxImages)
 {

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursorTheme.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursorTheme.cpp
@@ -67,9 +67,7 @@ WaylandCursorTheme::WaylandCursorTheme(std::unique_ptr<CursorTheme>&& theme, std
 
 }
 
-WaylandCursorTheme::~WaylandCursorTheme()
-{
-}
+WaylandCursorTheme::~WaylandCursorTheme() = default;
 
 const Vector<WaylandCursorTheme::Image>& WaylandCursorTheme::cursor(const char* name, double scale, std::optional<uint32_t> maxImages)
 {

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
@@ -41,9 +41,7 @@ WebCacheStorageConnection::WebCacheStorageConnection()
 {
 }
 
-WebCacheStorageConnection::~WebCacheStorageConnection()
-{
-}
+WebCacheStorageConnection::~WebCacheStorageConnection() = default;
 
 Ref<IPC::Connection> WebCacheStorageConnection::connection()
 {

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -141,9 +141,7 @@ WebModelPlayer::WebModelPlayer(WebCore::Page& page, WebCore::ModelPlayerClient& 
 {
 }
 
-WebModelPlayer::~WebModelPlayer()
-{
-}
+WebModelPlayer::~WebModelPlayer() = default;
 
 void WebModelPlayer::ensureOnMainThreadWithProtectedThis(Function<void(Ref<WebModelPlayer>)>&& task)
 {


### PR DESCRIPTION
#### f6b651d6547c1d6ce02a8f1addca5dd7410eb09a
<pre>
Use &quot;= default&quot; for destructor in WebKit code
<a href="https://bugs.webkit.org/show_bug.cgi?id=311429">https://bugs.webkit.org/show_bug.cgi?id=311429</a>
<a href="https://rdar.apple.com/174029338">rdar://174029338</a>

Reviewed by Aditya Keerthi.

This extends our &quot;= default&quot; usage across few leftover empty destructors
in WebKit code.

* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::~GPUProcess): Deleted.
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp:
(WebKit::RemoteCDMInstanceSessionProxy::~RemoteCDMInstanceSessionProxy): Deleted.
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm:
(WebKit::RemoteSampleBufferDisplayLayer::~RemoteSampleBufferDisplayLayer): Deleted.
* Source/WebKit/NetworkProcess/NetworkActivityTracker.cpp:
(WebKit::NetworkActivityTracker::~NetworkActivityTracker): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::~Cache): Deleted.
* Source/WebKit/NetworkProcess/cache/PrefetchCache.cpp:
(WebKit::PrefetchCache::~PrefetchCache): Deleted.
* Source/WebKit/NetworkProcess/cocoa/NetworkActivityTrackerCocoa.mm:
(WebKit::NetworkActivityTracker::~NetworkActivityTracker): Deleted.
* Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp:
(WebKit::NetworkSessionCurl::~NetworkSessionCurl): Deleted.
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp:
(WebKit::BackgroundFetchStoreImpl::~BackgroundFetchStoreImpl): Deleted.
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp:
(WebKit::BackgroundFetchStoreManager::~BackgroundFetchStoreManager): Deleted.
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm:
(WebKit::NetworkRTCUDPSocketCocoa::~NetworkRTCUDPSocketCocoa): Deleted.
* Source/WebKit/Platform/IPC/MessageReceiverMap.cpp:
(IPC::MessageReceiverMap::~MessageReceiverMap): Deleted.
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::~VideoPresentationInterfaceLMK): Deleted.
* Source/WebKit/Shared/APIWebArchive.mm:
(API::WebArchive::~WebArchive): Deleted.
* Source/WebKit/Shared/BlobDataFileReferenceWithSandboxExtension.cpp:
(WebKit::BlobDataFileReferenceWithSandboxExtension::~BlobDataFileReferenceWithSandboxExtension): Deleted.
* Source/WebKit/Shared/HangDetectionDisabler.h:
(WebKit::HangDetectionDisabler::~HangDetectionDisabler): Deleted.
* Source/WebKit/Shared/SandboxExtension.h:
(WebKit::SandboxExtensionHandle::~SandboxExtensionHandle): Deleted.
(WebKit::SandboxExtension::~SandboxExtension): Deleted.
* Source/WebKit/Shared/SandboxInitializationParameters.h:
(WebKit::SandboxInitializationParameters::~SandboxInitializationParameters): Deleted.
* Source/WebKit/Shared/SharedStringHashTable.cpp:
(WebKit::SharedStringHashTable::~SharedStringHashTable): Deleted.
* Source/WebKit/Shared/WebCompiledContentRuleList.cpp:
(WebKit::WebCompiledContentRuleList::~WebCompiledContentRuleList): Deleted.
* Source/WebKit/Shared/WebGeolocationPosition.cpp:
(WebKit::WebGeolocationPosition::~WebGeolocationPosition): Deleted.
* Source/WebKit/Shared/WebHitTestResultData.cpp:
(WebKit::WebHitTestResultData::~WebHitTestResultData): Deleted.
* Source/WebKit/Shared/WebKeyboardEvent.cpp:
(WebKit::WebKeyboardEvent::~WebKeyboardEvent): Deleted.
* Source/WebKit/Shared/glib/WebContextMenuItemGlib.cpp:
(WebKit::WebContextMenuItemGlib::~WebContextMenuItemGlib): Deleted.
* Source/WebKit/UIProcess/API/APIAttachment.cpp:
(API::Attachment::~Attachment): Deleted.
* Source/WebKit/UIProcess/API/APIContentRuleList.cpp:
(API::ContentRuleList::~ContentRuleList): Deleted.
* Source/WebKit/UIProcess/API/APIFormInfo.cpp:
(API::FormInfo::~FormInfo): Deleted.
* Source/WebKit/UIProcess/API/APINavigation.cpp:
(API::Navigation::~Navigation): Deleted.
* Source/WebKit/UIProcess/API/APINavigationData.cpp:
(API::NavigationData::~NavigationData): Deleted.
* Source/WebKit/UIProcess/API/APIOpenPanelParameters.cpp:
(API::OpenPanelParameters::~OpenPanelParameters): Deleted.
* Source/WebKit/UIProcess/API/APISessionState.cpp:
(API::SessionState::~SessionState): Deleted.
* Source/WebKit/UIProcess/API/APIWebsiteDataRecord.cpp:
(API::WebsiteDataRecord::~WebsiteDataRecord): Deleted.
* Source/WebKit/UIProcess/API/APIWindowFeatures.cpp:
(API::WindowFeatures::~WindowFeatures): Deleted.
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewLoadRequest.cpp:
(WPEQtViewLoadRequest::~WPEQtViewLoadRequest): Deleted.
* Source/WebKit/UIProcess/Authentication/WebCredential.cpp:
(WebKit::WebCredential::~WebCredential): Deleted.
* Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.cpp:
(WebKit::BackgroundProcessResponsivenessTimer::~BackgroundProcessResponsivenessTimer): Deleted.
* Source/WebKit/UIProcess/Cocoa/DisplayCaptureSessionManager.mm:
(WebKit::DisplayCaptureSessionManager::~DisplayCaptureSessionManager): Deleted.
* Source/WebKit/UIProcess/Cocoa/IconLoadingDelegate.mm:
(WebKit::IconLoadingDelegate::~IconLoadingDelegate): Deleted.
(WebKit::IconLoadingDelegate::IconLoadingClient::~IconLoadingClient): Deleted.
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::NavigationClient::~NavigationClient): Deleted.
(WebKit::NavigationState::HistoryClient::~HistoryClient): Deleted.
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::ContextMenuClient::~ContextMenuClient): Deleted.
* Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestProxyCocoa.mm:
(WebKit::UserMediaPermissionRequestProxyCocoa::~UserMediaPermissionRequestProxyCocoa): Deleted.
* Source/WebKit/UIProcess/FrameLoadState.cpp:
(WebKit::FrameLoadState::~FrameLoadState): Deleted.
* Source/WebKit/UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm:
(WebKit::InspectorExtensionDelegate::InspectorExtensionClient::~InspectorExtensionClient): Deleted.
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
(WebKit::WebInspectorUIProxy::~WebInspectorUIProxy): Deleted.
* Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp:
(WebKit::RemoteInspectorClient::~RemoteInspectorClient): Deleted.
* Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.cpp:
(WebKit::RemoteMediaSessionProxy::~RemoteMediaSessionProxy): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm:
(WebKit::RemoteLayerTreeScrollingPerformanceData::~RemoteLayerTreeScrollingPerformanceData): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm:
(WebKit::ScrollingTreeFrameScrollingNodeRemoteIOS::~ScrollingTreeFrameScrollingNodeRemoteIOS): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.mm:
(WebKit::ScrollingTreeOverflowScrollingNodeIOS::~ScrollingTreeOverflowScrollingNodeIOS): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.mm:
(WebKit::ScrollingTreePluginScrollingNodeIOS::~ScrollingTreePluginScrollingNodeIOS): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp:
(WebKit::ScrollingTreeFrameScrollingNodeRemoteMac::~ScrollingTreeFrameScrollingNodeRemoteMac): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp:
(WebKit::ScrollingTreeOverflowScrollingNodeRemoteMac::~ScrollingTreeOverflowScrollingNodeRemoteMac): Deleted.
* Source/WebKit/UIProcess/UserContent/WebScriptMessageHandler.cpp:
(WebKit::WebScriptMessageHandler::~WebScriptMessageHandler): Deleted.
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardListWrapper::~WebBackForwardListWrapper): Deleted.
* Source/WebKit/UIProcess/WebColorPicker.cpp:
(WebKit::WebColorPicker::~WebColorPicker): Deleted.
* Source/WebKit/UIProcess/WebDataListSuggestionsDropdown.cpp:
(WebKit::WebDataListSuggestionsDropdown::~WebDataListSuggestionsDropdown): Deleted.
* Source/WebKit/UIProcess/WebDateTimePicker.cpp:
(WebKit::WebDateTimePicker::~WebDateTimePicker): Deleted.
* Source/WebKit/UIProcess/WebNavigationState.cpp:
(WebKit::WebNavigationState::~WebNavigationState): Deleted.
* Source/WebKit/UIProcess/WebViewportAttributes.cpp:
(WebKit::WebViewportAttributes::~WebViewportAttributes): Deleted.
* Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp:
(WebKit::BackingStore::~BackingStore): Deleted.
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::~PageClientImpl): Deleted.
* Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm:
(WebKit::WebDataListSuggestionsDropdownMac::~WebDataListSuggestionsDropdownMac): Deleted.
* Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp:
(WebKit::PlayStationWebView::~PlayStationWebView): Deleted.
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursor.cpp:
(WPE::DRM::Cursor::~Cursor): Deleted.
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRMCursorTheme.cpp:
(WPE::DRM::CursorTheme::~CursorTheme): Deleted.
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursorTheme.cpp:
(WPE::WaylandCursorTheme::~WaylandCursorTheme): Deleted.
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp:
(WebKit::WebCacheStorageConnection::~WebCacheStorageConnection): Deleted.
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::~WebModelPlayer): Deleted.

Canonical link: <a href="https://commits.webkit.org/310546@main">https://commits.webkit.org/310546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5eb9c3ff021b6c19bcb489d8e482e491e2e4a695

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154130 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162883 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107598 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27520 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27238 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119206 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84270 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21451 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138410 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99902 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20539 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18540 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10716 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130201 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165356 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8565 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17863 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127299 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22582 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127445 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34584 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26858 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138048 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/83451 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22318 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14840 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26548 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90650 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26129 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26360 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26201 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->