### PR TITLE
[Swift in WebKit] Enable using WTF conditional compilation flags in more TestWebKitAPI targets

### DIFF
--- a/Tools/TestWebKitAPI/Configurations/Base.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/Base.xcconfig
@@ -133,3 +133,5 @@ SWIFT_VERSION = 6.0;
 
 SWIFT_OPTIMIZATION_LEVEL = -O;
 SWIFT_OPTIMIZATION_LEVEL[config=Debug] = -Onone;
+
+OTHER_SWIFT_FLAGS = $(inherited) @$(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/platform-enabled-swift-args.$(arch).resp;

--- a/Tools/TestWebKitAPI/Configurations/TestWebKitAPIBundle.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestWebKitAPIBundle.xcconfig
@@ -49,6 +49,6 @@ SWIFT_OBJC_INTEROP_MODE_SUPPORTS_SWIFT_OBJCXX_INTEROP_NO = $(inherited);
 
 // FIXME: (rdar://149474443) Swift/Cxx interop does not respect CLANG_CXX_LANGUAGE_STANDARD = "c++2b";
 // FIXME: (rdar://103177280) "-no-verify-emitted-module-interface;" is needed to workaround a SwiftVerifyEmittedModuleInterface bug
-OTHER_SWIFT_FLAGS = $(inherited) @$(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/platform-enabled-swift-args.$(arch).resp $(OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_$(WK_SUPPORTS_SWIFT_OBJCXX_INTEROP));
+OTHER_SWIFT_FLAGS = $(inherited) $(OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_$(WK_SUPPORTS_SWIFT_OBJCXX_INTEROP));
 OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_YES = -Xcc -std=c++2b -no-verify-emitted-module-interface;
 OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_NO = ;

--- a/Tools/TestWebKitAPI/Configurations/TestWebKitAPILibrary.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestWebKitAPILibrary.xcconfig
@@ -38,7 +38,7 @@ SWIFT_OBJC_INTEROP_MODE_SUPPORTS_SWIFT_OBJCXX_INTEROP_NO = $(inherited);
 
 // FIXME: (rdar://149474443) Swift/Cxx interop does not respect CLANG_CXX_LANGUAGE_STANDARD = "c++2b";
 // FIXME: (rdar://103177280) "-no-verify-emitted-module-interface;" is needed to workaround a SwiftVerifyEmittedModuleInterface bug
-OTHER_SWIFT_FLAGS = $(inherited) @$(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/platform-enabled-swift-args.$(arch).resp $(OTHER_SWIFT_FLAGS$(WK_XCODE_16)) $(OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_$(WK_SUPPORTS_SWIFT_OBJCXX_INTEROP));
+OTHER_SWIFT_FLAGS = $(inherited) $(OTHER_SWIFT_FLAGS$(WK_XCODE_16)) $(OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_$(WK_SUPPORTS_SWIFT_OBJCXX_INTEROP));
 OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_YES = -Xcc -std=c++2b -no-verify-emitted-module-interface;
 OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_NO = ;
 OTHER_SWIFT_FLAGS_XCODE_BEFORE_16 = -Xfrontend -enable-experimental-concurrency -Xfrontend -enable-upcoming-feature -Xfrontend IsolatedDefaultValues;

--- a/Tools/TestWebKitAPI/TestWebKitAPI.swift
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.swift
@@ -23,7 +23,7 @@
 
 import Foundation
 
-#if os(macOS) && !targetEnvironment(macCatalyst)
+#if WTF_PLATFORM_MAC
 private import AppKit
 #endif
 
@@ -67,7 +67,7 @@ struct TestWebKitAPI {
 
     @MainActor
     private func run() async {
-        #if targetEnvironment(macCatalyst)
+        #if WTF_PLATFORM_MACCATALYST
         UINSApplicationInstantiate()
         #endif
 
@@ -75,7 +75,7 @@ struct TestWebKitAPI {
 
         var argumentDomain = UserDefaults.standard.volatileDomain(forName: UserDefaults.argumentDomain)
 
-        #if os(macOS) && !targetEnvironment(macCatalyst)
+        #if WTF_PLATFORM_MAC
         // CAUTION: Defaults set here are not automatically propagated to the
         // Web Content process. Those listed below are propagated manually.
         handleArguments(&argumentDomain)
@@ -83,7 +83,7 @@ struct TestWebKitAPI {
 
         UserDefaults.standard.setVolatileDomain(argumentDomain, forName: UserDefaults.argumentDomain)
 
-        #if !os(macOS) || targetEnvironment(macCatalyst)
+        #if !WTF_PLATFORM_MAC
         let uiKitDefaults = UserDefaults(suiteName: "com.apple.UIKit")
         uiKitDefaults?
             .register(
@@ -91,11 +91,11 @@ struct TestWebKitAPI {
                     "ForceLegacyHostingRemoteViewControllerForService": "com.apple.ScreenTime.ScreenTimeWebExtension"
                 ]
             )
-        #endif // !os(macOS) || targetEnvironment(macCatalyst)
+        #endif // !WTF_PLATFORM_MAC
 
         TestWebKitAPIEnableAllSDKAlignedBehaviors()
 
-        #if os(macOS) && !targetEnvironment(macCatalyst)
+        #if WTF_PLATFORM_MAC
         _ = NSApplication.shared
         #endif
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -7,6 +7,19 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
+		0723A7492F80357300CB96E7 /* Derived Sources */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 0723A7532F80357300CB96E7 /* Build configuration list for PBXAggregateTarget "Derived Sources" */;
+			buildPhases = (
+				0723A7602F80360F00CB96E7 /* Generate Swift platform args */,
+			);
+			dependencies = (
+			);
+			name = "Derived Sources";
+			packageProductDependencies = (
+			);
+			productName = "Derived Sources";
+		};
 		537CF84322EFD64100C6EBB3 /* Apply Configuration to XCFileLists */ = {
 			isa = PBXAggregateTarget;
 			buildConfigurationList = 537CF84622EFD64100C6EBB3 /* Build configuration list for PBXAggregateTarget "Apply Configuration to XCFileLists" */;
@@ -1571,6 +1584,48 @@
 /* End PBXBuildRule section */
 
 /* Begin PBXContainerItemProxy section */
+		0723A7542F80358F00CB96E7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0723A7492F80357300CB96E7;
+			remoteInfo = "Derived Sources";
+		};
+		0723A7562F80359900CB96E7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0723A7492F80357300CB96E7;
+			remoteInfo = "Derived Sources";
+		};
+		0723A7582F80359E00CB96E7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0723A7492F80357300CB96E7;
+			remoteInfo = "Derived Sources";
+		};
+		0723A75A2F8035A300CB96E7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0723A7492F80357300CB96E7;
+			remoteInfo = "Derived Sources";
+		};
+		0723A75C2F8035B000CB96E7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0723A7492F80357300CB96E7;
+			remoteInfo = "Derived Sources";
+		};
+		0723A75E2F8035B400CB96E7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0723A7492F80357300CB96E7;
+			remoteInfo = "Derived Sources";
+		};
 		3A15785B28D1506E00142DB1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = DDF3A82928930475005920CF /* gtest.xcodeproj */;
@@ -7224,6 +7279,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				0723A75D2F8035B000CB96E7 /* PBXTargetDependency */,
 				3A15785C28D1506E00142DB1 /* PBXTargetDependency */,
 			);
 			name = TestWGSL;
@@ -7243,6 +7299,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				0723A7592F80359E00CB96E7 /* PBXTargetDependency */,
 			);
 			name = TestIPC;
 			productInstallPath = "$(HOME)/bin";
@@ -7261,6 +7318,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				0723A7572F80359900CB96E7 /* PBXTargetDependency */,
 				44134E632AC128AA00D2BFCB /* PBXTargetDependency */,
 			);
 			name = TestWTFLibrary;
@@ -7278,6 +7336,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				0723A75F2F8035B400CB96E7 /* PBXTargetDependency */,
 				7C83E0251D0A5B2500FEBCF3 /* PBXTargetDependency */,
 			);
 			name = TestWTF;
@@ -7290,13 +7349,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7CCE7EA11A41144E00447C4C /* Build configuration list for PBXNativeTarget "TestWebKitAPILibrary" */;
 			buildPhases = (
-				074DCD7B2EA6D34E00C7534A /* Generate Swift platform args */,
 				7CCE7E881A41144E00447C4C /* Sources */,
 				7CCE7E891A41144E00447C4C /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				0723A7552F80358F00CB96E7 /* PBXTargetDependency */,
 				DDF3A855289305F8005920CF /* PBXTargetDependency */,
 				5C9D922222D7DC84008E9266 /* PBXTargetDependency */,
 			);
@@ -7316,6 +7375,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				0723A75B2F8035A300CB96E7 /* PBXTargetDependency */,
 				BC575A96126E74E7006F0F12 /* PBXTargetDependency */,
 				7CCE7F511A4124DB00447C4C /* PBXTargetDependency */,
 				A17C48562C98EBF50023F3C7 /* PBXTargetDependency */,
@@ -7426,6 +7486,9 @@
 				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 1140;
 				TargetAttributes = {
+					0723A7492F80357300CB96E7 = {
+						CreatedOnToolsVersion = 26.0;
+					};
 					537CF84322EFD64100C6EBB3 = {
 						CreatedOnToolsVersion = 11.0;
 					};
@@ -7481,6 +7544,7 @@
 			projectRoot = "";
 			targets = (
 				7C83E02B1D0A5E1000FEBCF3 /* All */,
+				0723A7492F80357300CB96E7 /* Derived Sources */,
 				5C9D921422D7DA02008E9266 /* Generate Unified Sources */,
 				7CCE7E8B1A41144E00447C4C /* TestWebKitAPILibrary */,
 				7C83DE951D0A590C00FEBCF3 /* TestWTFLibrary */,
@@ -7571,7 +7635,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		074DCD7B2EA6D34E00C7534A /* Generate Swift platform args */ = {
+		0723A7602F80360F00CB96E7 /* Generate Swift platform args */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			dependencyFile = "$(DERIVED_FILES_DIR)/generate-platform-args.d";
@@ -8587,6 +8651,36 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		0723A7552F80358F00CB96E7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0723A7492F80357300CB96E7 /* Derived Sources */;
+			targetProxy = 0723A7542F80358F00CB96E7 /* PBXContainerItemProxy */;
+		};
+		0723A7572F80359900CB96E7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0723A7492F80357300CB96E7 /* Derived Sources */;
+			targetProxy = 0723A7562F80359900CB96E7 /* PBXContainerItemProxy */;
+		};
+		0723A7592F80359E00CB96E7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0723A7492F80357300CB96E7 /* Derived Sources */;
+			targetProxy = 0723A7582F80359E00CB96E7 /* PBXContainerItemProxy */;
+		};
+		0723A75B2F8035A300CB96E7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0723A7492F80357300CB96E7 /* Derived Sources */;
+			targetProxy = 0723A75A2F8035A300CB96E7 /* PBXContainerItemProxy */;
+		};
+		0723A75D2F8035B000CB96E7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0723A7492F80357300CB96E7 /* Derived Sources */;
+			targetProxy = 0723A75C2F8035B000CB96E7 /* PBXContainerItemProxy */;
+		};
+		0723A75F2F8035B400CB96E7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0723A7492F80357300CB96E7 /* Derived Sources */;
+			targetProxy = 0723A75E2F8035B400CB96E7 /* PBXContainerItemProxy */;
+		};
 		3A15785C28D1506E00142DB1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "gtest-framework";
@@ -8680,6 +8774,22 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		0723A74A2F80357300CB96E7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		0723A74B2F80357300CB96E7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		1DEB927508733DD40010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A17C58232C9AA491009DD0B5 /* TestWebKitAPI.xcconfig */;
@@ -8895,6 +9005,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		0723A7532F80357300CB96E7 /* Build configuration list for PBXAggregateTarget "Derived Sources" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0723A74A2F80357300CB96E7 /* Debug */,
+				0723A74B2F80357300CB96E7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		1DEB927408733DD40010E9CD /* Build configuration list for PBXNativeTarget "TestWebKitAPI" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (


### PR DESCRIPTION
#### 8ff8bee8756e1f7e4ab1154723aacb482e15bf5e
<pre>
[Swift in WebKit] Enable using WTF conditional compilation flags in more TestWebKitAPI targets
<a href="https://bugs.webkit.org/show_bug.cgi?id=311430">https://bugs.webkit.org/show_bug.cgi?id=311430</a>
<a href="https://rdar.apple.com/174029785">rdar://174029785</a>

Reviewed by Aditya Keerthi.

Allow WTF platform flags and feature flags to be used in more TestWebKitAPI targets.

* Tools/TestWebKitAPI/Configurations/Base.xcconfig:
* Tools/TestWebKitAPI/Configurations/TestWebKitAPIBundle.xcconfig:
* Tools/TestWebKitAPI/Configurations/TestWebKitAPILibrary.xcconfig:

Move the relevant OTHER_SWIFT_FLAGS flag from specific xcconfigs to the Base one

* Tools/TestWebKitAPI/TestWebKitAPI.swift:
(TestWebKitAPI.run):

Adopt WTF_PLATFORM_* instead of the built-in Swift directives.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:

Add a &quot;Derived Sources&quot; aggregate target to do the conditional compilation flag generation.

Canonical link: <a href="https://commits.webkit.org/310541@main">https://commits.webkit.org/310541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/338946b221c0c8ac8f468cbcfd9dc218469274ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162889 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c788d790-8ff4-46e6-91a5-310094266bcf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156008 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27243 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119210 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157094 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21458 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138417 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99906 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4a4b4a9a-5c67-45da-8f7b-ee9961dc05bf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20546 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18545 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10721 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130208 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165361 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17870 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127304 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26939 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127450 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34580 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26863 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138055 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83456 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22326 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14847 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26553 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26134 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26365 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26206 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->