### PR TITLE
Directory path is incorrect in http/tests/security/file-system-access-via-dataTransfer.html

### DIFF
--- a/LayoutTests/http/tests/security/file-system-access-via-dataTransfer.html
+++ b/LayoutTests/http/tests/security/file-system-access-via-dataTransfer.html
@@ -17,7 +17,7 @@ function runTest() {
     let path = location.pathname.split("/");
     let filename = path[path.length - 1];
     let targetFileName = internals.createTemporaryFile(`${filename}`, "");
-    let targetDirectory = targetFileName.substring(0, targetFileName.length - filename);
+    let targetDirectory = targetFileName.split("/").slice(0, -1).join("/");
 
     let input = document.createElement("input");
     input.type = "file";


### PR DESCRIPTION
#### 6e308cecbfca679453a425952ebc5d789ad2b06f
<pre>
Directory path is incorrect in http/tests/security/file-system-access-via-dataTransfer.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=311436">https://bugs.webkit.org/show_bug.cgi?id=311436</a>
<a href="https://rdar.apple.com/174033719">rdar://174033719</a>

Reviewed by Matthew Finkel.

In http/tests/security/file-system-access-via-dataTransfer.html ,
the targetDirectory variable doesn&apos;t have the path of a valid directory.
This is what the code looks like:

```
let path = location.pathname.split(&quot;/&quot;);
let filename = path[path.length - 1];
let targetFileName = internals.createTemporaryFile(`${filename}`, &quot;&quot;);
let targetDirectory = targetFileName.substring(0, targetFileName.length - filename);
```

Note that targetDirectory is created by taking the substring of targetFileName,
however the end of the substring is calculated by doing `targetFileName.length - filename`
where filename is a string, not a number. This should be `filename.length`
instead. However even when making that change, the targetDirectory still isn&apos;t
quite right. See the following debugging logs:

```
path: [&quot;&quot;,&quot;security&quot;,&quot;file-system-access-via-dataTransfer.html&quot;]
filename: file-system-access-via-dataTransfer.html
targetFileName: /var/folders/gt/fcd9q4nn66bbk9l0jq5bj6sw0000gn/T/WebKitTestRunners-w8rnouln/WebCoreTesting-file-system-access-via-dataTransfer.htmlnc3lIz
targetDirectory: /var/folders/gt/fcd9q4nn66bbk9l0jq5bj6sw0000gn/T/WebKitTestRunners-w8rnouln/WebCoreTesting-file-s
```

Note how targetDirectory has some trailing characters of &quot;WebCoreTesting-file-s&quot;
after the directory path. It seems like `internals.createTemporaryFile`
is padding some extra characters onto the original filename.

This patch updates how targetDirectory is created by chopping off
the full filename from the path of targetFileName. This is what
targetDirectory looks like now:

```
path: [&quot;&quot;,&quot;security&quot;,&quot;file-system-access-via-dataTransfer.html&quot;]
filename: file-system-access-via-dataTransfer.html
targetFileName: /var/folders/gt/fcd9q4nn66bbk9l0jq5bj6sw0000gn/T/WebKitTestRunners-arclxndi/WebCoreTesting-file-system-access-via-dataTransfer.htmljaLOWz
targetDirectory: /var/folders/gt/fcd9q4nn66bbk9l0jq5bj6sw0000gn/T/WebKitTestRunners-arclxndi
```

* LayoutTests/http/tests/security/file-system-access-via-dataTransfer.html:

Canonical link: <a href="https://commits.webkit.org/310549@main">https://commits.webkit.org/310549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb41229690520d9d4fb7011e6102238bee34b479

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162894 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107608 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d197586e-6393-4af3-97d9-b8f34dde3bd3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27248 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119215 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84275 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/be376757-b89b-49db-aa43-a0f714c787d0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138420 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99911 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/df4187df-7052-4e32-aa2d-5a003333d225) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20553 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18549 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10726 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130215 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16265 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165366 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17873 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127307 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26944 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127453 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34587 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26868 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138058 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83461 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22328 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14850 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26558 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26139 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26370 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26211 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->