### PR TITLE
Have filter-build-webkit highlight lines containing "error:"

### DIFF
--- a/Tools/Scripts/filter-build-webkit
+++ b/Tools/Scripts/filter-build-webkit
@@ -65,6 +65,7 @@ use constant {
     STYLE_HEADER => 1,
     STYLE_SUCCESS => 2,
     STYLE_ALERT => 3,
+    STYLE_ERROR => 4,
 
     HTML_HEADER =><<HTMLHEADER,
 <html>
@@ -77,6 +78,9 @@ use constant {
             p.alert { border-left-color: red; color: red; margin: 1.5em 0 0 0; }
             p.alert + p { margin: 1.5em 0 0 0; }
             p.alert + p.alert { margin: 0; }
+            p.error { border-left-color: magenta; color: magenta; margin: 1.5em 0 0 0; }
+            p.error + p { margin: 1.5em 0 0 0; }
+            p.error + p.error { margin: 0; }
             p.success { color: green; }
         </style>
     </head>
@@ -315,7 +319,8 @@ sub main() {
             if (($line =~ /\*\* BUILD FAILED \*\*/) || ($line =~ /^Build FAILED./)) {
                 $buildFailed = 1;
             }
-            printLine($line, $target, $project, $buildFinished ? STYLE_SUCCESS : STYLE_ALERT);
+            my $alertStyle = ($line =~ /error:/) ? STYLE_ERROR : STYLE_ALERT;
+            printLine($line, $target, $project, $buildFinished ? STYLE_SUCCESS : $alertStyle);
         }
     }
 
@@ -344,6 +349,7 @@ sub printLine($$$$)
         $line = escapeHTML($line);
         if    ($style == STYLE_HEADER)  { print OUTPUT_HANDLE "<h2>$line</h2>"; }
         elsif ($style == STYLE_SUCCESS) { print OUTPUT_HANDLE "<p class=\"success\">$line</p>"; }
+        elsif ($style == STYLE_ERROR)   { print OUTPUT_HANDLE "<p class=\"error\">$line</p>"; }
         elsif ($style == STYLE_ALERT)   { print OUTPUT_HANDLE "<p class=\"alert\">$line</p>"; }
         else                            { print OUTPUT_HANDLE "<p>$line</p>"; }
         OUTPUT_HANDLE->flush();
@@ -363,16 +369,18 @@ sub printLine($$$$)
         $reset = color("reset");
         if ($style == STYLE_HEADER)    { $color = color("blue"); }
         elsif ($style == STYLE_SUCCESS) { $color = color("green"); }
+        elsif ($style == STYLE_ERROR)   { $color = color("magenta"); }
         elsif ($style == STYLE_ALERT)   { $color = color("red"); }
         if ($outputFormat eq "oneline") {
             $erase = "\33[2K\r";
-            if ($style != STYLE_ALERT && $style != STYLE_SUCCESS) {
+            if ($style != STYLE_ALERT && $style != STYLE_ERROR && $style != STYLE_SUCCESS) {
                 $endl = "\r";
             }
         }
     } elsif ($outputFormat eq "debug") {
         if ($style == STYLE_HEADER)    { $color = "HEADER:"; }
         elsif ($style == STYLE_SUCCESS) { $color = "SUCCESS:"; }
+        elsif ($style == STYLE_ERROR)   { $color = "ERROR:"; }
         elsif ($style == STYLE_ALERT)   { $color = "ALERT:"; }
     }
     print OUTPUT_HANDLE $erase, $context, $color, $line, $reset, $endl;


### PR DESCRIPTION
#### 2888a5ec964f4f0848c1b788128e906531ebce52
<pre>
Have filter-build-webkit highlight lines containing &quot;error:&quot;
<a href="https://rdar.apple.com/174039157">rdar://174039157</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311442">https://bugs.webkit.org/show_bug.cgi?id=311442</a>

Reviewed by Abrar Rahman Protyasha.

Errors get lost in the sea of red warnings, so make them magenta.

I considered changing all the warnings to yellow, but that might
result in insufficient contrast with some color schemes.

* Tools/Scripts/filter-build-webkit:
(main):
(printLine):

Canonical link: <a href="https://commits.webkit.org/310544@main">https://commits.webkit.org/310544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8e5421d06428a21f424ddc6afe8832c77bad8b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162904 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6d7db6fb-2c9d-4891-960c-91173c556924) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156023 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119220 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cd7ca145-60c4-46f7-b63a-6c1ce53d95a0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138426 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99916 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dba80c32-ea16-4c88-ac2d-2b720e90e030) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20561 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18557 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10736 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130223 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16271 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165376 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17879 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127313 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26954 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22599 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127459 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34583 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26878 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138064 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83471 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22333 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14856 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26568 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26149 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26380 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26221 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->