### PR TITLE
[IndexedDB API] Remove unused function IDBResultData::getResultRef()

### DIFF
--- a/Source/WebCore/Modules/indexeddb/shared/IDBResultData.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBResultData.cpp
@@ -229,12 +229,6 @@ const IDBGetResult& IDBResultData::getResult() const
     return *m_getResult;
 }
 
-IDBGetResult& IDBResultData::getResultRef()
-{
-    RELEASE_ASSERT(m_getResult);
-    return *m_getResult;
-}
-
 const IDBGetAllResult& IDBResultData::getAllResult() const
 {
     RELEASE_ASSERT(m_getAllResult);

--- a/Source/WebCore/Modules/indexeddb/shared/IDBResultData.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBResultData.h
@@ -108,7 +108,6 @@ public:
     uint64_t resultInteger() const { return m_resultInteger; }
 
     WEBCORE_EXPORT const IDBGetResult& NODELETE getResult() const;
-    WEBCORE_EXPORT IDBGetResult& NODELETE getResultRef();
     WEBCORE_EXPORT const IDBGetAllResult& NODELETE getAllResult() const;
 
     WEBCORE_EXPORT IDBResultData();


### PR DESCRIPTION
#### 2d18b2adcaf0950d92e5e6e790f44b57f2eafbfb
<pre>
[IndexedDB API] Remove unused function IDBResultData::getResultRef()
<a href="https://bugs.webkit.org/show_bug.cgi?id=311445">https://bugs.webkit.org/show_bug.cgi?id=311445</a>
<a href="https://rdar.apple.com/174040866">rdar://174040866</a>

Reviewed by Aditya Keerthi.

The function was added in <a href="https://commits.webkit.org/211318@main">https://commits.webkit.org/211318@main</a> but never called.

* Source/WebCore/Modules/indexeddb/shared/IDBResultData.cpp:
(WebCore::IDBResultData::getResultRef): Deleted.
* Source/WebCore/Modules/indexeddb/shared/IDBResultData.h:

Canonical link: <a href="https://commits.webkit.org/310559@main">https://commits.webkit.org/310559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c64986890898cb2e64f0dc479ada2aae64295a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20577 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162913 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107627 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6dbba889-8fa6-4469-af74-fff7274b2f99) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156032 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27267 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119223 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84282 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/537cb2c3-63c1-4aef-8b9c-7f594fec5776) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157118 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21476 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138444 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99919 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20564 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18562 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10745 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130226 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16289 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165385 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8594 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127317 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26963 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22604 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127463 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26887 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138082 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83480 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23549 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22342 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14874 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26577 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90680 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26158 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26389 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26230 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->