### PR TITLE
Confusing error message gets logged after a failed declarativeNetRequest operation

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.cpp
@@ -45,7 +45,7 @@ WebExtensionDeclarativeNetRequestSQLiteStore::WebExtensionDeclarativeNetRequestS
     : WebExtensionSQLiteStore(uniqueIdentifier, directory, static_cast<bool>(useInMemoryDatabase))
     , m_storageType(storageType)
 {
-    m_tableName = makeString(storageType == WebExtensionDeclarativeNetRequestStorageType::Dynamic ? "dynamic"_s : "session"_s, "_rules"_s);
+    m_tableName = makeString(toString(m_storageType), "_rules"_s);
 }
 
 static Vector<String> ruleIdMapToString(Vector<double> ruleIDs)
@@ -118,9 +118,9 @@ void WebExtensionDeclarativeNetRequestSQLiteStore::addRules(Ref<JSON::Array> rul
             }
 
             if (existingRuleIDs.size() == 1)
-                errorMessage = makeString("Failed to add "_s, protectedThis->m_storageType, " rules. Rule "_s, existingRuleIDs.first(), " does not have a unique ID."_s);
+                errorMessage = makeString("Failed to add "_s, toString(protectedThis->m_storageType), " rules. Rule "_s, existingRuleIDs.first(), " does not have a unique ID."_s);
             else if (existingRuleIDs.size() >= 2)
-                errorMessage = makeString("Failed to add "_s, protectedThis->m_storageType, " rules. Some rules do not have unique IDs ("_s, makeStringByJoining(ruleIdMapToString(rulesIDs).span(), ", "_s), ")"_s);
+                errorMessage = makeString("Failed to add "_s, toString(protectedThis->m_storageType), " rules. Some rules do not have unique IDs ("_s, makeStringByJoining(ruleIdMapToString(rulesIDs).span(), ", "_s), ")"_s);
 
             if (!errorMessage.isEmpty()) {
                 WorkQueue::mainSingleton().dispatch([errorMessage = crossThreadCopy(errorMessage), completionHandler = WTF::move(completionHandler)]() mutable {
@@ -176,7 +176,7 @@ void WebExtensionDeclarativeNetRequestSQLiteStore::deleteRules(Vector<double> ru
         DatabaseResult result = SQLiteDatabaseExecute(*(protectedThis->database()), makeString("DELETE FROM "_s, protectedThis->m_tableName, " WHERE id IN ("_s, makeStringByJoining(ruleIdMapToString(ruleIDs).span(), ", "_s), ")"_s));
         if (result != SQLITE_DONE) {
             RELEASE_LOG_ERROR(Extensions, "Failed to delete rules for extension %s.", protectedThis->uniqueIdentifier().utf8().data());
-            errorMessage = makeString("Failed to delete rules from "_s, protectedThis->m_storageType, " rules storage."_s);
+            errorMessage = makeString("Failed to delete rules from "_s, toString(protectedThis->m_storageType), " rules storage."_s);
         }
 
         String deleteDatabaseErrorMessage = protectedThis->deleteDatabaseIfEmpty();
@@ -269,8 +269,8 @@ String WebExtensionDeclarativeNetRequestSQLiteStore::insertRule(const JSON::Obje
 
     DatabaseResult result = SQLiteDatabaseExecute(database, makeString("INSERT INTO "_s, m_tableName, " (id, rule) VALUES (?, ?)"_s), *ruleID, ruleData);
     if (result != SQLITE_DONE) {
-        RELEASE_LOG_ERROR(Extensions, "Failed to insert dynamic declarative net request rule for extension %s", uniqueIdentifier().utf8().data());
-        return makeString("Failed to add "_s, m_storageType, " rule."_s);
+        RELEASE_LOG_ERROR(Extensions, "Failed to insert %s rule for extension %s", toString(m_storageType).utf8().data(), uniqueIdentifier().utf8().data());
+        return makeString("Failed to add "_s, toString(m_storageType), " rule."_s);
     }
 
     return nullString();

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.h
@@ -38,6 +38,19 @@ enum class WebExtensionDeclarativeNetRequestStorageType : uint8_t {
     Session
 };
 
+inline String toString(WebExtensionDeclarativeNetRequestStorageType ruleType)
+{
+    switch (ruleType) {
+    case WebExtensionDeclarativeNetRequestStorageType::Dynamic:
+        return "dynamic"_s;
+    case WebExtensionDeclarativeNetRequestStorageType::Session:
+        return "session"_s;
+    default:
+        ASSERT_NOT_REACHED();
+        return emptyString();
+    }
+}
+
 class WebExtensionDeclarativeNetRequestSQLiteStore final : public WebExtensionSQLiteStore {
     WTF_MAKE_TZONE_ALLOCATED(WebExtensionDeclarativeNetRequestSQLiteStore);
 


### PR DESCRIPTION
#### bc38d97938269bc4c96c117c9e845b34937c2a6b
<pre>
Confusing error message gets logged after a failed declarativeNetRequest operation
<a href="https://bugs.webkit.org/show_bug.cgi?id=311444">https://bugs.webkit.org/show_bug.cgi?id=311444</a>
<a href="https://rdar.apple.com/174040915">rdar://174040915</a>

Reviewed by Brian Weinstein and Timothy Hatcher.

We&apos;re logging a number instead of the rule type. Convert the storage type enum to a string before
logging and constructing the error messages.

* Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.cpp:
(WebKit::WebExtensionDeclarativeNetRequestSQLiteStore::WebExtensionDeclarativeNetRequestSQLiteStore):
(WebKit::WebExtensionDeclarativeNetRequestSQLiteStore::addRules):
(WebKit::WebExtensionDeclarativeNetRequestSQLiteStore::deleteRules):
(WebKit::WebExtensionDeclarativeNetRequestSQLiteStore::insertRule):
* Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.h:
(WebKit::toString):

Canonical link: <a href="https://commits.webkit.org/310560@main">https://commits.webkit.org/310560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44e7ef4e15b2c856f3203495cfabeb0cd5f7c55d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162931 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107645 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27285 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119235 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84292 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21499 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138457 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99931 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20587 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18583 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10763 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130249 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165403 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8612 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17910 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127329 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127475 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34594 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26905 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138095 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83498 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22365 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14887 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26595 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90698 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26176 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26407 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26248 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->