### PR TITLE
Add wasm IPInt support for SIMD and atomic instructions

### DIFF
--- a/JSTests/wasm/stress/atomic-multimemory.js
+++ b/JSTests/wasm/stress/atomic-multimemory.js
@@ -1,6 +1,4 @@
-//@ requireOptions("--useWasmMultiMemory=1", "--useWasmIPInt=0")
-//@ $skipModes << "wasm-no-jit".to_sym
-//@ $skipModes << "wasm-no-wasm-jit".to_sym
+//@ requireOptions("--useWasmMultiMemory=1")
 
 import * as assert from "../assert.js";
 import { instantiate } from "../wabt-wrapper.js";
@@ -17,6 +15,7 @@ let wat = `
   (func (export "i32_store") (param i32 i32) (local.get 0) (local.get 1) (i32.store 1))
   (func (export "i64_load") (param i32) (result i64) (local.get 0) (i64.load 1))
   (func (export "i64_store") (param i32 i64) (local.get 0) (local.get 1) (i64.store 1))
+
 
   ;; memory.atomic.notify / wait
   (func (export "test_memory_atomic_notify") (param i32 i32) (result i32)

--- a/JSTests/wasm/stress/simd-multimemory.js
+++ b/JSTests/wasm/stress/simd-multimemory.js
@@ -1,6 +1,4 @@
-//@ requireOptions("--useWasmMultiMemory=1", "--useWasmIPInt=0")
-//@ $skipModes << "wasm-no-jit".to_sym
-//@ $skipModes << "wasm-no-wasm-jit".to_sym
+//@ requireOptions("--useWasmMultiMemory=1")
 
 import * as assert from "../assert.js";
 import { instantiate } from "../wabt-wrapper.js";
@@ -12,10 +10,8 @@ let wat = `
   (import "js" "memory0" (memory 1))
   (import "js" "memory1" (memory 1))
 
-
   (func (export "i64_load") (param i32) (result i64) (local.get 0) (i64.load 1))
   (func (export "i64_store") (param i32 i64) (local.get 0) (local.get 1) (i64.store 1))
-
 
 ;; (load address, store address)
   (func (export "test_v128_load") (param i32 i32) (local.get 1) (local.get 0) (v128.load 1) (v128.store 1))

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -59,6 +59,7 @@
 # registers (sc0, sc1, sc2, sc3)
 
 const alignIPInt = constexpr JSC::IPInt::alignIPInt
+const alignAtomicIPInt = constexpr JSC::IPInt::alignAtomicIPInt
 const alignArgumInt = constexpr JSC::IPInt::alignArgumInt
 const alignUInt = constexpr JSC::IPInt::alignUInt
 const alignMInt = constexpr JSC::IPInt::alignMInt
@@ -320,6 +321,31 @@ end
 
 macro reservedOpcode(opcode)
     unimplementedInstruction(_reserved_%opcode%)
+end
+
+macro atomicInstructionLabel(instrname)
+    aligned _ipint%instrname%_atomic_validate alignAtomicIPInt
+    _ipint%instrname%_atomic_validate:
+    _ipint%instrname%:
+end
+
+macro ipintAtomicOp(name, impl)
+    atomicInstructionLabel(name)
+
+    if TRACING
+        move cfr, a1
+        move PC, a2
+        move MC, a3
+        operationCall(macro() cCall4(_ipint_extern_trace) end)
+    end
+
+    impl()
+end
+
+macro reservedAtomicOpcode(opcode)
+    atomicInstructionLabel(_reserved_%opcode%)
+    validateOpcodeConfig(a0)
+    break
 end
 
 # ---------------------------------------

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
@@ -48,11 +48,20 @@ do { \
     RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * width, #name); \
 } while (false);
 
+#define VALIDATE_IPINT_ATOMIC_OPCODE_FROM_BASE(dispatchBase, width, opcode, name) \
+do { \
+    void* base = reinterpret_cast<void*>(dispatchBase); \
+    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _atomic_validate); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
+    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * width, #name); \
+} while (false);
+
 #define VALIDATE_IPINT_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_unreachable_validate, alignIPInt, opcode, name)
 #define VALIDATE_IPINT_GC_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_struct_new_validate, alignIPInt, opcode, name)
 #define VALIDATE_IPINT_CONVERSION_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_i32_trunc_sat_f32_s_validate, alignIPInt, opcode, name)
 #define VALIDATE_IPINT_SIMD_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_simd_v128_load_mem_validate, alignIPInt, opcode, name)
-#define VALIDATE_IPINT_ATOMIC_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_memory_atomic_notify_validate, alignIPInt, opcode, name)
+#define VALIDATE_IPINT_ATOMIC_OPCODE(opcode, name) VALIDATE_IPINT_ATOMIC_OPCODE_FROM_BASE(ipint_memory_atomic_notify_atomic_validate, alignAtomicIPInt, opcode, name)
 #define VALIDATE_IPINT_ARGUMINT_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_argumINT_a0_validate, alignArgumInt, opcode, name)
 #define VALIDATE_IPINT_SLOW_PATH(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_local_get_slow_path_validate, alignIPInt, opcode, name)
 #define VALIDATE_IPINT_MINT_CALL_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_mint_a0_validate, alignMInt, opcode, name)
@@ -64,7 +73,7 @@ do { \
     v(ipint_gc_dispatch_base, ipint_struct_new_validate) \
     v(ipint_conversion_dispatch_base, ipint_i32_trunc_sat_f32_s_validate) \
     v(ipint_simd_dispatch_base, ipint_simd_v128_load_mem_validate) \
-    v(ipint_atomic_dispatch_base, ipint_memory_atomic_notify_validate) \
+    v(ipint_atomic_dispatch_base, ipint_memory_atomic_notify_atomic_validate) \
 
 
 void initialize()

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
@@ -37,6 +37,9 @@ extern "C" void SYSV_ABI ipint_entry();
 #define IPINT_VALIDATE_DEFINE_FUNCTION(opcode, name) \
     extern "C" void SYSV_ABI ipint_ ## name ## _validate() REFERENCED_FROM_ASM WTF_INTERNAL NO_REORDER;
 
+#define IPINT_ATOMIC_VALIDATE_DEFINE_FUNCTION(opcode, name) \
+    extern "C" void SYSV_ABI ipint_ ## name ## _atomic_validate() REFERENCED_FROM_ASM WTF_INTERNAL NO_REORDER;
+
 #define FOR_EACH_IPINT_OPCODE(m) \
     m(0x00, unreachable) \
     m(0x01, nop) \
@@ -790,7 +793,7 @@ FOR_EACH_IPINT_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_GC_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_CONVERSION_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_SIMD_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
-FOR_EACH_IPINT_ATOMIC_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
+FOR_EACH_IPINT_ATOMIC_OPCODE(IPINT_ATOMIC_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_ARGUMINT_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_SLOW_PATH(IPINT_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_MINT_CALL_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
@@ -808,6 +811,8 @@ constexpr uint64_t alignIPInt = 512;
 #else
 constexpr uint64_t alignIPInt = 256;
 #endif
+// FIXME: adding an adds instruction to offlineasm could shrink atomic handlers back to 256 bytes
+constexpr uint64_t alignAtomicIPInt = 2 * alignIPInt;
 constexpr uint64_t alignArgumInt = 64;
 constexpr uint64_t alignUInt = 64;
 constexpr uint64_t alignMInt = 64;

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -903,37 +903,13 @@ macro popMemoryIndex(reg, tmp)
 .done:
 end
 
-# FIXME(wasm-multimemory): delete eventually
-macro ipintCheckMemoryBound(mem, scratch, size)
-    # Memory indices are 32 bit
-    leap size - 1[mem], scratch
-    bpb scratch, boundsCheckingSize, .continuation
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsMemoryAccess)
-.continuation:
-end
-
-# FIXME(wasm-multimemory): delete eventually
-macro loadMemoryOffsetAndAdvanceMC(dstReg, tmpReg, instrLenReg)
-	loadb JSWebAssemblyInstance::m_cachedIsMemory64[wasmInstance], tmpReg
-	btiz tmpReg, .memory32
-	loadq IPInt::Const64Metadata::value[MC], dstReg
-    loadb IPInt::Const64Metadata::instructionLength[MC], instrLenReg
-	advanceMC(constexpr (sizeof(IPInt::Const64Metadata)))
-	jmp .done
-.memory32:
-	loadi IPInt::Const32Metadata::value[MC], dstReg
-    loadb IPInt::Const32Metadata::instructionLength[MC], instrLenReg
-	advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
-.done:
-end
-
 macro baddpc(src, dst, label)
     # FIXME: make this a proper instruction
     addp src, dst
     bpb dst, src, label # unsigned overflow check
 end
 
-macro loadStoreAdvanceMCAndMakePointer(instrLenReg, wasmAddrReg, size, scratch, scratch2)
+macro memoryOpAdvanceMCAndMakePointer(instrLenReg, wasmAddrReg, size, scratch, scratch2)
     # overwrites wasmAddrReg with computed pointer
 
     loadb JSWebAssemblyInstance::m_cachedIsMemory64[wasmInstance], scratch
@@ -941,24 +917,22 @@ macro loadStoreAdvanceMCAndMakePointer(instrLenReg, wasmAddrReg, size, scratch, 
 
     btiz scratch, .memory32
     loadq memoryIndexSize + IPInt::Const64Metadata::value[MC], instrLenReg # reuse instrLenReg to store offset
-    baddpc(instrLenReg, wasmAddrReg, .outOfBounds)
-    move size - 1, scratch2
-    baddpc(wasmAddrReg, scratch2, .outOfBounds)
+    baddpc(instrLenReg, wasmAddrReg, .outOfBounds) # wasmAddrReg contains address + offset
     loadb memoryIndexSize + IPInt::Const64Metadata::instructionLength[MC], instrLenReg
     loadb IPInt::MemoryIndexMetadata::memoryIndex[MC], scratch # scratch contains memory index now
     advanceMC(memoryIndexSize + sizeof IPInt::Const64Metadata)
-    jmp .doneLoadingWasmAddress
+    jmp .commonMemoryCalculations
 
 .memory32:
     loadi memoryIndexSize + IPInt::Const32Metadata::value[MC], instrLenReg # reuse instrLenReg to store offset
-    baddpc(instrLenReg, wasmAddrReg, .outOfBounds)
-    move size - 1, scratch2
-    baddpc(wasmAddrReg, scratch2, .outOfBounds)
+    baddpc(instrLenReg, wasmAddrReg, .outOfBounds) # wasmAddrReg contains address + offset
     loadb memoryIndexSize + IPInt::Const32Metadata::instructionLength[MC], instrLenReg
     loadb IPInt::MemoryIndexMetadata::memoryIndex[MC], scratch # scratch contains memory index now
     advanceMC(memoryIndexSize + sizeof IPInt::Const32Metadata)
 
-.doneLoadingWasmAddress:
+.commonMemoryCalculations:
+    move size - 1, scratch2
+    baddpc(wasmAddrReg, scratch2, .outOfBounds)
 
     btinz scratch, .memoryIsNotZero
     bpaeq scratch2, boundsCheckingSize, .outOfBounds # scratch2 contains wasm address + size - 1
@@ -983,7 +957,7 @@ ipintOp(_i32_load_mem, macro()
     # i32.load
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
     # load memory location
     loadi [t0], t1
     pushInt32(t1)
@@ -996,7 +970,7 @@ ipintOp(_i64_load_mem, macro()
     # i32.load
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 8, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 8, t1, t2)
     # load memory location
     loadq [t0], t1
     pushInt64(t1)
@@ -1009,7 +983,7 @@ ipintOp(_f32_load_mem, macro()
     # f32.load
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
     # load memory location
     loadf [t0], ft0
     pushFloat32(ft0)
@@ -1022,7 +996,7 @@ ipintOp(_f64_load_mem, macro()
     # f64.load
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 8, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 8, t1, t2)
     # load memory location
     loadd [t0], ft0
     pushFloat64(ft0)
@@ -1035,7 +1009,7 @@ ipintOp(_i32_load8s_mem, macro()
     # i32.load8_s
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
     loadb [t0], t1
     sxb2i t1, t1
     pushInt32(t1)
@@ -1048,7 +1022,7 @@ ipintOp(_i32_load8u_mem, macro()
     # i32.load8_u
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
     # load memory location
     loadb [t0], t1
     pushInt32(t1)
@@ -1061,7 +1035,7 @@ ipintOp(_i32_load16s_mem, macro()
     # i32.load16_s
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
     # load memory location
     loadh [t0], t1
     sxh2i t1, t1
@@ -1075,7 +1049,7 @@ ipintOp(_i32_load16u_mem, macro()
     # i32.load16_u
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
     # load memory location
     loadh [t0], t1
     pushInt32(t1)
@@ -1088,7 +1062,7 @@ ipintOp(_i64_load8s_mem, macro()
     # i64.load8_s
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
     # load memory location
     loadb [t0], t1
     sxb2q t1, t1
@@ -1102,7 +1076,7 @@ ipintOp(_i64_load8u_mem, macro()
     # i64.load8_u
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
     # load memory location
     loadb [t0], t1
     pushInt64(t1)
@@ -1115,7 +1089,7 @@ ipintOp(_i64_load16s_mem, macro()
     # i64.load16_s
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
     # load memory location
     loadh [t0], t1
     sxh2q t1, t1
@@ -1129,7 +1103,7 @@ ipintOp(_i64_load16u_mem, macro()
     # i64.load16_u
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
     # load memory location
     loadh [t0], t1
     pushInt64(t1)
@@ -1142,7 +1116,7 @@ ipintOp(_i64_load32s_mem, macro()
     # i64.load32_s
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
     # load memory location
     loadi [t0], t1
     sxi2q t1, t1
@@ -1156,7 +1130,7 @@ ipintOp(_i64_load32u_mem, macro()
     # i64.load8_s
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
     # load memory location
     loadi [t0], t1
     pushInt64(t1)
@@ -1171,7 +1145,7 @@ ipintOp(_i32_store_mem, macro()
     popInt32(t3)
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
     # load memory location
     storei t3, [t0]
 
@@ -1185,7 +1159,7 @@ ipintOp(_i64_store_mem, macro()
     popInt64(t3)
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 8, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 8, t1, t2)
     # load memory location
     storeq t3, [t0]
 
@@ -1199,7 +1173,7 @@ ipintOp(_f32_store_mem, macro()
     popFloat32(ft0)
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
     # load memory location
     storef ft0, [t0]
 
@@ -1213,7 +1187,7 @@ ipintOp(_f64_store_mem, macro()
     popFloat64(ft0)
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 8, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 8, t1, t2)
     # load memory location
     stored ft0, [t0]
 
@@ -1227,7 +1201,7 @@ ipintOp(_i32_store8_mem, macro()
     popInt32(t3)
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
     # load memory location
     storeb t3, [t0]
 
@@ -1241,7 +1215,7 @@ ipintOp(_i32_store16_mem, macro()
     popInt32(t3)
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
     # load memory location
     storeh t3, [t0]
 
@@ -1255,7 +1229,7 @@ ipintOp(_i64_store8_mem, macro()
     popInt64(t3)
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
     # load memory location
     storeb t3, [t0]
 
@@ -1269,7 +1243,7 @@ ipintOp(_i64_store16_mem, macro()
     popInt64(t3)
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
     # load memory location
     storeh t3, [t0]
 
@@ -1283,7 +1257,7 @@ ipintOp(_i64_store32_mem, macro()
     popInt64(t3)
     # pop index
     popMemoryIndex(t0, t2)
-    loadStoreAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
     # load memory location
     storei t3, [t0]
 
@@ -3225,10 +3199,10 @@ ipintOp(_atomic_prefix, macro()
     leap _os_script_config_storage, t1
     loadp JSC::LLInt::OpcodeConfig::ipint_atomic_dispatch_base[t1], t1
     if ARM64 or ARM64E
-        addlshiftp t1, t0, 8, t0
+        addlshiftp t1, t0, constexpr (WTF::fastLog2(JSC::IPInt::alignAtomicIPInt)), t0
         jmp t0
     elsif X86_64
-        lshiftq 8, t0
+        lshiftq constexpr (WTF::fastLog2(JSC::IPInt::alignAtomicIPInt)), t0
         addq t1, t0
         jmp t0
     end
@@ -4080,22 +4054,19 @@ const ImmLaneIdx2Mask = 0x1
 # Wrapper for SIMD load/store operations. Places linear address in t0 for memOp()
 macro simdMemoryOp(accessSize, memOp)
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
-    addp t2, t0
-    ipintCheckMemoryBound(t0, t2, accessSize)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, accessSize, t1, t2)
 
+    # memOp must not clobber t4
     memOp()
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advancePCByReg(t4)
     nextIPIntInstruction()
 end
 
 ipintOp(_simd_v128_load_mem, macro()
     # v128.load
     simdMemoryOp(16, macro()
-        loadv [memoryBase, t0], v0
+        loadv [t0], v0
         pushVec(v0)
     end)
 end)
@@ -4104,13 +4075,13 @@ ipintOp(_simd_v128_load_8x8s_mem, macro()
     # v128.load8x8_s - load 8 8-bit values, sign-extend each to i16
     simdMemoryOp(8, macro()
         if ARM64 or ARM64E
-            loadd [memoryBase, t0], ft0
+            loadd [t0], ft0
             # offlineasm ft0 = ARM v0
             # offlineasm v0 = ARM v16
             emit "sxtl v16.8h, v0.8b"
         elsif X86_64
-            # memoryBase is r14, t0 is eax
-            emit "pmovsxbw (%r14,%rax), %xmm0"
+            # t0 is eax
+            emit "pmovsxbw (%rax), %xmm0"
         else
             break # Not implemented
         end
@@ -4122,13 +4093,13 @@ ipintOp(_simd_v128_load_8x8u_mem, macro()
     # v128.load8x8_u - load 8 8-bit values, zero-extend each to i16
     simdMemoryOp(8, macro()
         if ARM64 or ARM64E
-            loadd [memoryBase, t0], ft0
+            loadd [t0], ft0
             # offlineasm ft0 = ARM v0
             # offlineasm v0 = ARM v16
             emit "uxtl v16.8h, v0.8b"
         elsif X86_64
-            # memoryBase is r14, t0 is eax
-            emit "pmovzxbw (%r14,%rax), %xmm0"
+            # t0 is eax
+            emit "pmovzxbw (%rax), %xmm0"
         else
             break # Not implemented
         end
@@ -4140,13 +4111,13 @@ ipintOp(_simd_v128_load_16x4s_mem, macro()
     # v128.load16x4_s - load 4 16-bit values, sign-extend each to i32
     simdMemoryOp(8, macro()
         if ARM64 or ARM64E
-            loadd [memoryBase, t0], ft0
+            loadd [t0], ft0
             # offlineasm ft0 = ARM v0
             # offlineasm v0 = ARM v16
             emit "sxtl v16.4s, v0.4h"
         elsif X86_64
-            # memoryBase is r14, t0 is eax
-            emit "pmovsxwd (%r14,%rax), %xmm0"
+            # t0 is eax
+            emit "pmovsxwd (%rax), %xmm0"
         else
             break # Not implemented
         end
@@ -4158,13 +4129,13 @@ ipintOp(_simd_v128_load_16x4u_mem, macro()
     # v128.load16x4_u - load 4 16-bit values, zero-extend each to i32
     simdMemoryOp(8, macro()
         if ARM64 or ARM64E
-            loadd [memoryBase, t0], ft0
+            loadd [t0], ft0
             # offlineasm ft0 = ARM v0
             # offlineasm v0 = ARM v16
             emit "uxtl v16.4s, v0.4h"
         elsif X86_64
-            # memoryBase is r14, t0 is eax
-            emit "pmovzxwd (%r14,%rax), %xmm0"
+            # t0 is eax
+            emit "pmovzxwd (%rax), %xmm0"
         else
             break # Not implemented
         end
@@ -4176,13 +4147,13 @@ ipintOp(_simd_v128_load_32x2s_mem, macro()
     # v128.load32x2_s - load 2 32-bit values, sign-extend each to i64
     simdMemoryOp(8, macro()
         if ARM64 or ARM64E
-            loadd [memoryBase, t0], ft0
+            loadd [t0], ft0
             # offlineasm ft0 = ARM v0
             # offlineasm v0 = ARM v16
             emit "sxtl v16.2d, v0.2s"
         elsif X86_64
-            # memoryBase is r14, t0 is eax
-            emit "pmovsxdq (%r14,%rax), %xmm0"
+            # t0 is eax
+            emit "pmovsxdq (%rax), %xmm0"
         else
             break # Not implemented
         end
@@ -4194,13 +4165,13 @@ ipintOp(_simd_v128_load_32x2u_mem, macro()
     # v128.load32x2_u - load 2 32-bit values, zero-extend each to i64
     simdMemoryOp(8, macro()
         if ARM64 or ARM64E
-            loadd [memoryBase, t0], ft0
+            loadd [t0], ft0
             # offlineasm ft0 = ARM v0
             # offlineasm v0 = ARM v16
             emit "uxtl v16.2d, v0.2s"
         elsif X86_64
-            # memoryBase is r14, t0 is eax
-            emit "pmovzxdq (%r14,%rax), %xmm0"
+            # t0 is eax
+            emit "pmovzxdq (%rax), %xmm0"
         else
             break # Not implemented
         end
@@ -4212,11 +4183,11 @@ ipintOp(_simd_v128_load8_splat_mem, macro()
     # v128.load8_splat - load 1 8-bit value and splat to all 16 lanes
     simdMemoryOp(1, macro()
         if ARM64 or ARM64E
-            loadb [memoryBase, t0], t1
+            loadb [t0], t1
             emit "dup v16.16b, w1"
         elsif X86_64
-            # memoryBase is r14, t0 is eax
-            emit "vpinsrb $0, (%r14,%rax), %xmm0, %xmm0"
+            # t0 is eax
+            emit "vpinsrb $0, (%rax), %xmm0, %xmm0"
             emit "vpxor %xmm1, %xmm1, %xmm1"
             emit "vpshufb %xmm1, %xmm0, %xmm0"
         else
@@ -4230,11 +4201,11 @@ ipintOp(_simd_v128_load16_splat_mem, macro()
     # v128.load16_splat - load 1 16-bit value and splat to all 8 lanes
     simdMemoryOp(2, macro()
         if ARM64 or ARM64E
-            loadh [memoryBase, t0], t1
+            loadh [t0], t1
             emit "dup v16.8h, w1"
         elsif X86_64
-            # memoryBase is r14, t0 is eax
-            emit "vpinsrw $0, (%r14,%rax), %xmm0, %xmm0"
+            # t0 is eax
+            emit "vpinsrw $0, (%rax), %xmm0, %xmm0"
             emit "vpshuflw $0, %xmm0, %xmm0"
             emit "vpunpcklqdq %xmm0, %xmm0, %xmm0"
         else
@@ -4248,12 +4219,12 @@ ipintOp(_simd_v128_load32_splat_mem, macro()
     # v128.load32_splat - load 1 32-bit value and splat to all 4 lanes
     simdMemoryOp(4, macro()
         if ARM64 or ARM64E
-            loadi [memoryBase, t0], t1
+            loadi [t0], t1
             emit "dup v16.4s, w1"
         elsif X86_64
             # Load and broadcast 32-bit value directly from memory to all 4 dwords
-            # memoryBase is r14, t0 is eax
-            emit "vbroadcastss (%r14,%rax), %xmm0"
+            # t0 is eax
+            emit "vbroadcastss (%rax), %xmm0"
         else
             break # Not implemented
         end
@@ -4265,12 +4236,12 @@ ipintOp(_simd_v128_load64_splat_mem, macro()
     # v128.load64_splat - load 1 64-bit value and splat to all 2 lanes
     simdMemoryOp(8, macro()
         if ARM64 or ARM64E
-            loadq [memoryBase, t0], t1
+            loadq [t0], t1
             emit "dup v16.2d, x1"
         elsif X86_64
             # Load and broadcast 64-bit value directly from memory to both qwords
-            # memoryBase is r14, t0 is eax
-            emit "vmovddup (%r14,%rax), %xmm0"
+            # t0 is eax
+            emit "vmovddup (%rax), %xmm0"
         else
             break # Not implemented
         end
@@ -4282,7 +4253,7 @@ ipintOp(_simd_v128_store_mem, macro()
     # v128.store
     popVec(v0)
     simdMemoryOp(16, macro()
-        storev v0, [memoryBase, t0]
+        storev v0, [t0]
     end)
 end)
 
@@ -5681,20 +5652,51 @@ end)
 
 # 0xFD 0x54 - 0xFD 0x5D: v128 load/store lane
 
+# If simd ops used memoryOpAdvanceMCAndMakePointer the macro would read
+# memory index and advance MC and then the handler would read the constant
+# and advance MC, so there is a performance optimization here to only
+# advance MC once
+
+macro ipintCheckMemoryBoundAndMakePointer(whichMemory, mem, scratch, size)
+    # overwrites mem with computed pointer
+    btiz whichMemory, .checkBounds
+    # overwrites whichMemory
+    mulp (constexpr (sizeof(JSWebAssemblyInstance::WasmMemoryBaseAndSize))), whichMemory
+    addp (constexpr (JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0))), whichMemory
+    addp wasmInstance, whichMemory
+    loadp [whichMemory], memoryBase
+    loadp (constexpr (sizeof(void*)))[whichMemory], boundsCheckingSize
+    move 1, whichMemory # restore base and size registers afterward if using nonzero memory
+.checkBounds:
+    # Memory indices are 32 bit
+    leap size - 1[mem], scratch
+    bpb scratch, boundsCheckingSize, .continuation
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsMemoryAccess)
+.continuation:
+    addp memoryBase, mem
+    btiz whichMemory, .done
+    loadp (constexpr (JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0))) [wasmInstance], memoryBase
+    loadp (constexpr (JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0) + sizeof(void*))) [wasmInstance], boundsCheckingSize
+.done:
+end
+
 ipintOp(_simd_v128_load8_lane_mem, macro()
     # v128.load8_lane - load 8-bit value from memory and replace lane in existing vector
 
     popVec(v0)
     popMemoryIndex(t0, t2)
 
-    loadi IPInt::Const32Metadata::value[MC], t2
+    loadb IPInt::MemoryIndexMetadata::memoryIndex[MC], t3
+    const memoryIndexSize = sizeof IPInt::MemoryIndexMetadata
+
+    loadi memoryIndexSize + IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
-    ipintCheckMemoryBound(t0, t2, 1)
-    loadb [memoryBase, t0], t0
+    ipintCheckMemoryBoundAndMakePointer(t3, t0, t2, 1)
+    loadb [t0], t0
 
     # The lane index comes after the variable length memory offset, so find it by
     # advancing the PC and loading the byte before the next instruction.
-    loadb IPInt::Const32Metadata::instructionLength[MC], t1
+    loadb memoryIndexSize + IPInt::Const32Metadata::instructionLength[MC], t1
     advancePCByReg(t1)
     loadb -1[PC], t1
     andi ImmLaneIdx16Mask, t1
@@ -5703,7 +5705,7 @@ ipintOp(_simd_v128_load8_lane_mem, macro()
     pushVec(v0)
     storeb t0, [sp, t1]
 
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advanceMC(constexpr (sizeof(IPInt::MemoryIndexMetadata) + sizeof(IPInt::Const32Metadata)))
     nextIPIntInstruction()
 end)
 
@@ -5713,14 +5715,17 @@ ipintOp(_simd_v128_load16_lane_mem, macro()
     popVec(v0)
     popMemoryIndex(t0, t2)
 
-    loadi IPInt::Const32Metadata::value[MC], t2
+    loadb IPInt::MemoryIndexMetadata::memoryIndex[MC], t3
+    const memoryIndexSize = sizeof IPInt::MemoryIndexMetadata
+
+    loadi memoryIndexSize + IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
-    ipintCheckMemoryBound(t0, t2, 2)
-    loadh [memoryBase, t0], t0
+    ipintCheckMemoryBoundAndMakePointer(t3, t0, t2, 2)
+    loadh [t0], t0
 
     # The lane index comes after the variable length memory offset, so find it by
     # advancing the PC and loading the byte before the next instruction.
-    loadb IPInt::Const32Metadata::instructionLength[MC], t1
+    loadb memoryIndexSize + IPInt::Const32Metadata::instructionLength[MC], t1
     advancePCByReg(t1)
     loadb -1[PC], t1
     andi ImmLaneIdx8Mask, t1
@@ -5729,7 +5734,7 @@ ipintOp(_simd_v128_load16_lane_mem, macro()
     pushVec(v0)
     storeh t0, [sp, t1, 2]
 
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advanceMC(constexpr (sizeof(IPInt::MemoryIndexMetadata) + sizeof(IPInt::Const32Metadata)))
     nextIPIntInstruction()
 end)
 
@@ -5739,14 +5744,17 @@ ipintOp(_simd_v128_load32_lane_mem, macro()
     popVec(v0)
     popMemoryIndex(t0, t2)
 
-    loadi IPInt::Const32Metadata::value[MC], t2
+    loadb IPInt::MemoryIndexMetadata::memoryIndex[MC], t3
+    const memoryIndexSize = sizeof IPInt::MemoryIndexMetadata
+
+    loadi memoryIndexSize + IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
-    ipintCheckMemoryBound(t0, t2, 4)
-    loadi [memoryBase, t0], t0
+    ipintCheckMemoryBoundAndMakePointer(t3, t0, t2, 4)
+    loadi [t0], t0
 
     # The lane index comes after the variable length memory offset, so find it by
     # advancing the PC and loading the byte before the next instruction.
-    loadb IPInt::Const32Metadata::instructionLength[MC], t1
+    loadb memoryIndexSize + IPInt::Const32Metadata::instructionLength[MC], t1
     advancePCByReg(t1)
     loadb -1[PC], t1
     andi ImmLaneIdx4Mask, t1
@@ -5755,7 +5763,7 @@ ipintOp(_simd_v128_load32_lane_mem, macro()
     pushVec(v0)
     storei t0, [sp, t1, 4]
 
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advanceMC(constexpr (sizeof(IPInt::MemoryIndexMetadata) + sizeof(IPInt::Const32Metadata)))
     nextIPIntInstruction()
 end)
 
@@ -5765,14 +5773,17 @@ ipintOp(_simd_v128_load64_lane_mem, macro()
     popVec(v0)
     popMemoryIndex(t0, t2)
 
-    loadi IPInt::Const32Metadata::value[MC], t2
+    loadb IPInt::MemoryIndexMetadata::memoryIndex[MC], t3
+    const memoryIndexSize = sizeof IPInt::MemoryIndexMetadata
+
+    loadi memoryIndexSize + IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
-    ipintCheckMemoryBound(t0, t2, 8)
-    loadq [memoryBase, t0], t0
+    ipintCheckMemoryBoundAndMakePointer(t3, t0, t2, 8)
+    loadq [t0], t0
 
     # The lane index comes after the variable length memory offset, so find it by
     # advancing the PC and loading the byte before the next instruction.
-    loadb IPInt::Const32Metadata::instructionLength[MC], t1
+    loadb memoryIndexSize + IPInt::Const32Metadata::instructionLength[MC], t1
     advancePCByReg(t1)
     loadb -1[PC], t1
     andi ImmLaneIdx2Mask, t1
@@ -5781,16 +5792,19 @@ ipintOp(_simd_v128_load64_lane_mem, macro()
     pushVec(v0)
     storeq t0, [sp, t1, 8]
 
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advanceMC(constexpr (sizeof(IPInt::MemoryIndexMetadata) + sizeof(IPInt::Const32Metadata)))
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_store8_lane_mem, macro()
     # v128.store8_lane - extract 8-bit value from lane and store to memory
 
+    loadb IPInt::MemoryIndexMetadata::memoryIndex[MC], t3
+    const memoryIndexSize = sizeof IPInt::MemoryIndexMetadata
+
     # The lane index comes after the variable length memory offset, so find it by
     # advancing the PC and loading the byte before the next instruction.
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    loadb memoryIndexSize + IPInt::Const32Metadata::instructionLength[MC], t0
     advancePCByReg(t0)
     loadb -1[PC], t1
     andi ImmLaneIdx16Mask, t1
@@ -5800,22 +5814,25 @@ ipintOp(_simd_v128_store8_lane_mem, macro()
 
     popMemoryIndex(t0, t2)
 
-    loadi IPInt::Const32Metadata::value[MC], t2
+    loadi memoryIndexSize + IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
-    ipintCheckMemoryBound(t0, t2, 1)
+    ipintCheckMemoryBoundAndMakePointer(t3, t0, t2, 1)
 
-    storeb t1, [memoryBase, t0]
+    storeb t1, [t0]
 
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advanceMC(constexpr (sizeof(IPInt::MemoryIndexMetadata) + sizeof(IPInt::Const32Metadata)))
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_store16_lane_mem, macro()
     # v128.store16_lane - extract 16-bit value from lane and store to memory
 
+    loadb IPInt::MemoryIndexMetadata::memoryIndex[MC], t3
+    const memoryIndexSize = sizeof IPInt::MemoryIndexMetadata
+
     # The lane index comes after the variable length memory offset, so find it by
     # advancing the PC and loading the byte before the next instruction.
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    loadb memoryIndexSize + IPInt::Const32Metadata::instructionLength[MC], t0
     advancePCByReg(t0)
     loadb -1[PC], t1
     andi ImmLaneIdx8Mask, t1
@@ -5825,22 +5842,25 @@ ipintOp(_simd_v128_store16_lane_mem, macro()
 
     popMemoryIndex(t0, t2)
 
-    loadi IPInt::Const32Metadata::value[MC], t2
+    loadi memoryIndexSize + IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
-    ipintCheckMemoryBound(t0, t2, 2)
+    ipintCheckMemoryBoundAndMakePointer(t3, t0, t2, 2)
 
-    storeh t1, [memoryBase, t0]
+    storeh t1, [t0]
 
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advanceMC(constexpr (sizeof(IPInt::MemoryIndexMetadata) + sizeof(IPInt::Const32Metadata)))
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_store32_lane_mem, macro()
     # v128.store32_lane - extract 32-bit value from lane and store to memory
 
+    loadb IPInt::MemoryIndexMetadata::memoryIndex[MC], t3
+    const memoryIndexSize = sizeof IPInt::MemoryIndexMetadata
+
     # The lane index comes after the variable length memory offset, so find it by
     # advancing the PC and loading the byte before the next instruction.
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    loadb memoryIndexSize + IPInt::Const32Metadata::instructionLength[MC], t0
     advancePCByReg(t0)
     loadb -1[PC], t1
     andi ImmLaneIdx4Mask, t1
@@ -5850,22 +5870,25 @@ ipintOp(_simd_v128_store32_lane_mem, macro()
 
     popMemoryIndex(t0, t2)
 
-    loadi IPInt::Const32Metadata::value[MC], t2
+    loadi memoryIndexSize + IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
-    ipintCheckMemoryBound(t0, t2, 4)
+    ipintCheckMemoryBoundAndMakePointer(t3, t0, t2, 4)
 
-    storei t1, [memoryBase, t0]
+    storei t1, [t0]
 
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advanceMC(constexpr (sizeof(IPInt::MemoryIndexMetadata) + sizeof(IPInt::Const32Metadata)))
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_store64_lane_mem, macro()
     # v128.store64_lane - extract 64-bit value from lane and store to memory
 
+    loadb IPInt::MemoryIndexMetadata::memoryIndex[MC], t3
+    const memoryIndexSize = sizeof IPInt::MemoryIndexMetadata
+
     # The lane index comes after the variable length memory offset, so find it by
     # advancing the PC and loading the byte before the next instruction.
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    loadb memoryIndexSize + IPInt::Const32Metadata::instructionLength[MC], t0
     advancePCByReg(t0)
     loadb -1[PC], t1
     andi ImmLaneIdx2Mask, t1
@@ -5874,20 +5897,20 @@ ipintOp(_simd_v128_store64_lane_mem, macro()
     addp V128ISize, sp      # Pop the vector
 
     popMemoryIndex(t0, t2)
-    loadi IPInt::Const32Metadata::value[MC], t2
+    loadi memoryIndexSize + IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
-    ipintCheckMemoryBound(t0, t2, 8)
+    ipintCheckMemoryBoundAndMakePointer(t3, t0, t2, 8)
 
-    storeq t1, [memoryBase, t0]
+    storeq t1, [t0]
 
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advanceMC(constexpr (sizeof(IPInt::MemoryIndexMetadata) + sizeof(IPInt::Const32Metadata)))
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_load32_zero_mem, macro()
     # v128.load32_zero - load 32-bit value from memory and zero-pad to 128 bits
     simdMemoryOp(4, macro()
-        loadi [memoryBase, t0], t0
+        loadi [t0], t0
 
         subp V128ISize, sp
         storei t0, [sp]
@@ -5899,7 +5922,7 @@ end)
 ipintOp(_simd_v128_load64_zero_mem, macro()
     # v128.load64_zero - load 64-bit value from memory and zero-pad to 128 bits
     simdMemoryOp(8, macro()
-        loadq [memoryBase, t0], t0
+        loadq [t0], t0
 
         subp V128ISize, sp
         storeq t0, [sp]
@@ -9057,106 +9080,101 @@ end)
     ## Atomic instructions ##
     #########################
 
-macro ipintCheckMemoryBoundWithAlignmentCheck(mem, scratch, size)
-    leap size - 1[mem], scratch
-    bpb scratch, boundsCheckingSize, .continuationInBounds
-.throwOOB:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsMemoryAccess)
-.continuationInBounds:
-    btpz mem, (size - 1), .continuationAligned
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
-.continuationAligned:
+macro noAlignmentCheck(mem, label)
 end
 
-macro ipintCheckMemoryBoundWithAlignmentCheck1(mem, scratch)
-    ipintCheckMemoryBound(mem, scratch, 1)
+macro checkAlignment2(mem, label)
+    btpnz mem, 1, label
 end
 
-macro ipintCheckMemoryBoundWithAlignmentCheck2(mem, scratch)
-    ipintCheckMemoryBoundWithAlignmentCheck(mem, scratch, 2)
+macro checkAlignment4(mem, label)
+    btpnz mem, 3, label
 end
 
-macro ipintCheckMemoryBoundWithAlignmentCheck4(mem, scratch)
-    ipintCheckMemoryBoundWithAlignmentCheck(mem, scratch, 4)
+macro checkAlignment8(mem, label)
+    btpnz mem, 7, label
 end
 
-macro ipintCheckMemoryBoundWithAlignmentCheck8(mem, scratch)
-    ipintCheckMemoryBoundWithAlignmentCheck(mem, scratch, 8)
-end
+ipintAtomicOp(_memory_atomic_notify, macro()
+    # starting at sp: count, pointer
+    loadb IPInt::MemoryIndexMetadata::memoryIndex[MC], t0
+    pushInt32(t0)
+    const miMetaSize = sizeof IPInt::MemoryIndexMetadata
+    loadi miMetaSize + IPInt::Const32Metadata::value[MC], t0
+    pushInt32(t0) # offset
 
-ipintOp(_memory_atomic_notify, macro()
-    # pop count
-    popInt32(a3)
-    # pop pointer
-    popInt32(a1)
-    # load offset
-    loadi IPInt::Const32Metadata::value[MC], a2
+    move sp, a1
 
-    operationCall(macro() cCall4(_ipint_extern_memory_atomic_notify) end)
+    operationCall(macro() cCall2(_ipint_extern_memory_atomic_notify) end)
     bilt r0, 0, .atomic_notify_throw
 
+    addq (StackValueSize * 4), sp
+
     pushInt32(r0)
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    loadb miMetaSize + IPInt::Const32Metadata::instructionLength[MC], t0
     advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advanceMC(constexpr (sizeof(IPInt::MemoryIndexMetadata) + sizeof(IPInt::Const32Metadata)))
     nextIPIntInstruction()
 
 .atomic_notify_throw:
     handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsMemoryAccess)
 end)
 
-ipintOp(_memory_atomic_wait32, macro()
-    # pop timeout
-    popInt32(a3)
-    # pop value
-    popInt32(a2)
-    # pop pointer
-    popInt32(a1)
-    # load offset
-    loadi IPInt::Const32Metadata::value[MC], t0
-    # merge them since the slow path takes the combined pointer + offset.
-    addq t0, a1
+ipintAtomicOp(_memory_atomic_wait32, macro()
+    # starting at sp: timeout, value, pointer
+    loadb IPInt::MemoryIndexMetadata::memoryIndex[MC], t0
+    pushInt32(t0)
+    loadq (StackValueSize * 3)[sp], t0
+    const miMetaSize = sizeof IPInt::MemoryIndexMetadata
+    loadi miMetaSize + IPInt::Const32Metadata::value[MC], t1
+    addq t1, t0
+    storeq t0, (StackValueSize * 3)[sp] # replace pointer with pointer + offset
 
-    operationCall(macro() cCall4(_ipint_extern_memory_atomic_wait32) end)
+    move sp, a1
+
+    operationCall(macro() cCall2(_ipint_extern_memory_atomic_wait32) end)
     bilt r0, 0, .atomic_wait32_throw
 
+    addq (StackValueSize * 4), sp
+
     pushInt32(r0)
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    loadb miMetaSize + IPInt::Const32Metadata::instructionLength[MC], t0
     advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advanceMC(constexpr (sizeof(IPInt::MemoryIndexMetadata) + sizeof(IPInt::Const32Metadata)))
     nextIPIntInstruction()
 
 .atomic_wait32_throw:
     handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsMemoryAccess)
 end)
 
-ipintOp(_memory_atomic_wait64, macro()
-    # pop timeout
-    popInt32(a3)
-    # pop value
-    popInt64(a2)
-    # pop pointer
-    popInt32(a1)
-    # load offset
-    loadi IPInt::Const32Metadata::value[MC], t0
-    # merge them since the slow path takes the combined pointer + offset.
-    addq t0, a1
+ipintAtomicOp(_memory_atomic_wait64, macro()
+    # starting at sp: timeout, value, pointer
+    loadb IPInt::MemoryIndexMetadata::memoryIndex[MC], t0
+    pushInt32(t0)
+    loadq (StackValueSize * 3)[sp], t0
+    const miMetaSize = sizeof IPInt::MemoryIndexMetadata
+    loadi miMetaSize + IPInt::Const32Metadata::value[MC], t1
+    addq t1, t0
+    storeq t0, (StackValueSize * 3)[sp] # replace pointer with pointer + offset
 
-    operationCall(macro() cCall4(_ipint_extern_memory_atomic_wait64) end)
+    move sp, a1
+
+    operationCall(macro() cCall2(_ipint_extern_memory_atomic_wait64) end)
     bilt r0, 0, .atomic_wait64_throw
 
+    addq (StackValueSize * 4), sp
+
     pushInt32(r0)
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
+    loadb miMetaSize + IPInt::Const32Metadata::instructionLength[MC], t0
     advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+    advanceMC(constexpr (sizeof(IPInt::MemoryIndexMetadata) + sizeof(IPInt::Const32Metadata)))
     nextIPIntInstruction()
 
 .atomic_wait64_throw:
     handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsMemoryAccess)
 end)
 
-ipintOp(_atomic_fence, macro()
+ipintAtomicOp(_atomic_fence, macro()
     fence
 
     loadb IPInt::InstructionLengthMetadata::length[MC], t0
@@ -9165,111 +9183,129 @@ ipintOp(_atomic_fence, macro()
     nextIPIntInstruction()
 end)
 
-reservedOpcode(atomic_0x4)
-reservedOpcode(atomic_0x5)
-reservedOpcode(atomic_0x6)
-reservedOpcode(atomic_0x7)
-reservedOpcode(atomic_0x8)
-reservedOpcode(atomic_0x9)
-reservedOpcode(atomic_0xa)
-reservedOpcode(atomic_0xb)
-reservedOpcode(atomic_0xc)
-reservedOpcode(atomic_0xd)
-reservedOpcode(atomic_0xe)
-reservedOpcode(atomic_0xf)
+reservedAtomicOpcode(atomic_0x4)
+reservedAtomicOpcode(atomic_0x5)
+reservedAtomicOpcode(atomic_0x6)
+reservedAtomicOpcode(atomic_0x7)
+reservedAtomicOpcode(atomic_0x8)
+reservedAtomicOpcode(atomic_0x9)
+reservedAtomicOpcode(atomic_0xa)
+reservedAtomicOpcode(atomic_0xb)
+reservedAtomicOpcode(atomic_0xc)
+reservedAtomicOpcode(atomic_0xd)
+reservedAtomicOpcode(atomic_0xe)
+reservedAtomicOpcode(atomic_0xf)
 
-macro atomicLoadOp(boundsAndAlignmentCheck, loadAndPush)
-    # pop index
-    popInt32(t0)
-    ori 0, t0
-    # load offset
-    loadi IPInt::Const32Metadata::value[MC], t2
-    addp t2, t0
-    boundsAndAlignmentCheck(t0,  t3)
-    addq memoryBase, t0
-    loadAndPush(t0, t2)
-
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+ipintAtomicOp(_i32_atomic_load, macro()
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    checkAlignment4(t0, .throwUnaligned)
+    if ARM64 or ARM64E or X86_64
+        atomicloadi [t0], t2
+    else
+        error
+    end
+    pushInt32(t2)
+    advancePCByReg(t4)
     nextIPIntInstruction()
-end
-
-ipintOp(_i32_atomic_load, macro()
-    atomicLoadOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, scratch)
-        if ARM64 or ARM64E or X86_64
-            atomicloadi [mem], scratch
-        else
-            error
-        end
-        pushInt32(scratch)
-    end)
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
-ipintOp(_i64_atomic_load, macro()
-    atomicLoadOp(ipintCheckMemoryBoundWithAlignmentCheck8, macro(mem, scratch)
-        if ARM64 or ARM64E or X86_64
-            atomicloadq [mem], scratch
-        else
-            error
-        end
-        pushInt64(scratch)
-    end)
+ipintAtomicOp(_i64_atomic_load, macro()
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 8, t1, t2)
+    checkAlignment8(t0, .throwUnaligned)
+    if ARM64 or ARM64E or X86_64
+        atomicloadq [t0], t2
+    else
+        error
+    end
+    pushInt64(t2)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
-ipintOp(_i32_atomic_load8_u, macro()
-    atomicLoadOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, scratch)
-        if ARM64 or ARM64E or X86_64
-            atomicloadb [mem], scratch
-        else
-            error
-        end
-        pushInt32(scratch)
-    end)
+ipintAtomicOp(_i32_atomic_load8_u, macro()
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    noAlignmentCheck(t0, .throwUnaligned)
+    if ARM64 or ARM64E or X86_64
+        atomicloadb [t0], t2
+    else
+        error
+    end
+    pushInt32(t2)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
-ipintOp(_i32_atomic_load16_u, macro()
-    atomicLoadOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, scratch)
-        if ARM64 or ARM64E or X86_64
-            atomicloadh [mem], scratch
-        else
-            error
-        end
-        pushInt32(scratch)
-    end)
+ipintAtomicOp(_i32_atomic_load16_u, macro()
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    checkAlignment2(t0, .throwUnaligned)
+    if ARM64 or ARM64E or X86_64
+        atomicloadh [t0], t2
+    else
+        error
+    end
+    pushInt32(t2)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
-ipintOp(_i64_atomic_load8_u, macro()
-    atomicLoadOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, scratch)
-        if ARM64 or ARM64E or X86_64
-            atomicloadb [mem], scratch
-        else
-            error
-        end
-        pushInt64(scratch)
-    end)
+ipintAtomicOp(_i64_atomic_load8_u, macro()
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    noAlignmentCheck(t0, .throwUnaligned)
+    if ARM64 or ARM64E or X86_64
+        atomicloadb [t0], t2
+    else
+        error
+    end
+    pushInt64(t2)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
-ipintOp(_i64_atomic_load16_u, macro()
-    atomicLoadOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, scratch)
-        if ARM64 or ARM64E or X86_64
-            atomicloadh [mem], scratch
-        else
-            error
-        end
-        pushInt64(scratch)
-    end)
+ipintAtomicOp(_i64_atomic_load16_u, macro()
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    checkAlignment2(t0, .throwUnaligned)
+    if ARM64 or ARM64E or X86_64
+        atomicloadh [t0], t2
+    else
+        error
+    end
+    pushInt64(t2)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
-ipintOp(_i64_atomic_load32_u, macro()
-    atomicLoadOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, scratch)
-        if ARM64 or ARM64E or X86_64
-            atomicloadi [mem], scratch
-        else
-            error
-        end
-        pushInt64(scratch)
-    end)
+ipintAtomicOp(_i64_atomic_load32_u, macro()
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    checkAlignment4(t0, .throwUnaligned)
+    if ARM64 or ARM64E or X86_64
+        atomicloadi [t0], t2
+    else
+        error
+    end
+    pushInt64(t2)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 macro weakCASLoopByte(mem, value, scratch1AndOldValue, scratch2, fn)
@@ -9340,991 +9376,1276 @@ macro weakCASLoopQuad(mem, value, scratch1AndOldValue, scratch2, fn)
     end
 end
 
-macro atomicStoreOp(boundsAndAlignmentCheck, popAndStore)
-    # pop value
-    popInt64(t1)
-    # pop index
-    popInt32(t2)
-    ori 0, t2
-    # load offset
-    loadi IPInt::Const32Metadata::value[MC], t0
-    addp t0, t2
-    boundsAndAlignmentCheck(t2, t3)
-    addq memoryBase, t2
-    popAndStore(t2, t1, t0, t3)
 
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+ipintAtomicOp(_i32_atomic_store, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    checkAlignment4(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgi t3, [t2], t3
+    elsif X86_64
+        atomicxchgi t3, [t2]
+    elsif ARM64
+        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+    advancePCByReg(t4)
     nextIPIntInstruction()
-end
-
-ipintOp(_i32_atomic_store, macro()
-    atomicStoreOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgi value, [mem], value
-        elsif X86_64
-            atomicxchgi value, [mem]
-        elsif ARM64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                move value, newValue
-            end)
-        else
-            error
-        end
-    end)
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
-ipintOp(_i64_atomic_store, macro()
-    atomicStoreOp(ipintCheckMemoryBoundWithAlignmentCheck8, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgq value, [mem], value
-        elsif X86_64
-            atomicxchgq value, [mem]
-        elsif ARM64
-            weakCASLoopQuad(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                move value, newValue
-            end)
-        else
-            error
-        end
-    end)
-end)
-
-ipintOp(_i32_atomic_store8_u, macro()
-    atomicStoreOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgb value, [mem], value
-        elsif X86_64
-            atomicxchgb value, [mem]
-        elsif ARM64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                move value, newValue
-            end)
-        else
-            error
-        end
-    end)
-end)
-
-ipintOp(_i32_atomic_store16_u, macro()
-    atomicStoreOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgh value, [mem], value
-        elsif X86_64
-            atomicxchgh value, [mem]
-        elsif ARM64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                move value, newValue
-            end)
-        else
-            error
-        end
-    end)
-end)
-
-ipintOp(_i64_atomic_store8_u, macro()
-    atomicStoreOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgb value, [mem], value
-        elsif X86_64
-            atomicxchgb value, [mem]
-        elsif ARM64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                move value, newValue
-            end)
-        else
-            error
-        end
-    end)
-end)
-
-ipintOp(_i64_atomic_store16_u, macro()
-    atomicStoreOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgh value, [mem], value
-        elsif X86_64
-            atomicxchgh value, [mem]
-        elsif ARM64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                move value, newValue
-            end)
-        else
-            error
-        end
-    end)
-end)
-
-ipintOp(_i64_atomic_store32_u, macro()
-    atomicStoreOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgi value, [mem], value
-        elsif X86_64
-            atomicxchgi value, [mem]
-        elsif ARM64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                move value, newValue
-            end)
-        else
-            error
-        end
-    end)
-end)
-
-macro atomicRMWOp(boundsAndAlignmentCheck, rmw)
-    # pop value
-    popInt64(t1)
-    # pop index
-    popInt32(t2)
-    ori 0, t2
-    # load offset
-    loadi IPInt::Const32Metadata::value[MC], t0
-    addp t0, t2
-    boundsAndAlignmentCheck(t2, t3)
-    addq memoryBase, t2
-    rmw(t2, t1, t0, t3)
-
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+ipintAtomicOp(_i64_atomic_store, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 8, t1, t2)
+    checkAlignment8(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgq t3, [t2], t3
+    elsif X86_64
+        atomicxchgq t3, [t2]
+    elsif ARM64
+        weakCASLoopQuad(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+    advancePCByReg(t4)
     nextIPIntInstruction()
-end
-
-ipintOp(_i32_atomic_rmw_add, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgaddi value, [mem], scratch1
-        elsif X86_64
-            atomicxchgaddi value, [mem]
-            move value, scratch1
-        elsif ARM64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                addi value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt32(scratch1)
-    end)
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
-ipintOp(_i64_atomic_rmw_add, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck8, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgaddq value, [mem], scratch1
-        elsif X86_64
-            atomicxchgaddq value, [mem]
-            move value, scratch1
-        elsif ARM64
-            weakCASLoopQuad(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                addq value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i32_atomic_rmw8_add_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgaddb value, [mem], scratch1
-        elsif X86_64
-            atomicxchgaddb value, [mem]
-            move value, scratch1
-            andi 0xff, scratch1
-        elsif ARM64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                addi value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt32(scratch1)
-    end)
-end)
-
-ipintOp(_i32_atomic_rmw16_add_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgaddh value, [mem], scratch1
-        elsif X86_64
-            atomicxchgaddh value, [mem]
-            move value, scratch1
-            andi 0xffff, scratch1
-        elsif ARM64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                addi value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt32(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw8_add_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgaddb value, [mem], scratch1
-        elsif X86_64
-            atomicxchgaddb value, [mem]
-            move value, scratch1
-            andi 0xff, scratch1
-        elsif ARM64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                addi value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw16_add_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgaddh value, [mem], scratch1
-        elsif X86_64
-            atomicxchgaddh value, [mem]
-            move value, scratch1
-            andi 0xffff, scratch1
-        elsif ARM64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                addi value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw32_add_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgaddi value, [mem], scratch1
-        elsif X86_64
-            atomicxchgaddi value, [mem]
-            move value, scratch1
-            ori 0, scratch1
-        elsif ARM64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                addi value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i32_atomic_rmw_sub, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            negi value
-            atomicxchgaddi value, [mem], scratch1
-        elsif X86_64
-            negi value
-            atomicxchgaddi value, [mem]
-            move value, scratch1
-        elsif ARM64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                subi oldValue, value, newValue
-            end)
-        else
-            error
-        end
-        pushInt32(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw_sub, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck8, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            negq value
-            atomicxchgaddq value, [mem], scratch1
-        elsif X86_64
-            negq value
-            atomicxchgaddq value, [mem]
-            move value, scratch1
-        elsif ARM64
-            weakCASLoopQuad(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                subq oldValue, value, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i32_atomic_rmw8_sub_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            negi value
-            atomicxchgaddb value, [mem], scratch1
-        elsif X86_64
-            negi value
-            atomicxchgaddb value, [mem]
-            move value, scratch1
-            andi 0xff, scratch1
-        elsif ARM64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                subi oldValue, value, newValue
-            end)
-        else
-            error
-        end
-        pushInt32(scratch1)
-    end)
-end)
-
-ipintOp(_i32_atomic_rmw16_sub_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            negi value
-            atomicxchgaddh value, [mem], scratch1
-        elsif X86_64
-            negi value
-            atomicxchgaddh value, [mem]
-            move value, scratch1
-            andi 0xffff, scratch1
-        elsif ARM64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                subi oldValue, value, newValue
-            end)
-        else
-            error
-        end
-        pushInt32(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw8_sub_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            negq value
-            atomicxchgaddb value, [mem], scratch1
-        elsif X86_64
-            negq value
-            atomicxchgaddb value, [mem]
-            move value, scratch1
-            andi 0xff, scratch1
-        elsif ARM64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                subi oldValue, value, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw16_sub_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            negq value
-            atomicxchgaddh value, [mem], scratch1
-        elsif X86_64
-            negq value
-            atomicxchgaddh value, [mem]
-            move value, scratch1
-            andi 0xffff, scratch1
-        elsif ARM64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                subi oldValue, value, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw32_sub_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            negq value
-            atomicxchgaddi value, [mem], scratch1
-        elsif X86_64
-            negq value
-            atomicxchgaddi value, [mem]
-            move value, scratch1
-            ori 0, scratch1
-        elsif ARM64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                subi oldValue, value, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i32_atomic_rmw_and, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            noti value
-            atomicxchgcleari value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro (value, dst)
-                andq value, dst
-            end)
-        elsif ARM64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                andi value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt32(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw_and, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck8, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            notq value
-            atomicxchgclearq value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopQuad(mem, value, scratch1, scratch2, macro (value, dst)
-                andq value, dst
-            end)
-        elsif ARM64
-            weakCASLoopQuad(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                andq value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i32_atomic_rmw8_and_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            noti value
-            atomicxchgclearb value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro (value, dst)
-                andq value, dst
-            end)
-        elsif ARM64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                andi value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt32(scratch1)
-    end)
-end)
-
-ipintOp(_i32_atomic_rmw16_and_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            noti value
-            atomicxchgclearh value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro (value, dst)
-                andq value, dst
-            end)
-        elsif ARM64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                andi value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt32(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw8_and_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            notq value
-            atomicxchgclearb value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro (value, dst)
-                andq value, dst
-            end)
-        elsif ARM64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                andi value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw16_and_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            notq value
-            atomicxchgclearh value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro (value, dst)
-                andq value, dst
-            end)
-        elsif ARM64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                andi value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw32_and_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            notq value
-            atomicxchgcleari value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro (value, dst)
-                andq value, dst
-            end)
-        elsif ARM64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                andi value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i32_atomic_rmw_or, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgori value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro (value, dst)
-                ori value, dst
-            end)
-        elsif ARM64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                ori value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt32(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw_or, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck8, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgorq value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopQuad(mem, value, scratch1, scratch2, macro (value, dst)
-                orq value, dst
-            end)
-        elsif ARM64
-            weakCASLoopQuad(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                orq value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i32_atomic_rmw8_or_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgorb value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro (value, dst)
-                orq value, dst
-            end)
-        elsif ARM64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                ori value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt32(scratch1)
-    end)
-end)
-
-ipintOp(_i32_atomic_rmw16_or_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgorh value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro (value, dst)
-                orq value, dst
-            end)
-        elsif ARM64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                ori value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt32(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw8_or_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgorb value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro (value, dst)
-                orq value, dst
-            end)
-        elsif ARM64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                ori value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw16_or_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgorh value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro (value, dst)
-                orq value, dst
-            end)
-        elsif ARM64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                ori value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw32_or_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgori value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro (value, dst)
-                orq value, dst
-            end)
-        elsif ARM64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                ori value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i32_atomic_rmw_xor, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgxori value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro (value, dst)
-                xorq value, dst
-            end)
-        elsif ARM64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                xori value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt32(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw_xor, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck8, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgxorq value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopQuad(mem, value, scratch1, scratch2, macro (value, dst)
-                xorq value, dst
-            end)
-        elsif ARM64
-            weakCASLoopQuad(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                xorq value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i32_atomic_rmw8_xor_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgxorb value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro (value, dst)
-                xorq value, dst
-            end)
-        elsif ARM64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                xori value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt32(scratch1)
-    end)
-end)
-
-ipintOp(_i32_atomic_rmw16_xor_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgxorh value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro (value, dst)
-                xorq value, dst
-            end)
-        elsif ARM64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                xori value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt32(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw8_xor_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgxorb value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro (value, dst)
-                xorq value, dst
-            end)
-        elsif ARM64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                xori value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw16_xor_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgxorh value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro (value, dst)
-                xorq value, dst
-            end)
-        elsif ARM64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                xori value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw32_xor_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgxori value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro (value, dst)
-                xorq value, dst
-            end)
-        elsif ARM64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                xori value, oldValue, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i32_atomic_rmw_xchg, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgi value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro (value, dst)
-                move value, dst
-            end)
-        elsif ARM64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                move value, newValue
-            end)
-        else
-            error
-        end
-        pushInt32(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw_xchg, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck8, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgq value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopQuad(mem, value, scratch1, scratch2, macro (value, dst)
-                move value, dst
-            end)
-        elsif ARM64
-            weakCASLoopQuad(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                move value, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i32_atomic_rmw8_xchg_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgb value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro (value, dst)
-                move value, dst
-            end)
-        elsif ARM64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                move value, newValue
-            end)
-        else
-            error
-        end
-        pushInt32(scratch1)
-    end)
-end)
-
-ipintOp(_i32_atomic_rmw16_xchg_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgh value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro (value, dst)
-                move value, dst
-            end)
-        elsif ARM64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                move value, newValue
-            end)
-        else
-            error
-        end
-        pushInt32(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw8_xchg_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgb value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro (value, dst)
-                move value, dst
-            end)
-        elsif ARM64
-            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                move value, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw16_xchg_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgh value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro (value, dst)
-                move value, dst
-            end)
-        elsif ARM64
-            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                move value, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-ipintOp(_i64_atomic_rmw32_xchg_u, macro()
-    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
-        if ARM64E
-            atomicxchgi value, [mem], scratch1
-        elsif X86_64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro (value, dst)
-                move value, dst
-            end)
-        elsif ARM64
-            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
-                move value, newValue
-            end)
-        else
-            error
-        end
-        pushInt64(scratch1)
-    end)
-end)
-
-macro atomicCmpxchgOp(boundsAndAlignmentCheck, cmpxchg)
-    # pop value
-    popInt64(t1)
-    # pop expected
-    popInt64(t0)
-    # pop index
-    popInt32(t3)
-    ori 0, t3
-    # load offset
-    loadi IPInt::Const32Metadata::value[MC], t2
-    addp t2, t3
-    boundsAndAlignmentCheck(t3, t2)
-    addq memoryBase, t3
-    cmpxchg(t3, t1, t0, t2, t4)
-
-    loadb IPInt::Const32Metadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::Const32Metadata)))
+ipintAtomicOp(_i32_atomic_store8_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    noAlignmentCheck(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgb t3, [t2], t3
+    elsif X86_64
+        atomicxchgb t3, [t2]
+    elsif ARM64
+        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+    advancePCByReg(t4)
     nextIPIntInstruction()
-end
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i32_atomic_store16_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    checkAlignment2(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgh t3, [t2], t3
+    elsif X86_64
+        atomicxchgh t3, [t2]
+    elsif ARM64
+        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_store8_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    noAlignmentCheck(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgb t3, [t2], t3
+    elsif X86_64
+        atomicxchgb t3, [t2]
+    elsif ARM64
+        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_store16_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    checkAlignment2(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgh t3, [t2], t3
+    elsif X86_64
+        atomicxchgh t3, [t2]
+    elsif ARM64
+        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_store32_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    checkAlignment4(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgi t3, [t2], t3
+    elsif X86_64
+        atomicxchgi t3, [t2]
+    elsif ARM64
+        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i32_atomic_rmw_add, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    checkAlignment4(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgaddi t3, [t2], t0
+    elsif X86_64
+        atomicxchgaddi t3, [t2]
+        move t3, t0
+    elsif ARM64
+        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            addi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt32(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw_add, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 8, t1, t2)
+    checkAlignment8(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgaddq t3, [t2], t0
+    elsif X86_64
+        atomicxchgaddq t3, [t2]
+        move t3, t0
+    elsif ARM64
+        weakCASLoopQuad(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            addq value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i32_atomic_rmw8_add_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    noAlignmentCheck(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgaddb t3, [t2], t0
+    elsif X86_64
+        atomicxchgaddb t3, [t2]
+        move t3, t0
+        andi 0xff, t0
+    elsif ARM64
+        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            addi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt32(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i32_atomic_rmw16_add_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    checkAlignment2(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgaddh t3, [t2], t0
+    elsif X86_64
+        atomicxchgaddh t3, [t2]
+        move t3, t0
+        andi 0xffff, t0
+    elsif ARM64
+        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            addi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt32(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw8_add_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    noAlignmentCheck(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgaddb t3, [t2], t0
+    elsif X86_64
+        atomicxchgaddb t3, [t2]
+        move t3, t0
+        andi 0xff, t0
+    elsif ARM64
+        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            addi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw16_add_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    checkAlignment2(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgaddh t3, [t2], t0
+    elsif X86_64
+        atomicxchgaddh t3, [t2]
+        move t3, t0
+        andi 0xffff, t0
+    elsif ARM64
+        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            addi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw32_add_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    checkAlignment4(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgaddi t3, [t2], t0
+    elsif X86_64
+        atomicxchgaddi t3, [t2]
+        move t3, t0
+        ori 0, t0
+    elsif ARM64
+        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            addi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i32_atomic_rmw_sub, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    checkAlignment4(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        negi t3
+        atomicxchgaddi t3, [t2], t0
+    elsif X86_64
+        negi t3
+        atomicxchgaddi t3, [t2]
+        move t3, t0
+    elsif ARM64
+        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            subi oldValue, value, newValue
+        end)
+    else
+        error
+    end
+    pushInt32(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw_sub, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 8, t1, t2)
+    checkAlignment8(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        negq t3
+        atomicxchgaddq t3, [t2], t0
+    elsif X86_64
+        negq t3
+        atomicxchgaddq t3, [t2]
+        move t3, t0
+    elsif ARM64
+        weakCASLoopQuad(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            subq oldValue, value, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i32_atomic_rmw8_sub_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    noAlignmentCheck(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        negi t3
+        atomicxchgaddb t3, [t2], t0
+    elsif X86_64
+        negi t3
+        atomicxchgaddb t3, [t2]
+        move t3, t0
+        andi 0xff, t0
+    elsif ARM64
+        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            subi oldValue, value, newValue
+        end)
+    else
+        error
+    end
+    pushInt32(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i32_atomic_rmw16_sub_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    checkAlignment2(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        negi t3
+        atomicxchgaddh t3, [t2], t0
+    elsif X86_64
+        negi t3
+        atomicxchgaddh t3, [t2]
+        move t3, t0
+        andi 0xffff, t0
+    elsif ARM64
+        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            subi oldValue, value, newValue
+        end)
+    else
+        error
+    end
+    pushInt32(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw8_sub_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    noAlignmentCheck(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        negq t3
+        atomicxchgaddb t3, [t2], t0
+    elsif X86_64
+        negq t3
+        atomicxchgaddb t3, [t2]
+        move t3, t0
+        andi 0xff, t0
+    elsif ARM64
+        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            subi oldValue, value, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw16_sub_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    checkAlignment2(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        negq t3
+        atomicxchgaddh t3, [t2], t0
+    elsif X86_64
+        negq t3
+        atomicxchgaddh t3, [t2]
+        move t3, t0
+        andi 0xffff, t0
+    elsif ARM64
+        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            subi oldValue, value, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw32_sub_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    checkAlignment4(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        negq t3
+        atomicxchgaddi t3, [t2], t0
+    elsif X86_64
+        negq t3
+        atomicxchgaddi t3, [t2]
+        move t3, t0
+        ori 0, t0
+    elsif ARM64
+        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            subi oldValue, value, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i32_atomic_rmw_and, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    checkAlignment4(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        noti t3
+        atomicxchgcleari t3, [t2], t0
+    elsif X86_64
+        weakCASLoopInt(t2, t3, t0, t1, macro (value, dst)
+            andq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            andi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt32(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw_and, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 8, t1, t2)
+    checkAlignment8(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        notq t3
+        atomicxchgclearq t3, [t2], t0
+    elsif X86_64
+        weakCASLoopQuad(t2, t3, t0, t1, macro (value, dst)
+            andq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopQuad(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            andq value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i32_atomic_rmw8_and_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    noAlignmentCheck(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        noti t3
+        atomicxchgclearb t3, [t2], t0
+    elsif X86_64
+        weakCASLoopByte(t2, t3, t0, t1, macro (value, dst)
+            andq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            andi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt32(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i32_atomic_rmw16_and_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    checkAlignment2(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        noti t3
+        atomicxchgclearh t3, [t2], t0
+    elsif X86_64
+        weakCASLoopHalf(t2, t3, t0, t1, macro (value, dst)
+            andq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            andi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt32(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw8_and_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    noAlignmentCheck(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        notq t3
+        atomicxchgclearb t3, [t2], t0
+    elsif X86_64
+        weakCASLoopByte(t2, t3, t0, t1, macro (value, dst)
+            andq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            andi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw16_and_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    checkAlignment2(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        notq t3
+        atomicxchgclearh t3, [t2], t0
+    elsif X86_64
+        weakCASLoopHalf(t2, t3, t0, t1, macro (value, dst)
+            andq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            andi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw32_and_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    checkAlignment4(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        notq t3
+        atomicxchgcleari t3, [t2], t0
+    elsif X86_64
+        weakCASLoopInt(t2, t3, t0, t1, macro (value, dst)
+            andq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            andi value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i32_atomic_rmw_or, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    checkAlignment4(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgori t3, [t2], t0
+    elsif X86_64
+        weakCASLoopInt(t2, t3, t0, t1, macro (value, dst)
+            ori value, dst
+        end)
+    elsif ARM64
+        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            ori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt32(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw_or, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 8, t1, t2)
+    checkAlignment8(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgorq t3, [t2], t0
+    elsif X86_64
+        weakCASLoopQuad(t2, t3, t0, t1, macro (value, dst)
+            orq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopQuad(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            orq value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i32_atomic_rmw8_or_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    noAlignmentCheck(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgorb t3, [t2], t0
+    elsif X86_64
+        weakCASLoopByte(t2, t3, t0, t1, macro (value, dst)
+            orq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            ori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt32(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i32_atomic_rmw16_or_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    checkAlignment2(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgorh t3, [t2], t0
+    elsif X86_64
+        weakCASLoopHalf(t2, t3, t0, t1, macro (value, dst)
+            orq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            ori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt32(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw8_or_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    noAlignmentCheck(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgorb t3, [t2], t0
+    elsif X86_64
+        weakCASLoopByte(t2, t3, t0, t1, macro (value, dst)
+            orq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            ori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw16_or_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    checkAlignment2(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgorh t3, [t2], t0
+    elsif X86_64
+        weakCASLoopHalf(t2, t3, t0, t1, macro (value, dst)
+            orq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            ori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw32_or_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    checkAlignment4(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgori t3, [t2], t0
+    elsif X86_64
+        weakCASLoopInt(t2, t3, t0, t1, macro (value, dst)
+            orq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            ori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i32_atomic_rmw_xor, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    checkAlignment4(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgxori t3, [t2], t0
+    elsif X86_64
+        weakCASLoopInt(t2, t3, t0, t1, macro (value, dst)
+            xorq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            xori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt32(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw_xor, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 8, t1, t2)
+    checkAlignment8(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgxorq t3, [t2], t0
+    elsif X86_64
+        weakCASLoopQuad(t2, t3, t0, t1, macro (value, dst)
+            xorq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopQuad(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            xorq value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i32_atomic_rmw8_xor_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    noAlignmentCheck(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgxorb t3, [t2], t0
+    elsif X86_64
+        weakCASLoopByte(t2, t3, t0, t1, macro (value, dst)
+            xorq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            xori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt32(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i32_atomic_rmw16_xor_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    checkAlignment2(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgxorh t3, [t2], t0
+    elsif X86_64
+        weakCASLoopHalf(t2, t3, t0, t1, macro (value, dst)
+            xorq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            xori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt32(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw8_xor_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    noAlignmentCheck(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgxorb t3, [t2], t0
+    elsif X86_64
+        weakCASLoopByte(t2, t3, t0, t1, macro (value, dst)
+            xorq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            xori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw16_xor_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    checkAlignment2(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgxorh t3, [t2], t0
+    elsif X86_64
+        weakCASLoopHalf(t2, t3, t0, t1, macro (value, dst)
+            xorq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            xori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw32_xor_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    checkAlignment4(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgxori t3, [t2], t0
+    elsif X86_64
+        weakCASLoopInt(t2, t3, t0, t1, macro (value, dst)
+            xorq value, dst
+        end)
+    elsif ARM64
+        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            xori value, oldValue, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i32_atomic_rmw_xchg, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    checkAlignment4(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgi t3, [t2], t0
+    elsif X86_64
+        weakCASLoopInt(t2, t3, t0, t1, macro (value, dst)
+            move value, dst
+        end)
+    elsif ARM64
+        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+    pushInt32(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw_xchg, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 8, t1, t2)
+    checkAlignment8(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgq t3, [t2], t0
+    elsif X86_64
+        weakCASLoopQuad(t2, t3, t0, t1, macro (value, dst)
+            move value, dst
+        end)
+    elsif ARM64
+        weakCASLoopQuad(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i32_atomic_rmw8_xchg_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    noAlignmentCheck(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgb t3, [t2], t0
+    elsif X86_64
+        weakCASLoopByte(t2, t3, t0, t1, macro (value, dst)
+            move value, dst
+        end)
+    elsif ARM64
+        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+    pushInt32(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i32_atomic_rmw16_xchg_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    checkAlignment2(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgh t3, [t2], t0
+    elsif X86_64
+        weakCASLoopHalf(t2, t3, t0, t1, macro (value, dst)
+            move value, dst
+        end)
+    elsif ARM64
+        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+    pushInt32(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw8_xchg_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    noAlignmentCheck(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgb t3, [t2], t0
+    elsif X86_64
+        weakCASLoopByte(t2, t3, t0, t1, macro (value, dst)
+            move value, dst
+        end)
+    elsif ARM64
+        weakCASLoopByte(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw16_xchg_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    checkAlignment2(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgh t3, [t2], t0
+    elsif X86_64
+        weakCASLoopHalf(t2, t3, t0, t1, macro (value, dst)
+            move value, dst
+        end)
+    elsif ARM64
+        weakCASLoopHalf(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
+
+ipintAtomicOp(_i64_atomic_rmw32_xchg_u, macro()
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    checkAlignment4(t0, .throwUnaligned)
+    move t0, t2
+    if ARM64E
+        atomicxchgi t3, [t2], t0
+    elsif X86_64
+        weakCASLoopInt(t2, t3, t0, t1, macro (value, dst)
+            move value, dst
+        end)
+    elsif ARM64
+        weakCASLoopInt(t2, t3, t0, t1, macro(value, oldValue, newValue)
+            move value, newValue
+        end)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
+end)
 
 macro weakCASExchangeByte(mem, value, expected, scratch, scratch2)
     if ARM64
@@ -10406,101 +10727,178 @@ macro weakCASExchangeQuad(mem, value, expected, scratch, scratch2)
     end
 end
 
-ipintOp(_i32_atomic_rmw_cmpxchg, macro()
-    atomicCmpxchgOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, expected, scratch, scratch2)
-        andq 0xffffffff, expected
-        if ARM64E or X86_64
-            atomicweakcasi expected, value, [mem]
-        elsif ARM64
-            weakCASExchangeInt(mem, value, expected, scratch, scratch2)
-        else
-            error
-        end
-        pushInt32(expected)
-    end)
+ipintAtomicOp(_i32_atomic_rmw_cmpxchg, macro()
+    # t7 is safe for value: PL is t6 on ARM64, t5 on x86, csr10 on RISCV64.
+    # ARMv7 (where PL=t7) does not run 64-bit atomic instructions.
+    popInt64(t7)
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    checkAlignment4(t0, .throwUnaligned)
+    move t0, t2
+    move t3, t0
+    andq 0xffffffff, t0
+    if ARM64E or X86_64
+        atomicweakcasi t0, t7, [t2]
+    elsif ARM64
+        weakCASExchangeInt(t2, t7, t0, t1, t3)
+    else
+        error
+    end
+    pushInt32(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
-ipintOp(_i64_atomic_rmw_cmpxchg, macro()
-    atomicCmpxchgOp(ipintCheckMemoryBoundWithAlignmentCheck8, macro(mem, value, expected, scratch, scratch2)
-        if ARM64E or X86_64
-            atomicweakcasq expected, value, [mem]
-        elsif ARM64
-            weakCASExchangeQuad(mem, value, expected, scratch, scratch2)
-        else
-            error
-        end
-        pushInt64(expected)
-    end)
+ipintAtomicOp(_i64_atomic_rmw_cmpxchg, macro()
+    # t7 is safe for value: PL is t6 on ARM64, t5 on x86, csr10 on RISCV64.
+    # ARMv7 (where PL=t7) does not run 64-bit atomic instructions.
+    popInt64(t7)
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 8, t1, t2)
+    checkAlignment8(t0, .throwUnaligned)
+    move t0, t2
+    move t3, t0
+    if ARM64E or X86_64
+        atomicweakcasq t0, t7, [t2]
+    elsif ARM64
+        weakCASExchangeQuad(t2, t7, t0, t1, t3)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
-ipintOp(_i32_atomic_rmw8_cmpxchg_u, macro()
-    atomicCmpxchgOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, expected, scratch, scratch2)
-        andq 0xff, expected
-        if ARM64E or X86_64
-            atomicweakcasb expected, value, [mem]
-        elsif ARM64
-            weakCASExchangeByte(mem, value, expected, scratch, scratch2)
-        else
-            error
-        end
-        pushInt32(expected)
-    end)
+ipintAtomicOp(_i32_atomic_rmw8_cmpxchg_u, macro()
+    # t7 is safe for value: PL is t6 on ARM64, t5 on x86, csr10 on RISCV64.
+    # ARMv7 (where PL=t7) does not run 64-bit atomic instructions.
+    popInt64(t7)
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    noAlignmentCheck(t0, .throwUnaligned)
+    move t0, t2
+    move t3, t0
+    andq 0xff, t0
+    if ARM64E or X86_64
+        atomicweakcasb t0, t7, [t2]
+    elsif ARM64
+        weakCASExchangeByte(t2, t7, t0, t1, t3)
+    else
+        error
+    end
+    pushInt32(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
-ipintOp(_i32_atomic_rmw16_cmpxchg_u, macro()
-    atomicCmpxchgOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, expected, scratch, scratch2)
-        andq 0xffff, expected
-        if ARM64E or X86_64
-            atomicweakcash expected, value, [mem]
-        elsif ARM64
-            weakCASExchangeHalf(mem, value, expected, scratch, scratch2)
-        else
-            error
-        end
-        pushInt32(expected)
-    end)
+ipintAtomicOp(_i32_atomic_rmw16_cmpxchg_u, macro()
+    # t7 is safe for value: PL is t6 on ARM64, t5 on x86, csr10 on RISCV64.
+    # ARMv7 (where PL=t7) does not run 64-bit atomic instructions.
+    popInt64(t7)
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    checkAlignment2(t0, .throwUnaligned)
+    move t0, t2
+    move t3, t0
+    andq 0xffff, t0
+    if ARM64E or X86_64
+        atomicweakcash t0, t7, [t2]
+    elsif ARM64
+        weakCASExchangeHalf(t2, t7, t0, t1, t3)
+    else
+        error
+    end
+    pushInt32(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
-ipintOp(_i64_atomic_rmw8_cmpxchg_u, macro()
-    atomicCmpxchgOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, expected, scratch, scratch2)
-        andq 0xff, expected
-        if ARM64E or X86_64
-            atomicweakcasb expected, value, [mem]
-        elsif ARM64
-            weakCASExchangeByte(mem, value, expected, scratch, scratch2)
-        else
-            error
-        end
-        pushInt64(expected)
-    end)
+ipintAtomicOp(_i64_atomic_rmw8_cmpxchg_u, macro()
+    # t7 is safe for value: PL is t6 on ARM64, t5 on x86, csr10 on RISCV64.
+    # ARMv7 (where PL=t7) does not run 64-bit atomic instructions.
+    popInt64(t7)
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 1, t1, t2)
+    noAlignmentCheck(t0, .throwUnaligned)
+    move t0, t2
+    move t3, t0
+    andq 0xff, t0
+    if ARM64E or X86_64
+        atomicweakcasb t0, t7, [t2]
+    elsif ARM64
+        weakCASExchangeByte(t2, t7, t0, t1, t3)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
-ipintOp(_i64_atomic_rmw16_cmpxchg_u, macro()
-    atomicCmpxchgOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, expected, scratch, scratch2)
-        andq 0xffff, expected
-        if ARM64E or X86_64
-            atomicweakcash expected, value, [mem]
-        elsif ARM64
-            weakCASExchangeHalf(mem, value, expected, scratch, scratch2)
-        else
-            error
-        end
-        pushInt64(expected)
-    end)
+ipintAtomicOp(_i64_atomic_rmw16_cmpxchg_u, macro()
+    # t7 is safe for value: PL is t6 on ARM64, t5 on x86, csr10 on RISCV64.
+    # ARMv7 (where PL=t7) does not run 64-bit atomic instructions.
+    popInt64(t7)
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 2, t1, t2)
+    checkAlignment2(t0, .throwUnaligned)
+    move t0, t2
+    move t3, t0
+    andq 0xffff, t0
+    if ARM64E or X86_64
+        atomicweakcash t0, t7, [t2]
+    elsif ARM64
+        weakCASExchangeHalf(t2, t7, t0, t1, t3)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
-ipintOp(_i64_atomic_rmw32_cmpxchg_u, macro()
-    atomicCmpxchgOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, expected, scratch, scratch2)
-        andq 0xffffffff, expected
-        if ARM64E or X86_64
-            atomicweakcasi expected, value, [mem]
-        elsif ARM64
-            weakCASExchangeInt(mem, value, expected, scratch, scratch2)
-        else
-            error
-        end
-        pushInt64(expected)
-    end)
+ipintAtomicOp(_i64_atomic_rmw32_cmpxchg_u, macro()
+    # t7 is safe for value: PL is t6 on ARM64, t5 on x86, csr10 on RISCV64.
+    # ARMv7 (where PL=t7) does not run 64-bit atomic instructions.
+    popInt64(t7)
+    popInt64(t3)
+    popMemoryIndex(t0, t2)
+    memoryOpAdvanceMCAndMakePointer(t4, t0, 4, t1, t2)
+    checkAlignment4(t0, .throwUnaligned)
+    move t0, t2
+    move t3, t0
+    andq 0xffffffff, t0
+    if ARM64E or X86_64
+        atomicweakcasi t0, t7, [t2]
+    elsif ARM64
+        weakCASExchangeInt(t2, t7, t0, t1, t3)
+    else
+        error
+    end
+    pushInt64(t0)
+    advancePCByReg(t4)
+    nextIPIntInstruction()
+.throwUnaligned:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 #######################################

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -703,16 +703,18 @@ Value IPIntGenerator::addConstant(Type type, uint64_t value)
 
 // SIMD
 
-[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoad(ExpressionType, uint32_t offset, ExpressionType&, uint8_t /*memoryIndex*/)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoad(ExpressionType, uint32_t offset, ExpressionType&, uint8_t memoryIndex)
 {
     changeStackSize(0); // Pop address, push v128 value (net change = 0)
+    m_metadata->addMemoryIndex(memoryIndex);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addSIMDStore(ExpressionType, ExpressionType, uint32_t offset, uint8_t /*memoryIndex*/)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDStore(ExpressionType, ExpressionType, uint32_t offset, uint8_t memoryIndex)
 {
     changeStackSize(-2); // Pop address and v128 value
+    m_metadata->addMemoryIndex(memoryIndex);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
@@ -749,16 +751,18 @@ Value IPIntGenerator::addConstant(Type type, uint64_t value)
     return addSIMDLoad(pointer, offset, result, memoryIndex);
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t offset, uint8_t, ExpressionType&, uint8_t /*memoryIndex*/)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t offset, uint8_t, ExpressionType&, uint8_t memoryIndex)
 {
     changeStackSize(-1);
+    m_metadata->addMemoryIndex(memoryIndex);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t offset, uint8_t, uint8_t /*memoryIndex*/)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t offset, uint8_t, uint8_t memoryIndex)
 {
     changeStackSize(-2);
+    m_metadata->addMemoryIndex(memoryIndex);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
@@ -1152,43 +1156,49 @@ IPIntGenerator::ExpressionType IPIntGenerator::addSIMDConstant(v128_t)
 
 // Atomics
 
-[[nodiscard]] PartialResult IPIntGenerator::atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t offset, uint8_t /*memoryIndex*/)
+[[nodiscard]] PartialResult IPIntGenerator::atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t offset, uint8_t memoryIndex)
 {
+    m_metadata->addMemoryIndex(memoryIndex);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t offset, uint8_t /*memoryIndex*/)
+[[nodiscard]] PartialResult IPIntGenerator::atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t offset, uint8_t memoryIndex)
 {
     changeStackSize(-2);
+    m_metadata->addMemoryIndex(memoryIndex);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset, uint8_t /*memoryIndex*/)
+[[nodiscard]] PartialResult IPIntGenerator::atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset, uint8_t memoryIndex)
 {
     changeStackSize(-1);
+    m_metadata->addMemoryIndex(memoryIndex);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset, uint8_t /*memoryIndex*/)
+[[nodiscard]] PartialResult IPIntGenerator::atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset, uint8_t memoryIndex)
 {
     changeStackSize(-2);
+    m_metadata->addMemoryIndex(memoryIndex);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset, uint8_t /*memoryIndex*/)
+[[nodiscard]] PartialResult IPIntGenerator::atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset, uint8_t memoryIndex)
 {
     changeStackSize(-2);
+    m_metadata->addMemoryIndex(memoryIndex);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset, uint8_t /*memoryIndex*/)
+[[nodiscard]] PartialResult IPIntGenerator::atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset, uint8_t memoryIndex)
 {
     changeStackSize(-1);
+    m_metadata->addMemoryIndex(memoryIndex);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -1187,47 +1187,50 @@ WASM_IPINT_EXTERN_CPP_DECL(get_global_64, unsigned index)
 #endif
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_wait32, uint64_t pointerWithOffset, uint32_t value, uint64_t timeout)
+WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_wait32, IPIntStackEntry* args)
 {
 #if CPU(ARM64) || CPU(X86_64)
-    uint8_t memoryIndex = 0; // FIXME(wasm-multimemory)
+    uint8_t memoryIndex = args[0].i32;
+    uint64_t timeout = args[1].i64;
+    uint32_t value = args[2].i32;
+    uint64_t pointerWithOffset = args[3].i64;
     int32_t result = Wasm::memoryAtomicWait32(instance, pointerWithOffset, value, timeout, memoryIndex);
     WASM_RETURN_TWO(std::bit_cast<void*>(static_cast<intptr_t>(result)), nullptr);
 #else
     UNUSED_PARAM(instance);
-    UNUSED_PARAM(pointerWithOffset);
-    UNUSED_PARAM(value);
-    UNUSED_PARAM(timeout);
+    UNUSED_PARAM(args);
     RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
 #endif
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_wait64, uint64_t pointerWithOffset, uint64_t value, uint64_t timeout)
+WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_wait64, IPIntStackEntry* args)
 {
 #if CPU(ARM64) || CPU(X86_64)
-    uint8_t memoryIndex = 0; // FIXME(wasm-multimemory)
+    uint8_t memoryIndex = args[0].i32;
+    uint64_t timeout = args[1].i64;
+    uint64_t value = args[2].i64;
+    uint64_t pointerWithOffset = args[3].i64;
     int32_t result = Wasm::memoryAtomicWait64(instance, pointerWithOffset, value, timeout, memoryIndex);
     WASM_RETURN_TWO(std::bit_cast<void*>(static_cast<intptr_t>(result)), nullptr);
 #else
     UNUSED_PARAM(instance);
-    UNUSED_PARAM(pointerWithOffset);
-    UNUSED_PARAM(value);
-    UNUSED_PARAM(timeout);
+    UNUSED_PARAM(args);
     RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
 #endif
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_notify, unsigned base, unsigned offset, int32_t count)
+WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_notify, IPIntStackEntry* args)
 {
 #if CPU(ARM64) || CPU(X86_64)
-    uint8_t memoryIndex = 0; // FIXME(wasm-multimemory)
+    unsigned offset = args[0].i32;
+    uint8_t memoryIndex = args[1].i32;
+    int32_t count = args[2].i32;
+    unsigned base = args[3].i32;
     int32_t result = Wasm::memoryAtomicNotify(instance, base, offset, count, memoryIndex);
     WASM_RETURN_TWO(std::bit_cast<void*>(static_cast<intptr_t>(result)), nullptr);
 #else
     UNUSED_PARAM(instance);
-    UNUSED_PARAM(base);
-    UNUSED_PARAM(offset);
-    UNUSED_PARAM(count);
+    UNUSED_PARAM(args);
     RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
 #endif
 }

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
@@ -136,9 +136,9 @@ WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(set_global_ref, uint32_t globalIndex, JSValue 
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(get_global_64, unsigned);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(set_global_64, unsigned, uint64_t);
 
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_wait32, uint64_t, uint32_t, uint64_t);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_wait64, uint64_t, uint64_t, uint64_t);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_notify, unsigned, unsigned, int32_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_wait32, IPIntStackEntry*);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_wait64, IPIntStackEntry*);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_notify, IPIntStackEntry*);
 
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(check_stack_and_vm_traps, void* candidateNewStackPointer, Wasm::IPIntCallee*, CallFrame*);
 WASM_IPINT_EXTERN_CPP_DECL(handle_debugger_trap_if_needed, CallFrame*, Register*);


### PR DESCRIPTION
#### f9c6e488948549723f5ade89b26e7616a0d81425
<pre>
Add wasm IPInt support for SIMD and atomic instructions
<a href="https://bugs.webkit.org/show_bug.cgi?id=311572">https://bugs.webkit.org/show_bug.cgi?id=311572</a>
<a href="https://rdar.apple.com/174042474">rdar://174042474</a>

Reviewed by Keith Miller.

This patch adds support for SIMD and atomic wasm instructions to IPInt.
Support in BBQ/OMG was added in a previous patch. When this patch is
merged there will be end to end support for all wasm instructions that
access linear memory, gated behind the useWasmMultiMemory flag.

Atomic dispatch table handlers have been expanded to 512 bytes for now
to fit the new multimemory-aware entries.

Covered by existing tests that were disabled in IPInt-only mode.

* JSTests/wasm/stress/atomic-multimemory.js:
* JSTests/wasm/stress/simd-multimemory.js:
* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter.cpp:
* Source/JavaScriptCore/llint/InPlaceInterpreter.h:
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::addSIMDLoad):
(JSC::Wasm::IPIntGenerator::addSIMDStore):
(JSC::Wasm::IPIntGenerator::addSIMDLoadLane):
(JSC::Wasm::IPIntGenerator::addSIMDStoreLane):
(JSC::Wasm::IPIntGenerator::atomicLoad):
(JSC::Wasm::IPIntGenerator::atomicStore):
(JSC::Wasm::IPIntGenerator::atomicBinaryRMW):
(JSC::Wasm::IPIntGenerator::atomicCompareExchange):
(JSC::Wasm::IPIntGenerator::atomicWait):
(JSC::Wasm::IPIntGenerator::atomicNotify):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h:

Canonical link: <a href="https://commits.webkit.org/310946@main">https://commits.webkit.org/310946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d690765e11fbdf01bdc5bc1d961ed58d0314c4e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155357 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164119 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d2d4150-ecf8-40f0-831e-7caf23d76c3b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120230 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/63cc810e-18d6-45ad-85f3-5095bbe75482) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22431 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100920 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d1311056-2042-477f-b88c-a6d25a25fefc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21517 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19614 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11948 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147407 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131186 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17348 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166597 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16188 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10764 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18958 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128337 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28161 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128472 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34870 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28085 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139141 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85470 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23318 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15938 "Found 5 new test failures: http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.html http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py http/tests/site-isolation/frame-index.html http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss-ephemeral.html http/tests/websocket/tests/hybi/contentextensions/block-worker.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187242 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27779 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91882 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48008 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27356 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27586 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27429 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->