### PR TITLE
[Site Isolation] Fix provisional-load-cancels-previous-load.html layout test

### DIFF
--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -3,7 +3,6 @@
 ####################
 # Tests that crash #
 ####################
-http/tests/inspector/target/provisional-load-cancels-previous-load.html [ Crash ]
 http/tests/security/referrer-policy-header-empty.html [ Crash ]
 http/tests/security/referrer-policy-header-invalid.html [ Crash ]
 http/tests/security/referrer-policy-header-no-referrer-when-downgrade.html [ Crash ]

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -194,6 +194,11 @@ WebProcessProxy& ProvisionalPageProxy::process()
     return m_frameProcess->process();
 }
 
+bool ProvisionalPageProxy::hasActiveLoadForNavigation(const API::Navigation& navigation) const
+{
+    return !m_didFailProvisionalLoad && m_navigationID == navigation.navigationID();
+}
+
 void ProvisionalPageProxy::processDidTerminate()
 {
     PROVISIONALPAGEPROXY_RELEASE_LOG_ERROR(ProcessSwapping, "processDidTerminate:");

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -113,6 +113,7 @@ public:
 
     bool isProcessSwappingOnNavigationResponse() const { return m_isProcessSwappingOnNavigationResponse; }
     bool didFailProvisionalLoad() const { return m_didFailProvisionalLoad; }
+    bool hasActiveLoadForNavigation(const API::Navigation&) const;
 
     DrawingAreaProxy* drawingArea() const { return m_drawingArea.get(); }
     RefPtr<DrawingAreaProxy> takeDrawingArea();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5364,7 +5364,8 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
         RefPtr pageClientProtector = pageClient();
         Ref processNavigatingFrom = [&] {
             RefPtr provisionalPage = m_provisionalPage;
-            return protect(preferences->siteIsolationEnabled() && frame->isMainFrame() && provisionalPage && !provisionalPage->didFailProvisionalLoad() ? provisionalPage->process() : frame->process());
+            bool needsSwap = preferences->siteIsolationEnabled() && frame->isMainFrame() && provisionalPage && provisionalPage->hasActiveLoadForNavigation(navigation);
+            return protect(needsSwap ? provisionalPage->process() : frame->process());
         }();
 
         const bool navigationChangesFrameProcess = processNavigatingTo->coreProcessIdentifier() != processNavigatingFrom->coreProcessIdentifier();

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -40,6 +40,7 @@
 #include <WebKit/WKCast.h>
 #include <WebKit/WKRetainPtr.h>
 #include <WebKit/WebKit2_C.h>
+#include <wtf/Compiler.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Logging.h>
 #include <wtf/Vector.h>
@@ -159,11 +160,23 @@ void InjectedBundle::setUpInjectedBundleClients(WKBundlePageRef page)
 
 InjectedBundlePage* InjectedBundle::page() const
 {
-    // It might be better to have the UI process send over a reference to the main
-    // page instead of just assuming it's the first non-suspended one.
+    // With site isolation, the process may contain RemotePages whose main frames are remote.
+    // Prefer pages with a local main frame, as those are the actual test pages.
     for (auto& page : m_pages) {
-        if (!WKBundlePageIsSuspended(page->page()))
-            return page.get();
+        if (WKBundlePageIsSuspended(page->page()))
+            continue;
+
+        // WKBundleFrameGetJavaScriptContext returns null for remote frames.
+        // FIXME <https://webkit.org/b/311737>: Stop using the deprecated WKBundlePageGetMainFrame.
+        // Possibly provide a convenient way to check whether a WKBundlePageRef has a local main frame.
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+        bool isPageRemote = !WKBundleFrameGetJavaScriptContext(WKBundlePageGetMainFrame(page->page()));
+        ALLOW_DEPRECATED_DECLARATIONS_END
+
+        if (isPageRemote)
+            continue;
+
+        return page.get();
     }
     return m_pages[0].get();
 }


### PR DESCRIPTION
#### a46910834aed22f3688291def7a9c396877b5ba4
<pre>
[Site Isolation] Fix provisional-load-cancels-previous-load.html layout test
<a href="https://bugs.webkit.org/show_bug.cgi?id=311381">https://bugs.webkit.org/show_bug.cgi?id=311381</a>

Reviewed by Basuke Suzuki.

The test crashing under site isolation was due to two issues:

1. Assertion failure in NetworkProcess::allowsFirstPartyForCookies:
   when a second cross-origin navigation starts while a provisional page
   is paused (e.g. by the inspector), processNavigatingFrom incorrectly
   used the provisional page&apos;s process. If the provisional and target
   processes matched, the UI process saw no process change needed and
   told the original process to load the cross-origin URL directly,
   crashing the network process on a cookie access check.

   Fix this by adding a navigation id comparison:
      provisionalPage-&gt;navigationID() == navigation-&gt;navigationID()
   The provisional page&apos;s process should only be used as
   processNavigatingFrom when it belongs to the same navigation (e.g. a
   server redirect). When the provisional page&apos;s load is being cancelled
   by a new navigation, the frame&apos;s committed process should be used so
   the swap is correctly detected.

2. Assertion failure in InjectedBundlePage::resetAfterTest:
   when the test completes, resetAfterTest might target a remote page
   instead of the committed test page after the test performed a
   cross-origin page navigation.

   Fix this by making InjectedBundle::page() prefer pages also having a
   local main frame instead so resetAfterTest operates on the intended
   test page.

Rework the surrounding code in both places to be a bit more readable.

Verified the test&apos;s progression with:
    run-webkit-tests --site-isolation provisional-load-cancels-previous-load.html

* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::hasActiveLoadForNavigation const):
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::page const):

Canonical link: <a href="https://commits.webkit.org/310813@main">https://commits.webkit.org/310813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de7c3f9f20fa79ad2eada5b32927f58b00346bba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21409 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163750 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108461 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156863 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28098 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119911 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84749 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139179 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100604 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/209412a0-4f5b-4801-95d8-93fc70ae370a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21260 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19296 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11576 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130922 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17023 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166226 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9802 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18632 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128012 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27794 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128151 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34785 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138816 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84427 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23026 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15611 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27410 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91514 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26988 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27219 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27061 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->