### PR TITLE
Add Memory64 support for memory grow and size in OMG tier

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmAddressType.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAddressType.cpp
@@ -36,6 +36,8 @@ AddressType::AddressType(AddressType::Kind addressType) : m_type(addressType) { 
 
 AddressType::AddressType(bool is64Bit) : m_type(is64Bit ? AddressType::I64 : AddressType::I32) { };
 
+static constexpr const char* invalidAddressTypeConversion = "Invalid Wasm Type to AddressType conversion";
+
 AddressType::AddressType(TypeKind typeKind)
 {
     switch (typeKind) {
@@ -46,7 +48,7 @@ AddressType::AddressType(TypeKind typeKind)
         m_type = AddressType::I64;
         break;
     default:
-        RELEASE_ASSERT_NOT_REACHED("Invalid Wasm Type to AddressType conversion");
+        RELEASE_ASSERT_NOT_REACHED(invalidAddressTypeConversion);
     }
 }
 
@@ -61,12 +63,12 @@ AddressType::AddressType(B3::Type type)
         m_type = AddressType::I64;
         break;
     default:
-        RELEASE_ASSERT_NOT_REACHED("Invalid Wasm Type to AddressType conversion");
+        RELEASE_ASSERT_NOT_REACHED(invalidAddressTypeConversion);
     }
 }
 #endif
 
-TypeKind AddressType::asTypeKind() const
+TypeKind AddressType::asWasmTypeKind() const
 {
     switch (m_type) {
     case AddressType::I32:
@@ -74,8 +76,23 @@ TypeKind AddressType::asTypeKind() const
     case AddressType::I64:
         return TypeKind::I64;
     }
-    RELEASE_ASSERT_NOT_REACHED("Invalid Wasm Type to AddressType conversion");
+
+    RELEASE_ASSERT_NOT_REACHED(invalidAddressTypeConversion);
 }
+
+#if !PLATFORM(PLAYSTATION)
+B3::TypeKind AddressType::asB3TypeKind() const
+{
+    switch (m_type) {
+    case AddressType::I32:
+        return B3::TypeKind::Int32;
+    case AddressType::I64:
+        return B3::TypeKind::Int64;
+    }
+
+    RELEASE_ASSERT_NOT_REACHED(invalidAddressTypeConversion);
+}
+#endif
 
 bool operator==(const AddressType& lhs, const AddressType& rhs)
 {

--- a/Source/JavaScriptCore/wasm/WasmAddressType.h
+++ b/Source/JavaScriptCore/wasm/WasmAddressType.h
@@ -29,6 +29,7 @@
 namespace JSC {
 namespace B3 {
 class Type;
+enum TypeKind : uint32_t;
 }
 
 namespace Wasm {
@@ -50,7 +51,8 @@ public:
     explicit AddressType(bool is64bit);
 
     AddressType::Kind type() const { return m_type; }
-    TypeKind NODELETE asTypeKind() const;
+    TypeKind NODELETE asWasmTypeKind() const;
+    B3::TypeKind NODELETE asB3TypeKind() const;
 
     friend bool NODELETE operator==(const AddressType& lhs, const AddressType& rhs);
     friend bool operator!=(const AddressType& lhs, const AddressType& rhs);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -1102,7 +1102,7 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint32_t uoffset)
 [[nodiscard]] PartialResult BBQJIT::addGrowMemory(Value delta, Value& result, uint8_t memoryIndex)
 {
     Vector<Value, 8> arguments = { instanceValue(), delta, Value::fromI32(memoryIndex) };
-    result = topValue(m_info.memory(memoryIndex).addressType().asTypeKind());
+    result = topValue(m_info.memory(memoryIndex).addressType().asWasmTypeKind());
     emitCCall(&operationGrowMemory, arguments, result);
     restoreWebAssemblyGlobalState();
 
@@ -1113,14 +1113,15 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint32_t uoffset)
 
 [[nodiscard]] PartialResult BBQJIT::addCurrentMemory(Value& result, uint8_t memoryIndex)
 {
-    result = topValue(m_info.memory(memoryIndex).addressType().asTypeKind());
+    result = topValue(m_info.memory(memoryIndex).addressType().asWasmTypeKind());
     if (!memoryIndex) {
         Location resultLocation = allocate(result);
-        m_jit.loadPtr(Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfCachedMemory0Size()), wasmScratchGPR);
         constexpr uint32_t shiftValue = 16;
         static_assert(PageCount::pageSize == 1ull << shiftValue, "This must hold for the code below to be correct.");
-        m_jit.urshiftPtr(Imm32(shiftValue), wasmScratchGPR);
-        m_jit.zeroExtend32ToWord(wasmScratchGPR, resultLocation.asGPR());
+        m_jit.loadPtr(Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfCachedMemory0Size()), resultLocation.asGPR());
+        m_jit.urshiftPtr(TrustedImm32(shiftValue), resultLocation.asGPR());
+        if (!m_info.memory(memoryIndex).isMemory64())
+            m_jit.zeroExtend32ToWord(resultLocation.asGPR(), resultLocation.asGPR());
     } else {
         Vector<Value, 8> arguments = { instanceValue(), Value::fromI32(memoryIndex) };
         emitCCall(&operationWasmMemorySizeInPages, arguments, result);

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -2042,7 +2042,7 @@ auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, 
 
 auto OMGIRGenerator::addGrowMemory(ExpressionType delta, ExpressionType& result, uint8_t memoryIndex) -> PartialResult
 {
-    result = push(callWasmOperation(m_currentBlock, Int32, operationGrowMemory,
+    result = push(callWasmOperation(m_currentBlock, m_info.memory(memoryIndex).addressType().asB3TypeKind(), operationGrowMemory,
         instanceValue(), get(delta), constant(Int32, memoryIndex)));
 
     restoreWebAssemblyGlobalState(m_info.memories, instanceValue(), m_currentBlock);
@@ -2062,9 +2062,12 @@ auto OMGIRGenerator::addCurrentMemory(ExpressionType& result, uint8_t memoryInde
         static_assert(PageCount::pageSize == 1ull << shiftValue, "This must hold for the code below to be correct.");
         Value* numPages = m_currentBlock->appendNew<Value>(m_proc, ZShr, origin(), size, constant(Int32, shiftValue));
 
-        result = push(int32OfPointer(numPages));
+        if (m_info.memory(memoryIndex).isMemory64())
+            result = push(numPages);
+        else
+            result = push(int32OfPointer(numPages));
     } else {
-        Value* resultValue = callWasmOperation(m_currentBlock, toB3Type(Types::I32), operationWasmMemorySizeInPages,
+        Value* resultValue = callWasmOperation(m_currentBlock, m_info.memory(memoryIndex).addressType().asB3TypeKind(), operationWasmMemorySizeInPages,
             instanceValue(), constant(Int32, memoryIndex));
         result = push(resultValue);
     }

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -656,11 +656,8 @@ inline int32_t tableSize(JSWebAssemblyInstance* instance, unsigned tableIndex)
     return instance->table(tableIndex)->length();
 }
 
-inline int32_t growMemory(JSWebAssemblyInstance* instance, int32_t delta, uint8_t memoryIndex)
+inline uint64_t growMemory(JSWebAssemblyInstance* instance, uint64_t delta, uint8_t memoryIndex)
 {
-    if (delta < 0)
-        return -1;
-
     auto grown = instance->memory(memoryIndex)->memory().grow(instance->vm(), PageCount(delta));
     if (!grown) {
         switch (grown.error()) {


### PR DESCRIPTION
#### 14c9a4cfcf8a7f63dfcb2af6672ca9ee81cde228
<pre>
Add Memory64 support for memory grow and size in OMG tier
<a href="https://bugs.webkit.org/show_bug.cgi?id=311449">https://bugs.webkit.org/show_bug.cgi?id=311449</a>
<a href="https://rdar.apple.com/174044445">rdar://174044445</a>

Reviewed by Keith Miller.

This patch adds support for memory.grow and memory.size
in the OMG tier

* Source/JavaScriptCore/wasm/WasmAddressType.cpp:
(JSC::Wasm::AddressType::asWasmTypeKind const):
(JSC::Wasm::AddressType::asB3TypeKind const):
(JSC::Wasm::AddressType::asTypeKind const): Deleted.
* Source/JavaScriptCore/wasm/WasmAddressType.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addGrowMemory):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCurrentMemory):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addGrowMemory):
(JSC::Wasm::OMGIRGenerator::addCurrentMemory):
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::growMemory):

Canonical link: <a href="https://commits.webkit.org/311464@main">https://commits.webkit.org/311464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d0fcb3ee2ae41a17c8d66182d84bb18345e79a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30405 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/23596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165892 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b2fa0b75-a8f5-4d4a-a062-23032cf63587) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30408 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa9ece12-59c9-4e8e-9f75-bc02f9523381) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23888 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/102316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13664 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149119 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/18876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168377 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17904 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/12536 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/20496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25254 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/129882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35175 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29930 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/140670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87751 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/24707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/17474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/189032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29641 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/93655 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/189032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29163 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29393 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29290 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->