### PR TITLE
LCP in shadow DOM is not reported

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/image-in-shadow-DOM-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/image-in-shadow-DOM-expected.txt
@@ -1,0 +1,3 @@
+
+PASS LCP includes image in shadow DOM
+

--- a/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/image-in-shadow-DOM.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/image-in-shadow-DOM.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<title>LCP entries are produced for an image in the shadow tree</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/largest-contentful-paint-helpers.js"></script>
+
+<div id="host"></div>
+<script>
+async_test(function (t) {
+  assert_implements(window.LargestContentfulPaint, "LargestContentfulPaint is not implemented");
+
+  const beforeLoad = performance.now();
+
+  const observer = new PerformanceObserver(
+    t.step_func_done(function(entryList) {
+      const entries = entryList.getEntries();
+      assert_equals(entries.length, 1);
+      const url = window.location.origin + '/images/lcp-256x256.png';
+      checkImage(entries[0], url, undefined, 65536, beforeLoad, ['elementUnavailable']);
+  }));
+  observer.observe({entryTypes: ['largest-contentful-paint']});
+
+  host.attachShadow({ mode: "open" }).innerHTML = `
+    <img id="target" src="/images/lcp-256x256.png">
+  `;
+
+}, "LCP includes image in shadow DOM")
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/resources/largest-contentful-paint-helpers.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/resources/largest-contentful-paint-helpers.js
@@ -26,6 +26,7 @@ const await_with_timeout = async (delay, message, promise, cleanup = ()=>{}) => 
 //     When not present, |expectedSize| must be exactly equal to the size attribute value.
 // * 'approximateSize': the |expectedSize| is only approximate to the size attribute value.
 //     This option is mutually exclusive to 'sizeLowerBound'.
+// * 'elementUnavailable': the target element is not available (e.g. in shadow DOM).
 function checkImage(entry, expectedUrl, expectedID, expectedSize, timeLowerBound, options = []) {
   assert_equals(entry.name, '', "Entry name should be the empty string");
   assert_equals(entry.entryType, 'largest-contentful-paint',
@@ -34,9 +35,13 @@ function checkImage(entry, expectedUrl, expectedID, expectedSize, timeLowerBound
   // The entry's url can be truncated.
   assert_equals(expectedUrl.substr(0, 100), entry.url.substr(0, 100),
     `Expected URL ${expectedUrl} should at least start with the entry's URL ${entry.url}`);
-  assert_equals(entry.id, expectedID, "Entry ID matches expected one");
-  assert_equals(entry.element, document.getElementById(expectedID),
-    "Entry element is expected one");
+
+  if (!options.includes('elementUnavailable')) {
+    assert_equals(entry.id, expectedID, "Entry ID matches expected one");
+    assert_equals(entry.element, document.getElementById(expectedID),
+      "Entry element is expected one");
+  }
+
   if (options.includes('skip')) {
     return;
   }

--- a/Source/WebCore/page/LargestContentfulPaintData.cpp
+++ b/Source/WebCore/page/LargestContentfulPaintData.cpp
@@ -69,7 +69,7 @@ bool LargestContentfulPaintData::isExposedForPaintTiming(const Element& element)
     if (!protect(element.document())->isFullyActive())
         return false;
 
-    if (!element.isInDocumentTree()) // Also checks isConnected().
+    if (!element.isConnected())
         return false;
 
     return true;


### PR DESCRIPTION
#### 0b5c61add5d5702c182c59e6aff7664bbb893299
<pre>
LCP in shadow DOM is not reported
<a href="https://bugs.webkit.org/show_bug.cgi?id=310264">https://bugs.webkit.org/show_bug.cgi?id=310264</a>
<a href="https://rdar.apple.com/173197678">rdar://173197678</a>

Reviewed by Alan Baradlay.

Use `Element::isConnected()` so that elements in Shadow DOM are considered for LCP.

Test: imported/w3c/web-platform-tests/largest-contentful-paint/image-in-shadow-DOM.html

* LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/image-in-shadow-DOM-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/image-in-shadow-DOM.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/resources/largest-contentful-paint-helpers.js:
(checkImage):
* Source/WebCore/page/LargestContentfulPaintData.cpp:
(WebCore::LargestContentfulPaintData::isExposedForPaintTiming):

Canonical link: <a href="https://commits.webkit.org/310575@main">https://commits.webkit.org/310575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8baab0249415608f303cd683e2863afb7684645f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20602 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162938 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107652 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27292 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119241 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84296 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1a54e17c-e4b7-47ce-8a26-c5c9cdb4b0e2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21509 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138468 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99937 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2cefca8-acd1-4982-ac3b-325dcda49d00) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20597 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18588 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10770 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165410 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8619 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17922 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127335 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26988 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127481 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34602 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26912 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138106 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83505 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22367 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14898 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26602 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90705 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26183 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26414 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26255 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->