### PR TITLE
Build Time Improvement: Move variant-heavy inline functions from CalcTree headers to .cpp files

### DIFF
--- a/Source/WebCore/css/calc/CSSCalcTree.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree.cpp
@@ -67,6 +67,14 @@ WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Sqrt);
 WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Sum);
 WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Tan);
 
+bool isNumeric(const Child& root)
+{
+    return WTF::switchOn(root,
+        []<Numeric T>(const T&) { return true; },
+        [](const auto&) { return false; }
+    );
+}
+
 Child makeNumeric(double value, CSSUnitType unit)
 {
     switch (unit) {
@@ -175,6 +183,47 @@ Child makeNumeric(double value, CSSUnitType unit)
 
     ASSERT_NOT_REACHED();
     return makeChild(Number { .value = 0 });
+}
+
+Sum add(Child&& a, Child&& b)
+{
+    Vector<Child> sumChildren;
+    sumChildren.append(WTF::move(a));
+    sumChildren.append(WTF::move(b));
+    return Sum { .children = WTF::move(sumChildren) };
+}
+
+Product multiply(Child&& a, Child&& b)
+{
+    Vector<Child> productChildren;
+    productChildren.append(WTF::move(a));
+    productChildren.append(WTF::move(b));
+    return Product { .children = WTF::move(productChildren) };
+}
+
+Sum subtract(Child&& a, Child&& b)
+{
+    return add(WTF::move(a), makeChild(Negate { .a = WTF::move(b) }, getType(b)));
+}
+
+Child makeChildWithValueBasedOn(double value, const Number&)
+{
+    return makeChild(Number { .value = value });
+}
+
+Child makeChildWithValueBasedOn(double value, const Percentage& a)
+{
+    return makeChild(Percentage { .value = value, .hint = a.hint });
+}
+
+Child makeChildWithValueBasedOn(double value, const CanonicalDimension& a)
+{
+    return makeChild(CanonicalDimension { .value = value, .dimension = a.dimension });
+}
+
+Child makeChildWithValueBasedOn(double value, const NonCanonicalDimension& a)
+{
+    return makeChild(NonCanonicalDimension { .value = value, .unit = a.unit });
 }
 
 Type getType(CanonicalDimension::Dimension dimension)

--- a/Source/WebCore/css/calc/CSSCalcTree.h
+++ b/Source/WebCore/css/calc/CSSCalcTree.h
@@ -955,59 +955,21 @@ constexpr CSSUnitType toCSSUnit(const NonCanonicalDimension& dimension) { return
 
 // MARK: Predicates
 
-inline bool isNumeric(const Child& root)
-{
-    return WTF::switchOn(root,
-        []<Numeric T>(const T&) { return true; },
-        [](const auto&) { return false; }
-    );
-}
+bool isNumeric(const Child& root);
 
 // Convenience constructors
 
 // Makes the appropriate child type (number, percentage, canonical-dimensions, non-canonical-dimension) based on the CSSUnitType.
 Child makeNumeric(double, CSSUnitType);
 
-inline Sum add(Child&& a, Child&& b)
-{
-    Vector<Child> sumChildren;
-    sumChildren.append(WTF::move(a));
-    sumChildren.append(WTF::move(b));
-    return Sum { .children = WTF::move(sumChildren) };
-}
+Sum add(Child&& a, Child&& b);
+Product multiply(Child&& a, Child&& b);
+Sum subtract(Child&& a, Child&& b);
 
-inline Product multiply(Child&& a, Child&& b)
-{
-    Vector<Child> productChildren;
-    productChildren.append(WTF::move(a));
-    productChildren.append(WTF::move(b));
-    return Product { .children = WTF::move(productChildren) };
-}
-
-inline Sum subtract(Child&& a, Child&& b)
-{
-    return add(WTF::move(a), makeChild(Negate { .a = WTF::move(b) }, getType(b)));
-}
-
-inline Child makeChildWithValueBasedOn(double value, const Number&)
-{
-    return makeChild(Number { .value = value });
-}
-
-inline Child makeChildWithValueBasedOn(double value, const Percentage& a)
-{
-    return makeChild(Percentage { .value = value, .hint = a.hint });
-}
-
-inline Child makeChildWithValueBasedOn(double value, const CanonicalDimension& a)
-{
-    return makeChild(CanonicalDimension { .value = value, .dimension = a.dimension });
-}
-
-inline Child makeChildWithValueBasedOn(double value, const NonCanonicalDimension& a)
-{
-    return makeChild(NonCanonicalDimension { .value = value, .unit = a.unit });
-}
+Child makeChildWithValueBasedOn(double value, const Number&);
+Child makeChildWithValueBasedOn(double value, const Percentage&);
+Child makeChildWithValueBasedOn(double value, const CanonicalDimension&);
+Child makeChildWithValueBasedOn(double value, const NonCanonicalDimension&);
 
 // MARK: Tuple Conformance
 

--- a/Source/WebCore/style/calc/StyleCalculationTree.cpp
+++ b/Source/WebCore/style/calc/StyleCalculationTree.cpp
@@ -65,6 +65,47 @@ WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Sqrt);
 WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Sum);
 WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Tan);
 
+Child number(double value)
+{
+    return makeChild(Number { .value = value });
+}
+
+Child percentage(double value)
+{
+    return makeChild(Percentage { .value = value });
+}
+
+Child dimension(double value)
+{
+    return makeChild(Dimension { .value = value });
+}
+
+Child add(Child&& a, Child&& b)
+{
+    Vector<Child> sumChildren;
+    sumChildren.append(WTF::move(a));
+    sumChildren.append(WTF::move(b));
+    return makeChild(Sum { .children = WTF::move(sumChildren) });
+}
+
+Child multiply(Child&& a, Child&& b)
+{
+    Vector<Child> productChildren;
+    productChildren.append(WTF::move(a));
+    productChildren.append(WTF::move(b));
+    return makeChild(Product { .children = WTF::move(productChildren) });
+}
+
+Child subtract(Child&& a, Child&& b)
+{
+    return add(WTF::move(a), makeChild(Negate { .a = WTF::move(b) }));
+}
+
+Child blend(Child&& from, Child&& to, double progress)
+{
+    return makeChild(Blend { .progress = progress, .from = WTF::move(from), .to = WTF::move(to) });
+}
+
 static size_t computeDepth(const Child& root)
 {
     size_t maximumChildDepth = 0;

--- a/Source/WebCore/style/calc/StyleCalculationTree.h
+++ b/Source/WebCore/style/calc/StyleCalculationTree.h
@@ -566,46 +566,13 @@ template<typename Op> Child makeChild(Op&& op)
 
 // Convenience constructors
 
-inline Child number(double value)
-{
-    return makeChild(Number { .value = value });
-}
-
-inline Child percentage(double value)
-{
-    return makeChild(Percentage { .value = value });
-}
-
-inline Child dimension(double value)
-{
-    return makeChild(Dimension { .value = value });
-}
-
-inline Child add(Child&& a, Child&& b)
-{
-    Vector<Child> sumChildren;
-    sumChildren.append(WTF::move(a));
-    sumChildren.append(WTF::move(b));
-    return makeChild(Sum { .children = WTF::move(sumChildren) });
-}
-
-inline Child multiply(Child&& a, Child&& b)
-{
-    Vector<Child> productChildren;
-    productChildren.append(WTF::move(a));
-    productChildren.append(WTF::move(b));
-    return makeChild(Product { .children = WTF::move(productChildren) });
-}
-
-inline Child subtract(Child&& a, Child&& b)
-{
-    return add(WTF::move(a), makeChild(Negate { .a = WTF::move(b) }));
-}
-
-inline Child blend(Child&& from, Child&& to, double progress)
-{
-    return makeChild(Blend { .progress = progress, .from = WTF::move(from), .to = WTF::move(to) });
-}
+Child number(double value);
+Child percentage(double value);
+Child dimension(double value);
+Child add(Child&& a, Child&& b);
+Child multiply(Child&& a, Child&& b);
+Child subtract(Child&& a, Child&& b);
+Child blend(Child&& from, Child&& to, double progress);
 
 // MARK: Dumping
 


### PR DESCRIPTION
#### 0bd48dfc0abc8ec777b704fa303ffab37b38d0a9
<pre>
Build Time Improvement: Move variant-heavy inline functions from CalcTree headers to .cpp files
<a href="https://bugs.webkit.org/show_bug.cgi?id=311452">https://bugs.webkit.org/show_bug.cgi?id=311452</a>
<a href="https://rdar.apple.com/174049948">rdar://174049948</a>

Reviewed by Abrar Rahman Protyasha.

The CSSCalc::Node (38-type variant) and Style::Calculation::Node (33-type variant) trigger
expensive mpark::variant template instantiations (constructor, destructor, move_constructor,
switchOn dispatch) in every translation unit that includes their headers.

This patch moves convenience functions that create, move, or switchOn these variant types
from inline definitions in headers to their corresponding .cpp files. This avoids unnecessary
variant template instantiation in files that include the headers but don&apos;t call these functions.

(1) CSSCalcTree.h =&gt; CSSCalcTree.cpp:
* isNumeric() (switchOn over 38-type variant)add(), multiply(), subtract()
* makeChildWithValueBasedOn() (4 overloads)

(2) StyleCalculationTree.h =&gt; StyleCalculationTree.cpp:
* number(), percentage(), dimension()
* add(), multiply(), subtract(), blend()

Note: Trivial move constructors/operators (Children, ChildOrNone) were left inline to avoid
runtime overhead on hot paths.

* Source/WebCore/css/calc/CSSCalcTree.cpp:
(WebCore::CSSCalc::isNumeric): Moved from header.
(WebCore::CSSCalc::add): Ditto.
(WebCore::CSSCalc::multiply): Ditto.
(WebCore::CSSCalc::subtract): Ditto.
(WebCore::CSSCalc::makeChildWithValueBasedOn): Ditto.
* Source/WebCore/css/calc/CSSCalcTree.h:
(WebCore::CSSCalc::isNumeric): Deleted.
(WebCore::CSSCalc::add): Deleted.
(WebCore::CSSCalc::multiply): Deleted.
(WebCore::CSSCalc::subtract): Deleted.
(WebCore::CSSCalc::makeChildWithValueBasedOn): Deleted.
* Source/WebCore/style/calc/StyleCalculationTree.cpp:
(WebCore::Style::Calculation::number): Moved from header.
(WebCore::Style::Calculation::percentage): Ditto.
(WebCore::Style::Calculation::dimension): Ditto.
(WebCore::Style::Calculation::add): Ditto.
(WebCore::Style::Calculation::multiply): Ditto.
(WebCore::Style::Calculation::subtract): Ditto.
(WebCore::Style::Calculation::blend): Ditto.
* Source/WebCore/style/calc/StyleCalculationTree.h:
(WebCore::Style::Calculation::number): Deleted.
(WebCore::Style::Calculation::percentage): Deleted.
(WebCore::Style::Calculation::dimension): Deleted.
(WebCore::Style::Calculation::add): Deleted.
(WebCore::Style::Calculation::multiply): Deleted.
(WebCore::Style::Calculation::subtract): Deleted.
(WebCore::Style::Calculation::blend): Deleted.

Canonical link: <a href="https://commits.webkit.org/310727@main">https://commits.webkit.org/310727@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cb45f986f73ea5b835f7de27085f059716271c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162934 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107648 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b5ce5961-5a7d-4baa-959c-15e8575e6a40) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156053 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27570 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27288 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119239 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84294 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23990c62-5e26-4f9c-bc2b-caa4487032b0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21501 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138458 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99935 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd264d42-bd68-4b2b-aae7-65a745b6f949) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20589 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18586 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10766 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130251 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165406 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8615 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17911 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127333 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26984 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127479 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34716 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26908 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138096 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83501 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22368 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14888 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26598 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90701 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26179 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26410 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26251 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->