### PR TITLE
Skip variant dispatch for touch-action: auto elements during event region unification

### DIFF
--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -471,7 +471,10 @@ void EventRegion::unite(const Region& region, const RenderObject& renderer, cons
     m_region.unite(region);
 
 #if ENABLE(TOUCH_ACTION_REGIONS)
-    uniteTouchActions(region, Style::toPlatform(style.usedTouchAction()));
+    if (auto touchAction = style.usedTouchAction(); !touchAction.isAuto())
+        uniteTouchActions(region, Style::toPlatform(touchAction));
+    else if (!m_touchActionRegions.isEmpty())
+        subtractAutoFromTouchActions(region);
 #endif
 
     uniteEventListeners(region, style.eventListenerRegionTypes());
@@ -580,6 +583,12 @@ void EventRegion::uniteTouchActions(const Region& touchRegion, OptionSet<TouchAc
             LOG_WITH_STREAM(EventRegions, stream << " subtracting for TouchAction " << regionTouchAction);
         }
     }
+}
+
+void EventRegion::subtractAutoFromTouchActions(const Region& region)
+{
+    for (auto& regionEntry : m_touchActionRegions)
+        regionEntry.subtract(region);
 }
 
 const Region* EventRegion::regionForTouchAction(TouchAction action) const

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -174,6 +174,7 @@ private:
     friend struct IPC::ArgumentCoder<EventRegion>;
 #if ENABLE(TOUCH_ACTION_REGIONS)
     void uniteTouchActions(const Region&, OptionSet<TouchAction>);
+    void subtractAutoFromTouchActions(const Region&);
 #endif
     void uniteEventListeners(const Region&, OptionSet<EventListenerRegionType>);
 


### PR DESCRIPTION
#### 268bd784c772dc11d4ed4d22592203ede0656a20
<pre>
Skip variant dispatch for touch-action: auto elements during event region unification
<a href="https://bugs.webkit.org/show_bug.cgi?id=311453">https://bugs.webkit.org/show_bug.cgi?id=311453</a>
<a href="https://rdar.apple.com/173455838">rdar://173455838</a>

Reviewed by Richard Robinson and Megan Gardner.

When `ENABLE_TOUCH_ACTION_REGIONS` is on, EventRegion::unite() calls
uniteTouchActions() unconditionally for every element, which requires a
Style::toPlatform() variant dispatch, even for the overwhelming majority
of elements with touch-action: auto.

As an optimization opportunity, we check isAuto() first (a single integer
comparison on the variant index) and skip the toPlatform() conversion
entirely when possible. If m_touchActionRegions is empty, meaning no
non-auto region has been found yet, we can skip uniteTouchActions()
altogether. When non-empty, we just use a helper dedicated to subtract
from the existing regions for touch-action: auto, again avoiding the
toPlatform conversion.

* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegion::unite):
(WebCore::EventRegion::subtractAutoFromTouchActions):
* Source/WebCore/rendering/EventRegion.h:

Canonical link: <a href="https://commits.webkit.org/310561@main">https://commits.webkit.org/310561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b36f3cceebb3c0f91195d1a73c2a46ee3ed5cbc0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162935 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107649 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d6d610c-9aae-4b97-bd2b-cd2ee81c2a31) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156054 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119240 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84295 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c667ce91-d68a-4205-a823-ab05f71eccef) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99936 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/204cb2ee-27e6-401b-85ce-59316c00de2b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20590 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18587 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10767 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130252 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165407 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8616 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17918 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127334 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26985 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22629 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127480 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26909 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138102 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83502 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23550 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22370 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14894 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26599 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90702 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26180 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26411 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26252 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->