### PR TITLE
[BFCache] Add multi-process suspension for BFCache with Site Isolation

### DIFF
--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -246,8 +246,18 @@ void BrowsingContextGroup::addRemotePage(WebPageProxy& page, Ref<RemotePageProxy
 void BrowsingContextGroup::removePage(WebPageProxy& page)
 {
     m_pages.remove(page);
+    closeRemotePagesForPage(page);
+}
+
+void BrowsingContextGroup::closeRemotePagesForPage(WebPageProxy& page)
+{
     for (auto& remotePage : m_remotePages.take(page))
-        remotePage->disconnect();
+        protect(remotePage)->disconnect();
+}
+
+bool BrowsingContextGroup::hasMultiplePages() const
+{
+    return m_pages.computeSize() > 1;
 }
 
 void BrowsingContextGroup::forEachRemotePage(const WebPageProxy& page, Function<void(RemotePageProxy&)>&& function)
@@ -257,6 +267,20 @@ void BrowsingContextGroup::forEachRemotePage(const WebPageProxy& page, Function<
         return;
     for (Ref remotePage : it->value)
         function(remotePage);
+}
+
+void BrowsingContextGroup::forEachFrameInRemotePage(WebPageProxy& page, WebFrameProxy& mainFrame, NOESCAPE const Function<void(RemotePageProxy&, WebFrameProxy&)>& callback) const
+{
+    auto it = m_remotePages.find(page);
+    if (it == m_remotePages.end())
+        return;
+    for (Ref remotePage : it->value) {
+        Ref process = remotePage->siteIsolatedProcess();
+        for (RefPtr frame = mainFrame.traverseNext().frame; frame; frame = frame->traverseNext().frame) {
+            if (&frame->process() == process.ptr())
+                callback(remotePage, *frame);
+        }
+    }
 }
 
 RefPtr<RemotePageProxy> BrowsingContextGroup::remotePageInProcess(const WebPageProxy& page, const WebProcessProxy& process)

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -49,6 +49,7 @@ namespace WebKit {
 class FrameProcess;
 class ProvisionalPageProxy;
 class RemotePageProxy;
+class WebFrameProxy;
 class WebPageProxy;
 class WebPreferences;
 class WebProcessPool;
@@ -74,7 +75,10 @@ public:
     void addPage(WebPageProxy&);
     void addRemotePage(WebPageProxy&, Ref<RemotePageProxy>&&);
     void removePage(WebPageProxy&);
+    void closeRemotePagesForPage(WebPageProxy&);
+    bool NODELETE hasMultiplePages() const;
     void forEachRemotePage(const WebPageProxy&, Function<void(RemotePageProxy&)>&&);
+    void forEachFrameInRemotePage(WebPageProxy&, WebFrameProxy& mainFrame, NOESCAPE const Function<void(RemotePageProxy&, WebFrameProxy&)>&) const;
 
     RefPtr<RemotePageProxy> remotePageInProcess(const WebPageProxy&, const WebProcessProxy&);
 

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -33,8 +33,11 @@
 #include "HandleMessage.h"
 #include "Logging.h"
 #include "MessageSenderInlines.h"
+#include "RemotePageProxy.h"
 #include "WebBackForwardCache.h"
 #include "WebBackForwardList.h"
+#include "WebBackForwardListFrameItem.h"
+#include "WebBackForwardListItem.h"
 #include "WebBackForwardListMessages.h"
 #include "WebFrameProxy.h"
 #include "WebPageMessages.h"
@@ -134,16 +137,6 @@ SuspendedPageProxy::SuspendedPageProxy(WebPageProxy& page, Ref<WebProcessProxy>&
 #endif
 #endif
 {
-    allSuspendedPages().add(*this);
-    m_process->addSuspendedPageProxy(*this);
-    m_messageReceiverRegistration.startReceivingMessages(m_process, m_webPageID, *this, *this);
-    m_suspensionTimeoutTimer.startOneShot(suspensionTimeout);
-    sendWithAsyncReply(Messages::WebPage::SetIsSuspended(true), [weakThis = WeakPtr { *this }](std::optional<bool> didSuspend) {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !didSuspend)
-            return;
-        protectedThis->didProcessRequestToSuspend(*didSuspend ? SuspensionState::Suspended : SuspensionState::FailedToSuspend);
-    });
 }
 
 template<typename M>
@@ -158,21 +151,57 @@ void SuspendedPageProxy::sendWithAsyncReply(M&& message, C&& completionHandler)
     m_process->sendWithAsyncReply(std::forward<M>(message), std::forward<C>(completionHandler), m_webPageID);
 }
 
+bool SuspendedPageProxy::startSuspension(WebBackForwardListItem* fromItem)
+{
+    ASSERT(!m_browsingContextGroup->hasMultiplePages());
+
+    RefPtr page = m_page.get();
+    if (page && protect(page->preferences())->multiProcessBackForwardCacheEnabled()) {
+        // Iframe suspension is only needed when the page is being added to the
+        // back/forward cache (fromItem is non-null). When fromItem is null, the
+        // page is only kept temporarily to prevent a white flash during navigation.
+        if (fromItem && !suspendIframeProcesses(*fromItem))
+            return false;
+    }
+
+    m_messageReceiverRegistration.startReceivingMessages(m_process, m_webPageID, *this, *this);
+    m_suspensionTimeoutTimer.startOneShot(suspensionTimeout);
+    sendWithAsyncReply(Messages::WebPage::SetIsSuspended(true), [weakThis = WeakPtr { *this }](std::optional<bool> didSuspend) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !didSuspend)
+            return;
+        protectedThis->didProcessRequestToSuspend(*didSuspend ? SuspensionState::Suspended : SuspensionState::FailedToSuspend);
+    });
+
+    allSuspendedPages().add(*this);
+    m_process->addSuspendedPageProxy(*this);
+    return true;
+}
+
 SuspendedPageProxy::~SuspendedPageProxy()
+{
+    if (auto handler = std::exchange(m_readyToUnsuspendHandler, nullptr)) {
+        RunLoop::mainSingleton().dispatch([handler = WTF::move(handler)]() mutable {
+            handler(nullptr);
+        });
+    }
+    teardown();
+}
+
+void SuspendedPageProxy::teardown()
 {
     allSuspendedPages().remove(*this);
 
-    if (m_readyToUnsuspendHandler) {
-        RunLoop::mainSingleton().dispatch([readyToUnsuspendHandler = WTF::move(m_readyToUnsuspendHandler)]() mutable {
-            readyToUnsuspendHandler(nullptr);
+    if (RefPtr page = m_page.get()) {
+        m_browsingContextGroup->forEachRemotePage(*page, [suspendedPage = Ref { *this }](auto& remotePage) {
+            protect(remotePage.siteIsolatedProcess())->removeSuspendedPageProxy(suspendedPage);
         });
+        if (m_suspensionState != SuspensionState::Resumed)
+            m_browsingContextGroup->closeRemotePagesForPage(*page);
     }
 
-    if (m_suspensionState != SuspensionState::Resumed) {
-        // If the suspended page was not consumed before getting destroyed, then close the corresponding page
-        // on the WebProcess side.
+    if (m_suspensionState != SuspensionState::Resumed)
         close();
-    }
 
     m_process->removeSuspendedPageProxy(*this);
 }
@@ -198,6 +227,8 @@ void SuspendedPageProxy::waitUntilReadyToUnsuspend(CompletionHandler<void(Suspen
         m_readyToUnsuspendHandler = WTF::move(completionHandler);
         break;
     case SuspensionState::FailedToSuspend:
+        completionHandler(this);
+        break;
     case SuspensionState::Suspended:
         completionHandler(this);
         break;
@@ -263,27 +294,121 @@ void SuspendedPageProxy::didProcessRequestToSuspend(SuspensionState newSuspensio
     ASSERT(m_suspensionState == SuspensionState::Suspending);
     ASSERT(newSuspensionState == SuspensionState::Suspended || newSuspensionState == SuspensionState::FailedToSuspend);
 
-    m_suspensionState = newSuspensionState;
-
-    m_suspensionTimeoutTimer.stop();
-
 #if USE(RUNNINGBOARD)
     m_suspensionActivity = nullptr;
 #endif
 
     m_messageReceiverRegistration.stopReceivingMessages();
 
-    if (m_suspensionState == SuspensionState::FailedToSuspend)
+    if (newSuspensionState == SuspensionState::FailedToSuspend) {
+        m_suspensionState = SuspensionState::FailedToSuspend;
+        m_suspensionTimeoutTimer.stop();
         closeWithoutFlashing();
+        if (auto handler = std::exchange(m_readyToUnsuspendHandler, nullptr))
+            handler(this);
+        return;
+    }
 
-    if (m_readyToUnsuspendHandler)
-        m_readyToUnsuspendHandler(this);
+    m_mainFrameSuspended = true;
+    maybeCompleteSuspension();
 }
 
 void SuspendedPageProxy::suspensionTimedOut()
 {
     RELEASE_LOG_ERROR(ProcessSwapping, "%p - SuspendedPageProxy::suspensionTimedOut() destroying the suspended page because it failed to suspend in time", this);
     protect(backForwardCache())->removeEntry(*this); // Will destroy |this|.
+}
+
+bool SuspendedPageProxy::suspendIframeProcesses(WebBackForwardListItem& fromItem)
+{
+    RefPtr page = m_page.get();
+    if (!page)
+        return false;
+
+    Ref rootFrameItem = fromItem.mainFrameItem();
+
+    // Phase 1: Validate all frame items exist before sending any IPCs.
+    using SuspensionTarget = std::tuple<WebCore::BackForwardFrameItemIdentifier, Ref<WebProcessProxy>, WebCore::PageIdentifier>;
+    Vector<SuspensionTarget> targets;
+    bool missingFrameItem = false;
+
+    m_browsingContextGroup->forEachFrameInRemotePage(*page, m_mainFrame, [&](auto& remotePage, auto& frame) {
+        if (missingFrameItem)
+            return;
+        RefPtr frameItem = rootFrameItem->childItemForFrameID(frame.frameID());
+        if (!frameItem) {
+            RELEASE_LOG_ERROR(ProcessSwapping, "%p - SuspendedPageProxy::suspendIframeProcesses: No frame item found for frame %" PRIu64 " in process pid %i, skipping iframe suspension", this, frame.frameID().toUInt64(), remotePage.siteIsolatedProcess().processID());
+            missingFrameItem = true;
+            return;
+        }
+        targets.append({ frameItem->identifier(), remotePage.siteIsolatedProcess(), remotePage.identifierInSiteIsolatedProcess() });
+    });
+
+    if (missingFrameItem)
+        return false;
+
+    // Phase 2: Register with each iframe process and send suspension IPCs.
+    m_browsingContextGroup->forEachRemotePage(*page, [suspendedPage = Ref { *this }](auto& remotePage) {
+        protect(remotePage.siteIsolatedProcess())->addSuspendedPageProxy(suspendedPage);
+    });
+
+    m_expectedIframeSuspensions = targets.size();
+    for (auto& [frameItemIdentifier, process, remotePageIdentifier] : targets) {
+        RELEASE_LOG(ProcessSwapping, "%p - SuspendedPageProxy::suspendIframeProcesses: Sending SetIsSuspendedWithFrameItem to iframe process pid %i for frameItem %s", this, process->processID(), frameItemIdentifier.toString().utf8().data());
+
+        process->sendWithAsyncReply(Messages::WebPage::SetIsSuspendedWithFrameItem(true, frameItemIdentifier), [weakThis = WeakPtr { *this }](std::optional<bool> didSuspend) {
+            RefPtr protectedThis = weakThis.get();
+            if (protectedThis)
+                protectedThis->didIframeSuspensionComplete(didSuspend.value_or(false));
+        }, remotePageIdentifier);
+    }
+    return true;
+}
+
+bool SuspendedPageProxy::hasIframeInProcess(WebCore::ProcessIdentifier processIdentifier) const
+{
+    // FIXME: Add WebFrameProxy::forEachDescendant() to avoid manual traverseNext() loops.
+    for (RefPtr frame = m_mainFrame->traverseNext().frame; frame; frame = frame->traverseNext().frame) {
+        if (protect(frame->process())->coreProcessIdentifier() == processIdentifier)
+            return true;
+    }
+    return false;
+}
+
+void SuspendedPageProxy::didIframeSuspensionComplete(bool success)
+{
+    if (m_suspensionState == SuspensionState::Resumed || m_anyIframeSuspensionFailed)
+        return;
+
+    ++m_completedIframeSuspensions;
+    if (!success) {
+        m_anyIframeSuspensionFailed = true;
+        RELEASE_LOG_ERROR(ProcessSwapping, "%p - SuspendedPageProxy::didIframeSuspensionComplete: iframe suspension failed, invalidating cache entry", this);
+        protect(backForwardCache())->removeEntry(*this); // Will destroy |this|.
+        return;
+    }
+
+    if (m_completedIframeSuspensions < m_expectedIframeSuspensions)
+        return;
+
+    RELEASE_LOG(ProcessSwapping, "%p - SuspendedPageProxy::didIframeSuspensionComplete: All %u iframe suspensions completed", this, m_expectedIframeSuspensions);
+
+    maybeCompleteSuspension();
+}
+
+void SuspendedPageProxy::maybeCompleteSuspension()
+{
+    if (!m_mainFrameSuspended)
+        return;
+
+    if (m_completedIframeSuspensions < m_expectedIframeSuspensions)
+        return;
+
+    m_suspensionTimeoutTimer.stop();
+    m_suspensionState = SuspensionState::Suspended;
+
+    if (auto handler = std::exchange(m_readyToUnsuspendHandler, nullptr))
+        handler(this);
 }
 
 WebPageProxy* SuspendedPageProxy::page() const

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -73,7 +73,8 @@ public:
     WebCore::PageIdentifier webPageID() const { return m_webPageID; }
     WebProcessProxy& process() const { return m_process.get(); }
     WebFrameProxy& mainFrame() { return m_mainFrame.get(); }
-    const BrowsingContextGroup& browsingContextGroup() { return m_browsingContextGroup.get(); }
+    const BrowsingContextGroup& browsingContextGroup() const { return m_browsingContextGroup.get(); }
+    BrowsingContextGroup& browsingContextGroup() { return m_browsingContextGroup.get(); }
 
     WebBackForwardCache& NODELETE backForwardCache() const;
 
@@ -81,8 +82,11 @@ public:
 
     bool NODELETE pageIsClosedOrClosing() const;
 
+    bool startSuspension(WebBackForwardListItem* fromItem);
     void waitUntilReadyToUnsuspend(CompletionHandler<void(SuspendedPageProxy*)>&&);
     void unsuspend();
+
+    bool hasIframeInProcess(WebCore::ProcessIdentifier) const;
 
     void pageDidFirstLayerFlush();
     void closeWithoutFlashing();
@@ -104,8 +108,12 @@ private:
     enum class SuspensionState : uint8_t { Suspending, FailedToSuspend, Suspended, Resumed };
     void didProcessRequestToSuspend(SuspensionState);
     void suspensionTimedOut();
+    bool suspendIframeProcesses(WebBackForwardListItem&);
+    void didIframeSuspensionComplete(bool success);
+    void maybeCompleteSuspension();
 
     void close();
+    void teardown();
     void didDestroyNavigation(WebCore::NavigationIdentifier);
 
     // IPC::MessageReceiver
@@ -128,6 +136,10 @@ private:
     SuspensionState m_suspensionState { SuspensionState::Suspending };
     CompletionHandler<void(SuspendedPageProxy*)> m_readyToUnsuspendHandler;
     RunLoop::Timer m_suspensionTimeoutTimer;
+    bool m_mainFrameSuspended { false };
+    unsigned m_expectedIframeSuspensions { 0 };
+    unsigned m_completedIframeSuspensions { 0 };
+    bool m_anyIframeSuspensionFailed { false };
 #if USE(RUNNINGBOARD)
     RefPtr<ProcessThrottler::BackgroundActivity> m_suspensionActivity;
 #endif

--- a/Source/WebKit/UIProcess/WebBackForwardCache.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.cpp
@@ -143,9 +143,22 @@ Ref<SuspendedPageProxy> WebBackForwardCache::takeSuspendedPage(WebBackForwardLis
 
 void WebBackForwardCache::removeEntriesForProcess(WebProcessProxy& process)
 {
-    removeEntriesMatching([processIdentifier = process.coreProcessIdentifier()](auto& entry) {
+    auto processIdentifier = process.coreProcessIdentifier();
+    removeEntriesMatching([&](auto& entry) {
         ASSERT(entry.backForwardCacheEntry());
-        return entry.backForwardCacheEntry()->processIdentifier() == processIdentifier;
+
+        // Check main process (existing behavior).
+        if (entry.backForwardCacheEntry()->processIdentifier() == processIdentifier)
+            return true;
+
+        // Check iframe processes (multi-process BFCache).
+        if (RefPtr suspendedPage = entry.suspendedPage()) {
+            if (suspendedPage->hasIframeInProcess(processIdentifier)) {
+                RELEASE_LOG(ProcessSwapping, "WebBackForwardCache::removeEntriesForProcess: iframe process terminated while in BFCache, invalidating cache entry");
+                return true;
+            }
+        }
+        return false;
     });
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1467,6 +1467,11 @@ bool WebPageProxy::suspendCurrentPageIfPossible(API::Navigation& navigation, Ref
         return false;
     }
 
+    if (m_browsingContextGroup->hasMultiplePages()) {
+        WEBPAGEPROXY_RELEASE_LOG(ProcessSwapping, "suspendCurrentPageIfPossible: Not suspending current page for process pid %i because BrowsingContextGroup has multiple pages", m_legacyMainFrameProcess->processID());
+        return false;
+    }
+
     RefPtr fromItem = navigation.fromItem();
 
     // If the source and the destination back / forward list items are the same, then this is a client-side redirect. In this case,
@@ -1494,6 +1499,10 @@ bool WebPageProxy::suspendCurrentPageIfPossible(API::Navigation& navigation, Ref
     mainFrame->frameLoadState().didSuspend();
 
     Ref suspendedPage = SuspendedPageProxy::create(*this, protect(legacyMainFrameProcess()), mainFrame.releaseNonNull(), std::exchange(m_browsingContextGroup, BrowsingContextGroup::create()), shouldDelayClosingUntilFirstLayerFlush);
+    if (!suspendedPage->startSuspension(fromItem.get())) {
+        WEBPAGEPROXY_RELEASE_LOG(ProcessSwapping, "suspendCurrentPageIfPossible: iframe suspension failed, not caching page for process pid %i", m_legacyMainFrameProcess->processID());
+        return false;
+    }
 
     LOG(ProcessSwapping, "WebPageProxy %" PRIu64 " created suspended page %s for process pid %i, back/forward item %s" PRIu64, identifier().toUInt64(), suspendedPage->loggingString().utf8().data(), m_legacyMainFrameProcess->processID(), fromItem ? fromItem->identifier().toString().utf8().data() : "0"_s);
 
@@ -5623,7 +5632,6 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
         // handles the update).
         if (*oldMainFrameID != frameID)
             backForwardList().updateFrameIdentifier(*oldMainFrameID, frameID);
-        mainFrameInPreviousProcess->removeChildFrames();
     }
 
     ASSERT(m_legacyMainFrameProcess.ptr() != &provisionalPage->process() || preferences->siteIsolationEnabled());
@@ -5644,6 +5652,10 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
     removeAllMessageReceivers();
     RefPtr navigation = m_navigationState->navigation(provisionalPage->navigationID());
     bool didSuspendPreviousPage = navigation ? suspendCurrentPageIfPossible(*navigation, WTF::move(mainFrameInPreviousProcess), shouldDelayClosingUntilFirstLayerFlush) : false;
+
+    if (!didSuspendPreviousPage && mainFrameInPreviousProcess && preferences->siteIsolationEnabled())
+        mainFrameInPreviousProcess->removeChildFrames();
+
     // Defer shutting down old process as it might lead WebPageProxy to be closed and removeWebPage to be invoked again.
     auto preventProcessShutdownScope = protect(legacyMainFrameProcess())->shutdownPreventingScope();
     protect(legacyMainFrameProcess())->removeWebPage(*this, m_websiteDataStore.ptr() == provisionalPage->process().websiteDataStore() ? WebProcessProxy::EndsUsingDataStore::No : WebProcessProxy::EndsUsingDataStore::Yes);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8554,6 +8554,54 @@ void WebPage::setIsSuspended(bool suspended, CompletionHandler<void(std::optiona
     suspendForProcessSwap(WTF::move(completionHandler));
 }
 
+RefPtr<HistoryItem> WebPage::findHistoryItemByFrameItemID(BackForwardFrameItemIdentifier frameItemID)
+{
+    for (RefPtr frame = &corePage()->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        if (RefPtr item = localFrame->loader().history().currentItem()) {
+            if (item->frameItemID() == frameItemID)
+                return item;
+        }
+    }
+    return nullptr;
+}
+
+void WebPage::suspendForProcessSwapWithFrameItem(BackForwardFrameItemIdentifier frameItemID, CompletionHandler<void(std::optional<bool>)>&& completionHandler)
+{
+    flushDeferredDidReceiveMouseEvent();
+    RefPtr historyItem = findHistoryItemByFrameItemID(frameItemID);
+    if (!historyItem) {
+        WEBPAGE_RELEASE_LOG_ERROR(ProcessSwapping, "suspendForProcessSwapWithFrameItem: Failed to find history item for frameItemID %s", frameItemID.toString().utf8().data());
+        return completionHandler(false);
+    }
+    if (!BackForwardCache::singleton().addIfCacheable(*historyItem, protect(corePage()).get())) {
+        WEBPAGE_RELEASE_LOG_ERROR(ProcessSwapping, "suspendForProcessSwapWithFrameItem: BackForwardCache::addIfCacheable failed for frameItemID %s", frameItemID.toString().utf8().data());
+        return completionHandler(false);
+    }
+    WEBPAGE_RELEASE_LOG(ProcessSwapping, "suspendForProcessSwapWithFrameItem: Successfully cached page for frameItemID %s", frameItemID.toString().utf8().data());
+    completionHandler(true);
+}
+
+void WebPage::setIsSuspendedWithFrameItem(bool suspended, BackForwardFrameItemIdentifier frameItemID, CompletionHandler<void(std::optional<bool>)>&& completionHandler)
+{
+    if (m_isSuspended == suspended)
+        return completionHandler({ });
+    m_isSuspended = suspended;
+
+    if (!suspended) {
+        // FIXME: Restore path (implemented in a follow-up patch).
+        return completionHandler({ });
+    }
+
+    freezeLayerTree(LayerTreeFreezeReason::PageSuspended);
+    // Unlike the main-frame path in setIsSuspended, sendPrewarmInformation is
+    // intentionally omitted here because prewarming is a main-frame optimization.
+    unfreezeLayerTree(LayerTreeFreezeReason::BackgroundApplication);
+    suspendForProcessSwapWithFrameItem(frameItemID, WTF::move(completionHandler));
+}
+
 void WebPage::hasStorageAccess(RegistrableDomain&& subFrameDomain, RegistrableDomain&& topFrameDomain, WebFrame& frame, CompletionHandler<void(bool)>&& completionHandler)
 {
     if (hasPageLevelStorageAccess(topFrameDomain, subFrameDomain)) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2632,6 +2632,9 @@ private:
     void setNeedsDOMWindowResizeEvent();
 
     void setIsSuspended(bool, CompletionHandler<void(std::optional<bool>)>&&);
+    void setIsSuspendedWithFrameItem(bool suspended, WebCore::BackForwardFrameItemIdentifier, CompletionHandler<void(std::optional<bool>)>&&);
+    void suspendForProcessSwapWithFrameItem(WebCore::BackForwardFrameItemIdentifier, CompletionHandler<void(std::optional<bool>)>&&);
+    RefPtr<WebCore::HistoryItem> findHistoryItemByFrameItemID(WebCore::BackForwardFrameItemIdentifier);
 
     RefPtr<WebImage> snapshotAtSize(const WebCore::IntRect&, const WebCore::IntSize& bitmapSize, SnapshotOptions, WebCore::LocalFrame&, WebCore::LocalFrameView&);
     RefPtr<WebImage> snapshotNode(WebCore::Node&, SnapshotOptions, unsigned maximumPixelCount = std::numeric_limits<unsigned>::max());

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -718,6 +718,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     URLSchemeTaskDidComplete(WebKit::WebURLSchemeHandlerIdentifier handlerIdentifier, WebCore::ResourceLoaderIdentifier taskIdentifier, WebCore::ResourceError error)
 
     SetIsSuspended(bool suspended) -> (std::optional<bool> didSuspend)
+    SetIsSuspendedWithFrameItem(bool suspended, WebCore::BackForwardFrameItemIdentifier frameItemID) -> (std::optional<bool> didSuspend)
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     InsertAttachment(String identifier, std::optional<uint64_t> fileSize, String fileName, String contentType) -> ()

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -8501,4 +8501,75 @@ TEST(SiteIsolation, OpenEmptySiteFromProcessWithNonEmptySite)
     Util::run(&openedFinishedLoading);
 }
 
+TEST(SiteIsolation, MultiProcessBFCacheIframeProcessSurvival)
+{
+    HTTPServer server({
+        { "/a"_s, { "<iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "iframe content"_s } },
+        { "/c"_s, { "page c"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    });
+
+    pid_t iframePID = findFramePID(frameTrees(webView.get()).get(), FrameType::Remote);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Iframe process must survive. Without multi-process suspension,
+    // removeChildFrames() sends WebPage::Close() and kills it.
+    EXPECT_TRUE(processStillRunning(iframePID));
+}
+
+// FIXME: Use openerAndOpenedViews() once MultiProcessBackForwardCacheEnabled is on by default.
+TEST(SiteIsolation, MultiProcessBFCacheOpenerSkipsBFCache)
+{
+    HTTPServer server({
+        { "/a"_s, { "<script>window.open('https://a.com/child');</script>"_s } },
+        { "/child"_s, { "child page"_s } },
+        { "/b"_s, { "page b"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    [webView setUIDelegate:uiDelegate.get()];
+    webView.get().configuration.preferences.javaScriptCanOpenWindowsAutomatically = YES;
+
+    __block RetainPtr<WKWebView> openedWebView;
+    uiDelegate.get().createWebViewWithConfiguration = ^WKWebView *(WKWebViewConfiguration *config, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
+        openedWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:config]);
+        return openedWebView.get();
+    };
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Set a BFCache marker on the opener page.
+    [webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker = true"];
+
+    // Navigate to a different site to trigger PSON.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://b.com/b"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Go back.
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Verify the marker is gone (full reload, not BFCache restore).
+    EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker ? true : false"] boolValue]);
+}
+
 }


### PR DESCRIPTION
#### f2292b0997a2998dc3beeab7c8f53849d63ed775
<pre>
[BFCache] Add multi-process suspension for BFCache with Site Isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=311224">https://bugs.webkit.org/show_bug.cgi?id=311224</a>
<a href="https://rdar.apple.com/173743585">rdar://173743585</a>

Reviewed by NOBODY (OOPS!).

Implement iframe process suspension for BFCache with Site Isolation.
Navigating away from a page with cross-origin iframes correctly
suspends all iframe processes alongside the main frame. Cache entries
are created but not yet consumed on goBack (full page reload).
Restoration is implemented in a follow-up patch.

Key changes:
- SuspendedPageProxy::startSuspension() orchestrates the full suspension
  lifecycle: validates iframe frame items, registers with iframe processes,
  sends suspension IPCs, then suspends the main frame.
- Suspension state semantics: m_suspensionState stays Suspending until ALL
  processes (main + iframes) respond, then transitions to Suspended.
- BrowsingContextGroup::forEachFrameInRemotePage() iterates descendant
  frames matched to their remote page&apos;s process.
- SuspendedPageProxy constructor is lightweight (member init only);
  all registration and IPC happens in startSuspension().
- suspendIframeProcesses() validates all frame items before sending any
  IPCs to avoid partial suspension state.
- Timeout timer covers the full suspension (main + iframes), not just
  the main frame.
- SetIsSuspendedWithFrameItem IPC for iframe process suspension.
- WebFrameProxy tree survival (conditional removeChildFrames).
- Opener relationship guard (hasMultiplePages) to prevent BFCache with
  window.open pages.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::removePage):
(WebKit::BrowsingContextGroup::closeRemotePagesForPage):
(WebKit::BrowsingContextGroup::hasMultiplePages const):
(WebKit::BrowsingContextGroup::forEachFrameInRemotePage const):
* Source/WebKit/UIProcess/BrowsingContextGroup.h:
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::SuspendedPageProxy):
(WebKit::SuspendedPageProxy::startSuspension):
(WebKit::SuspendedPageProxy::~SuspendedPageProxy):
(WebKit::SuspendedPageProxy::teardown):
(WebKit::SuspendedPageProxy::waitUntilReadyToUnsuspend):
(WebKit::SuspendedPageProxy::didProcessRequestToSuspend):
(WebKit::SuspendedPageProxy::suspendIframeProcesses):
(WebKit::SuspendedPageProxy::hasIframeInProcess const):
(WebKit::SuspendedPageProxy::didIframeSuspensionComplete):
(WebKit::SuspendedPageProxy::maybeCompleteSuspension):
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Source/WebKit/UIProcess/WebBackForwardCache.cpp:
(WebKit::WebBackForwardCache::removeEntriesForProcess):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::suspendCurrentPageIfPossible):
(WebKit::WebPageProxy::commitProvisionalPage):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::findHistoryItemByFrameItemID):
(WebKit::WebPage::suspendForProcessSwapWithFrameItem):
(WebKit::WebPage::setIsSuspendedWithFrameItem):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, MultiProcessBFCacheIframeProcessSurvival)):
(TestWebKitAPI::(SiteIsolation, MultiProcessBFCacheOpenerSkipsBFCache)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2292b0997a2998dc3beeab7c8f53849d63ed775

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164178 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157289 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28526 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120277 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f711997e-e376-476f-8c50-baf6613425c2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158375 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139559 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100967 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa6016fc-4dfd-4926-b182-5c2e2d4a4288) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12007 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17391 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166656 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19001 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128387 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23698 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128523 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28144 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139184 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23354 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27838 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91941 "Found 1 new failure in UIProcess/BrowsingContextGroup.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27415 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27645 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27488 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->