### PR TITLE
[IndexedDB API] Consolidate the parsing logic in getAll* functions

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IDBGetAllOptions.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBGetAllOptions.cpp
@@ -27,34 +27,48 @@
 #include "IDBGetAllOptions.h"
 
 #include "IDBKeyRange.h"
+#include "IndexedDB.h"
 #include "JSIDBGetAllOptions.h"
 #include "JSIDBKeyRange.h"
+#include "ScriptExecutionContext.h"
+#include "Settings.h"
 #include <JavaScriptCore/JSGlobalObject.h>
 
 namespace WebCore {
 
-// https://w3c.github.io/IndexedDB/#create-a-request-to-retrieve-multiple-items (Step 9).
-ExceptionOr<ParsedGetAllQueryOrOptions> parseGetAllOptions(JSC::JSGlobalObject& execState, JSC::JSValue keyOrOptions)
+// https://w3c.github.io/IndexedDB/#create-a-request-to-retrieve-multiple-items (Steps 8 and 9).
+ExceptionOr<ParsedGetAllQueryOrOptions> parseQueryOrOptions(JSC::JSGlobalObject& execState, ScriptExecutionContext* context, JSC::JSValue queryOrOptions, std::optional<uint32_t> count)
 {
+    if (queryOrOptions.isUndefinedOrNull())
+        return ParsedGetAllQueryOrOptions { IDBKeyRange::unbounded(), count, IndexedDB::CursorDirection::Next };
+
+    if (IDBKeyRange::isPotentiallyValidKeyRange(execState, queryOrOptions)) {
+        auto keyRangeOrException = IDBKeyRange::fromValue(execState, queryOrOptions);
+        if (keyRangeOrException.hasException())
+            return Exception(ExceptionCode::DataError, "The parameter is not a valid key range."_s);
+
+        return ParsedGetAllQueryOrOptions { keyRangeOrException.releaseReturnValue(), count, IndexedDB::CursorDirection::Next };
+    }
+
+    if (!context || !context->settingsValues().indexedDBGetAllRecordsAndGetAllOptionsEnabled)
+        return Exception(ExceptionCode::DataError, "The parameter is not a valid key range."_s);
+
     auto throwScope = DECLARE_THROW_SCOPE(execState.vm());
-    auto optionsResult = convertDictionary<IDBGetAllOptions>(execState, keyOrOptions);
+    auto optionsOrException = convertDictionary<IDBGetAllOptions>(execState, queryOrOptions);
     if (throwScope.exception())
         return Exception { ExceptionCode::DataError, "The parameter is not a valid options object."_s };
 
-    auto options = optionsResult.releaseReturnValue();
-    auto query = options.query;
+    return parseGetAllOptions(execState, optionsOrException.releaseReturnValue());
+}
 
-    if (query.isUndefinedOrNull())
-        return ParsedGetAllQueryOrOptions { nullptr, options.count, options.direction };
+// https://w3c.github.io/IndexedDB/#create-a-request-to-retrieve-multiple-items (Step 9).
+ExceptionOr<ParsedGetAllQueryOrOptions> parseGetAllOptions(JSC::JSGlobalObject& execState, IDBGetAllOptions options)
+{
+    auto keyRangeOrException = IDBKeyRange::fromValue(execState, options.query);
+    if (keyRangeOrException.hasException())
+        return Exception(ExceptionCode::DataError, "The query specified in options is not a valid key range."_s);
 
-    if (RefPtr keyRange = JSIDBKeyRange::toWrapped(execState.vm(), query))
-        return ParsedGetAllQueryOrOptions { WTF::move(keyRange), options.count, options.direction };
-
-    auto onlyResultFromQuery = IDBKeyRange::only(execState, query);
-    if (onlyResultFromQuery.hasException())
-        return Exception(ExceptionCode::DataError, "The query specified in options is not a valid key."_s);
-
-    return ParsedGetAllQueryOrOptions { onlyResultFromQuery.releaseReturnValue(), options.count, options.direction };
+    return ParsedGetAllQueryOrOptions { keyRangeOrException.releaseReturnValue(), options.count, options.direction };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/IDBGetAllOptions.h
+++ b/Source/WebCore/Modules/indexeddb/IDBGetAllOptions.h
@@ -37,6 +37,7 @@ class JSGlobalObject;
 namespace WebCore {
 
 class IDBKeyRange;
+class ScriptExecutionContext;
 
 struct IDBGetAllOptions {
     JSC::JSValue query;
@@ -50,6 +51,8 @@ struct ParsedGetAllQueryOrOptions {
     IDBCursorDirection cursorDirection { IDBCursorDirection::Next };
 };
 
-ExceptionOr<ParsedGetAllQueryOrOptions> parseGetAllOptions(JSC::JSGlobalObject& execState, JSC::JSValue keyOrOptions);
+ExceptionOr<ParsedGetAllQueryOrOptions> parseQueryOrOptions(JSC::JSGlobalObject&, ScriptExecutionContext*, JSC::JSValue queryOrOptions, std::optional<uint32_t> count);
+
+ExceptionOr<ParsedGetAllQueryOrOptions> parseGetAllOptions(JSC::JSGlobalObject&, IDBGetAllOptions);
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
@@ -37,9 +37,7 @@
 #include "IDBObjectStore.h"
 #include "IDBRequest.h"
 #include "IDBTransaction.h"
-#include "JSIDBKeyRange.h"
 #include "Logging.h"
-#include "Settings.h"
 #include "WebCoreOpaqueRoot.h"
 #include <JavaScriptCore/HeapInlines.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -153,7 +151,7 @@ void IDBIndex::rollbackInfoForVersionChangeAbort()
     m_deleted = false;
 }
 
-ExceptionOr<Ref<IDBRequest>> IDBIndex::doOpenCursor(IDBCursorDirection direction, Function<ExceptionOr<RefPtr<IDBKeyRange>>()>&& function)
+ExceptionOr<Ref<IDBRequest>> IDBIndex::doOpenCursor(IDBCursorDirection direction, NOESCAPE Function<ExceptionOr<RefPtr<IDBKeyRange>>()>&& function)
 {
     LOG(IndexedDB, "IDBIndex::openCursor");
     Ref transaction = m_objectStore->transaction();
@@ -197,7 +195,7 @@ ExceptionOr<Ref<IDBRequest>> IDBIndex::openCursor(JSGlobalObject& execState, JSV
     });
 }
 
-ExceptionOr<Ref<IDBRequest>> IDBIndex::doOpenKeyCursor(IDBCursorDirection direction, Function<ExceptionOr<RefPtr<IDBKeyRange>>()>&& function)
+ExceptionOr<Ref<IDBRequest>> IDBIndex::doOpenKeyCursor(IDBCursorDirection direction, NOESCAPE Function<ExceptionOr<RefPtr<IDBKeyRange>>()>&& function)
 {
     LOG(IndexedDB, "IDBIndex::openKeyCursor");
     Ref transaction = m_objectStore->transaction();
@@ -349,7 +347,7 @@ ExceptionOr<Ref<IDBRequest>> IDBIndex::doGetKey(ExceptionOr<IDBKeyRangeData> ran
 }
 
 // https://w3c.github.io/IndexedDB/#create-a-request-to-retrieve-multiple-items
-ExceptionOr<Ref<IDBRequest>> IDBIndex::doGetAllShared(IndexedDB::GetAllType getAllType, std::optional<uint32_t> count, Function<ExceptionOr<ParsedGetAllQueryOrOptions>()>&& function)
+ExceptionOr<Ref<IDBRequest>> IDBIndex::doGetAllShared(IndexedDB::GetAllType getAllType, NOESCAPE Function<ExceptionOr<ParsedGetAllQueryOrOptions>()>&& function)
 {
     String callingFunctionExceptionMessagePrefix;
     switch (getAllType) {
@@ -380,67 +378,25 @@ ExceptionOr<Ref<IDBRequest>> IDBIndex::doGetAllShared(IndexedDB::GetAllType getA
     }
 
     auto parsedGetAllQueryOrOptions = exceptionOrParsedGetAllQueryOrOptions.releaseReturnValue();
-    if (parsedGetAllQueryOrOptions.count)
-        count = parsedGetAllQueryOrOptions.count;
 
-    return transaction->requestGetAllIndexRecords(*this, parsedGetAllQueryOrOptions.keyRange.get(), getAllType, count, parsedGetAllQueryOrOptions.cursorDirection);
+    return transaction->requestGetAllIndexRecords(*this, parsedGetAllQueryOrOptions.keyRange.get(), getAllType, parsedGetAllQueryOrOptions.count, parsedGetAllQueryOrOptions.cursorDirection);
 }
 
-ExceptionOr<Ref<IDBRequest>> IDBIndex::getAll(RefPtr<IDBKeyRange>&& range, std::optional<uint32_t> count)
+ExceptionOr<Ref<IDBRequest>> IDBIndex::getAll(JSGlobalObject& execState, JSValue queryOrOptions, std::optional<uint32_t> count)
 {
     LOG(IndexedDB, "IDBIndex::getAll");
 
-    return doGetAllShared(IndexedDB::GetAllType::Values, count, [range = WTF::move(range)]() {
-        return ParsedGetAllQueryOrOptions { range };
+    return doGetAllShared(IndexedDB::GetAllType::Values, [context = RefPtr { scriptExecutionContext() }, execState = &execState, queryOrOptions, count]() -> ExceptionOr<ParsedGetAllQueryOrOptions> {
+        return parseQueryOrOptions(*execState, context, queryOrOptions, count);
     });
 }
 
-ExceptionOr<Ref<IDBRequest>> IDBIndex::getAll(JSGlobalObject& execState, JSValue keyOrOptions, std::optional<uint32_t> count)
-{
-    LOG(IndexedDB, "IDBIndex::getAll");
-
-    return doGetAllShared(IndexedDB::GetAllType::Values, count, [context = RefPtr { scriptExecutionContext() }, execState = &execState, keyOrOptions, count]() -> ExceptionOr<ParsedGetAllQueryOrOptions> {
-        if (IDBKeyRange::isPotentiallyValidKeyRange(*execState, keyOrOptions)) {
-            auto onlyResult = IDBKeyRange::only(*execState, keyOrOptions);
-            if (onlyResult.hasException())
-                return onlyResult.releaseException();
-
-            return ParsedGetAllQueryOrOptions { onlyResult.releaseReturnValue(), count };
-        }
-
-        if (!context || !context->settingsValues().indexedDBGetAllRecordsAndGetAllOptionsEnabled)
-            return Exception(ExceptionCode::DataError, "The parameter is not a valid key."_s);
-
-        return parseGetAllOptions(*execState, keyOrOptions);
-    });
-}
-
-ExceptionOr<Ref<IDBRequest>> IDBIndex::getAllKeys(RefPtr<IDBKeyRange>&& range, std::optional<uint32_t> count)
+ExceptionOr<Ref<IDBRequest>> IDBIndex::getAllKeys(JSGlobalObject& execState, JSValue queryOrOptions, std::optional<uint32_t> count)
 {
     LOG(IndexedDB, "IDBIndex::getAllKeys");
 
-    return doGetAllShared(IndexedDB::GetAllType::Keys, count, [range = WTF::move(range)]() {
-        return ParsedGetAllQueryOrOptions { range };
-    });
-}
-
-ExceptionOr<Ref<IDBRequest>> IDBIndex::getAllKeys(JSGlobalObject& execState, JSValue keyOrOptions, std::optional<uint32_t> count)
-{
-    LOG(IndexedDB, "IDBIndex::getAllKeys");
-
-    return doGetAllShared(IndexedDB::GetAllType::Keys, count, [context = RefPtr { scriptExecutionContext() }, execState = &execState, keyOrOptions, count]() -> ExceptionOr<ParsedGetAllQueryOrOptions> {
-        if (IDBKeyRange::isPotentiallyValidKeyRange(*execState, keyOrOptions)) {
-            auto onlyResult = IDBKeyRange::only(*execState, keyOrOptions);
-            if (onlyResult.hasException())
-                return onlyResult.releaseException();
-
-            return ParsedGetAllQueryOrOptions { onlyResult.releaseReturnValue(), count };
-        }
-
-        if (!context || !context->settingsValues().indexedDBGetAllRecordsAndGetAllOptionsEnabled)
-            return Exception(ExceptionCode::DataError, "The parameter is not a valid key."_s);
-
-        return parseGetAllOptions(*execState, keyOrOptions);
+    return doGetAllShared(IndexedDB::GetAllType::Keys, [context = RefPtr { scriptExecutionContext() }, execState = &execState, queryOrOptions, count]() -> ExceptionOr<ParsedGetAllQueryOrOptions> {
+        return parseQueryOrOptions(*execState, context, queryOrOptions, count);
     });
 }
 
@@ -448,20 +404,8 @@ ExceptionOr<Ref<IDBRequest>> IDBIndex::getAllRecords(JSGlobalObject& execState, 
 {
     LOG(IndexedDB, "IDBIndex::getAllRecords");
 
-    return doGetAllShared(IndexedDB::GetAllType::Records, std::nullopt, [execState = &execState, options]() -> ExceptionOr<ParsedGetAllQueryOrOptions> {
-        auto query = options.query;
-
-        if (query.isUndefinedOrNull())
-            return ParsedGetAllQueryOrOptions { nullptr, options.count, options.direction };
-
-        if (RefPtr keyRange = JSIDBKeyRange::toWrapped(execState->vm(), query))
-            return ParsedGetAllQueryOrOptions { WTF::move(keyRange), options.count, options.direction };
-
-        auto onlyResultFromQuery = IDBKeyRange::only(*execState, query);
-        if (onlyResultFromQuery.hasException())
-            return Exception(ExceptionCode::DataError, "The query specified in options is not a valid key."_s);
-
-        return ParsedGetAllQueryOrOptions { onlyResultFromQuery.releaseReturnValue(), options.count, options.direction };
+    return doGetAllShared(IndexedDB::GetAllType::Records, [execState = &execState, options]() -> ExceptionOr<ParsedGetAllQueryOrOptions> {
+        return parseGetAllOptions(*execState, options);
     });
 }
 

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.h
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.h
@@ -73,10 +73,8 @@ public:
     ExceptionOr<Ref<IDBRequest>> getKey(IDBKeyRange*);
     ExceptionOr<Ref<IDBRequest>> getKey(JSC::JSGlobalObject&, JSC::JSValue key);
 
-    ExceptionOr<Ref<IDBRequest>> getAll(RefPtr<IDBKeyRange>&&, std::optional<uint32_t> count);
-    ExceptionOr<Ref<IDBRequest>> getAll(JSC::JSGlobalObject&, JSC::JSValue keyOrOptions, std::optional<uint32_t> count);
-    ExceptionOr<Ref<IDBRequest>> getAllKeys(RefPtr<IDBKeyRange>&&, std::optional<uint32_t> count);
-    ExceptionOr<Ref<IDBRequest>> getAllKeys(JSC::JSGlobalObject&, JSC::JSValue keyOrOptions, std::optional<uint32_t> count);
+    ExceptionOr<Ref<IDBRequest>> getAll(JSC::JSGlobalObject&, JSC::JSValue queryOrOptions, std::optional<uint32_t> count);
+    ExceptionOr<Ref<IDBRequest>> getAllKeys(JSC::JSGlobalObject&, JSC::JSValue queryOrOptions, std::optional<uint32_t> count);
     ExceptionOr<Ref<IDBRequest>> getAllRecords(JSC::JSGlobalObject&, IDBGetAllOptions&&);
 
     const IDBIndexInfo& info() const LIFETIME_BOUND { return m_info; }
@@ -96,9 +94,9 @@ private:
     ExceptionOr<Ref<IDBRequest>> doCount(const IDBKeyRangeData&);
     ExceptionOr<Ref<IDBRequest>> doGet(ExceptionOr<IDBKeyRangeData>);
     ExceptionOr<Ref<IDBRequest>> doGetKey(ExceptionOr<IDBKeyRangeData>);
-    ExceptionOr<Ref<IDBRequest>> doOpenCursor(IDBCursorDirection, Function<ExceptionOr<RefPtr<IDBKeyRange>>()> &&);
-    ExceptionOr<Ref<IDBRequest>> doOpenKeyCursor(IDBCursorDirection, Function<ExceptionOr<RefPtr<IDBKeyRange>>()> &&);
-    ExceptionOr<Ref<IDBRequest>> doGetAllShared(IndexedDB::GetAllType, std::optional<uint32_t> count, Function<ExceptionOr<ParsedGetAllQueryOrOptions>()>&&);
+    ExceptionOr<Ref<IDBRequest>> doOpenCursor(IDBCursorDirection, NOESCAPE Function<ExceptionOr<RefPtr<IDBKeyRange>>()> &&);
+    ExceptionOr<Ref<IDBRequest>> doOpenKeyCursor(IDBCursorDirection, NOESCAPE Function<ExceptionOr<RefPtr<IDBKeyRange>>()> &&);
+    ExceptionOr<Ref<IDBRequest>> doGetAllShared(IndexedDB::GetAllType, NOESCAPE Function<ExceptionOr<ParsedGetAllQueryOrOptions>()>&&);
 
     // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.idl
@@ -47,11 +47,9 @@ typedef (DOMString or sequence<DOMString>) IDBKeyPath;
     [NewObject] IDBRequest getKey(IDBKeyRange? key);
     [NewObject, CallWith=CurrentGlobalObject] IDBRequest getKey(any key);
 
-    [NewObject] IDBRequest getAll(optional IDBKeyRange? range = null, optional [EnforceRange] unsigned long count);
-    [NewObject, CallWith=CurrentGlobalObject] IDBRequest getAll(any keyOrOptions, optional [EnforceRange] unsigned long count);
+    [NewObject, CallWith=CurrentGlobalObject] IDBRequest getAll(optional any queryOrOptions, optional [EnforceRange] unsigned long count);
 
-    [NewObject] IDBRequest getAllKeys(optional IDBKeyRange? range = null, optional [EnforceRange] unsigned long count);
-    [NewObject, CallWith=CurrentGlobalObject] IDBRequest getAllKeys(any keyOrOptions, optional [EnforceRange] unsigned long count);
+    [NewObject, CallWith=CurrentGlobalObject] IDBRequest getAllKeys(optional any queryOrOptions, optional [EnforceRange] unsigned long count);
 
     [NewObject, CallWith=CurrentGlobalObject, EnabledBySetting=IndexedDBGetAllRecordsAndGetAllOptionsEnabled] IDBRequest getAllRecords(optional IDBGetAllOptions options = {});
 

--- a/Source/WebCore/Modules/indexeddb/IDBKeyRange.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyRange.cpp
@@ -67,6 +67,18 @@ IDBKeyRange::IDBKeyRange(RefPtr<IDBKey>&& lower, RefPtr<IDBKey>&& upper, bool is
 
 IDBKeyRange::~IDBKeyRange() = default;
 
+// https://w3c.github.io/IndexedDB/#convert-a-value-to-a-key-range.
+ExceptionOr<Ref<IDBKeyRange>> IDBKeyRange::fromValue(JSC::JSGlobalObject& execState, JSC::JSValue value)
+{
+    if (RefPtr keyRange = JSIDBKeyRange::toWrapped(execState.vm(), value))
+        return { *keyRange };
+
+    if (value.isUndefinedOrNull())
+        return IDBKeyRange::unbounded();
+
+    return IDBKeyRange::only(execState, value);
+}
+
 ExceptionOr<Ref<IDBKeyRange>> IDBKeyRange::only(RefPtr<IDBKey>&& key)
 {
     if (!key || !key->isValid())
@@ -129,6 +141,12 @@ ExceptionOr<Ref<IDBKeyRange>> IDBKeyRange::bound(JSGlobalObject& state, JSValue 
         return Exception { ExceptionCode::DataError };
 
     return create(WTF::move(lower), WTF::move(upper), lowerOpen, upperOpen);
+}
+
+// https://w3c.github.io/IndexedDB/#unbounded-key-range.
+Ref<IDBKeyRange> IDBKeyRange::unbounded()
+{
+    return IDBKeyRange::create(nullptr, nullptr, false, false);
 }
 
 ExceptionOr<bool> IDBKeyRange::includes(JSC::JSGlobalObject& state, JSC::JSValue keyValue)

--- a/Source/WebCore/Modules/indexeddb/IDBKeyRange.h
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyRange.h
@@ -55,6 +55,8 @@ public:
 
     static bool isPotentiallyValidKeyRange(JSC::JSGlobalObject& execState, JSC::JSValue value);
 
+    static ExceptionOr<Ref<IDBKeyRange>> fromValue(JSC::JSGlobalObject&, JSC::JSValue value);
+
     static ExceptionOr<Ref<IDBKeyRange>> only(RefPtr<IDBKey>&& value);
     static ExceptionOr<Ref<IDBKeyRange>> only(JSC::JSGlobalObject&, JSC::JSValue key);
 
@@ -62,6 +64,7 @@ public:
     static ExceptionOr<Ref<IDBKeyRange>> upperBound(JSC::JSGlobalObject&, JSC::JSValue bound, bool open);
 
     static ExceptionOr<Ref<IDBKeyRange>> bound(JSC::JSGlobalObject&, JSC::JSValue lower, JSC::JSValue upper, bool lowerOpen, bool upperOpen);
+    static Ref<IDBKeyRange> unbounded();
 
     ExceptionOr<bool> includes(JSC::JSGlobalObject&, JSC::JSValue key);
 

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
@@ -41,12 +41,10 @@
 #include "IDBRequest.h"
 #include "IDBTransaction.h"
 #include "IndexedDB.h"
-#include "JSIDBKeyRange.h"
 #include "Logging.h"
 #include "Page.h"
 #include "ScriptExecutionContext.h"
 #include "SerializedScriptValue.h"
-#include "Settings.h"
 #include "WebCoreOpaqueRootInlines.h"
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/JSCJSValueInlines.h>
@@ -608,7 +606,7 @@ ExceptionOr<Ref<IDBRequest>> IDBObjectStore::doCount(const IDBKeyRangeData& rang
 }
 
 // https://w3c.github.io/IndexedDB/#create-a-request-to-retrieve-multiple-items
-ExceptionOr<Ref<IDBRequest>> IDBObjectStore::doGetAllShared(IndexedDB::GetAllType getAllType, std::optional<uint32_t> count, NOESCAPE const Function<ExceptionOr<ParsedGetAllQueryOrOptions>()>& function)
+ExceptionOr<Ref<IDBRequest>> IDBObjectStore::doGetAllShared(IndexedDB::GetAllType getAllType, NOESCAPE const Function<ExceptionOr<ParsedGetAllQueryOrOptions>()>& function)
 {
     String callingFunctionExceptionMessagePrefix;
     switch (getAllType) {
@@ -639,67 +637,25 @@ ExceptionOr<Ref<IDBRequest>> IDBObjectStore::doGetAllShared(IndexedDB::GetAllTyp
     }
 
     auto parsedGetAllQueryOrOptions = exceptionOrParsedGetAllQueryOrOptions.releaseReturnValue();
-    if (parsedGetAllQueryOrOptions.count)
-        count = parsedGetAllQueryOrOptions.count;
 
-    return transaction->requestGetAllObjectStoreRecords(*this, parsedGetAllQueryOrOptions.keyRange.get(), getAllType, count, parsedGetAllQueryOrOptions.cursorDirection);
+    return transaction->requestGetAllObjectStoreRecords(*this, parsedGetAllQueryOrOptions.keyRange.get(), getAllType, parsedGetAllQueryOrOptions.count, parsedGetAllQueryOrOptions.cursorDirection);
 }
 
-ExceptionOr<Ref<IDBRequest>> IDBObjectStore::getAll(RefPtr<IDBKeyRange>&& range, std::optional<uint32_t> count)
+ExceptionOr<Ref<IDBRequest>> IDBObjectStore::getAll(JSGlobalObject& execState, JSValue queryOrOptions, std::optional<uint32_t> count)
 {
     LOG(IndexedDB, "IDBObjectStore::getAll");
 
-    return doGetAllShared(IndexedDB::GetAllType::Values, count, [range = WTF::move(range)]() {
-        return ParsedGetAllQueryOrOptions { range };
+    return doGetAllShared(IndexedDB::GetAllType::Values, [context = RefPtr { scriptExecutionContext() }, execState = &execState, queryOrOptions, count]() -> ExceptionOr<ParsedGetAllQueryOrOptions> {
+        return parseQueryOrOptions(*execState, context, queryOrOptions, count);
     });
 }
 
-ExceptionOr<Ref<IDBRequest>> IDBObjectStore::getAll(JSGlobalObject& execState, JSValue keyOrOptions, std::optional<uint32_t> count)
-{
-    LOG(IndexedDB, "IDBObjectStore::getAll");
-
-    return doGetAllShared(IndexedDB::GetAllType::Values, count, [context = RefPtr { scriptExecutionContext() }, execState = &execState, keyOrOptions, count]() -> ExceptionOr<ParsedGetAllQueryOrOptions> {
-        if (IDBKeyRange::isPotentiallyValidKeyRange(*execState, keyOrOptions)) {
-            auto onlyResult = IDBKeyRange::only(*execState, keyOrOptions);
-            if (onlyResult.hasException())
-                return onlyResult.releaseException();
-
-            return ParsedGetAllQueryOrOptions { onlyResult.releaseReturnValue(), count };
-        }
-
-        if (!context || !context->settingsValues().indexedDBGetAllRecordsAndGetAllOptionsEnabled)
-            return Exception(ExceptionCode::DataError, "The parameter is not a valid key."_s);
-
-        return parseGetAllOptions(*execState, keyOrOptions);
-    });
-}
-
-ExceptionOr<Ref<IDBRequest>> IDBObjectStore::getAllKeys(RefPtr<IDBKeyRange>&& range, std::optional<uint32_t> count)
+ExceptionOr<Ref<IDBRequest>> IDBObjectStore::getAllKeys(JSGlobalObject& execState, JSValue queryOrOptions, std::optional<uint32_t> count)
 {
     LOG(IndexedDB, "IDBObjectStore::getAllKeys");
 
-    return doGetAllShared(IndexedDB::GetAllType::Keys, count, [range = WTF::move(range)]() {
-        return ParsedGetAllQueryOrOptions { range };
-    });
-}
-
-ExceptionOr<Ref<IDBRequest>> IDBObjectStore::getAllKeys(JSGlobalObject& execState, JSValue keyOrOptions, std::optional<uint32_t> count)
-{
-    LOG(IndexedDB, "IDBObjectStore::getAllKeys");
-
-    return doGetAllShared(IndexedDB::GetAllType::Keys, count, [context = RefPtr { scriptExecutionContext() }, execState = &execState, keyOrOptions, count]() -> ExceptionOr<ParsedGetAllQueryOrOptions> {
-        if (IDBKeyRange::isPotentiallyValidKeyRange(*execState, keyOrOptions)) {
-            auto onlyResult = IDBKeyRange::only(*execState, keyOrOptions);
-            if (onlyResult.hasException())
-                return onlyResult.releaseException();
-
-            return ParsedGetAllQueryOrOptions { onlyResult.releaseReturnValue(), count };
-        }
-
-        if (!context || !context->settingsValues().indexedDBGetAllRecordsAndGetAllOptionsEnabled)
-            return Exception(ExceptionCode::DataError, "The parameter is not a valid key."_s);
-
-        return parseGetAllOptions(*execState, keyOrOptions);
+    return doGetAllShared(IndexedDB::GetAllType::Keys, [context = RefPtr { scriptExecutionContext() }, execState = &execState, queryOrOptions, count]() -> ExceptionOr<ParsedGetAllQueryOrOptions> {
+        return parseQueryOrOptions(*execState, context, queryOrOptions, count);
     });
 }
 
@@ -707,20 +663,8 @@ ExceptionOr<Ref<IDBRequest>> IDBObjectStore::getAllRecords(JSGlobalObject& execS
 {
     LOG(IndexedDB, "IDBObjectStore::getAllRecords");
 
-    return doGetAllShared(IndexedDB::GetAllType::Records, std::nullopt, [execState = &execState, options]() -> ExceptionOr<ParsedGetAllQueryOrOptions> {
-        auto query = options.query;
-
-        if (query.isUndefinedOrNull())
-            return ParsedGetAllQueryOrOptions { nullptr, options.count, options.direction };
-
-        if (RefPtr keyRange = JSIDBKeyRange::toWrapped(execState->vm(), query))
-            return ParsedGetAllQueryOrOptions { WTF::move(keyRange), options.count, options.direction };
-
-        auto onlyResultFromQuery = IDBKeyRange::only(*execState, query);
-        if (onlyResultFromQuery.hasException())
-            return Exception(ExceptionCode::DataError, "The query specified in options is not a valid key."_s);
-
-        return ParsedGetAllQueryOrOptions { onlyResultFromQuery.releaseReturnValue(), options.count, options.direction };
+    return doGetAllShared(IndexedDB::GetAllType::Records, [execState = &execState, options]() -> ExceptionOr<ParsedGetAllQueryOrOptions> {
+        return parseGetAllOptions(*execState, options);
     });
 }
 

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
@@ -102,11 +102,8 @@ public:
     ExceptionOr<void> deleteIndex(const String& name);
     ExceptionOr<Ref<IDBRequest>> count(IDBKeyRange*);
     ExceptionOr<Ref<IDBRequest>> count(JSC::JSGlobalObject&, JSC::JSValue key);
-    ExceptionOr<Ref<IDBRequest>> getAll(RefPtr<IDBKeyRange>&&, std::optional<uint32_t> count);
-    ExceptionOr<Ref<IDBRequest>> getAll(JSC::JSGlobalObject&, JSC::JSValue keyOrOptions, std::optional<uint32_t> count);
-    ExceptionOr<Ref<IDBRequest>> getAllKeys(RefPtr<IDBKeyRange>&&, std::optional<uint32_t> count);
-    ExceptionOr<Ref<IDBRequest>> getAllKeys(JSC::JSGlobalObject&, JSC::JSValue keyOrOptions, std::optional<uint32_t> count);
-
+    ExceptionOr<Ref<IDBRequest>> getAll(JSC::JSGlobalObject&, JSC::JSValue queryOrOptions, std::optional<uint32_t> count);
+    ExceptionOr<Ref<IDBRequest>> getAllKeys(JSC::JSGlobalObject&, JSC::JSValue queryOrOptions, std::optional<uint32_t> count);
     ExceptionOr<Ref<IDBRequest>> getAllRecords(JSC::JSGlobalObject&, IDBGetAllOptions&&);
 
     ExceptionOr<Ref<IDBRequest>> putForCursorUpdate(JSC::JSGlobalObject&, JSC::JSValue, RefPtr<IDBKey>&&, RefPtr<SerializedScriptValue>&&);
@@ -134,7 +131,7 @@ private:
     ExceptionOr<Ref<IDBRequest>> doDelete(NOESCAPE const Function<ExceptionOr<RefPtr<IDBKeyRange>>()>&);
     ExceptionOr<Ref<IDBRequest>> doOpenCursor(IDBCursorDirection, NOESCAPE const Function<ExceptionOr<RefPtr<IDBKeyRange>>()>&);
     ExceptionOr<Ref<IDBRequest>> doOpenKeyCursor(IDBCursorDirection, NOESCAPE const Function<ExceptionOr<RefPtr<IDBKeyRange>>()>&);
-    ExceptionOr<Ref<IDBRequest>> doGetAllShared(IndexedDB::GetAllType, std::optional<uint32_t> count, NOESCAPE const Function<ExceptionOr<ParsedGetAllQueryOrOptions>()>&);
+    ExceptionOr<Ref<IDBRequest>> doGetAllShared(IndexedDB::GetAllType, NOESCAPE const Function<ExceptionOr<ParsedGetAllQueryOrOptions>()>&);
 
     // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.idl
@@ -55,11 +55,9 @@ typedef (DOMString or sequence<DOMString>) IDBKeyPath;
     [NewObject] IDBRequest getKey(IDBKeyRange? key);
     [NewObject, CallWith=CurrentGlobalObject] IDBRequest getKey(any key);
 
-    [NewObject] IDBRequest getAll(optional IDBKeyRange? range = null, optional [EnforceRange] unsigned long count);
-    [NewObject, CallWith=CurrentGlobalObject] IDBRequest getAll(any keyOrOptions, optional [EnforceRange] unsigned long count);
+    [NewObject, CallWith=CurrentGlobalObject] IDBRequest getAll(optional any queryOrOptions, optional [EnforceRange] unsigned long count);
 
-    [NewObject] IDBRequest getAllKeys(optional IDBKeyRange? range = null, optional [EnforceRange] unsigned long count);
-    [NewObject, CallWith=CurrentGlobalObject] IDBRequest getAllKeys(any keyOrOptions, optional [EnforceRange] unsigned long count);
+    [NewObject, CallWith=CurrentGlobalObject] IDBRequest getAllKeys(optional any queryOrOptions, optional [EnforceRange] unsigned long count);
 
     [NewObject, CallWith=CurrentGlobalObject, EnabledBySetting=IndexedDBGetAllRecordsAndGetAllOptionsEnabled] IDBRequest getAllRecords(optional IDBGetAllOptions options = {});
 


### PR DESCRIPTION
#### 3adac8a5320e8d4ebf7b0ca230da312fa1b08236
<pre>
[IndexedDB API] Consolidate the parsing logic in getAll* functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=311455">https://bugs.webkit.org/show_bug.cgi?id=311455</a>
<a href="https://rdar.apple.com/174054869">rdar://174054869</a>

Reviewed by Sihui Liu.

The functions getAll() / getAllKeys() / getAllRecords() all follow these steps:
<a href="https://w3c.github.io/IndexedDB/#create-a-request-to-retrieve-multiple-items.">https://w3c.github.io/IndexedDB/#create-a-request-to-retrieve-multiple-items.</a>

The inputs to getAll() and getAllKeys() are JSValues that can be many different
things: undefined, IDBKey, IDBKeyRange, or IDBGetAllOptions. To parse their
input, they use steps 8 and 9 of the above algorithm.

The input to getAllRecords() may only be IDBGetAllOptions. So this uses only
step 9 of the algorithm.

The current implementation scatters and duplicates the implementations of these
two steps:

1. Both steps run <a href="https://w3c.github.io/IndexedDB/#convert-a-value-to-a-key-range.">https://w3c.github.io/IndexedDB/#convert-a-value-to-a-key-range.</a>
   But there is no central implementation that they both call.

   getAll() / getAllKeys implement this by having two different overloads so the
   bindings code can do part of the algorithm. But they must still do the rest.
   getAllRecords() implements the whole algorithm.

2. The implementations of all three functions in their scattered forms are all
   duplicated in IDBIndex and IDBObjectStore.

To fix this, we:

1. Introduce a single implementation of
   <a href="https://w3c.github.io/IndexedDB/#convert-a-value-to-a-key-range.">https://w3c.github.io/IndexedDB/#convert-a-value-to-a-key-range.</a>

   Implemented in IDBKeyRange::fromValue().

2. Formalize the concept of an unbounded key range. Up to now, we have been relying
   on the fact that a IDBKeyRangeData created from a nullptr IDBKeyRange is basically
   an unbounded key range. This is error prone.

   Implemented in IDBKeyRange::unbounded().

3. Use IDBKeyRange::fromValue() in Step 9 of the algorithm (parsing IDBGetAllOptions)

   Implemented in parseGetAllOptions().

4. Encapsulate Steps 8 and 9 -- parsing a queryOrOptions (which can be any of the
   mulitple input types noted above) into one function by using the above functions.

   Implemented in parseQueryOrOptions().

5. Consolidate getAll() and getAllKeys() to each use a single function instead of two
   overloads by calling parseQueryOrOptions(). This is done in both IDBIndex and
   IDBObjectStore.

6. Simplify getAllRecords() to just calling parseGetAllOptions(). This is done in both
   IDBIndex and IDBObjectStore.

There is no behavior change. This is covered by existing tests.

* Source/WebCore/Modules/indexeddb/IDBGetAllOptions.cpp:
(WebCore::parseQueryOrOptions):
(WebCore::parseGetAllOptions):
* Source/WebCore/Modules/indexeddb/IDBGetAllOptions.h:
* Source/WebCore/Modules/indexeddb/IDBIndex.cpp:
(WebCore::IDBIndex::doGetAllShared):
(WebCore::IDBIndex::getAll):
(WebCore::IDBIndex::getAllKeys):
(WebCore::IDBIndex::getAllRecords):
* Source/WebCore/Modules/indexeddb/IDBIndex.h:
* Source/WebCore/Modules/indexeddb/IDBIndex.idl:
* Source/WebCore/Modules/indexeddb/IDBKeyRange.cpp:
(WebCore::IDBKeyRange::fromValue):
(WebCore::IDBKeyRange::unbounded):
* Source/WebCore/Modules/indexeddb/IDBKeyRange.h:
* Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp:
(WebCore::IDBObjectStore::doGetAllShared):
(WebCore::IDBObjectStore::getAll):
(WebCore::IDBObjectStore::getAllKeys):
(WebCore::IDBObjectStore::getAllRecords):
* Source/WebCore/Modules/indexeddb/IDBObjectStore.h:
* Source/WebCore/Modules/indexeddb/IDBObjectStore.idl:

Canonical link: <a href="https://commits.webkit.org/310848@main">https://commits.webkit.org/310848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7fbdcbe57de801a349e08c8b6493379800bb786

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155044 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21463 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163804 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108515 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28443 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119953 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84767 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/08216512-a1c2-4f41-b1a8-0cc7612bd44f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158003 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22217 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139234 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100646 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21302 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19339 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11630 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130964 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166280 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9982 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18686 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128054 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27848 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23378 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128192 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27772 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138870 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84481 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23650 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23070 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15665 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27464 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91568 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27043 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27273 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27115 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->