### PR TITLE
[Scroll anchoring] learn.umgc.edu: scrolls to the bottom/top automatically

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/suppress-for-top-change-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/suppress-for-top-change-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Changing `top` on a positioned anchor should not trigger anchoring
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/suppress-for-top-change.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/suppress-for-top-change.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+#anchor {
+    position: absolute;
+    background-color: green;
+    top: 100px;
+    width: 120px;
+    height: 120px;
+}
+
+.filler {
+  height: 2000px;
+}
+
+body.done .filler {
+  display: none;
+}
+</style>
+<div id="anchor"></div>
+<div class="filler"></div>
+<script>
+const anchor = document.getElementById('anchor');
+
+test(() => {
+  document.scrollingElement.scrollTop = 120;
+
+  anchor.style.top = "160px";
+
+  const expectedTop = 120;
+  assert_equals(document.scrollingElement.scrollTop, expectedTop);
+
+  document.body.classList.add('done');
+}, "Changing `top` on a positioned anchor should not trigger anchoring");
+
+</script>

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1132,7 +1132,25 @@ void RenderElement::styleDidChange(Style::Difference diff, const RenderStyle* ol
         issueRepaintForOutlineAuto(hasOutlineAuto ? outlineStyleForRepaint().usedOutlineSize() : oldStyle->usedOutlineSize());
     }
 
-    if (settings().cssScrollAnchoringEnabled() && (diff >= Style::DifferenceResult::Layout) && style().scrollAnchoringSuppressionStyleDidChange(oldStyle)) {
+    auto isLayoutDiff = [](Style::DifferenceResult diff) {
+        switch (diff) {
+        case Style::DifferenceResult::Equal:
+        case Style::DifferenceResult::RecompositeLayer:
+        case Style::DifferenceResult::Repaint:
+        case Style::DifferenceResult::RepaintIfText:
+        case Style::DifferenceResult::RepaintLayer:
+        case Style::DifferenceResult::Overflow:
+        case Style::DifferenceResult::NewStyle:
+            return false;
+        case Style::DifferenceResult::LayoutOutOfFlowMovementOnly:
+        case Style::DifferenceResult::OverflowAndOutOfFlowMovement:
+        case Style::DifferenceResult::Layout:
+            return true;
+        }
+        return false;
+    };
+
+    if (settings().cssScrollAnchoringEnabled() && isLayoutDiff(diff.result) && style().scrollAnchoringSuppressionStyleDidChange(oldStyle)) {
         auto findNearestScrollAnchoringController = [](const RenderElement& renderer) -> CheckedPtr<ScrollAnchoringController> {
             // At this point we can't find the appropriate enclosing ScrollAnchoringController, because we haven't done layout.
             // We will, however, have created a ScrollAnchoringController for potentially scrollable ancestors, so store


### PR DESCRIPTION
#### 048234caf02d206285ea0e6f3aebeb9544128276
<pre>
[Scroll anchoring] learn.umgc.edu: scrolls to the bottom/top automatically
<a href="https://bugs.webkit.org/show_bug.cgi?id=311456">https://bugs.webkit.org/show_bug.cgi?id=311456</a>
<a href="https://rdar.apple.com/173885027">rdar://173885027</a>

Reviewed by Abrar Rahman Protyasha.

This page scrolls uncontrollably because there&apos;s a sidebar item whose `top`
is set from script based on scroll position. This should not act as an anchor,
because changing `top` should suppress anchoring.

However, the code was only suppressing anchoring when the `Style::Difference`
was `&gt; Layout`, but this is a `LayoutOutOfFlowMovementOnly` because the anchor
is positioned, so test against the diff types that can result from changes in
the suppression properties[1].

[1] <a href="https://drafts.csswg.org/css-scroll-anchoring/#suppression-triggers">https://drafts.csswg.org/css-scroll-anchoring/#suppression-triggers</a>

Test: imported/w3c/web-platform-tests/css/css-scroll-anchoring/suppress-for-top-change.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/suppress-for-top-change-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/suppress-for-top-change.html: Added.
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::styleDidChange):

Canonical link: <a href="https://commits.webkit.org/310574@main">https://commits.webkit.org/310574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d8254610288893f7d2bb468d69aa7672b54484b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154200 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162954 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107668 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156073 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27590 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119258 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84308 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138482 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99954 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20607 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18606 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10786 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165426 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8635 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17936 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127353 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27004 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127498 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34601 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26928 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138120 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83521 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22387 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14912 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26618 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90721 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26199 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26430 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26271 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->