### PR TITLE
[css-anchor-position-1] First child precedes second child if first child is ancestor of second child

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-008-expected.txt
@@ -1,0 +1,3 @@
+
+PASS .target 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-008.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-008.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+
+<link rel="help" href="https://drafts.csswg.org/css-anchor-1/#target">
+<link rel="author" title="Kiet Ho" mailto="mailto:kiet.ho@apple.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<script src="support/test-common.js"></script>
+
+<style>
+  body { margin: 0px; }
+
+  .containing-block {
+    position: fixed;
+    width: 200px;
+    height: 200px;
+  }
+
+  #anchor {
+    left: 100px;
+    width: 100px;
+    height: 100px;
+    background-color: magenta;
+    anchor-name: --anchor;
+    position: absolute;
+  }
+
+  #anchored {
+    width: 100px;
+    height: 100px;
+    background-color: green;
+    position: fixed;
+    left: anchor(--anchor left);
+    top: anchor(--anchor bottom);
+  }
+</style>
+
+<body onload="checkLayoutForAnchorPos('.target')">
+  <div class="containing-block">
+    <div id="anchor"></div>
+    <div id="anchored" class="target" data-offset-x="100" data-offset-y="100"></div>
+  </div>
+</body>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3024,6 +3024,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/RenderTextLineBoxes.h
     rendering/RenderTheme.h
     rendering/RenderTreeAsText.h
+    rendering/RenderTreeOrder.h
     rendering/RenderVideo.h
     rendering/RenderVideoInlines.h
     rendering/RenderView.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2985,6 +2985,7 @@ rendering/RenderTextFragment.cpp
 rendering/RenderTextLineBoxes.cpp
 rendering/RenderTheme.cpp
 rendering/RenderTreeAsText.cpp
+rendering/RenderTreeOrder.cpp
 rendering/RenderTreeMutationDisallowedScope.cpp
 rendering/RenderVTTCue.cpp
 rendering/RenderVideo.cpp

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1475,6 +1475,8 @@ inline CachedImageClient& RenderObject::cachedImageClient() const
     return *m_cachedImageClient.get();
 }
 
+std::partial_ordering renderTreeOrder(const RenderObject&, const RenderObject&);
+
 WTF::TextStream& operator<<(WTF::TextStream&, const RenderObject&);
 WTF::TextStream& operator<<(WTF::TextStream&, const RenderObject::RepaintRects&);
 

--- a/Source/WebCore/rendering/RenderTreeOrder.cpp
+++ b/Source/WebCore/rendering/RenderTreeOrder.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RenderTreeOrder.h"
+
+#include "RenderElement.h"
+#include "RenderObject.h"
+
+namespace WebCore {
+
+static size_t renderTreeDepth(const RenderObject& renderer)
+{
+    size_t depth = 0;
+    CheckedPtr ancestor = &renderer;
+    while ((ancestor = ancestor->parent()))
+        ++depth;
+    return depth;
+}
+
+struct AncestorAndChildren {
+    const CheckedPtr<const RenderObject> commonAncestor;
+    const CheckedPtr<const RenderObject> distinctAncestorA;
+    const CheckedPtr<const RenderObject> distinctAncestorB;
+};
+
+static AncestorAndChildren commonInclusiveAncestorAndChildren(const RenderObject& a, const RenderObject& b)
+{
+    // This check isn't needed for correctness, but it is cheap and likely to be
+    // common enough to be worth optimizing so we don't have to walk to the root.
+    if (&a == &b)
+        return { &a, nullptr, nullptr };
+
+    auto [depthA, depthB] = std::make_tuple(renderTreeDepth(a), renderTreeDepth(b));
+    auto [x, y, difference] = depthA >= depthB
+    ? std::make_tuple(CheckedPtr<const RenderObject> { a }, CheckedPtr<const RenderObject> { b }, depthA - depthB)
+    : std::make_tuple(CheckedPtr<const RenderObject> { b }, CheckedPtr<const RenderObject> { a }, depthB - depthA);
+
+    CheckedPtr<const RenderObject> distinctAncestorA = nullptr;
+    for (decltype(difference) i = 0; i < difference; ++i) {
+        distinctAncestorA = x;
+        x = x->parent();
+    }
+
+    CheckedPtr<const RenderObject>  distinctAncestorB = nullptr;
+    while (x != y) {
+        distinctAncestorA = x;
+        distinctAncestorB = y;
+        x = x->parent();
+        y = y->parent();
+    }
+
+    if (depthA < depthB)
+        std::swap(distinctAncestorA, distinctAncestorB);
+
+    return { x, distinctAncestorA, distinctAncestorB };
+}
+
+static bool isSiblingSubsequent(const RenderObject& a, const RenderObject& b)
+{
+    ASSERT(a.parent());
+    ASSERT(a.parent() == b.parent());
+    ASSERT(&a != &b);
+
+    for (CheckedPtr sibling = &a; sibling; sibling = sibling->nextSibling()) {
+        if (sibling == &b)
+            return true;
+    }
+
+    return false;
+}
+
+std::partial_ordering renderTreeOrder(const RenderObject& a, const RenderObject& b)
+{
+    if (&a == &b)
+        return std::partial_ordering::equivalent;
+    auto result = commonInclusiveAncestorAndChildren(a, b);
+    if (!result.commonAncestor)
+        return std::partial_ordering::unordered;
+    if (!result.distinctAncestorA)
+        return std::partial_ordering::less;
+    if (!result.distinctAncestorB)
+        return std::partial_ordering::greater;
+    return isSiblingSubsequent(*result.distinctAncestorA, *result.distinctAncestorB) ? std::partial_ordering::less : std::partial_ordering::greater;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/RenderTreeOrder.h
+++ b/Source/WebCore/rendering/RenderTreeOrder.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <compare>
+
+namespace WebCore {
+
+class RenderObject;
+
+std::partial_ordering renderTreeOrder(const RenderObject&, const RenderObject&);
+
+} // namespace WebCore

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1055,29 +1055,6 @@ static const RenderElement* penultimateContainingBlockChainElement(const RenderE
     return nullptr;
 }
 
-static bool firstChildPrecedesSecondChild(const RenderObject* firstChild, const RenderObject* secondChild, const RenderObject* containingBlock)
-{
-    HashSet<CheckedRef<const RenderObject>> firstAncestorChain;
-
-    for (auto* first = firstChild; first; first = first->parent()) {
-        firstAncestorChain.add(*first);
-        if (first == containingBlock)
-            break;
-    }
-
-    auto* second = secondChild;
-    for (; second != containingBlock; second = second->parent()) {
-        if (firstAncestorChain.contains(second->parent())) {
-            for (auto* sibling = second->previousSibling(); sibling; sibling = sibling->previousSibling()) {
-                if (firstAncestorChain.contains(sibling))
-                    return true;
-            }
-            return false;
-        }
-    }
-    return false;
-}
-
 // Given an element and its anchor name, locate the closest ancestor (*) element
 // that establishes an anchor scope affecting this anchor name, and return the pointer
 // to such element. If no ancestor establishes an anchor scope affecting this name,
@@ -1173,9 +1150,6 @@ static bool isAcceptableAnchorElement(const RenderBoxModelObject& anchorRenderer
             return false;
     }
 
-    CheckedPtr containingBlock = anchorPositionedRenderer->container();
-    ASSERT(containingBlock);
-
     // "possible anchor is laid out strictly before positioned el, aka one of the following is true:"
     auto topLayerStatus = computeTopLayerStatus(*anchorPositionedRenderer, anchorRenderer);
     switch (topLayerStatus) {
@@ -1184,6 +1158,9 @@ static bool isAcceptableAnchorElement(const RenderBoxModelObject& anchorRenderer
         return true;
     case TopLayerStatus::Same: {
         // "- Both elements are in the same top layer..."
+        CheckedPtr containingBlock = anchorPositionedRenderer->container();
+        ASSERT(containingBlock);
+
         auto* penultimateElement = penultimateContainingBlockChainElement(anchorRenderer, containingBlock.get());
         if (!penultimateElement)
             return false;
@@ -1191,7 +1168,7 @@ static bool isAcceptableAnchorElement(const RenderBoxModelObject& anchorRenderer
         if (!penultimateElement->isOutOfFlowPositioned())
             return true;
 
-        return firstChildPrecedesSecondChild(penultimateElement, anchorPositionedRenderer.get(), containingBlock.get());
+        return is_lt(renderTreeOrder(*penultimateElement, *anchorPositionedRenderer));
     }
     case TopLayerStatus::Lower:
         return false;


### PR DESCRIPTION
#### e63d3f7077b5e0cbcb98c9ffb51a3c80cd9f542b
<pre>
[css-anchor-position-1] First child precedes second child if first child is ancestor of second child
<a href="https://rdar.apple.com/162903640">rdar://162903640</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=301023">https://bugs.webkit.org/show_bug.cgi?id=301023</a>

Reviewed by Antti Koivisto.

firstChildPrecedesSecondChild (in AnchorPositionEvaluator.cpp) checks if one
RenderObject is before (in pre-order traversal) another RenderObject in the
render tree. It&apos;s possible to construct a render tree such that the method
is wrong:

  A
 / \
B   C

When comparing the order of A and C, the method will say A is after C, which is
wrong, as A is visited before C.

This patch fixes this by adapting the existing treeOrder method to work
with the render tree (called renderTreeOrder), then use renderTreeOrder to
compute the ordering instead of firstChildPrecedesSecondChild.

Test: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-008.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-008-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-008.html: Added.
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/RenderTreeOrder.cpp: Added.
(WebCore::renderTreeDepth):
(WebCore::commonInclusiveAncestorAndChildren):
(WebCore::isSiblingSubsequent):
(WebCore::renderTreeOrder):
* Source/WebCore/rendering/RenderTreeOrder.h: Added.
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::firstChildPrecedesSecondChild): Deleted.

Canonical link: <a href="https://commits.webkit.org/310970@main">https://commits.webkit.org/310970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ce6f6a76930c858cca4f6c4bf4d5823e8ac3d44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164217 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/08874717-7168-4686-a294-f0d37c67c186) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120310 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/33800c3a-c050-41fe-ba2e-0ea813200c6c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158414 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22506 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139604 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101000 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7fea1254-20c9-464c-992a-8fc95131ef9b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21592 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19697 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12047 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131261 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17436 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166695 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10872 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19046 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128421 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28259 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23731 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128557 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34884 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28183 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139229 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85620 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23396 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16026 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27877 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91980 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27454 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27684 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27527 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->