### PR TITLE
[JSC] Eagerly build AST for likely IIFEs

### DIFF
--- a/JSTests/stress/eager-iife-column-tracking.js
+++ b/JSTests/stress/eager-iife-column-tracking.js
@@ -1,0 +1,37 @@
+//@ requireOptions("--useEagerIIFEParsing=true")
+
+// Column numbers inside eagerly parsed IIFEs must be tracked correctly. That is not a given
+// because on the eager parsing path the start offset is absolute and not relative to the
+// enclosing function start as it is during the normal lazy parse.
+
+function assert(condition, message) {
+    if (!condition)
+        throw new Error(message);
+}
+
+function getFirstFrameColumn(e) {
+    var line = e.stack.split('\n')[0];
+    var match = line.match(/:(\d+)$/);
+    assert(match, "Could not parse column from stack frame: " + line);
+    return parseInt(match[1]);
+}
+
+// Case 1: same-line nested function in IIFE.
+try { (function() { (function() { throw new Error(); })(); })(); } catch(e) { assert(getFirstFrameColumn(e) === 50, "Case 1: expected column 50, got " + getFirstFrameColumn(e)); }
+
+// Case 2: multi-line — nested function on a different line than IIFE's '('.
+try {
+    (function() {
+        (function() { throw new Error(); })();
+    })();
+} catch(e) { assert(getFirstFrameColumn(e) === 38, "Case 2: expected column 38, got " + getFirstFrameColumn(e)); }
+
+// Case 3: deeper nesting — IIFE inside IIFE, same line.
+try { (function() { (function() { (function() { throw new Error(); })(); })(); })(); } catch(e) { assert(getFirstFrameColumn(e) === 64, "Case 3: expected column 64, got " + getFirstFrameColumn(e)); }
+
+// Case 4: multi-line, inner function offset within the line.
+try {
+    (function() {
+        var x = 1; (function() { throw new Error(); })();
+    })();
+} catch(e) { assert(getFirstFrameColumn(e) === 49, "Case 4: expected column 49, got " + getFirstFrameColumn(e)); }

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -809,6 +809,7 @@
 		234E91BF2EE2571E000BAE2C /* JSWebAssemblySuspendError.h in Headers */ = {isa = PBXBuildFile; fileRef = 234E91BD2EE2571E000BAE2C /* JSWebAssemblySuspendError.h */; };
 		234E91C52EE25777000BAE2C /* WebAssemblySuspendErrorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 234E91C32EE25777000BAE2C /* WebAssemblySuspendErrorPrototype.h */; };
 		234E91C62EE25777000BAE2C /* WebAssemblySuspendErrorConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 234E91C12EE25777000BAE2C /* WebAssemblySuspendErrorConstructor.h */; };
+		235A9D742F983D1600A1E8FE /* EagerIIFERegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 235A9D722F983D0100A1E8FE /* EagerIIFERegistry.h */; };
 		237C93DD2E95A87900F62455 /* WebAssemblySuspendingConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 237C93D92E95A85F00F62455 /* WebAssemblySuspendingConstructor.h */; };
 		237C93DE2E95A89A00F62455 /* WebAssemblySuspendingPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 237C93DB2E95A85F00F62455 /* WebAssemblySuspendingPrototype.h */; };
 		23863EEB2E5EC93E00E57879 /* WebAssemblyBuiltinTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = 23863EEA2E5EC92900E57879 /* WebAssemblyBuiltinTrampoline.h */; };
@@ -4033,6 +4034,8 @@
 		234E91C22EE25777000BAE2C /* WebAssemblySuspendErrorConstructor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblySuspendErrorConstructor.cpp; path = js/WebAssemblySuspendErrorConstructor.cpp; sourceTree = "<group>"; };
 		234E91C32EE25777000BAE2C /* WebAssemblySuspendErrorPrototype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblySuspendErrorPrototype.h; path = js/WebAssemblySuspendErrorPrototype.h; sourceTree = "<group>"; };
 		234E91C42EE25777000BAE2C /* WebAssemblySuspendErrorPrototype.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblySuspendErrorPrototype.cpp; path = js/WebAssemblySuspendErrorPrototype.cpp; sourceTree = "<group>"; };
+		235A9D722F983D0100A1E8FE /* EagerIIFERegistry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EagerIIFERegistry.h; sourceTree = "<group>"; };
+		235A9D732F983D0100A1E8FE /* EagerIIFERegistry.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EagerIIFERegistry.cpp; sourceTree = "<group>"; };
 		237C93D92E95A85F00F62455 /* WebAssemblySuspendingConstructor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblySuspendingConstructor.h; path = js/WebAssemblySuspendingConstructor.h; sourceTree = "<group>"; };
 		237C93DA2E95A85F00F62455 /* WebAssemblySuspendingConstructor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblySuspendingConstructor.cpp; path = js/WebAssemblySuspendingConstructor.cpp; sourceTree = "<group>"; };
 		237C93DB2E95A85F00F62455 /* WebAssemblySuspendingPrototype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblySuspendingPrototype.h; path = js/WebAssemblySuspendingPrototype.h; sourceTree = "<group>"; };
@@ -8407,6 +8410,8 @@
 			isa = PBXGroup;
 			children = (
 				A7A7EE7411B98B8D0065A14F /* ASTBuilder.h */,
+				235A9D732F983D0100A1E8FE /* EagerIIFERegistry.cpp */,
+				235A9D722F983D0100A1E8FE /* EagerIIFERegistry.h */,
 				93F1981A08245AAE001E9ABC /* Keywords.table */,
 				F692A8650255597D01FF60F7 /* Lexer.cpp */,
 				F692A8660255597D01FF60F7 /* Lexer.h */,
@@ -11513,6 +11518,7 @@
 				E35CA1541DBC3A5C00F83516 /* DOMJITHeapRange.h in Headers */,
 				E350708A1DC49BBF0089BCD6 /* DOMJITSignature.h in Headers */,
 				A70447EE17A0BD7000F5898E /* DumpContext.h in Headers */,
+				235A9D742F983D1600A1E8FE /* EagerIIFERegistry.h in Headers */,
 				145FF2C8243BB9D600569E71 /* ECMAMode.h in Headers */,
 				2A83638618D7D0EE0000EBCC /* EdenGCActivityCallback.h in Headers */,
 				1AB2A6FB9608AD5DF73332D4 /* EmbedderArrayLike.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -713,6 +713,7 @@ llint/LLIntExceptions.cpp
 llint/LLIntSlowPaths.cpp
 llint/LLIntThunks.cpp
 
+parser/EagerIIFERegistry.cpp
 parser/Lexer.cpp
 parser/LexerUnicodeProperties.cpp
 parser/ModuleAnalyzer.cpp

--- a/Source/JavaScriptCore/parser/ASTBuilder.h
+++ b/Source/JavaScriptCore/parser/ASTBuilder.h
@@ -79,9 +79,9 @@ class ASTBuilder {
         Operator m_op;
     };
 public:
-    ASTBuilder(VM& vm, ParserArena& parserArena, SourceCode* sourceCode)
+    ASTBuilder(VM& vm, Ref<ParserArena>&& parserArena, SourceCode* sourceCode)
         : m_vm(vm)
-        , m_parserArena(parserArena)
+        , m_parserArena(WTF::move(parserArena))
         , m_sourceCode(sourceCode)
         , m_evalCount(0)
     {
@@ -134,7 +134,7 @@ public:
     ExpressionNode* makeStaticBlockFunctionCallNode(const JSTokenLocation&, ExpressionNode* func, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd);
     ExpressionNode* makeFunctionCallNode(const JSTokenLocation&, ExpressionNode* func, bool previousBaseWasSuper, ArgumentsNode* args, const JSTextPosition& divotStart, const JSTextPosition& divot, const JSTextPosition& divotEnd, size_t callOrApplyChildDepth, bool isOptionalCall);
 
-    JSC::SourceElements* createSourceElements() { return new (m_parserArena) JSC::SourceElements(); }
+    JSC::SourceElements* createSourceElements() { return new (m_parserArena.get()) JSC::SourceElements(); }
 
     int features() const { return m_scope.m_features; }
     int numConstants() const { return m_scope.m_numConstants; }
@@ -165,35 +165,35 @@ public:
         if (expr->isNumber())
             return createBoolean(location, isZeroOrUnordered(static_cast<NumberNode*>(expr)->value()));
 
-        return new (m_parserArena) LogicalNotNode(location, expr);
+        return new (m_parserArena.get()) LogicalNotNode(location, expr);
     }
-    ExpressionNode* createUnaryPlus(const JSTokenLocation& location, ExpressionNode* expr) { return new (m_parserArena) UnaryPlusNode(location, expr); }
+    ExpressionNode* createUnaryPlus(const JSTokenLocation& location, ExpressionNode* expr) { return new (m_parserArena.get()) UnaryPlusNode(location, expr); }
     ExpressionNode* createVoid(const JSTokenLocation& location, ExpressionNode* expr)
     {
         incConstants();
-        return new (m_parserArena) VoidNode(location, expr);
+        return new (m_parserArena.get()) VoidNode(location, expr);
     }
     ExpressionNode* createThisExpr(const JSTokenLocation& location)
     {
         usesThis();
-        return new (m_parserArena) ThisNode(location);
+        return new (m_parserArena.get()) ThisNode(location);
     }
     ExpressionNode* createSuperExpr(const JSTokenLocation& location)
     {
-        return new (m_parserArena) SuperNode(location);
+        return new (m_parserArena.get()) SuperNode(location);
     }
     ExpressionNode* createImportExpr(const JSTokenLocation& location, ExpressionNode* expr, ExpressionNode* option, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end)
     {
-        auto* node = new (m_parserArena) ImportNode(location, expr, option);
+        auto* node = new (m_parserArena.get()) ImportNode(location, expr, option);
         setExceptionLocation(node, start, divot, end);
         return node;
     }
     ExpressionNode* createNewTargetExpr(const JSTokenLocation location)
     {
         usesNewTarget();
-        return new (m_parserArena) NewTargetNode(location);
+        return new (m_parserArena.get()) NewTargetNode(location);
     }
-    ExpressionNode* createImportMetaExpr(const JSTokenLocation& location, ExpressionNode* expr) { return new (m_parserArena) ImportMetaNode(location, expr); }
+    ExpressionNode* createImportMetaExpr(const JSTokenLocation& location, ExpressionNode* expr) { return new (m_parserArena.get()) ImportMetaNode(location, expr); }
     bool isMetaProperty(ExpressionNode* node) { return node->isMetaProperty(); }
     bool isNewTarget(ExpressionNode* node) { return node->isNewTarget(); }
     bool isImportMeta(ExpressionNode* node) { return node->isImportMeta(); }
@@ -205,66 +205,66 @@ public:
         if (ident.isSymbol()) {
             auto entry = m_vm.bytecodeIntrinsicRegistry().lookup(ident);
             if (entry)
-                return new (m_parserArena) BytecodeIntrinsicNode(BytecodeIntrinsicNode::Type::Constant, location, entry.value(), ident, nullptr, start, start, end);
+                return new (m_parserArena.get()) BytecodeIntrinsicNode(BytecodeIntrinsicNode::Type::Constant, location, entry.value(), ident, nullptr, start, start, end);
         }
 
-        return new (m_parserArena) ResolveNode(location, ident, start);
+        return new (m_parserArena.get()) ResolveNode(location, ident, start);
     }
     ExpressionNode* createPrivateIdentifierNode(const JSTokenLocation& location, const Identifier& ident)
     {
-        return new (m_parserArena) PrivateIdentifierNode(location, ident);
+        return new (m_parserArena.get()) PrivateIdentifierNode(location, ident);
     }
-    ExpressionNode* createObjectLiteral(const JSTokenLocation& location) { return new (m_parserArena) ObjectLiteralNode(location); }
-    ExpressionNode* createObjectLiteral(const JSTokenLocation& location, PropertyListNode* properties) { return new (m_parserArena) ObjectLiteralNode(location, properties); }
+    ExpressionNode* createObjectLiteral(const JSTokenLocation& location) { return new (m_parserArena.get()) ObjectLiteralNode(location); }
+    ExpressionNode* createObjectLiteral(const JSTokenLocation& location, PropertyListNode* properties) { return new (m_parserArena.get()) ObjectLiteralNode(location, properties); }
 
     ExpressionNode* createArray(const JSTokenLocation& location, int elisions)
     {
         if (elisions)
             incConstants();
-        return new (m_parserArena) ArrayNode(location, elisions);
+        return new (m_parserArena.get()) ArrayNode(location, elisions);
     }
 
-    ExpressionNode* createArray(const JSTokenLocation& location, ElementNode* elems) { return new (m_parserArena) ArrayNode(location, elems); }
+    ExpressionNode* createArray(const JSTokenLocation& location, ElementNode* elems) { return new (m_parserArena.get()) ArrayNode(location, elems); }
     ExpressionNode* createArray(const JSTokenLocation& location, int elisions, ElementNode* elems)
     {
         if (elisions)
             incConstants();
-        return new (m_parserArena) ArrayNode(location, elisions, elems);
+        return new (m_parserArena.get()) ArrayNode(location, elisions, elems);
     }
     ExpressionNode* createDoubleExpr(const JSTokenLocation& location, double d)
     {
         incConstants();
-        return new (m_parserArena) DoubleNode(location, d);
+        return new (m_parserArena.get()) DoubleNode(location, d);
     }
     ExpressionNode* createIntegerExpr(const JSTokenLocation& location, double d)
     {
         incConstants();
-        return new (m_parserArena) IntegerNode(location, d);
+        return new (m_parserArena.get()) IntegerNode(location, d);
     }
     
     ExpressionNode* createBigInt(const JSTokenLocation& location, const Identifier* bigInt, uint8_t radix)
     {
         incConstants();
-        return new (m_parserArena) BigIntNode(location, *bigInt, radix);
+        return new (m_parserArena.get()) BigIntNode(location, *bigInt, radix);
     }
 
     ExpressionNode* createString(const JSTokenLocation& location, const Identifier* string)
     {
         ASSERT(string);
         incConstants();
-        return new (m_parserArena) StringNode(location, *string);
+        return new (m_parserArena.get()) StringNode(location, *string);
     }
 
     ExpressionNode* createBoolean(const JSTokenLocation& location, bool b)
     {
         incConstants();
-        return new (m_parserArena) BooleanNode(location, b);
+        return new (m_parserArena.get()) BooleanNode(location, b);
     }
 
     ExpressionNode* createNull(const JSTokenLocation& location)
     {
         incConstants();
-        return new (m_parserArena) NullNode(location);
+        return new (m_parserArena.get()) NullNode(location);
     }
 
     ExpressionNode* createBracketAccess(const JSTokenLocation& location, ExpressionNode* base, ExpressionNode* property, bool propertyHasAssignments, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end)
@@ -272,7 +272,7 @@ public:
         if (base->isSuperNode())
             usesSuperProperty();
 
-        BracketAccessorNode* node = new (m_parserArena) BracketAccessorNode(location, base, property, propertyHasAssignments);
+        BracketAccessorNode* node = new (m_parserArena.get()) BracketAccessorNode(location, base, property, propertyHasAssignments);
         setExceptionLocation(node, start, divot, end);
         return node;
     }
@@ -282,63 +282,63 @@ public:
         if (base->isSuperNode())
             usesSuperProperty();
         
-        DotAccessorNode* node = new (m_parserArena) DotAccessorNode(location, base, *property, type);
+        DotAccessorNode* node = new (m_parserArena.get()) DotAccessorNode(location, base, *property, type);
         setExceptionLocation(node, start, divot, end);
         return node;
     }
 
     ExpressionNode* createSpreadExpression(const JSTokenLocation& location, ExpressionNode* expression, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end)
     {
-        auto node = new (m_parserArena) SpreadExpressionNode(location, expression);
+        auto node = new (m_parserArena.get()) SpreadExpressionNode(location, expression);
         setExceptionLocation(node, start, divot, end);
         return node;
     }
 
     ExpressionNode* createObjectSpreadExpression(const JSTokenLocation& location, ExpressionNode* expression, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end)
     {
-        auto node = new (m_parserArena) ObjectSpreadExpressionNode(location, expression);
+        auto node = new (m_parserArena.get()) ObjectSpreadExpressionNode(location, expression);
         setExceptionLocation(node, start, divot, end);
         return node;
     }
 
     TemplateStringNode* createTemplateString(const JSTokenLocation& location, const Identifier* cooked, const Identifier* raw)
     {
-        return new (m_parserArena) TemplateStringNode(location, cooked, raw);
+        return new (m_parserArena.get()) TemplateStringNode(location, cooked, raw);
     }
 
     TemplateStringListNode* createTemplateStringList(TemplateStringNode* templateString)
     {
-        return new (m_parserArena) TemplateStringListNode(templateString);
+        return new (m_parserArena.get()) TemplateStringListNode(templateString);
     }
 
     TemplateStringListNode* createTemplateStringList(TemplateStringListNode* templateStringList, TemplateStringNode* templateString)
     {
-        return new (m_parserArena) TemplateStringListNode(templateStringList, templateString);
+        return new (m_parserArena.get()) TemplateStringListNode(templateStringList, templateString);
     }
 
     TemplateExpressionListNode* createTemplateExpressionList(ExpressionNode* expression)
     {
-        return new (m_parserArena) TemplateExpressionListNode(expression);
+        return new (m_parserArena.get()) TemplateExpressionListNode(expression);
     }
 
     TemplateExpressionListNode* createTemplateExpressionList(TemplateExpressionListNode* templateExpressionListNode, ExpressionNode* expression)
     {
-        return new (m_parserArena) TemplateExpressionListNode(templateExpressionListNode, expression);
+        return new (m_parserArena.get()) TemplateExpressionListNode(templateExpressionListNode, expression);
     }
 
     TemplateLiteralNode* createTemplateLiteral(const JSTokenLocation& location, TemplateStringListNode* templateStringList)
     {
-        return new (m_parserArena) TemplateLiteralNode(location, templateStringList);
+        return new (m_parserArena.get()) TemplateLiteralNode(location, templateStringList);
     }
 
     TemplateLiteralNode* createTemplateLiteral(const JSTokenLocation& location, TemplateStringListNode* templateStringList, TemplateExpressionListNode* templateExpressionList)
     {
-        return new (m_parserArena) TemplateLiteralNode(location, templateStringList, templateExpressionList);
+        return new (m_parserArena.get()) TemplateLiteralNode(location, templateStringList, templateExpressionList);
     }
 
     ExpressionNode* createTaggedTemplate(const JSTokenLocation& location, ExpressionNode* base, TemplateLiteralNode* templateLiteral, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end)
     {
-        auto node = new (m_parserArena) TaggedTemplateNode(location, base, templateLiteral);
+        auto node = new (m_parserArena.get()) TaggedTemplateNode(location, base, templateLiteral);
         setExceptionLocation(node, start, divot, end);
         setEndOffset(node, end.offset);
         return node;
@@ -348,7 +348,7 @@ public:
     {
         if (!skipSyntaxCheck && Yarr::hasError(Yarr::checkSyntax(pattern.string(), flags.string())))
             return nullptr;
-        RegExpNode* node = new (m_parserArena) RegExpNode(location, pattern, flags);
+        RegExpNode* node = new (m_parserArena.get()) RegExpNode(location, pattern, flags);
         int size = pattern.length() + 2; // + 2 for the two /'s
         JSTextPosition end = start + size;
         setExceptionLocation(node, start, end, end);
@@ -357,14 +357,14 @@ public:
 
     ExpressionNode* createNewExpr(const JSTokenLocation& location, ExpressionNode* expr, ArgumentsNode* arguments, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end)
     {
-        NewExprNode* node = new (m_parserArena) NewExprNode(location, expr, arguments);
+        NewExprNode* node = new (m_parserArena.get()) NewExprNode(location, expr, arguments);
         setExceptionLocation(node, start, divot, end);
         return node;
     }
 
     ExpressionNode* createNewExpr(const JSTokenLocation& location, ExpressionNode* expr, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end)
     {
-        NewExprNode* node = new (m_parserArena) NewExprNode(location, expr);
+        NewExprNode* node = new (m_parserArena.get()) NewExprNode(location, expr);
         setExceptionLocation(node, start, divot, end);
         return node;
     }
@@ -373,12 +373,12 @@ public:
     {
         if (base)
             base->setIsOptionalChainBase();
-        return new (m_parserArena) OptionalChainNode(location, expr, isOutermost);
+        return new (m_parserArena.get()) OptionalChainNode(location, expr, isOutermost);
     }
 
     ExpressionNode* createConditionalExpr(const JSTokenLocation& location, ExpressionNode* condition, ExpressionNode* lhs, ExpressionNode* rhs)
     {
-        return new (m_parserArena) ConditionalNode(location, condition, lhs, rhs);
+        return new (m_parserArena.get()) ConditionalNode(location, condition, lhs, rhs);
     }
 
     ExpressionNode* createAssignResolve(const JSTokenLocation& location, const Identifier& ident, ExpressionNode* rhs, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end, AssignmentContext assignmentContext)
@@ -390,19 +390,19 @@ public:
             static_cast<ClassExprNode*>(rhs)->setEcmaName(ident);
         if (assignmentContext == AssignmentContext::AwaitUsingDeclarationStatement)
             usesAwait();
-        AssignResolveNode* node = new (m_parserArena) AssignResolveNode(location, ident, rhs, assignmentContext);
+        AssignResolveNode* node = new (m_parserArena.get()) AssignResolveNode(location, ident, rhs, assignmentContext);
         setExceptionLocation(node, start, divot, end);
         return node;
     }
 
     YieldExprNode* createYield(const JSTokenLocation& location)
     {
-        return new (m_parserArena) YieldExprNode(location, nullptr, /* delegate */ false);
+        return new (m_parserArena.get()) YieldExprNode(location, nullptr, /* delegate */ false);
     }
 
     YieldExprNode* createYield(const JSTokenLocation& location, ExpressionNode* argument, bool delegate, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end)
     {
-        YieldExprNode* node = new (m_parserArena) YieldExprNode(location, argument, delegate);
+        YieldExprNode* node = new (m_parserArena.get()) YieldExprNode(location, argument, delegate);
         setExceptionLocation(node, start, divot, end);
         return node;
     }
@@ -411,28 +411,28 @@ public:
     {
         ASSERT(argument);
         usesAwait();
-        AwaitExprNode* node = new (m_parserArena) AwaitExprNode(location, argument);
+        AwaitExprNode* node = new (m_parserArena.get()) AwaitExprNode(location, argument);
         setExceptionLocation(node, start, divot, end);
         return node;
     }
 
     DefineFieldNode* createDefineField(const JSTokenLocation& location, const Identifier& ident, ExpressionNode* initializer, DefineFieldNode::Type type)
     {
-        return new (m_parserArena) DefineFieldNode(location, ident, initializer, type);
+        return new (m_parserArena.get()) DefineFieldNode(location, ident, initializer, type);
     }
 
     ClassExprNode* createClassExpr(const JSTokenLocation& location, const ParserClassInfo<ASTBuilder>& classInfo, VariableEnvironment&& classHeadEnvironment, VariableEnvironment&& classEnvironment, ExpressionNode* constructor,
         ExpressionNode* parentClass, PropertyListNode* classElements, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end)
     {
         SourceCode source = m_sourceCode->subExpression(classInfo.startOffset, classInfo.endOffset, classInfo.startLine, classInfo.startColumn);
-        ClassExprNode* node = new (m_parserArena) ClassExprNode(location, *classInfo.className, source, WTF::move(classHeadEnvironment), WTF::move(classEnvironment), constructor, parentClass, classElements);
+        ClassExprNode* node = new (m_parserArena.get()) ClassExprNode(location, *classInfo.className, source, WTF::move(classHeadEnvironment), WTF::move(classEnvironment), constructor, parentClass, classElements);
         setExceptionLocation(node, start, divot, end);
         return node;
     }
 
     ExpressionNode* createFunctionExpr(const JSTokenLocation& location, const ParserFunctionInfo<ASTBuilder>& functionInfo)
     {
-        FuncExprNode* result = new (m_parserArena) FuncExprNode(location, *functionInfo.name, functionInfo.body,
+        FuncExprNode* result = new (m_parserArena.get()) FuncExprNode(location, *functionInfo.name, functionInfo.body,
             m_sourceCode->subExpression(functionInfo.startOffset, functionInfo.endOffset, functionInfo.startLine, functionInfo.parametersStartColumn));
         functionInfo.body->setLoc(functionInfo.startLine, functionInfo.endLine, location.startOffset, location.lineStartOffset);
         return result;
@@ -450,7 +450,7 @@ public:
     {
         if (parseMode == SourceParseMode::AsyncArrowFunctionBodyMode) {
             SourceCode source = m_sourceCode->subExpression(functionInfo.startOffset, functionInfo.body->isArrowFunctionBodyExpression() ? functionInfo.endOffset - 1 : functionInfo.endOffset, functionInfo.startLine, functionInfo.parametersStartColumn);
-            FuncExprNode* result = new (m_parserArena) FuncExprNode(location, *functionInfo.name, functionInfo.body, source);
+            FuncExprNode* result = new (m_parserArena.get()) FuncExprNode(location, *functionInfo.name, functionInfo.body, source);
             if (!name.isNull())
                 result->metadata()->setEcmaName(name);
             functionInfo.body->setLoc(functionInfo.startLine, functionInfo.endLine, location.startOffset, location.lineStartOffset);
@@ -464,7 +464,7 @@ public:
 
     ExpressionNode* createMethodDefinition(const JSTokenLocation& location, const ParserFunctionInfo<ASTBuilder>& functionInfo)
     {
-        MethodDefinitionNode* result = new (m_parserArena) MethodDefinitionNode(location, *functionInfo.name, functionInfo.body,
+        MethodDefinitionNode* result = new (m_parserArena.get()) MethodDefinitionNode(location, *functionInfo.name, functionInfo.body,
             m_sourceCode->subExpression(functionInfo.startOffset, functionInfo.endOffset, functionInfo.startLine, functionInfo.parametersStartColumn));
         functionInfo.body->setLoc(functionInfo.startLine, functionInfo.endLine, location.startOffset, location.lineStartOffset);
         return result;
@@ -478,8 +478,8 @@ public:
         unsigned parameterCount,
         SourceParseMode mode, bool isArrowFunctionBodyExpression)
     {
-        return new (m_parserArena) FunctionMetadataNode(
-            m_parserArena, startLocation, endLocation, startColumn, endColumn, functionStart,
+        return new (m_parserArena.get()) FunctionMetadataNode(
+            m_parserArena.get(), startLocation, endLocation, startColumn, endColumn, functionStart,
             functionNameStart, parametersStart, implementationVisibility,
             lexicallyScopedFeatures, constructorKind, superBinding,
             parameterCount, mode, isArrowFunctionBodyExpression);
@@ -489,15 +489,15 @@ public:
     {
         usesArrowFunction();
         SourceCode source = m_sourceCode->subExpression(functionInfo.startOffset, functionInfo.body->isArrowFunctionBodyExpression() ? functionInfo.endOffset - 1 : functionInfo.endOffset, functionInfo.startLine, functionInfo.parametersStartColumn);
-        ArrowFuncExprNode* result = new (m_parserArena) ArrowFuncExprNode(location, *functionInfo.name, functionInfo.body, source);
+        ArrowFuncExprNode* result = new (m_parserArena.get()) ArrowFuncExprNode(location, *functionInfo.name, functionInfo.body, source);
         functionInfo.body->setLoc(functionInfo.startLine, functionInfo.endLine, location.startOffset, location.lineStartOffset);
         return result;
     }
 
-    ArgumentsNode* createArguments() { return new (m_parserArena) ArgumentsNode(); }
-    ArgumentsNode* createArguments(ArgumentListNode* args, bool hasAssignments) { return new (m_parserArena) ArgumentsNode(args, hasAssignments); }
-    ArgumentListNode* createArgumentsList(const JSTokenLocation& location, ExpressionNode* arg) { return new (m_parserArena) ArgumentListNode(location, arg); }
-    ArgumentListNode* createArgumentsList(const JSTokenLocation& location, ArgumentListNode* args, ExpressionNode* arg) { return new (m_parserArena) ArgumentListNode(location, args, arg); }
+    ArgumentsNode* createArguments() { return new (m_parserArena.get()) ArgumentsNode(); }
+    ArgumentsNode* createArguments(ArgumentListNode* args, bool hasAssignments) { return new (m_parserArena.get()) ArgumentsNode(args, hasAssignments); }
+    ArgumentListNode* createArgumentsList(const JSTokenLocation& location, ExpressionNode* arg) { return new (m_parserArena.get()) ArgumentListNode(location, arg); }
+    ArgumentListNode* createArgumentsList(const JSTokenLocation& location, ArgumentListNode* args, ExpressionNode* arg) { return new (m_parserArena.get()) ArgumentListNode(location, args, arg); }
 
     NEVER_INLINE PropertyNode* createGetterOrSetterProperty(const JSTokenLocation& location, PropertyNode::Type type,
         const Identifier* name, const ParserFunctionInfo<ASTBuilder>& functionInfo, ClassElementTag tag)
@@ -506,8 +506,8 @@ public:
         functionInfo.body->setLoc(functionInfo.startLine, functionInfo.endLine, location.startOffset, location.lineStartOffset);
         functionInfo.body->setEcmaName(*name);
         SourceCode source = m_sourceCode->subExpression(functionInfo.startOffset, functionInfo.endOffset, functionInfo.startLine, functionInfo.parametersStartColumn);
-        MethodDefinitionNode* methodDef = new (m_parserArena) MethodDefinitionNode(location, m_vm.propertyNames->nullIdentifier, functionInfo.body, source);
-        return new (m_parserArena) PropertyNode(*name, methodDef, type, SuperBinding::Needed, tag);
+        MethodDefinitionNode* methodDef = new (m_parserArena.get()) MethodDefinitionNode(location, m_vm.propertyNames->nullIdentifier, functionInfo.body, source);
+        return new (m_parserArena.get()) PropertyNode(*name, methodDef, type, SuperBinding::Needed, tag);
     }
 
     NEVER_INLINE PropertyNode* createGetterOrSetterProperty(const JSTokenLocation& location, PropertyNode::Type type,
@@ -516,8 +516,8 @@ public:
         ASSERT(name);
         functionInfo.body->setLoc(functionInfo.startLine, functionInfo.endLine, location.startOffset, location.lineStartOffset);
         SourceCode source = m_sourceCode->subExpression(functionInfo.startOffset, functionInfo.endOffset, functionInfo.startLine, functionInfo.parametersStartColumn);
-        MethodDefinitionNode* methodDef = new (m_parserArena) MethodDefinitionNode(location, m_vm.propertyNames->nullIdentifier, functionInfo.body, source);
-        return new (m_parserArena) PropertyNode(name, methodDef, type, SuperBinding::Needed, tag);
+        MethodDefinitionNode* methodDef = new (m_parserArena.get()) MethodDefinitionNode(location, m_vm.propertyNames->nullIdentifier, functionInfo.body, source);
+        return new (m_parserArena.get()) PropertyNode(name, methodDef, type, SuperBinding::Needed, tag);
     }
 
     NEVER_INLINE PropertyNode* createGetterOrSetterProperty(VM& vm, ParserArena& parserArena, const JSTokenLocation& location, PropertyNode::Type type,
@@ -527,13 +527,13 @@ public:
         const Identifier& ident = parserArena.identifierArena().makeNumericIdentifier(vm, name);
         functionInfo.body->setEcmaName(ident);
         SourceCode source = m_sourceCode->subExpression(functionInfo.startOffset, functionInfo.endOffset, functionInfo.startLine, functionInfo.parametersStartColumn);
-        MethodDefinitionNode* methodDef = new (m_parserArena) MethodDefinitionNode(location, vm.propertyNames->nullIdentifier, functionInfo.body, source);
-        return new (m_parserArena) PropertyNode(ident, methodDef, type, SuperBinding::Needed, tag);
+        MethodDefinitionNode* methodDef = new (m_parserArena.get()) MethodDefinitionNode(location, vm.propertyNames->nullIdentifier, functionInfo.body, source);
+        return new (m_parserArena.get()) PropertyNode(ident, methodDef, type, SuperBinding::Needed, tag);
     }
 
     PropertyNode* createProperty(const Identifier* propertyName, PropertyNode::Type type, SuperBinding superBinding, ClassElementTag tag)
     {
-        return new (m_parserArena) PropertyNode(*propertyName, type, superBinding, tag);
+        return new (m_parserArena.get()) PropertyNode(*propertyName, type, superBinding, tag);
     }
     PropertyNode* createProperty(const Identifier* propertyName, ExpressionNode* node, PropertyNode::Type type, SuperBinding superBinding, InferName inferName, ClassElementTag tag)
     {
@@ -544,49 +544,49 @@ public:
             } else if (node->isClassExprNode())
                 static_cast<ClassExprNode*>(node)->setEcmaName(*propertyName);
         }
-        return new (m_parserArena) PropertyNode(*propertyName, node, type, superBinding, tag);
+        return new (m_parserArena.get()) PropertyNode(*propertyName, node, type, superBinding, tag);
     }
     PropertyNode* createProperty(ExpressionNode* node, PropertyNode::Type type, SuperBinding superBinding, ClassElementTag tag)
     {
-        return new (m_parserArena) PropertyNode(node, type, superBinding, tag);
+        return new (m_parserArena.get()) PropertyNode(node, type, superBinding, tag);
     }
     PropertyNode* createProperty(VM& vm, ParserArena& parserArena, double propertyName, ExpressionNode* node, PropertyNode::Type type, SuperBinding superBinding, ClassElementTag tag)
     {
-        return new (m_parserArena) PropertyNode(parserArena.identifierArena().makeNumericIdentifier(vm, propertyName), node, type, superBinding, tag);
+        return new (m_parserArena.get()) PropertyNode(parserArena.identifierArena().makeNumericIdentifier(vm, propertyName), node, type, superBinding, tag);
     }
-    PropertyNode* createProperty(ExpressionNode* propertyName, ExpressionNode* node, PropertyNode::Type type, SuperBinding superBinding, ClassElementTag tag) { return new (m_parserArena) PropertyNode(propertyName, node, type, superBinding, tag); }
-    PropertyNode* createProperty(const Identifier* identifier, ExpressionNode* propertyName, ExpressionNode* node, PropertyNode::Type type, SuperBinding superBinding, ClassElementTag tag) { return new (m_parserArena) PropertyNode(*identifier, propertyName, node, type, superBinding, tag); }
-    PropertyListNode* createPropertyList(const JSTokenLocation& location, PropertyNode* property) { return new (m_parserArena) PropertyListNode(location, property); }
-    PropertyListNode* createPropertyList(const JSTokenLocation& location, PropertyNode* property, PropertyListNode* tail) { return new (m_parserArena) PropertyListNode(location, property, tail); }
+    PropertyNode* createProperty(ExpressionNode* propertyName, ExpressionNode* node, PropertyNode::Type type, SuperBinding superBinding, ClassElementTag tag) { return new (m_parserArena.get()) PropertyNode(propertyName, node, type, superBinding, tag); }
+    PropertyNode* createProperty(const Identifier* identifier, ExpressionNode* propertyName, ExpressionNode* node, PropertyNode::Type type, SuperBinding superBinding, ClassElementTag tag) { return new (m_parserArena.get()) PropertyNode(*identifier, propertyName, node, type, superBinding, tag); }
+    PropertyListNode* createPropertyList(const JSTokenLocation& location, PropertyNode* property) { return new (m_parserArena.get()) PropertyListNode(location, property); }
+    PropertyListNode* createPropertyList(const JSTokenLocation& location, PropertyNode* property, PropertyListNode* tail) { return new (m_parserArena.get()) PropertyListNode(location, property, tail); }
 
-    ElementNode* createElementList(int elisions, ExpressionNode* expr) { return new (m_parserArena) ElementNode(elisions, expr); }
-    ElementNode* createElementList(ElementNode* elems, int elisions, ExpressionNode* expr) { return new (m_parserArena) ElementNode(elems, elisions, expr); }
+    ElementNode* createElementList(int elisions, ExpressionNode* expr) { return new (m_parserArena.get()) ElementNode(elisions, expr); }
+    ElementNode* createElementList(ElementNode* elems, int elisions, ExpressionNode* expr) { return new (m_parserArena.get()) ElementNode(elems, elisions, expr); }
     ElementNode* createElementList(ArgumentListNode* elems)
     {
-        ElementNode* head = new (m_parserArena) ElementNode(0, elems->m_expr);
+        ElementNode* head = new (m_parserArena.get()) ElementNode(0, elems->m_expr);
         ElementNode* tail = head;
         elems = elems->m_next;
         while (elems) {
-            tail = new (m_parserArena) ElementNode(tail, 0, elems->m_expr);
+            tail = new (m_parserArena.get()) ElementNode(tail, 0, elems->m_expr);
             elems = elems->m_next;
         }
         return head;
     }
 
-    FormalParameterList createFormalParameterList() { return new (m_parserArena) FunctionParameters(); }
+    FormalParameterList createFormalParameterList() { return new (m_parserArena.get()) FunctionParameters(); }
     void appendParameter(FormalParameterList list, DestructuringPattern pattern, ExpressionNode* defaultValue) 
     { 
         list->append(pattern, defaultValue); 
         tryInferNameInPattern(pattern, defaultValue);
     }
 
-    CaseClauseNode* createClause(ExpressionNode* expr, JSC::SourceElements* statements) { return new (m_parserArena) CaseClauseNode(expr, statements); }
-    ClauseListNode* createClauseList(CaseClauseNode* clause) { return new (m_parserArena) ClauseListNode(clause); }
-    ClauseListNode* createClauseList(ClauseListNode* tail, CaseClauseNode* clause) { return new (m_parserArena) ClauseListNode(tail, clause); }
+    CaseClauseNode* createClause(ExpressionNode* expr, JSC::SourceElements* statements) { return new (m_parserArena.get()) CaseClauseNode(expr, statements); }
+    ClauseListNode* createClauseList(CaseClauseNode* clause) { return new (m_parserArena.get()) ClauseListNode(clause); }
+    ClauseListNode* createClauseList(ClauseListNode* tail, CaseClauseNode* clause) { return new (m_parserArena.get()) ClauseListNode(tail, clause); }
 
     StatementNode* createFuncDeclStatement(const JSTokenLocation& location, const ParserFunctionInfo<ASTBuilder>& functionInfo)
     {
-        FuncDeclNode* decl = new (m_parserArena) FuncDeclNode(location, *functionInfo.name, functionInfo.body,
+        FuncDeclNode* decl = new (m_parserArena.get()) FuncDeclNode(location, *functionInfo.name, functionInfo.body,
             m_sourceCode->subExpression(functionInfo.startOffset, functionInfo.endOffset, functionInfo.startLine, functionInfo.parametersStartColumn));
         if (*functionInfo.name == m_vm.propertyNames->arguments)
             usesArguments();
@@ -598,42 +598,42 @@ public:
         const JSTextPosition& classStart, const JSTextPosition& classEnd, unsigned startLine, unsigned endLine)
     {
         ExpressionNode* assign = createAssignResolve(location, classExpression->name(), classExpression, classStart, classStart + 1, classEnd, AssignmentContext::DeclarationStatement);
-        ClassDeclNode* decl = new (m_parserArena) ClassDeclNode(location, assign);
+        ClassDeclNode* decl = new (m_parserArena.get()) ClassDeclNode(location, assign);
         decl->setLoc(startLine, endLine, location.startOffset, location.lineStartOffset);
         return decl;
     }
 
     StatementNode* createBlockStatement(const JSTokenLocation& location, JSC::SourceElements* elements, int startLine, int endLine, VariableEnvironment&& lexicalVariables, DeclarationStacks::FunctionStack&& functionStack)
     {
-        BlockNode* block = new (m_parserArena) BlockNode(location, elements, WTF::move(lexicalVariables), WTF::move(functionStack));
+        BlockNode* block = new (m_parserArena.get()) BlockNode(location, elements, WTF::move(lexicalVariables), WTF::move(functionStack));
         block->setLoc(startLine, endLine, location.startOffset, location.lineStartOffset);
         return block;
     }
 
     StatementNode* createExprStatement(const JSTokenLocation& location, ExpressionNode* expr, const JSTextPosition& start, int end)
     {
-        ExprStatementNode* result = new (m_parserArena) ExprStatementNode(location, expr);
+        ExprStatementNode* result = new (m_parserArena.get()) ExprStatementNode(location, expr);
         result->setLoc(start.line, end, start.offset, start.lineStartOffset);
         return result;
     }
 
     StatementNode* createIfStatement(const JSTokenLocation& location, ExpressionNode* condition, StatementNode* trueBlock, StatementNode* falseBlock, int start, int end)
     {
-        IfElseNode* result = new (m_parserArena) IfElseNode(location, condition, trueBlock, falseBlock);
+        IfElseNode* result = new (m_parserArena.get()) IfElseNode(location, condition, trueBlock, falseBlock);
         result->setLoc(start, end, location.startOffset, location.lineStartOffset);
         return result;
     }
 
     StatementNode* createForLoop(const JSTokenLocation& location, ExpressionNode* initializer, ExpressionNode* condition, ExpressionNode* iter, StatementNode* statements, int start, int end, VariableEnvironment&& lexicalVariables, bool initializerContainsClosure)
     {
-        ForNode* result = new (m_parserArena) ForNode(location, initializer, condition, iter, statements, WTF::move(lexicalVariables), initializerContainsClosure);
+        ForNode* result = new (m_parserArena.get()) ForNode(location, initializer, condition, iter, statements, WTF::move(lexicalVariables), initializerContainsClosure);
         result->setLoc(start, end, location.startOffset, location.lineStartOffset);
         return result;
     }
 
     StatementNode* createForInLoop(const JSTokenLocation& location, ExpressionNode* lhs, ExpressionNode* iter, StatementNode* statements, const JSTokenLocation&, const JSTextPosition& eStart, const JSTextPosition& eDivot, const JSTextPosition& eEnd, int start, int end, VariableEnvironment&& lexicalVariables)
     {
-        ForInNode* result = new (m_parserArena) ForInNode(location, lhs, iter, statements, WTF::move(lexicalVariables));
+        ForInNode* result = new (m_parserArena.get()) ForInNode(location, lhs, iter, statements, WTF::move(lexicalVariables));
         result->setLoc(start, end, location.startOffset, location.lineStartOffset);
         setExceptionLocation(result, eStart, eDivot, eEnd);
         return result;
@@ -641,13 +641,13 @@ public:
     
     StatementNode* createForInLoop(const JSTokenLocation& location, DestructuringPatternNode* pattern, ExpressionNode* iter, StatementNode* statements, const JSTokenLocation& declLocation, const JSTextPosition& eStart, const JSTextPosition& eDivot, const JSTextPosition& eEnd, int start, int end, VariableEnvironment&& lexicalVariables)
     {
-        auto lexpr = new (m_parserArena) DestructuringAssignmentNode(declLocation, pattern, nullptr);
+        auto lexpr = new (m_parserArena.get()) DestructuringAssignmentNode(declLocation, pattern, nullptr);
         return createForInLoop(location, lexpr, iter, statements, declLocation, eStart, eDivot, eEnd, start, end, WTF::move(lexicalVariables));
     }
     
     StatementNode* createForOfLoop(bool isForAwait, const JSTokenLocation& location, ExpressionNode* lhs, ExpressionNode* iter, StatementNode* statements, const JSTokenLocation&, const JSTextPosition& eStart, const JSTextPosition& eDivot, const JSTextPosition& eEnd, int start, int end, VariableEnvironment&& lexicalVariables)
     {
-        ForOfNode* result = new (m_parserArena) ForOfNode(isForAwait, location, lhs, iter, statements, WTF::move(lexicalVariables));
+        ForOfNode* result = new (m_parserArena.get()) ForOfNode(isForAwait, location, lhs, iter, statements, WTF::move(lexicalVariables));
         result->setLoc(start, end, location.startOffset, location.lineStartOffset);
         setExceptionLocation(result, eStart, eDivot, eEnd);
         if (isForAwait)
@@ -657,7 +657,7 @@ public:
     
     StatementNode* createForOfLoop(bool isForAwait, const JSTokenLocation& location, DestructuringPatternNode* pattern, ExpressionNode* iter, StatementNode* statements, const JSTokenLocation& declLocation, const JSTextPosition& eStart, const JSTextPosition& eDivot, const JSTextPosition& eEnd, int start, int end, VariableEnvironment&& lexicalVariables)
     {
-        auto lexpr = new (m_parserArena) DestructuringAssignmentNode(declLocation, pattern, nullptr);
+        auto lexpr = new (m_parserArena.get()) DestructuringAssignmentNode(declLocation, pattern, nullptr);
         return createForOfLoop(isForAwait, location, lexpr, iter, statements, declLocation, eStart, eDivot, eEnd, start, end, WTF::move(lexicalVariables));
     }
 
@@ -706,29 +706,29 @@ public:
         return !statement || statement->isLabel();
     }
 
-    StatementNode* createEmptyStatement(const JSTokenLocation& location) { return new (m_parserArena) EmptyStatementNode(location); }
+    StatementNode* createEmptyStatement(const JSTokenLocation& location) { return new (m_parserArena.get()) EmptyStatementNode(location); }
 
     StatementNode* createDeclarationStatement(const JSTokenLocation& location, ExpressionNode* expr, int start, int end)
     {
         StatementNode* result;
-        result = new (m_parserArena) DeclarationStatement(location, expr);
+        result = new (m_parserArena.get()) DeclarationStatement(location, expr);
         result->setLoc(start, end, location.startOffset, location.lineStartOffset);
         return result;
     }
 
     ExpressionNode* createEmptyVarExpression(const JSTokenLocation& location, const Identifier& identifier)
     {
-        return new (m_parserArena) EmptyVarExpression(location, identifier);
+        return new (m_parserArena.get()) EmptyVarExpression(location, identifier);
     }
 
     ExpressionNode* createEmptyLetExpression(const JSTokenLocation& location, const Identifier& identifier)
     {
-        return new (m_parserArena) EmptyLetExpression(location, identifier);
+        return new (m_parserArena.get()) EmptyLetExpression(location, identifier);
     }
 
     StatementNode* createReturnStatement(const JSTokenLocation& location, ExpressionNode* expression, const JSTextPosition& start, const JSTextPosition& end)
     {
-        ReturnNode* result = new (m_parserArena) ReturnNode(location, expression);
+        ReturnNode* result = new (m_parserArena.get()) ReturnNode(location, expression);
         setExceptionLocation(result, start, end, end);
         result->setLoc(start.line, end.line, start.offset, start.lineStartOffset);
         return result;
@@ -736,7 +736,7 @@ public:
 
     StatementNode* createBreakStatement(const JSTokenLocation& location, const Identifier* ident, const JSTextPosition& start, const JSTextPosition& end)
     {
-        BreakNode* result = new (m_parserArena) BreakNode(location, *ident);
+        BreakNode* result = new (m_parserArena.get()) BreakNode(location, *ident);
         setExceptionLocation(result, start, end, end);
         result->setLoc(start.line, end.line, start.offset, start.lineStartOffset);
         return result;
@@ -744,7 +744,7 @@ public:
 
     StatementNode* createContinueStatement(const JSTokenLocation& location, const Identifier* ident, const JSTextPosition& start, const JSTextPosition& end)
     {
-        ContinueNode* result = new (m_parserArena) ContinueNode(location, *ident);
+        ContinueNode* result = new (m_parserArena.get()) ContinueNode(location, *ident);
         setExceptionLocation(result, start, end, end);
         result->setLoc(start.line, end.line, start.offset, start.lineStartOffset);
         return result;
@@ -752,36 +752,36 @@ public:
 
     StatementNode* createTryStatement(const JSTokenLocation& location, StatementNode* tryBlock, DestructuringPatternNode* catchPattern, StatementNode* catchBlock, StatementNode* finallyBlock, int startLine, int endLine, VariableEnvironment&& catchEnvironment)
     {
-        TryNode* result = new (m_parserArena) TryNode(location, tryBlock, catchPattern, catchBlock, WTF::move(catchEnvironment), finallyBlock);
+        TryNode* result = new (m_parserArena.get()) TryNode(location, tryBlock, catchPattern, catchBlock, WTF::move(catchEnvironment), finallyBlock);
         result->setLoc(startLine, endLine, location.startOffset, location.lineStartOffset);
         return result;
     }
 
     StatementNode* createSwitchStatement(const JSTokenLocation& location, ExpressionNode* expr, ClauseListNode* firstClauses, CaseClauseNode* defaultClause, ClauseListNode* secondClauses, int startLine, int endLine, VariableEnvironment&& lexicalVariables, DeclarationStacks::FunctionStack&& functionStack)
     {
-        CaseBlockNode* cases = new (m_parserArena) CaseBlockNode(firstClauses, defaultClause, secondClauses);
-        SwitchNode* result = new (m_parserArena) SwitchNode(location, expr, cases, WTF::move(lexicalVariables), WTF::move(functionStack));
+        CaseBlockNode* cases = new (m_parserArena.get()) CaseBlockNode(firstClauses, defaultClause, secondClauses);
+        SwitchNode* result = new (m_parserArena.get()) SwitchNode(location, expr, cases, WTF::move(lexicalVariables), WTF::move(functionStack));
         result->setLoc(startLine, endLine, location.startOffset, location.lineStartOffset);
         return result;
     }
 
     StatementNode* createWhileStatement(const JSTokenLocation& location, ExpressionNode* expr, StatementNode* statement, int startLine, int endLine)
     {
-        WhileNode* result = new (m_parserArena) WhileNode(location, expr, statement);
+        WhileNode* result = new (m_parserArena.get()) WhileNode(location, expr, statement);
         result->setLoc(startLine, endLine, location.startOffset, location.lineStartOffset);
         return result;
     }
 
     StatementNode* createDoWhileStatement(const JSTokenLocation& location, StatementNode* statement, ExpressionNode* expr, int startLine, int endLine)
     {
-        DoWhileNode* result = new (m_parserArena) DoWhileNode(location, statement, expr);
+        DoWhileNode* result = new (m_parserArena.get()) DoWhileNode(location, statement, expr);
         result->setLoc(startLine, endLine, location.startOffset, location.lineStartOffset);
         return result;
     }
 
     StatementNode* createLabelStatement(const JSTokenLocation& location, const Identifier* ident, StatementNode* statement, const JSTextPosition& start, const JSTextPosition& end)
     {
-        LabelNode* result = new (m_parserArena) LabelNode(location, *ident, statement);
+        LabelNode* result = new (m_parserArena.get()) LabelNode(location, *ident, statement);
         setExceptionLocation(result, start, end, end);
         return result;
     }
@@ -789,14 +789,14 @@ public:
     StatementNode* createWithStatement(const JSTokenLocation& location, ExpressionNode* expr, StatementNode* statement, unsigned start, const JSTextPosition& end, unsigned startLine, unsigned endLine)
     {
         usesWith();
-        WithNode* result = new (m_parserArena) WithNode(location, expr, statement, end, end - start);
+        WithNode* result = new (m_parserArena.get()) WithNode(location, expr, statement, end, end - start);
         result->setLoc(startLine, endLine, location.startOffset, location.lineStartOffset);
         return result;
     }    
     
     StatementNode* createThrowStatement(const JSTokenLocation& location, ExpressionNode* expr, const JSTextPosition& start, const JSTextPosition& end)
     {
-        ThrowNode* result = new (m_parserArena) ThrowNode(location, expr);
+        ThrowNode* result = new (m_parserArena.get()) ThrowNode(location, expr);
         result->setLoc(start.line, end.line, start.offset, start.lineStartOffset);
         setExceptionLocation(result, start, end, end);
         return result;
@@ -804,24 +804,24 @@ public:
     
     StatementNode* createDebugger(const JSTokenLocation& location, int startLine, int endLine)
     {
-        DebuggerStatementNode* result = new (m_parserArena) DebuggerStatementNode(location);
+        DebuggerStatementNode* result = new (m_parserArena.get()) DebuggerStatementNode(location);
         result->setLoc(startLine, endLine, location.startOffset, location.lineStartOffset);
         return result;
     }
 
     ModuleNameNode* createModuleName(const JSTokenLocation& location, const Identifier& moduleName)
     {
-        return new (m_parserArena) ModuleNameNode(location, moduleName);
+        return new (m_parserArena.get()) ModuleNameNode(location, moduleName);
     }
 
     ImportSpecifierNode* createImportSpecifier(const JSTokenLocation& location, const Identifier& importedName, const Identifier& localName)
     {
-        return new (m_parserArena) ImportSpecifierNode(location, importedName, localName);
+        return new (m_parserArena.get()) ImportSpecifierNode(location, importedName, localName);
     }
 
     ImportSpecifierListNode* createImportSpecifierList()
     {
-        return new (m_parserArena) ImportSpecifierListNode();
+        return new (m_parserArena.get()) ImportSpecifierListNode();
     }
 
     void appendImportSpecifier(ImportSpecifierListNode* specifierList, ImportSpecifierNode* specifier)
@@ -831,7 +831,7 @@ public:
 
     ImportAttributesListNode* createImportAttributesList()
     {
-        return new (m_parserArena) ImportAttributesListNode();
+        return new (m_parserArena.get()) ImportAttributesListNode();
     }
 
     void appendImportAttribute(ImportAttributesListNode* attributesList, const Identifier& key, const Identifier& value)
@@ -841,37 +841,37 @@ public:
 
     StatementNode* createImportDeclaration(const JSTokenLocation& location, ImportDeclarationNode::ImportType type, ImportSpecifierListNode* importSpecifierList, ModuleNameNode* moduleName, ImportAttributesListNode* importAttributesList)
     {
-        return new (m_parserArena) ImportDeclarationNode(location, type, importSpecifierList, moduleName, importAttributesList);
+        return new (m_parserArena.get()) ImportDeclarationNode(location, type, importSpecifierList, moduleName, importAttributesList);
     }
 
     StatementNode* createExportAllDeclaration(const JSTokenLocation& location, ModuleNameNode* moduleName, ImportAttributesListNode* importAttributesList)
     {
-        return new (m_parserArena) ExportAllDeclarationNode(location, moduleName, importAttributesList);
+        return new (m_parserArena.get()) ExportAllDeclarationNode(location, moduleName, importAttributesList);
     }
 
     StatementNode* createExportDefaultDeclaration(const JSTokenLocation& location, StatementNode* declaration, const Identifier& localName)
     {
-        return new (m_parserArena) ExportDefaultDeclarationNode(location, declaration, localName);
+        return new (m_parserArena.get()) ExportDefaultDeclarationNode(location, declaration, localName);
     }
 
     StatementNode* createExportLocalDeclaration(const JSTokenLocation& location, StatementNode* declaration)
     {
-        return new (m_parserArena) ExportLocalDeclarationNode(location, declaration);
+        return new (m_parserArena.get()) ExportLocalDeclarationNode(location, declaration);
     }
 
     StatementNode* createExportNamedDeclaration(const JSTokenLocation& location, ExportSpecifierListNode* exportSpecifierList, ModuleNameNode* moduleName, ImportAttributesListNode* importAttributesList)
     {
-        return new (m_parserArena) ExportNamedDeclarationNode(location, exportSpecifierList, moduleName, importAttributesList);
+        return new (m_parserArena.get()) ExportNamedDeclarationNode(location, exportSpecifierList, moduleName, importAttributesList);
     }
 
     ExportSpecifierNode* createExportSpecifier(const JSTokenLocation& location, const Identifier& localName, const Identifier& exportedName)
     {
-        return new (m_parserArena) ExportSpecifierNode(location, localName, exportedName);
+        return new (m_parserArena.get()) ExportSpecifierNode(location, localName, exportedName);
     }
 
     ExportSpecifierListNode* createExportSpecifierList()
     {
-        return new (m_parserArena) ExportSpecifierListNode();
+        return new (m_parserArena.get()) ExportSpecifierListNode();
     }
 
     void appendExportSpecifier(ExportSpecifierListNode* specifierList, ExportSpecifierNode* specifier)
@@ -886,14 +886,14 @@ public:
 
     CommaNode* createCommaExpr(const JSTokenLocation& location, ExpressionNode* node)
     {
-        return new (m_parserArena) CommaNode(location, node);
+        return new (m_parserArena.get()) CommaNode(location, node);
     }
 
     CommaNode* appendToCommaExpr(const JSTokenLocation& location, ExpressionNode* tail, ExpressionNode* next)
     {
         ASSERT(tail->isCommaNode());
         ASSERT(next);
-        CommaNode* newTail = new (m_parserArena) CommaNode(location, next);
+        CommaNode* newTail = new (m_parserArena.get()) CommaNode(location, next);
         static_cast<CommaNode*>(tail)->setNext(newTail);
         return newTail;
     }
@@ -1001,12 +1001,12 @@ public:
 
     ExpressionNode* createDestructuringAssignment(const JSTokenLocation& location, DestructuringPattern pattern, ExpressionNode* initializer)
     {
-        return new (m_parserArena) DestructuringAssignmentNode(location, pattern, initializer);
+        return new (m_parserArena.get()) DestructuringAssignmentNode(location, pattern, initializer);
     }
     
     ArrayPattern createArrayPattern(const JSTokenLocation&)
     {
-        return new (m_parserArena) ArrayPatternNode();
+        return new (m_parserArena.get()) ArrayPatternNode();
     }
     
     void appendArrayPatternSkipEntry(ArrayPattern node, const JSTokenLocation& location)
@@ -1032,7 +1032,7 @@ public:
     
     ObjectPattern createObjectPattern(const JSTokenLocation&)
     {
-        return new (m_parserArena) ObjectPatternNode();
+        return new (m_parserArena.get()) ObjectPatternNode();
     }
 
     void appendObjectPatternEntry(ObjectPattern node, const JSTokenLocation& location, bool wasString, const Identifier& identifier, DestructuringPattern pattern, ExpressionNode* defaultValue)
@@ -1071,18 +1071,18 @@ public:
     {
         if (context == AssignmentContext::AwaitUsingDeclarationStatement)
             usesAwait();
-        return new (m_parserArena) BindingNode(boundProperty, start, end, context);
+        return new (m_parserArena.get()) BindingNode(boundProperty, start, end, context);
     }
 
     RestParameterNode* createRestParameter(DestructuringPatternNode* pattern, size_t numParametersToSkip)
     {
-        return new (m_parserArena) RestParameterNode(pattern, numParametersToSkip);
+        return new (m_parserArena.get()) RestParameterNode(pattern, numParametersToSkip);
     }
 
     AssignmentElement createAssignmentElement(const Expression& assignmentTarget, const JSTextPosition& start, const JSTextPosition& end)
     {
         checkArgumentsLengthModification(assignmentTarget);
-        return new (m_parserArena) AssignmentElementNode(assignmentTarget, start, end);
+        return new (m_parserArena.get()) AssignmentElementNode(assignmentTarget, start, end);
     }
 
     void setEndOffset(Node* node, int offset)
@@ -1157,15 +1157,15 @@ private:
     void usesAwait() { m_scope.m_features |= AwaitFeature; }
     ExpressionNode* createIntegerLikeNumber(const JSTokenLocation& location, double d)
     {
-        return new (m_parserArena) IntegerNode(location, d);
+        return new (m_parserArena.get()) IntegerNode(location, d);
     }
     ExpressionNode* createDoubleLikeNumber(const JSTokenLocation& location, double d)
     {
-        return new (m_parserArena) DoubleNode(location, d);
+        return new (m_parserArena.get()) DoubleNode(location, d);
     }
     ExpressionNode* createBigIntWithSign(const JSTokenLocation& location, const Identifier& bigInt, uint8_t radix, bool sign)
     {
-        return new (m_parserArena) BigIntNode(location, bigInt, radix, sign);
+        return new (m_parserArena.get()) BigIntNode(location, bigInt, radix, sign);
     }
     ExpressionNode* createNumberFromBinaryOperation(const JSTokenLocation& location, double value, const NumberNode& originalNodeA, const NumberNode& originalNodeB)
     {
@@ -1211,7 +1211,7 @@ private:
     }
 
     VM& m_vm;
-    ParserArena& m_parserArena;
+    Ref<ParserArena> m_parserArena;
     SourceCode* m_sourceCode;
     Scope m_scope;
     Vector<BinaryOperand, 10, UnsafeVectorOverflow> m_binaryOperandStack;
@@ -1225,9 +1225,9 @@ ExpressionNode* ASTBuilder::makeTypeOfNode(const JSTokenLocation& location, Expr
 {
     if (expr->isResolveNode()) {
         ResolveNode* resolve = static_cast<ResolveNode*>(expr);
-        return new (m_parserArena) TypeOfResolveNode(location, resolve->identifier(), start, divot, end);
+        return new (m_parserArena.get()) TypeOfResolveNode(location, resolve->identifier(), start, divot, end);
     }
-    return new (m_parserArena) TypeOfValueNode(location, expr);
+    return new (m_parserArena.get()) TypeOfValueNode(location, expr);
 }
 
 ExpressionNode* ASTBuilder::makeDeleteNode(const JSTokenLocation& location, ExpressionNode* expr, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end)
@@ -1242,19 +1242,19 @@ ExpressionNode* ASTBuilder::makeDeleteNode(const JSTokenLocation& location, Expr
     }
 
     if (!expr->isLocation())
-        return new (m_parserArena) DeleteValueNode(location, expr);
+        return new (m_parserArena.get()) DeleteValueNode(location, expr);
     if (expr->isResolveNode()) {
         ResolveNode* resolve = static_cast<ResolveNode*>(expr);
-        return new (m_parserArena) DeleteResolveNode(location, resolve->identifier(), divot, start, end);
+        return new (m_parserArena.get()) DeleteResolveNode(location, resolve->identifier(), divot, start, end);
     }
     if (expr->isBracketAccessorNode()) {
         BracketAccessorNode* bracket = static_cast<BracketAccessorNode*>(expr);
-        return new (m_parserArena) DeleteBracketNode(location, bracket->base(), bracket->subscript(), divot, start, end);
+        return new (m_parserArena.get()) DeleteBracketNode(location, bracket->base(), bracket->subscript(), divot, start, end);
     }
     ASSERT(expr->isDotAccessorNode());
     checkArgumentsLengthModification(expr);
     DotAccessorNode* dot = static_cast<DotAccessorNode*>(expr);
-    return new (m_parserArena) DeleteDotNode(location, dot->base(), dot->identifier(), divot, start, end);
+    return new (m_parserArena.get()) DeleteDotNode(location, dot->base(), dot->identifier(), divot, start, end);
 }
 
 ExpressionNode* ASTBuilder::makeNegateNode(const JSTokenLocation& location, ExpressionNode* n)
@@ -1269,14 +1269,14 @@ ExpressionNode* ASTBuilder::makeNegateNode(const JSTokenLocation& location, Expr
         return createBigIntFromUnaryOperation(location, !bigIntNode.sign(), bigIntNode);
     }
 
-    return new (m_parserArena) NegateNode(location, n);
+    return new (m_parserArena.get()) NegateNode(location, n);
 }
 
 ExpressionNode* ASTBuilder::makeBitwiseNotNode(const JSTokenLocation& location, ExpressionNode* expr)
 {
     if (expr->isNumber())
         return createIntegerLikeNumber(location, ~toInt32(static_cast<NumberNode*>(expr)->value()));
-    return new (m_parserArena) BitwiseNotNode(location, expr);
+    return new (m_parserArena.get()) BitwiseNotNode(location, expr);
 }
 
 ExpressionNode* ASTBuilder::makePowNode(const JSTokenLocation& location, ExpressionNode* expr1, ExpressionNode* expr2, bool rightHasAssignments)
@@ -1295,7 +1295,7 @@ ExpressionNode* ASTBuilder::makePowNode(const JSTokenLocation& location, Express
     if (strippedExpr2->isNumber())
         expr2 = strippedExpr2;
 
-    return new (m_parserArena) PowNode(location, expr1, expr2, rightHasAssignments);
+    return new (m_parserArena.get()) PowNode(location, expr1, expr2, rightHasAssignments);
 }
 
 ExpressionNode* ASTBuilder::makeMultNode(const JSTokenLocation& location, ExpressionNode* expr1, ExpressionNode* expr2, bool rightHasAssignments)
@@ -1312,12 +1312,12 @@ ExpressionNode* ASTBuilder::makeMultNode(const JSTokenLocation& location, Expres
     }
 
     if (expr1->isNumber() && static_cast<NumberNode*>(expr1)->value() == 1)
-        return new (m_parserArena) UnaryPlusNode(location, expr2);
+        return new (m_parserArena.get()) UnaryPlusNode(location, expr2);
 
     if (expr2->isNumber() && static_cast<NumberNode*>(expr2)->value() == 1)
-        return new (m_parserArena) UnaryPlusNode(location, expr1);
+        return new (m_parserArena.get()) UnaryPlusNode(location, expr1);
 
-    return new (m_parserArena) MultNode(location, expr1, expr2, rightHasAssignments);
+    return new (m_parserArena.get()) MultNode(location, expr1, expr2, rightHasAssignments);
 }
 
 ExpressionNode* ASTBuilder::makeDivNode(const JSTokenLocation& location, ExpressionNode* expr1, ExpressionNode* expr2, bool rightHasAssignments)
@@ -1335,7 +1335,7 @@ ExpressionNode* ASTBuilder::makeDivNode(const JSTokenLocation& location, Express
             return createNumberFromBinaryOperation(location, result, numberExpr1, numberExpr2);
         return createDoubleLikeNumber(location, result);
     }
-    return new (m_parserArena) DivNode(location, expr1, expr2, rightHasAssignments);
+    return new (m_parserArena.get()) DivNode(location, expr1, expr2, rightHasAssignments);
 }
 
 ExpressionNode* ASTBuilder::makeModNode(const JSTokenLocation& location, ExpressionNode* expr1, ExpressionNode* expr2, bool rightHasAssignments)
@@ -1350,7 +1350,7 @@ ExpressionNode* ASTBuilder::makeModNode(const JSTokenLocation& location, Express
         const NumberNode& numberExpr2 = static_cast<NumberNode&>(*expr2);
         return createIntegerLikeNumber(location, fmod(numberExpr1.value(), numberExpr2.value()));
     }
-    return new (m_parserArena) ModNode(location, expr1, expr2, rightHasAssignments);
+    return new (m_parserArena.get()) ModNode(location, expr1, expr2, rightHasAssignments);
 }
 
 ExpressionNode* ASTBuilder::makeAddNode(const JSTokenLocation& location, ExpressionNode* expr1, ExpressionNode* expr2, bool rightHasAssignments)
@@ -1361,7 +1361,7 @@ ExpressionNode* ASTBuilder::makeAddNode(const JSTokenLocation& location, Express
         const NumberNode& numberExpr2 = static_cast<NumberNode&>(*expr2);
         return createNumberFromBinaryOperation(location, numberExpr1.value() + numberExpr2.value(), numberExpr1, numberExpr2);
     }
-    return new (m_parserArena) AddNode(location, expr1, expr2, rightHasAssignments);
+    return new (m_parserArena.get()) AddNode(location, expr1, expr2, rightHasAssignments);
 }
 
 ExpressionNode* ASTBuilder::makeSubNode(const JSTokenLocation& location, ExpressionNode* expr1, ExpressionNode* expr2, bool rightHasAssignments)
@@ -1376,7 +1376,7 @@ ExpressionNode* ASTBuilder::makeSubNode(const JSTokenLocation& location, Express
         const NumberNode& numberExpr2 = static_cast<NumberNode&>(*expr2);
         return createNumberFromBinaryOperation(location, numberExpr1.value() - numberExpr2.value(), numberExpr1, numberExpr2);
     }
-    return new (m_parserArena) SubNode(location, expr1, expr2, rightHasAssignments);
+    return new (m_parserArena.get()) SubNode(location, expr1, expr2, rightHasAssignments);
 }
 
 ExpressionNode* ASTBuilder::makeLeftShiftNode(const JSTokenLocation& location, ExpressionNode* expr1, ExpressionNode* expr2, bool rightHasAssignments)
@@ -1386,7 +1386,7 @@ ExpressionNode* ASTBuilder::makeLeftShiftNode(const JSTokenLocation& location, E
         const NumberNode& numberExpr2 = static_cast<NumberNode&>(*expr2);
         return createIntegerLikeNumber(location, toInt32(numberExpr1.value()) << (toUInt32(numberExpr2.value()) & 0x1f));
     }
-    return new (m_parserArena) LeftShiftNode(location, expr1, expr2, rightHasAssignments);
+    return new (m_parserArena.get()) LeftShiftNode(location, expr1, expr2, rightHasAssignments);
 }
 
 ExpressionNode* ASTBuilder::makeRightShiftNode(const JSTokenLocation& location, ExpressionNode* expr1, ExpressionNode* expr2, bool rightHasAssignments)
@@ -1396,7 +1396,7 @@ ExpressionNode* ASTBuilder::makeRightShiftNode(const JSTokenLocation& location, 
         const NumberNode& numberExpr2 = static_cast<NumberNode&>(*expr2);
         return createIntegerLikeNumber(location, toInt32(numberExpr1.value()) >> (toUInt32(numberExpr2.value()) & 0x1f));
     }
-    return new (m_parserArena) RightShiftNode(location, expr1, expr2, rightHasAssignments);
+    return new (m_parserArena.get()) RightShiftNode(location, expr1, expr2, rightHasAssignments);
 }
 
 ExpressionNode* ASTBuilder::makeURightShiftNode(const JSTokenLocation& location, ExpressionNode* expr1, ExpressionNode* expr2, bool rightHasAssignments)
@@ -1406,7 +1406,7 @@ ExpressionNode* ASTBuilder::makeURightShiftNode(const JSTokenLocation& location,
         const NumberNode& numberExpr2 = static_cast<NumberNode&>(*expr2);
         return createIntegerLikeNumber(location, toUInt32(numberExpr1.value()) >> (toUInt32(numberExpr2.value()) & 0x1f));
     }
-    return new (m_parserArena) UnsignedRightShiftNode(location, expr1, expr2, rightHasAssignments);
+    return new (m_parserArena.get()) UnsignedRightShiftNode(location, expr1, expr2, rightHasAssignments);
 }
 
 ExpressionNode* ASTBuilder::makeBitOrNode(const JSTokenLocation& location, ExpressionNode* expr1, ExpressionNode* expr2, bool rightHasAssignments)
@@ -1416,7 +1416,7 @@ ExpressionNode* ASTBuilder::makeBitOrNode(const JSTokenLocation& location, Expre
         const NumberNode& numberExpr2 = static_cast<NumberNode&>(*expr2);
         return createIntegerLikeNumber(location, toInt32(numberExpr1.value()) | toInt32(numberExpr2.value()));
     }
-    return new (m_parserArena) BitOrNode(location, expr1, expr2, rightHasAssignments);
+    return new (m_parserArena.get()) BitOrNode(location, expr1, expr2, rightHasAssignments);
 }
 
 ExpressionNode* ASTBuilder::makeBitAndNode(const JSTokenLocation& location, ExpressionNode* expr1, ExpressionNode* expr2, bool rightHasAssignments)
@@ -1426,7 +1426,7 @@ ExpressionNode* ASTBuilder::makeBitAndNode(const JSTokenLocation& location, Expr
         const NumberNode& numberExpr2 = static_cast<NumberNode&>(*expr2);
         return createIntegerLikeNumber(location, toInt32(numberExpr1.value()) & toInt32(numberExpr2.value()));
     }
-    return new (m_parserArena) BitAndNode(location, expr1, expr2, rightHasAssignments);
+    return new (m_parserArena.get()) BitAndNode(location, expr1, expr2, rightHasAssignments);
 }
 
 ExpressionNode* ASTBuilder::makeBitXOrNode(const JSTokenLocation& location, ExpressionNode* expr1, ExpressionNode* expr2, bool rightHasAssignments)
@@ -1436,7 +1436,7 @@ ExpressionNode* ASTBuilder::makeBitXOrNode(const JSTokenLocation& location, Expr
         const NumberNode& numberExpr2 = static_cast<NumberNode&>(*expr2);
         return createIntegerLikeNumber(location, toInt32(numberExpr1.value()) ^ toInt32(numberExpr2.value()));
     }
-    return new (m_parserArena) BitXOrNode(location, expr1, expr2, rightHasAssignments);
+    return new (m_parserArena.get()) BitXOrNode(location, expr1, expr2, rightHasAssignments);
 }
 
 ExpressionNode* ASTBuilder::makeCoalesceNode(const JSTokenLocation& location, ExpressionNode* expr1, ExpressionNode* expr2)
@@ -1446,16 +1446,16 @@ ExpressionNode* ASTBuilder::makeCoalesceNode(const JSTokenLocation& location, Ex
         OptionalChainNode* optionalChain = static_cast<OptionalChainNode*>(expr1);
         if (!optionalChain->expr()->isDeleteNode()) {
             constexpr bool hasAbsorbedOptionalChain = true;
-            return new (m_parserArena) CoalesceNode(location, optionalChain->expr(), expr2, hasAbsorbedOptionalChain);
+            return new (m_parserArena.get()) CoalesceNode(location, optionalChain->expr(), expr2, hasAbsorbedOptionalChain);
         }
     }
     constexpr bool hasAbsorbedOptionalChain = false;
-    return new (m_parserArena) CoalesceNode(location, expr1, expr2, hasAbsorbedOptionalChain);
+    return new (m_parserArena.get()) CoalesceNode(location, expr1, expr2, hasAbsorbedOptionalChain);
 }
 
 ExpressionNode* ASTBuilder::makeStaticBlockFunctionCallNode(const JSTokenLocation& location, ExpressionNode* func, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
 {
-    return new (m_parserArena) StaticBlockFunctionCallNode(location, func, divot, divotStart, divotEnd);
+    return new (m_parserArena.get()) StaticBlockFunctionCallNode(location, func, divot, divotStart, divotEnd);
 }
 
 ExpressionNode* ASTBuilder::makeFunctionCallNode(const JSTokenLocation& location, ExpressionNode* func, bool previousBaseWasSuper, ArgumentsNode* args, const JSTextPosition& divotStart, const JSTextPosition& divot, const JSTextPosition& divotEnd, size_t callOrApplyChildDepth, bool isOptionalCall)
@@ -1468,7 +1468,7 @@ ExpressionNode* ASTBuilder::makeFunctionCallNode(const JSTokenLocation& location
         ASSERT(!isOptionalCall);
         BytecodeIntrinsicNode* intrinsic = static_cast<BytecodeIntrinsicNode*>(func);
         if (intrinsic->type() == BytecodeIntrinsicNode::Type::Constant && intrinsic->entry().type() == BytecodeIntrinsicRegistry::Type::Emitter)
-            return new (m_parserArena) BytecodeIntrinsicNode(BytecodeIntrinsicNode::Type::Function, location, intrinsic->entry(), intrinsic->identifier(), args, divot, divotStart, divotEnd);
+            return new (m_parserArena.get()) BytecodeIntrinsicNode(BytecodeIntrinsicNode::Type::Function, location, intrinsic->entry(), intrinsic->identifier(), args, divot, divotStart, divotEnd);
     }
 
     if (func->isOptionalChain()) {
@@ -1484,19 +1484,19 @@ ExpressionNode* ASTBuilder::makeFunctionCallNode(const JSTokenLocation& location
     }
 
     if (!func->isLocation())
-        return new (m_parserArena) FunctionCallValueNode(location, func, args, divot, divotStart, divotEnd, isOptionalCall);
+        return new (m_parserArena.get()) FunctionCallValueNode(location, func, args, divot, divotStart, divotEnd, isOptionalCall);
     if (func->isResolveNode()) {
         ResolveNode* resolve = static_cast<ResolveNode*>(func);
         const Identifier& identifier = resolve->identifier();
         if (identifier == m_vm.propertyNames->eval && !isOptionalCall) {
             usesEval();
-            return new (m_parserArena) EvalFunctionCallNode(location, args, divot, divotStart, divotEnd);
+            return new (m_parserArena.get()) EvalFunctionCallNode(location, args, divot, divotStart, divotEnd);
         }
-        return new (m_parserArena) FunctionCallResolveNode(location, identifier, args, divot, divotStart, divotEnd, isOptionalCall);
+        return new (m_parserArena.get()) FunctionCallResolveNode(location, identifier, args, divot, divotStart, divotEnd, isOptionalCall);
     }
     if (func->isBracketAccessorNode()) {
         BracketAccessorNode* bracket = static_cast<BracketAccessorNode*>(func);
-        FunctionCallBracketNode* node = new (m_parserArena) FunctionCallBracketNode(location, bracket->base(), bracket->subscript(), bracket->subscriptHasAssignments(), args, divot, divotStart, divotEnd, isOptionalCall);
+        FunctionCallBracketNode* node = new (m_parserArena.get()) FunctionCallBracketNode(location, bracket->base(), bracket->subscript(), bracket->subscriptHasAssignments(), args, divot, divotStart, divotEnd, isOptionalCall);
         node->setSubexpressionInfo(bracket->divot(), bracket->divotEnd().offset);
         return node;
     }
@@ -1504,12 +1504,12 @@ ExpressionNode* ASTBuilder::makeFunctionCallNode(const JSTokenLocation& location
     DotAccessorNode* dot = static_cast<DotAccessorNode*>(func);
     FunctionCallDotNode* node = nullptr;
     if (!previousBaseWasSuper && (dot->identifier() == m_vm.propertyNames->builtinNames().callPublicName() || dot->identifier() == m_vm.propertyNames->builtinNames().callPrivateName()))
-        node = new (m_parserArena) CallFunctionCallDotNode(location, dot->base(), dot->identifier(), dot->type(), args, divot, divotStart, divotEnd, isOptionalCall, callOrApplyChildDepth);
+        node = new (m_parserArena.get()) CallFunctionCallDotNode(location, dot->base(), dot->identifier(), dot->type(), args, divot, divotStart, divotEnd, isOptionalCall, callOrApplyChildDepth);
     else if (!previousBaseWasSuper && (dot->identifier() == m_vm.propertyNames->builtinNames().applyPublicName() || dot->identifier() == m_vm.propertyNames->builtinNames().applyPrivateName())) {
         // FIXME: This check is only needed because we haven't taught the bytecode generator to inline
         // Reflect.apply yet. See https://bugs.webkit.org/show_bug.cgi?id=190668.
         if (!dot->base()->isResolveNode() || static_cast<ResolveNode*>(dot->base())->identifier() != m_vm.propertyNames->Reflect)
-            node = new (m_parserArena) ApplyFunctionCallDotNode(location, dot->base(), dot->identifier(), dot->type(), args, divot, divotStart, divotEnd, isOptionalCall, callOrApplyChildDepth);
+            node = new (m_parserArena.get()) ApplyFunctionCallDotNode(location, dot->base(), dot->identifier(), dot->type(), args, divot, divotStart, divotEnd, isOptionalCall, callOrApplyChildDepth);
     } else if (!previousBaseWasSuper 
         && dot->identifier() == m_vm.propertyNames->hasOwnProperty
         && args->m_listNode
@@ -1521,10 +1521,10 @@ ExpressionNode* ASTBuilder::makeFunctionCallNode(const JSTokenLocation& location
         // <resolveNode|thisNode>.hasOwnProperty(<resolveNode>)
         // i.e:
         // o.hasOwnProperty(p)
-        node = new (m_parserArena) HasOwnPropertyFunctionCallDotNode(location, dot->base(), dot->identifier(), dot->type(), args, divot, divotStart, divotEnd, isOptionalCall);
+        node = new (m_parserArena.get()) HasOwnPropertyFunctionCallDotNode(location, dot->base(), dot->identifier(), dot->type(), args, divot, divotStart, divotEnd, isOptionalCall);
     }
     if (!node)
-        node = new (m_parserArena) FunctionCallDotNode(location, dot->base(), dot->identifier(), dot->type(), args, divot, divotStart, divotEnd, isOptionalCall);
+        node = new (m_parserArena.get()) FunctionCallDotNode(location, dot->base(), dot->identifier(), dot->type(), args, divot, divotStart, divotEnd, isOptionalCall);
     node->setSubexpressionInfo(dot->divot(), dot->divotEnd().offset);
     return node;
 }
@@ -1536,10 +1536,10 @@ ExpressionNode* ASTBuilder::makeBinaryNode(const JSTokenLocation& location, int 
         return makeCoalesceNode(location, lhs.first, rhs.first);
 
     case OR:
-        return new (m_parserArena) LogicalOpNode(location, lhs.first, rhs.first, LogicalOperator::Or);
+        return new (m_parserArena.get()) LogicalOpNode(location, lhs.first, rhs.first, LogicalOperator::Or);
 
     case AND:
-        return new (m_parserArena) LogicalOpNode(location, lhs.first, rhs.first, LogicalOperator::And);
+        return new (m_parserArena.get()) LogicalOpNode(location, lhs.first, rhs.first, LogicalOperator::And);
 
     case BITOR:
         return makeBitOrNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
@@ -1551,37 +1551,37 @@ ExpressionNode* ASTBuilder::makeBinaryNode(const JSTokenLocation& location, int 
         return makeBitAndNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
 
     case EQEQ:
-        return new (m_parserArena) EqualNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
+        return new (m_parserArena.get()) EqualNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
 
     case NE:
-        return new (m_parserArena) NotEqualNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
+        return new (m_parserArena.get()) NotEqualNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
 
     case STREQ:
-        return new (m_parserArena) StrictEqualNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
+        return new (m_parserArena.get()) StrictEqualNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
 
     case STRNEQ:
-        return new (m_parserArena) NotStrictEqualNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
+        return new (m_parserArena.get()) NotStrictEqualNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
 
     case LT:
-        return new (m_parserArena) LessNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
+        return new (m_parserArena.get()) LessNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
 
     case GT:
-        return new (m_parserArena) GreaterNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
+        return new (m_parserArena.get()) GreaterNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
 
     case LE:
-        return new (m_parserArena) LessEqNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
+        return new (m_parserArena.get()) LessEqNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
 
     case GE:
-        return new (m_parserArena) GreaterEqNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
+        return new (m_parserArena.get()) GreaterEqNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
 
     case INSTANCEOF: {
-        InstanceOfNode* node = new (m_parserArena) InstanceOfNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
+        InstanceOfNode* node = new (m_parserArena.get()) InstanceOfNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
         setExceptionLocation(node, lhs.second.start, rhs.second.start, rhs.second.end);
         return node;
     }
 
     case INTOKEN: {
-        InNode* node = new (m_parserArena) InNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
+        InNode* node = new (m_parserArena.get()) InNode(location, lhs.first, rhs.first, rhs.second.hasAssignment);
         setExceptionLocation(node, lhs.second.start, rhs.second.start, rhs.second.end);
         return node;
     }
@@ -1621,7 +1621,7 @@ ExpressionNode* ASTBuilder::makeAssignNode(const JSTokenLocation& location, Expr
 {
     if (!loc->isLocation()) {
         ASSERT(loc->isFunctionCall());
-        return new (m_parserArena) AssignErrorNode(location, loc, divot, start, end);
+        return new (m_parserArena.get()) AssignErrorNode(location, loc, divot, start, end);
     }
 
     if (loc->isResolveNode()) {
@@ -1633,7 +1633,7 @@ ExpressionNode* ASTBuilder::makeAssignNode(const JSTokenLocation& location, Expr
                 metadata->setEcmaName(resolve->identifier());
             } else if (expr->isClassExprNode())
                 static_cast<ClassExprNode*>(expr)->setEcmaName(resolve->identifier());
-            AssignResolveNode* node = new (m_parserArena) AssignResolveNode(location, resolve->identifier(), expr, AssignmentContext::AssignmentExpression);
+            AssignResolveNode* node = new (m_parserArena.get()) AssignResolveNode(location, resolve->identifier(), expr, AssignmentContext::AssignmentExpression);
             setExceptionLocation(node, start, divot, end);
             return node;
         }
@@ -1644,25 +1644,25 @@ ExpressionNode* ASTBuilder::makeAssignNode(const JSTokenLocation& location, Expr
                 metadata->setEcmaName(resolve->identifier());
             } else if (expr->isClassExprNode())
                 static_cast<ClassExprNode*>(expr)->setEcmaName(resolve->identifier());
-            return new (m_parserArena) ShortCircuitReadModifyResolveNode(location, resolve->identifier(), op, expr, exprHasAssignments, divot, start, end);
+            return new (m_parserArena.get()) ShortCircuitReadModifyResolveNode(location, resolve->identifier(), op, expr, exprHasAssignments, divot, start, end);
         }
 
-        return new (m_parserArena) ReadModifyResolveNode(location, resolve->identifier(), op, expr, exprHasAssignments, divot, start, end);
+        return new (m_parserArena.get()) ReadModifyResolveNode(location, resolve->identifier(), op, expr, exprHasAssignments, divot, start, end);
     }
 
     if (loc->isBracketAccessorNode()) {
         BracketAccessorNode* bracket = static_cast<BracketAccessorNode*>(loc);
 
         if (op == Operator::Equal)
-            return new (m_parserArena) AssignBracketNode(location, bracket->base(), bracket->subscript(), expr, locHasAssignments, exprHasAssignments, bracket->divot(), start, end);
+            return new (m_parserArena.get()) AssignBracketNode(location, bracket->base(), bracket->subscript(), expr, locHasAssignments, exprHasAssignments, bracket->divot(), start, end);
 
         if (op == Operator::CoalesceEq || op == Operator::OrEq || op == Operator::AndEq) {
-            auto* node = new (m_parserArena) ShortCircuitReadModifyBracketNode(location, bracket->base(), bracket->subscript(), op, expr, locHasAssignments, exprHasAssignments, divot, start, end);
+            auto* node = new (m_parserArena.get()) ShortCircuitReadModifyBracketNode(location, bracket->base(), bracket->subscript(), op, expr, locHasAssignments, exprHasAssignments, divot, start, end);
             node->setSubexpressionInfo(bracket->divot(), bracket->divotEnd().offset);
             return node;
         }
 
-        ReadModifyBracketNode* node = new (m_parserArena) ReadModifyBracketNode(location, bracket->base(), bracket->subscript(), op, expr, locHasAssignments, exprHasAssignments, divot, start, end);
+        ReadModifyBracketNode* node = new (m_parserArena.get()) ReadModifyBracketNode(location, bracket->base(), bracket->subscript(), op, expr, locHasAssignments, exprHasAssignments, divot, start, end);
         node->setSubexpressionInfo(bracket->divot(), bracket->divotEnd().offset);
         return node;
     }
@@ -1671,15 +1671,15 @@ ExpressionNode* ASTBuilder::makeAssignNode(const JSTokenLocation& location, Expr
     DotAccessorNode* dot = static_cast<DotAccessorNode*>(loc);
 
     if (op == Operator::Equal)
-        return new (m_parserArena) AssignDotNode(location, dot->base(), dot->identifier(), dot->type(), expr, exprHasAssignments, dot->divot(), start, end);
+        return new (m_parserArena.get()) AssignDotNode(location, dot->base(), dot->identifier(), dot->type(), expr, exprHasAssignments, dot->divot(), start, end);
 
     if (op == Operator::CoalesceEq || op == Operator::OrEq || op == Operator::AndEq) {
-        auto* node = new (m_parserArena) ShortCircuitReadModifyDotNode(location, dot->base(), dot->identifier(), dot->type(), op, expr, exprHasAssignments, divot, start, end);
+        auto* node = new (m_parserArena.get()) ShortCircuitReadModifyDotNode(location, dot->base(), dot->identifier(), dot->type(), op, expr, exprHasAssignments, divot, start, end);
         node->setSubexpressionInfo(dot->divot(), dot->divotEnd().offset);
         return node;
     }
 
-    ReadModifyDotNode* node = new (m_parserArena) ReadModifyDotNode(location, dot->base(), dot->identifier(), dot->type(), op, expr, exprHasAssignments, divot, start, end);
+    ReadModifyDotNode* node = new (m_parserArena.get()) ReadModifyDotNode(location, dot->base(), dot->identifier(), dot->type(), op, expr, exprHasAssignments, divot, start, end);
     node->setSubexpressionInfo(dot->divot(), dot->divotEnd().offset);
     return node;
 }
@@ -1687,13 +1687,13 @@ ExpressionNode* ASTBuilder::makeAssignNode(const JSTokenLocation& location, Expr
 ExpressionNode* ASTBuilder::makePrefixNode(const JSTokenLocation& location, ExpressionNode* expr, Operator op, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end)
 {
     checkArgumentsLengthModification(expr);
-    return new (m_parserArena) PrefixNode(location, expr, op, divot, start, end);
+    return new (m_parserArena.get()) PrefixNode(location, expr, op, divot, start, end);
 }
 
 ExpressionNode* ASTBuilder::makePostfixNode(const JSTokenLocation& location, ExpressionNode* expr, Operator op, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end)
 {
     checkArgumentsLengthModification(expr);
-    return new (m_parserArena) PostfixNode(location, expr, op, divot, start, end);
+    return new (m_parserArena.get()) PostfixNode(location, expr, op, divot, start, end);
 }
 
 }

--- a/Source/JavaScriptCore/parser/EagerIIFERegistry.cpp
+++ b/Source/JavaScriptCore/parser/EagerIIFERegistry.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "EagerIIFERegistry.h"
+
+namespace JSC {
+
+EagerIIFERegistry::~EagerIIFERegistry()
+{
+    clear();
+}
+
+void EagerIIFERegistry::clear()
+{
+    m_map.clear();
+}
+
+void EagerIIFERegistry::add(int sourcePosition, std::unique_ptr<FunctionNode> node)
+{
+    m_map.add(sourcePosition, WTF::move(node));
+}
+
+std::unique_ptr<FunctionNode> EagerIIFERegistry::take(int sourcePosition)
+{
+    return m_map.take(sourcePosition);
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/parser/EagerIIFERegistry.h
+++ b/Source/JavaScriptCore/parser/EagerIIFERegistry.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Nodes.h"
+#include <wtf/InlineMap.h>
+#include <wtf/RefCounted.h>
+
+namespace JSC {
+
+class EagerIIFERegistry : public RefCounted<EagerIIFERegistry> {
+public:
+    EagerIIFERegistry() { }
+    ~EagerIIFERegistry();
+
+    void clear();
+    void add(int sourcePosition, std::unique_ptr<FunctionNode>);
+    std::unique_ptr<FunctionNode> take(int sourcePosition);
+
+private:
+    InlineMap<int, std::unique_ptr<FunctionNode>, 4, WTF::IntHash<int>, WTF::UnsignedWithZeroKeyHashTraits<int>> m_map;
+};
+
+} // namespace JSC

--- a/Source/JavaScriptCore/parser/NodeConstructors.h
+++ b/Source/JavaScriptCore/parser/NodeConstructors.h
@@ -36,9 +36,9 @@ namespace JSC {
         return parserArena.allocateDeletable<T>(size);
     }
 
-    inline ParserArenaRoot::ParserArenaRoot(ParserArena& parserArena)
+    inline ParserArenaRoot::ParserArenaRoot(Ref<ParserArena>&& parserArena)
+        : m_arena(WTF::move(parserArena))
     {
-        m_arena.swap(parserArena);
     }
 
     inline Node::Node(const JSTokenLocation& location)

--- a/Source/JavaScriptCore/parser/Nodes.cpp
+++ b/Source/JavaScriptCore/parser/Nodes.cpp
@@ -118,9 +118,9 @@ bool BlockNode::hasEarlyBreakOrContinue() const
 
 // ------------------------------ ScopeNode -----------------------------
 
-ScopeNode::ScopeNode(ParserArena& parserArena, const JSTokenLocation& startLocation, const JSTokenLocation& endLocation, LexicallyScopedFeatures lexicallyScopedFeatures)
+ScopeNode::ScopeNode(Ref<ParserArena>&& parserArena, const JSTokenLocation& startLocation, const JSTokenLocation& endLocation, LexicallyScopedFeatures lexicallyScopedFeatures)
     : StatementNode(endLocation)
-    , ParserArenaRoot(parserArena)
+    , ParserArenaRoot(WTF::move(parserArena))
     , m_startLineNumber(startLocation.line)
     , m_startStartOffset(startLocation.startOffset)
     , m_startLineStartOffset(startLocation.lineStartOffset)
@@ -132,9 +132,9 @@ ScopeNode::ScopeNode(ParserArena& parserArena, const JSTokenLocation& startLocat
 {
 }
 
-ScopeNode::ScopeNode(ParserArena& parserArena, const JSTokenLocation& startLocation, const JSTokenLocation& endLocation, const SourceCode& source, SourceElements* children, VariableEnvironment&& varEnvironment, FunctionStack&& funcStack, VariableEnvironment&& lexicalVariables, CodeFeatures features, LexicallyScopedFeatures lexicallyScopedFeatures, InnerArrowFunctionCodeFeatures innerArrowFunctionCodeFeatures, int numConstants)
+ScopeNode::ScopeNode(Ref<ParserArena>&& parserArena, const JSTokenLocation& startLocation, const JSTokenLocation& endLocation, const SourceCode& source, SourceElements* children, VariableEnvironment&& varEnvironment, FunctionStack&& funcStack, VariableEnvironment&& lexicalVariables, CodeFeatures features, LexicallyScopedFeatures lexicallyScopedFeatures, InnerArrowFunctionCodeFeatures innerArrowFunctionCodeFeatures, int numConstants)
     : StatementNode(endLocation)
-    , ParserArenaRoot(parserArena)
+    , ParserArenaRoot(WTF::move(parserArena))
     , VariableEnvironmentNode(WTF::move(lexicalVariables), WTF::move(funcStack))
     , m_startLineNumber(startLocation.line)
     , m_startStartOffset(startLocation.startOffset)
@@ -166,8 +166,8 @@ bool ScopeNode::hasEarlyBreakOrContinue() const
 
 // ------------------------------ ProgramNode -----------------------------
 
-ProgramNode::ProgramNode(ParserArena& parserArena, const JSTokenLocation& startLocation, const JSTokenLocation& endLocation, unsigned startColumn, unsigned endColumn, SourceElements* children, VariableEnvironment&& varEnvironment, FunctionStack&& funcStack, VariableEnvironment&& lexicalVariables, FunctionParameters*, const SourceCode& source, CodeFeatures features, LexicallyScopedFeatures lexicallyScopedFeatures, InnerArrowFunctionCodeFeatures innerArrowFunctionCodeFeatures, int numConstants, RefPtr<ModuleScopeData>&&)
-    : ScopeNode(parserArena, startLocation, endLocation, source, children, WTF::move(varEnvironment), WTF::move(funcStack), WTF::move(lexicalVariables), features, lexicallyScopedFeatures, innerArrowFunctionCodeFeatures, numConstants)
+ProgramNode::ProgramNode(Ref<ParserArena>&& parserArena, const JSTokenLocation& startLocation, const JSTokenLocation& endLocation, unsigned startColumn, unsigned endColumn, SourceElements* children, VariableEnvironment&& varEnvironment, FunctionStack&& funcStack, VariableEnvironment&& lexicalVariables, FunctionParameters*, const SourceCode& source, CodeFeatures features, LexicallyScopedFeatures lexicallyScopedFeatures, InnerArrowFunctionCodeFeatures innerArrowFunctionCodeFeatures, int numConstants, RefPtr<ModuleScopeData>&&)
+    : ScopeNode(WTF::move(parserArena), startLocation, endLocation, source, children, WTF::move(varEnvironment), WTF::move(funcStack), WTF::move(lexicalVariables), features, lexicallyScopedFeatures, innerArrowFunctionCodeFeatures, numConstants)
     , m_startColumn(startColumn)
     , m_endColumn(endColumn)
 {
@@ -175,8 +175,8 @@ ProgramNode::ProgramNode(ParserArena& parserArena, const JSTokenLocation& startL
 
 // ------------------------------ ModuleProgramNode -----------------------------
 
-ModuleProgramNode::ModuleProgramNode(ParserArena& parserArena, const JSTokenLocation& startLocation, const JSTokenLocation& endLocation, unsigned startColumn, unsigned endColumn, SourceElements* children, VariableEnvironment&& varEnvironment, FunctionStack&& funcStack, VariableEnvironment&& lexicalVariables, FunctionParameters*, const SourceCode& source, CodeFeatures features, LexicallyScopedFeatures lexicallyScopedFeatures, InnerArrowFunctionCodeFeatures innerArrowFunctionCodeFeatures, int numConstants, RefPtr<ModuleScopeData>&& moduleScopeData)
-    : ScopeNode(parserArena, startLocation, endLocation, source, children, WTF::move(varEnvironment), WTF::move(funcStack), WTF::move(lexicalVariables), features, lexicallyScopedFeatures, innerArrowFunctionCodeFeatures, numConstants)
+ModuleProgramNode::ModuleProgramNode(Ref<ParserArena>&& parserArena, const JSTokenLocation& startLocation, const JSTokenLocation& endLocation, unsigned startColumn, unsigned endColumn, SourceElements* children, VariableEnvironment&& varEnvironment, FunctionStack&& funcStack, VariableEnvironment&& lexicalVariables, FunctionParameters*, const SourceCode& source, CodeFeatures features, LexicallyScopedFeatures lexicallyScopedFeatures, InnerArrowFunctionCodeFeatures innerArrowFunctionCodeFeatures, int numConstants, RefPtr<ModuleScopeData>&& moduleScopeData)
+    : ScopeNode(WTF::move(parserArena), startLocation, endLocation, source, children, WTF::move(varEnvironment), WTF::move(funcStack), WTF::move(lexicalVariables), features, lexicallyScopedFeatures, innerArrowFunctionCodeFeatures, numConstants)
     , m_startColumn(startColumn)
     , m_endColumn(endColumn)
     , m_usesAwait(features & AwaitFeature)
@@ -186,8 +186,8 @@ ModuleProgramNode::ModuleProgramNode(ParserArena& parserArena, const JSTokenLoca
 
 // ------------------------------ EvalNode -----------------------------
 
-EvalNode::EvalNode(ParserArena& parserArena, const JSTokenLocation& startLocation, const JSTokenLocation& endLocation, unsigned, unsigned endColumn, SourceElements* children, VariableEnvironment&& varEnvironment, FunctionStack&& funcStack, VariableEnvironment&& lexicalVariables, FunctionParameters*, const SourceCode& source, CodeFeatures features, LexicallyScopedFeatures lexicallyScopedFeatures, InnerArrowFunctionCodeFeatures innerArrowFunctionCodeFeatures, int numConstants, RefPtr<ModuleScopeData>&&)
-    : ScopeNode(parserArena, startLocation, endLocation, source, children, WTF::move(varEnvironment), WTF::move(funcStack), WTF::move(lexicalVariables), features, lexicallyScopedFeatures, innerArrowFunctionCodeFeatures, numConstants)
+EvalNode::EvalNode(Ref<ParserArena>&& parserArena, const JSTokenLocation& startLocation, const JSTokenLocation& endLocation, unsigned, unsigned endColumn, SourceElements* children, VariableEnvironment&& varEnvironment, FunctionStack&& funcStack, VariableEnvironment&& lexicalVariables, FunctionParameters*, const SourceCode& source, CodeFeatures features, LexicallyScopedFeatures lexicallyScopedFeatures, InnerArrowFunctionCodeFeatures innerArrowFunctionCodeFeatures, int numConstants, RefPtr<ModuleScopeData>&&)
+    : ScopeNode(WTF::move(parserArena), startLocation, endLocation, source, children, WTF::move(varEnvironment), WTF::move(funcStack), WTF::move(lexicalVariables), features, lexicallyScopedFeatures, innerArrowFunctionCodeFeatures, numConstants)
     , m_endColumn(endColumn)
 {
 }
@@ -314,8 +314,8 @@ void FunctionMetadataNode::dump(PrintStream& stream) const
 
 // ------------------------------ FunctionNode -----------------------------
 
-FunctionNode::FunctionNode(ParserArena& parserArena, const JSTokenLocation& startLocation, const JSTokenLocation& endLocation, unsigned startColumn, unsigned endColumn, SourceElements* children, VariableEnvironment&& varEnvironment, FunctionStack&& funcStack, VariableEnvironment&& lexicalVariables, FunctionParameters* parameters, const SourceCode& sourceCode, CodeFeatures features, LexicallyScopedFeatures lexicallyScopedFeatures, InnerArrowFunctionCodeFeatures innerArrowFunctionCodeFeatures, int numConstants, RefPtr<ModuleScopeData>&&)
-    : ScopeNode(parserArena, startLocation, endLocation, sourceCode, children, WTF::move(varEnvironment), WTF::move(funcStack), WTF::move(lexicalVariables), features, lexicallyScopedFeatures, innerArrowFunctionCodeFeatures, numConstants)
+FunctionNode::FunctionNode(Ref<ParserArena>&& parserArena, const JSTokenLocation& startLocation, const JSTokenLocation& endLocation, unsigned startColumn, unsigned endColumn, SourceElements* children, VariableEnvironment&& varEnvironment, FunctionStack&& funcStack, VariableEnvironment&& lexicalVariables, FunctionParameters* parameters, const SourceCode& sourceCode, CodeFeatures features, LexicallyScopedFeatures lexicallyScopedFeatures, InnerArrowFunctionCodeFeatures innerArrowFunctionCodeFeatures, int numConstants, RefPtr<ModuleScopeData>&&)
+    : ScopeNode(WTF::move(parserArena), startLocation, endLocation, sourceCode, children, WTF::move(varEnvironment), WTF::move(funcStack), WTF::move(lexicalVariables), features, lexicallyScopedFeatures, innerArrowFunctionCodeFeatures, numConstants)
     , m_parameters(parameters)
     , m_startColumn(startColumn)
     , m_endColumn(endColumn)

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -139,14 +139,14 @@ namespace JSC {
     class ParserArenaRoot {
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(ParserArenaRoot, ParserArenaRoot);
     protected:
-        ParserArenaRoot(ParserArena&);
+        ParserArenaRoot(Ref<ParserArena>&&);
 
     public:
-        ParserArena& parserArena() LIFETIME_BOUND { return m_arena; }
+        ParserArena& parserArena() LIFETIME_BOUND { return m_arena.get(); }
         virtual ~ParserArenaRoot() { }
 
     protected:
-        ParserArena m_arena;
+        Ref<ParserArena> m_arena;
     };
 
     class Node : public ParserArenaFreeable {
@@ -1951,8 +1951,8 @@ namespace JSC {
         // new for allocation.
         using ParserArenaRoot::operator new;
 
-        ScopeNode(ParserArena&, const JSTokenLocation& start, const JSTokenLocation& end, LexicallyScopedFeatures);
-        ScopeNode(ParserArena&, const JSTokenLocation& start, const JSTokenLocation& end, const SourceCode&, SourceElements*, VariableEnvironment&&, FunctionStack&&, VariableEnvironment&&, CodeFeatures, LexicallyScopedFeatures, InnerArrowFunctionCodeFeatures, int numConstants);
+        ScopeNode(Ref<ParserArena>&&, const JSTokenLocation& start, const JSTokenLocation& end, LexicallyScopedFeatures);
+        ScopeNode(Ref<ParserArena>&&, const JSTokenLocation& start, const JSTokenLocation& end, const SourceCode&, SourceElements*, VariableEnvironment&&, FunctionStack&&, VariableEnvironment&&, CodeFeatures, LexicallyScopedFeatures, InnerArrowFunctionCodeFeatures, int numConstants);
 
         const SourceCode& source() const LIFETIME_BOUND { return m_source; }
         SourceID sourceID() const { return m_source.providerID(); }
@@ -2030,7 +2030,7 @@ namespace JSC {
 
     class ProgramNode final : public ScopeNode {
     public:
-        ProgramNode(ParserArena&, const JSTokenLocation& start, const JSTokenLocation& end, unsigned startColumn, unsigned endColumn, SourceElements*, VariableEnvironment&&, FunctionStack&&, VariableEnvironment&&, FunctionParameters*, const SourceCode&, CodeFeatures, LexicallyScopedFeatures, InnerArrowFunctionCodeFeatures, int numConstants, RefPtr<ModuleScopeData>&&);
+        ProgramNode(Ref<ParserArena>&&, const JSTokenLocation& start, const JSTokenLocation& end, unsigned startColumn, unsigned endColumn, SourceElements*, VariableEnvironment&&, FunctionStack&&, VariableEnvironment&&, FunctionParameters*, const SourceCode&, CodeFeatures, LexicallyScopedFeatures, InnerArrowFunctionCodeFeatures, int numConstants, RefPtr<ModuleScopeData>&&);
 
         unsigned startColumn() const { return m_startColumn; }
         unsigned endColumn() const { return m_endColumn; }
@@ -2045,7 +2045,7 @@ namespace JSC {
 
     class EvalNode final : public ScopeNode {
     public:
-        EvalNode(ParserArena&, const JSTokenLocation& start, const JSTokenLocation& end, unsigned startColumn, unsigned endColumn, SourceElements*, VariableEnvironment&&, FunctionStack&&, VariableEnvironment&&, FunctionParameters*, const SourceCode&, CodeFeatures, LexicallyScopedFeatures, InnerArrowFunctionCodeFeatures, int numConstants, RefPtr<ModuleScopeData>&&);
+        EvalNode(Ref<ParserArena>&&, const JSTokenLocation& start, const JSTokenLocation& end, unsigned startColumn, unsigned endColumn, SourceElements*, VariableEnvironment&&, FunctionStack&&, VariableEnvironment&&, FunctionParameters*, const SourceCode&, CodeFeatures, LexicallyScopedFeatures, InnerArrowFunctionCodeFeatures, int numConstants, RefPtr<ModuleScopeData>&&);
 
         ALWAYS_INLINE unsigned startColumn() const { return 0; }
         unsigned endColumn() const { return m_endColumn; }
@@ -2060,7 +2060,7 @@ namespace JSC {
 
     class ModuleProgramNode final : public ScopeNode {
     public:
-        ModuleProgramNode(ParserArena&, const JSTokenLocation& start, const JSTokenLocation& end, unsigned startColumn, unsigned endColumn, SourceElements*, VariableEnvironment&&, FunctionStack&&, VariableEnvironment&&, FunctionParameters*, const SourceCode&, CodeFeatures, LexicallyScopedFeatures, InnerArrowFunctionCodeFeatures, int numConstants, RefPtr<ModuleScopeData>&&);
+        ModuleProgramNode(Ref<ParserArena>&&, const JSTokenLocation& start, const JSTokenLocation& end, unsigned startColumn, unsigned endColumn, SourceElements*, VariableEnvironment&&, FunctionStack&&, VariableEnvironment&&, FunctionParameters*, const SourceCode&, CodeFeatures, LexicallyScopedFeatures, InnerArrowFunctionCodeFeatures, int numConstants, RefPtr<ModuleScopeData>&&);
 
         unsigned startColumn() const { return m_startColumn; }
         unsigned endColumn() const { return m_endColumn; }
@@ -2347,7 +2347,7 @@ namespace JSC {
 
     class FunctionNode final : public ScopeNode {
     public:
-        FunctionNode(ParserArena&, const JSTokenLocation& start, const JSTokenLocation& end, unsigned startColumn, unsigned endColumn, SourceElements*, VariableEnvironment&&, FunctionStack&&, VariableEnvironment&&, FunctionParameters*, const SourceCode&, CodeFeatures, LexicallyScopedFeatures, InnerArrowFunctionCodeFeatures, int numConstants, RefPtr<ModuleScopeData>&&);
+        FunctionNode(Ref<ParserArena>&&, const JSTokenLocation& start, const JSTokenLocation& end, unsigned startColumn, unsigned endColumn, SourceElements*, VariableEnvironment&&, FunctionStack&&, VariableEnvironment&&, FunctionParameters*, const SourceCode&, CodeFeatures, LexicallyScopedFeatures, InnerArrowFunctionCodeFeatures, int numConstants, RefPtr<ModuleScopeData>&&);
 
         FunctionParameters* parameters() const { return m_parameters; }
 

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -89,6 +89,36 @@ std::atomic<unsigned> globalParseCount { 0 };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ModuleScopeData);
 
+// When the parser encounters an immediately-invoked function expression (IIFE), it can
+// build the AST right away instead of the usual syntax-checking parse followed by a full
+// AST-building reparse.
+//
+// EagerIIFEParseScope and EagerIIFEParseState work together to enable this optimization.
+// EagerIIFEParseScope is created as a local in parseFunctionInfo when an IIFE candidate
+// is detected. It owns an ASTBuilder and constructs an EagerIIFEParseState that installs
+// itself into the parser. The ASTBuilder uses the parser's own arena, so the eagerly built
+// AST nodes live in the same arena as the rest of the parse. The FunctionNode created for
+// the IIFE holds a Ref to this shared arena, keeping it alive.
+
+template<typename LexerType>
+class EagerIIFEParseScope {
+public:
+    EagerIIFEParseScope(Parser<LexerType>* parser, unsigned startOffset)
+        : m_builder(const_cast<VM&>(parser->m_vm), parser->m_parserArena.copyRef(), const_cast<SourceCode*>(parser->m_source))
+        , m_parseState(*parser, &m_builder, startOffset)
+    { }
+
+private:
+    ASTBuilder m_builder;
+    Parser<LexerType>::EagerIIFEParseState m_parseState;
+};
+
+template <typename LexerType>
+CodeFeatures Parser<LexerType>::EagerIIFEParseState::features() const { return m_builder->features(); }
+
+template <typename LexerType>
+int Parser<LexerType>::EagerIIFEParseState::numConstants() const { return m_builder->numConstants(); }
+
 ALWAYS_INLINE static SourceParseMode getAsyncFunctionBodyParseMode(SourceParseMode parseMode)
 {
     if (isAsyncGeneratorWrapperParseMode(parseMode))
@@ -138,16 +168,18 @@ Parser<LexerType>::Parser(VM& vm, const SourceCode& source, ImplementationVisibi
     , m_implementationVisibility(implementationVisibility)
     , m_parsingBuiltin(builtinMode == JSParserBuiltinMode::Builtin)
     , m_isInsideOrdinaryFunction(isInsideOrdinaryFunction)
+    , m_parserArena(ParserArena::create())
     , m_hasStackOverflow(false)
     , m_debuggerParseData(debuggerParseData)
 {
     m_lexer = makeUnique<LexerType>(vm, builtinMode, scriptMode);
-    m_lexer->setCode(source, &m_parserArena);
+    m_lexer->setCode(source, m_parserArena.ptr());
     m_token.m_startPosition.line = source.firstLine().oneBasedInt();
     m_token.m_startPosition.offset = source.startOffset();
     m_token.m_startPosition.lineStartOffset = source.startOffset();
     m_token.m_endPosition.offset = source.startOffset();
     m_functionCache = vm.addSourceProviderCache(source.provider());
+    m_eagerIIFERegistry = vm.addEagerIIFERegistry(source.provider());
 
     Scope* scope = pushScope();
     scope->setLexicallyScopedFeatures(lexicallyScopedFeatures);
@@ -214,7 +246,7 @@ static ALWAYS_INLINE bool NODELETE isPrivateFieldName(UniquedStringImpl* uid)
 template <typename LexerType>
 Expected<typename Parser<LexerType>::ParseInnerResult, String> Parser<LexerType>::parseInner(const Identifier& calleeName, ParsingContext parsingContext, std::optional<int> functionConstructorParametersEndPosition, const FixedVector<UnlinkedFunctionExecutable::ClassElementDefinition>* classElementDefinitions, const PrivateNameEnvironment* parentScopePrivateNames)
 {
-    ASTBuilder context(const_cast<VM&>(m_vm), m_parserArena, const_cast<SourceCode*>(m_source));
+    ASTBuilder context(const_cast<VM&>(m_vm), m_parserArena.copyRef(), const_cast<SourceCode*>(m_source));
     SourceParseMode parseMode = sourceParseMode();
     Scope* scope = currentScope();
     scope->setIsLexicalScope();
@@ -320,21 +352,7 @@ Expected<typename Parser<LexerType>::ParseInnerResult, String> Parser<LexerType>
             context.propagateArgumentsUse();
     }
 
-    CodeFeatures features = context.features();
-    if (scope->shadowsArguments())
-        features |= ShadowsArgumentsFeature;
-    if (m_seenTaggedTemplateInNonReparsingFunctionMode)
-        features |= NoEvalCacheFeature;
-    if (scope->hasNonSimpleParameterList())
-        features |= NonSimpleParameterListFeature;
-    if (scope->usesImportMeta())
-        features |= ImportMetaFeature;
-    if (m_seenArgumentsDotLength && scope->hasDeclaredGlobalArguments())
-        features |= ArgumentsFeature;
-    if (scope->asyncFunctionBodyDoesNotUseAwait())
-        features |= AsyncFunctionWithoutAwaitFeature;
-    if (scope->usesAwait())
-        features |= AwaitFeature;
+    CodeFeatures features = collectCodeFeatures(context.features(), scope);
 
 #if ASSERT_ENABLED
     if (m_parsingBuiltin && isProgramParseMode(parseMode)) {
@@ -352,6 +370,26 @@ Expected<typename Parser<LexerType>::ParseInnerResult, String> Parser<LexerType>
 #endif // ASSERT_ENABLED
 
     return ParseInnerResult { parameters, sourceElements, scope->takeFunctionDeclarations(), scope->takeDeclaredVariables(), scope->takeLexicalEnvironment(), features, context.numConstants() };
+}
+
+template <typename LexerType>
+CodeFeatures Parser<LexerType>::collectCodeFeatures(CodeFeatures features, Scope* scope)
+{
+    if (scope->shadowsArguments())
+        features |= ShadowsArgumentsFeature;
+    if (scope->hasNonSimpleParameterList())
+        features |= NonSimpleParameterListFeature;
+    if (m_seenTaggedTemplateInNonReparsingFunctionMode)
+        features |= NoEvalCacheFeature;
+    if (scope->usesImportMeta())
+        features |= ImportMetaFeature;
+    if (m_seenArgumentsDotLength && scope->hasDeclaredGlobalArguments())
+        features |= ArgumentsFeature;
+    if (scope->asyncFunctionBodyDoesNotUseAwait())
+        features |= AsyncFunctionWithoutAwaitFeature;
+    if (scope->usesAwait())
+        features |= AwaitFeature;
+    return features;
 }
 
 template <typename LexerType>
@@ -1388,14 +1426,14 @@ template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseDe
                 switch (m_token.m_type) {
                 case DOUBLE:
                 case INTEGER:
-                    propertyName = &m_parserArena.identifierArena().makeNumericIdentifier(const_cast<VM&>(m_vm), m_token.m_data.doubleValue);
+                    propertyName = &m_parserArena->identifierArena().makeNumericIdentifier(const_cast<VM&>(m_vm), m_token.m_data.doubleValue);
                     break;
                 case STRING:
                     propertyName = m_token.m_data.ident;
                     wasString = true;
                     break;
                 case BIGINT:
-                    propertyName = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+                    propertyName = m_parserArena->identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
                     failIfFalse(propertyName, "Cannot parse big int property name");
                     break;
                 case OPENBRACKET:
@@ -2376,7 +2414,9 @@ template <class TreeBuilder> TreeFunctionBody Parser<LexerType>::parseFunctionBo
         else
             failIfFalse(parseArrowFunctionSingleExpressionBodySourceElements(syntaxChecker), "Cannot parse body of this arrow function");
     } else {
-        if (m_debuggerParseData)
+        if (m_iifeParseState && !m_iifeParseState->isInUse()) [[unlikely]]
+            failIfFalse(m_iifeParseState->parseSourceElements(CheckForStrictMode), bodyType == StandardFunctionBodyBlock ? "Cannot parse body of this function" : "Cannot parse body of this arrow function");
+        else if (m_debuggerParseData)
             failIfFalse(parseSourceElements(context, CheckForStrictMode), bodyType == StandardFunctionBodyBlock ? "Cannot parse body of this function" : "Cannot parse body of this arrow function");
         else
             failIfFalse(parseSourceElements(syntaxChecker, CheckForStrictMode), bodyType == StandardFunctionBodyBlock ? "Cannot parse body of this function" : "Cannot parse body of this arrow function");
@@ -2570,7 +2610,7 @@ template <class TreeBuilder> typename TreeBuilder::FormalParameterList Parser<Le
 }
 
 template <typename LexerType>
-template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuilder& context, FunctionNameRequirements requirements, bool nameIsInContainingScope, ConstructorKind constructorKind, SuperBinding expectedSuperBinding, unsigned functionStart, ParserFunctionInfo<TreeBuilder>& functionInfo, FunctionDefinitionType functionDefinitionType, std::optional<int> functionConstructorParametersEndPosition)
+template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuilder& context, FunctionNameRequirements requirements, bool nameIsInContainingScope, ConstructorKind constructorKind, SuperBinding expectedSuperBinding, unsigned functionStart, ParserFunctionInfo<TreeBuilder>& functionInfo, FunctionDefinitionType functionDefinitionType, std::optional<int> functionConstructorParametersEndPosition, bool isLikelyIIFE)
 {
     auto mode = sourceParseMode();
     RELEASE_ASSERT(isFunctionParseMode(mode));
@@ -2675,6 +2715,8 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
 
     SyntaxChecker syntaxChecker(const_cast<VM&>(m_vm), m_lexer.get());
 
+    std::optional<EagerIIFEParseScope<LexerType>> eagerIIFEParseScope;
+
     ParserState oldState;
     if ((SourceParseModeSet(SourceParseMode::ArrowFunctionMode, SourceParseMode::AsyncArrowFunctionMode).contains(mode))) [[unlikely]] {
         startLocation = tokenLocation();
@@ -2758,7 +2800,20 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
 
         startLocation = tokenLocation();
         functionInfo.startLine = tokenLine();
+
         startColumn = tokenColumn();
+        // If we are parsing a function nested inside an eagerly parsed IIFE, and we are
+        // still on the same line where the IIFE started, the start column needs to be
+        // adjusted. During lazy parsing the startColumn of this function would be
+        // relative to the start of the IIFE, but during eager parsing it is relative to
+        // the start of the source code containing the IIFE.
+        if (m_iifeParseState
+            && m_iifeParseState->isInUse()
+            && tokenLineStart() <= m_iifeParseState->startOffset()) [[unlikely]] {
+
+            int adjustment = m_iifeParseState->startOffset() - tokenLineStart();
+            startColumn -= adjustment;
+        }
         functionInfo.parametersStartColumn = startColumn;
 
         parametersStart = m_token.m_startPosition.offset;
@@ -2767,11 +2822,27 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
         if (tryLoadCachedFunction())
             return true;
 
+        // Detect IIFE candidates and set up eager AST building.
+        // Because we are past tryLoadCachedFunction(), we know the candidate hasn't been syntax-checked yet.
+        if constexpr (std::is_same_v<TreeBuilder, ASTBuilder>) {
+            const bool shouldEagerlyBuildAST = isLikelyIIFE
+                && Options::useEagerIIFEParsing()
+                && mode == SourceParseMode::NormalFunctionMode
+                && functionDefinitionType == FunctionDefinitionType::Expression
+                && !m_debuggerParseData
+                && m_eagerIIFERegistry;
+            if (shouldEagerlyBuildAST) [[unlikely]]
+                eagerIIFEParseScope.emplace(this, parametersStart);
+        }
+
         m_parserState.lastFunctionName = lastFunctionName;
         oldState = internalSaveParserState(context);
         {
             SetForScope overrideAllowAwait(m_parserState.allowAwait, !isAsyncFunctionParseMode(mode));
-            parseFunctionParameters(syntaxChecker, functionInfo);
+            if (m_iifeParseState && !m_iifeParseState->isInUse()) [[unlikely]]
+                m_iifeParseState->template parseFunctionParameters<TreeBuilder>(functionInfo);
+            else
+                parseFunctionParameters(syntaxChecker, functionInfo);
             propagateError();
         }
         
@@ -2890,9 +2961,43 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
     }
 
     bool functionScopeWasStrictMode = functionScope->strictMode();
-    
-    popScope(functionScope, TreeBuilder::NeedsFreeVariableInfo);
-    
+
+    const bool hasEagerlyBuiltAST = m_iifeParseState && m_iifeParseState->sourceElements();
+    ASSERT_IMPLIES(hasEagerlyBuiltAST, m_iifeParseState->functionParameters());
+
+    // Collect IIFE scope data before popScope destroys scope state.
+    CodeFeatures iifeFeatures = 0;
+    int iifeNumConstants = 0;
+    LexicallyScopedFeatures iifeLexFeatures = NoLexicallyScopedFeatures;
+    InnerArrowFunctionCodeFeatures iifeInnerFeatures = 0;
+    VariableEnvironment iifeVarDeclarations;
+    if (hasEagerlyBuiltAST) [[unlikely]] {
+        // Finalize sloppy-mode function hoisting before collecting scope data.
+        // This adds hoisted function names to declaredVariables and sets
+        // isSloppyModeHoistedFunction on the FunctionMetadataNodes, matching
+        // what parseInner() does during a normal reparse.
+        if (!functionScope->strictMode()) {
+            functionScope->finalizeSloppyModeFunctionHoisting();
+            // Clear candidates so they don't bubble up to outer scopes
+            // when popScope runs — the metadata nodes belong to the cached
+            // FunctionNode and must not be mutated by outer finalization.
+            functionScope->clearSloppyModeFunctionHoistingCandidates();
+        }
+
+        iifeFeatures = collectCodeFeatures(m_iifeParseState->features(), functionScope.scope());
+        iifeNumConstants = m_iifeParseState->numConstants();
+        iifeLexFeatures = functionScope->lexicallyScopedFeatures();
+        iifeInnerFeatures = functionScope->innerArrowFunctionFeatures();
+
+        iifeVarDeclarations = functionScope->declaredVariables();
+        IdentifierSet capturedVariables;
+        functionScope->getCapturedVars(capturedVariables);
+        for (auto& entry : capturedVariables)
+            iifeVarDeclarations.markVariableAsCaptured(entry.get());
+    }
+
+    auto [lexicalEnvironment, functionDeclarations] = popScope(functionScope, TreeBuilder::NeedsFreeVariableInfo);
+
     if (functionBodyType != ArrowFunctionBodyExpression)
         consumeOrFail(CLOSEBRACE, "Expected a closing '}' after a ", stringForFunctionMode(mode), " body");
     else {
@@ -2908,6 +3013,43 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
 
     if (newInfo)
         m_functionCache->add(functionInfo.startOffset, WTF::move(newInfo));
+
+    if (hasEagerlyBuiltAST) [[unlikely]] {
+        SourceCode functionSource = m_source->subExpression(
+            functionInfo.startOffset, functionInfo.endOffset,
+            functionInfo.startLine, functionInfo.parametersStartColumn);
+
+        JSTokenLocation endLocation;
+        endLocation.line = m_lastTokenLocation.line;
+        endLocation.startOffset = functionInfo.endOffset;
+        endLocation.lineStartOffset = m_lastTokenLocation.lineStartOffset;
+
+        auto functionNode = makeUnique<FunctionNode>(
+            m_parserArena.copyRef(),
+            startLocation,
+            endLocation,
+            startColumn,
+            tokenColumn(),
+            m_iifeParseState->sourceElements(),
+            WTF::move(iifeVarDeclarations),
+            WTF::move(functionDeclarations),
+            WTF::move(lexicalEnvironment),
+            m_iifeParseState->functionParameters(),
+            functionSource,
+            iifeFeatures,
+            iifeLexFeatures,
+            iifeInnerFeatures,
+            iifeNumConstants,
+            nullptr /* moduleScopeData */);
+
+        functionNode->setLoc(functionInfo.startLine, m_lastTokenLocation.line, m_lastTokenLocation.endOffset, m_lastTokenLocation.lineStartOffset);
+        functionNode->setEndOffset(functionInfo.endOffset);
+        functionNode->finishParsing(
+            functionInfo.name ? *functionInfo.name : m_vm.propertyNames->nullIdentifier,
+            FunctionMode::FunctionExpression);
+
+        m_eagerIIFERegistry->add(functionInfo.startOffset, WTF::move(functionNode));
+    }
     
     functionInfo.endLine = m_lastTokenLocation.line;
     return true;
@@ -3211,7 +3353,7 @@ parseMethod:
             next();
             break;
         case BIGINT:
-            ident = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+            ident = m_parserArena->identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
             failIfFalse(ident, "Cannot parse big int property name");
             next();
             break;
@@ -3246,7 +3388,7 @@ parseMethod:
         }
         case DOUBLE:
         case INTEGER:
-            ident = &m_parserArena.identifierArena().makeNumericIdentifier(const_cast<VM&>(m_vm), m_token.m_data.doubleValue);
+            ident = &m_parserArena->identifierArena().makeNumericIdentifier(const_cast<VM&>(m_vm), m_token.m_data.doubleValue);
             ASSERT(ident);
             next();
             break;
@@ -3327,9 +3469,9 @@ parseMethod:
 
             if (computedPropertyName) {
                 if (tag == ClassElementTag::Instance)
-                    ident = &m_parserArena.identifierArena().makePrivateIdentifier(m_vm, instanceComputedNamePrefix, nextInstanceComputedFieldID++);
+                    ident = &m_parserArena->identifierArena().makePrivateIdentifier(m_vm, instanceComputedNamePrefix, nextInstanceComputedFieldID++);
                 else
-                    ident = &m_parserArena.identifierArena().makePrivateIdentifier(m_vm, staticComputedNamePrefix, nextStaticComputedFieldID++);
+                    ident = &m_parserArena->identifierArena().makePrivateIdentifier(m_vm, staticComputedNamePrefix, nextStaticComputedFieldID++);
                 DeclarationResultMask declarationResult = classScope->declareLexicalVariable(ident, true);
                 ASSERT_UNUSED(declarationResult, declarationResult == DeclarationResult::Valid);
                 classScope->useVariable(ident, false);
@@ -3362,7 +3504,7 @@ parseMethod:
             m_statementDepth = 0;
             failIfFalse(parseBlockStatement(context, BlockType::StaticBlock), "Cannot parse class static block");
             auto* symbolImpl = std::bit_cast<SymbolImpl*>(m_vm.propertyNames->builtinNames().staticInitializerBlockPrivateName().impl());
-            ident = &m_parserArena.identifierArena().makeIdentifier(const_cast<VM&>(m_vm), symbolImpl);
+            ident = &m_parserArena->identifierArena().makeIdentifier(const_cast<VM&>(m_vm), symbolImpl);
             property = context.createProperty(ident, type, SuperBinding::Needed, tag);
             classScope->markLastUsedVariablesSetAsCaptured(usedVariablesSize);
         } else {
@@ -4723,7 +4865,7 @@ namedProperty:
     case DOUBLE:
     case INTEGER: {
         unsigned functionStart = timesPosition.value_or(asyncPosition.value_or(m_token.m_startPosition));
-        const Identifier& ident = m_parserArena.identifierArena().makeNumericIdentifier(const_cast<VM&>(m_vm), m_token.m_data.doubleValue);
+        const Identifier& ident = m_parserArena->identifierArena().makeNumericIdentifier(const_cast<VM&>(m_vm), m_token.m_data.doubleValue);
         next();
 
         if (match(OPENPAREN)) {
@@ -4741,7 +4883,7 @@ namedProperty:
         return context.createProperty(&ident, node, PropertyNode::Constant, SuperBinding::NotNeeded, InferName::Allowed, ClassElementTag::No);
     }
     case BIGINT: {
-        const Identifier* ident = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+        const Identifier* ident = m_parserArena->identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
         failIfFalse(ident, "Cannot parse big int property name");
         unsigned functionStart = timesPosition.value_or(asyncPosition.value_or(m_token.m_startPosition));
         next();
@@ -4835,7 +4977,7 @@ template <class TreeBuilder> TreeProperty Parser<LexerType>::parseGetterSetter(T
         numericPropertyName = m_token.m_data.doubleValue;
         next();
     } else if (match(BIGINT)) {
-        stringPropertyName = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+        stringPropertyName = m_parserArena->identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
         failIfFalse(stringPropertyName, "Cannot parse big int property name");
         next();
     } else if (consume(OPENBRACKET)) [[likely]] {
@@ -4870,7 +5012,7 @@ template <class TreeBuilder> TreeProperty Parser<LexerType>::parseGetterSetter(T
     if (computedPropertyName)
         return context.createGetterOrSetterProperty(location, static_cast<PropertyNode::Type>(type | PropertyNode::Computed), computedPropertyName, info, tag);
 
-    return context.createGetterOrSetterProperty(const_cast<VM&>(m_vm), m_parserArena, location, type, numericPropertyName, info, tag);
+    return context.createGetterOrSetterProperty(const_cast<VM&>(m_vm), m_parserArena.get(), location, type, numericPropertyName, info, tag);
 }
 
 template <typename LexerType>
@@ -5018,6 +5160,7 @@ template <typename LexerType>
 template <class TreeBuilder> TreeExpression Parser<LexerType>::parseFunctionExpression(TreeBuilder& context)
 {
     ASSERT(match(FUNCTION));
+    bool isLikelyIIFE = m_lastTokenType == OPENPAREN || m_lastTokenType == EXCLAMATION;
     SetForScope nonLHSCountScope(m_parserState.nonLHSCount);
     JSTokenLocation location(tokenLocation());
     unsigned functionStart = tokenStart();
@@ -5032,7 +5175,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseFunctionExpr
     ConstructorKind constructorKind = currentScope()->isGlobalCode() ? m_constructorKindForTopLevelFunctionExpressions : ConstructorKind::None;
     SuperBinding expectedSuperBinding = constructorKind == ConstructorKind::Extends ? SuperBinding::Needed : SuperBinding::NotNeeded;
 
-    failIfFalse((parseFunctionInfo(context, FunctionNameRequirements::None, false, constructorKind, expectedSuperBinding, functionStart, functionInfo, FunctionDefinitionType::Expression)), "Cannot parse function expression");
+    failIfFalse((parseFunctionInfo(context, FunctionNameRequirements::None, false, constructorKind, expectedSuperBinding, functionStart, functionInfo, FunctionDefinitionType::Expression, std::nullopt, isLikelyIIFE)), "Cannot parse function expression");
     return context.createFunctionExpr(location, functionInfo);
 }
 

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "EagerIIFERegistry.h"
 #include "ExecutableInfo.h"
 #include "Lexer.h"
 #include "ModuleScopeData.h"
@@ -48,8 +49,10 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
+class ASTBuilder;
 class FunctionMetadataNode;
 class FunctionParameters;
+template <typename LexerType> class EagerIIFEParseScope;
 class Identifier;
 class VM;
 class SourceCode;
@@ -831,6 +834,7 @@ public:
     bool hasNonSimpleParameterList() const { return m_hasNonSimpleParameterList; }
 
     bool hasSloppyModeFunctionHoistingCandidates() const { return !m_sloppyModeFunctionHoistingCandidates.isEmpty(); }
+    void clearSloppyModeFunctionHoistingCandidates() { m_sloppyModeFunctionHoistingCandidates.clear(); }
 
     void copyCapturedVariablesToVector(const UniquedStringImplPtrSet& usedVariables, Vector<UniquedStringImpl*, 8>& vector)
     {
@@ -1158,6 +1162,76 @@ private:
         Scope* m_scope;
         Parser* m_parser;
     };
+
+    // A specialized parser state activated in parseFunctionInfo() to parse a likely IIFE.
+    // See also EagerIIFEParseScope in Parser.cpp.
+    //
+    // The parse state provides methods to parse the function's parameters and body using
+    // an ASTBuilder instead of a SyntaxChecker, collecting the resulting FunctionParameters
+    // and SourceElements.
+    //
+    // Because IIFE parameters and body may themselves contain nested function definitions
+    // (including nested IIFEs), the IIFE parse state marks itself as isInUse while
+    // parsing those constructs. This prevents nested functions from mistakenly reusing
+    // the outer IIFE's parse state — they follow the normal syntax-checking path instead,
+    // or set up their own eager parse state if they are IIFEs too.
+
+    class EagerIIFEParseState {
+    public:
+        EagerIIFEParseState(Parser& parser, ASTBuilder* builder, unsigned startOffset)
+            : m_parser(parser)
+            , m_builder(builder)
+            , m_startOffset(startOffset)
+            , m_savedIIFEParseState(parser.m_iifeParseState)
+        {
+            parser.m_iifeParseState = this;
+        }
+
+        ~EagerIIFEParseState()
+        {
+            m_parser.m_iifeParseState = m_savedIIFEParseState;
+        }
+
+        template <typename TreeBuilder>
+        void parseFunctionParameters(ParserFunctionInfo<TreeBuilder>& functionInfo)
+        {
+            ASSERT(!m_functionParameters);
+            m_isInUse = true;
+            m_functionParameters = m_parser.parseFunctionParameters(*m_builder, functionInfo);
+            m_isInUse = false;
+        }
+
+        SourceElements* parseSourceElements(SourceElementsMode mode)
+        {
+            ASSERT(!m_sourceElements);
+            m_isInUse = true;
+            m_sourceElements = m_parser.parseSourceElements(*m_builder, mode);
+            m_isInUse = false;
+            return m_sourceElements;
+        }
+
+        bool isInUse() const { return m_isInUse; }
+        unsigned startOffset() const { return m_startOffset; }
+
+        CodeFeatures features() const;
+        int numConstants() const;
+        FunctionParameters* functionParameters() const { return m_functionParameters; }
+        SourceElements* sourceElements() const { return m_sourceElements; }
+
+    private:
+        Parser& m_parser;
+        ASTBuilder* m_builder;
+        bool m_isInUse { false };
+        unsigned m_startOffset;
+
+        EagerIIFEParseState* m_savedIIFEParseState;
+
+        FunctionParameters* m_functionParameters { nullptr };
+        SourceElements* m_sourceElements { nullptr };
+    };
+
+    friend class EagerIIFEParseState;
+    friend class EagerIIFEParseScope<LexerType>;
 
     ALWAYS_INLINE DestructuringKind destructuringKindFromDeclarationType(DeclarationType type)
     {
@@ -1821,7 +1895,8 @@ private:
     template <class TreeBuilder> ALWAYS_INLINE TreeExpression createResolveAndUseVariable(TreeBuilder&, const Identifier*, bool isEval, const JSTextPosition&, const JSTokenLocation&);
 
     enum class FunctionDefinitionType { Expression, Declaration, Method };
-    template <class TreeBuilder> NEVER_INLINE bool parseFunctionInfo(TreeBuilder&, FunctionNameRequirements, bool nameIsInContainingScope, ConstructorKind, SuperBinding, unsigned functionStart, ParserFunctionInfo<TreeBuilder>&, FunctionDefinitionType, std::optional<int> functionConstructorParametersEndPosition = std::nullopt);
+    template <class TreeBuilder> NEVER_INLINE bool parseFunctionInfo(TreeBuilder&, FunctionNameRequirements, bool nameIsInContainingScope, ConstructorKind, SuperBinding, unsigned functionStart, ParserFunctionInfo<TreeBuilder>&, FunctionDefinitionType, std::optional<int> functionConstructorParametersEndPosition = std::nullopt, bool isLikelyIIFE = false);
+    [[nodiscard]] CodeFeatures collectCodeFeatures(CodeFeatures, Scope*);
     
     template <class TreeBuilder> ALWAYS_INLINE bool isArrowFunctionParameters(TreeBuilder&);
     
@@ -2073,7 +2148,7 @@ private:
         m_errorMessage = String();
     }
 
-    // Cache line 0 (hot)
+    // Hotter fields first
     VM& m_vm;
     Scope* m_currentScope { nullptr };
     JSTokenLocation m_lastTokenLocation;
@@ -2088,13 +2163,11 @@ private:
     FunctionMode m_functionMode;
     SuperBinding m_superBinding;
 
-    // Cache line 1 (hot)
     std::unique_ptr<LexerType> m_lexer;
     JSToken m_token;
-
-    // Cache line 2 (m_parserState is hot)
     ParserState m_parserState;
 
+    // Colder fields
     ConstructorKind m_constructorKindForTopLevelFunctionExpressions { ConstructorKind::None };
     ImplementationVisibility m_implementationVisibility;
     bool m_parsingBuiltin;
@@ -2102,13 +2175,15 @@ private:
     bool m_isInsideOrdinaryFunction;
     bool m_insideSwitchCaseBody { false };
 
-    ParserArena m_parserArena;
+    Ref<ParserArena> m_parserArena;
     CallOrApplyDepthScope* m_callOrApplyDepthScope { nullptr };
     ScopeStack m_scopeStack;
     bool m_hasStackOverflow;
     String m_errorMessage;
     RefPtr<ModuleScopeData> m_moduleScopeData;
     DebuggerParseData* m_debuggerParseData;
+    EagerIIFEParseState* m_iifeParseState { nullptr };
+    RefPtr<EagerIIFERegistry> m_eagerIIFERegistry;
     bool m_seenTaggedTemplateInNonReparsingFunctionMode { false };
     bool m_seenPrivateNameUseInNonReparsingFunctionMode { false };
     bool m_seenArgumentsDotLength { false };
@@ -2124,6 +2199,15 @@ std::unique_ptr<ParsedNode> Parser<LexerType>::parse(ParserError& error, const I
 
     if (ParsedNode::scopeIsFunction)
         m_lexer->setIsReparsingFunction();
+
+    if constexpr (std::is_same_v<ParsedNode, FunctionNode>) {
+        if (m_eagerIIFERegistry) {
+            if (auto cached = m_eagerIIFERegistry->take(m_source->startOffset())) {
+                m_lexer->clear();
+                return std::unique_ptr<ParsedNode>(cached.release());
+            }
+        }
+    }
 
     errLine = -1;
     errMsg = String();
@@ -2152,7 +2236,7 @@ std::unique_ptr<ParsedNode> Parser<LexerType>::parse(ParserError& error, const I
         endLocation.lineStartOffset = m_lexer->currentLineStartOffset();
         endLocation.startOffset = m_lexer->currentOffset();
         unsigned endColumn = endLocation.startOffset - endLocation.lineStartOffset;
-        result = makeUnique<ParsedNode>(m_parserArena,
+        result = makeUnique<ParsedNode>(m_parserArena.copyRef(),
                                     startLocation,
                                     endLocation,
                                     startColumn,

--- a/Source/JavaScriptCore/parser/ParserArena.h
+++ b/Source/JavaScriptCore/parser/ParserArena.h
@@ -30,6 +30,8 @@
 #include <JavaScriptCore/MathCommon.h>
 #include <array>
 #include <type_traits>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
 #include <wtf/SegmentedVector.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -147,20 +149,10 @@ namespace JSC {
 
     DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ParserArena);
 
-    class ParserArena {
-        WTF_MAKE_NONCOPYABLE(ParserArena);
+    class ParserArena : public RefCounted<ParserArena> {
     public:
-        ParserArena();
+        static Ref<ParserArena> create() { return adoptRef(*new ParserArena); }
         ~ParserArena();
-
-        void swap(ParserArena& otherArena)
-        {
-            std::swap(m_freeableMemory, otherArena.m_freeableMemory);
-            std::swap(m_freeablePoolEnd, otherArena.m_freeablePoolEnd);
-            m_identifierArena.swap(otherArena.m_identifierArena);
-            m_freeablePools.swap(otherArena.m_freeablePools);
-            m_deletableObjects.swap(otherArena.m_deletableObjects);
-        }
 
         void* allocateFreeable(size_t size)
         {
@@ -196,6 +188,8 @@ namespace JSC {
         }
 
     private:
+        ParserArena();
+
         static const size_t freeablePoolSize = 8000;
 
         static size_t alignSize(size_t size)

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -552,6 +552,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useSuperSampler, false, Normal, nullptr) \
     \
     v(Bool, useSourceProviderCache, true, Normal, "If false, the parser will not use the source provider cache. It's good to verify everything works when this is false. Because the cache is so successful, it can mask bugs."_s) \
+    v(Bool, useEagerIIFEParsing, true, Normal, "Eagerly build AST for likely IIFEs during the initial parse."_s) \
     v(Bool, useCodeCache, true, Normal, "If false, the unlinked byte code cache will not be used."_s) \
     \
     v(Bool, useWasm, canUseWasm(), Normal, "Expose the Wasm global object."_s) \

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -48,6 +48,7 @@
 #include "DeferredWorkTimer.h"
 #include "Disassembler.h"
 #include "DoublePredictionFuzzerAgent.h"
+#include "EagerIIFERegistry.h"
 #include "ErrorInstance.h"
 #include "EvalCodeBlockInlines.h"
 #include "EvalExecutableInlines.h"
@@ -1008,9 +1009,18 @@ SourceProviderCache* VM::addSourceProviderCache(SourceProvider* sourceProvider)
     return addResult.iterator->value.get();
 }
 
+EagerIIFERegistry* VM::addEagerIIFERegistry(SourceProvider* sourceProvider)
+{
+    auto addResult = eagerIIFERegistryMap.add(sourceProvider, nullptr);
+    if (addResult.isNewEntry)
+        addResult.iterator->value = adoptRef(new EagerIIFERegistry);
+    return addResult.iterator->value.get();
+}
+
 void VM::clearSourceProviderCaches()
 {
     sourceProviderCacheMap.clear();
+    eagerIIFERegistryMap.clear();
 }
 
 bool VM::hasExceptionsAfterHandlingTraps()

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -112,6 +112,7 @@ class CompactTDZEnvironmentMap;
 class ConservativeRoots;
 class ControlFlowProfiler;
 class CrossTaskToken;
+class EagerIIFERegistry;
 class Exception;
 class ExceptionScope;
 class FuzzerAgent;
@@ -798,10 +799,12 @@ public:
     static void computeCanUseJIT();
 
     SourceProviderCache* addSourceProviderCache(SourceProvider*);
+    EagerIIFERegistry* addEagerIIFERegistry(SourceProvider*);
     void clearSourceProviderCaches();
 
     typedef UncheckedKeyHashMap<RefPtr<SourceProvider>, RefPtr<SourceProviderCache>> SourceProviderCacheMap;
     SourceProviderCacheMap sourceProviderCacheMap;
+    UncheckedKeyHashMap<RefPtr<SourceProvider>, RefPtr<EagerIIFERegistry>> eagerIIFERegistryMap;
 #if ENABLE(JIT)
     std::unique_ptr<JITThunks> jitStubs;
     MacroAssemblerCodeRef<JITThunkPtrTag> getCTIStub(ThunkGenerator);


### PR DESCRIPTION
#### 709e4e7e7ec7e5488be35a7fe48938e150fb7f22
<pre>
[JSC] Eagerly build AST for likely IIFEs
<a href="https://bugs.webkit.org/show_bug.cgi?id=311459">https://bugs.webkit.org/show_bug.cgi?id=311459</a>
<a href="https://rdar.apple.com/174062165">rdar://174062165</a>

Reviewed by Yusuke Suzuki.

This patch detects likely IIFEs (immediately invoked function expressions) and builds
their AST right away, bypassing the usual initial syntax check.

In general, we can&apos;t tell if a function expression is immediately invoked until after we
parse it, but the following heuristic catches most real world cases. A function expression
is expected to be an IIFE if the token preceding the `function` keyword is either `(` or
`!` (`!` is commonly used by minifiers to introduce a function expression using one fewer
character than wrapping it in parentheses). Another potential heuristic is if the
`function` keyword is preceded by `,` and the expression before the comma was an IIFE.
This heuristic is not used at this time because the cost/benefit tradeoff is not as clear
in this case.

Key changes:

- A FunctionNode created when eagerly parsing an IIFE is independent from the AST created
  for the containing code and has its own lifetime. To support this, we change ParserArena
  and ParserArenaRoot so that an arena can be shared by multiple roots. A root no longer
  takes ownership of the arena memory, instead it retains a Ref to the arena.

- Eager IIFE parsing is controlled by two classes, EagerIIFEParseScope and
  EagerIIFEParseState. The scope is created in Parser::parseFunctionInfo() when the IIFE
  prediction heuristic triggers. The scope contains an ASTBuilder to use for the IIFE and
  an EagerIIFEParseState. The state is registered with the parser as an indication of the
  special parsing mode it is currently in. It collects parsing artifacts such as function
  parameter and source elements until we are ready to create the final FunctionNode.
  When parseFunctionInfo exits, the scope is destroyed and its destructor returns the
  parser into the original state.

- At the end of parseFunctionInfo, if an IIFE AST was eagerly built, we create a
  FunctionNode stored in m_eagerIIFERegistry. Parser::parse() checks the cache when the
  function is invoked and takes the ready-to-use AST from the cache.

Testing:
    - Regression-checked by existing tests.
    - Eager parsing is not directly testable in stress tests.
    - Added `JSTests/stress/eager-iife-column-tracking.js` to test the source column
    adjustment required on the first line of IIFEs, as uncovered by one of the layout
    tests.

Canonical link: <a href="https://commits.webkit.org/312444@main">https://commits.webkit.org/312444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e6a77f534b5ec92068e0cb34565734dda92dc6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26346 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168630 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114153 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7ff32a6f-4c53-4c46-93d9-b893738f07ba) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33243 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123816 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86865 "1 flakes 9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dfc16bcc-763f-4e56-8617-dcf8251d185a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26065 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143511 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104448 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7ba255d0-0c24-4ec6-9654-d16e00a1da44) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25117 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23591 "Found 2 new API test failures: TestWebKitAPI.WKWebExtension.LoadFromiOSAppExtensionBundle, TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16393 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/151828 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134808 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21283 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171123 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/20609 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17140 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132069 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32918 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27670 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132119 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35786 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32903 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143077 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91001 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26736 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19890 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192056 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32412 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98809 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49388 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31909 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32156 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32060 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->