### PR TITLE
StringImpl::characterStartingAt should return lone surrogates instead of 0

### DIFF
--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -391,7 +391,7 @@ char32_t NODELETE StringImpl::characterStartingAt(unsigned i)
         return span[i];
     if (i + 1 < m_length && U16_IS_LEAD(span[i]) && U16_IS_TRAIL(span[i + 1]))
         return U16_GET_SUPPLEMENTARY(span[i], span[i + 1]);
-    return 0;
+    return span[i];
 }
 
 Ref<StringImpl> StringImpl::convertToLowercaseWithoutLocale()

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -85,6 +85,7 @@ public:
 
     char16_t characterAt(unsigned index) const;
     char16_t operator[](unsigned index) const;
+    char32_t characterStartingAt(unsigned index) const;
 
     class CodeUnits;
     CodeUnits codeUnits() const;
@@ -609,6 +610,19 @@ inline char16_t StringView::characterAt(unsigned index) const
 inline char16_t StringView::operator[](unsigned index) const
 {
     return characterAt(index);
+}
+
+inline char32_t StringView::characterStartingAt(unsigned index) const
+{
+    ASSERT(index < length());
+    if (m_is8Bit)
+        return span8()[index];
+    auto characters = span16();
+    if (U16_IS_SINGLE(characters[index]))
+        return characters[index];
+    if (index + 1 < length() && U16_IS_LEAD(characters[index]) && U16_IS_TRAIL(characters[index + 1]))
+        return U16_GET_SUPPLEMENTARY(characters[index], characters[index + 1]);
+    return characters[index];
 }
 
 inline bool StringView::contains(char16_t character) const

--- a/Source/WebCore/css/CSSMarkup.cpp
+++ b/Source/WebCore/css/CSSMarkup.cpp
@@ -81,10 +81,6 @@ void serializeIdentifier(const String& identifier, StringBuilder& appendTo, bool
     unsigned index = 0;
     while (index < identifier.length()) {
         char32_t c = identifier.characterStartingAt(index);
-        if (!c) {
-            // Check for lone surrogate which characterStartingAt does not return.
-            c = identifier[index];
-        }
 
         index += U16_LENGTH(c);
 

--- a/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
@@ -878,4 +878,63 @@ TEST(WTF, CreateSubstringSharingImpl)
     ASSERT_TRUE(equal(small16Bit.ptr(), String::fromUTF8("日本語").impl()));
 }
 
+TEST(WTF, StringImplCharacterStartingAtASCII)
+{
+    auto string = StringImpl::create("Hello"_s);
+    ASSERT_EQ(string->characterStartingAt(0), static_cast<char32_t>('H'));
+    ASSERT_EQ(string->characterStartingAt(4), static_cast<char32_t>('o'));
+}
+
+TEST(WTF, StringImplCharacterStartingAtBMP)
+{
+    // U+00E9 (LATIN SMALL LETTER E WITH ACUTE) - single 16-bit code unit.
+    auto string = String::fromUTF8("caf\xC3\xA9");
+    ASSERT_FALSE(string.impl()->is8Bit());
+    ASSERT_EQ(string.impl()->characterStartingAt(0), static_cast<char32_t>('c'));
+    ASSERT_EQ(string.impl()->characterStartingAt(3), 0x00E9u);
+}
+
+TEST(WTF, StringImplCharacterStartingAtSupplementary)
+{
+    // U+1F600 (GRINNING FACE) is encoded as a surrogate pair: D83D DE00.
+    auto string = String::fromUTF8("A\xF0\x9F\x98\x80Z");
+    ASSERT_FALSE(string.impl()->is8Bit());
+    ASSERT_EQ(string.impl()->length(), 4u); // 'A' + surrogate pair + 'Z'
+    ASSERT_EQ(string.impl()->characterStartingAt(0), static_cast<char32_t>('A'));
+    ASSERT_EQ(string.impl()->characterStartingAt(1), 0x1F600u);
+    ASSERT_EQ(string.impl()->characterStartingAt(3), static_cast<char32_t>('Z'));
+}
+
+TEST(WTF, StringImplCharacterStartingAtLoneSurrogate)
+{
+    // Construct a string with lone surrogates directly via 16-bit code units.
+    std::array<char16_t, 5> data { 0xD800, u'A', 0xDC00, u'B', 0xD83D };
+    auto string = StringImpl::create(std::span<const char16_t> { data });
+    ASSERT_EQ(string->length(), 5u);
+
+    // Lone lead surrogate at index 0 (not followed by a trail).
+    ASSERT_EQ(string->characterStartingAt(0), 0xD800u);
+
+    // Regular character.
+    ASSERT_EQ(string->characterStartingAt(1), static_cast<char32_t>('A'));
+
+    // Lone trail surrogate at index 2 (not preceded by a lead in terms of this API).
+    ASSERT_EQ(string->characterStartingAt(2), 0xDC00u);
+
+    // Regular character.
+    ASSERT_EQ(string->characterStartingAt(3), static_cast<char32_t>('B'));
+
+    // Lone lead surrogate at end of string.
+    ASSERT_EQ(string->characterStartingAt(4), 0xD83Du);
+}
+
+TEST(WTF, StringImplCharacterStartingAtNUL)
+{
+    // Ensure actual NUL character is distinguishable from lone surrogates.
+    std::array<char16_t, 2> data { 0x0000, 0xD800 };
+    auto string = StringImpl::create(std::span<const char16_t> { data });
+    ASSERT_EQ(string->characterStartingAt(0), 0u);
+    ASSERT_EQ(string->characterStartingAt(1), 0xD800u);
+}
+
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
@@ -1033,4 +1033,51 @@ TEST(WTF, StringViewUpconvert)
     }
 }
 
+TEST(WTF, StringViewCharacterStartingAtASCII)
+{
+    StringView string("Hello"_s);
+    ASSERT_EQ(string.characterStartingAt(0), static_cast<char32_t>('H'));
+    ASSERT_EQ(string.characterStartingAt(4), static_cast<char32_t>('o'));
+}
+
+TEST(WTF, StringViewCharacterStartingAtBMP)
+{
+    auto string = String::fromUTF8("caf\xC3\xA9");
+    ASSERT_FALSE(StringView(string).is8Bit());
+    ASSERT_EQ(StringView(string).characterStartingAt(0), static_cast<char32_t>('c'));
+    ASSERT_EQ(StringView(string).characterStartingAt(3), 0x00E9u);
+}
+
+TEST(WTF, StringViewCharacterStartingAtSupplementary)
+{
+    auto string = String::fromUTF8("A\xF0\x9F\x98\x80Z");
+    StringView view(string);
+    ASSERT_FALSE(view.is8Bit());
+    ASSERT_EQ(view.length(), 4u);
+    ASSERT_EQ(view.characterStartingAt(0), static_cast<char32_t>('A'));
+    ASSERT_EQ(view.characterStartingAt(1), 0x1F600u);
+    ASSERT_EQ(view.characterStartingAt(3), static_cast<char32_t>('Z'));
+}
+
+TEST(WTF, StringViewCharacterStartingAtLoneSurrogate)
+{
+    std::array<char16_t, 5> data { 0xD800, u'A', 0xDC00, u'B', 0xD83D };
+    StringView view(std::span<const UChar> { data });
+    ASSERT_EQ(view.length(), 5u);
+
+    ASSERT_EQ(view.characterStartingAt(0), 0xD800u);
+    ASSERT_EQ(view.characterStartingAt(1), static_cast<char32_t>('A'));
+    ASSERT_EQ(view.characterStartingAt(2), 0xDC00u);
+    ASSERT_EQ(view.characterStartingAt(3), static_cast<char32_t>('B'));
+    ASSERT_EQ(view.characterStartingAt(4), 0xD83Du);
+}
+
+TEST(WTF, StringViewCharacterStartingAtNUL)
+{
+    std::array<char16_t, 2> data { 0x0000, 0xD800 };
+    StringView view(std::span<const UChar> { data });
+    ASSERT_EQ(view.characterStartingAt(0), 0u);
+    ASSERT_EQ(view.characterStartingAt(1), 0xD800u);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### e94c2e91e23993244d6ba54a60f6e2233d4a21df
<pre>
StringImpl::characterStartingAt should return lone surrogates instead of 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=311463">https://bugs.webkit.org/show_bug.cgi?id=311463</a>

Reviewed by Anne van Kesteren.

Previously, characterStartingAt() returned 0 for lone surrogates, making
them indistinguishable from U+0000 (NUL). Return the raw surrogate code
unit value instead.

Also add the same function to StringView because I will need it for my
next two PRs, and add API test coverage for both StringImpl and
StringView.

Reviewed all call sites:
  - CSSMarkup.cpp (serializeIdentifier): Remove workaround that re-fetched
    the raw code unit via operator[] when characterStartingAt returned 0.

  - CSSMarkup.cpp (serializeString): Previously a lone surrogate returned 0
    which matched c &lt;= 0x1f and was serialized as \0. Now the surrogate value
    (&gt;= 0xD800) falls through to appendTo.append(c), which is more correct.

  - URLHelpers.cpp: Passes results to isLookalikeCharacter() and
    U16_LENGTH(). A lone surrogate won&apos;t be a lookalike, and U16_LENGTH on a
    BMP-range surrogate value correctly returns 1. No issue.

  - EventHandler.cpp: Checks !U_IS_BMP(c). Lone surrogates (0xD800-0xDFFF)
    are in the BMP range, so U_IS_BMP returns true, same as for 0.

  - KeyboardScrollingAnimator.cpp: Compares against &apos; &apos;. A lone surrogate
    won&apos;t match, same as 0.

  - RenderTreeBuilderFirstLetter.cpp: Passes result to
    shouldSkipForFirstLetter() and isPunctuationForFirstLetter(). A lone
    surrogate won&apos;t match any of those conditions.

  - KeyboardEvent.cpp: Returns the value as a charCode. Returning the actual
    surrogate value is more correct than returning 0.

* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::characterStartingAt):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::characterStartingAt):
* Source/WebCore/css/CSSMarkup.cpp:
(WebCore::serializeIdentifier):
* Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp:
* Tools/TestWebKitAPI/Tests/WTF/StringView.cpp:

Canonical link: <a href="https://commits.webkit.org/310568@main">https://commits.webkit.org/310568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59ce826f62cd3d839bb91543c23051aa756da462

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162978 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107692 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156097 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27332 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119276 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/84316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157183 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21543 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138506 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99972 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20631 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18629 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10810 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146273 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130293 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16351 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165450 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15055 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8659 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17960 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127371 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27028 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22671 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127516 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34597 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138144 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83545 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22407 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14936 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185859 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26642 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90745 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47661 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26223 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26454 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26295 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->