### PR TITLE
Add modern HSL syntax fast path to CSSParserFastPaths

### DIFF
--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -500,18 +500,40 @@ static std::optional<SRGBA<uint8_t>> NODELETE parseHexColorInternal(std::span<co
     return finishParsingHexColor(value, characters.size());
 }
 
-template<typename CharacterType> static std::optional<SRGBA<uint8_t>> parseLegacyHSL(std::span<const CharacterType> characters)
+template<typename CharacterType> static std::optional<SRGBA<uint8_t>> parseHSL(std::span<const CharacterType> characters)
 {
-    // Commas only exist in the legacy syntax.
-    size_t delimiter = find(characters, ',');
-    if (delimiter == notFound)
-        return std::nullopt;
-
     auto skipWhitespace = [](std::span<const CharacterType>& characters) ALWAYS_INLINE_LAMBDA {
         skipWhile<isCSSSpace>(characters);
     };
 
-    auto parsePercentageWithOptionalLeadingWhitespace = [&](std::span<const CharacterType>& characters) -> std::optional<double> {
+    // Find the end of the hue token (terminated by comma or whitespace).
+    // A comma means legacy syntax (comma-separated), whitespace means modern (space-separated).
+    size_t hueEnd = 0;
+    bool isLegacy = false;
+    while (hueEnd < characters.size()) {
+        if (characters[hueEnd] == ',') {
+            isLegacy = true;
+            break;
+        }
+        if (isCSSSpace(characters[hueEnd]))
+            break;
+        ++hueEnd;
+    }
+    if (!hueEnd || hueEnd == characters.size())
+        return std::nullopt;
+
+    double hue;
+    auto angleUnit = CSS::AngleUnit::Deg;
+    if (!parseSimpleAngle(characters.first(hueEnd), RequireUnits::No, angleUnit, hue))
+        return std::nullopt;
+
+    skip(characters, hueEnd);
+
+    // In legacy syntax, components are separated by commas.
+    if (isLegacy && !skipExactly(characters, ','))
+        return std::nullopt;
+
+    auto parsePercentage = [&]() -> std::optional<double> {
         skipWhitespace(characters);
 
         double value = 0;
@@ -526,73 +548,51 @@ template<typename CharacterType> static std::optional<SRGBA<uint8_t>> parseLegac
         return value;
     };
 
-    auto skipComma = [](std::span<const CharacterType>& characters) {
-        return skipExactly(characters, ',');
-    };
-
-    double hue;
-    auto angleChars = characters.first(delimiter);
-    auto angleUnit = CSS::AngleUnit::Deg;
-    if (!parseSimpleAngle(angleChars, RequireUnits::No, angleUnit, hue))
-        return std::nullopt;
-
-    skip(characters, delimiter);
-    if (!skipComma(characters))
-        return std::nullopt;
-
-    auto saturation = parsePercentageWithOptionalLeadingWhitespace(characters);
+    auto saturation = parsePercentage();
     if (!saturation)
         return std::nullopt;
 
-    if (!skipComma(characters))
+    if (isLegacy && !skipExactly(characters, ','))
         return std::nullopt;
 
-    auto lightness = parsePercentageWithOptionalLeadingWhitespace(characters);
+    auto lightness = parsePercentage();
     if (!lightness)
         return std::nullopt;
 
-    auto parseAlpha = [&](std::span<const CharacterType>& characters) -> std::optional<double> {
+    skipWhitespace(characters);
+
+    // Alpha is optional. Legacy uses comma separator, modern uses slash.
+    double alpha = 1.0;
+    char alphaSeparator = isLegacy ? ',' : '/';
+    if (!characters.empty() && characters.front() == alphaSeparator) {
+        skip(characters, 1);
         skipWhitespace(characters);
 
         size_t numCharactersParsed;
-        double alpha = 1;
         if ((numCharactersParsed = parseDouble(characters, ')', alpha))) {
             skip(characters, numCharactersParsed);
-            return alpha;
-        }
-
-        if ((numCharactersParsed = parseDouble(characters, '%', alpha))) {
-            skip(characters, numCharactersParsed + 1); // Skip the '%'
-            return alpha / 100.0;
-        }
-
-        return std::nullopt;
-    };
-
-    double alpha = 1.0;
-    // Alpha is optional for both hsl() and hsla().
-    if (skipComma(characters)) {
-        auto alphaValue = parseAlpha(characters);
-        if (!alphaValue)
+        } else if ((numCharactersParsed = parseDouble(characters, '%', alpha))) {
+            skip(characters, numCharactersParsed);
+            if (!skipExactly(characters, '%'))
+                return std::nullopt;
+            alpha /= 100.0;
+        } else
             return std::nullopt;
 
-        alpha = *alphaValue;
+        skipWhitespace(characters);
     }
-
-    skipWhitespace(characters);
 
     if (characters.empty() || characters.front() != ')')
         return std::nullopt;
 
-    auto parsedColor = StyleColorParseType<HSLFunctionLegacy> {
+    auto parsedColor = StyleColorParseType<HSLFunctionModern> {
         Style::Angle<>      { narrowPrecisionToFloat(CSS::convertAngle<CSS::AngleUnit::Deg>(hue, angleUnit)) },
         Style::Percentage<> { narrowPrecisionToFloat(*saturation) },
         Style::Percentage<> { narrowPrecisionToFloat(*lightness) },
         Style::Number<>     { narrowPrecisionToFloat(alpha) }
     };
-    auto typedColor = convertToTypedColor<HSLFunctionLegacy>(parsedColor, 1.0);
-    auto resultColor = convertToColor<HSLFunctionLegacy, CSSColorFunctionForm::Absolute>(typedColor, 0);
-    return resultColor.tryGetAsSRGBABytes();
+    auto typedColor = convertToTypedColor<HSLFunctionModern>(parsedColor, 1.0);
+    return convertToColor<HSLFunctionModern, CSSColorFunctionForm::Absolute>(typedColor, 0).tryGetAsSRGBABytes();
 }
 
 template<typename CharacterType>
@@ -651,10 +651,10 @@ static std::optional<SRGBA<uint8_t>> parseNumericColor(std::span<const Character
 
     // hsl() and hsla() are synonyms.
     if (mightBeHSLA(characters))
-        return parseLegacyHSL(characters.subspan(5));
+        return parseHSL(characters.subspan(5));
 
     if (mightBeHSL(characters))
-        return parseLegacyHSL(characters.subspan(4));
+        return parseHSL(characters.subspan(4));
 
     return std::nullopt;
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/CSSParserFastPaths.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CSSParserFastPaths.cpp
@@ -75,4 +75,182 @@ TEST(CSSParserFastPaths, ParseRgbAndRgba)
         EXPECT_FALSE(CSSParserFastPaths::parseSimpleColor(input, strictCSSParserContext()));
 }
 
+TEST(CSSParserFastPaths, ParseLegacyHsl)
+{
+    auto& context = strictCSSParserContext();
+
+    // Basic legacy HSL colors (comma-separated).
+    auto red = CSSParserFastPaths::parseSimpleColor("hsl(0, 100%, 50%)"_s, context);
+    ASSERT_TRUE(red);
+    auto redResolved = red->resolved();
+    EXPECT_EQ(redResolved.red, 255);
+    EXPECT_EQ(redResolved.green, 0);
+    EXPECT_EQ(redResolved.blue, 0);
+
+    auto green = CSSParserFastPaths::parseSimpleColor("hsl(120, 100%, 50%)"_s, context);
+    ASSERT_TRUE(green);
+    auto greenResolved = green->resolved();
+    EXPECT_EQ(greenResolved.red, 0);
+    EXPECT_EQ(greenResolved.green, 255);
+    EXPECT_EQ(greenResolved.blue, 0);
+
+    auto blue = CSSParserFastPaths::parseSimpleColor("hsl(240, 100%, 50%)"_s, context);
+    ASSERT_TRUE(blue);
+    auto blueResolved = blue->resolved();
+    EXPECT_EQ(blueResolved.red, 0);
+    EXPECT_EQ(blueResolved.green, 0);
+    EXPECT_EQ(blueResolved.blue, 255);
+
+    // hsla() synonym.
+    auto redA = CSSParserFastPaths::parseSimpleColor("hsla(0, 100%, 50%, 0.5)"_s, context);
+    ASSERT_TRUE(redA);
+    auto redAResolved = redA->resolved();
+    EXPECT_EQ(redAResolved.red, 255);
+    EXPECT_EQ(redAResolved.green, 0);
+    EXPECT_EQ(redAResolved.blue, 0);
+    EXPECT_EQ(redAResolved.alpha, 128);
+
+    // With angle units.
+    auto degColor = CSSParserFastPaths::parseSimpleColor("hsl(120deg, 100%, 50%)"_s, context);
+    ASSERT_TRUE(degColor);
+    EXPECT_EQ(degColor->resolved().green, 255);
+
+    // Hue wrapping.
+    auto wrapped = CSSParserFastPaths::parseSimpleColor("hsl(480, 100%, 50%)"_s, context);
+    ASSERT_TRUE(wrapped);
+    auto wrappedResolved = wrapped->resolved();
+    EXPECT_EQ(wrappedResolved.red, 0);
+    EXPECT_EQ(wrappedResolved.green, 255);
+    EXPECT_EQ(wrappedResolved.blue, 0);
+}
+
+TEST(CSSParserFastPaths, ParseModernHsl)
+{
+    auto& context = strictCSSParserContext();
+
+    // Basic modern HSL colors (space-separated).
+    auto red = CSSParserFastPaths::parseSimpleColor("hsl(0 100% 50%)"_s, context);
+    ASSERT_TRUE(red);
+    auto redResolved = red->resolved();
+    EXPECT_EQ(redResolved.red, 255);
+    EXPECT_EQ(redResolved.green, 0);
+    EXPECT_EQ(redResolved.blue, 0);
+
+    auto green = CSSParserFastPaths::parseSimpleColor("hsl(120 100% 50%)"_s, context);
+    ASSERT_TRUE(green);
+    auto greenResolved = green->resolved();
+    EXPECT_EQ(greenResolved.red, 0);
+    EXPECT_EQ(greenResolved.green, 255);
+    EXPECT_EQ(greenResolved.blue, 0);
+
+    auto blue = CSSParserFastPaths::parseSimpleColor("hsl(240 100% 50%)"_s, context);
+    ASSERT_TRUE(blue);
+    auto blueResolved = blue->resolved();
+    EXPECT_EQ(blueResolved.red, 0);
+    EXPECT_EQ(blueResolved.green, 0);
+    EXPECT_EQ(blueResolved.blue, 255);
+
+    // Black and white.
+    auto black = CSSParserFastPaths::parseSimpleColor("hsl(0 0% 0%)"_s, context);
+    ASSERT_TRUE(black);
+    auto blackResolved = black->resolved();
+    EXPECT_EQ(blackResolved.red, 0);
+    EXPECT_EQ(blackResolved.green, 0);
+    EXPECT_EQ(blackResolved.blue, 0);
+
+    auto white = CSSParserFastPaths::parseSimpleColor("hsl(0 0% 100%)"_s, context);
+    ASSERT_TRUE(white);
+    auto whiteResolved = white->resolved();
+    EXPECT_EQ(whiteResolved.red, 255);
+    EXPECT_EQ(whiteResolved.green, 255);
+    EXPECT_EQ(whiteResolved.blue, 255);
+
+    // With alpha (/ separator).
+    auto semiRed = CSSParserFastPaths::parseSimpleColor("hsl(0 100% 50% / 0.5)"_s, context);
+    ASSERT_TRUE(semiRed);
+    auto semiRedResolved = semiRed->resolved();
+    EXPECT_EQ(semiRedResolved.red, 255);
+    EXPECT_EQ(semiRedResolved.green, 0);
+    EXPECT_EQ(semiRedResolved.blue, 0);
+    EXPECT_EQ(semiRedResolved.alpha, 128);
+
+    // Alpha as percentage.
+    auto alphaPercent = CSSParserFastPaths::parseSimpleColor("hsl(0 100% 50% / 50%)"_s, context);
+    ASSERT_TRUE(alphaPercent);
+    auto alphaPercentResolved = alphaPercent->resolved();
+    EXPECT_EQ(alphaPercentResolved.red, 255);
+    EXPECT_EQ(alphaPercentResolved.alpha, 128);
+
+    // With angle units.
+    auto degColor = CSSParserFastPaths::parseSimpleColor("hsl(120deg 100% 50%)"_s, context);
+    ASSERT_TRUE(degColor);
+    auto degColorResolved = degColor->resolved();
+    EXPECT_EQ(degColorResolved.red, 0);
+    EXPECT_EQ(degColorResolved.green, 255);
+    EXPECT_EQ(degColorResolved.blue, 0);
+
+    auto radColor = CSSParserFastPaths::parseSimpleColor("hsl(3.14rad 100% 50%)"_s, context);
+    ASSERT_TRUE(radColor);
+    // 3.14 rad ~= 179.9 deg, close to cyan (180 deg).
+    EXPECT_EQ(radColor->resolved().red, 0);
+
+    // hsla() synonym with modern syntax.
+    auto hslaModern = CSSParserFastPaths::parseSimpleColor("hsla(120 100% 50% / 1)"_s, context);
+    ASSERT_TRUE(hslaModern);
+    auto hslaModernResolved = hslaModern->resolved();
+    EXPECT_EQ(hslaModernResolved.green, 255);
+    EXPECT_EQ(hslaModernResolved.alpha, 255);
+
+    // No space around slash.
+    auto noSpaceSlash = CSSParserFastPaths::parseSimpleColor("hsl(0 100% 50%/0.5)"_s, context);
+    ASSERT_TRUE(noSpaceSlash);
+    auto noSpaceSlashResolved = noSpaceSlash->resolved();
+    EXPECT_EQ(noSpaceSlashResolved.red, 255);
+    EXPECT_EQ(noSpaceSlashResolved.alpha, 128);
+
+    // Hue wrapping.
+    auto wrapped = CSSParserFastPaths::parseSimpleColor("hsl(480 100% 50%)"_s, context);
+    ASSERT_TRUE(wrapped);
+    auto wrappedResolved = wrapped->resolved();
+    EXPECT_EQ(wrappedResolved.red, 0);
+    EXPECT_EQ(wrappedResolved.green, 255);
+    EXPECT_EQ(wrappedResolved.blue, 0);
+
+    // Modern and legacy should produce the same result.
+    auto modern = CSSParserFastPaths::parseSimpleColor("hsl(120 50% 75%)"_s, context);
+    auto legacy = CSSParserFastPaths::parseSimpleColor("hsl(120, 50%, 75%)"_s, context);
+    ASSERT_TRUE(modern);
+    ASSERT_TRUE(legacy);
+    EXPECT_EQ(*modern, *legacy);
+}
+
+TEST(CSSParserFastPaths, ParseModernHslInvalid)
+{
+    auto& context = strictCSSParserContext();
+
+    // Missing closing paren.
+    EXPECT_FALSE(CSSParserFastPaths::parseSimpleColor("hsl(0 100% 50%"_s, context));
+
+    // Missing lightness.
+    EXPECT_FALSE(CSSParserFastPaths::parseSimpleColor("hsl(0 100%)"_s, context));
+
+    // Missing saturation and lightness.
+    EXPECT_FALSE(CSSParserFastPaths::parseSimpleColor("hsl(0)"_s, context));
+
+    // Empty.
+    EXPECT_FALSE(CSSParserFastPaths::parseSimpleColor("hsl()"_s, context));
+
+    // Mixing commas and spaces.
+    EXPECT_FALSE(CSSParserFastPaths::parseSimpleColor("hsl(0 100%, 50%)"_s, context));
+
+    // Alpha with comma instead of slash.
+    EXPECT_FALSE(CSSParserFastPaths::parseSimpleColor("hsl(0 100% 50%, 0.5)"_s, context));
+
+    // Slash without alpha value.
+    EXPECT_FALSE(CSSParserFastPaths::parseSimpleColor("hsl(0 100% 50% /)"_s, context));
+
+    // Double slash.
+    EXPECT_FALSE(CSSParserFastPaths::parseSimpleColor("hsl(0 100% 50% / / 0.5)"_s, context));
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 524b854c9d8aadd91ebba5fa158b9fb46fe5c1a6
<pre>
Add modern HSL syntax fast path to CSSParserFastPaths
<a href="https://bugs.webkit.org/show_bug.cgi?id=311468">https://bugs.webkit.org/show_bug.cgi?id=311468</a>

Reviewed by Darin Adler.

The existing HSL fast path only handled the legacy comma-separated syntax
(e.g., hsl(120, 100%, 50%)). Modern CSS uses space-separated syntax
(e.g., hsl(120 100% 50%) or hsl(120 100% 50% / 0.5)), which was falling
through to the full tokenizer and parser.

Rename parseLegacyHSL() to parseHSL() and teach it to handle the modern
space-separated syntax with optional slash-separated alpha, including
support for angle units (deg, rad) and percentage alpha values. The
legacy path is tried first since its comma check is effectively free
when it fails.

Also add API tests for both legacy and modern HSL parsing through
parseSimpleColor(), covering primary colors, black/white, alpha variants,
angle units, hue wrapping, and modern-vs-legacy equivalence, along with
negative tests for malformed modern HSL inputs.

Test: Tools/TestWebKitAPI/Tests/WebCore/CSSParserFastPaths.cpp

* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::parseHSL):
(WebCore::parseNumericColor):
(WebCore::parseColor):
(WebCore::CSSParserFastPaths::parseNamedColor):
(WebCore::isUniversalKeyword):
(WebCore::parseLegacyHSL): Deleted.
* Tools/TestWebKitAPI/Tests/WebCore/CSSParserFastPaths.cpp:
(TestWebKitAPI::TEST(CSSParserFastPaths, ParseLegacyHsl)):
(TestWebKitAPI::TEST(CSSParserFastPaths, ParseModernHsl)):
(TestWebKitAPI::TEST(CSSParserFastPaths, ParseModernHslInvalid)):

Canonical link: <a href="https://commits.webkit.org/310603@main">https://commits.webkit.org/310603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ad8e88455c8183a3bb1b90b4cc666865f4a3311

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163080 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107795 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dea66f79-ffa3-422c-84f6-d728d3a1686f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27434 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119354 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84389 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/964b01f4-78ee-4bae-8878-9f0a322049aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157285 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21615 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100050 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20703 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18717 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10912 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130365 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165552 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8761 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18053 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127449 "Found 1 new test failure: media/media-vp8-webm.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27130 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127594 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34626 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27054 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138237 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83685 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22482 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15029 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26744 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90847 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26325 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26556 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26398 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->