### PR TITLE
SVGPointList should keep valid coordinate pairs when trailing y value is missing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-parse-invalid-clears-items-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-parse-invalid-clears-items-expected.txt
@@ -2,5 +2,6 @@
 PASS SVGLengthList clears items when attribute value is invalid
 PASS SVGNumberList clears items when attribute value is invalid
 PASS SVGPointList clears items when attribute value is invalid
+PASS SVGPointList truncates items when y attribute value is missing
 PASS SVGTransformList clears items when attribute value is invalid
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-parse-invalid-clears-items.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-parse-invalid-clears-items.html
@@ -38,11 +38,25 @@ test(function() {
 
     assert_equals(polygon.points.numberOfItems, 4, "initial valid parse gives 4 items");
 
-    // Setting a partially invalid value: valid point pairs followed by an incomplete pair.
+    // Setting a partially invalid value: valid point pairs followed by an invalid one.
     polygon.setAttribute("points", "0,0 100,0 INVALID");
     assert_equals(polygon.points.numberOfItems, 0,
         "SVGPointList: partially invalid attribute value should result in 0 items");
 }, "SVGPointList clears items when attribute value is invalid");
+
+test(function() {
+    const polygon = document.createElementNS("http://www.w3.org/2000/svg", "polygon");
+
+    // Valid point pairs followed by an incomplete pair.
+    polygon.setAttribute("points", "0,0 100,0 20");
+    assert_equals(polygon.points.numberOfItems, 2,
+        "SVGPointList: partially invalid attribute value should result in 2 items");
+
+    // Valid point pairs followed by an incomplete pair.
+    polygon.setAttribute("points", "0,0 100,0 20,");
+    assert_equals(polygon.points.numberOfItems, 2,
+        "SVGPointList: partially invalid attribute value should result in 2 items");
+}, "SVGPointList truncates items when y attribute value is missing");
 
 test(function() {
     const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");

--- a/LayoutTests/svg/custom/poly-parsing-error-expected.txt
+++ b/LayoutTests/svg/custom/poly-parsing-error-expected.txt
@@ -1,20 +1,16 @@
-CONSOLE MESSAGE: Error: Problem parsing points="80,200 80,300 150,250 80,200 250"
-CONSOLE MESSAGE: Error: Problem parsing points="180,200 180,300 250,250 180,200 250"
-CONSOLE MESSAGE: Error: Problem parsing points="80,60 80,160 150,110 80"
-CONSOLE MESSAGE: Error: Problem parsing points="180,60 180,160 250,110 180"
-Tests whether polygons clear items on parsing error per SVG2 spec.
+Tests whether polygons render up to first parsing error.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS poly1.points.numberOfItems is 0
+PASS poly1.points.numberOfItems is 4
 PASS poly2.points.numberOfItems is 4
 PASS poly3.points.numberOfItems is 4
-PASS poly4.points.numberOfItems is 0
-PASS poly5.points.numberOfItems is 0
+PASS poly4.points.numberOfItems is 4
+PASS poly5.points.numberOfItems is 3
 PASS poly6.points.numberOfItems is 3
 PASS poly7.points.numberOfItems is 3
-PASS poly8.points.numberOfItems is 0
+PASS poly8.points.numberOfItems is 3
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/svg/custom/poly-parsing-error.html
+++ b/LayoutTests/svg/custom/poly-parsing-error.html
@@ -1,13 +1,11 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
-<p id="description"></p>
-<div id="console"></div>
 <script>
-description("Tests whether polygons clear items on parsing error per SVG2 spec.");
+description("Tests whether polygons render up to first parsing error.");
 
 var svgDoc = document.implementation.createDocument("http://www.w3.org/2000/svg", "svg", null);
 var svg = svgDoc.rootElement;
@@ -16,7 +14,7 @@ var poly1 = document.createElementNS("http://www.w3.org/2000/svg", "polyline");
 poly1.setAttribute("points", "80,200 80,300 150,250 80,200 250");
 svg.appendChild(poly1);
 
-shouldBe("poly1.points.numberOfItems", "0");
+shouldBe("poly1.points.numberOfItems", "4");
 
 var poly2 = document.createElementNS("http://www.w3.org/2000/svg", "polyline");
 poly2.setAttribute("points", "80,200 80,300 150,250 80,200");
@@ -34,13 +32,13 @@ var poly4 = document.createElementNS("http://www.w3.org/2000/svg", "polyline");
 poly4.setAttribute("points", "180,200 180,300 250,250 180,200 250");
 svg.appendChild(poly4);
 
-shouldBe("poly4.points.numberOfItems", "0");
+shouldBe("poly4.points.numberOfItems", "4");
 
 var poly5 = document.createElementNS("http://www.w3.org/2000/svg", "polygon");
 poly5.setAttribute("points", "80,60 80,160 150,110 80");
 svg.appendChild(poly5);
 
-shouldBe("poly5.points.numberOfItems", "0");
+shouldBe("poly5.points.numberOfItems", "3");
 
 var poly6 = document.createElementNS("http://www.w3.org/2000/svg", "polygon");
 poly6.setAttribute("points", "80,60 80,160 150,110");
@@ -58,10 +56,9 @@ var poly8 = document.createElementNS("http://www.w3.org/2000/svg", "polygon");
 poly8.setAttribute("points", "180,60 180,160 250,110 180");
 svg.appendChild(poly8);
 
-shouldBe("poly8.points.numberOfItems", "0");
+shouldBe("poly8.points.numberOfItems", "3");
 
 var successfullyParsed = true;
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/svg/dom/points-parser-expected.txt
+++ b/LayoutTests/svg/dom/points-parser-expected.txt
@@ -1,6 +1,4 @@
 CONSOLE MESSAGE: Error: Problem parsing points="a"
-CONSOLE MESSAGE: Error: Problem parsing points="10"
-CONSOLE MESSAGE: Error: Problem parsing points="10,"
 CONSOLE MESSAGE: Error: Problem parsing points="10,,"
 CONSOLE MESSAGE: Error: Problem parsing points="10,,10"
 CONSOLE MESSAGE: Error: Problem parsing points="10,10,"

--- a/Source/WebCore/svg/SVGPointList.cpp
+++ b/Source/WebCore/svg/SVGPointList.cpp
@@ -47,8 +47,12 @@ bool SVGPointList::parse(StringView value)
                 return false;
 
             auto yPos = parseNumber(buffer, SuffixSkippingPolicy::DontSkip);
-            if (!yPos)
-                return false;
+            if (!yPos) {
+                skipOptionalSVGSpaces(buffer);
+                if (buffer.hasCharactersRemaining())
+                    return false;
+                break;
+            }
 
             skipOptionalSVGSpaces(buffer);
 


### PR DESCRIPTION
#### 31e8f16d17b17ef294c7ed1a17a92612fa5e5370
<pre>
SVGPointList should keep valid coordinate pairs when trailing y value is missing
<a href="https://bugs.webkit.org/show_bug.cgi?id=311469">https://bugs.webkit.org/show_bug.cgi?id=311469</a>
<a href="https://rdar.apple.com/174069252">rdar://174069252</a>

Reviewed by Brent Fulgham.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Per SVG 2 [1], if an odd number of coordinates is provided for a
polyline/polygon points attribute, the element is in error with the
same behavior as an incorrectly specified path element. Successfully
parsed coordinate pairs before the incomplete trailing coordinate
are retained, while any other parse error (e.g. an invalid token)
rejects the entire list.

[1] <a href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#PolylineElement">https://w3c.github.io/svgwg/svg2-draft/shapes.html#PolylineElement</a>

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/d1bf16a5383b29e7bc7845cef5f5aa4775936613">https://github.com/web-platform-tests/wpt/commit/d1bf16a5383b29e7bc7845cef5f5aa4775936613</a> (Test Sync)

* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-parse-invalid-clears-items-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGList-parse-invalid-clears-items.html: Synced WPT
* LayoutTests/svg/custom/poly-parsing-error.html: Rebaselined
* LayoutTests/svg/custom/poly-parsing-error-expected.txt: Ditto
* LayoutTests/svg/dom/points-parser-expected.txt: Ditto
* Source/WebCore/svg/SVGPointList.cpp:
(WebCore::SVGPointList::parse):

Canonical link: <a href="https://commits.webkit.org/310798@main">https://commits.webkit.org/310798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f4ae07b0e83520bd3f668a2c015de3d8bc90a90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163800 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f09b93be-2bd0-4767-a641-dc1f9706e35d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156913 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/28439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28148 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/119950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d5b8978e-5f38-41eb-b97e-69f3a03fb140) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157999 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/28439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/139224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100643 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c0e2e209-ed16-471f-a7c6-d0ac3fdd85ca) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/28439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11626 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/28439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17067 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166276 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/9965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/18676 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/128052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/27844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/23375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128190 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34771 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138860 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/84477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/23069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27460 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/91564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/27039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/27269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/27111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->