### PR TITLE
Minor CSS parser cleanups: avoid token copy and redundant null check

### DIFF
--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Primitives.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Primitives.cpp
@@ -33,7 +33,7 @@ namespace CSSPropertyParserHelpers {
 
 bool consumeCommaIncludingWhitespace(CSSParserTokenRange& range)
 {
-    CSSParserToken value = range.peek();
+    auto& value = range.peek();
     if (value.type() != CommaToken)
         return false;
     range.consumeIncludingWhitespace();
@@ -42,7 +42,7 @@ bool consumeCommaIncludingWhitespace(CSSParserTokenRange& range)
 
 bool consumeSlashIncludingWhitespace(CSSParserTokenRange& range)
 {
-    CSSParserToken value = range.peek();
+    auto& value = range.peek();
     if (value.type() != DelimiterToken || value.delimiter() != '/')
         return false;
     range.consumeIncludingWhitespace();

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.cpp
@@ -243,7 +243,7 @@ RefPtr<CSSValue> consumeTranslate(CSSParserTokenRange& range, CSS::PropertyParse
         return nullptr;
 
     // If the z value is a zero value and not a percent value, we have nothing left to add to the list.
-    bool haveNonZeroZ = z && (z->isCalculated() || z->isPercentage() || !*z->isZero());
+    bool haveNonZeroZ = z->isCalculated() || z->isPercentage() || !*z->isZero();
 
     if (!haveNonZeroY && !haveNonZeroZ)
         return CSSValueList::createSpaceSeparated(x.releaseNonNull());


### PR DESCRIPTION
#### af57c6d8b53b6583f2f0d42fbf3695cc0b774a7b
<pre>
Minor CSS parser cleanups: avoid token copy and redundant null check
<a href="https://bugs.webkit.org/show_bug.cgi?id=311472">https://bugs.webkit.org/show_bug.cgi?id=311472</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Primitives.cpp:
(WebCore::CSSPropertyParserHelpers::consumeCommaIncludingWhitespace):
(WebCore::CSSPropertyParserHelpers::consumeSlashIncludingWhitespace):
Use a reference from peek() instead of copying CSSParserToken.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.cpp:
(WebCore::CSSPropertyParserHelpers::consumeTranslate):
Remove redundant null check on z; already guarded by early return.

Canonical link: <a href="https://commits.webkit.org/310585@main">https://commits.webkit.org/310585@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08b54f690ef67ea2eae3350807b77f4f29abfae7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162999 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107713 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f1fec8e-5d67-4f8c-8f34-2c12e0c573f7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156118 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27353 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119290 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84330 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6d3a8812-fe14-46ae-8785-82124095d49c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21559 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138522 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99986 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3ee7327f-5602-4516-97ba-b3fb812815cc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20647 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18643 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10831 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130309 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16367 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165471 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8680 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17976 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127385 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27049 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127530 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34608 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26973 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138160 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83573 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22420 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14952 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26663 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90766 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26244 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26475 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26316 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->