### PR TITLE
Drop unused LayoutRange::floorMinEdgeTo()

### DIFF
--- a/Source/WebCore/platform/graphics/LayoutRange.h
+++ b/Source/WebCore/platform/graphics/LayoutRange.h
@@ -60,7 +60,6 @@ public:
     inline void sizeFromMinEdge(LayoutUnit size = 0_lu);
     inline void sizeFromMaxEdge(LayoutUnit size = 0_lu);
 
-    inline void floorMinEdgeTo(LayoutUnit target);
     inline void floorMaxEdgeTo(LayoutUnit target);
     inline void capMinEdgeTo(LayoutUnit target);
     inline void capMaxEdgeTo(LayoutUnit target);
@@ -94,12 +93,6 @@ inline void LayoutRange::shiftMaxEdgeBy(LayoutUnit shift)
 
 inline void LayoutRange::shiftMinEdgeTo(LayoutUnit target) { shiftMinEdgeBy(target - min()); }
 inline void LayoutRange::shiftMaxEdgeTo(LayoutUnit target) { shiftMaxEdgeBy(target - max()); }
-
-inline void LayoutRange::floorMinEdgeTo(LayoutUnit target)
-{
-    if (target > max())
-        shiftMaxEdgeTo(target);
-}
 
 inline void LayoutRange::floorMaxEdgeTo(LayoutUnit target)
 {


### PR DESCRIPTION
#### ab5f789c97349e3b31279253743e7a93440159fe
<pre>
Drop unused LayoutRange::floorMinEdgeTo()
<a href="https://bugs.webkit.org/show_bug.cgi?id=311473">https://bugs.webkit.org/show_bug.cgi?id=311473</a>

Reviewed by Alan Baradlay.

Drop unused LayoutRange::floorMinEdgeTo(). Its implementation was not
correct, it was identical to LayoutRange::floorMaxEdgeTo().

* Source/WebCore/platform/graphics/LayoutRange.h:
(WebCore::LayoutRange::floorMinEdgeTo):

Canonical link: <a href="https://commits.webkit.org/310571@main">https://commits.webkit.org/310571@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbb9e5e0cbbd2e56c869c7efdd7daa5182edc17e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163004 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/df0f20db-3f68-4d6c-a1f6-ef7a41a1d739) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156123 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27358 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119298 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f279b74a-5d9d-4421-850c-e30850eff7a6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138528 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99994 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/81e7970f-9a08-41f4-878c-5c7bc97e6184) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20648 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18651 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10836 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130310 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16373 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165476 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8685 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17982 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127392 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22693 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127537 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34598 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26978 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138166 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83578 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22427 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14958 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26668 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90771 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26249 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26480 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26322 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->