### PR TITLE
CSSTokenizer: bulk-append validated prefix in slow paths

### DIFF
--- a/Source/WebCore/css/parser/CSSTokenizer.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizer.cpp
@@ -624,7 +624,8 @@ CSSParserToken CSSTokenizer::consumeIdentLikeToken()
 CSSParserToken CSSTokenizer::consumeStringTokenUntil(char16_t endingCodePoint)
 {
     // Strings without escapes get handled without allocations
-    for (unsigned size = 0; ; size++) {
+    unsigned size = 0;
+    for (; ; size++) {
         char16_t cc = m_input.peek(size);
         if (cc == endingCodePoint) {
             unsigned startOffset = m_input.offset();
@@ -640,6 +641,12 @@ CSSParserToken CSSTokenizer::consumeStringTokenUntil(char16_t endingCodePoint)
     }
 
     StringBuilder output;
+    // Bulk-append the already-validated prefix instead of re-consuming character by character.
+    if (size) {
+        unsigned startOffset = m_input.offset();
+        m_input.advance(size);
+        output.append(m_input.rangeAt(startOffset, size));
+    }
     while (true) {
         char16_t cc = consume();
         if (cc == endingCodePoint || cc == kEndOfFileMarker)
@@ -769,7 +776,8 @@ bool CSSTokenizer::consumeIfNext(char16_t character)
 StringView CSSTokenizer::consumeName()
 {
     // Names without escapes get handled without allocations
-    for (unsigned size = 0; ; ++size) {
+    unsigned size = 0;
+    for (; ; ++size) {
         char16_t cc = m_input.peek(size);
         if (isNameCodePoint(cc))
             continue;
@@ -786,6 +794,12 @@ StringView CSSTokenizer::consumeName()
     }
 
     StringBuilder result;
+    // Bulk-append the already-validated prefix instead of re-consuming character by character.
+    if (size) {
+        unsigned startOffset = m_input.offset();
+        m_input.advance(size);
+        result.append(m_input.rangeAt(startOffset, size));
+    }
     while (true) {
         char16_t cc = consume();
         if (isNameCodePoint(cc)) {

--- a/Source/WebCore/css/parser/CSSTokenizer.h
+++ b/Source/WebCore/css/parser/CSSTokenizer.h
@@ -118,7 +118,6 @@ private:
     CSSParserToken commercialAt(char16_t);
     CSSParserToken reverseSolidus(char16_t);
     CSSParserToken asciiDigit(char16_t);
-    CSSParserToken letterU(char16_t);
     CSSParserToken nameStart(char16_t);
     CSSParserToken stringStart(char16_t);
     CSSParserToken endOfFile(char16_t);


### PR DESCRIPTION
#### 1ba4919f607fdd385b9b02b269c76e2eb47a83d8
<pre>
CSSTokenizer: bulk-append validated prefix in slow paths
<a href="https://bugs.webkit.org/show_bug.cgi?id=311477">https://bugs.webkit.org/show_bug.cgi?id=311477</a>

Reviewed by NOBODY (OOPS!).

In consumeName() and consumeStringTokenUntil(), the fast peek loop
validates characters without consuming them. When it falls through to
the StringBuilder slow path (due to an escape sequence or embedded NUL),
those already-validated characters were re-consumed and re-checked one
by one. Bulk-append them as a StringView instead, avoiding redundant
per-character validation and individual StringBuilder::append() calls.

Also remove the letterU(char16_t) declaration which has no definition
and is unused in the codePoints dispatch table.

* Source/WebCore/css/parser/CSSTokenizer.cpp:
(WebCore::CSSTokenizer::consumeStringTokenUntil):
(WebCore::CSSTokenizer::consumeName):
* Source/WebCore/css/parser/CSSTokenizer.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ba4919f607fdd385b9b02b269c76e2eb47a83d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163005 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107719 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd6747d3-8246-4215-b370-c48856bc51a2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27359 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119297 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84335 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2331c7b5-437d-49fb-b324-538971a1d2a7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138529 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99993 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dbfdc8b2-e598-4edf-b696-7da48561ca52) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20653 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18652 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10837 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130315 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165477 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8686 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17983 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127393 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27055 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127538 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26979 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138167 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83579 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22428 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14959 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26669 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90772 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26250 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26481 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26323 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->