### PR TITLE
[css-values-5 attr()] Some cleanups

### DIFF
--- a/Source/WebCore/css/CSSSubstitutionValue.cpp
+++ b/Source/WebCore/css/CSSSubstitutionValue.cpp
@@ -34,13 +34,6 @@
 
 namespace WebCore {
 
-CSSSubstitutionValue::CSSSubstitutionValue(Ref<CSSVariableData>&& data)
-    : CSSValue(ClassType::Substitution)
-    , m_data(WTF::move(data))
-{
-    cacheSimpleReference();
-}
-
 CSSSubstitutionValue::CSSSubstitutionValue(Ref<CSSVariableData>&& data, const CSSNamespacePrefixMap& namespacePrefixMap)
     : CSSValue(ClassType::Substitution)
     , m_data(WTF::move(data))
@@ -56,7 +49,7 @@ Ref<CSSSubstitutionValue> CSSSubstitutionValue::create(const CSSParserTokenRange
 
 Ref<CSSSubstitutionValue> CSSSubstitutionValue::create(Ref<CSSVariableData>&& data)
 {
-    return adoptRef(*new CSSSubstitutionValue(WTF::move(data)));
+    return adoptRef(*new CSSSubstitutionValue(WTF::move(data), CSSNamespacePrefixMap { }));
 }
 
 bool CSSSubstitutionValue::equals(const CSSSubstitutionValue& other) const

--- a/Source/WebCore/css/CSSSubstitutionValue.h
+++ b/Source/WebCore/css/CSSSubstitutionValue.h
@@ -64,7 +64,6 @@ public:
 private:
     friend class Style::SubstitutionResolver;
 
-    explicit CSSSubstitutionValue(Ref<CSSVariableData>&&);
     CSSSubstitutionValue(Ref<CSSVariableData>&&, const CSSNamespacePrefixMap&);
 
     void cacheSimpleReference();

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -344,9 +344,8 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
         return substituteFailure();
 
     if (isInCycle) {
-        // Mark as in-cycle within attr() type() context for transitive detection.
-        if (m_isInAttrTypeSyntax)
-            m_styleBuilder.state().m_inCycleAttrAttributes.add(attributeName);
+        // Mark as in-cycle for transitive detection.
+        m_styleBuilder.state().m_inCycleAttrAttributes.add(attributeName);
         if (parsedAttrType)
             return false;
         return substituteFailure();
@@ -411,8 +410,6 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
     case AttrType::Syntax: {
         CSSTokenizer tokenizer(attributeValue.string());
         m_intermediateTokenStrings.appendVector(tokenizer.escapedStringsForAdoption());
-
-        SetForScope isInAttrTypeSyntax(m_isInAttrTypeSyntax, true);
 
         auto substitutedTokens = substituteTokenRange(tokenizer.tokenRange(), context);
         if (!substitutedTokens)

--- a/Source/WebCore/style/StyleSubstitutionResolver.h
+++ b/Source/WebCore/style/StyleSubstitutionResolver.h
@@ -79,7 +79,6 @@ private:
     RefPtr<const CSSSubstitutionValue> m_substitutionValue;
     Vector<String> m_intermediateTokenStrings;
     unsigned m_urlContextDepth { 0 };
-    bool m_isInAttrTypeSyntax { false };
     bool m_isAttrTainted { false };
     bool m_hasTaintedURL { false };
 };


### PR DESCRIPTION
#### f037d92e0ac2bad469eee55c1bb0447e004f6970
<pre>
[css-values-5 attr()] Some cleanups
<a href="https://bugs.webkit.org/show_bug.cgi?id=311480">https://bugs.webkit.org/show_bug.cgi?id=311480</a>
<a href="https://rdar.apple.com/174075941">rdar://174075941</a>

Reviewed by Tim Nguyen.

* Source/WebCore/css/CSSSubstitutionValue.cpp:
(WebCore::CSSSubstitutionValue::create):
* Source/WebCore/css/CSSSubstitutionValue.h:

Remove unncessary constructor.

* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteAttrFunction):
* Source/WebCore/style/StyleSubstitutionResolver.h:

Remove unncessary m_isInAttrTypeSyntax bit. Cycles can be detected unconditionally.

Canonical link: <a href="https://commits.webkit.org/310600@main">https://commits.webkit.org/310600@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23a4f489c7660057ebba4f933655f38b79cf3880

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154256 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163010 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107724 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/318035ba-5b68-4fd8-9768-fb9201df6099) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156129 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27364 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119300 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84338 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2cf84966-e882-415b-811f-f7420f47470e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138530 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99996 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b9ce41db-5ba5-4a41-bd34-b37f171f8ff3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20654 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18654 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10842 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130316 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16375 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165482 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8691 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127395 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27060 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22696 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127540 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34624 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26984 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138168 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83584 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22429 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14960 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26674 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90777 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26255 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26486 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26328 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->