### PR TITLE
Fix missing m_hasStickyAncestor check in RenderLayer::ancestorLayerPositionStateChanged

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1180,7 +1180,7 @@ bool RenderLayer::ancestorLayerPositionStateChanged(OptionSet<UpdateLayerPositio
         || m_hasFixedAncestor != flags.contains(SeenFixedLayer)
         || m_hasPaginatedAncestor != flags.contains(UpdatePagination)
         || m_hasCompositedScrollingAncestor != flags.contains(SeenCompositedScrollingLayer)
-        || m_hasPaginatedAncestor != flags.contains(UpdatePagination);
+        || m_hasStickyAncestor != flags.contains(SeenStickyLayer);
 }
 
 #define LAYER_POSITIONS_ASSERT_ENABLED ASSERT_ENABLED || ENABLE(CONJECTURE_ASSERT)


### PR DESCRIPTION
#### 3fbfed522d7d675bfaea837af1a854aa8d1041ae
<pre>
Fix missing m_hasStickyAncestor check in RenderLayer::ancestorLayerPositionStateChanged
<a href="https://bugs.webkit.org/show_bug.cgi?id=311481">https://bugs.webkit.org/show_bug.cgi?id=311481</a>

Reviewed by Alan Baradlay.

ancestorLayerPositionStateChanged() had a duplicate check for
m_hasPaginatedAncestor/UpdatePagination and was missing the check for
m_hasStickyAncestor/SeenStickyLayer. Every other state bit tracked by
UPDATE_OR_VERIFY_STATE_BIT in recursiveUpdateLayerPositions had a
corresponding check in this function except m_hasStickyAncestor.

Without this check, if m_hasStickyAncestor becomes stale on a
descendant layer, ancestorLayerPositionStateChanged() will not detect
the mismatch, SubtreeNeedsUpdate will not be set, and the descendant
will be skipped rather than updated.

No new tests. ancestorLayerPositionStateChanged() is a safety net that
catches cases where the normal dirty-bit propagation is insufficient to
update descendant state. In practice, changing position:sticky triggers
layout, which dirties layers via repaint-status changes, causing
updateLayerPositionsAfterLayout to traverse and update the full subtree
through the normal path. The safety net only matters for edge cases
where an ancestor&apos;s state changes but descendants remain clean while
the tree is being traversed for an unrelated reason -- a scenario that
is difficult to trigger deterministically from web content. The
existing LAYER_POSITIONS_ASSERT verification mode covers this in debug
builds.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::ancestorLayerPositionStateChanged):

Canonical link: <a href="https://commits.webkit.org/310586@main">https://commits.webkit.org/310586@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fde88ace352acbc5c7a82ae39df0208c08b58293

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154257 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163011 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107725 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/833266d8-8f99-4181-a3a0-76f30fe1ccd6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156130 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27648 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27365 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119302 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84344 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/14cbcd64-c99b-4627-9309-7dfaaa1fdb80) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157216 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21568 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138532 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99998 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ce6c126c-f352-4337-aed7-b18f2a9f6ba5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20656 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18656 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10843 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130318 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165483 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8692 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17986 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127397 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27061 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22698 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127542 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34610 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26985 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138170 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83585 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22433 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14962 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26675 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90778 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26256 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26487 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26329 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->