### PR TITLE
setAncestorChainHasSelfPaintingLayerDescendant should use loop variable instead of this

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1435,9 +1435,9 @@ void RenderLayer::setRepaintStatus(RepaintStatus status)
 void RenderLayer::setAncestorChainHasSelfPaintingLayerDescendant()
 {
     for (RenderLayer* layer = this; layer; layer = layer->parent()) {
-        if (renderer().shouldApplyPaintContainment()) {
-            m_hasSelfPaintingLayerDescendant = true;
-            m_hasSelfPaintingLayerDescendantDirty = false;
+        if (layer->renderer().shouldApplyPaintContainment()) {
+            layer->m_hasSelfPaintingLayerDescendant = true;
+            layer->m_hasSelfPaintingLayerDescendantDirty = false;
             break;
         }
         if (!layer->m_hasSelfPaintingLayerDescendantDirty && layer->hasSelfPaintingLayerDescendant())


### PR DESCRIPTION
#### 066241971c0fdca3344fec22eb7fe0fa056b4b88
<pre>
setAncestorChainHasSelfPaintingLayerDescendant should use loop variable instead of this
<a href="https://bugs.webkit.org/show_bug.cgi?id=311482">https://bugs.webkit.org/show_bug.cgi?id=311482</a>

Reviewed by Alan Baradlay.

The paint containment check and the flag assignments inside the loop
used unqualified renderer() and member variables, which resolve to
this-&gt; rather than the current loop variable layer-&gt;. On the first
iteration (layer == this) this is harmless, but on subsequent
iterations the code checks the wrong renderer for paint containment
and sets the flags on the wrong layer.

The effect is that hasSelfPaintingLayerDescendant propagates past
contain:paint boundaries to ancestors that should be isolated. Those
ancestors then fail to early-out in paintLayerWithEffects, paintList,
hitTestLayer, and hitTestList, doing unnecessary traversal work before
finding nothing to paint or hit.

No new tests. The over-propagation only affects skip-optimizations in
painting and hit testing; visual output, elementFromPoint() results,
and all DOM-observable behavior are unchanged. The stale flag is also
transient: updateDescendantDependentFlags() recomputes the correct
value from children on the next dirty pass.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::setAncestorChainHasSelfPaintingLayerDescendant):

Canonical link: <a href="https://commits.webkit.org/310587@main">https://commits.webkit.org/310587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51a8a8bb6a0290e8cdec12ce42a43c81b21e94b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163013 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107727 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/36b35339-857d-4714-b38e-692e7d9ffd5a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119304 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84340 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/79fe36b0-34f8-44b3-a491-59de3aac67a7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21571 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138534 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100000 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1f9c2193-cbd5-4438-9131-e5fe76990faa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20659 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18657 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10845 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130321 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16379 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165485 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8694 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17988 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127399 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27063 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22699 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127544 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34611 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26987 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138172 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83587 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22434 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14964 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26677 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90780 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26258 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26489 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26331 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->