### PR TITLE
Avoid redundant updateValidity() in HTMLInputElement::initializeInputTypeAfterParsingOrCloning()

### DIFF
--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -747,10 +747,9 @@ void HTMLInputElement::initializeInputTypeAfterParsingOrCloning()
 
     m_hasType = true;
     m_inputType = InputType::createIfDifferent(*this, type);
-    updateWillValidateAndValidity();
     registerForSuspensionCallbackIfNeeded();
     runPostTypeUpdateTasks();
-    updateValidity();
+    updateWillValidateAndValidity();
 }
 
 void HTMLInputElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)


### PR DESCRIPTION
#### 17fd4c9c02bfa2bb3aef379a9aedf9ab847c8dfc
<pre>
Avoid redundant updateValidity() in HTMLInputElement::initializeInputTypeAfterParsingOrCloning()
<a href="https://bugs.webkit.org/show_bug.cgi?id=311484">https://bugs.webkit.org/show_bug.cgi?id=311484</a>

Reviewed by Darin Adler.

initializeInputTypeAfterParsingOrCloning() was calling updateWillValidateAndValidity()
followed by registerForSuspensionCallbackIfNeeded(), runPostTypeUpdateTasks(), and then
a second updateValidity(). Since m_willValidateInitialized is always false at this point,
updateWillValidateAndValidity() never takes its early return and always calls
updateValidity() internally. The code between the two calls does not affect validity
state (no renderer exists during parsing, the element is not focused, and
registerForSuspensionCallbackIfNeeded() only checks autocomplete state). So the second
updateValidity() recomputed the same result and discarded it.

This is meaningful because updateValidity() calls computeValidity() which calls value()
which calls shouldApplyScriptTrackingPrivacyProtection(), and that walks the JS call
stack via sourceTaintedOriginFromStack() on every invocation. Eliminating the redundant
call avoids one JS stack walk per input element initialization.

Fix by moving the single updateWillValidateAndValidity() call to the end, after
registerForSuspensionCallbackIfNeeded() and runPostTypeUpdateTasks(), and removing the
separate updateValidity() call.

* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::initializeInputTypeAfterParsingOrCloning):

Canonical link: <a href="https://commits.webkit.org/310591@main">https://commits.webkit.org/310591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d91968dd1a55f92366c56bd543ea9a1e9ba2123

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163015 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107729 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/165cf8d3-9bb8-493d-94e1-1e31a1761397) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156134 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27369 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119306 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84342 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/67e8abfc-a544-43d0-aa67-238f2d86a82d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157220 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21573 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138536 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100002 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20661 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18660 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10847 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130323 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165487 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8696 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17990 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127401 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27065 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22702 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127546 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34614 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26989 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138174 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83590 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22436 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14966 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26679 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90782 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26260 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26491 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26333 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->