### PR TITLE
constructTree should use the adjusted current node for integration point checks

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/cdata-in-integration-point-fragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/cdata-in-integration-point-fragment-expected.txt
@@ -1,0 +1,11 @@
+
+PASS CDATA not allowed when fragment-parsing with <mi> context (MathML text integration point)
+PASS CDATA not allowed when fragment-parsing with <mo> context (MathML text integration point)
+PASS CDATA not allowed when fragment-parsing with <mn> context (MathML text integration point)
+PASS CDATA not allowed when fragment-parsing with <ms> context (MathML text integration point)
+PASS CDATA not allowed when fragment-parsing with <mtext> context (MathML text integration point)
+PASS CDATA not allowed when fragment-parsing with <foreignObject> context (SVG HTML integration point)
+PASS CDATA not allowed when fragment-parsing with <desc> context (SVG HTML integration point)
+PASS CDATA not allowed when fragment-parsing with <title> context (SVG HTML integration point)
+PASS CDATA allowed when fragment-parsing with <path> context (non-integration-point SVG element)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/cdata-in-integration-point-fragment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/cdata-in-integration-point-fragment.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CDATA sections should not be allowed when fragment-parsing with integration point context elements</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/parsing.html#tree-construction">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/parsing.html#adjusted-current-node">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+// After processing each token, the tree construction stage sets the tokenizer's
+// "CDATA sections allowed" flag based on the adjusted current node. When
+// fragment-parsing with only the root DocumentFragment on the open elements
+// stack, the adjusted current node is the context element (not the
+// DocumentFragment). If the context element is an integration point, then it
+// should be treated as HTML content and CDATA sections should NOT be allowed.
+//
+// The input "x<![CDATA[y]]>" is used because:
+// 1. "x" is emitted as a character token first
+// 2. After processing "x", the tree builder sets tokenizer flags
+// 3. "<![CDATA[y]]>" is then tokenized with those flags
+//
+// If CDATA is incorrectly allowed, "y" becomes text content.
+// If CDATA is correctly disallowed, "<![CDATA[y]]>" becomes a bogus comment.
+
+// MathML text integration points
+for (const tagName of ["mi", "mo", "mn", "ms", "mtext"]) {
+    test(function() {
+        const el = document.createElementNS("http://www.w3.org/1998/Math/MathML", tagName);
+        el.innerHTML = "x<![CDATA[y]]>";
+        assert_equals(el.firstChild.nodeType, Node.TEXT_NODE, "first child should be a text node");
+        assert_equals(el.firstChild.data, "x", "text node should contain only 'x'");
+        assert_equals(el.childNodes.length, 2, "should have 2 child nodes (text + comment)");
+        assert_equals(el.lastChild.nodeType, Node.COMMENT_NODE,
+            "CDATA should be parsed as a bogus comment, not as character data");
+    }, "CDATA not allowed when fragment-parsing with <" + tagName + "> context (MathML text integration point)");
+}
+
+// SVG HTML integration points
+for (const tagName of ["foreignObject", "desc", "title"]) {
+    test(function() {
+        const el = document.createElementNS("http://www.w3.org/2000/svg", tagName);
+        el.innerHTML = "x<![CDATA[y]]>";
+        assert_equals(el.firstChild.nodeType, Node.TEXT_NODE, "first child should be a text node");
+        assert_equals(el.firstChild.data, "x", "text node should contain only 'x'");
+        assert_equals(el.childNodes.length, 2, "should have 2 child nodes (text + comment)");
+        assert_equals(el.lastChild.nodeType, Node.COMMENT_NODE,
+            "CDATA should be parsed as a bogus comment, not as character data");
+    }, "CDATA not allowed when fragment-parsing with <" + tagName + "> context (SVG HTML integration point)");
+}
+
+// Verify that CDATA IS allowed for non-integration-point foreign elements
+test(function() {
+    const el = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    el.innerHTML = "x<![CDATA[y]]>";
+    // For a non-integration-point foreign element, CDATA should be allowed
+    // and "y" should appear as text content
+    assert_equals(el.textContent, "xy",
+        "CDATA should be parsed as character data for non-integration-point foreign elements");
+}, "CDATA allowed when fragment-parsing with <path> context (non-integration-point SVG element)");
+</script>

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -344,10 +344,16 @@ void HTMLTreeBuilder::constructTree(AtomHTMLToken&& token)
     else
         processToken(WTF::move(token));
 
-    bool inForeignContent = !m_tree.isEmpty()
-        && !isInHTMLNamespace(adjustedCurrentStackItem())
-        && !HTMLElementStack::isHTMLIntegrationPoint(m_tree.currentStackItem())
-        && !HTMLElementStack::isMathMLTextIntegrationPoint(m_tree.currentStackItem());
+    // Use the adjusted current node for all checks, matching shouldProcessTokenInForeignContent().
+    // When fragment-parsing with only one element on the stack, the adjusted current node is the
+    // context element, not the DocumentFragment.
+    bool inForeignContent = false;
+    if (!m_tree.isEmpty()) {
+        auto& adjustedCurrentNode = adjustedCurrentStackItem();
+        inForeignContent = !isInHTMLNamespace(adjustedCurrentNode)
+            && !HTMLElementStack::isHTMLIntegrationPoint(adjustedCurrentNode)
+            && !HTMLElementStack::isMathMLTextIntegrationPoint(adjustedCurrentNode);
+    }
 
     m_parser->tokenizer().setForceNullCharacterReplacement(m_insertionMode == InsertionMode::Text || inForeignContent);
     m_parser->tokenizer().setShouldAllowCDATA(inForeignContent);


### PR DESCRIPTION
#### 1915ee470dcfbb539afd8069209b7a5c019e6869
<pre>
constructTree should use the adjusted current node for integration point checks
<a href="https://bugs.webkit.org/show_bug.cgi?id=311486">https://bugs.webkit.org/show_bug.cgi?id=311486</a>

Reviewed by Anne van Kesteren.

The post-token-processing code in constructTree() that sets the tokenizer&apos;s
shouldAllowCDATA and forceNullCharacterReplacement flags was using
m_tree.currentStackItem() for the integration point checks, while using
adjustedCurrentStackItem() for the namespace check. This is inconsistent
with shouldProcessTokenInForeignContent(), which correctly uses the
adjusted current node for all checks.

Per <a href="https://html.spec.whatwg.org/multipage/parsing.html#tree-construction">https://html.spec.whatwg.org/multipage/parsing.html#tree-construction</a>,
the tree construction dispatcher uses the &quot;adjusted current node&quot; to
determine whether to process tokens as foreign content, and to set
tokenizer flags after each token. The adjusted current node is defined at
<a href="https://html.spec.whatwg.org/multipage/parsing.html#adjusted-current-node">https://html.spec.whatwg.org/multipage/parsing.html#adjusted-current-node</a>
as the context element during fragment parsing when the stack of open
elements has only one element.

During fragment parsing when only the root DocumentFragment is on the open
elements stack, adjustedCurrentStackItem() returns the context element
while m_tree.currentStackItem() returns the DocumentFragment. If the
context element is a MathML text integration point (mi, mo, mn, ms, mtext)
or an HTML integration point (svg foreignObject, svg desc, svg title),
the DocumentFragment would not be recognized as an integration point,
causing the tokenizer to incorrectly allow CDATA sections and force null
character replacement in what should be treated as HTML content.

Test: imported/w3c/web-platform-tests/html/syntax/parsing/cdata-in-integration-point-fragment.html
- This test is failing in shipping Safari but passing in Chrome.

* LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/cdata-in-integration-point-fragment-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/cdata-in-integration-point-fragment.html: Added.
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::constructTree):

Canonical link: <a href="https://commits.webkit.org/310593@main">https://commits.webkit.org/310593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15508e7c87df1441758247c03dff399e9e6b0704

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163016 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107730 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40188ffa-b819-40c9-9987-71b2dbfca0c7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156135 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119307 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84343 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4d4ec71b-e408-4313-9481-4b8d016022e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157221 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21572 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138538 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100003 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4e11d319-e8dd-448b-a5c6-e9121a14d2cf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20660 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18661 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10848 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130322 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16383 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165488 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8697 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17992 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127402 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22703 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127547 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34615 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26990 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138176 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83591 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22435 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14968 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26680 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90783 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26261 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26492 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26334 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->