### PR TITLE
[JSC][WASM][Debugger] Fix WasmDebuggerDebuggable leak when process shuts down

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -738,7 +738,7 @@ void WebProcessProxy::shutDown()
     shutDownProcess();
 
 #if ENABLE(WEBASSEMBLY_DEBUGGER) && ENABLE(REMOTE_INSPECTOR)
-    if (JSC::Options::enableWasmDebugger()) [[unlikely]]
+    if (m_wasmDebuggerDebuggable)
         destroyWasmDebuggerTarget();
 #endif
 


### PR DESCRIPTION
#### c51e9ffac777f72df41726bdc86e3e0be9f67844
<pre>
[JSC][WASM][Debugger] Fix WasmDebuggerDebuggable leak when process shuts down
<a href="https://bugs.webkit.org/show_bug.cgi?id=311491">https://bugs.webkit.org/show_bug.cgi?id=311491</a>
<a href="https://rdar.apple.com/169471661">rdar://169471661</a>

Reviewed by Mark Lam.

destroyWasmDebuggerTarget() was guarded by JSC::Options::enableWasmDebugger(),
but createWasmDebuggerTarget() is also called when m_createWasmDebuggerDebuggable
is true (set via EnableWebAssemblyDebugger::Yes). When the latter path created the
debuggable, shutDown() would skip destroying it, leaving m_wasmDebuggerDebuggable
registered with RemoteInspector until the WebProcessProxy was eventually destroyed.

This caused WasmDebugger debuggable counts to exceed Webpage debuggable counts
during tab manipulation, because WebPageDebuggable is torn down on tab close while
the cached WebProcessProxy held a lingering WasmDebuggerDebuggable registration.

Fix: replace the flag-derived guard with a direct existence check — if the
debuggable was created, destroy it.

Canonical link: <a href="https://commits.webkit.org/310578@main">https://commits.webkit.org/310578@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60b32c8380ba2dbbd5165a2c230d8cd0a7258cc5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154275 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163029 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107744 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119319 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84351 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/39fb9d2d-06fd-4dba-b8df-11476ffa80bb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138547 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100015 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d853b5e-1730-4358-ba15-884038db4b17) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20670 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18670 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10861 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130332 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165501 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8710 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18001 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127413 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27079 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22712 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127558 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27003 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138185 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83613 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23560 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22446 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14977 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26693 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90796 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26274 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26505 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26347 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->