### PR TITLE
[JSC] Allow wider bulk copy in GC safe memory operations

### DIFF
--- a/Source/JavaScriptCore/heap/GCMemoryOperations.h
+++ b/Source/JavaScriptCore/heap/GCMemoryOperations.h
@@ -37,10 +37,10 @@ namespace JSC {
 // chunks. If we happened to fall into the system's normal byte copy loop, we may see a torn JSValue in the
 // concurrent collector.
 
-constexpr size_t smallCutoff = 30 * 8;
+constexpr size_t smallCutoff = 8 * 8;
 constexpr size_t mediumCutoff = 4 * 1024;
 
-// This is a forwards loop so gcSafeMemmove can rely on the direction. 
+// This is a forwards loop so gcSafeMemmove can rely on the direction.
 template <typename T>
 ALWAYS_INLINE void gcSafeMemcpy(T* dst, const T* src, size_t bytes)
 {
@@ -63,7 +63,7 @@ ALWAYS_INLINE void gcSafeMemcpy(T* dst, const T* src, size_t bytes)
         size_t alignedBytes = (bytes / 64) * 64;
         size_t tmp;
         size_t offset = 0;
-        asm volatile(
+        __asm__ volatile(
             ".balign 32\t\n"
             "1:\t\n"
             "cmpq %q[offset], %q[alignedBytes]\t\n"
@@ -97,19 +97,22 @@ ALWAYS_INLINE void gcSafeMemcpy(T* dst, const T* src, size_t bytes)
         // On Windows ARM64, LLVM has a bug (llvm/llvm-project#47432) that causes a
         // fatal error "Failed to evaluate function length in SEH unwind info" when
         // inline assembly contains alignment directives. Fall back to scalar code.
-        uint64_t alignedBytes = (static_cast<uint64_t>(bytes) / 32) * 32;
+        uint64_t alignedBytes = (static_cast<uint64_t>(bytes) / 64) * 64;
 
         uint64_t dstPtr = static_cast<uint64_t>(std::bit_cast<uintptr_t>(dst));
         uint64_t srcPtr = static_cast<uint64_t>(std::bit_cast<uintptr_t>(src));
         uint64_t end = dstPtr + bytes;
         uint64_t alignedEnd = dstPtr + alignedBytes;
 
-        asm volatile(
+        __asm__ volatile(
             "1:\t\n"
             "cmp %x[dstPtr], %x[alignedEnd]\t\n"
             "b.eq 2f\t\n"
+
             "ldp q0, q1, [%x[srcPtr]], #0x20\t\n"
+            "ldp q2, q3, [%x[srcPtr]], #0x20\t\n"
             "stp q0, q1, [%x[dstPtr]], #0x20\t\n"
+            "stp q2, q3, [%x[dstPtr]], #0x20\t\n"
             "b 1b\t\n"
 
             "2:\t\n"
@@ -120,17 +123,16 @@ ALWAYS_INLINE void gcSafeMemcpy(T* dst, const T* src, size_t bytes)
             "b 2b\t\n"
 
             "3:\t\n"
-
             : [end] "+r" (end), [alignedEnd] "+r" (alignedEnd), [dstPtr] "+r" (dstPtr), [srcPtr] "+r" (srcPtr)
             :
-            : "d0", "d1", "memory", "cc"
+            : "d0", "d1", "d2", "d3", "memory", "cc"
         );
 #endif // CPU(X86_64)
     } else {
         RELEASE_ASSERT(isX86_64());
 #if CPU(X86_64)
         size_t count = bytes / 8;
-        asm volatile(
+        __asm__ volatile(
             ".balign 16\t\n"
             "cld\t\n"
             "rep movsq\t\n"
@@ -179,7 +181,7 @@ ALWAYS_INLINE void gcSafeMemmove(T* dst, const T* src, size_t bytes)
 
         size_t tail = alignedBytes;
         size_t tmp;
-        asm volatile(
+        __asm__ volatile(
             "2:\t\n"
             "cmpq %q[tail], %q[bytes]\t\n"
             "je 1f\t\n"
@@ -213,32 +215,37 @@ ALWAYS_INLINE void gcSafeMemmove(T* dst, const T* src, size_t bytes)
             : "xmm0", "xmm1", "xmm2", "xmm3", "memory", "cc"
         );
 #elif CPU(ARM64) && !OS(WINDOWS)
-        uint64_t alignedBytes = (static_cast<uint64_t>(bytes) / 32) * 32;
+        uint64_t alignedBytes = (static_cast<uint64_t>(bytes) / 64) * 64;
+
         uint64_t dstPtr = static_cast<uint64_t>(std::bit_cast<uintptr_t>(dst) + static_cast<uint64_t>(bytes));
         uint64_t srcPtr = static_cast<uint64_t>(std::bit_cast<uintptr_t>(src) + static_cast<uint64_t>(bytes));
-        uint64_t alignedEnd = std::bit_cast<uintptr_t>(dst) + alignedBytes;
-        uint64_t end = std::bit_cast<uintptr_t>(dst);
 
-        asm volatile(
+        uint64_t alignedStart = std::bit_cast<uintptr_t>(dst) + (static_cast<uint64_t>(bytes) - alignedBytes);
+        uint64_t start = std::bit_cast<uintptr_t>(dst);
+
+        __asm__ volatile(
             "1:\t\n"
-            "cmp %x[dstPtr], %x[alignedEnd]\t\n"
+            "cmp %x[dstPtr], %x[alignedStart]\t\n"
             "b.eq 2f\t\n"
-            "ldr d0, [%x[srcPtr], #-0x8]!\t\n"
-            "str d0, [%x[dstPtr], #-0x8]!\t\n"
+
+            "ldp q2, q3, [%x[srcPtr], #-0x20]!\t\n"
+            "ldp q0, q1, [%x[srcPtr], #-0x20]!\t\n"
+            "stp q2, q3, [%x[dstPtr], #-0x20]!\t\n"
+            "stp q0, q1, [%x[dstPtr], #-0x20]!\t\n"
             "b 1b\t\n"
 
             "2:\t\n"
-            "cmp %x[dstPtr], %x[end]\t\n"
+            "cmp %x[dstPtr], %x[start]\t\n"
             "b.eq 3f\t\n"
-            "ldp q0, q1, [%x[srcPtr], #-0x20]!\t\n"
-            "stp q0, q1, [%x[dstPtr], #-0x20]!\t\n"
+            "ldr d0, [%x[srcPtr], #-0x8]!\t\n"
+            "str d0, [%x[dstPtr], #-0x8]!\t\n"
             "b 2b\t\n"
 
             "3:\t\n"
 
-            : [alignedEnd] "+r" (alignedEnd), [end] "+r" (end), [dstPtr] "+r" (dstPtr), [srcPtr] "+r" (srcPtr)
+            : [alignedStart] "+r" (alignedStart), [start] "+r" (start), [dstPtr] "+r" (dstPtr), [srcPtr] "+r" (srcPtr)
             :
-            : "d0", "d1", "memory", "cc"
+            : "d0", "d1", "d2", "d3", "memory", "cc"
         );
 #endif // CPU(X86_64)
     }
@@ -259,7 +266,7 @@ ALWAYS_INLINE void gcSafeZeroMemory(T* dst, size_t bytes)
 #if CPU(X86_64)
     uint64_t zero = 0;
     size_t count = bytes / 8;
-    asm volatile (
+    __asm__ volatile (
         "rep stosq\n\t"
         : "+D"(dst), "+c"(count)
         : "a"(zero)
@@ -273,30 +280,32 @@ ALWAYS_INLINE void gcSafeZeroMemory(T* dst, size_t bytes)
     uint64_t dstPtr = static_cast<uint64_t>(std::bit_cast<uintptr_t>(dst));
     uint64_t end = dstPtr + bytes;
     uint64_t alignedEnd = dstPtr + alignedBytes;
-    asm volatile(
-        "movi d0, #0\t\n"
-        "movi d1, #0\t\n"
+
+    __asm__ volatile(
+        "movi v0.16b, #0\t\n"
 
         ".p2align 4\t\n"
-        "2:\t\n"
+        "1:\t\n"
         "cmp %x[dstPtr], %x[alignedEnd]\t\n"
-        "b.eq 4f\t\n"
+        "b.eq 2f\t\n"
+
         "stnp q0, q0, [%x[dstPtr]]\t\n"
         "stnp q0, q0, [%x[dstPtr], #0x20]\t\n"
         "add %x[dstPtr], %x[dstPtr], #0x40\t\n"
+        "b 1b\t\n"
+
+        "2:\t\n"
+        "cmp %x[dstPtr], %x[end]\t\n"
+        "b.eq 3f\t\n"
+
+        "str d0, [%x[dstPtr]], #0x8\t\n"
         "b 2b\t\n"
 
-        "4:\t\n"
-        "cmp %x[dstPtr], %x[end]\t\n"
-        "b.eq 5f\t\n"
-        "str d0, [%x[dstPtr]], #0x8\t\n"
-        "b 4b\t\n"
+        "3:\t\n"
 
-        "5:\t\n"
-
-        : [alignedBytes] "+r" (alignedBytes), [bytes] "+r" (bytes), [dstPtr] "+r" (dstPtr), [end] "+r" (end), [alignedEnd] "+r" (alignedEnd)
-        :
-        : "d0", "d1", "memory", "cc"
+        : [dstPtr] "+r" (dstPtr)
+        : [end] "r" (end), [alignedEnd] "r" (alignedEnd)
+        : "v0", "memory", "cc"
     );
 #else
     size_t count = bytes / 8;


### PR DESCRIPTION
#### 7a412e324d10e49ad71a7327b0204f2e26237611
<pre>
[JSC] Allow wider bulk copy in GC safe memory operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=311492">https://bugs.webkit.org/show_bug.cgi?id=311492</a>
<a href="https://rdar.apple.com/174084423">rdar://174084423</a>

Reviewed by Yijia Huang.

Optimize gcSafeZeroMemory, gcSafeMemcpy, gcSafeMemmove.

1. Reduce the threshold for bulk copy loop. 8 elements are enough to
   gain SIMD performance benefit.
2. Do 64byte bulk copying, which is wider than the previous 32byte bulk
   copying.

Note that GC safe memory operations are intentionally written in asm
volatile code (not using intrinisc) to ensure that the exact code will
be performed. If some torn reads / writes happen, GC crashes.

* Source/JavaScriptCore/heap/GCMemoryOperations.h:
(JSC::gcSafeMemcpy):
(JSC::gcSafeMemmove):
(JSC::gcSafeZeroMemory):

Canonical link: <a href="https://commits.webkit.org/310580@main">https://commits.webkit.org/310580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bec10df0451955a2993d6a94f825da3fdc5aa57a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154277 "13 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20695 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163031 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107746 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba4d5f44-bb75-4cab-a86e-73e7e00d6378) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27385 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119321 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84353 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4dc935a2-a3ef-4761-a8fe-e87a70d0a81c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21584 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138552 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100017 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d842e909-6b0c-40c5-a192-362f4c8ed190) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20672 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18672 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10863 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146326 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130334 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16397 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165503 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15108 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8712 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127415 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27081 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22714 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127560 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138190 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83615 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23561 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22448 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14982 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185912 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26695 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90798 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47669 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26276 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26507 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26349 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->