### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF/wtf/text/StringCommon

### DIFF
--- a/Source/WTF/wtf/text/StringCommon.cpp
+++ b/Source/WTF/wtf/text/StringCommon.cpp
@@ -28,70 +28,68 @@
 
 #include <wtf/SIMDUTF.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 SUPPRESS_NODELETE SUPPRESS_ASAN
-const float* findFloatAlignedImpl(const float* pointer, float target, size_t length)
+const float* findFloatAlignedImpl(std::span<const float> buffer, float target)
 {
-    ASSERT(!(reinterpret_cast<uintptr_t>(pointer) & 0b11));
+    ASSERT(!(reinterpret_cast<uintptr_t>(buffer.data()) & 0b11));
 
     constexpr simde_uint32x4_t indexMask { 0, 1, 2, 3 };
 
-    ASSERT(length);
-    ASSERT(!(reinterpret_cast<uintptr_t>(pointer) & 0xf));
-    ASSERT((reinterpret_cast<uintptr_t>(pointer) & ~static_cast<uintptr_t>(0xf)) == reinterpret_cast<uintptr_t>(pointer));
-    const float* cursor = pointer;
+    ASSERT(buffer.size());
+    ASSERT(!(reinterpret_cast<uintptr_t>(buffer.data()) & 0xf));
+    ASSERT((reinterpret_cast<uintptr_t>(buffer.data()) & ~static_cast<uintptr_t>(0xf)) == reinterpret_cast<uintptr_t>(buffer.data()));
+    std::span<const float> cursor = buffer;
     constexpr size_t stride = SIMD::stride<float>;
 
     simde_float32x4_t targetsVector = simde_vdupq_n_f32(target);
 
     while (true) {
-        simde_float32x4_t value = simde_vld1q_f32(cursor);
+        simde_float32x4_t value = simde_vld1q_f32(cursor.data());
         simde_uint32x4_t mask = simde_vceqq_f32(value, targetsVector);
         if (simde_vget_lane_u64(simde_vreinterpret_u64_u16(simde_vmovn_u32(mask)), 0)) {
             simde_uint32x4_t ranked = simde_vornq_u32(indexMask, mask);
             uint32_t index = simde_vminvq_u32(ranked);
-            return (index < length) ? cursor + index : nullptr;
+            return (index < cursor.size()) ? cursor.subspan(index).data() : nullptr;
         }
-        if (length <= stride)
+        if (cursor.size() <= stride)
             return nullptr;
-        length -= stride;
-        cursor += stride;
+        cursor = cursor.subspan(stride);
     }
 }
 
 SUPPRESS_NODELETE SUPPRESS_ASAN
-const double* findDoubleAlignedImpl(const double* pointer, double target, size_t length)
+const double* findDoubleAlignedImpl(std::span<const double> buffer, double target)
 {
-    ASSERT(!(reinterpret_cast<uintptr_t>(pointer) & 0b111));
+    ASSERT(!(reinterpret_cast<uintptr_t>(buffer.data()) & 0b111));
 
     constexpr simde_uint32x2_t indexMask { 0, 1 };
 
-    ASSERT(length);
-    ASSERT(!(reinterpret_cast<uintptr_t>(pointer) & 0xf));
-    ASSERT((reinterpret_cast<uintptr_t>(pointer) & ~static_cast<uintptr_t>(0xf)) == reinterpret_cast<uintptr_t>(pointer));
-    const double* cursor = pointer;
+    ASSERT(buffer.size());
+    ASSERT(!(reinterpret_cast<uintptr_t>(buffer.data()) & 0xf));
+    ASSERT((reinterpret_cast<uintptr_t>(buffer.data()) & ~static_cast<uintptr_t>(0xf)) == reinterpret_cast<uintptr_t>(buffer.data()));
+    std::span<const double> cursor = buffer;
     constexpr size_t stride = SIMD::stride<double>;
 
     simde_float64x2_t targetsVector = simde_vdupq_n_f64(target);
 
     while (true) {
-        simde_float64x2_t value = simde_vld1q_f64(cursor);
+        simde_float64x2_t value = simde_vld1q_f64(cursor.data());
         simde_uint64x2_t mask = simde_vceqq_f64(value, targetsVector);
         simde_uint32x2_t reducedMask = simde_vmovn_u64(mask);
         if (simde_vget_lane_u64(simde_vreinterpret_u64_u32(reducedMask), 0)) {
             simde_uint32x2_t ranked = simde_vorn_u32(indexMask, reducedMask);
             uint32_t index = simde_vminv_u32(ranked);
-            return (index < length) ? cursor + index : nullptr;
+            return (index < cursor.size()) ? cursor.subspan(index).data() : nullptr;
         }
-        if (length <= stride)
+        if (cursor.size() <= stride)
             return nullptr;
-        length -= stride;
-        cursor += stride;
+        cursor = cursor.subspan(stride);
     }
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 SUPPRESS_NODELETE SUPPRESS_ASAN
 const Latin1Character* find8NonASCIIAlignedImpl(std::span<const Latin1Character> data)

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -796,7 +796,7 @@ ALWAYS_INLINE const Float16* NODELETE findFloat16(const Float16* pointer, Float1
     return nullptr;
 }
 
-WTF_EXPORT_PRIVATE const float* NODELETE findFloatAlignedImpl(const float* pointer, float target, size_t length);
+WTF_EXPORT_PRIVATE const float* NODELETE findFloatAlignedImpl(std::span<const float> buffer, float target);
 
 #if CPU(ARM64)
 SUPPRESS_NODELETE ALWAYS_INLINE const float* NODELETE findFloat(const float* pointer, float target, size_t length)
@@ -816,7 +816,7 @@ SUPPRESS_NODELETE ALWAYS_INLINE const float* NODELETE findFloat(const float* poi
         return nullptr;
 
     ASSERT(index < length);
-    return findFloatAlignedImpl(pointer + index, target, length - index);
+    return findFloatAlignedImpl(std::span { pointer + index, length - index }, target);
 }
 #else
 ALWAYS_INLINE const float* NODELETE findFloat(const float* pointer, float target, size_t length)
@@ -829,7 +829,7 @@ ALWAYS_INLINE const float* NODELETE findFloat(const float* pointer, float target
 }
 #endif
 
-WTF_EXPORT_PRIVATE const double* NODELETE findDoubleAlignedImpl(const double* pointer, double target, size_t length);
+WTF_EXPORT_PRIVATE const double* NODELETE findDoubleAlignedImpl(std::span<const double> buffer, double target);
 
 #if CPU(ARM64)
 SUPPRESS_NODELETE ALWAYS_INLINE const double* NODELETE findDouble(const double* pointer, double target, size_t length)
@@ -849,7 +849,7 @@ SUPPRESS_NODELETE ALWAYS_INLINE const double* NODELETE findDouble(const double* 
         return nullptr;
 
     ASSERT(index < length);
-    return findDoubleAlignedImpl(pointer + index, target, length - index);
+    return findDoubleAlignedImpl(std::span { pointer + index, length - index }, target);
 }
 #else
 ALWAYS_INLINE const double* NODELETE findDouble(const double* pointer, double target, size_t length)


### PR DESCRIPTION
#### 6d210f80aba24903b70e732b5a8b378e693d8b82
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF/wtf/text/StringCommon
<a href="https://bugs.webkit.org/show_bug.cgi?id=311495">https://bugs.webkit.org/show_bug.cgi?id=311495</a>
<a href="https://rdar.apple.com/174090571">rdar://174090571</a>

Reviewed by NOBODY (OOPS!).

* Source/WTF/wtf/text/StringCommon.cpp:
(WTF::findFloatAlignedImpl):
(WTF::findDoubleAlignedImpl):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::findFloat):
(WTF::findDouble):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d210f80aba24903b70e732b5a8b378e693d8b82

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155094 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163854 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108565 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28202 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120002 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84789 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139276 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100695 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21340 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19385 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11680 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147144 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131002 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17119 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166330 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15925 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10829 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18728 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128104 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23424 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128242 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27822 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138912 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84531 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23107 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15707 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186881 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27514 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91618 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47886 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27093 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27323 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27165 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->