### PR TITLE
Use size_t or auto and std::views::reverse to fix 64-bit truncation in rendering loops

### DIFF
--- a/Source/WebCore/rendering/LayerAncestorClippingStack.cpp
+++ b/Source/WebCore/rendering/LayerAncestorClippingStack.cpp
@@ -123,9 +123,9 @@ bool LayerAncestorClippingStack::updateWithClipData(ScrollingCoordinator* scroll
 {
     bool stackChanged = false;
 
-    int clipEntryCount = clipDataStack.size();
-    int stackEntryCount = m_stack.size();
-    for (int i = 0; i < clipEntryCount; ++i) {
+    auto clipEntryCount = clipDataStack.size();
+    auto stackEntryCount = m_stack.size();
+    for (size_t i = 0; i < clipEntryCount; ++i) {
         auto& clipDataEntry = clipDataStack[i];
         
         if (i >= stackEntryCount) {
@@ -149,7 +149,7 @@ bool LayerAncestorClippingStack::updateWithClipData(ScrollingCoordinator* scroll
     }
     
     if (stackEntryCount > clipEntryCount) {
-        for (int i = clipEntryCount; i < stackEntryCount; ++i) {
+        for (auto i = clipEntryCount; i < stackEntryCount; ++i) {
             auto& entry = m_stack[i];
             if (entry.overflowScrollProxyNodeID) {
                 ASSERT(scrollingCoordinator);

--- a/Source/WebCore/rendering/RenderGeometryMap.cpp
+++ b/Source/WebCore/rendering/RenderGeometryMap.cpp
@@ -56,7 +56,7 @@ void RenderGeometryMap::mapToContainer(TransformState& transformState, const Ren
     bool foundContainer = !container || (m_mapping.size() && m_mapping[0].m_renderer == container);
 #endif
 
-    for (int i = m_mapping.size() - 1; i >= 0; --i) {
+    for (auto i = m_mapping.size(); i--;) {
         const RenderGeometryMapStep& currentStep = m_mapping[i];
 
         // If container is the RenderView (step 0) we want to apply its scroll offset.

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -159,6 +159,7 @@
 #include "TransformationMatrix.h"
 #include "ViewTransition.h"
 #include "WheelEventTestMonitor.h"
+#include <ranges>
 #include <stdio.h>
 #include <wtf/HexNumber.h>
 #include <wtf/MonotonicTime.h>
@@ -4947,8 +4948,7 @@ bool RenderLayer::hitTestContentsForFragments(const LayerFragments& layerFragmen
     if (layerFragments.isEmpty())
         return false;
 
-    for (int i = layerFragments.size() - 1; i >= 0; --i) {
-        const auto& fragment = layerFragments.at(i);
+    for (auto& fragment : std::views::reverse(layerFragments)) {
         if ((hitTestFilter == HitTestSelf && !fragment.dirtyBackgroundRect().intersects(hitTestLocation))
             || (hitTestFilter == HitTestDescendants && !fragment.dirtyForegroundRect().intersects(hitTestLocation)))
             continue;
@@ -4970,8 +4970,7 @@ RenderLayer::HitLayer RenderLayer::hitTestTransformedLayerInFragments(RenderLaye
     paginatedLayer->collectFragments(enclosingPaginationFragments, rootLayer, hitTestRect, IncludeCompositedPaginatedLayers,
         RootRelativeClipRects, { ClipRectsOption::RespectOverflowClip }, offsetOfPaginationLayerFromRoot, &transformedExtent);
 
-    for (int i = enclosingPaginationFragments.size() - 1; i >= 0; --i) {
-        const LayerFragment& fragment = enclosingPaginationFragments.at(i);
+    for (auto& fragment : std::views::reverse(enclosingPaginationFragments)) {
         
         // Apply the page/column clip for this fragment, as well as any clips established by layers in between us and
         // the enclosing pagination layer.

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1027,12 +1027,11 @@ unsigned RenderText::lastCharacterIndexStrippingSpaces() const
     if (!style().collapseWhiteSpace())
         return text().length() - 1;
     
-    int i = text().length() - 1;
-    for ( ; i  >= 0; --i) {
+    for (auto i = text().length(); i--;) {
         if (text()[i] != ' ' && (text()[i] != '\n' || style().preserveNewline()) && text()[i] != '\t')
-            break;
+            return i;
     }
-    return i;
+    return 0;
 }
 
 RenderText::Widths RenderText::trimmedPreferredWidths(float leadWidth, bool& stripFrontSpaces)


### PR DESCRIPTION
#### 333674335eb2131051a2685a4ca87ef4ce318950
<pre>
Use size_t or auto and std::views::reverse to fix 64-bit truncation in rendering loops
<a href="https://bugs.webkit.org/show_bug.cgi?id=311499">https://bugs.webkit.org/show_bug.cgi?id=311499</a>
<a href="https://rdar.apple.com/174093705">rdar://174093705</a>

Reviewed by Alan Baradlay.

Replace int loop counters with auto to avoid implicit 64-bit
truncation from size() return values. Use std::views::reverse for
reverse iteration where the index is not needed for control flow.

* Source/WebCore/rendering/LayerAncestorClippingStack.cpp:
(WebCore::LayerAncestorClippingStack::updateWithClipData):
* Source/WebCore/rendering/RenderGeometryMap.cpp:
(WebCore::RenderGeometryMap::mapToContainer const):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::hitTestContentsForFragments const):
(WebCore::RenderLayer::hitTestTransformedLayerInFragments):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::lastCharacterIndexStrippingSpaces const):

Canonical link: <a href="https://commits.webkit.org/310598@main">https://commits.webkit.org/310598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37b8b5c534a88e840d1de47a2bdb0eae23396c25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163067 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107782 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e12e8664-80d7-4c7c-8abd-e37ab41354b2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156186 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27421 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119344 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84376 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4eed3cb-0b48-46c7-bbf1-b84b6cde32fc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21606 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138583 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100040 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/97b49e67-2734-4855-9ad2-8936ebf52d2b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20694 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18703 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10899 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130356 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165539 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8748 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18037 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127440 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27117 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22745 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127585 "Found 1 new API test failure: TestWebKit:WebKit.NewFirstVisuallyNonEmptyLayoutFrames (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34621 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27041 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138221 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83669 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22469 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15013 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26731 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90834 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26312 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26543 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26385 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->