### PR TITLE
[WTF] Rename characterAt() / characterStartingAt() to codeUnitAt() / codePointAt()

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2735,7 +2735,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                 int32_t index = node->child2()->asInt32();
                 if (index >= 0 && static_cast<unsigned>(index) < string.length()) {
                     if (node->op() == StringCharCodeAt)
-                        setConstant(node, jsNumber(string.characterAt(static_cast<unsigned>(index))));
+                        setConstant(node, jsNumber(string.codeUnitAt(static_cast<unsigned>(index))));
                     else
                         setConstant(node, jsNumber(codePointAt(string, static_cast<unsigned>(index), string.length())));
                     break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -17549,7 +17549,7 @@ void SpeculativeJIT::compileStringIndexOf(Node* node)
     String searchString = node->child2()->tryGetString(m_graph);
     if (!!searchString) {
         if (searchString.length() == 1)
-            character = searchString.characterAt(0);
+            character = searchString.codeUnitAt(0);
     }
 
     if (node->child3()) {

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -11625,7 +11625,7 @@ IGNORE_CLANG_WARNINGS_END
         String searchString = m_node->child2()->tryGetString(m_graph);
         if (!!searchString) {
             if (searchString.length() == 1)
-                character = searchString.characterAt(0);
+                character = searchString.codeUnitAt(0);
         }
 
         LValue base = lowString(m_node->child1());

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -890,7 +890,7 @@ static unsigned sortBucketSort(std::span<EncodedJSValue> sorted, unsigned dst, S
             continue;
         }
 
-        char16_t character = std::get<1>(entry).characterAt(depth);
+        char16_t character = std::get<1>(entry).codeUnitAt(depth);
         buckets.insert(std::pair { character, SortEntryVector { } }).first->second.append(entry);
     }
 

--- a/Source/JavaScriptCore/runtime/IdentifierInlines.h
+++ b/Source/JavaScriptCore/runtime/IdentifierInlines.h
@@ -89,7 +89,7 @@ inline Identifier::Identifier(VM& vm, StringImpl* rep)
 inline Ref<AtomStringImpl> Identifier::add(VM& vm, ASCIILiteral literal)
 {
     if (literal.length() == 1)
-        return vm.smallStrings.singleCharacterStringRep(literal.characterAt(0));
+        return vm.smallStrings.singleCharacterStringRep(literal.codeUnitAt(0));
     return AtomStringImpl::add(literal);
 }
 

--- a/Source/JavaScriptCore/runtime/IntlObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/IntlObjectInlines.h
@@ -40,7 +40,7 @@ namespace JSC {
 template<typename StringType>
 static constexpr uint32_t computeTwoCharacters16Code(const StringType& string)
 {
-    return static_cast<uint16_t>(string.characterAt(0)) | (static_cast<uint32_t>(static_cast<uint16_t>(string.characterAt(1))) << 16);
+    return static_cast<uint16_t>(string.codeUnitAt(0)) | (static_cast<uint32_t>(static_cast<uint16_t>(string.codeUnitAt(1))) << 16);
 }
 
 template<typename Predicate> String bestAvailableLocale(const String& locale, Predicate predicate)

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -942,7 +942,7 @@ inline JSString* jsString(VM& vm, const String& s)
     if (!size)
         return vm.smallStrings.emptyString();
     if (size == 1) {
-        if (auto c = s.characterAt(0); c <= maxSingleCharacterString)
+        if (auto c = s.codeUnitAt(0); c <= maxSingleCharacterString)
             return vm.smallStrings.singleCharacterString(c);
     }
     return JSString::create(vm, *s.impl());
@@ -954,7 +954,7 @@ inline JSString* jsString(VM& vm, String&& s)
     if (!size)
         return vm.smallStrings.emptyString();
     if (size == 1) {
-        if (auto c = s.characterAt(0); c <= maxSingleCharacterString)
+        if (auto c = s.codeUnitAt(0); c <= maxSingleCharacterString)
             return vm.smallStrings.singleCharacterString(c);
     }
     return JSString::create(vm, s.releaseImpl().releaseNonNull());
@@ -976,7 +976,7 @@ inline JSString* jsString(VM& vm, StringView s)
     if (!size)
         return vm.smallStrings.emptyString();
     if (size == 1) {
-        if (auto c = s.characterAt(0); c <= maxSingleCharacterString)
+        if (auto c = s.codeUnitAt(0); c <= maxSingleCharacterString)
             return vm.smallStrings.singleCharacterString(c);
     }
     auto impl = s.is8Bit() ? StringImpl::create(s.span8()) : StringImpl::create(s.span16());
@@ -1094,7 +1094,7 @@ inline JSString* jsSubstring(VM& vm, const String& s, unsigned offset, unsigned 
     if (!length)
         return vm.smallStrings.emptyString();
     if (length == 1) {
-        if (auto c = s.characterAt(offset); c <= maxSingleCharacterString)
+        if (auto c = s.codeUnitAt(offset); c <= maxSingleCharacterString)
             return vm.smallStrings.singleCharacterString(c);
     }
     auto impl = StringImpl::createSubstringSharingImpl(*s.impl(), offset, length);
@@ -1109,7 +1109,7 @@ inline JSString* jsOwnedString(VM& vm, const String& s)
     if (!size)
         return vm.smallStrings.emptyString();
     if (size == 1) {
-        if (auto c = s.characterAt(0); c <= maxSingleCharacterString)
+        if (auto c = s.codeUnitAt(0); c <= maxSingleCharacterString)
             return vm.smallStrings.singleCharacterString(c);
     }
     return JSString::createHasOtherOwner(vm, *s.impl());

--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -730,11 +730,11 @@ inline JSString* jsSubstringOfResolved(VM& vm, GCDeferralContext* deferralContex
         return s;
 
     if (length == 1) {
-        if (auto c = base.characterAt(offset); c <= maxSingleCharacterString)
+        if (auto c = base.codeUnitAt(offset); c <= maxSingleCharacterString)
             return vm.smallStrings.singleCharacterString(c);
     } else if (length == 2) {
-        char16_t first = base.characterAt(offset);
-        char16_t second = base.characterAt(offset + 1);
+        char16_t first = base.codeUnitAt(offset);
+        char16_t second = base.codeUnitAt(offset + 1);
         if ((first | second) < 0x80) {
             auto createFromSubstring = [&](VM& vm, auto& buffer) {
                 auto impl = AtomStringImpl::add(buffer);

--- a/Source/JavaScriptCore/runtime/RegExpCachedResult.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpCachedResult.cpp
@@ -68,7 +68,7 @@ JSArray* RegExpCachedResult::lastResult(JSGlobalObject* globalObject, JSObject* 
                 ASSERT(!pattern.isEmpty());
                 ASSERT(pattern.length() == 1);
                 // Reify precise m_result.
-                size_t found = input->reverseFind(pattern.characterAt(0));
+                size_t found = input->reverseFind(pattern.codeUnitAt(0));
                 if (found != notFound) {
                     m_result.start = found;
                     m_result.end = found + 1;

--- a/Source/JavaScriptCore/runtime/RegExpObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpObjectInlines.h
@@ -295,7 +295,7 @@ ALWAYS_INLINE JSValue collectGlobalAtomMatches(JSGlobalObject* globalObject, JSS
         } else {
             if (pattern.length() == 1) {
                 oneCharacterMatch = true;
-                numberOfMatches = WTF::countMatchedCharacters(input->span16(), pattern.characterAt(0));
+                numberOfMatches = WTF::countMatchedCharacters(input->span16(), pattern.codeUnitAt(0));
             } else {
                 size_t startIndex = 0;
                 lastResult = genericMatches(vm, input->span16(), pattern.span8(), numberOfMatches, startIndex);
@@ -308,7 +308,7 @@ ALWAYS_INLINE JSValue collectGlobalAtomMatches(JSGlobalObject* globalObject, JSS
         } else {
             if (pattern.length() == 1) {
                 oneCharacterMatch = true;
-                numberOfMatches = WTF::countMatchedCharacters(input->span16(), pattern.characterAt(0));
+                numberOfMatches = WTF::countMatchedCharacters(input->span16(), pattern.codeUnitAt(0));
             } else {
                 size_t startIndex = 0;
                 lastResult = genericMatches(vm, input->span16(), pattern.span16(), numberOfMatches, startIndex);

--- a/Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.cpp
@@ -115,7 +115,7 @@ JSValue RegExpSubstringGlobalAtomCache::collectMatches(JSGlobalObject* globalObj
             if (pattern.length() == 1) {
                 if (input->length() >= startIndex) {
                     oneCharacterMatch = true;
-                    numberOfMatches += WTF::countMatchedCharacters(input->span16().subspan(startIndex), pattern.characterAt(0));
+                    numberOfMatches += WTF::countMatchedCharacters(input->span16().subspan(startIndex), pattern.codeUnitAt(0));
                     startIndex = input->length(); // Because the pattern atom is one character, it is ensured that we no longer find anything until this input string's end.
                 }
             } else {
@@ -133,7 +133,7 @@ JSValue RegExpSubstringGlobalAtomCache::collectMatches(JSGlobalObject* globalObj
             if (pattern.length() == 1) {
                 if (input->length() >= startIndex) {
                     oneCharacterMatch = true;
-                    numberOfMatches += WTF::countMatchedCharacters(input->span16().subspan(startIndex), pattern.characterAt(0));
+                    numberOfMatches += WTF::countMatchedCharacters(input->span16().subspan(startIndex), pattern.codeUnitAt(0));
                     startIndex = input->length(); // Because the pattern atom is one character, it is ensured that we no longer find anything until this input string's end.
                 }
             } else {

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -812,7 +812,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSplitFast, (JSGlobalObject* globalObject
             for (unsigned i = 0; i < resultSize; ++i) {
                 unsigned end = result[i];
                 JSString* string = nullptr;
-                const bool isPotentiallyIdentifier = start < end && isASCIIIdentifierStart(view->characterAt(start));
+                const bool isPotentiallyIdentifier = start < end && isASCIIIdentifierStart(view->codeUnitAt(start));
                 if (makeAtomStringsArray && isPotentiallyIdentifier) {
                     auto subView = view->substring(start, end - start);
                     auto identifier = subView.is8Bit() ? Identifier::fromString(vm, subView.span8()) : Identifier::fromString(vm, subView.span16());

--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -842,8 +842,8 @@ static String escapeUnsafeCharacters(const String& sourceBuffer)
 
     unsigned i;
     for (i = 0; i < length; ) {
-        char32_t c = sourceBuffer.characterStartingAt(i);
-        if (isLookalikeCharacter(previousCodePoint, sourceBuffer.characterStartingAt(i)))
+        char32_t c = sourceBuffer.codePointAt(i);
+        if (isLookalikeCharacter(previousCodePoint, sourceBuffer.codePointAt(i)))
             break;
         previousCodePoint = c;
         i += U16_LENGTH(c);
@@ -861,7 +861,7 @@ static String escapeUnsafeCharacters(const String& sourceBuffer)
         StringImpl::copyCharacters(outBuffer.mutableSpan(), sourceBuffer.span16().first(i));
 
     for (; i < length; ) {
-        char32_t c = sourceBuffer.characterStartingAt(i);
+        char32_t c = sourceBuffer.codePointAt(i);
         unsigned characterLength = U16_LENGTH(c);
         if (isLookalikeCharacter(previousCodePoint, c)) {
             std::array<uint8_t, 4> utf8Buffer;

--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -81,7 +81,7 @@ public:
     bool isEmpty() const { return m_charactersWithNullTerminator.size() <= 1; }
 
     constexpr char operator[](size_t index) const { return m_charactersWithNullTerminator[index]; }
-    constexpr char characterAt(size_t index) const { return m_charactersWithNullTerminator[index]; }
+    constexpr char codeUnitAt(size_t index) const { return m_charactersWithNullTerminator[index]; }
 
 #ifdef __OBJC__
     // This function convert null strings to empty strings.

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -382,7 +382,7 @@ Ref<StringImpl> StringImpl::substring(unsigned start, unsigned length)
     return create(span16().subspan(start, length));
 }
 
-char32_t NODELETE StringImpl::characterStartingAt(unsigned i)
+char32_t NODELETE StringImpl::codePointAt(unsigned i)
 {
     if (is8Bit())
         return span8()[i];

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -449,7 +449,7 @@ public:
 
     char16_t at(unsigned) const;
     char16_t operator[](unsigned i) const { return at(i); }
-    WTF_EXPORT_PRIVATE char32_t NODELETE characterStartingAt(unsigned);
+    WTF_EXPORT_PRIVATE char32_t NODELETE codePointAt(unsigned);
 
     // FIXME: Like the strict functions above, these give false for "ok" when there is trailing garbage.
     // Like the non-strict functions above, these return the value when there is trailing garbage.

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -83,9 +83,10 @@ public:
     explicit operator bool() const;
     bool isNull() const;
 
-    char16_t characterAt(unsigned index) const;
+    char16_t codeUnitAt(unsigned index) const;
     char16_t operator[](unsigned index) const;
     char32_t characterStartingAt(unsigned index) const;
+    char32_t codePointAt(unsigned index) const;
     char32_t codePointBefore(unsigned index) const;
 
     class CodeUnits;
@@ -601,7 +602,7 @@ inline StringView StringView::substring(unsigned start, unsigned length) const
     return result;
 }
 
-inline char16_t StringView::characterAt(unsigned index) const
+inline char16_t StringView::codeUnitAt(unsigned index) const
 {
     if (is8Bit())
         return span8()[index];
@@ -610,10 +611,10 @@ inline char16_t StringView::characterAt(unsigned index) const
 
 inline char16_t StringView::operator[](unsigned index) const
 {
-    return characterAt(index);
+    return codeUnitAt(index);
 }
 
-inline char32_t StringView::characterStartingAt(unsigned index) const
+inline char32_t StringView::codePointAt(unsigned index) const
 {
     ASSERT(index < length());
     if (m_is8Bit)
@@ -1108,7 +1109,7 @@ inline auto StringView::CodeUnits::Iterator::operator++() -> Iterator&
 
 inline char16_t StringView::CodeUnits::Iterator::operator*() const
 {
-    return m_stringView.characterAt(m_index);
+    return m_stringView.codeUnitAt(m_index);
 }
 
 inline bool StringView::CodeUnits::Iterator::operator==(const Iterator& other) const

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -74,11 +74,11 @@ std::strong_ordering codePointCompare(const String& a, const String& b)
     return codePointCompare(a.impl(), b.impl());
 }
 
-char32_t String::characterStartingAt(unsigned i) const
+char32_t String::codePointAt(unsigned i) const
 {
     if (!m_impl || i >= m_impl->length())
         return 0;
-    SUPPRESS_UNCOUNTED_ARG return m_impl->characterStartingAt(i);
+    SUPPRESS_UNCOUNTED_ARG return m_impl->codePointAt(i);
 }
 
 String makeStringByJoining(std::span<const String> strings, const String& separator)

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -128,8 +128,8 @@ public:
     WTF_EXPORT_PRIVATE Expected<CString, UTF8ConversionError> tryGetUTF8(ConversionMode) const;
     WTF_EXPORT_PRIVATE Expected<CString, UTF8ConversionError> tryGetUTF8() const;
 
-    char16_t characterAt(unsigned index) const;
-    char16_t operator[](unsigned index) const { return characterAt(index); }
+    char16_t codeUnitAt(unsigned index) const;
+    char16_t operator[](unsigned index) const { return codeUnitAt(index); }
 
     WTF_EXPORT_PRIVATE static String NODELETE number(int);
     WTF_EXPORT_PRIVATE static String NODELETE number(unsigned);
@@ -169,7 +169,7 @@ public:
     WTF_EXPORT_PRIVATE Expected<Vector<char16_t>, UTF8ConversionError> charactersWithNullTermination() const;
     WTF_EXPORT_PRIVATE Expected<Vector<char16_t>, UTF8ConversionError> charactersWithoutNullTermination() const;
 
-    WTF_EXPORT_PRIVATE char32_t NODELETE characterStartingAt(unsigned) const;
+    WTF_EXPORT_PRIVATE char32_t NODELETE codePointAt(unsigned) const;
 
     bool contains(char16_t character) const { return find(character) != notFound; }
     bool contains(ASCIILiteral literal) const { return find(literal) != notFound; }
@@ -459,7 +459,7 @@ template<> inline std::span<const char16_t> String::span<char16_t>() const LIFET
     return span16();
 }
 
-inline char16_t String::characterAt(unsigned index) const
+inline char16_t String::codeUnitAt(unsigned index) const
 {
     if (!m_impl || index >= m_impl->length())
         return 0;

--- a/Source/WebCore/css/CSSMarkup.cpp
+++ b/Source/WebCore/css/CSSMarkup.cpp
@@ -80,7 +80,7 @@ void serializeIdentifier(const String& identifier, StringBuilder& appendTo, bool
     bool isFirstCharHyphen = false;
     unsigned index = 0;
     while (index < identifier.length()) {
-        char32_t c = identifier.characterStartingAt(index);
+        char32_t c = identifier.codePointAt(index);
 
         index += U16_LENGTH(c);
 
@@ -110,7 +110,7 @@ void serializeString(const String& string, StringBuilder& appendTo)
 
     unsigned index = 0;
     while (index < string.length()) {
-        char32_t c = string.characterStartingAt(index);
+        char32_t c = string.codePointAt(index);
         index += U16_LENGTH(c);
 
         if (c <= 0x1f || c == deleteCharacter)

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -191,7 +191,7 @@ CSSValueID cssValueKeywordID(StringView string)
 
 bool isCustomPropertyName(StringView propertyName)
 {
-    return propertyName.length() > 2 && propertyName.characterAt(0) == '-' && propertyName.characterAt(1) == '-';
+    return propertyName.length() > 2 && propertyName.codeUnitAt(0) == '-' && propertyName.codeUnitAt(1) == '-';
 }
 
 // MARK: - CSS-wide keyword value consumer

--- a/Source/WebCore/dom/KeyboardEvent.cpp
+++ b/Source/WebCore/dom/KeyboardEvent.cpp
@@ -239,7 +239,7 @@ int KeyboardEvent::charCode() const
 
     if (!m_underlyingPlatformEvent || (type() != eventNames().keypressEvent && !backwardCompatibilityMode))
         return 0;
-    return m_underlyingPlatformEvent->text().characterStartingAt(0);
+    return m_underlyingPlatformEvent->text().codePointAt(0);
 }
 
 unsigned KeyboardEvent::which() const

--- a/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
@@ -2130,7 +2130,7 @@ void HTMLConverter::_processText(Text& text)
     bool wasSpace = false;
     if (_caches->propertyValueForNode(text, CSSPropertyWhiteSpace).startsWith("pre"_s)) {
         if (textLength && originalString.length() && _flags.isSoft) {
-            unichar c = originalString.characterAt(0);
+            unichar c = originalString.codeUnitAt(0);
             if (c == '\n' || c == '\r' || c == NSParagraphSeparatorCharacter || c == NSLineSeparatorCharacter || c == NSFormFeedCharacter || c == WebNextLineCharacter)
                 rangeToReplace = NSMakeRange(textLength - 1, 1);
         }
@@ -2140,7 +2140,7 @@ void HTMLConverter::_processText(Text& text)
         StringBuilder builder;
         Latin1Character noBreakSpaceRepresentation = 0;
         for (unsigned i = 0; i < count; i++) {
-            char16_t c = originalString.characterAt(i);
+            char16_t c = originalString.codeUnitAt(i);
             bool isWhitespace = c == ' ' || c == '\n' || c == '\r' || c == '\t' || c == 0xc || c == 0x200b;
             if (isWhitespace)
                 wasSpace = (!wasLeading || !suppressLeadingSpace);

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -1134,7 +1134,7 @@ ExceptionOr<void> InspectorStyleSheet::setRuleHeaderText(const InspectorCSSId& i
 
     if (!cssStyleRule
         && sourceData->ruleHeaderRange.start
-        && sheetText.characterAt(sourceData->ruleHeaderRange.start - 1) != ' '
+        && sheetText.codeUnitAt(sourceData->ruleHeaderRange.start - 1) != ' '
         && !correctedHeaderText.startsWith('(')) {
         // @ rules do not include the `@whatever` part of the declaration in their header text range, nor do they
         // include the space between the `@whatever` and the query/name/etc.. However, not all rules must contain a

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -215,7 +215,7 @@ void InlineItemsBuilder::computeInlineBoxBoundaryTextSpacings(const InlineItemLi
         size_t boundaryIndex = inlineBoxStartIndexesOnInlineItemsList[inlineBoxStartOnBoundaryIndex];
         CheckedRef boundaryOwnerStyle = inlineItemList[boundaryIndex].layoutBox().parent().style();
         auto boundaryTextAutospace = boundaryOwnerStyle->textAutospace();
-        if (!boundaryTextAutospace.isNoAutospace() && boundaryTextAutospace.shouldApplySpacing(inlineTextBox->content().characterAt(start), lastCharacterFromPreviousRun))
+        if (!boundaryTextAutospace.isNoAutospace() && boundaryTextAutospace.shouldApplySpacing(inlineTextBox->content().codeUnitAt(start), lastCharacterFromPreviousRun))
             spacings.add(boundaryIndex, TextAutospace::textAutospaceSize(protect(boundaryOwnerStyle->fontCascade().primaryFont())));
 
         lastCharacterFromPreviousRun = TextUtil::lastBaseCharacterFromText(content);
@@ -789,7 +789,7 @@ static void handleTextSpacing(TextSpacing::SpacingState& spacingState, Trimmable
     auto autospace = inlineTextItem.style().textAutospace();
     if (!autospace.isNoAutospace()) {
         // We need to store information about spacing added between inline text items since it needs to be trimmed during line breaking if the consecutive items are placed on different lines
-        auto characterClass = TextSpacing::characterClass(inlineTextItem.content().characterAt(0));
+        auto characterClass = TextSpacing::characterClass(inlineTextItem.content().codeUnitAt(0));
         if (autospace.shouldApplySpacing(spacingState.lastCharacterClassFromPreviousRun, characterClass))
             trimmableTextSpacings.add(inlineItemIndex, TextAutospace::textAutospaceSize(protect(inlineTextItem.style().fontCascade().primaryFont())));
 

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -758,7 +758,7 @@ char32_t TextUtil::lastBaseCharacterFromText(StringView string)
         return 0;
 
     for (size_t characterIndex = string.length(); characterIndex > 0; --characterIndex) {
-        auto character = string.characterAt(characterIndex - 1);
+        auto character = string.codeUnitAt(characterIndex - 1);
         if (!isCombiningMark(character))
             return character;
     }

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -103,7 +103,7 @@ static String getFileNameFromURIComponent(StringView input)
     StringBuilder result;
     result.reserveCapacity(length);
     for (unsigned index = 0; index < length; ++index) {
-        char16_t character = decodedInput->characterAt(index);
+        char16_t character = decodedInput->codeUnitAt(index);
         if (isUnreservedURICharacter(character)) {
             result.append(character);
             continue;

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4363,7 +4363,7 @@ bool EventHandler::internalKeyEvent(const PlatformKeyboardEvent& initialKeyEvent
     // webkit.org/b/305666: Emojis appear as Chinese characters in Google Docs
     auto shouldAvoidDispatchingKeyPressEvent = [&] {
         auto text = keyPressEvent.text();
-        if (!text.isEmpty() && !U_IS_BMP(text.characterStartingAt(0)))
+        if (!text.isEmpty() && !U_IS_BMP(text.codePointAt(0)))
             return true;
 
         // Suppress keypress for command shortcuts (Cmd+key, Ctrl+key).

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
@@ -68,7 +68,7 @@ const std::optional<KeyboardScrollingKey> keyboardScrollingKeyForKeyboardEvent(c
     if (auto* result = map.tryGet(identifier))
         return *result;
 
-    if (platformEvent->text().characterStartingAt(0) == ' ')
+    if (platformEvent->text().codePointAt(0) == ' ')
         return KeyboardScrollingKey::Space;
 
     return { };

--- a/Source/WebCore/platform/PlatformKeyboardEvent.cpp
+++ b/Source/WebCore/platform/PlatformKeyboardEvent.cpp
@@ -168,7 +168,7 @@ static std::optional<KeyEventData> lookup(const String& key)
     if (key.length() != 1)
         return { };
 
-    auto character = key.characterAt(0);
+    auto character = key.codeUnitAt(0);
     if (character >= 'A' && character <= 'Z') {
         return { {
             key,

--- a/Source/WebCore/platform/graphics/AV1Utilities.cpp
+++ b/Source/WebCore/platform/graphics/AV1Utilities.cpp
@@ -238,7 +238,7 @@ std::optional<AV1CodecConfigurationRecord> parseAV1CodecParameters(StringView co
 
     // The tier parameter value SHALL be equal to M when the first seq_tier
     // value in the Sequence Header OBU is equal to 0, and H when it is equal to 1.
-    auto tierCharacter = tierView.characterAt(0);
+    auto tierCharacter = tierView.codeUnitAt(0);
     if (tierCharacter == 'M')
         configuration.tier = AV1ConfigurationTier::Main;
     else if (tierCharacter == 'H')

--- a/Source/WebCore/platform/graphics/TextMeasurementCache.h
+++ b/Source/WebCore/platform/graphics/TextMeasurementCache.h
@@ -232,7 +232,7 @@ private:
             return true;
         const auto& text = textRun.textAsString();
         for (unsigned index = 0; index < text.length(); ++index) {
-            if (TextSpacing::isIdeograph(text.characterAt(index))) {
+            if (TextSpacing::isIdeograph(text.codeUnitAt(index))) {
                 m_hasSeenIdeograph = true;
                 clear();
                 return true;

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -333,7 +333,7 @@ public:
             auto data = buffer->read(0, 7);
             StringView dataString(byteCast<Latin1Character>(data.span()));
             if (dataString.endsWith(":Type:"_s)) {
-                m_type.emplace(static_cast<WebCore::MediaKeyMessageType>(dataString.characterAt(0) - '0'));
+                m_type.emplace(static_cast<WebCore::MediaKeyMessageType>(dataString.codeUnitAt(0) - '0'));
                 offset = 7;
             }
         }

--- a/Source/WebCore/platform/network/curl/CookieJarDB.cpp
+++ b/Source/WebCore/platform/network/curl/CookieJarDB.cpp
@@ -428,7 +428,7 @@ std::optional<Vector<Cookie>> CookieJarDB::searchCookies(const URL& firstParty, 
         // https://tools.ietf.org/html/rfc6265#section-5.1.4 "Paths and Path-Match"
         bool isPathMatched = cookiePath == requestPath
             || (requestPath.startsWith(cookiePath) && cookiePath.endsWith('/'))
-            || (requestPath.startsWith(cookiePath) && (requestPath.characterAt(cookiePath.length()) == '/'));
+            || (requestPath.startsWith(cookiePath) && (requestPath.codeUnitAt(cookiePath.length()) == '/'));
 
         if (!isPathMatched)
             continue;

--- a/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
@@ -188,7 +188,7 @@ std::tuple<unsigned, char16_t> SVGTextMetricsBuilder::measureTextRenderer(Render
 
             // m_canUseSimplifiedTextMeasuring ensures that this does not include surrogate pairs. So we do not need to consider about them.
             for (unsigned i = 0; i < length; ++i) {
-                char16_t currentCharacter = view.characterAt(i);
+                char16_t currentCharacter = view.codeUnitAt(i);
                 ASSERT(!U16_IS_LEAD(currentCharacter));
                 if (currentCharacter == space && !preserveWhiteSpace && (!lastCharacter || lastCharacter == space)) {
                     if (data.processRenderer)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -243,7 +243,7 @@ void RenderTreeBuilder::FirstLetter::createRenderers(RenderText& currentTextChil
         unsigned length = 0;
 
         // Account for leading spaces and punctuation.
-        while (length < oldText.length() && shouldSkipForFirstLetter(oldText.characterStartingAt(length)))
+        while (length < oldText.length() && shouldSkipForFirstLetter(oldText.codePointAt(length)))
             length += numCodeUnitsInGraphemeClusters(StringView(oldText).substring(length), 1);
 
         // Account for first grapheme cluster.
@@ -253,7 +253,7 @@ void RenderTreeBuilder::FirstLetter::createRenderers(RenderText& currentTextChil
         // accumulating just whitespace into the :first-letter.
         unsigned numCodeUnits = 0;
         for (unsigned scanLength = length; scanLength < oldText.length(); scanLength += numCodeUnits) {
-            char32_t c = oldText.characterStartingAt(scanLength);
+            char32_t c = oldText.codePointAt(scanLength);
 
             if (!shouldSkipForFirstLetter(c))
                 break;

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -1200,7 +1200,7 @@ static void addPartsForText(const TextExtraction::TextItemData& textItem, Vector
             } else {
                 size_t endIndex = filteredText.length() - 1;
                 for (size_t i = filteredText.length(); i > 0; --i) {
-                    if (!isASCIIWhitespace(filteredText.characterAt(i - 1))) {
+                    if (!isASCIIWhitespace(filteredText.codeUnitAt(i - 1))) {
                         endIndex = i - 1;
                         break;
                     }

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -1407,7 +1407,7 @@ void WebAutomationSession::handleRunOpenPanel(const WebPageProxy& page, const We
     for (RefPtr type : acceptFileExtensions->elementsOfType<API::String>()) {
         // WebCore vends extensions with leading periods. Strip these to simplify matching later.
         String extension = type->string();
-        ASSERT(extension.characterAt(0) == '.');
+        ASSERT(extension.codeUnitAt(0) == '.');
         allowedFileExtensions.add(extension.substring(1));
     }
 
@@ -2675,10 +2675,10 @@ static std::optional<char32_t> pressedCharKey(const String& pressedCharKeyString
 {
     switch (pressedCharKeyString.length()) {
     case 1:
-        return pressedCharKeyString.characterAt(0);
+        return pressedCharKeyString.codeUnitAt(0);
     case 2: {
-        auto lead = pressedCharKeyString.characterAt(0);
-        auto trail = pressedCharKeyString.characterAt(1);
+        auto lead = pressedCharKeyString.codeUnitAt(0);
+        auto trail = pressedCharKeyString.codeUnitAt(1);
         if (U16_IS_LEAD(lead) && U16_IS_TRAIL(trail))
             return U16_GET_SUPPLEMENTARY(lead, trail);
     }

--- a/Source/WebKit/UIProcess/Automation/win/WebAutomationSessionWin.cpp
+++ b/Source/WebKit/UIProcess/Automation/win/WebAutomationSessionWin.cpp
@@ -359,7 +359,7 @@ void WebAutomationSession::platformSimulateKeySequence(WebPageProxy& page, const
     //        If we need that information, the 4th argument should be set to an appropriate value, not 0.
     // https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-char
     // https://learn.microsoft.com/en-us/windows/win32/inputdev/about-keyboard-input#keystroke-message-flags
-    NativeWebKeyboardEvent event(hwnd, WM_CHAR, keySequence.characterAt(0), 0, { });
+    NativeWebKeyboardEvent event(hwnd, WM_CHAR, keySequence.codeUnitAt(0), 0, { });
     page.handleKeyboardEvent(event);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
@@ -878,34 +878,34 @@ TEST(WTF, CreateSubstringSharingImpl)
     ASSERT_TRUE(equal(small16Bit.ptr(), String::fromUTF8("日本語").impl()));
 }
 
-TEST(WTF, StringImplCharacterStartingAtASCII)
+TEST(WTF, StringImplCodePointAtASCII)
 {
     auto string = StringImpl::create("Hello"_s);
-    ASSERT_EQ(string->characterStartingAt(0), static_cast<char32_t>('H'));
-    ASSERT_EQ(string->characterStartingAt(4), static_cast<char32_t>('o'));
+    ASSERT_EQ(string->codePointAt(0), static_cast<char32_t>('H'));
+    ASSERT_EQ(string->codePointAt(4), static_cast<char32_t>('o'));
 }
 
-TEST(WTF, StringImplCharacterStartingAtBMP)
+TEST(WTF, StringImplCodePointAtBMP)
 {
     // U+00E9 (LATIN SMALL LETTER E WITH ACUTE) - single 16-bit code unit.
     auto string = String::fromUTF8("caf\xC3\xA9");
     ASSERT_FALSE(string.impl()->is8Bit());
-    ASSERT_EQ(string.impl()->characterStartingAt(0), static_cast<char32_t>('c'));
-    ASSERT_EQ(string.impl()->characterStartingAt(3), 0x00E9u);
+    ASSERT_EQ(string.impl()->codePointAt(0), static_cast<char32_t>('c'));
+    ASSERT_EQ(string.impl()->codePointAt(3), 0x00E9u);
 }
 
-TEST(WTF, StringImplCharacterStartingAtSupplementary)
+TEST(WTF, StringImplCodePointAtSupplementary)
 {
     // U+1F600 (GRINNING FACE) is encoded as a surrogate pair: D83D DE00.
     auto string = String::fromUTF8("A\xF0\x9F\x98\x80Z");
     ASSERT_FALSE(string.impl()->is8Bit());
     ASSERT_EQ(string.impl()->length(), 4u); // 'A' + surrogate pair + 'Z'
-    ASSERT_EQ(string.impl()->characterStartingAt(0), static_cast<char32_t>('A'));
-    ASSERT_EQ(string.impl()->characterStartingAt(1), 0x1F600u);
-    ASSERT_EQ(string.impl()->characterStartingAt(3), static_cast<char32_t>('Z'));
+    ASSERT_EQ(string.impl()->codePointAt(0), static_cast<char32_t>('A'));
+    ASSERT_EQ(string.impl()->codePointAt(1), 0x1F600u);
+    ASSERT_EQ(string.impl()->codePointAt(3), static_cast<char32_t>('Z'));
 }
 
-TEST(WTF, StringImplCharacterStartingAtLoneSurrogate)
+TEST(WTF, StringImplCodePointAtLoneSurrogate)
 {
     // Construct a string with lone surrogates directly via 16-bit code units.
     std::array<char16_t, 5> data { 0xD800, u'A', 0xDC00, u'B', 0xD83D };
@@ -913,28 +913,28 @@ TEST(WTF, StringImplCharacterStartingAtLoneSurrogate)
     ASSERT_EQ(string->length(), 5u);
 
     // Lone lead surrogate at index 0 (not followed by a trail).
-    ASSERT_EQ(string->characterStartingAt(0), 0xD800u);
+    ASSERT_EQ(string->codePointAt(0), 0xD800u);
 
     // Regular character.
-    ASSERT_EQ(string->characterStartingAt(1), static_cast<char32_t>('A'));
+    ASSERT_EQ(string->codePointAt(1), static_cast<char32_t>('A'));
 
     // Lone trail surrogate at index 2 (not preceded by a lead in terms of this API).
-    ASSERT_EQ(string->characterStartingAt(2), 0xDC00u);
+    ASSERT_EQ(string->codePointAt(2), 0xDC00u);
 
     // Regular character.
-    ASSERT_EQ(string->characterStartingAt(3), static_cast<char32_t>('B'));
+    ASSERT_EQ(string->codePointAt(3), static_cast<char32_t>('B'));
 
     // Lone lead surrogate at end of string.
-    ASSERT_EQ(string->characterStartingAt(4), 0xD83Du);
+    ASSERT_EQ(string->codePointAt(4), 0xD83Du);
 }
 
-TEST(WTF, StringImplCharacterStartingAtNUL)
+TEST(WTF, StringImplCodePointAtNUL)
 {
     // Ensure actual NUL character is distinguishable from lone surrogates.
     std::array<char16_t, 2> data { 0x0000, 0xD800 };
     auto string = StringImpl::create(std::span<const char16_t> { data });
-    ASSERT_EQ(string->characterStartingAt(0), 0u);
-    ASSERT_EQ(string->characterStartingAt(1), 0xD800u);
+    ASSERT_EQ(string->codePointAt(0), 0u);
+    ASSERT_EQ(string->codePointAt(1), 0xD800u);
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
@@ -1033,51 +1033,51 @@ TEST(WTF, StringViewUpconvert)
     }
 }
 
-TEST(WTF, StringViewCharacterStartingAtASCII)
+TEST(WTF, StringViewCodePointAtASCII)
 {
     StringView string("Hello"_s);
-    ASSERT_EQ(string.characterStartingAt(0), static_cast<char32_t>('H'));
-    ASSERT_EQ(string.characterStartingAt(4), static_cast<char32_t>('o'));
+    ASSERT_EQ(string.codePointAt(0), static_cast<char32_t>('H'));
+    ASSERT_EQ(string.codePointAt(4), static_cast<char32_t>('o'));
 }
 
-TEST(WTF, StringViewCharacterStartingAtBMP)
+TEST(WTF, StringViewCodePointAtBMP)
 {
     auto string = String::fromUTF8("caf\xC3\xA9");
     ASSERT_FALSE(StringView(string).is8Bit());
-    ASSERT_EQ(StringView(string).characterStartingAt(0), static_cast<char32_t>('c'));
-    ASSERT_EQ(StringView(string).characterStartingAt(3), 0x00E9u);
+    ASSERT_EQ(StringView(string).codePointAt(0), static_cast<char32_t>('c'));
+    ASSERT_EQ(StringView(string).codePointAt(3), 0x00E9u);
 }
 
-TEST(WTF, StringViewCharacterStartingAtSupplementary)
+TEST(WTF, StringViewCodePointAtSupplementary)
 {
     auto string = String::fromUTF8("A\xF0\x9F\x98\x80Z");
     StringView view(string);
     ASSERT_FALSE(view.is8Bit());
     ASSERT_EQ(view.length(), 4u);
-    ASSERT_EQ(view.characterStartingAt(0), static_cast<char32_t>('A'));
-    ASSERT_EQ(view.characterStartingAt(1), 0x1F600u);
-    ASSERT_EQ(view.characterStartingAt(3), static_cast<char32_t>('Z'));
+    ASSERT_EQ(view.codePointAt(0), static_cast<char32_t>('A'));
+    ASSERT_EQ(view.codePointAt(1), 0x1F600u);
+    ASSERT_EQ(view.codePointAt(3), static_cast<char32_t>('Z'));
 }
 
-TEST(WTF, StringViewCharacterStartingAtLoneSurrogate)
+TEST(WTF, StringViewCodePointAtLoneSurrogate)
 {
     std::array<char16_t, 5> data { 0xD800, u'A', 0xDC00, u'B', 0xD83D };
     StringView view(std::span<const UChar> { data });
     ASSERT_EQ(view.length(), 5u);
 
-    ASSERT_EQ(view.characterStartingAt(0), 0xD800u);
-    ASSERT_EQ(view.characterStartingAt(1), static_cast<char32_t>('A'));
-    ASSERT_EQ(view.characterStartingAt(2), 0xDC00u);
-    ASSERT_EQ(view.characterStartingAt(3), static_cast<char32_t>('B'));
-    ASSERT_EQ(view.characterStartingAt(4), 0xD83Du);
+    ASSERT_EQ(view.codePointAt(0), 0xD800u);
+    ASSERT_EQ(view.codePointAt(1), static_cast<char32_t>('A'));
+    ASSERT_EQ(view.codePointAt(2), 0xDC00u);
+    ASSERT_EQ(view.codePointAt(3), static_cast<char32_t>('B'));
+    ASSERT_EQ(view.codePointAt(4), 0xD83Du);
 }
 
-TEST(WTF, StringViewCharacterStartingAtNUL)
+TEST(WTF, StringViewCodePointAtNUL)
 {
     std::array<char16_t, 2> data { 0x0000, 0xD800 };
     StringView view(std::span<const UChar> { data });
-    ASSERT_EQ(view.characterStartingAt(0), 0u);
-    ASSERT_EQ(view.characterStartingAt(1), 0xD800u);
+    ASSERT_EQ(view.codePointAt(0), 0u);
+    ASSERT_EQ(view.codePointAt(1), 0xD800u);
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
@@ -971,7 +971,7 @@ static int sequenceInstances(const Vector<T> vector, ASCIILiteral sequence)
     size_t instances = 0;
     for (size_t i = 0; i <= vector.size() - sequenceLength; ++i) {
         for (size_t j = 0; j < sequenceLength; j++) {
-            if (vector[i + j] != sequence.characterAt(j))
+            if (vector[i + j] != sequence.codeUnitAt(j))
                 break;
             if (j == sequenceLength - 1)
                 instances++;


### PR DESCRIPTION
#### e4f1bb7dd2dc7e776450937be0190abfff8cecc4
<pre>
[WTF] Rename characterAt() / characterStartingAt() to codeUnitAt() / codePointAt()
<a href="https://bugs.webkit.org/show_bug.cgi?id=311504">https://bugs.webkit.org/show_bug.cgi?id=311504</a>

Reviewed by Yusuke Suzuki.

Rename characterAt() / characterStartingAt() to codeUnitAt() / codePointAt() on
String and StringView.

* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileStringIndexOf):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::sortBucketSort):
* Source/JavaScriptCore/runtime/IdentifierInlines.h:
(JSC::Identifier::add):
* Source/JavaScriptCore/runtime/IntlObjectInlines.h:
(JSC::computeTwoCharacters16Code):
* Source/JavaScriptCore/runtime/JSString.h:
(JSC::jsString):
(JSC::jsSubstring):
(JSC::jsOwnedString):
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::jsSubstringOfResolved):
* Source/JavaScriptCore/runtime/RegExpCachedResult.cpp:
(JSC::RegExpCachedResult::lastResult):
* Source/JavaScriptCore/runtime/RegExpObjectInlines.h:
(JSC::collectGlobalAtomMatches):
* Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.cpp:
(JSC::RegExpSubstringGlobalAtomCache::collectMatches):
* Source/WTF/wtf/URLHelpers.cpp:
(WTF::URLHelpers::escapeUnsafeCharacters):
* Source/WTF/wtf/text/ASCIILiteral.h:
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::codePointAt):
(WTF::StringImpl::characterStartingAt): Deleted.
* Source/WTF/wtf/text/StringImpl.h:
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::codeUnitAt const):
(WTF::StringView::operator[] const):
(WTF::StringView::codePointAt const):
(WTF::StringView::CodeUnits::Iterator::operator* const):
(WTF::StringView::characterAt const): Deleted.
(WTF::StringView::characterStartingAt const): Deleted.
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::codePointAt const):
(WTF::String::characterStartingAt const): Deleted.
* Source/WTF/wtf/text/WTFString.h:
(WTF::String::codeUnitAt const):
(WTF::String::characterAt const): Deleted.
* Source/WebCore/css/CSSMarkup.cpp:
(WebCore::serializeIdentifier):
(WebCore::serializeString):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::isCustomPropertyName):
* Source/WebCore/dom/KeyboardEvent.cpp:
(WebCore::KeyboardEvent::charCode const):
* Source/WebCore/editing/cocoa/NodeHTMLConverter.mm:
(HTMLConverter::_processText):
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::InspectorStyleSheet::setRuleHeaderText):
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::computeInlineBoxBoundaryTextSpacings):
(WebCore::Layout::handleTextSpacing):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::lastBaseCharacterFromText):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::internalKeyEvent):
* Source/WebCore/platform/KeyboardScrollingAnimator.cpp:
(WebCore::keyboardScrollingKeyForKeyboardEvent):
* Source/WebCore/platform/PlatformKeyboardEvent.cpp:
(WebCore::lookup):
* Source/WebCore/platform/graphics/AV1Utilities.cpp:
(WebCore::parseAV1CodecParameters):
* Source/WebCore/platform/graphics/TextMeasurementCache.h:
(WebCore::TextMeasurementCache::invalidateCacheForTextSpacing):
* Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp:
(WebCore::ParsedResponseMessage::ParsedResponseMessage):
* Source/WebCore/platform/network/curl/CookieJarDB.cpp:
(WebCore::CookieJarDB::searchCookies):
* Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp:
(WebCore::SVGTextMetricsBuilder::measureTextRenderer):
* Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp:
(WebCore::RenderTreeBuilder::FirstLetter::createRenderers):
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::handleRunOpenPanel):
(WebKit::pressedCharKey):
* Source/WebKit/UIProcess/Automation/win/WebAutomationSessionWin.cpp:
(WebKit::WebAutomationSession::platformSimulateKeySequence):
* Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp:
(TestWebKitAPI::TEST(WTF, StringImplCodePointAtASCII)):
(TestWebKitAPI::TEST(WTF, StringImplCodePointAtBMP)):
(TestWebKitAPI::TEST(WTF, StringImplCodePointAtSupplementary)):
(TestWebKitAPI::TEST(WTF, StringImplCodePointAtLoneSurrogate)):
(TestWebKitAPI::TEST(WTF, StringImplCodePointAtNUL)):
(TestWebKitAPI::TEST(WTF, StringImplCharacterStartingAtASCII)): Deleted.
(TestWebKitAPI::TEST(WTF, StringImplCharacterStartingAtBMP)): Deleted.
(TestWebKitAPI::TEST(WTF, StringImplCharacterStartingAtSupplementary)): Deleted.
(TestWebKitAPI::TEST(WTF, StringImplCharacterStartingAtLoneSurrogate)): Deleted.
(TestWebKitAPI::TEST(WTF, StringImplCharacterStartingAtNUL)): Deleted.
* Tools/TestWebKitAPI/Tests/WTF/StringView.cpp:
(TestWebKitAPI::TEST(WTF, StringViewCodePointAtASCII)):
(TestWebKitAPI::TEST(WTF, StringViewCodePointAtBMP)):
(TestWebKitAPI::TEST(WTF, StringViewCodePointAtSupplementary)):
(TestWebKitAPI::TEST(WTF, StringViewCodePointAtLoneSurrogate)):
(TestWebKitAPI::TEST(WTF, StringViewCodePointAtNUL)):
(TestWebKitAPI::TEST(WTF, StringViewCharacterStartingAtASCII)): Deleted.
(TestWebKitAPI::TEST(WTF, StringViewCharacterStartingAtBMP)): Deleted.
(TestWebKitAPI::TEST(WTF, StringViewCharacterStartingAtSupplementary)): Deleted.
(TestWebKitAPI::TEST(WTF, StringViewCharacterStartingAtLoneSurrogate)): Deleted.
(TestWebKitAPI::TEST(WTF, StringViewCharacterStartingAtNUL)): Deleted.
* Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp:
(TestWebKitAPI::sequenceInstances):

Canonical link: <a href="https://commits.webkit.org/310601@main">https://commits.webkit.org/310601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1df5e4db24dc2c8ca323c3cf1fa8115834ac7b8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20739 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163075 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107790 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4dec83a4-5c89-47af-a6f2-27492988b4ee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156194 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27713 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27429 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/119359 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84386 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc57db54-db3c-4ecf-99c2-4e6f052b6c43) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21613 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138593 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100055 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5a3ad963-e279-4247-a92a-7135723136c3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20701 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18714 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10907 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146370 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130363 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165547 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15152 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8756 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18047 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127450 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22756 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127595 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34623 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138231 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83679 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22484 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15023 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185956 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26739 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90842 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47688 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26320 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26551 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26393 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->