### PR TITLE
[JSC] `isWithinPowerOfTwo` is unsound for BitAnd with negative mask in DFG BackwardsPropagation

### DIFF
--- a/JSTests/stress/dfg-arith-mul-bitand-negative-mask-unchecked.js
+++ b/JSTests/stress/dfg-arith-mul-bitand-negative-mask-unchecked.js
@@ -1,0 +1,30 @@
+function testMaskRight(a, b) {
+    return ((a & -4) * b) | 0;
+}
+noInline(testMaskRight);
+
+function testMaskLeft(a, b) {
+    return ((-4 & a) * b) | 0;
+}
+noInline(testMaskLeft);
+
+function testMaskRightSwappedMul(a, b) {
+    return (b * (a & -4)) | 0;
+}
+noInline(testMaskRightSwappedMul);
+
+let a = 0x7ffffffc;
+let b = 0x7ffffffc;
+let expected = 0;
+
+for (let i = 0; i < testLoopCount; ++i) {
+    let r1 = testMaskRight(a, b);
+    if (r1 !== expected)
+        throw new Error("testMaskRight: expected " + expected + " but got " + r1 + " at iteration " + i);
+    let r2 = testMaskLeft(a, b);
+    if (r2 !== expected)
+        throw new Error("testMaskLeft: expected " + expected + " but got " + r2 + " at iteration " + i);
+    let r3 = testMaskRightSwappedMul(a, b);
+    if (r3 !== expected)
+        throw new Error("testMaskRightSwappedMul: expected " + expected + " but got " + r3 + " at iteration " + i);
+}

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
@@ -166,14 +166,6 @@ private:
     }
     
     template<int power>
-    bool isWithinPowerOfTwoNonRecursive(Node* node)
-    {
-        if (!node->isNumberConstant())
-            return false;
-        return isWithinPowerOfTwoForConstant<power>(node);
-    }
-    
-    template<int power>
     bool isWithinPowerOfTwo(Node* node)
     {
         switch (node->op()) {
@@ -187,9 +179,17 @@ private:
         case ArithBitAnd: {
             if (power > 31)
                 return true;
-            
-            return isWithinPowerOfTwoNonRecursive<power>(node->child1().node())
-                || isWithinPowerOfTwoNonRecursive<power>(node->child2().node());
+
+            // (x & mask) is only bounded by |mask| when mask is non-negative; a negative
+            // mask preserves the sign bit and the result can span the full int32 range.
+            auto isNonNegativeMaskWithinPower = [](Node* operand) {
+                if (!operand->isNumberConstant())
+                    return false;
+                double immediate = operand->asNumber();
+                return immediate >= 0 && immediate < (static_cast<int64_t>(1) << power);
+            };
+            return isNonNegativeMaskWithinPower(node->child1().node())
+                || isNonNegativeMaskWithinPower(node->child2().node());
         }
             
         case ArithBitOr:


### PR DESCRIPTION
#### 83895848013f99c39586e536b8ea0d25b7ad7b31
<pre>
[JSC] `isWithinPowerOfTwo` is unsound for BitAnd with negative mask in DFG BackwardsPropagation
<a href="https://bugs.webkit.org/show_bug.cgi?id=311505">https://bugs.webkit.org/show_bug.cgi?id=311505</a>

Reviewed by Justin Michaud.

isWithinPowerOfTwo&lt;power&gt;() returned true for `x &amp; c` whenever |c| &lt; 2^power,
but this bound only holds when c is non-negative. A negative mask preserves
the sign bit, so `x &amp; -4` can span the full int32 range. This caused ArithMul
to drop NodeBytecodeUsesAsNumber and become Arith::Unchecked, producing the
low 32 bits of the exact product instead of the spec-mandated double-rounded
result.

    function f(a, b) { return ((a &amp; -4) * b) | 0; }
    f(0x7ffffffc, 0x7ffffffc) // LLInt: 0, DFG/FTL: 16

Fix by requiring the BitAnd constant operand to be non-negative. Also remove
isWithinPowerOfTwoNonRecursive() which is now unused.

Test: JSTests/stress/dfg-arith-mul-bitand-negative-mask-unchecked.js

* JSTests/stress/dfg-arith-mul-bitand-negative-mask-unchecked.js: Added.
(testMaskRight):
(testMaskLeft):
(testMaskRightSwappedMul):
* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp:
(JSC::DFG::BackwardsPropagationPhase::isWithinPowerOfTwo):
(JSC::DFG::BackwardsPropagationPhase::isWithinPowerOfTwoNonRecursive): Deleted.

Canonical link: <a href="https://commits.webkit.org/310678@main">https://commits.webkit.org/310678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e76e585cb70623b136387881a9b2f8c565d41d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163062 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107777 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27416 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119339 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84372 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21603 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138578 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100035 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20691 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18699 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10894 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146357 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130353 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16423 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165534 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15139 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8743 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18032 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127435 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27112 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127580 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34679 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27036 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138216 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83661 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22467 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15008 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185943 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26726 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90829 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47686 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26307 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26538 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26380 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->