### PR TITLE
CSS calc() should reject percentages in calculation contexts that don't resolve them

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4460,7 +4460,6 @@ imported/w3c/web-platform-tests/css/css-values/calc-min-height-block-1.html [ Im
 imported/w3c/web-platform-tests/css/css-values/calc-min-width-block-intrinsic-1.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/calc-size/calc-size-no-body-height-quirk-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/ch-unit-019.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-values/resolution-with-percentage-without-context.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/viewport-units-scrollbars-scroll-vw-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/vh-update-and-transition-in-subframe.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-values/attr-universal-selector.html [ Pass Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/percentage-without-context-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/percentage-without-context-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL e.style['font-style'] = "oblique calc(sign(50%) * 1deg)" should not set the property value assert_equals: expected "" but got "oblique calc(1deg)"
-FAIL e.style['background'] = "linear-gradient(calc(sign(50%) * 1turn), #3f87a6, #ebf8e1, #f69d3c)" should not set the property value assert_equals: expected "" but got "linear-gradient(calc(360deg), rgb(63, 135, 166), rgb(235, 248, 225), rgb(246, 157, 60))"
-FAIL e.style['background'] = "conic-gradient(from calc(sign(50%) * 1rad) at 10% 50%, #e66465, #9198e5)" should not set the property value assert_equals: expected "" but got "conic-gradient(from calc(57.29578deg) at 10% 50%, rgb(230, 100, 101), rgb(145, 152, 229))"
-FAIL e.style['filter'] = "hue-rotate(calc(sign(50%) * 1deg))" should not set the property value assert_equals: expected "" but got "hue-rotate(calc(1deg))"
-FAIL e.style['offset-rotate'] = "calc(sign(50%) * 1deg)" should not set the property value assert_equals: expected "" but got "calc(1deg)"
-FAIL e.style['offset-path'] = "ray(calc(sign(50%) * 1deg))" should not set the property value assert_equals: expected "" but got "ray(calc(1deg))"
-FAIL e.style['color'] = "hsl(calc(sign(50%) * 1deg) 82% 43%)" should not set the property value assert_equals: expected "" but got "rgb(200, 23, 20)"
-FAIL e.style['transform'] = "rotate(calc(sign(50%) * 1deg))" should not set the property value assert_equals: expected "" but got "rotate(calc(1deg))"
-FAIL e.style['animation-duration'] = "calc(sign(50%) * 1s)" should not set the property value assert_equals: expected "" but got "calc(1s)"
-FAIL e.style['animation-delay'] = "calc(sign(50%) * 1s)" should not set the property value assert_equals: expected "" but got "calc(1s)"
-FAIL e.style['transition-duration'] = "calc(sign(50%) * 1s)" should not set the property value assert_equals: expected "" but got "calc(1s)"
-FAIL e.style['transition-delay'] = "calc(sign(50%) * 1s)" should not set the property value assert_equals: expected "" but got "calc(1s)"
+PASS e.style['font-style'] = "oblique calc(sign(50%) * 1deg)" should not set the property value
+PASS e.style['background'] = "linear-gradient(calc(sign(50%) * 1turn), #3f87a6, #ebf8e1, #f69d3c)" should not set the property value
+PASS e.style['background'] = "conic-gradient(from calc(sign(50%) * 1rad) at 10% 50%, #e66465, #9198e5)" should not set the property value
+PASS e.style['filter'] = "hue-rotate(calc(sign(50%) * 1deg))" should not set the property value
+PASS e.style['offset-rotate'] = "calc(sign(50%) * 1deg)" should not set the property value
+PASS e.style['offset-path'] = "ray(calc(sign(50%) * 1deg))" should not set the property value
+PASS e.style['color'] = "hsl(calc(sign(50%) * 1deg) 82% 43%)" should not set the property value
+PASS e.style['transform'] = "rotate(calc(sign(50%) * 1deg))" should not set the property value
+PASS e.style['animation-duration'] = "calc(sign(50%) * 1s)" should not set the property value
+PASS e.style['animation-delay'] = "calc(sign(50%) * 1s)" should not set the property value
+PASS e.style['transition-duration'] = "calc(sign(50%) * 1s)" should not set the property value
+PASS e.style['transition-delay'] = "calc(sign(50%) * 1s)" should not set the property value
 

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -1599,7 +1599,26 @@ std::optional<TypedChild> parseCalcNumber(const CSSParserToken& token, ParserSta
 
 std::optional<TypedChild> parseCalcPercentage(const CSSParserToken& token, ParserState& state)
 {
-    auto child = Percentage { .value = token.numericValue(), .hint = Type::determinePercentHint(state.parserOptions.category) };
+    auto category = state.parserOptions.category;
+
+    // Per https://drafts.csswg.org/css-values-4/#calc-context, percentages are
+    // only valid in calculation contexts that define how they resolve.
+    // Dimension types without a percentage variant (<length>, <angle>, <time>,
+    // <frequency>, <resolution>, <flex>) have no calculation context for
+    // percentages, so they must be rejected at parse time.
+    switch (category) {
+    case CSS::Category::Length:
+    case CSS::Category::Angle:
+    case CSS::Category::Time:
+    case CSS::Category::Frequency:
+    case CSS::Category::Resolution:
+    case CSS::Category::Flex:
+        return std::nullopt;
+    default:
+        break;
+    }
+
+    auto child = Percentage { .value = token.numericValue(), .hint = Type::determinePercentHint(category) };
     auto type = getType(child);
 
     return TypedChild { makeChild(WTF::move(child)), type };


### PR DESCRIPTION
#### 8d0b061f1665608a0a6a55fcb494a6f687a6db58
<pre>
CSS calc() should reject percentages in calculation contexts that don&apos;t resolve them
<a href="https://bugs.webkit.org/show_bug.cgi?id=311507">https://bugs.webkit.org/show_bug.cgi?id=311507</a>
<a href="https://rdar.apple.com/174102304">rdar://174102304</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Per CSS Values 4 [1], percentages in math functions are only valid
when the calculation context defines how they resolve. Dimension types
without a percentage variant (&lt;length&gt;, &lt;angle&gt;, &lt;time&gt;, &lt;frequency&gt;,
&lt;resolution&gt;, &lt;flex&gt;) have no such context, so percentage values must
be rejected at parse time.

[1] <a href="https://drafts.csswg.org/css-values-4/#calc-context">https://drafts.csswg.org/css-values-4/#calc-context</a>

* LayoutTests/TestExpectations: Progression
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/percentage-without-context-expected.txt: Ditto
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::parseCalcPercentage):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d0b061f1665608a0a6a55fcb494a6f687a6db58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154316 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163070 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107785 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cc4b664f-5c82-493d-ba5a-d0c7ae3b8f7e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156189 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27424 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119346 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84380 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a868397b-bab3-49e8-8945-739b8c3c672d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21612 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138587 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100042 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9e15a17-9f71-4c23-867c-9cc0288ddd61) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20700 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18707 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10902 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130362 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16432 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165542 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8751 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18041 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127443 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27120 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22749 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127588 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27044 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138225 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83673 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22474 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15017 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26734 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90837 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26315 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26546 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26388 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->