### PR TITLE
[JSC] DFG LoopUnrolling should verify that the induction `SetLocal` stores `data.update`

### DIFF
--- a/JSTests/stress/loop-unrolling-induction-update-mismatch.js
+++ b/JSTests/stress/loop-unrolling-induction-update-mismatch.js
@@ -1,0 +1,34 @@
+//@ requireOptions("--useConcurrentJIT=0")
+function assert(actual, expected, name) {
+    if (actual !== expected)
+        throw new Error(name + ": bad actual=" + actual + " but expected=" + expected);
+}
+
+// The branch condition's update expression (i + 3) does not match the
+// SetLocal that actually advances the induction variable (i = i + 1).
+// LoopUnrolling must not derive the trip count from the condition's stride.
+function overCount() {
+    let i = 0;
+    let x = 0;
+    let t;
+    do {
+        x++;
+    } while ((t = i + 3, i = i + 1, t < 9));
+    return x;
+}
+noInline(overCount);
+
+function underCount() {
+    let i = 0;
+    let x = 0;
+    do {
+        x++;
+    } while (i + 1 < (i = i + 5, 3));
+    return x;
+}
+noInline(underCount);
+
+for (let k = 0; k < testLoopCount; k++) {
+    assert(overCount(), 7, "overCount");
+    assert(underCount(), 2, "underCount");
+}

--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -452,6 +452,8 @@ public:
                     if (node->op() != SetLocal || !data.isInductionVariable(node))
                         continue;
                     dataLogLnIf(Options::verboseLoopUnrolling(), "Induction variable ", data.inductionVariable->index(), " is updated at node ", node->index(), " at ", *body);
+                    if (node->child1().node() != data.update)
+                        return false;
                     ++updateCount;
                     // FIXME: Maybe we can extend this and do better here?
                     if (updateCount != 1)


### PR DESCRIPTION
#### 07a9e61a54e811baf9bace02b13bd9bc046af7a6
<pre>
[JSC] DFG LoopUnrolling should verify that the induction `SetLocal` stores `data.update`
<a href="https://bugs.webkit.org/show_bug.cgi?id=311508">https://bugs.webkit.org/show_bug.cgi?id=311508</a>

Reviewed by NOBODY (OOPS!).

identifyInductionVariable() derives data.update (and the stride) from the
Branch condition&apos;s left operand, and isInductionVariableValid() then scans
the loop body to ensure exactly one SetLocal targets the induction operand.
However, it never checked that this SetLocal&apos;s child1 is the same node as
data.update. When the condition observes `i + 3` while the body actually
stores `i + 1` (e.g. via a comma expression), the trip count is computed
with the wrong stride and the Branch is replaced with a Jump, causing the
unrolled loop to execute the wrong number of iterations.

    function f() {
        let i = 0, x = 0, t;
        do {
            x++;
        } while ((t = i + 3, i = i + 1, t &lt; 9));
        return x;
    }
    // LLInt: 7, FTL: 3

Fix by bailing out when the SetLocal&apos;s child1 does not match data.update.
For ordinary for/do-while loops the same ArithAdd node feeds both the
SetLocal and the condition, so no legitimate unrolling is lost.

Test: JSTests/stress/loop-unrolling-induction-update-mismatch.js

* JSTests/stress/loop-unrolling-induction-update-mismatch.js: Added.
(assert):
(overCount):
(underCount):
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::identifyInductionVariable):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07a9e61a54e811baf9bace02b13bd9bc046af7a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163071 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107786 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27425 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119347 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84381 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21611 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138588 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100043 "Found 1 new API test failure: WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cache (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20699 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18708 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10903 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146366 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130361 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16433 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165543 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15148 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8752 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18042 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127442 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27121 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22750 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127587 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27045 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138226 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83674 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22475 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15018 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/185952 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26735 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90838 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47687 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26316 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26547 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26389 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->