### PR TITLE
Move embed to the void element case in HTMLTreeBuilder

### DIFF
--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -801,18 +801,11 @@ void HTMLTreeBuilder::processStartTagForInBody(AtomHTMLToken&& token)
         m_tree.insertFormattingElement(WTF::move(token));
         return;
     case TagName::applet:
-    case TagName::embed:
     case TagName::object:
     case TagName::marquee:
         m_tree.reconstructTheActiveFormattingElements();
-        if (token.tagName() == TagName::embed) {
-            m_tree.reconstructTheActiveFormattingElements();
-            m_tree.insertSelfClosingHTMLElement(WTF::move(token));
-        } else {
-            m_tree.reconstructTheActiveFormattingElements();
-            m_tree.insertHTMLElement(WTF::move(token));
-            m_tree.activeFormattingElements().appendMarker();
-        }
+        m_tree.insertHTMLElement(WTF::move(token));
+        m_tree.activeFormattingElements().appendMarker();
         m_framesetOk = false;
         return;
     case TagName::table:
@@ -831,6 +824,7 @@ void HTMLTreeBuilder::processStartTagForInBody(AtomHTMLToken&& token)
         [[fallthrough]];
     case TagName::area:
     case TagName::br:
+    case TagName::embed:
     case TagName::img:
     case TagName::keygen:
     case TagName::wbr:


### PR DESCRIPTION
#### 8d32cf1ef9b9172286fdfc3b2c5fcaf05761aeb8
<pre>
Move embed to the void element case in HTMLTreeBuilder
<a href="https://bugs.webkit.org/show_bug.cgi?id=311510">https://bugs.webkit.org/show_bug.cgi?id=311510</a>

Reviewed by Anne van Kesteren.

The &lt;embed&gt; element was grouped with applet/marquee/object, which are
non-void elements that push a marker onto the active formatting elements.
Since &lt;embed&gt; is a void element, it was handled via a runtime tagName
check that called insertSelfClosingHTMLElement instead, with redundant
calls to reconstructTheActiveFormattingElements().

Per the WHATWG spec, &lt;embed&gt; belongs in the same case as area/br/img/keygen/wbr:
<a href="https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody">https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody</a>
(see &quot;A start tag whose tag name is one of: &quot;area&quot;, &quot;br&quot;, &quot;embed&quot;, &quot;img&quot;, &quot;keygen&quot;, &quot;wbr&quot;&quot;)

Move it there and simplify the applet/marquee/object case by removing
the now-unnecessary if/else branch and redundant reconstruct calls.

No behavior change — the previous code was correct but inefficient,
as reconstructTheActiveFormattingElements() is idempotent.

* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::processStartTagForInBody):

Canonical link: <a href="https://commits.webkit.org/310605@main">https://commits.webkit.org/310605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30aa51fc1ac4c9d5d91d857823faed96c2b1a206

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163081 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107796 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5dae3586-b786-4539-9e8a-686387353a47) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27719 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119356 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84394 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d05caef3-9c0e-44ea-b097-b2c51c9348c8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157286 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21618 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100052 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/195085a0-e0cb-41ef-9d55-41e90ce2ffbd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20706 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18718 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10913 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130368 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165553 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8762 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127451 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27131 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22760 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127596 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34628 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27055 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138238 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83686 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22483 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15030 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26745 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90848 "Failed to build and analyze WebKit") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26326 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26557 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26399 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->