### PR TITLE
[css-values-5] Make cycle detection match spec language

### DIFF
--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -232,18 +232,11 @@ void Builder::applyCustomPropertyImpl(const AtomString& name, const PropertyCasc
 
     Ref customPropertyValue = downcast<CSSCustomPropertyValue>(*property.cssValue[SelectorChecker::MatchDefault]);
 
-    bool inCycle = !m_state->m_inProgressCustomProperties.add(name).isNewEntry;
-    if (inCycle) {
-        auto isNewCycle = m_state->m_inCycleCustomProperties.add(name).isNewEntry;
-        if (isNewCycle) {
-            // Continue resolving dependencies so we detect cycles for them as well.
-            resolveCustomPropertyValue(customPropertyValue.get());
-        }
-        return;
-    }
+    // https://drafts.csswg.org/css-values-5/#guarded
+    auto guard = m_state->guardSubstitutionContext({ SubstitutionContext::Type::Property, name });
 
-    // There may be multiple cycles through the same property. Avoid interference from any previously detected cycles.
-    auto savedInCycleProperties = std::exchange(m_state->m_inCycleCustomProperties, { });
+    if (guard.isCyclicContext())
+        return;
 
     auto createInvalidOrUnset = [&] -> Variant<Ref<const Style::CustomProperty>, CSSWideKeyword> {
         // https://drafts.csswg.org/css-variables-2/#invalid-variables
@@ -263,14 +256,13 @@ void Builder::applyCustomPropertyImpl(const AtomString& name, const PropertyCasc
 
     auto resolvedValue = resolveCustomPropertyValue(customPropertyValue.get());
 
-    if (!resolvedValue || m_state->m_inCycleCustomProperties.contains(name))
+    // If the context became cyclic during resolution, the value is invalid.
+    if (!resolvedValue || guard.isCyclicContext())
         resolvedValue = createInvalidOrUnset();
 
     applyCustomProperty(name, WTF::move(*resolvedValue));
 
-    AtomString takenName = m_state->m_inProgressCustomProperties.take(name);
-    m_state->m_appliedCustomProperties.add(WTF::move(takenName));
-    m_state->m_inCycleCustomProperties.addAll(WTF::move(savedInCycleProperties));
+    m_state->m_appliedCustomProperties.add(name);
 }
 
 inline void Builder::applyCascadeProperty(const PropertyCascade::Property& property)

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -34,6 +34,7 @@
 #include "RuleSet.h"
 #include "SelectorChecker.h"
 #include "StyleForVisitedLink.h"
+#include "StyleSubstitutionContext.h"
 #include "TextFlags.h"
 #include "TreeResolutionState.h"
 #include <wtf/BitSet.h>
@@ -150,6 +151,8 @@ public:
 
     const CSSToLengthConversionData& cssToLengthConversionData() const LIFETIME_BOUND { return m_cssToLengthConversionData; }
 
+    GuardedSubstitutionContexts::Guard guardSubstitutionContext(SubstitutionContext&& context) { return m_guardedSubstitutionContexts.guard(WTF::move(context)); }
+
     void setIsBuildingKeyframeStyle() { m_isBuildingKeyframeStyle = true; }
     bool hasRevertRuleOrLayerInKeyframeStyle() const { return m_hasRevertRuleOrLayerInKeyframeStyle; }
 
@@ -250,10 +253,7 @@ private:
     const CSSToLengthConversionData m_cssToLengthConversionData;
 
     HashSet<AtomString> m_appliedCustomProperties;
-    HashSet<AtomString> m_inProgressCustomProperties;
-    HashSet<AtomString> m_inCycleCustomProperties;
-    HashSet<AtomString> m_inProgressAttrAttributes;
-    HashSet<AtomString> m_inCycleAttrAttributes;
+    GuardedSubstitutionContexts m_guardedSubstitutionContexts;
     WTF::BitSet<cssPropertyIDEnumValueCount> m_inProgressProperties;
     WTF::BitSet<cssPropertyIDEnumValueCount> m_invalidAtComputedValueTimeProperties;
 

--- a/Source/WebCore/style/StyleSubstitutionContext.h
+++ b/Source/WebCore/style/StyleSubstitutionContext.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/GenericHashKey.h>
+#include <wtf/HashSet.h>
+#include <wtf/text/AtomString.h>
+
+namespace WebCore {
+namespace Style {
+
+// https://drafts.csswg.org/css-values-5/#substitution-context
+// A substitution context is «dependency type, name».
+struct SubstitutionContext {
+    enum class Type : uint8_t { Property, Attribute };
+    Type type;
+    AtomString name;
+
+    bool operator==(const SubstitutionContext&) const = default;
+};
+
+inline void add(Hasher& hasher, const SubstitutionContext& context)
+{
+    add(hasher, context.type, context.name);
+}
+
+// https://drafts.csswg.org/css-values-5/#guarded
+class GuardedSubstitutionContexts {
+public:
+    // RAII guard for a substitution context. If the context is already guarded,
+    // all contexts involved in the cycle are marked as cyclic per spec.
+    // Unguards on destruction (unless the context was already guarded).
+    class Guard {
+        WTF_MAKE_NONCOPYABLE(Guard);
+    public:
+        Guard(GuardedSubstitutionContexts& contexts, SubstitutionContext&& context)
+            : m_contexts(contexts)
+            , m_context(WTF::move(context))
+            , m_previous(contexts.m_top)
+        {
+            if (contexts.m_guarded.add(m_context).isNewEntry) {
+                contexts.m_top = this;
+                return;
+            }
+            m_isCyclicContext = true;
+            // Mark all contexts involved in the cycle as cyclic.
+            for (auto* guard = m_previous; guard; guard = guard->m_previous) {
+                guard->m_isCyclicContext = true;
+                if (guard->m_context == m_context)
+                    break;
+            }
+        }
+        ~Guard()
+        {
+            if (m_contexts.m_top != this)
+                return;
+            m_contexts.m_guarded.remove(m_context);
+            m_contexts.m_top = m_previous;
+        }
+
+        // Whether the guarded context is a cyclic substitution context.
+        bool isCyclicContext() const { return m_isCyclicContext; }
+
+    private:
+        GuardedSubstitutionContexts& m_contexts;
+        SubstitutionContext m_context;
+        Guard* m_previous;
+        bool m_isCyclicContext { false };
+    };
+
+    Guard guard(SubstitutionContext&& context) { return { *this, WTF::move(context) }; }
+
+private:
+    HashSet<GenericHashKey<SubstitutionContext>> m_guarded;
+    Guard* m_top { nullptr };
+};
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -309,12 +309,8 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
         return m_substitutionValue->m_namespacePrefixMap.get(prefix);
     }();
 
-    // Check if this attribute is already being substituted (cycle detection).
-    auto isInCycle = !m_styleBuilder.state().m_inProgressAttrAttributes.add(attributeName).isNewEntry;
-    auto removeOnExit = makeScopeExit([&] {
-        if (!isInCycle)
-            m_styleBuilder.state().m_inProgressAttrAttributes.remove(attributeName);
-    });
+    // https://drafts.csswg.org/css-values-5/#guarded
+    auto guard = m_styleBuilder.state().guardSubstitutionContext({ SubstitutionContext::Type::Attribute, attributeName });
 
     // Resolve fallback lazily to avoid var() cycle detection side effects during primary resolution.
     auto resolveFallback = [&]() -> std::optional<Vector<CSSParserToken>> {
@@ -343,9 +339,7 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
     if (!parsedName->namespacePrefix.isEmpty() && namespaceURI.isNull())
         return substituteFailure();
 
-    if (isInCycle) {
-        // Mark as in-cycle for transitive detection.
-        m_styleBuilder.state().m_inCycleAttrAttributes.add(attributeName);
+    if (guard.isCyclicContext()) {
         if (parsedAttrType)
             return false;
         return substituteFailure();
@@ -415,9 +409,8 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
         if (!substitutedTokens)
             return substituteFailure();
 
-        // If this attribute was found to be in a cycle during substitution,
-        // the attr value transitively references itself.
-        if (m_styleBuilder.state().m_inCycleAttrAttributes.contains(attributeName))
+        // If the context became cyclic during substitution, the value is invalid.
+        if (guard.isCyclicContext())
             return substituteFailure();
 
         if (parsedAttrType->syntax.isUniversal()) {


### PR DESCRIPTION
#### 5ea07f2accfcf85ccbb434b849f83641a33a3212
<pre>
[css-values-5] Make cycle detection match spec language
<a href="https://bugs.webkit.org/show_bug.cgi?id=311514">https://bugs.webkit.org/show_bug.cgi?id=311514</a>
<a href="https://rdar.apple.com/174105259">rdar://174105259</a>

Reviewed by Sam Weinig.

Implement cycle detection using &quot;substition contexts&quot; and &quot;guards&quot; matchig the spec text.
Unifies the cycle detection between custom properties, attr and any future guarded functions.

<a href="https://drafts.csswg.org/css-values-5/#substitution-context">https://drafts.csswg.org/css-values-5/#substitution-context</a>

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyCustomPropertyImpl):
* Source/WebCore/style/StyleBuilderState.h:
(WebCore::Style::BuilderState::guardSubstitutionContext):

Replace various maps with GuardedSubstitutionContexts type.

* Source/WebCore/style/StyleSubstitutionContext.h: Added.
(WebCore::Style::add):
(WebCore::Style::GuardedSubstitutionContexts::Guard::Guard):
(WebCore::Style::GuardedSubstitutionContexts::Guard::~Guard):

RAII helper for guarding a substitution context. Detects cycles and marks all participating contexts as cyclic.

(WebCore::Style::GuardedSubstitutionContexts::Guard::isCyclicContext const):
(WebCore::Style::GuardedSubstitutionContexts::guard):
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteAttrFunction):
* Source/WebCore/style/StyleSubstitutionResolver.h:

Canonical link: <a href="https://commits.webkit.org/310610@main">https://commits.webkit.org/310610@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e9de031c9ef652db5f4c67d94085160c512fe93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154364 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27622 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/20782 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163118 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107833 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27472 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/119387 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/84419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157323 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/21655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/138631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100083 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18750 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10950 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/130404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/16475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165590 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/8799 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/18084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/127483 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22792 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127628 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34631 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27092 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/138268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83728 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/22520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26782 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/90885 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26363 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26594 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26436 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->