### PR TITLE
text-autospace should handle supplementary Unicode characters

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-supplementary-ideograph-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-supplementary-ideograph-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>text-autospace with supplementary ideographs (reference)</title>
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#text-autospace-property">
+<style>
+.test {
+  font-size: 40px;
+  border: solid 3px salmon;
+  width: fit-content;
+  margin-bottom: 2px;
+  text-autospace: no-autospace;
+}
+.manual-spacing-right {
+  margin-right: 0.125em;
+}
+.manual-spacing-left {
+  margin-left: 0.125em;
+}
+</style>
+<!-- BMP ideograph -->
+<div class="test"><span class="manual-spacing-right">国</span>A</div>
+<div class="test">A<span class="manual-spacing-left">国</span></div>
+
+<!-- Supplementary ideograph: same spacing expected -->
+<div class="test"><span class="manual-spacing-right">&#x20000;</span>A</div>
+<div class="test">A<span class="manual-spacing-left">&#x20000;</span></div>
+
+<!-- Across a span boundary -->
+<div class="test"><span class="manual-spacing-right">&#x20000;</span><span>A</span></div>
+<div class="test"><span>A</span><span class="manual-spacing-left">&#x20000;</span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-supplementary-ideograph.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-supplementary-ideograph.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>text-autospace with supplementary ideographs</title>
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#text-autospace-property">
+<link rel="match" href="text-autospace-supplementary-ideograph-expected.html">
+<style>
+.test {
+  font-size: 40px;
+  border: solid 3px salmon;
+  width: fit-content;
+  margin-bottom: 2px;
+}
+.normal {
+  text-autospace: normal;
+}
+</style>
+<!-- U+20000 is a CJK Unified Ideographs Extension B character (supplementary plane).
+     Autospacing should apply between it and Latin letters, just as it does for BMP ideographs. -->
+
+<!-- BMP ideograph (U+56FD) as baseline: these should get autospacing -->
+<div class="test normal">国A</div>
+<div class="test normal">A国</div>
+
+<!-- Supplementary ideograph (U+20000) must also get autospacing -->
+<div class="test normal">&#x20000;A</div>
+<div class="test normal">A&#x20000;</div>
+
+<!-- Across a span boundary -->
+<div class="test normal"><span>&#x20000;</span><span>A</span></div>
+<div class="test normal"><span>A</span><span>&#x20000;</span></div>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5473,6 +5473,9 @@ webkit.org/b/197473 imported/w3c/web-platform-tests/speculation-rules/prefetch/n
 
 webkit.org/b/278719 fast/events/touch/inserted-fragment-touch-target.html [ Timeout ]
 
+# This test has been failing on glib ports since its creation.
+imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-supplementary-ideograph.html [ ImageOnlyFailure ]
+
 
 # End: Common failures between GTK and WPE.
 

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -947,18 +947,25 @@ private:
 class StringView::CodePoints::Iterator {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(Iterator);
 public:
-    using iterator_category = std::forward_iterator_tag;
+    using iterator_category = std::bidirectional_iterator_tag;
+    using value_type = char32_t;
+    using difference_type = ptrdiff_t;
+    Iterator() = default;
     Iterator(StringView view LIFETIME_BOUND, unsigned index);
 
     char32_t operator*() const;
     Iterator& operator++();
+    Iterator operator++(int);
+    Iterator& operator--();
+    Iterator operator--(int);
 
     bool operator==(const Iterator&) const;
 
 private:
-    const void* m_current;
-    const void* m_end;
-    bool m_is8Bit;
+    const void* m_begin { nullptr };
+    const void* m_current { nullptr };
+    const void* m_end { nullptr };
+    bool m_is8Bit { true };
 #if CHECK_STRINGVIEW_LIFETIME
     StringView m_stringView;
 #endif
@@ -1022,10 +1029,12 @@ inline StringView::CodePoints::Iterator::Iterator(StringView stringView LIFETIME
 {
     if (m_is8Bit) {
         auto characters = stringView.span8();
+        m_begin = std::to_address(characters.begin());
         m_current = characters.subspan(index).data();
         m_end = std::to_address(characters.end());
     } else {
         auto characters = stringView.span16();
+        m_begin = std::to_address(characters.begin());
         m_current = characters.subspan(index).data();
         m_end = std::to_address(characters.end());
     }
@@ -1047,6 +1056,38 @@ inline auto StringView::CodePoints::Iterator::operator++() -> Iterator&
         m_current = static_cast<const char16_t*>(m_current) + i;
     }
     return *this;
+}
+
+inline auto StringView::CodePoints::Iterator::operator++(int) -> Iterator
+{
+    auto result = *this;
+    ++*this;
+    return result;
+}
+
+inline auto StringView::CodePoints::Iterator::operator--() -> Iterator&
+{
+#if CHECK_STRINGVIEW_LIFETIME
+    ASSERT(m_stringView.underlyingStringIsValid());
+#endif
+    ASSERT(m_current > m_begin);
+    if (m_is8Bit)
+        m_current = static_cast<const Latin1Character*>(m_current) - 1;
+    else {
+        auto* begin = static_cast<const char16_t*>(m_begin);
+        auto* current = static_cast<const char16_t*>(m_current);
+        unsigned i = current - begin;
+        U16_BACK_1(begin, 0, i);
+        m_current = begin + i;
+    }
+    return *this;
+}
+
+inline auto StringView::CodePoints::Iterator::operator--(int) -> Iterator
+{
+    auto result = *this;
+    --*this;
+    return result;
 }
 
 inline char32_t StringView::CodePoints::Iterator::operator*() const

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -215,7 +215,7 @@ void InlineItemsBuilder::computeInlineBoxBoundaryTextSpacings(const InlineItemLi
         size_t boundaryIndex = inlineBoxStartIndexesOnInlineItemsList[inlineBoxStartOnBoundaryIndex];
         CheckedRef boundaryOwnerStyle = inlineItemList[boundaryIndex].layoutBox().parent().style();
         auto boundaryTextAutospace = boundaryOwnerStyle->textAutospace();
-        if (!boundaryTextAutospace.isNoAutospace() && boundaryTextAutospace.shouldApplySpacing(inlineTextBox->content().codeUnitAt(start), lastCharacterFromPreviousRun))
+        if (!boundaryTextAutospace.isNoAutospace() && boundaryTextAutospace.shouldApplySpacing(inlineTextBox->content().codePointAt(start), lastCharacterFromPreviousRun))
             spacings.add(boundaryIndex, TextAutospace::textAutospaceSize(protect(boundaryOwnerStyle->fontCascade().primaryFont())));
 
         lastCharacterFromPreviousRun = TextUtil::lastBaseCharacterFromText(content);
@@ -789,7 +789,7 @@ static void handleTextSpacing(TextSpacing::SpacingState& spacingState, Trimmable
     auto autospace = inlineTextItem.style().textAutospace();
     if (!autospace.isNoAutospace()) {
         // We need to store information about spacing added between inline text items since it needs to be trimmed during line breaking if the consecutive items are placed on different lines
-        auto characterClass = TextSpacing::characterClass(inlineTextItem.content().codeUnitAt(0));
+        auto characterClass = TextSpacing::characterClass(inlineTextItem.content().codePointAt(0));
         if (autospace.shouldApplySpacing(spacingState.lastCharacterClassFromPreviousRun, characterClass))
             trimmableTextSpacings.add(inlineItemIndex, TextAutospace::textAutospaceSize(protect(inlineTextItem.style().fontCascade().primaryFont())));
 

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -751,15 +751,11 @@ bool TextUtil::hasPositionDependentContentWidth(StringView textContent)
     return charactersContain<char16_t, tabCharacter>(textContent.span16());
 }
 
-char32_t TextUtil::lastBaseCharacterFromText(StringView string)
+SUPPRESS_NODELETE char32_t TextUtil::lastBaseCharacterFromText(StringView string)
 {
-    if (!string.length())
-        return 0;
-
-    for (size_t characterIndex = string.length(); characterIndex > 0; --characterIndex) {
-        auto character = string.codeUnitAt(characterIndex - 1);
-        if (!isCombiningMark(character))
-            return character;
+    for (auto codePoint : string.codePoints() | std::views::reverse) {
+        if (!isCombiningMark(codePoint))
+            return codePoint;
     }
     return 0;
 }

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -642,7 +642,7 @@ TextSpacing::CharacterClass WidthIterator::applyTextAutospaceIfNeededAndGetChara
     if (textAutospace.isNoAutospace())
         return TextSpacing::CharacterClass::Undefined;
 
-    auto currentCharacterClass = TextSpacing::characterClass(m_run.get()[characterIndex]);
+    auto currentCharacterClass = TextSpacing::characterClass(m_run->text().codePointAt(characterIndex));
     if (textAutospace.shouldApplySpacing(currentCharacterClass, previousCharacterClass)) {
         auto textAutospaceSpacing = TextAutospace::textAutospaceSize(protect(glyphBuffer.fontAt(glyphIndexRange.leadingGlyphIndex)));
         glyphBuffer.expandAdvanceToLogicalRight(glyphIndexRange.leadingGlyphIndex, textAutospaceSpacing);


### PR DESCRIPTION
#### e502e18a549c34cb199f788608b35e97b6a1565c
<pre>
text-autospace should handle supplementary Unicode characters
<a href="https://bugs.webkit.org/show_bug.cgi?id=311517">https://bugs.webkit.org/show_bug.cgi?id=311517</a>

Reviewed by Darin Adler.

Text autospacing between ideographs and alphabetic/numeric characters
failed for supplementary-plane characters (e.g. CJK Extension B,
U+20000+). Four call sites read individual char16_t code units instead
of decoding full char32_t code points, so surrogate halves were passed
to TextSpacing::characterClass(), which returned Undefined instead of
Ideograph, and no autospacing was applied.

1. TextUtil::lastBaseCharacterFromText() used StringView::characterAt()
   to iterate backwards, returning lone surrogates for supplementary
   characters. Rewrite using reversed codePoints() iteration to properly
   decode surrogate pairs.

2-3. InlineItemsBuilder: two calls to characterAt() for the first
     character of a text item (within-text-node path and span-boundary
     path). Replace with characterStartingAt() which assembles surrogate
     pairs into code points.

4. WidthIterator::applyTextAutospaceIfNeededAndGetCharacterClass()
   used TextRun::operator[] which returns char16_t. Replace with
   TextRun::text().characterStartingAt() to get the full code point.

To support reversed iteration over code points, upgrade
StringView::CodePoints::Iterator from a forward iterator to a
bidirectional iterator by adding operator--, post-increment/decrement
operators, a default constructor, and storing the begin pointer for
bounds checking.

Test: imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-supplementary-ideograph.html
- This test is failing in shipping Safari but passing in Chrome and Firefox.

* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-supplementary-ideograph-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-supplementary-ideograph.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::CodePoints::Iterator::operator--):
(WTF::StringView::CodePoints::Iterator::operator++(int)):
(WTF::StringView::CodePoints::Iterator::operator--(int)):
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::computeInlineBoxBoundaryTextSpacings):
(WebCore::Layout::handleTextSpacing):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::lastBaseCharacterFromText):
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::applyTextAutospaceIfNeededAndGetCharacterClass):

Canonical link: <a href="https://commits.webkit.org/310633@main">https://commits.webkit.org/310633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4793a9094ecf68359d695208f3a84ef99a98be0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154447 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163202 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107916 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/12073e72-3fd1-40d5-94d9-f0f1f3799635) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156320 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27555 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119459 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84483 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138709 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100156 "Found 1 new API test failure: TestWebCore:MIMETypeRegistry.CanShowMIMEType (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/20fde78d-f3f0-45e8-aa46-ed021b923fd1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20820 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18830 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11033 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146496 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130482 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165673 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15278 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8882 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18162 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127554 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127698 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34645 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27175 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138346 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83840 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22594 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15138 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186155 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26865 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90968 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47714 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26446 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26677 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26519 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->