### PR TITLE
REGRESSION (306393@main): <select> control vertical writing mode is broken

### DIFF
--- a/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-dimensions-expected.txt
+++ b/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-dimensions-expected.txt
@@ -1,0 +1,24 @@
+Test that vertical writing mode selects have swapped dimensions compared to a horizontal one
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+vertical-rl
+PASS verticalRL.offsetWidth is horizontal.offsetHeight
+PASS verticalRL.offsetHeight is horizontal.offsetWidth
+
+vertical-lr
+PASS verticalLR.offsetWidth is horizontal.offsetHeight
+PASS verticalLR.offsetHeight is horizontal.offsetWidth
+
+sideways-rl
+PASS sidewaysRL.offsetWidth is horizontal.offsetHeight
+PASS sidewaysRL.offsetHeight is horizontal.offsetWidth
+
+sideways-lr
+PASS sidewaysLR.offsetWidth is horizontal.offsetHeight
+PASS sidewaysLR.offsetHeight is horizontal.offsetWidth
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-dimensions.html
+++ b/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-dimensions.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<select id="horizontal"><option>Option 1</option></select>
+<select id="verticalRL" style="writing-mode: vertical-rl"><option>Option 1</option></select>
+<select id="verticalLR" style="writing-mode: vertical-lr"><option>Option 1</option></select>
+<select id="sidewaysRL" style="writing-mode: sideways-rl"><option>Option 1</option></select>
+<select id="sidewaysLR" style="writing-mode: sideways-lr"><option>Option 1</option></select>
+</body>
+<script>
+
+description("Test that vertical writing mode selects have swapped dimensions compared to a horizontal one");
+
+var horizontal = document.getElementById("horizontal");
+
+debug("vertical-rl");
+shouldBe("verticalRL.offsetWidth", "horizontal.offsetHeight");
+shouldBe("verticalRL.offsetHeight", "horizontal.offsetWidth");
+debug("");
+
+debug("vertical-lr");
+shouldBe("verticalLR.offsetWidth", "horizontal.offsetHeight");
+shouldBe("verticalLR.offsetHeight", "horizontal.offsetWidth");
+debug("");
+
+debug("sideways-rl");
+shouldBe("sidewaysRL.offsetWidth", "horizontal.offsetHeight");
+shouldBe("sidewaysRL.offsetHeight", "horizontal.offsetWidth");
+debug("");
+
+debug("sideways-lr");
+shouldBe("sidewaysLR.offsetWidth", "horizontal.offsetHeight");
+shouldBe("sidewaysLR.offsetHeight", "horizontal.offsetWidth");
+
+</script>
+</html>

--- a/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-expected.html
+++ b/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<style>
+
+.wrapper {
+    position: absolute;
+    display: inline-block;
+    transform: rotate(90deg) translate(0, -100%);
+    transform-origin: left top;
+}
+
+#first { left: 50px; top: 50px; }
+#second { left: 50px; top: 250px; }
+
+.cover {
+    position: absolute;
+    left: 0;
+    width: 200px;
+    height: 100px;
+    background: white;
+}
+
+#cover1 { top: 90px; }
+#cover2 { top: 290px; }
+
+</style>
+<div id="first" class="wrapper">
+    <select><option>Option 1</option></select>
+</div>
+<div id="second" class="wrapper">
+    <select><option>Option 1</option></select>
+</div>
+<div id="cover1" class="cover"></div>
+<div id="cover2" class="cover"></div>

--- a/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-sideways-lr-expected.html
+++ b/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-sideways-lr-expected.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style>
+
+.wrapper {
+    position: absolute;
+    left: 50px;
+    top: 50px;
+    display: inline-block;
+}
+
+select {
+    writing-mode: sideways-rl;
+    transform: rotate(180deg);
+}
+
+</style>
+<div class="wrapper">
+    <select><option>Option 1</option></select>
+</div>

--- a/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-sideways-lr.html
+++ b/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-sideways-lr.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta name="fuzzy" content="maxDifference=0-67; totalPixels=0-40">
+<style>
+
+.wrapper {
+    position: absolute;
+    left: 50px;
+    top: 50px;
+    display: inline-block;
+}
+
+select {
+    writing-mode: sideways-lr;
+}
+
+</style>
+<div class="wrapper">
+    <select><option>Option 1</option></select>
+</div>

--- a/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-vertical-variants-expected.html
+++ b/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-vertical-variants-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<style>
+
+.wrapper {
+    position: absolute;
+    display: inline-block;
+}
+
+#first { left: 50px; top: 50px; }
+#second { left: 50px; top: 250px; }
+#third { left: 50px; top: 450px; }
+
+</style>
+<div id="first" class="wrapper">
+    <select style="writing-mode: vertical-lr"><option>Option 1</option></select>
+</div>
+<div id="second" class="wrapper">
+    <select style="writing-mode: vertical-lr"><option>Option 1</option></select>
+</div>
+<div id="third" class="wrapper">
+    <select style="writing-mode: vertical-lr"><option>Option 1</option></select>
+</div>

--- a/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-vertical-variants.html
+++ b/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-vertical-variants.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<link rel="match" href="select-menulist-vertical-variants-expected.html">
+<style>
+
+.wrapper {
+    position: absolute;
+    display: inline-block;
+}
+
+#first { left: 50px; top: 50px; }
+#second { left: 50px; top: 250px; }
+#third { left: 50px; top: 450px; }
+
+</style>
+<div id="first" class="wrapper">
+    <select style="writing-mode: vertical-rl"><option>Option 1</option></select>
+</div>
+<div id="second" class="wrapper">
+    <select style="writing-mode: vertical-lr"><option>Option 1</option></select>
+</div>
+<div id="third" class="wrapper">
+    <select style="writing-mode: sideways-rl"><option>Option 1</option></select>
+</div>

--- a/LayoutTests/fast/forms/vertical-writing-mode/select-menulist.html
+++ b/LayoutTests/fast/forms/vertical-writing-mode/select-menulist.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<link rel="match" href="select-menulist-expected.html">
+<meta name="fuzzy" content="maxDifference=0-50; totalPixels=0-284">
+<style>
+
+.wrapper {
+    position: absolute;
+    display: inline-block;
+}
+
+#first { left: 50px; top: 50px; }
+#second { left: 50px; top: 250px; }
+
+/* Cover the arrow area which keeps its orientation in vertical writing mode
+   but rotates with a CSS transform, so it would differ between test and ref.
+   Positioned in page coordinates outside the wrapper so both files can use
+   the same cover placement. */
+.cover {
+    position: absolute;
+    left: 0;
+    width: 200px;
+    height: 100px;
+    background: white;
+}
+
+#cover1 { top: 90px; }
+#cover2 { top: 290px; }
+
+</style>
+<div id="first" class="wrapper">
+    <select style="writing-mode: vertical-rl"><option>Option 1</option></select>
+</div>
+<div id="second" class="wrapper">
+    <select style="writing-mode: vertical-lr"><option>Option 1</option></select>
+</div>
+<div id="cover1" class="cover"></div>
+<div id="cover2" class="cover"></div>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -213,6 +213,10 @@ fast/forms/switch/zoom-approximates-transform-vertical-rl.html [ Pass ]
 fast/forms/switch/zoom-approximates-transform.html [ Pass ]
 fast/forms/switch/zoom-computed-style.html [ Pass ]
 
+# Vertical <select> support needs some further changes.
+fast/forms/vertical-writing-mode/select-menulist-sideways-lr.html [ Skip ]
+fast/forms/vertical-writing-mode/select-menulist.html [ Skip ]
+
 # Some Apple ports don't support RTL scrollbars.
 fast/scrolling/rtl-scrollbars-alternate-body-dir-attr-does-not-update-scrollbar-placement.html [ Pass ]
 fast/scrolling/rtl-scrollbars-elementFromPoint-static.html [ Pass ]

--- a/LayoutTests/platform/mac-sequoia/TestExpectations
+++ b/LayoutTests/platform/mac-sequoia/TestExpectations
@@ -19,6 +19,7 @@ fast/forms/datalist/datalist-fallback-content.html [ Pass ]
 # Tests which pass only with form control refresh enabled (support added in Tahoe)
 fast/forms/appearance-default-button.html  [ Skip ]
 fast/forms/form-control-refresh [ Skip ]
+fast/forms/vertical-writing-mode/select-menulist.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-ui/button-author-level-padding-applies.html [ Skip ]
 
 # Tests which pass only with form control refresh disabled (support added in Tahoe)

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm
@@ -91,15 +91,18 @@ void MenuListButtonMac::draw(GraphicsContext& context, const FloatRoundedRect& b
     bool isVerticalWritingMode = style.states.contains(ControlStyle::State::VerticalWritingMode);
     auto logicalBounds = isVerticalWritingMode ? bounds.transposedRect() : bounds;
 
+    auto glyphInlineSize = isVerticalWritingMode ? glyphSize.height() : glyphSize.width();
+    auto glyphBlockSize = isVerticalWritingMode ? glyphSize.width() : glyphSize.height();
+
     bool isInlineFlipped = style.states.contains(ControlStyle::State::InlineFlippedWritingMode);
     float endEdge = [&] {
         static constexpr int arrowPaddingAfter = 6;
         if (isInlineFlipped)
             return logicalBounds.x() + arrowPaddingAfter * style.zoomFactor;
-        return logicalBounds.maxX() - arrowPaddingAfter * style.zoomFactor - glyphSize.width();
+        return logicalBounds.maxX() - arrowPaddingAfter * style.zoomFactor - glyphInlineSize;
     }();
 
-    FloatPoint glyphOrigin { endEdge, logicalBounds.y() + (logicalBounds.height() - glyphSize.height()) / 2 };
+    FloatPoint glyphOrigin { endEdge, logicalBounds.y() + (logicalBounds.height() - glyphBlockSize) / 2 };
 
     if (isVerticalWritingMode)
         glyphOrigin = glyphOrigin.transposedPoint();

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -151,10 +151,10 @@ void RenderMenuList::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, 
     maxLogicalWidth = shouldApplySizeContainment() ? minimumSize : std::max(LayoutUnit(m_optionsWidth), minimumSize);
 
     auto internalPadding = theme().popupInternalPaddingBox(style());
-    if (auto left = internalPadding.left().tryFixed())
-        maxLogicalWidth += LayoutUnit(left->resolveZoom(style().usedZoomForLength()));
-    if (auto right = internalPadding.right().tryFixed())
-        maxLogicalWidth += LayoutUnit(right->resolveZoom(style().usedZoomForLength()));
+    if (auto start = internalPadding.start(writingMode()).tryFixed())
+        maxLogicalWidth += LayoutUnit(start->resolveZoom(style().usedZoomForLength()));
+    if (auto end = internalPadding.end(writingMode()).tryFixed())
+        maxLogicalWidth += LayoutUnit(end->resolveZoom(style().usedZoomForLength()));
 
     if (shouldApplySizeOrInlineSizeContainment()) {
         if (auto logicalWidth = explicitIntrinsicInnerLogicalWidth())

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1694,7 +1694,19 @@ void RenderTheme::adjustSwitchStyle(RenderStyle& style, const Element*) const
     style.setLogicalHeight(Style::PreferredSize { controlSize.height() });
 }
 
-Style::PaddingBox RenderTheme::popupInternalPaddingBox(const RenderStyle&) const
+Style::PaddingBox RenderTheme::popupInternalPaddingBox(const RenderStyle& style) const
+{
+    auto padding = platformPopupInternalPaddingBox(style);
+    if (!style.writingMode().isHorizontal()) {
+        if (style.writingMode().computedWritingMode() == StyleWritingMode::SidewaysLr)
+            padding = { padding.right(), padding.bottom(), padding.left(), padding.top() };
+        else
+            padding = { padding.left(), padding.top(), padding.right(), padding.bottom() };
+    }
+    return padding;
+}
+
+Style::PaddingBox RenderTheme::platformPopupInternalPaddingBox(const RenderStyle&) const
 {
     return Style::PaddingBox { 0_css_px };
 }

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -219,7 +219,7 @@ public:
 
     virtual void adjustSliderThumbSize(RenderStyle&, const Element*) const { }
 
-    virtual Style::PaddingBox popupInternalPaddingBox(const RenderStyle&) const;
+    Style::PaddingBox popupInternalPaddingBox(const RenderStyle&) const;
     virtual PopupMenuStyle::Size popupMenuSize(const RenderStyle&, IntRect&) const { return PopupMenuStyle::Size::Normal; }
 
     virtual ScrollbarWidth scrollbarWidthStyleForPart(StyleAppearance) { return ScrollbarWidth::Auto; }
@@ -411,6 +411,8 @@ protected:
 
     // The font description result should have a zoomed font size.
     virtual std::optional<FontCascadeDescription> controlFont(StyleAppearance, const FontCascade&, float) const;
+
+    virtual Style::PaddingBox platformPopupInternalPaddingBox(const RenderStyle&) const;
 
     virtual Style::PaddingBox controlPadding(StyleAppearance, const Style::PaddingBox&, float zoomFactor) const;
 

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
@@ -352,7 +352,7 @@ void RenderThemeAdwaita::adjustMenuListButtonStyle(RenderStyle& style, const Ele
     adjustMenuListStyle(style, element);
 }
 
-Style::PaddingBox RenderThemeAdwaita::popupInternalPaddingBox(const RenderStyle& style) const
+Style::PaddingBox RenderThemeAdwaita::platformPopupInternalPaddingBox(const RenderStyle& style) const
 {
     if (style.usedAppearance() == StyleAppearance::None || style.usedAppearance() == StyleAppearance::Base)
         return { 0_css_px };

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.h
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.h
@@ -82,7 +82,7 @@ public:
     bool popsMenuBySpaceOrReturn() const final { return true; }
     void adjustMenuListStyle(RenderStyle&, const Element*) const final;
     void adjustMenuListButtonStyle(RenderStyle&, const Element*) const final;
-    Style::PaddingBox popupInternalPaddingBox(const RenderStyle&) const final;
+    Style::PaddingBox platformPopupInternalPaddingBox(const RenderStyle&) const final;
 
     Seconds animationRepeatIntervalForProgressBar(const RenderProgress&) const final;
     IntRect progressBarRectForBounds(const RenderProgress&, const IntRect&) const final;

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -3466,7 +3466,9 @@ bool RenderThemeCocoa::paintMenuListButtonDecorationsForVectorBasedControls(cons
     const auto logicalRect = isHorizontalWritingMode ? rect : rect.transposedRect();
 
     FloatPoint glyphOrigin;
-    glyphOrigin.setY(logicalRect.center().y() - glyphSize.height() / 2.0f);
+    auto glyphInlineSize = isHorizontalWritingMode ? glyphSize.width() : glyphSize.height();
+    auto glyphBlockSize = isHorizontalWritingMode ? glyphSize.height() : glyphSize.width();
+    glyphOrigin.setY(logicalRect.center().y() - glyphBlockSize / 2.0f);
 
     auto glyphPaddingEnd = logicalRect.width();
     auto usedZoom = style->usedZoomForLength();
@@ -3481,7 +3483,7 @@ bool RenderThemeCocoa::paintMenuListButtonDecorationsForVectorBasedControls(cons
     }
 
     if (!style->writingMode().isInlineFlipped())
-        glyphOrigin.setX(logicalRect.maxX() - glyphSize.width() - Style::evaluate<float>(box.style().usedBorderWidthEnd(), Style::ZoomNeeded { }) - glyphPaddingEnd);
+        glyphOrigin.setX(logicalRect.maxX() - glyphInlineSize - Style::evaluate<float>(box.style().usedBorderWidthEnd(), Style::ZoomNeeded { }) - glyphPaddingEnd);
     else
         glyphOrigin.setX(logicalRect.x() + Style::evaluate<float>(box.style().usedBorderWidthEnd(), Style::ZoomNeeded { }) + glyphPaddingEnd);
 

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.h
@@ -65,7 +65,7 @@ public:
 
     bool canCreateControlPartForRenderer(const RenderElement&) const final;
 
-    Style::PaddingBox popupInternalPaddingBox(const RenderStyle&) const final;
+    Style::PaddingBox platformPopupInternalPaddingBox(const RenderStyle&) const final;
 
     int baselinePosition(const RenderBox&) const final;
 

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -379,7 +379,7 @@ static Style::PaddingEdge toTruncatedPaddingEdge(auto value)
     return Style::PaddingEdge::Fixed { static_cast<float>(std::trunc(value)) };
 }
 
-Style::PaddingBox RenderThemeIOS::popupInternalPaddingBox(const RenderStyle& style) const
+Style::PaddingBox RenderThemeIOS::platformPopupInternalPaddingBox(const RenderStyle& style) const
 {
     const auto padding = Style::emToPx<float>(1, style);
 
@@ -620,10 +620,13 @@ void RenderThemeIOS::paintMenuListButtonDecorations(const RenderBox& box, const 
     bool isHorizontalWritingMode = style.writingMode().isHorizontal();
     auto logicalRect = isHorizontalWritingMode ? rect : rect.transposedRect();
 
+    auto glyphInlineSize = isHorizontalWritingMode ? glyphSize.width() : glyphSize.height();
+    auto glyphBlockSize = isHorizontalWritingMode ? glyphSize.height() : glyphSize.width();
+
     FloatPoint glyphOrigin;
-    glyphOrigin.setY(logicalRect.center().y() - glyphSize.height() / 2.0f);
+    glyphOrigin.setY(logicalRect.center().y() - glyphBlockSize / 2.0f);
     if (!style.writingMode().isInlineFlipped())
-        glyphOrigin.setX(logicalRect.maxX() - glyphSize.width() - Style::evaluate<float>(box.style().usedBorderWidthEnd(), Style::ZoomNeeded { }) - Style::evaluate<float>(box.style().paddingEnd(), logicalRect.width(), box.style().usedZoomForLength()));
+        glyphOrigin.setX(logicalRect.maxX() - glyphInlineSize - Style::evaluate<float>(box.style().usedBorderWidthEnd(), Style::ZoomNeeded { }) - Style::evaluate<float>(box.style().paddingEnd(), logicalRect.width(), box.style().usedZoomForLength()));
     else
         glyphOrigin.setX(logicalRect.x() + Style::evaluate<float>(box.style().usedBorderWidthEnd(), Style::ZoomNeeded { }) + Style::evaluate<float>(box.style().paddingEnd(), logicalRect.width(), box.style().usedZoomForLength()));
 

--- a/Source/WebCore/rendering/mac/RenderThemeMac.h
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.h
@@ -76,7 +76,7 @@ public:
     IntSize NODELETE sliderTickSize() const final;
     int NODELETE sliderTickOffsetFromTrackCenter() const final;
 
-    Style::PaddingBox popupInternalPaddingBox(const RenderStyle&) const final;
+    Style::PaddingBox platformPopupInternalPaddingBox(const RenderStyle&) const final;
     PopupMenuStyle::Size popupMenuSize(const RenderStyle&, IntRect&) const final;
 
     std::optional<FontCascadeDescription> controlFont(StyleAppearance, const FontCascade&, float zoomFactor) const final;

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1360,7 +1360,7 @@ static Style::PaddingEdge NODELETE toTruncatedPaddingEdge(auto value)
     return Style::PaddingEdge::Fixed { static_cast<float>(std::trunc(value)) };
 }
 
-Style::PaddingBox RenderThemeMac::popupInternalPaddingBox(const RenderStyle& style) const
+Style::PaddingBox RenderThemeMac::platformPopupInternalPaddingBox(const RenderStyle& style) const
 {
     if (style.usedAppearance() == StyleAppearance::Menulist) {
         auto padding = popupButtonPadding(controlSizeForFont(style), style.writingMode().isBidiRTL());


### PR DESCRIPTION
#### 867feab5939a8a57ea6375269d9b0590d2aa73de
<pre>
REGRESSION (306393@main): &lt;select&gt; control vertical writing mode is broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=311522">https://bugs.webkit.org/show_bug.cgi?id=311522</a>
<a href="https://rdar.apple.com/174068353">rdar://174068353</a>

Reviewed by Darin Adler.

Before each caller of popupInternalPaddingBox() had to do adjustments.
We now make it so that calling popupInternalPaddingBox() always gives
you the logical padding box.

This also ends up adding support for sideways-lr, which was not working
before the regression.

In addition we improve the code for positioning the &quot;chevron&quot; glyph as
it wasn&apos;t correctly centered in vertical writing modes before the
regression. We also fix this in the pre-26 code paths.

We also add test coverage so this is less likely to happen again in a
future refactoring.

Unfortunately Linux platforms don&apos;t fully support vertical writing
mode for &lt;select&gt;. And we skip select-menulist.html pre-26 on macOS
because NSPopUpButtonCell ends up rendering vertical &lt;select&gt;
differently from a transformed &lt;select&gt; (border is light vs dark).

Tests: fast/forms/vertical-writing-mode/select-menulist-dimensions.html
       fast/forms/vertical-writing-mode/select-menulist-sideways-lr.html
       fast/forms/vertical-writing-mode/select-menulist-vertical-variants.html
       fast/forms/vertical-writing-mode/select-menulist.html

Canonical link: <a href="https://commits.webkit.org/310622@main">https://commits.webkit.org/310622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc674bcba3e5dfd2e503c818b225e14db3a3c1cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163112 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107827 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156231 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119379 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84412 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21651 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138622 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100075 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20738 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18744 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10944 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130400 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16467 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165584 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8793 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18076 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127476 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27162 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22786 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127621 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27086 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138260 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83720 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23569 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22512 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15052 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26776 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90879 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26357 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26588 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26430 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->