### PR TITLE
Match select in ::picker(select) ASCII-case-insensitively

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-forms/parsing/picker-select-pseudo-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-forms/parsing/picker-select-pseudo-element-expected.txt
@@ -6,7 +6,7 @@ PASS "::picker(select) *" should be an invalid selector
 PASS "::picker(foo)" should be an invalid selector
 PASS "::picker()" should be an invalid selector
 PASS "::picker" should be an invalid selector
-FAIL "::picker(SELECT)" should be a valid selector '::picker(SELECT)' is not a valid selector.
+PASS "::picker(SELECT)" should be a valid selector
 PASS "::picker(select)::picker(select)" should be a valid selector
 PASS "::before::picker(select)" should be an invalid selector
 PASS "::after::picker(select)" should be an invalid selector

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -814,9 +814,9 @@ static AtomString consumePickerArgument(CSSParserTokenRange& block)
     auto& ident = block.consumeIncludingWhitespace();
     if (ident.type() != IdentToken || !block.atEnd())
         return nullAtom();
-    if (ident.value() != "select"_s)
+    if (!equalLettersIgnoringASCIICase(ident.value(), "select"_s))
         return nullAtom();
-    return ident.value().toAtomString();
+    return ident.value().convertToASCIILowercaseAtom();
 }
 
 std::unique_ptr<MutableCSSSelector> CSSSelectorParser::consumePseudo(CSSParserTokenRange& range)


### PR DESCRIPTION
#### 02173bb657715ea25a6244ab5c7b7b30150006b3
<pre>
Match select in ::picker(select) ASCII-case-insensitively
<a href="https://bugs.webkit.org/show_bug.cgi?id=311523">https://bugs.webkit.org/show_bug.cgi?id=311523</a>

Reviewed by Tim Nguyen.

Canonical link: <a href="https://commits.webkit.org/310607@main">https://commits.webkit.org/310607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e581cffdd18dd0e8e34ba5b2b4f6367911e4cf67

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163109 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107824 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156228 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27463 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119378 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84410 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21644 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138620 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100074 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20731 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18742 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10941 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130393 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165581 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8790 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18074 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127474 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27159 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22784 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127619 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27083 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138258 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83717 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23563 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22508 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15050 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26773 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90876 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26354 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26585 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26427 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->