### PR TITLE
Remove HTMLOptionElement::willResetComputedStyle()

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5785,16 +5785,11 @@ void Element::resetComputedStyle()
     if (!hasRareData() || !elementRareData()->computedStyle())
         return;
 
-    auto reset = [](Element& element) {
-        if (element.hasCustomStyleResolveCallbacks())
-            element.willResetComputedStyle();
-        element.elementRareData()->setComputedStyle(nullptr);
-    };
-    reset(*this);
+    elementRareData()->setComputedStyle(nullptr);
     for (Ref child : descendantsOfType<Element>(*this)) {
         if (!child->hasRareData() || !child->elementRareData()->computedStyle() || child->hasDisplayContents() || child->hasDisplayNone())
             continue;
-        reset(child);
+        child->elementRareData()->setComputedStyle(nullptr);
     }
 }
 
@@ -5845,11 +5840,6 @@ void Element::willRecalcStyle(OptionSet<Style::Change>)
 }
 
 void Element::didRecalcStyle(OptionSet<Style::Change>)
-{
-    ASSERT(hasCustomStyleResolveCallbacks());
-}
-
-void Element::willResetComputedStyle()
 {
     ASSERT(hasCustomStyleResolveCallbacks());
 }

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -786,7 +786,6 @@ public:
 
     virtual void willRecalcStyle(OptionSet<Style::Change>);
     virtual void didRecalcStyle(OptionSet<Style::Change>);
-    virtual void willResetComputedStyle();
     virtual void willAttachRenderers();
     virtual void didAttachRenderers();
     virtual void willDetachRenderers();

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -64,7 +64,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLOptionElement);
 using namespace HTMLNames;
 
 HTMLOptionElement::HTMLOptionElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document, TypeFlag::HasCustomStyleResolveCallbacks)
+    : HTMLElement(tagName, document)
 {
     ASSERT(hasTagName(optionTag));
 }
@@ -494,16 +494,6 @@ String HTMLOptionElement::displayLabel() const
     if (document().inQuirksMode())
         return collectOptionInnerTextCollapsingWhitespace();
     return label();
-}
-
-void HTMLOptionElement::willResetComputedStyle()
-{
-    // FIXME: This is nasty, we ask our owner select to repaint even if the new
-    // style is exactly the same.
-    if (RefPtr select = ownerSelectElement()) {
-        if (CheckedPtr renderer = select->renderer())
-            renderer->repaint();
-    }
 }
 
 String HTMLOptionElement::textIndentedToRespectGroupLabel() const

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -96,8 +96,6 @@ private:
 
     void childrenChanged(const ChildChange&) final;
 
-    void willResetComputedStyle() final;
-
     String collectOptionInnerText() const;
     String collectOptionInnerTextCollapsingWhitespace() const;
 


### PR DESCRIPTION
#### 4b927e49756cc0415a795b42b81fc9ab95c5813d
<pre>
Remove HTMLOptionElement::willResetComputedStyle()
<a href="https://bugs.webkit.org/show_bug.cgi?id=311524">https://bugs.webkit.org/show_bug.cgi?id=311524</a>

Reviewed by Chris Dumez.

Back in 2011, we had bug 49790 about the background property not
working for &lt;option&gt;s when set through script. This was fixed in
67043@main through a repaint() hack. And a regression test was added
that&apos;s still functional and passing:

    fast/repaint/select-option-background-color.html

In 2012 bug 100397 performed some refactoring and added a FIXME.

In 2014 bug 135938 there was more refactoring creating the current
setup.

With the way we handle style invalidation today this workaround appears
no longer to be needed.

Canonical link: <a href="https://commits.webkit.org/310623@main">https://commits.webkit.org/310623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86eead6182ab4fc64c69403ddd9386ccf9334c98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27640 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163137 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107851 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4d44ae7d-d640-4fa9-9aad-c83ab5d7be9a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27490 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119403 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84436 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/334b9b5a-428b-4c41-ae52-d1519b7c2eaf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157341 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21673 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138648 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100100 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8a782b7d-c834-4268-bcb1-d08b346d3c47) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20760 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18768 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10968 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130422 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165608 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8817 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18101 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127500 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22810 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127644 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27110 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138285 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83752 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23570 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22536 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15077 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26800 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90903 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26381 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26612 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26454 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->