### PR TITLE
exp: 2-layer cache interaction

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -301,6 +301,40 @@ float FontCascade::width(StringView text) const
     return width (run);
 }
 
+void FontCascade::computeGlyphOverflow(const GlyphBuffer& glyphBuffer, float totalWidth, GlyphOverflow& glyphOverflow) const
+{
+    float minY = 0;
+    float maxY = 0;
+    float minX = 0;
+    float maxX = 0;
+    float xPosition = 0;
+
+    for (unsigned glyphIndex = 0; glyphIndex < glyphBuffer.size(); ++glyphIndex) {
+        auto glyph = glyphBuffer.glyphAt(glyphIndex);
+        auto& font = glyphBuffer.fontAt(glyphIndex);
+        auto bounds = font.boundsForGlyph(glyph);
+
+        float glyphX = xPosition + bounds.x();
+        float glyphRight = glyphX + bounds.width();
+        float glyphTop = bounds.y();
+        float glyphBottom = glyphTop + bounds.height();
+
+        minX = std::min(minX, glyphX);
+        maxX = std::max(maxX, glyphRight);
+        minY = std::min(minY, glyphTop);
+        maxY = std::max(maxY, glyphBottom);
+
+        xPosition += WebCore::width(glyphBuffer.advanceAt(glyphIndex));
+    }
+
+    auto ascent = metricsOfPrimaryFont().ascent();
+    auto descent = metricsOfPrimaryFont().descent();
+    glyphOverflow.top = std::max<double>(glyphOverflow.top, -minY - (glyphOverflow.computeBounds ? 0 : ascent));
+    glyphOverflow.bottom = std::max<double>(glyphOverflow.bottom, maxY - (glyphOverflow.computeBounds ? 0 : descent));
+    glyphOverflow.left = std::max<double>(0, -minX);
+    glyphOverflow.right = std::max<double>(0, maxX - totalWidth);
+}
+
 float FontCascade::width(const TextRun& run, SingleThreadWeakHashSet<const Font>* fallbackFonts, GlyphOverflow* glyphOverflow) const
 {
     if (!run.length())
@@ -330,6 +364,24 @@ float FontCascade::width(const TextRun& run, SingleThreadWeakHashSet<const Font>
     SingleThreadWeakHashSet<const Font> localFallbackFonts;
     if (!fallbackFonts)
         fallbackFonts = &localFallbackFonts;
+
+    // Go through layoutText() so the GlyphBuffer gets stashed in the shaping cache
+    // for painting to reuse later, avoiding a redundant reshape.
+    TextShapingContext shapingContext { *this };
+    if (shapingContext.hasKerningOrLigatures && !shapingContext.hasWordSpacingOrLetterSpacing
+        && !run.rtl() && !run.directionalOverride() && !run.expansion()
+        && run.length() <= ShapedTextCacheDefaults::maxTextLength
+        && isMainThread()) {
+        auto result = layoutText(codePathToUse, run, 0, run.length(), ForTextEmphasis::No);
+        if (cacheEntry)
+            cacheEntry->width = result.width;
+        if (glyphOverflow) {
+            computeGlyphOverflow(result.glyphBuffer, result.width, *glyphOverflow);
+            if (cacheEntry)
+                cacheEntry->glyphOverflow = *glyphOverflow;
+        }
+        return result.width;
+    }
 
     float result = width(codePathToUse, run, fallbackFonts, glyphOverflow);
     if (cacheEntry && fallbackFonts->isEmptyIgnoringNullReferences()) {

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -219,6 +219,7 @@ private:
     void adjustSelectionRectForSimpleText(const TextRun&, LayoutRect& selectionRect, unsigned from, unsigned to) const;
     void adjustSelectionRectForSimpleTextWithFixedPitch(const TextRun&, LayoutRect& selectionRect, unsigned from, unsigned to) const;
     float width(CodePath, const TextRun&, SingleThreadWeakHashSet<const Font>* fallbackFonts = nullptr, GlyphOverflow* = nullptr) const;
+    void computeGlyphOverflow(const GlyphBuffer&, float totalWidth, GlyphOverflow&) const;
     WEBCORE_EXPORT float widthForSimpleTextSlow(StringView text, TextDirection, GlyphGeometryCacheEntry*) const;
     ALWAYS_INLINE bool NODELETE canHandleRunAsSimpleText(const TextRun&, unsigned from, unsigned to) const;
 


### PR DESCRIPTION
#### 3dffd200a0fa5c3b72da26d37d3716f033fbb6b0
<pre>
exp: 2-layer cache interaction
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::computeGlyphOverflow const):
(WebCore::FontCascade::width const):
* Source/WebCore/platform/graphics/FontCascade.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3dffd200a0fa5c3b72da26d37d3716f033fbb6b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163105 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107820 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1470880f-e578-4509-8f39-dc0886eca9c1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156224 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27459 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119375 "Failure limit exceed. At least found 413 new test failures: accessibility/dialog-slotted-content.html accessibility/file-upload-button-stringvalue.html accessibility/press-targets-center-point.html compositing/backing/inline-block-no-backing.html compositing/shared-backing/update-backing-sharing-on-size-change.html css1/basic/containment.html css1/basic/contextual_selectors.html css1/basic/grouping.html css1/basic/id_as_selector.html css1/basic/inheritance.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84407 "Exiting early after 60 failures. 4601 tests run. 60 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/374858e5-564f-487b-a849-c7c0b2819bfc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157310 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21646 "Found 60 new test failures: editing/selection/ios/bidi-visually-contiguous-selection-10.html editing/selection/ios/bidi-visually-contiguous-selection-2.html editing/selection/ios/bidi-visually-contiguous-selection-3.html editing/selection/ios/bidi-visually-contiguous-selection-6.html editing/selection/ios/bidi-visually-contiguous-selection-7.html editing/selection/ios/bidi-visually-contiguous-selection-9.html editing/selection/ios/bidi-visually-contiguous-selection-extending.html editing/selection/ios/bidi-visually-contiguous-selection-multiline.html editing/selection/ios/bidi-visually-contiguous-selection.html fast/canvas/canvas-measureText-2.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138619 "Found 1 new API test failure: TestWebKitAPI.WebKitLegacyStringWidth.ThaiWidthForWeb (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100071 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20733 "Found 60 new test failures: imported/w3c/web-platform-tests/css/css-content/quotes-005.html imported/w3c/web-platform-tests/css/css-content/quotes-006.html imported/w3c/web-platform-tests/css/css-content/quotes-009.html imported/w3c/web-platform-tests/css/css-content/quotes-012.html imported/w3c/web-platform-tests/css/css-content/quotes-014.html imported/w3c/web-platform-tests/css/css-content/quotes-017.html imported/w3c/web-platform-tests/css/css-content/quotes-019.html imported/w3c/web-platform-tests/css/css-content/quotes-020.html imported/w3c/web-platform-tests/css/css-content/quotes-023.html imported/w3c/web-platform-tests/css/css-content/quotes-024.html ... (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18739 "Found 1 new API test failure: TestWebKitAPI.WebKitLegacyStringWidth.ThaiWidthForWeb (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10937 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130395 "Found 4 new API test failures: TestWebKitAPI.DocumentEditingContext.CharacterRectConsistencyWithRTLAndVerticalText, TestWebKitAPI.DocumentEditingContext.CharacterRectConsistency, TestWebKitAPI.DocumentEditingContext.CharacterRectConsistencyWithVerticalText, TestWebKitAPI.DocumentEditingContext.CharacterRectConsistencyWithRTL (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16464 "Found 1 new test failure: editing/selection/move-left-right.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165577 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8786 "Found 1 new failure in platform/graphics/FontCascade.cpp") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18073 "Found 60 new test failures: accessibility/text-marker/text-marker-bidi-element-arabic.html editing/mac/dictionary-lookup/dictionary-lookup-rtl.html editing/mac/input/devanagari-ligature.html editing/selection/extend-by-character-007.html editing/selection/extend-to-line-boundary.html fast/canvas/canvas-measureText-2.html fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127471 "Failure limit exceed. At least found 405 new test failures: accessibility/dialog-slotted-content.html accessibility/file-upload-button-stringvalue.html accessibility/press-targets-center-point.html compositing/backing/inline-block-no-backing.html compositing/shared-backing/update-backing-sharing-on-size-change.html css1/basic/containment.html css1/basic/contextual_selectors.html css1/basic/grouping.html css1/basic/id_as_selector.html css1/basic/inheritance.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27155 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22781 "Found 60 new test failures: accessibility/text-marker/text-marker-bidi-element-arabic.html editing/mac/dictionary-lookup/dictionary-lookup-rtl.html editing/mac/input/devanagari-ligature.html editing/selection/extend-by-character-007.html editing/selection/extend-to-line-boundary.html fast/canvas/canvas-measureText-2.html fast/dom/52776.html fast/lists/bidi-text-as-list-marker.html fast/overflow/scroll-div-hide-show.html fast/repaint/emoji-glyph-overflow-repaint-fail.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127616 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27079 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138257 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83712 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22507 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15049 "Found 60 new test failures: accessibility/text-marker/text-marker-bidi-element-arabic.html compositing/style-change/perspective-origin-change.html css3/blending/background-blend-mode-background-size-cover.html css3/masking/clip-path-margin-box.html editing/mac/dictionary-lookup/dictionary-lookup-rtl.html editing/mac/input/devanagari-ligature.html editing/selection/extend-by-character-007.html editing/selection/extend-to-line-boundary.html fast/canvas/canvas-measureText-2.html fast/canvas/webgl/gl-teximage-imagebitmap-memory.html ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26769 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90872 "Found 1 new failure in platform/graphics/FontCascade.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26350 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26581 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26423 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->