### PR TITLE
[WIP] FontCascade::width: populate shaping cache on simple text path to avoid redundant reshape

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -331,6 +331,18 @@ float FontCascade::width(const TextRun& run, SingleThreadWeakHashSet<const Font>
     if (!fallbackFonts)
         fallbackFonts = &localFallbackFonts;
 
+    TextShapingContext shapingContext { *this };
+    if (!glyphOverflow && shapingContext.hasKerningOrLigatures && !shapingContext.hasWordSpacingOrLetterSpacing
+        && !run.rtl() && !run.directionalOverride() && !run.expansion()
+        && run.length() <= ShapedTextCacheDefaults::maxTextLength
+        && !shouldUseComplexTextController(codePathToUse)
+        && isMainThread()) {
+        auto result = layoutText(codePathToUse, run, 0, run.length(), ForTextEmphasis::No);
+        if (cacheEntry)
+            cacheEntry->width = result.width;
+        return result.width;
+    }
+
     float result = width(codePathToUse, run, fallbackFonts, glyphOverflow);
     if (cacheEntry && fallbackFonts->isEmptyIgnoringNullReferences()) {
         cacheEntry->width = result;


### PR DESCRIPTION
#### 11fc07c40703bebed86d37f16f85d3483f2ab4bb
<pre>
[WIP] FontCascade::width: populate shaping cache on simple text path to avoid redundant reshape
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41d9254bedaea3fa5a6eaa879d25d98551a4cbc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168742 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114257 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161745 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123902 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86908 "9 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162834 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26155 "Found 3 new test failures: fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104526 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25207 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-002.html (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23681 "Found 1 new API test failure: TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16497 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134899 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21372 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171230 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17244 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23010 "Found 5 new test failures: fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed.html imported/w3c/web-platform-tests/css/css-fonts/cjk-kerning.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132166 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33022 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27762 "Found 5 new test failures: fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed.html imported/w3c/web-platform-tests/css/css-fonts/cjk-kerning.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132198 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33007 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143166 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91115 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26815 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19980 "Found 5 new test failures: fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed.html imported/w3c/web-platform-tests/css/css-fonts/cjk-kerning.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32516 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98913 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32013 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32260 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32164 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->