### PR TITLE
Avoid constantly updating models that are "at rest"

### DIFF
--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3521,10 +3521,6 @@ void RenderLayerBacking::contentChanged(ContentChangeType changeType, const std:
 
 #if ENABLE(MODEL_ELEMENT)
     if (changeType == ContentChangeType::Model) {
-#if ENABLE(GPU_PROCESS_MODEL)
-        if (m_graphicsLayer && m_graphicsLayer->drawsContent())
-            m_graphicsLayer->setNeedsDisplay();
-#endif
         compositor().scheduleCompositingLayerUpdate();
         return;
     }

--- a/Source/WebCore/rendering/RenderModel.cpp
+++ b/Source/WebCore/rendering/RenderModel.cpp
@@ -28,10 +28,7 @@
 
 #if ENABLE(MODEL_ELEMENT)
 
-#include "GraphicsLayer.h"
 #include "HTMLModelElement.h"
-#include "RenderLayer.h"
-#include "RenderLayerBacking.h"
 #include "RenderStyle.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -68,21 +65,8 @@ void RenderModel::update()
 {
     if (renderTreeBeingDestroyed())
         return;
-    
+
     contentChanged(ContentChangeType::Model);
-#if ENABLE(GPU_PROCESS_MODEL)
-    auto renderLayer = layer();
-    if (!renderLayer)
-        return;
-
-    auto backing = renderLayer->backing();
-    if (!backing)
-        return;
-
-    auto graphicsLayer = backing->graphicsLayer();
-    if (graphicsLayer)
-        graphicsLayer->setNeedsDisplay();
-#endif
 }
 
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
@@ -278,7 +278,7 @@ Vector<UniqueRef<WebCore::IOSurface>> RemoteGPU::createRenderBuffers(unsigned wi
 
     Vector<UniqueRef<WebCore::IOSurface>> ioSurfaces;
 
-    constexpr auto surfaceCount = 3;
+    constexpr auto surfaceCount = 2;
     for (auto i = 0; i < surfaceCount; ++i) {
         if (auto buffer = WebCore::IOSurface::create(nullptr, WebCore::IntSize(width, height), colorSpace, WebCore::IOSurface::Name::WebGPU, colorFormat)) {
             buffer->setOwnershipIdentity(processIdentity);

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.h
@@ -29,6 +29,7 @@
 #if ENABLE(GPU_PROCESS_MODEL)
 
 #include "ModelTypes.h"
+#include <WebCore/Color.h>
 #include <WebCore/Model.h>
 #include <WebCore/ModelPlayer.h>
 #include <WebCore/ModelPlayerAnimationState.h>
@@ -65,7 +66,7 @@ public:
 
     WebCore::ModelPlayerIdentifier identifier() const final;
     bool isPlaceholder() const final;
-    void update();
+    void scheduleUpdateIfNeeded();
 
 private:
     WebModelPlayer(WebCore::Page&, WebCore::ModelPlayerClient&);
@@ -115,10 +116,15 @@ private:
     Seconds currentTime() const final;
     void setCurrentTime(Seconds, CompletionHandler<void()>&&) final;
     void play(bool);
-    void simulate(float elapsedTime);
+    bool simulate(float elapsedTime);
     double duration() const final;
 
     void ensureOnMainThreadWithProtectedThis(Function<void(Ref<WebModelPlayer>)>&& task);
+    void startUpdateLoopIfNeeded();
+    void update();
+    bool render();
+    void scheduleDisplayUpdate();
+
     void setStageMode(WebCore::StageModeOperation) final;
     void notifyEntityTransformUpdated();
     void setEnvironmentMap(Ref<WebCore::SharedBuffer>&&) final;
@@ -132,8 +138,11 @@ private:
     RetainPtr<NSData> m_retainedData;
     WeakRef<WebCore::Page> m_page;
     mutable RefPtr<ModelDisplayBufferDisplayDelegate> m_contentsDisplayDelegate;
-    uint32_t m_currentTexture { 0 };
+    WeakPtr<WebCore::GraphicsLayer> m_graphicsLayer;
+    uint32_t m_renderTextureIndex { 0 };
+    uint32_t m_displayTextureIndex { 0 };
     WebCore::StageModeOperation m_stageMode { WebCore::StageModeOperation::None };
+    std::optional<WebCore::Color> m_backgroundColor;
     WebCore::IntSize m_currentPixelSize;
     bool m_didFinishLoading { false };
     enum class PauseState {
@@ -149,8 +158,12 @@ private:
     std::optional<WebCore::ModelPlayerAnimationState> m_cachedAnimationState;
     std::optional<std::unique_ptr<WebCore::ModelPlayerTransformState>> m_cachedTransformState;
     float m_playbackRate { 1.0f };
-    uint32_t m_completedFrames { 0 };
     bool m_isLooping { false };
+
+    bool m_isUpdateLoopRunning { false };
+    bool m_isUpdateScheduled { false };
+    bool m_isUpdating { false };
+    bool m_needsEntityTransformNotification { false };
 };
 
 }

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -36,6 +36,7 @@
 #import "RemoteGPUProxy.h"
 #import "WKStageModeOrbitSimulator.h"
 #import <WebCore/Document.h>
+#import <WebCore/DocumentEventLoop.h>
 #import <WebCore/FloatPoint3D.h>
 #import <WebCore/GPU.h>
 #import <WebCore/GraphicsLayer.h>
@@ -82,11 +83,8 @@ public:
         } else
             layer.clearContents();
 
-        layer.setNeedsDisplay();
-
         if (RefPtr player = m_modelPlayer.get())
-            player->update();
-
+            player->scheduleUpdateIfNeeded();
     }
     WebCore::GraphicsLayer::CompositingCoordinatesOrientation orientation() const final
     {
@@ -253,6 +251,9 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
     RefPtr corePage = m_page.get();
     m_modelLoader = nil;
     m_didFinishLoading = false;
+    m_renderTextureIndex = 0;
+    m_displayTextureIndex = 0;
+    m_isUpdateLoopRunning = false;
     RefPtr document = corePage->localTopDocument();
     if (!document)
         return;
@@ -336,6 +337,7 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
                     }
                 }
             }
+            protectedThis->startUpdateLoopIfNeeded();
         });
     } textureUpdatedCallback:^(NSArray<WKBridgeUpdateTexture *> *updateTexture) {
         ensureOnMainThreadWithProtectedThis([updateTexture] (Ref<WebModelPlayer> protectedThis) {
@@ -345,6 +347,7 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
                 }));
 
             [protectedThis->m_modelLoader requestCompleted:updateTexture];
+            protectedThis->startUpdateLoopIfNeeded();
         });
     } materialUpdatedCallback:^(NSArray<WKBridgeUpdateMaterial *> *updateMaterial) {
         ensureOnMainThreadWithProtectedThis([updateMaterial] (Ref<WebModelPlayer> protectedThis) {
@@ -354,6 +357,7 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
                 }));
 
             [protectedThis->m_modelLoader requestCompleted:updateMaterial];
+            protectedThis->startUpdateLoopIfNeeded();
         });
     }];
 
@@ -368,6 +372,7 @@ void WebModelPlayer::notifyEntityTransformUpdated()
     if (!model || !client || !model->entityTransform())
         return;
 
+    m_needsEntityTransformNotification = false;
     client->didUpdateEntityTransform(*this, WebCore::TransformationMatrix(static_cast<simd_float4x4>(*model->entityTransform())));
 }
 
@@ -397,9 +402,11 @@ void WebModelPlayer::sizeDidChange(WebCore::LayoutSize size)
             return;
 
         protectedThis->m_displayBuffers = WTF::move(newBuffers);
-        protectedThis->m_currentTexture = 0;
+        protectedThis->m_renderTextureIndex = 0;
+        protectedThis->m_displayTextureIndex = 0;
         if (protectedThis->m_contentsDisplayDelegate)
             RefPtr { protectedThis->m_contentsDisplayDelegate }->setDisplayBuffer(*protectedThis->displayBuffer());
+        protectedThis->startUpdateLoopIfNeeded();
     });
 
     if (RefPtr model = m_currentModel)
@@ -417,6 +424,7 @@ void WebModelPlayer::handleMouseDown(const WebCore::LayoutPoint& startingPoint, 
     if (!m_orbitSimulator)
         m_orbitSimulator = adoptNS([[WKStageModeOrbitSimulator alloc] init]);
     [m_orbitSimulator gestureDidBegin];
+    startUpdateLoopIfNeeded();
 }
 
 void WebModelPlayer::handleMouseMove(const WebCore::LayoutPoint& currentPoint, MonotonicTime)
@@ -434,10 +442,7 @@ void WebModelPlayer::handleMouseMove(const WebCore::LayoutPoint& currentPoint, M
         return;
 
     [orbitSimulator gestureDidUpdateWithDeltaX:totalDeltaX deltaY:totalDeltaY];
-    if (RefPtr model = m_currentModel) {
-        model->setRotation([orbitSimulator currentYaw], [orbitSimulator currentPitch]);
-        notifyEntityTransformUpdated();
-    }
+    startUpdateLoopIfNeeded();
 }
 
 bool WebModelPlayer::supportsMouseInteraction()
@@ -448,8 +453,10 @@ bool WebModelPlayer::supportsMouseInteraction()
 void WebModelPlayer::handleMouseUp(const WebCore::LayoutPoint&, MonotonicTime)
 {
     m_initialPoint = std::nullopt;
-    if (RetainPtr orbitSimulator = m_orbitSimulator)
+    if (RetainPtr orbitSimulator = m_orbitSimulator) {
         [orbitSimulator gestureDidEnd];
+        startUpdateLoopIfNeeded();
+    }
 }
 
 void WebModelPlayer::getCamera(CompletionHandler<void(std::optional<WebCore::HTMLModelElementCamera>&&)>&&)
@@ -525,23 +532,26 @@ bool WebModelPlayer::isPlaceholder() const
 
 void WebModelPlayer::configureGraphicsLayer(WebCore::GraphicsLayer& graphicsLayer, WebCore::ModelPlayerGraphicsLayerConfiguration&& configuration)
 {
+    m_graphicsLayer = graphicsLayer;
     graphicsLayer.setContentsDisplayDelegate(contentsDisplayDelegate(), WebCore::GraphicsLayer::ContentsLayerPurpose::Canvas);
     if (RefPtr currentModel = m_currentModel) {
         auto backgroundColor = configuration.backgroundColor;
-        if (backgroundColor.isValid()) {
+        if (backgroundColor.isValid() && m_backgroundColor != backgroundColor) {
+            m_backgroundColor = backgroundColor;
             auto opaqueColor = backgroundColor.opaqueColor();
             auto [r, g, b, _a] = opaqueColor.toResolvedColorComponentsInColorSpace(WebCore::ColorSpace::LinearSRGB);
             currentModel->setBackgroundColor(simd_make_float3(r, g, b));
+            startUpdateLoopIfNeeded();
         }
     }
 }
 
 const MachSendRight* WebModelPlayer::displayBuffer() const
 {
-    if (m_currentTexture >= m_displayBuffers.size())
+    if (m_displayTextureIndex >= m_displayBuffers.size())
         return nullptr;
 
-    return &m_displayBuffers[m_currentTexture];
+    return &m_displayBuffers[m_displayTextureIndex];
 }
 
 WebCore::GraphicsLayerContentsDisplayDelegate* WebModelPlayer::contentsDisplayDelegate()
@@ -555,35 +565,77 @@ WebCore::GraphicsLayerContentsDisplayDelegate* WebModelPlayer::contentsDisplayDe
     return m_contentsDisplayDelegate.get();
 }
 
-void WebModelPlayer::simulate(float elapsedTime)
+bool WebModelPlayer::simulate(float elapsedTime)
 {
     RefPtr model = m_currentModel;
-    if (!model || !m_didFinishLoading)
-        return;
+    if (!model)
+        return false;
 
     RetainPtr orbitSimulator = m_orbitSimulator;
     if (!orbitSimulator)
-        return;
-    if ([orbitSimulator stepWithElapsedTime:elapsedTime]) {
-        model->setRotation([orbitSimulator currentYaw], [orbitSimulator currentPitch]);
-        notifyEntityTransformUpdated();
+        return false;
+
+    bool isGestureActive = m_initialPoint.has_value();
+    bool inertiaActive = [orbitSimulator stepWithElapsedTime:elapsedTime];
+    if (isGestureActive || inertiaActive) {
+        float yaw = [orbitSimulator currentYaw];
+        float pitch = [orbitSimulator currentPitch];
+        model->setRotation(yaw, pitch);
+        m_needsEntityTransformNotification = true;
+        return true;
     }
+    return false;
 }
 
 void WebModelPlayer::setPlaybackRate(double newRate, CompletionHandler<void(double effectivePlaybackRate)>&& completion)
 {
     m_playbackRate = newRate;
+    startUpdateLoopIfNeeded();
     completion(newRate);
+}
+
+void WebModelPlayer::startUpdateLoopIfNeeded()
+{
+    if (m_isUpdateLoopRunning)
+        return;
+    m_isUpdateLoopRunning = true;
+    scheduleUpdateIfNeeded();
+}
+
+void WebModelPlayer::scheduleUpdateIfNeeded()
+{
+    if (!m_isUpdateLoopRunning || m_isUpdateScheduled)
+        return;
+
+    RefPtr corePage = m_page.get();
+    if (!corePage)
+        return;
+
+    RefPtr document = corePage->localTopDocument();
+    if (!document)
+        return;
+
+    m_isUpdateScheduled = true;
+    document->eventLoop().queueTask(WebCore::TaskSource::ModelElement, [protectedThis = Ref { *this }] {
+        protectedThis->m_isUpdateScheduled = false;
+        protectedThis->update();
+    });
 }
 
 void WebModelPlayer::update()
 {
+    if (!m_isUpdateLoopRunning || m_isUpdating)
+        return;
+
+    m_isUpdating = true;
+
     auto now = MonotonicTime::now();
     float elapsed = m_lastUpdateTime ? static_cast<float>((now - m_lastUpdateTime).seconds()) : (1.f / 60.f);
     float elapsedTime = std::clamp(elapsed, 1.f / 120.f, 1.f / 15.f);
     m_lastUpdateTime = now;
 
-    simulate(elapsedTime);
+    bool stageModeActive = simulate(elapsedTime);
+    bool isAtRest = paused() && !stageModeActive;
 
     auto timeDelta = paused() ? 0.f : (m_playbackRate * elapsedTime);
 
@@ -591,32 +643,58 @@ void WebModelPlayer::update()
     [m_modelLoader update:timeDelta completionHandler:[&completion] mutable {
         completion.signal();
     }];
-    if (!completion.waitFor(500_ms))
+    if (!completion.waitFor(500_ms)) {
+        m_isUpdating = false;
         return;
+    }
 
     if (!m_isLooping && !paused() && [m_modelLoader currentTime] >= [m_modelLoader duration])
         m_pauseState = PauseState::Paused;
 
-    if (m_didFinishLoading) {
-        if (RefPtr currentModel = m_currentModel) {
-            currentModel->render(m_currentTexture, [protectedThis = Ref { *this }] (bool result) mutable {
-                if (result) {
-                    protectedThis->m_completedFrames = std::min<uint32_t>(protectedThis->m_completedFrames + 1, protectedThis->m_displayBuffers.size());
-                    if (++protectedThis->m_currentTexture >= protectedThis->m_completedFrames)
-                        protectedThis->m_currentTexture = 0;
-                }
-            });
-        }
+    if (!render())
+        m_isUpdating = false;
 
-        if (!m_completedFrames)
-            return;
+    if (isAtRest)
+        m_isUpdateLoopRunning = false;
 
-        if (auto* machSendRight = displayBuffer(); machSendRight && contentsDisplayDelegate())
-            RefPtr { m_contentsDisplayDelegate }->setDisplayBuffer(*machSendRight);
-    }
+    if (m_needsEntityTransformNotification)
+        notifyEntityTransformUpdated();
+}
 
-    if (RefPtr client = m_client.get())
-        client->didUpdate(*this);
+bool WebModelPlayer::render()
+{
+    if (!m_didFinishLoading)
+        return false;
+
+    RefPtr currentModel = m_currentModel;
+    if (!currentModel)
+        return false;
+
+    uint32_t textureIndex = m_renderTextureIndex;
+    if (++m_renderTextureIndex >= m_displayBuffers.size())
+        m_renderTextureIndex = 0;
+
+    currentModel->render(textureIndex, [protectedThis = Ref { *this }, textureIndex] (bool result) mutable {
+        protectedThis->ensureOnMainThreadWithProtectedThis([result, textureIndex] (Ref<WebModelPlayer> protectedThis) {
+            protectedThis->m_isUpdating = false;
+            if (!result)
+                return;
+
+            protectedThis->m_displayTextureIndex = textureIndex;
+            if (auto* machSendRight = protectedThis->displayBuffer(); machSendRight && protectedThis->contentsDisplayDelegate())
+                RefPtr { protectedThis->m_contentsDisplayDelegate }->setDisplayBuffer(*machSendRight);
+
+            protectedThis->scheduleDisplayUpdate();
+        });
+    });
+
+    return true;
+}
+
+void WebModelPlayer::scheduleDisplayUpdate()
+{
+    if (RefPtr graphicsLayer = m_graphicsLayer.get())
+        graphicsLayer->setContentsNeedsDisplay();
 }
 
 bool WebModelPlayer::supportsTransform(WebCore::TransformationMatrix transformationMatrix)
@@ -637,6 +715,8 @@ void WebModelPlayer::play(bool playing)
             [m_modelLoader setCurrentTime:0];
         model->play(playing);
         m_pauseState = playing ? PauseState::Playing : PauseState::Paused;
+        if (playing)
+            startUpdateLoopIfNeeded();
     }
 }
 
@@ -647,6 +727,7 @@ void WebModelPlayer::setLoop(bool loop)
 
     m_isLooping = loop;
     [m_modelLoader setLoop:loop];
+    startUpdateLoopIfNeeded();
 }
 
 void WebModelPlayer::setAutoplay(bool autoplay)
@@ -678,6 +759,7 @@ void WebModelPlayer::setCurrentTime(Seconds currentTime, CompletionHandler<void(
 {
     double clamped = std::clamp(currentTime.seconds(), 0.0, duration());
     [m_modelLoader setCurrentTime:clamped];
+    startUpdateLoopIfNeeded();
     completion();
 }
 
@@ -698,6 +780,7 @@ void WebModelPlayer::setStageMode(WebCore::StageModeOperation stageMode)
     if (RefPtr model = m_currentModel) {
         model->setStageMode(m_stageMode);
         notifyEntityTransformUpdated();
+        startUpdateLoopIfNeeded();
     }
 }
 
@@ -706,6 +789,7 @@ void WebModelPlayer::setEntityTransform(WebCore::TransformationMatrix matrix)
     if (RefPtr model = m_currentModel) {
         model->setEntityTransform(static_cast<simd_float4x4>(matrix));
         notifyEntityTransformUpdated();
+        startUpdateLoopIfNeeded();
     }
 }
 
@@ -718,6 +802,7 @@ void WebModelPlayer::setEnvironmentMap(Ref<WebCore::SharedBuffer>&& data)
             m_environmentMap = std::nullopt;
         }
         success = true;
+        startUpdateLoopIfNeeded();
     } else
         m_environmentMap = WTF::move(data);
 
@@ -744,7 +829,10 @@ void WebModelPlayer::visibilityStateDidChange()
         m_modelLoader = nil;
         m_displayBuffers.clear();
         m_environmentMap = std::nullopt;
-        m_completedFrames = 0;
+        m_backgroundColor = std::nullopt;
+        m_isUpdateLoopRunning = false;
+        m_isUpdateScheduled = false;
+        m_isUpdating = false;
     }
 }
 


### PR DESCRIPTION
#### 3388dd2d1027cf92f3efa4976a7e835a54693e6d
<pre>
Avoid constantly updating models that are &quot;at rest&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=311530">https://bugs.webkit.org/show_bug.cgi?id=311530</a>
&lt;<a href="https://rdar.apple.com/172484538">rdar://172484538</a>&gt;

Reviewed by Mike Wyrzykowski.

Implement a clean update / render / display loop for the WebModelPlayer.
When no interaction or animations are playing the model is at rest and
stops updating and rendering.

* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::contentChanged):
* Source/WebCore/rendering/RenderModel.cpp:
(WebCore::RenderModel::update):
Remove extra `setNeedsDisplay` calls making it harder to reason about
the WebModelPlayer render loop.

* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::createRenderBuffers):
Use double-buffering for the WebModelPlayer.

* Source/WebKit/WebProcess/Model/WebModelPlayer.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::load):
(WebKit::WebModelPlayer::notifyEntityTransformUpdated):
(WebKit::WebModelPlayer::sizeDidChange):
(WebKit::WebModelPlayer::handleMouseDown):
(WebKit::WebModelPlayer::handleMouseMove):
(WebKit::WebModelPlayer::handleMouseUp):
(WebKit::WebModelPlayer::configureGraphicsLayer):
(WebKit::WebModelPlayer::displayBuffer const):
(WebKit::WebModelPlayer::simulate):
Only update the stagemode rotation from this one method, that runs at
most once per tick.
(WebKit::WebModelPlayer::setPlaybackRate):
(WebKit::WebModelPlayer::startUpdateLoopIfNeeded):
(WebKit::WebModelPlayer::scheduleUpdateIfNeeded):
(WebKit::WebModelPlayer::update):
(WebKit::WebModelPlayer::render):
(WebKit::WebModelPlayer::scheduleDisplayUpdate):
(WebKit::WebModelPlayer::play):
(WebKit::WebModelPlayer::setLoop):
(WebKit::WebModelPlayer::setCurrentTime):
(WebKit::WebModelPlayer::setStageMode):
(WebKit::WebModelPlayer::setEntityTransform):
(WebKit::WebModelPlayer::setEnvironmentMap):
(WebKit::WebModelPlayer::visibilityStateDidChange):
Implement the new update loop and trigger it from all the places where
something changes.

Canonical link: <a href="https://commits.webkit.org/310754@main">https://commits.webkit.org/310754@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a03952effa7450f5bd54bf27ff3009aa3e11e93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154751 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163511 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108221 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/163329a2-ce46-4579-9594-41ab2afd2bfa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119704 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84647 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157710 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138987 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100397 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0720f96a-1ace-4aec-9d2d-16441bc040d4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21086 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19097 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11337 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130748 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16831 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165985 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9272 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18440 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127805 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27555 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23137 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127945 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34738 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27479 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138624 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84184 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22838 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15418 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27171 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91273 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26749 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26980 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26822 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->