### PR TITLE
[Navigation API] Break up innerDispatchNavigateEvent into logical helpers

### DIFF
--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -1014,6 +1014,134 @@ static void waitForAllPromises(Document& document, const Vector<Ref<DOMPromise>>
     }
 }
 
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#inner-navigate-event-firing-algorithm Step 32
+void Navigation::setupInterceptionState(NavigateEvent& event, NavigationNavigationType navigationType, NavigationDestination& destination, Document& document, SerializedScriptValue* classicHistoryAPIState)
+{
+    ASSERT(event.wasIntercepted());
+
+    event.setInterceptionState(InterceptionState::Committed);
+
+    RefPtr fromNavigationHistoryEntry = currentEntry();
+    ASSERT(fromNavigationHistoryEntry);
+    if (!fromNavigationHistoryEntry) {
+        abortOngoingNavigation(event);
+        return;
+    }
+
+    {
+        auto& domGlobalObject = *jsCast<JSDOMGlobalObject*>(document.globalObject());
+        JSC::JSLockHolder locker(domGlobalObject.vm());
+        m_transition = NavigationTransition::create(navigationType, *fromNavigationHistoryEntry, DeferredPromise::create(domGlobalObject, DeferredPromise::Mode::RetainPromiseOnResolve).releaseNonNull());
+    }
+
+    if (navigationType == NavigationNavigationType::Traverse) {
+        m_suppressNormalScrollRestorationDuringOngoingNavigation = true;
+        // For intercepted traverse navigations, update the Navigation API state and fire currententrychange.
+        // This must happen AFTER the navigate event but BEFORE intercept handlers run.
+        // For committed promise timing:
+        // - If there are NO handlers (just intercept() called), fulfill committed now (before currententrychange)
+        // - If there ARE handlers (intercept({ handler() {...} })), fulfill committed after handlers are invoked
+        if (destination.sameDocument()) {
+            RefPtr entry = findEntryByKey(destination.key());
+            if (entry) {
+                document.updateURLForPushOrReplaceState(destination.url());
+
+                // Only notify committed now if there are no handlers to wait for
+                auto shouldNotifyCommited = event.handlers().isEmpty() ? ShouldNotifyCommitted::Yes : ShouldNotifyCommitted::No;
+                updateForNavigation(entry->associatedHistoryItem(), navigationType, ShouldCopyStateObjectFromCurrentEntry::No, shouldNotifyCommited);
+            }
+        }
+    } else if (navigationType == NavigationNavigationType::Reload) {
+        // Not in specification but matches chromium implementation and tests.
+        updateForNavigation(currentEntry()->associatedHistoryItem(), navigationType);
+    } else if (navigationType == NavigationNavigationType::Push || navigationType == NavigationNavigationType::Replace) {
+        auto historyHandling = navigationType == NavigationNavigationType::Replace ? NavigationHistoryBehavior::Replace : NavigationHistoryBehavior::Push;
+        frame()->loader().updateURLAndHistory(destination.url(), classicHistoryAPIState, historyHandling);
+    }
+}
+
+std::optional<Navigation::DispatchResult> Navigation::handleSameDocumentNavigation(NavigateEvent& event, NavigationNavigationType navigationType, NavigationAPIMethodTracker* apiMethodTracker, AbortController& abortController, Document& document)
+{
+    Vector<Ref<DOMPromise>> promiseList;
+
+    for (auto& handler : event.handlers()) {
+        auto callbackResult = handler->invoke();
+        if (callbackResult.type() != CallbackResultType::UnableToExecute) {
+            Ref promise = callbackResult.releaseReturnValue();
+            // Because rejection is reported as `navigateerror` event, we can mark this as handled.
+            if (!promise->isSuspended())
+                promise->markAsHandled();
+            promiseList.append(WTF::move(promise));
+        }
+    }
+
+    // For intercepted traverse navigations, notify committed after handlers have been invoked but before
+    // they complete. This ensures the correct event ordering.
+    if (navigationType == NavigationNavigationType::Traverse && event.wasIntercepted() && apiMethodTracker && !apiMethodTracker->committedToEntry)
+        notifyCommittedToEntry(apiMethodTracker, protect(currentEntry()).get(), navigationType);
+
+    // FIXME: this emulates the behavior of a Promise wrapped around waitForAll, but we may want the real
+    // thing if the ordering-and-transition tests show timing related issues related to this.
+    RefPtr scriptExecutionContext = this->scriptExecutionContext();
+    protect(scriptExecutionContext->eventLoop())->queueTask(TaskSource::DOMManipulation, [weakThis = WeakPtr { this }, promiseList, abortController = Ref { abortController }, document = Ref { document }, apiMethodTracker = RefPtr { apiMethodTracker }]() {
+        waitForAllPromises(document.get(), promiseList, [abortController, document, apiMethodTracker, weakThis]() mutable {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis || abortController->signal().aborted() || !document->isFullyActive() || !protectedThis->m_ongoingNavigateEvent)
+                return;
+
+            auto focusChanged = std::exchange(protectedThis->m_focusChangedDuringOngoingNavigation, FocusDidChange::No);
+            protect(protectedThis->ongoingNavigateEvent())->finish(document.get(), InterceptionHandlersDidFulfill::Yes, focusChanged);
+            protectedThis->m_ongoingNavigateEvent = nullptr;
+
+            protectedThis->dispatchEvent(Event::create(eventNames().navigatesuccessEvent, { }));
+
+            if (apiMethodTracker)
+                protectedThis->resolveFinishedPromise(apiMethodTracker.get());
+
+            if (RefPtr transition = std::exchange(protectedThis->m_transition, nullptr))
+                transition->resolvePromise();
+
+            protectedThis->m_ongoingNavigateEvent = nullptr;
+
+        }, [abortController, document, apiMethodTracker, weakThis](JSC::JSValue result) mutable {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis || abortController->signal().aborted() || !document->isFullyActive() || !protectedThis->m_ongoingNavigateEvent)
+                return;
+
+            auto focusChanged = std::exchange(protectedThis->m_focusChangedDuringOngoingNavigation, FocusDidChange::No);
+            protect(protectedThis->ongoingNavigateEvent())->finish(document.get(), InterceptionHandlersDidFulfill::No, focusChanged);
+
+            abortController->signal().signalAbort(result);
+
+            protectedThis->m_ongoingNavigateEvent = nullptr;
+
+            ErrorInformation errorInformation;
+            String errorMessage;
+            if (auto* errorInstance = jsDynamicCast<JSC::ErrorInstance*>(result)) {
+                if (auto result = extractErrorInformationFromErrorInstance(protect(protectedThis->scriptExecutionContext())->globalObject(), *errorInstance)) {
+                    errorInformation = WTF::move(*result);
+                    errorMessage = makeString("Uncaught "_s, errorInformation.errorTypeString, ": "_s, errorInformation.message);
+                }
+            }
+
+            auto* navGlobalObject = protect(protectedThis->scriptExecutionContext())->globalObject();
+            protectedThis->dispatchEvent(ErrorEvent::create(*navGlobalObject, eventNames().navigateerrorEvent, errorMessage, errorInformation.sourceURL, errorInformation.line, errorInformation.column, { navGlobalObject->vm(), result }));
+
+            if (apiMethodTracker)
+                Ref { apiMethodTracker->finishedPromise }->reject<IDLAny>(result, RejectAsHandled::Yes);
+
+            if (RefPtr transition = std::exchange(protectedThis->m_transition, nullptr))
+                transition->rejectPromise(result);
+        });
+    });
+
+    // If a new event has been dispatched in our event handler then we were aborted above.
+    if (m_ongoingNavigateEvent != &event)
+        return DispatchResult::Aborted;
+
+    return std::nullopt;
+}
+
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#inner-navigate-event-firing-algorithm
 Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavigationType navigationType, Ref<NavigationDestination>&& destination, const String& downloadRequestFilename, FormState* formState, SerializedScriptValue* classicHistoryAPIState, Element* sourceElement)
 {
@@ -1144,125 +1272,12 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
     // FIXME: Prepare to run script given navigation's relevant settings object.
 
     // Step 32:
-    if (event->wasIntercepted()) {
-        event->setInterceptionState(InterceptionState::Committed);
-
-        RefPtr fromNavigationHistoryEntry = currentEntry();
-        ASSERT(fromNavigationHistoryEntry);
-        if (!fromNavigationHistoryEntry) {
-            abortOngoingNavigation(event);
-            return DispatchResult::Aborted;
-        }
-
-        {
-            auto& domGlobalObject = *jsCast<JSDOMGlobalObject*>(scriptExecutionContext->globalObject());
-            JSC::JSLockHolder locker(domGlobalObject.vm());
-            m_transition = NavigationTransition::create(navigationType, *fromNavigationHistoryEntry, DeferredPromise::create(domGlobalObject, DeferredPromise::Mode::RetainPromiseOnResolve).releaseNonNull());
-        }
-
-        if (navigationType == NavigationNavigationType::Traverse) {
-            m_suppressNormalScrollRestorationDuringOngoingNavigation = true;
-            // For intercepted traverse navigations, update the Navigation API state and fire currententrychange.
-            // This must happen AFTER the navigate event but BEFORE intercept handlers run.
-            // For committed promise timing:
-            // - If there are NO handlers (just intercept() called), fulfill committed now (before currententrychange)
-            // - If there ARE handlers (intercept({ handler() {...} })), fulfill committed after handlers are invoked
-            if (destination->sameDocument()) {
-                RefPtr entry = findEntryByKey(destination->key());
-                if (entry) {
-                    document->updateURLForPushOrReplaceState(destination->url());
-
-                    // Only notify committed now if there are no handlers to wait for
-                    auto shouldNotifyCommited = event->handlers().isEmpty() ? ShouldNotifyCommitted::Yes : ShouldNotifyCommitted::No;
-                    updateForNavigation(entry->associatedHistoryItem(), navigationType, ShouldCopyStateObjectFromCurrentEntry::No, shouldNotifyCommited);
-                }
-            }
-        } else if (navigationType == NavigationNavigationType::Reload) {
-            // Not in specification but matches chromium implementation and tests.
-            updateForNavigation(currentEntry()->associatedHistoryItem(), navigationType);
-        } else if (navigationType == NavigationNavigationType::Push || navigationType == NavigationNavigationType::Replace) {
-            auto historyHandling = navigationType == NavigationNavigationType::Replace ? NavigationHistoryBehavior::Replace : NavigationHistoryBehavior::Push;
-            frame()->loader().updateURLAndHistory(destination->url(), classicHistoryAPIState, historyHandling);
-        }
-    }
+    if (event->wasIntercepted())
+        setupInterceptionState(event.get(), navigationType, destination.get(), *document, classicHistoryAPIState);
 
     if (endResultIsSameDocument) {
-        Vector<Ref<DOMPromise>> promiseList;
-
-        for (auto& handler : event->handlers()) {
-            auto callbackResult = handler->invoke();
-            if (callbackResult.type() != CallbackResultType::UnableToExecute) {
-                Ref promise = callbackResult.releaseReturnValue();
-                // Because rejection is reported as `navigateerror` event, we can mark this as handled.
-                if (!promise->isSuspended())
-                    promise->markAsHandled();
-                promiseList.append(WTF::move(promise));
-            }
-        }
-
-        // For intercepted traverse navigations, notify committed after handlers have been invoked but before
-        // they complete. This ensures the correct event ordering.
-        if (navigationType == NavigationNavigationType::Traverse && event->wasIntercepted() && apiMethodTracker && !apiMethodTracker->committedToEntry)
-            notifyCommittedToEntry(apiMethodTracker.get(), protect(currentEntry()).get(), navigationType);
-
-        // FIXME: this emulates the behavior of a Promise wrapped around waitForAll, but we may want the real
-        // thing if the ordering-and-transition tests show timing related issues related to this.
-        protect(scriptExecutionContext->eventLoop())->queueTask(TaskSource::DOMManipulation, [weakThis = WeakPtr { this }, promiseList, abortController, document, apiMethodTracker]() {
-            waitForAllPromises(*document, promiseList, [abortController, document, apiMethodTracker, weakThis]() mutable {
-                RefPtr protectedThis = weakThis.get();
-                if (!protectedThis || abortController->signal().aborted() || !document->isFullyActive() || !protectedThis->m_ongoingNavigateEvent)
-                    return;
-
-                auto focusChanged = std::exchange(protectedThis->m_focusChangedDuringOngoingNavigation, FocusDidChange::No);
-                protect(protectedThis->ongoingNavigateEvent())->finish(*document, InterceptionHandlersDidFulfill::Yes, focusChanged);
-                protectedThis->m_ongoingNavigateEvent = nullptr;
-
-                protectedThis->dispatchEvent(Event::create(eventNames().navigatesuccessEvent, { }));
-
-                if (apiMethodTracker)
-                    protectedThis->resolveFinishedPromise(apiMethodTracker.get());
-
-                if (RefPtr transition = std::exchange(protectedThis->m_transition, nullptr))
-                    transition->resolvePromise();
-
-                protectedThis->m_ongoingNavigateEvent = nullptr;
-
-            }, [abortController, document, apiMethodTracker, weakThis](JSC::JSValue result) mutable {
-                RefPtr protectedThis = weakThis.get();
-                if (!protectedThis || abortController->signal().aborted() || !document->isFullyActive() || !protectedThis->m_ongoingNavigateEvent)
-                    return;
-
-                auto focusChanged = std::exchange(protectedThis->m_focusChangedDuringOngoingNavigation, FocusDidChange::No);
-                protect(protectedThis->ongoingNavigateEvent())->finish(*document, InterceptionHandlersDidFulfill::No, focusChanged);
-
-                if (abortController)
-                    abortController->signal().signalAbort(result);
-
-                protectedThis->m_ongoingNavigateEvent = nullptr;
-
-                ErrorInformation errorInformation;
-                String errorMessage;
-                if (auto* errorInstance = jsDynamicCast<JSC::ErrorInstance*>(result)) {
-                    if (auto result = extractErrorInformationFromErrorInstance(protect(protectedThis->scriptExecutionContext())->globalObject(), *errorInstance)) {
-                        errorInformation = WTF::move(*result);
-                        errorMessage = makeString("Uncaught "_s, errorInformation.errorTypeString, ": "_s, errorInformation.message);
-                    }
-                }
-
-                auto* navGlobalObject = protect(protectedThis->scriptExecutionContext())->globalObject();
-                protectedThis->dispatchEvent(ErrorEvent::create(*navGlobalObject, eventNames().navigateerrorEvent, errorMessage, errorInformation.sourceURL, errorInformation.line, errorInformation.column, { navGlobalObject->vm(), result }));
-
-                if (apiMethodTracker)
-                    Ref { apiMethodTracker->finishedPromise }->reject<IDLAny>(result, RejectAsHandled::Yes);
-
-                if (RefPtr transition = std::exchange(protectedThis->m_transition, nullptr))
-                    transition->rejectPromise(result);
-            });
-        });
-
-        // If a new event has been dispatched in our event handler then we were aborted above.
-        if (m_ongoingNavigateEvent != event.ptr())
-            return DispatchResult::Aborted;
+        if (auto result = handleSameDocumentNavigation(event.get(), navigationType, apiMethodTracker.get(), *abortController, *document))
+            return *result;
     } else if (apiMethodTracker) {
         // For cross-document navigations, don't cleanup the tracker immediately.
         // It should remain ongoing until the navigation completes, fails, or gets interrupted.

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -245,6 +245,8 @@ private:
     Result performTraversal(JSC::JSGlobalObject&, const String& key, Navigation::Options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished);
     ExceptionOr<RefPtr<SerializedScriptValue>> serializeState(JSC::JSValue state);
     DispatchResult innerDispatchNavigateEvent(NavigationNavigationType, Ref<NavigationDestination>&&, const String& downloadRequestFilename, FormState* = nullptr, SerializedScriptValue* classicHistoryAPIState = nullptr, Element* sourceElement = nullptr);
+    void setupInterceptionState(NavigateEvent&, NavigationNavigationType, NavigationDestination&, Document&, SerializedScriptValue* classicHistoryAPIState);
+    std::optional<DispatchResult> handleSameDocumentNavigation(NavigateEvent&, NavigationNavigationType, NavigationAPIMethodTracker*, AbortController&, Document&);
 
     void setActivation(HistoryItem* previousItem, std::optional<NavigationNavigationType>);
 


### PR DESCRIPTION
#### c0722f0a0eda53df6c20f7d087243cd8e0abf138
<pre>
[Navigation API] Break up innerDispatchNavigateEvent into logical helpers
<a href="https://bugs.webkit.org/show_bug.cgi?id=311531">https://bugs.webkit.org/show_bug.cgi?id=311531</a>
<a href="https://rdar.apple.com/174120905">rdar://174120905</a>

Reviewed by Simon Fraser.

Extract two methods from innerDispatchNavigateEvent() to improve readability:

- setupInterceptionState(): Handles NavigateEvent interception setup including
  transition creation and type-specific navigation state updates (Traverse,
  Reload, Push/Replace). ~40 lines extracted.

- handleSameDocumentNavigation(): Handles same-document navigation handler
  invocation, promise settlement via waitForAllPromises, and dispatching
  navigatesuccess/navigateerror events. ~90 lines extracted.

This is a pure structural refactoring with no behavior change. The extracted
methods are called from innerDispatchNavigateEvent() at the same points where
the inline code previously existed.

* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::setupInterceptionState):
(WebCore::Navigation::handleSameDocumentNavigation):
(WebCore::Navigation::innerDispatchNavigateEvent):
* Source/WebCore/page/Navigation.h:

Canonical link: <a href="https://commits.webkit.org/310617@main">https://commits.webkit.org/310617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ab54e2a21ddd5e417c18c19839988536fa00297

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20805 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163142 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107856 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7fc6d085-f3a4-4e2a-a0ae-78d2975544a8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27779 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119407 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84439 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a21753df-7dee-45b3-a9ca-facf6a2b298e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157346 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21676 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100104 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3cccc630-e75d-4224-b9b3-f3f809aa5201) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20763 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18771 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10973 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130425 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16495 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165613 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8822 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18104 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127504 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127648 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34636 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138288 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83769 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22542 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15080 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26805 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90908 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26386 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26617 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26459 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->