### PR TITLE
perspective-origin fails to resolve var() when used as the second value

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-reference-perspective-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-reference-perspective-origin-expected.txt
@@ -1,0 +1,8 @@
+
+PASS var() as first value of perspective-origin
+PASS var() as second value of perspective-origin
+PASS var() as both values of perspective-origin
+PASS same var() for both values of perspective-origin
+PASS var() as second value with keyword
+PASS var() as first value with keyword
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-reference-perspective-origin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-reference-perspective-origin.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Variables: perspective-origin with var() references</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#perspective-origin-property">
+<link rel="help" href="https://drafts.csswg.org/css-variables-2/">
+<meta name="assert" content="perspective-origin correctly resolves CSS variables in both value positions">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+    .target {
+        width: 200px;
+        height: 200px;
+        perspective: 800px;
+    }
+</style>
+</head>
+<body>
+<script>
+function test_perspective_origin_var(style, expected, description) {
+    test(() => {
+        const div = document.createElement('div');
+        div.className = 'target';
+        div.setAttribute('style', style);
+        document.body.appendChild(div);
+        assert_equals(getComputedStyle(div).perspectiveOrigin, expected);
+        div.remove();
+    }, description);
+}
+
+test_perspective_origin_var(
+    '--x: 0%; perspective-origin: var(--x) 50%',
+    '0px 100px',
+    'var() as first value of perspective-origin'
+);
+
+test_perspective_origin_var(
+    '--y: 0%; perspective-origin: 50% var(--y)',
+    '100px 0px',
+    'var() as second value of perspective-origin'
+);
+
+test_perspective_origin_var(
+    '--x: 10%; --y: 20%; perspective-origin: var(--x) var(--y)',
+    '20px 40px',
+    'var() as both values of perspective-origin'
+);
+
+test_perspective_origin_var(
+    '--pos: 25%; perspective-origin: var(--pos) var(--pos)',
+    '50px 50px',
+    'same var() for both values of perspective-origin'
+);
+
+test_perspective_origin_var(
+    '--y: top; perspective-origin: 50% var(--y)',
+    '100px 0px',
+    'var() as second value with keyword'
+);
+
+test_perspective_origin_var(
+    '--x: left; perspective-origin: var(--x) 50%',
+    '0px 100px',
+    'var() as first value with keyword'
+);
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -1786,6 +1786,8 @@ inline bool PropertyParserCustom::consumeTransformOriginShorthand(CSSParserToken
 inline bool PropertyParserCustom::consumePerspectiveOriginShorthand(CSSParserTokenRange& range, PropertyParserState& state, const StylePropertyShorthand&, PropertyParserResult& result)
 {
     if (auto position = consumePositionUnresolved(range, state)) {
+        if (!range.atEnd())
+            return false;
         auto [positionX, positionY] = split(WTF::move(*position));
         result.addPropertyForCurrentShorthand(state, CSSPropertyPerspectiveOriginX, CSSPositionXValue::create(WTF::move(positionX)));
         result.addPropertyForCurrentShorthand(state, CSSPropertyPerspectiveOriginY, CSSPositionYValue::create(WTF::move(positionY)));


### PR DESCRIPTION
#### cb1338276a4d9230ca403c295d5fd8c273dc1ffc
<pre>
perspective-origin fails to resolve var() when used as the second value
<a href="https://bugs.webkit.org/show_bug.cgi?id=276121">https://bugs.webkit.org/show_bug.cgi?id=276121</a>
<a href="https://rdar.apple.com/131288246">rdar://131288246</a>

Reviewed by Sam Weinig.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

When parsing `perspective-origin: 50% var(--y)`, consumePositionUnresolved()
successfully parses `50%` as the first component but fails to parse `var()`
as the second. It then falls back to the one-component interpretation,
returning `{50%, center}` and leaving the var() token unconsumed.
consumePerspectiveOriginShorthand() returns true, preventing the substitution
function fallback in consumeStyleProperty() from ever being reached.

Fix by adding a range.atEnd() check in consumePerspectiveOriginShorthand(),
matching the pattern already used by consumeTransformOriginShorthand().

* Source/WebCore/css/parser/CSSPropertyParserCustom.h:
(WebCore::CSS::PropertyParserCustom::consumePerspectiveOriginShorthand):
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-reference-perspective-origin-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-reference-perspective-origin.html: Added.

Canonical link: <a href="https://commits.webkit.org/310650@main">https://commits.webkit.org/310650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7311369694c25fdf1ef896f4128f8c47bfe1e12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163133 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107847 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2784a45c-ffaa-408b-b1c0-7bb4afafdd23) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156251 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27486 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119398 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84431 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d77b81ce-4650-457b-b13c-4e694f915568) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157337 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21667 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138643 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100095 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a61092dd-e61c-4bdb-8ffb-282cc9e7a668) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20754 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18762 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10964 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130416 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165604 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8813 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18096 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127495 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27182 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22804 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127639 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34661 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27106 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138280 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83743 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22530 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15072 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26796 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90899 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26377 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26608 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26450 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->