### PR TITLE
Resync `css/css-transforms/parsing` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/WEB_FEATURES.yml
@@ -7,3 +7,10 @@ features:
   files:
   - backface-visibility-*
   - perspective-*
+- name: transforms2d
+  files:
+  - "*"
+  - "!rotate-parsing-computed.html"
+  - "!rotate-parsing-valid.html"
+  - "!backface-visibility-*"
+  - "!perspective-*"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/perspective-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/perspective-invalid-expected.txt
@@ -1,0 +1,5 @@
+
+PASS e.style['perspective'] = "1000" should not set the property value
+PASS e.style['perspective'] = "-1px" should not set the property value
+PASS e.style['perspective'] = "80%" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/perspective-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/perspective-invalid.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Transform Module Level 2: parsing perspective with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#perspective-property">
+<meta name="assert" content="perspective supports only the grammar 'none | <length [0,∞]>'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("perspective", "1000");
+test_invalid_value("perspective", "-1px");
+test_invalid_value("perspective", "80%");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/rotate-parsing-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/rotate-parsing-computed-expected.txt
@@ -12,8 +12,14 @@ PASS Property rotate value 'y 400grad'
 PASS Property rotate value '400grad y'
 PASS Property rotate value '0 0.5 0 400grad'
 PASS Property rotate value '0 1 0 400grad'
+FAIL Property rotate value '-0.5 0 0 400grad' assert_equals: expected "x -360deg" but got "x 360deg"
+FAIL Property rotate value '-1 0 0 400grad' assert_equals: expected "x -360deg" but got "x 360deg"
+FAIL Property rotate value '0 -0.5 0 400grad' assert_equals: expected "y -360deg" but got "y 360deg"
+FAIL Property rotate value '0 -1 0 400grad' assert_equals: expected "y -360deg" but got "y 360deg"
 PASS Property rotate value '400grad'
 PASS Property rotate value '400grad z'
 PASS Property rotate value '0 0 0.5 400grad'
 PASS Property rotate value '0 0 1 400grad'
+FAIL Property rotate value '0 0 -0.5 400grad' assert_equals: expected "-360deg" but got "360deg"
+FAIL Property rotate value '0 0 -1 400grad' assert_equals: expected "-360deg" but got "360deg"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/rotate-parsing-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/rotate-parsing-computed.html
@@ -37,11 +37,21 @@ test_computed_value("rotate", "400grad y", "y 360deg");
 test_computed_value("rotate", "0 0.5 0 400grad", "y 360deg");
 test_computed_value("rotate", "0 1 0 400grad", "y 360deg");
 
+// ...though if the axis is in the reverse direction, the angle is negated.
+test_computed_value("rotate", "-0.5 0 0 400grad", "x -360deg");
+test_computed_value("rotate", "-1 0 0 400grad", "x -360deg");
+
+test_computed_value("rotate", "0 -0.5 0 400grad", "y -360deg");
+test_computed_value("rotate", "0 -1 0 400grad", "y -360deg");
+
 // If the axis is parallel with the z axis the property must serialize as just an <angle>.
 test_computed_value("rotate", "400grad", "360deg");
 test_computed_value("rotate", "400grad z", "360deg");
 test_computed_value("rotate", "0 0 0.5 400grad", "360deg");
 test_computed_value("rotate", "0 0 1 400grad", "360deg");
+
+test_computed_value("rotate", "0 0 -0.5 400grad", "-360deg");
+test_computed_value("rotate", "0 0 -1 400grad", "-360deg");
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/rotate-parsing-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/rotate-parsing-valid-expected.txt
@@ -12,8 +12,14 @@ PASS e.style['rotate'] = "y 400grad" should set the property value
 PASS e.style['rotate'] = "400grad y" should set the property value
 PASS e.style['rotate'] = "0 0.5 0 400grad" should set the property value
 PASS e.style['rotate'] = "0 1 0 400grad" should set the property value
+FAIL e.style['rotate'] = "-0.5 0 0 400grad" should set the property value assert_equals: serialization should be canonical expected "x -400grad" but got "x 400grad"
+FAIL e.style['rotate'] = "-1 0 0 400grad" should set the property value assert_equals: serialization should be canonical expected "x -400grad" but got "x 400grad"
+FAIL e.style['rotate'] = "0 -0.5 0 400grad" should set the property value assert_equals: serialization should be canonical expected "y -400grad" but got "y 400grad"
+FAIL e.style['rotate'] = "0 -1 0 400grad" should set the property value assert_equals: serialization should be canonical expected "y -400grad" but got "y 400grad"
 PASS e.style['rotate'] = "400grad" should set the property value
 PASS e.style['rotate'] = "400grad z" should set the property value
 PASS e.style['rotate'] = "0 0 0.5 400grad" should set the property value
 PASS e.style['rotate'] = "0 0 1 400grad" should set the property value
+FAIL e.style['rotate'] = "0 0 -0.5 400grad" should set the property value assert_equals: serialization should be canonical expected "-400grad" but got "400grad"
+FAIL e.style['rotate'] = "0 0 -1 400grad" should set the property value assert_equals: serialization should be canonical expected "-400grad" but got "400grad"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/rotate-parsing-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/rotate-parsing-valid.html
@@ -35,11 +35,21 @@ test_valid_value("rotate", "400grad y", "y 400grad");
 test_valid_value("rotate", "0 0.5 0 400grad", "y 400grad");
 test_valid_value("rotate", "0 1 0 400grad", "y 400grad");
 
+// ...though if the axis is in the reverse direction, the angle is negated.
+test_valid_value("rotate", "-0.5 0 0 400grad", "x -400grad");
+test_valid_value("rotate", "-1 0 0 400grad", "x -400grad");
+
+test_valid_value("rotate", "0 -0.5 0 400grad", "y -400grad");
+test_valid_value("rotate", "0 -1 0 400grad", "y -400grad");
+
 // If the axis is parallel with the z axis the property must serialize as just an <angle>.
 test_valid_value("rotate", "400grad");
 test_valid_value("rotate", "400grad z", "400grad");
 test_valid_value("rotate", "0 0 0.5 400grad", "400grad");
 test_valid_value("rotate", "0 0 1 400grad", "400grad");
+
+test_valid_value("rotate", "0 0 -0.5 400grad", "-400grad");
+test_valid_value("rotate", "0 0 -1 400grad", "-400grad");
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/transform-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/transform-computed-expected.txt
@@ -1,4 +1,8 @@
 
 PASS Property transform value 'perspective(none)'
 PASS Property transform value 'perspective(10px)'
+PASS Property transform value 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)'
+PASS Property -webkit-transform value 'perspective(none)'
+PASS Property -webkit-transform value 'perspective(10px)'
+PASS Property -webkit-transform value 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/transform-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/transform-computed.html
@@ -18,10 +18,19 @@
 <body>
 <div id="target"></div>
 <script>
-test_computed_value("transform", "perspective(none)", "matrix(1, 0, 0, 1, 0, 0)");
-test_computed_value("transform", "perspective(10px)", "matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, -0.1, 0, 0, 0, 1)");
-
-// FIXME: This needs more tests to cover all the other transform functions.
+let props = ["transform"];
+if (CSS.supports("-webkit-transform", "none")) {
+  props.push("-webkit-transform");
+}
+if (CSS.supports("-moz-transform", "none")) {
+  props.push("-moz-transform");
+}
+for (let prop of props) {
+  test_computed_value(prop, "perspective(none)", "matrix(1, 0, 0, 1, 0, 0)");
+  test_computed_value(prop, "perspective(10px)", "matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, -0.1, 0, 0, 0, 1)");
+  test_computed_value(prop, "matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)", "matrix(1, 0, 0, 1, 0, 0)");
+  // FIXME: This needs more tests to cover all the other transform functions.
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/transform-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/transform-invalid-expected.txt
@@ -18,4 +18,5 @@ PASS e.style['transform'] = "skew(0, 0, 0)" should not set the property value
 PASS e.style['transform'] = "skewX(0, 0)" should not set the property value
 PASS e.style['transform'] = "skewY(0, 0)" should not set the property value
 PASS e.style['transform'] = "scaleX(2), scaleY(3)" should not set the property value
+FAIL e.style['transform'] = "perspective(1000)" should not set the property value assert_equals: expected "" but got "perspective(1000)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/transform-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/transform-invalid.html
@@ -42,6 +42,8 @@ test_invalid_value("transform", "skewX(0, 0)");
 test_invalid_value("transform", "skewY(0, 0)");
 
 test_invalid_value("transform", "scaleX(2), scaleY(3)");
+
+test_invalid_value("transform", "perspective(1000)");
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/w3c-import.log
@@ -18,6 +18,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/backface-visibility-computed.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/backface-visibility-invalid.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/backface-visibility-valid.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/perspective-invalid.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/perspective-origin-computed.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/perspective-origin-invalid.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/perspective-origin-valid.html
@@ -39,3 +40,6 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/translate-parsing-computed.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/translate-parsing-invalid.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/translate-parsing-valid.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-perspective-invalid.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-perspective-valid.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-transform-valid.tentative.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-perspective-invalid.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-perspective-invalid.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL e.style['-webkit-perspective'] = "calc(1000)" should not set the property value assert_equals: expected "" but got "calc(1000)"
+FAIL e.style['-webkit-perspective'] = "calc(25)" should not set the property value assert_equals: expected "" but got "calc(25)"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-perspective-invalid.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-perspective-invalid.tentative.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Compatibility: parsing -webkit-perspective with invalid values</title>
+<link rel="help" href="https://compat.spec.whatwg.org/#propdef--webkit-perspective">
+<link rel="help" href="https://github.com/whatwg/compat/issues/100">
+<meta name="assert" content="-webkit-perspective also supports '<number [0,∞]>' in addition to 'none | <length [0,∞]>', but not 'calc([ <number [0,∞]> ])'">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("-webkit-perspective", "calc(1000)");
+test_invalid_value("-webkit-perspective", "calc(25)");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-perspective-valid.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-perspective-valid.tentative-expected.txt
@@ -1,0 +1,12 @@
+
+PASS e.style['-webkit-perspective'] = "initial" should set the property value
+PASS e.style['-webkit-perspective'] = "inherit" should set the property value
+PASS e.style['-webkit-perspective'] = "unset" should set the property value
+PASS e.style['-webkit-perspective'] = "revert" should set the property value
+PASS e.style['-webkit-perspective'] = "revert-layer" should set the property value
+PASS e.style['-webkit-perspective'] = "none" should set the property value
+FAIL e.style['-webkit-perspective'] = "1000" should set the property value assert_equals: serialization should be canonical expected "1000px" but got "1000"
+FAIL e.style['-webkit-perspective'] = "25" should set the property value assert_equals: serialization should be canonical expected "25px" but got "25"
+PASS e.style['-webkit-perspective'] = "12px" should set the property value
+PASS e.style['-webkit-perspective'] = "3.5em" should set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-perspective-valid.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-perspective-valid.tentative.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Compatibility: parsing -webkit-perspective with valid values</title>
+<link rel="help" href="https://compat.spec.whatwg.org/#propdef--webkit-perspective">
+<link rel="help" href="https://github.com/whatwg/compat/issues/100">
+<meta name="assert" content="-webkit-perspective also supports '<number [0,∞]>' in addition to 'none | <length [0,∞]>'">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("-webkit-perspective", "initial");
+test_valid_value("-webkit-perspective", "inherit");
+test_valid_value("-webkit-perspective", "unset");
+test_valid_value("-webkit-perspective", "revert");
+test_valid_value("-webkit-perspective", "revert-layer");
+
+test_valid_value("-webkit-perspective", "none");
+test_valid_value("-webkit-perspective", "1000", "1000px");
+test_valid_value("-webkit-perspective", "25", "25px");
+test_valid_value("-webkit-perspective", "12px", "12px");
+test_valid_value("-webkit-perspective", "3.5em", "3.5em");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-transform-valid.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-transform-valid.tentative-expected.txt
@@ -1,0 +1,11 @@
+
+PASS e.style['-webkit-transform'] = "initial" should set the property value
+PASS e.style['-webkit-transform'] = "inherit" should set the property value
+PASS e.style['-webkit-transform'] = "unset" should set the property value
+PASS e.style['-webkit-transform'] = "revert" should set the property value
+PASS e.style['-webkit-transform'] = "revert-layer" should set the property value
+FAIL e.style['-webkit-transform'] = "perspective(1000)" should set the property value assert_equals: serialization should be canonical expected "perspective(1000px)" but got "perspective(1000)"
+FAIL e.style['-webkit-transform'] = "perspective(25)" should set the property value assert_equals: serialization should be canonical expected "perspective(25px)" but got "perspective(25)"
+PASS e.style['-webkit-transform'] = "perspective(12px)" should set the property value
+PASS e.style['-webkit-transform'] = "perspective(3.5em)" should set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-transform-valid.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-transform-valid.tentative.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Compatibility: parsing -webkit-transform with valid values</title>
+<link rel="help" href="https://compat.spec.whatwg.org/#propdef--webkit-transform">
+<link rel="help" href="https://github.com/whatwg/compat/issues/100">
+<meta name="assert" content="-webkit-transform additionally supports the function call 'perspective([ <number [0,∞]> ])' in '<transform-list>'">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("-webkit-transform", "initial");
+test_valid_value("-webkit-transform", "inherit");
+test_valid_value("-webkit-transform", "unset");
+test_valid_value("-webkit-transform", "revert");
+test_valid_value("-webkit-transform", "revert-layer");
+
+test_valid_value("-webkit-transform", "perspective(1000)", "perspective(1000px)");
+test_valid_value("-webkit-transform", "perspective(25)", "perspective(25px)");
+test_valid_value("-webkit-transform", "perspective(12px)");
+test_valid_value("-webkit-transform", "perspective(3.5em)");
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### f4a93a4b1be59208769f4293743ad14f43362549
<pre>
Resync `css/css-transforms/parsing` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=311533">https://bugs.webkit.org/show_bug.cgi?id=311533</a>
<a href="https://rdar.apple.com/174126458">rdar://174126458</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/d1bf16a5383b29e7bc7845cef5f5aa4775936613">https://github.com/web-platform-tests/wpt/commit/d1bf16a5383b29e7bc7845cef5f5aa4775936613</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/perspective-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/perspective-invalid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/rotate-parsing-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/rotate-parsing-computed.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/rotate-parsing-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/rotate-parsing-valid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/transform-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/transform-computed.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/transform-invalid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/transform-invalid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-perspective-invalid.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-perspective-invalid.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-perspective-valid.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-perspective-valid.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-transform-valid.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-transform-valid.tentative.html: Added.

Canonical link: <a href="https://commits.webkit.org/310614@main">https://commits.webkit.org/310614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62778c095c031c4d6d44667f9044f7ab0a488c94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163134 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107848 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/236cf190-32ef-4176-8aa4-c1324bfe13d8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119399 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84432 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f5f35105-49dc-4d55-86b7-c61329a4680b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21669 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138644 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100096 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/22681b2a-9565-48e3-9499-66d97d7d866d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20756 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18764 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10965 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130418 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165605 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18097 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127496 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27183 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127640 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34633 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27107 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138281 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83747 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22531 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15073 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26797 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26378 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26609 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26451 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->