### PR TITLE
clip-path: inset() border-radius dropped at specific sizes due to float precision

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-inset-round-rendering-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-inset-round-rendering-expected.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<title>CSS Test Reference</title>
+<style>
+body { margin: 0; }
+.test { display: inline-block; }
+#case1 {
+  width: 661px;
+  height: 445px;
+  clip-path: inset(50.25px 74.64px round 255.86px 255.86px 0px 0px / 172.25px 172.25px 0px 0px);
+}
+.inner {
+  background: green;
+  height: 100%;
+}
+</style>
+<div class="test" id="case1"><div class="inner"></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-inset-round-rendering-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-inset-round-rendering-ref.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<title>CSS Test Reference</title>
+<style>
+body { margin: 0; }
+.test { display: inline-block; }
+#case1 {
+  width: 661px;
+  height: 445px;
+  clip-path: inset(50.25px 74.64px round 255.86px 255.86px 0px 0px / 172.25px 172.25px 0px 0px);
+}
+.inner {
+  background: green;
+  height: 100%;
+}
+</style>
+<div class="test" id="case1"><div class="inner"></div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-inset-round-rendering.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-inset-round-rendering.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<title>clip-path: inset() border-radius not dropped due to floating-point precision</title>
+<link rel="help" href="https://drafts.csswg.org/css-shapes/#funcdef-basic-shape-inset">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=258125">
+<link rel="match" href="clip-path-inset-round-rendering-ref.html">
+<meta name="assert" content="clip-path: inset() with border-radius should render rounded corners even when constraint scaling of radii introduces floating-point imprecision.">
+<meta name="fuzzy" content="maxDifference=0-13; totalPixels=0-677" />
+<style>
+body { margin: 0; }
+.test { display: inline-block; }
+/*
+ * 661px x 445px with inset(11.2923% round 50% 50% 0 0) triggers a
+ * floating-point precision edge case where constrained radii sum can
+ * exceed the inset rect width by an epsilon, causing border-radius
+ * to be dropped entirely.
+ */
+#case1 {
+  width: 661px;
+  height: 445px;
+  clip-path: inset(11.2923% round 50% 50% 0 0);
+}
+.inner {
+  background: green;
+  height: 100%;
+}
+</style>
+<div class="test" id="case1"><div class="inner"></div></div>

--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -174,8 +174,18 @@ void Path::addRoundedRect(const FloatRoundedRect& roundedRect, PathRoundedRect::
         return;
 
     if (!roundedRect.isRenderable()) {
-        // If all the radii cannot be accommodated, return a rect.
-        addRect(roundedRect.rect());
+        // If radii cannot be accommodated (e.g. due to floating-point precision
+        // after constraint scaling), adjust them to fit rather than dropping them.
+        auto adjustedRect = roundedRect;
+        adjustedRect.adjustRadii();
+        if (!adjustedRect.isRounded()) {
+            addRect(adjustedRect.rect());
+            return;
+        }
+        if (isEmpty())
+            m_data = PathSegment(PathRoundedRect { adjustedRect, strategy });
+        else
+            protect(ensureImpl())->add(PathRoundedRect { adjustedRect, strategy });
         return;
     }
 


### PR DESCRIPTION
#### 785dda5a7b969116787e33654a459c03ece58021
<pre>
clip-path: inset() border-radius dropped at specific sizes due to float precision
<a href="https://bugs.webkit.org/show_bug.cgi?id=258125">https://bugs.webkit.org/show_bug.cgi?id=258125</a>
<a href="https://rdar.apple.com/110847266">rdar://110847266</a>

Reviewed by Simon Fraser.

Path::addRoundedRect() falls back to a plain rectangle when
FloatRoundedRect::isRenderable() returns false. After
calcBorderRadiiConstraintScaleFor() scales radii to fit the inset rect,
floating-point imprecision can cause the sum of adjacent scaled radii to
exceed the rect dimension by an epsilon, making isRenderable() fail.

Instead of dropping radii entirely, call adjustRadii() to re-constrain
them, matching the approach already used in
BackgroundPainter::clipRoundedInnerRect(). Only fall back to a plain
rect if adjustRadii() yields zero radii.

Tests: imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-inset-round-rendering-ref.html
 imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-inset-round-rendering.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-inset-round-rendering-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-inset-round-rendering-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-inset-round-rendering.html: Added.
* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::addRoundedRect):

Canonical link: <a href="https://commits.webkit.org/310643@main">https://commits.webkit.org/310643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ac9aec6cc57f33b2bef59becf6076368d8e0f35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163140 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107854 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/89b92d71-c6d0-40af-9989-3c3c9c249a37) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27493 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119404 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84438 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/800bd17e-94ed-42fd-92e0-c414846119e9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138653 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100101 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1aaf0aaa-0093-49b2-96cf-1c284ab9e1f7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20761 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18770 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10971 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130423 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165611 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8820 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18106 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127501 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27189 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22812 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127645 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34657 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27113 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138290 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83758 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22537 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15082 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26803 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90906 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26384 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26615 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26457 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->