### PR TITLE
base-select option hover style clipping with rotated transforms

### DIFF
--- a/LayoutTests/compositing/repaint/overflow-visible-transformed-child-repaint-expected.txt
+++ b/LayoutTests/compositing/repaint/overflow-visible-transformed-child-repaint-expected.txt
@@ -1,0 +1,21 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 108.00 100.00)
+          (bounds 235.00 354.00)
+          (drawsContent 1)
+          (repaint rects
+            (rect 0.00 0.00 235.00 353.00)
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/repaint/overflow-visible-transformed-child-repaint.html
+++ b/LayoutTests/compositing/repaint/overflow-visible-transformed-child-repaint.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        #container {
+            width: 200px;
+            height: 200px;
+            will-change: transform;
+            /* overflow: visible is the default */
+            margin: 100px;
+            background: gray;
+        }
+        .child {
+            width: 200px;
+            height: 40px;
+            background: blue;
+            transform-origin: right top;
+        }
+        .child:nth-child(1) { rotate: 0deg; }
+        .child:nth-child(2) { rotate: -15deg; }
+        .child:nth-child(3) { rotate: -30deg; }
+        .child:nth-child(4) { rotate: -45deg; }
+        .child:nth-child(5) { rotate: -60deg; }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        window.addEventListener('load', () => {
+            setTimeout(() => {
+                // Force compositing update before making changes.
+                if (window.internals)
+                    window.internals.layerTreeAsText(document);
+
+                document.body.offsetTop;
+
+                if (window.internals)
+                    window.internals.startTrackingRepaints();
+
+                // Change the container's background. This triggers repaint() on
+                // the container renderer, whose clippedOverflowRectForRepaint()
+                // is just the border box — it does not include transform overflow
+                // from the rotated children. The fix in setContentsNeedDisplayInRect
+                // expands the dirty rect to the full compositedBounds so the
+                // overflow region where rotated children extend is invalidated.
+                document.getElementById('container').style.backgroundColor = 'lightblue';
+
+                if (window.internals)
+                    document.getElementById('layers').textContent = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_REPAINT_RECTS);
+
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            }, 0);
+        }, false);
+    </script>
+</head>
+<body>
+    <div id="container">
+        <div class="child"></div>
+        <div class="child"></div>
+        <div class="child"></div>
+        <div class="child"></div>
+        <div class="child"></div>
+    </div>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/platform/ios/compositing/repaint/overflow-visible-transformed-child-repaint-expected.txt
+++ b/LayoutTests/platform/ios/compositing/repaint/overflow-visible-transformed-child-repaint-expected.txt
@@ -1,0 +1,21 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 108.00 100.00)
+          (bounds 235.00 353.50)
+          (drawsContent 1)
+          (repaint rects
+            (rect 0.00 0.00 234.50 353.00)
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5804,6 +5804,26 @@ bool RenderLayer::paintsWithTransform(OptionSet<PaintBehavior> paintBehavior) co
     return transform() && ((paintBehavior & PaintBehavior::FlattenCompositingLayers) || paintsToWindow);
 }
 
+bool RenderLayer::hasNonCompositedDescendantWithTransform() const
+{
+    auto checkLayers = [](auto layerList, auto& self) {
+        for (auto* child : layerList) {
+            if (child->isComposited() || child->paintsIntoProvidedBacking())
+                continue;
+            if (child->paintsWithTransform(PaintBehavior::Normal))
+                return true;
+            if (self(child->negativeZOrderLayers(), self)
+                || self(child->normalFlowLayers(), self)
+                || self(child->positiveZOrderLayers(), self))
+                return true;
+        }
+        return false;
+    };
+    return checkLayers(negativeZOrderLayers(), checkLayers)
+        || checkLayers(normalFlowLayers(), checkLayers)
+        || checkLayers(positiveZOrderLayers(), checkLayers);
+}
+
 bool RenderLayer::shouldPaintMask(OptionSet<PaintBehavior> paintBehavior, OptionSet<PaintLayerFlag> paintFlags) const
 {
     if (!renderer().hasMask())

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -912,6 +912,7 @@ public:
     inline bool canPaintTransparencyWithSetOpacity() const;
 
     bool paintsWithTransform(OptionSet<PaintBehavior>) const;
+    bool hasNonCompositedDescendantWithTransform() const;
     bool shouldPaintMask(OptionSet<PaintBehavior>, OptionSet<PaintLayerFlag>) const;
     bool shouldApplyClipPath(OptionSet<PaintBehavior>, OptionSet<PaintLayerFlag>) const;
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1072,6 +1072,10 @@ bool RenderLayerBacking::updateCompositedBounds()
     } else
         m_artificiallyInflatedBounds = false;
 
+    m_hasDescendantNonCompositedTransformOverflow = !m_owningLayer.isRenderViewLayer()
+        && !renderer().hasNonVisibleOverflow()
+        && m_owningLayer.hasNonCompositedDescendantWithTransform();
+
     return setCompositedBounds(layerBounds);
 }
 
@@ -3786,6 +3790,10 @@ void RenderLayerBacking::setContentsNeedDisplayInRect(const LayoutRect& r, Graph
     m_owningLayer.invalidateEventRegion(RenderLayer::EventRegionInvalidationReason::Paint);
 
     FloatRect pixelSnappedRectForPainting = snapRectToDevicePixelsIfNeeded(r, renderer());
+
+    if (m_hasDescendantNonCompositedTransformOverflow)
+        pixelSnappedRectForPainting.unite(snapRectToDevicePixelsIfNeeded(compositedBounds(), renderer()));
+
     CheckedRef frameView = renderer().view().frameView();
     if (m_isMainFrameRenderViewLayer && frameView->isTrackingRepaints())
         frameView->addTrackedRepaintRect(pixelSnappedRectForPainting);

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -498,6 +498,7 @@ private:
     bool m_needsEventRegionUpdate { true };
 #endif
     bool m_shouldPaintUsingCompositeCopy { false };
+    bool m_hasDescendantNonCompositedTransformOverflow { false };
 };
 
 enum CanvasCompositingStrategy {


### PR DESCRIPTION
#### 5bbbb9a1ff107b38f42e25515e28cb77bafff570
<pre>
base-select option hover style clipping with rotated transforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=311402">https://bugs.webkit.org/show_bug.cgi?id=311402</a>
<a href="https://rdar.apple.com/171933742">rdar://171933742</a>

Reviewed by NOBODY (OOPS!).

In <a href="https://patrickbrosset.com/lab/custom-select/folders/">https://patrickbrosset.com/lab/custom-select/folders/</a> the options
drawn outside the ::picker(select) rectangle have their :hover effect
clipped by the rectangle.

::picker(select) has a correctly sized composited layer, but only the
::picker(select)&apos;s border box is marked as dirty. The overflow region
where rotated options extend is never invalidated. This is a problem
when ::picker(select) gets repainted during :hover.

Test: compositing/repaint/overflow-visible-transformed-child-repaint.html
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bbbb9a1ff107b38f42e25515e28cb77bafff570

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163463 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108172 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/104b92b4-6c3a-47c1-9f38-cdf9f3f65ae2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156576 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27811 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119668 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84625 "3 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/507da9c0-e7c0-4100-9288-fa495ca1f527) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157662 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138934 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100362 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21041 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19059 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11289 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130703 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165937 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9154 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18387 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127770 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27507 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23099 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127909 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27431 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138571 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84130 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22804 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15365 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27123 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91225 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26701 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26932 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26774 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->