### PR TITLE
Skip site validation in WebStorage messages if StorageBlockingPolicy is AllowAll

### DIFF
--- a/Source/WTF/Scripts/GeneratePreferences.rb
+++ b/Source/WTF/Scripts/GeneratePreferences.rb
@@ -261,7 +261,7 @@ class Preferences
     @preferences.sort_by! { |p| p.humanReadableName.empty? ? p.name : p.humanReadableName }
     @exposedPreferences = @preferences.select { |p| p.exposed }
     @exposedFeatures = @exposedPreferences.select { |p| p.type == "bool" }
-    @sharedPreferencesForWebProcess = @exposedFeatures.select { |p| p.type == "bool" && p.sharedPreferenceForWebProcess }
+    @sharedPreferencesForWebProcess = @exposedPreferences.select { |p| p.sharedPreferenceForWebProcess }
     @inspectorOverridePreferences = @preferences.select { |p| p.hasInspectorOverride? }
 
     @preferencesBoundToSetting = @preferences.select { |p| !p.webcoreBinding }

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7955,6 +7955,7 @@ StorageBlockingPolicy:
       default: WebCore::StorageBlockingPolicy::BlockThirdParty
     WebCore:
       default: StorageBlockingPolicy::AllowAll
+  sharedPreferenceForWebProcess: true
 
 SubpixelInlineLayoutEnabled:
   type: bool

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -56,6 +56,7 @@
 #include <WebCore/IDBRequestData.h>
 #include <WebCore/SecurityOriginData.h>
 #include <WebCore/ServiceWorkerContextData.h>
+#include <WebCore/StorageBlockingPolicy.h>
 #include <WebCore/StorageEstimate.h>
 #include <WebCore/StorageUtilities.h>
 #include <WebCore/UniqueIDBDatabaseConnection.h>
@@ -1593,10 +1594,28 @@ bool NetworkStorageManager::isSiteAllowedForConnection(IPC::Connection::UniqueID
     });
 }
 
+bool NetworkStorageManager::canConnectionAccessSiteForWebStorage(IPC::Connection& connection, const WebCore::RegistrableDomain& site) const
+{
+    assertIsCurrent(workQueue());
+
+    // When storage blocking policy is AllowAll, third-party context will use non-partitioned storage,
+    // but currently m_allowedSitesForConnections only tracks first-party sites, so we skip the check.
+    auto isStorageBlockingPolicyAllowAll = [&]() {
+        if (auto preferences = sharedPreferencesForWebProcess(connection))
+            return preferences->storageBlockingPolicy == static_cast<uint32_t>(WebCore::StorageBlockingPolicy::AllowAll);
+        return true;
+    };
+
+    if (isStorageBlockingPolicyAllowAll())
+        return true;
+
+    return isSiteAllowedForConnection(connection.uniqueID(), site);
+}
+
 void NetworkStorageManager::connectToStorageArea(IPC::Connection& connection, WebCore::StorageType type, StorageAreaMapIdentifier sourceIdentifier, std::optional<StorageNamespaceIdentifier> namespaceIdentifier, const WebCore::ClientOrigin& origin, CompletionHandler<void(std::optional<StorageAreaIdentifier>, HashMap<String, String>, uint64_t)>&& completionHandler)
 {
     ASSERT(!RunLoop::isMain());
-    MESSAGE_CHECK_COMPLETION(isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { origin.topOrigin }), connection, completionHandler(std::nullopt, { }, StorageAreaBase::nextMessageIdentifier()));
+    MESSAGE_CHECK_COMPLETION(canConnectionAccessSiteForWebStorage(connection, WebCore::RegistrableDomain { origin.topOrigin }), connection, completionHandler(std::nullopt, { }, StorageAreaBase::nextMessageIdentifier()));
 
     MESSAGE_CHECK_COMPLETION(isStorageTypeEnabled(connection, type), connection, completionHandler(std::nullopt, { }, StorageAreaBase::nextMessageIdentifier()));
 
@@ -1637,7 +1656,7 @@ void NetworkStorageManager::connectToStorageAreaSync(IPC::Connection& connection
 void NetworkStorageManager::cancelConnectToStorageArea(IPC::Connection& connection, WebCore::StorageType type, std::optional<StorageNamespaceIdentifier> namespaceIdentifier, const WebCore::ClientOrigin& origin)
 {
     assertIsCurrent(workQueue());
-    MESSAGE_CHECK(isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { origin.topOrigin }), connection);
+    MESSAGE_CHECK(canConnectionAccessSiteForWebStorage(connection, WebCore::RegistrableDomain { origin.topOrigin }), connection);
 
     auto iterator = m_originStorageManagers.find(origin);
     if (iterator == m_originStorageManagers.end())
@@ -1672,7 +1691,7 @@ void NetworkStorageManager::disconnectFromStorageArea(IPC::Connection& connectio
     if (!storageArea)
         return;
 
-    MESSAGE_CHECK(isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { storageArea->origin().topOrigin }), connection);
+    MESSAGE_CHECK(canConnectionAccessSiteForWebStorage(connection, WebCore::RegistrableDomain { storageArea->origin().topOrigin }), connection);
 
     CheckedRef originStorageManager = this->originStorageManager(storageArea->origin());
     if (storageArea->storageType() == StorageAreaBase::StorageType::Local)
@@ -1691,7 +1710,7 @@ void NetworkStorageManager::setItem(IPC::Connection& connection, StorageAreaIden
     if (!storageArea)
         return completionHandler(hasError, WTF::move(allItems));
 
-    MESSAGE_CHECK_COMPLETION(isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { storageArea->origin().topOrigin }), connection, completionHandler(hasError, WTF::move(allItems)));
+    MESSAGE_CHECK_COMPLETION(canConnectionAccessSiteForWebStorage(connection, WebCore::RegistrableDomain { storageArea->origin().topOrigin }), connection, completionHandler(hasError, WTF::move(allItems)));
 
     MESSAGE_CHECK_COMPLETION(isStorageAreaTypeEnabled(connection, storageArea->storageType()), connection, completionHandler(true, HashMap<String, String> { }));
 
@@ -1714,7 +1733,7 @@ void NetworkStorageManager::removeItem(IPC::Connection& connection, StorageAreaI
     if (!storageArea)
         return completionHandler(hasError, WTF::move(allItems));
 
-    MESSAGE_CHECK_COMPLETION(isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { storageArea->origin().topOrigin }), connection, completionHandler(hasError, WTF::move(allItems)));
+    MESSAGE_CHECK_COMPLETION(canConnectionAccessSiteForWebStorage(connection, WebCore::RegistrableDomain { storageArea->origin().topOrigin }), connection, completionHandler(hasError, WTF::move(allItems)));
 
     MESSAGE_CHECK_COMPLETION(isStorageAreaTypeEnabled(connection, storageArea->storageType()), connection, completionHandler(true, HashMap<String, String> { }));
 
@@ -1735,7 +1754,7 @@ void NetworkStorageManager::clear(IPC::Connection& connection, StorageAreaIdenti
     if (!storageArea)
         return completionHandler();
 
-    MESSAGE_CHECK_COMPLETION(isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { storageArea->origin().topOrigin }), connection, completionHandler());
+    MESSAGE_CHECK_COMPLETION(canConnectionAccessSiteForWebStorage(connection, WebCore::RegistrableDomain { storageArea->origin().topOrigin }), connection, completionHandler());
 
     MESSAGE_CHECK_COMPLETION(isStorageAreaTypeEnabled(connection, storageArea->storageType()), connection, completionHandler());
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -290,6 +290,7 @@ private:
     void setStorageSiteValidationEnabledInternal(bool);
     void updateAllowedSitesForConnectionInternal(IPC::Connection::UniqueID, std::optional<HashSet<WebCore::RegistrableDomain>>&&);
     bool isSiteAllowedForConnection(IPC::Connection::UniqueID, const WebCore::RegistrableDomain&) const;
+    bool canConnectionAccessSiteForWebStorage(IPC::Connection&, const WebCore::RegistrableDomain&) const;
 
     WeakPtr<NetworkProcess> m_process;
     PAL::SessionID m_sessionID;

--- a/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.cpp.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.cpp.erb
@@ -40,10 +40,14 @@ SharedPreferencesForWebProcess sharedPreferencesForWebProcess(const WebPreferenc
 <%- if @pref.condition -%>
 #if <%= @pref.condition %>
 <%- end -%>
+<%- if @pref.type == "bool" -%>
 <%- if @pref.opts["disableInLockdownMode"] -%>
     sharedPreferences.<%= @pref.nameLower %> = !isLockdownModeEnabled && preferencesStore.getBoolValueForKey(WebPreferencesKey::<%= @pref.nameLower %>Key());
 <%- else -%>
     sharedPreferences.<%= @pref.nameLower %> = preferencesStore.getBoolValueForKey(WebPreferencesKey::<%= @pref.nameLower %>Key());
+<%- end -%>
+<%- elsif @pref.type == "uint32_t" -%>
+    sharedPreferences.<%= @pref.nameLower %> = preferencesStore.getUInt32ValueForKey(WebPreferencesKey::<%= @pref.nameLower %>Key());
 <%- end -%>
 <%- if @pref.condition -%>
 #endif
@@ -59,6 +63,7 @@ bool updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess& shared
 <%- if @pref.condition -%>
 #if <%= @pref.condition %>
 <%- end -%>
+<%- if @pref.type == "bool" -%>
 <%- if @pref.opts["disableInLockdownMode"] -%>
     if (!isLockdownModeEnabled && preferencesStore.getBoolValueForKey(WebPreferencesKey::<%= @pref.nameLower %>Key()) && !sharedPreferences.<%= @pref.nameLower %>) {
         sharedPreferences.<%= @pref.nameLower %> = true;
@@ -68,6 +73,15 @@ bool updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess& shared
     if (preferencesStore.getBoolValueForKey(WebPreferencesKey::<%= @pref.nameLower %>Key()) && !sharedPreferences.<%= @pref.nameLower %>) {
         sharedPreferences.<%= @pref.nameLower %> = true;
         didChange = true;
+    }
+<%- end -%>
+<%- elsif @pref.type == "uint32_t" -%>
+    {
+        auto value = preferencesStore.getUInt32ValueForKey(WebPreferencesKey::<%= @pref.nameLower %>Key());
+        if (value != sharedPreferences.<%= @pref.nameLower %>) {
+            sharedPreferences.<%= @pref.nameLower %> = value;
+            didChange = true;
+        }
     }
 <%- end -%>
 <%- if @pref.condition -%>

--- a/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.h.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.h.erb
@@ -37,7 +37,11 @@ struct SharedPreferencesForWebProcess {
 <%- if @pref.condition -%>
 #if <%= @pref.condition %>
 <%- end -%>
+<%- if @pref.type == "bool" -%>
     bool <%= @pref.nameLower %> : 1 { false };
+<%- elsif @pref.type == "uint32_t" -%>
+    uint32_t <%= @pref.nameLower %> { 0 };
+<%- end -%>
 <%- if @pref.condition -%>
 #endif
 <%- end -%>

--- a/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.serialization.in.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.serialization.in.erb
@@ -29,7 +29,11 @@ struct WebKit::SharedPreferencesForWebProcess {
 <%- if @pref.condition -%>
 #if <%= @pref.condition %>
 <%- end -%>
+<%- if @pref.type == "bool" -%>
     [BitField] bool <%= @pref.nameLower %>;
+<%- elsif @pref.type == "uint32_t" -%>
+    uint32_t <%= @pref.nameLower %>;
+<%- end -%>
 <%- if @pref.condition -%>
 #endif
 <%- end -%>

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -2369,6 +2369,12 @@ WKWebViewConfiguration *WebExtensionContext::webViewConfiguration(WebViewPurpose
         preferences.inactiveSchedulingPolicy = WKInactiveSchedulingPolicyNone;
     }
 
+    if (purpose == WebViewPurpose::Inspector) {
+        // Match the Web Inspector's own AllowAll policy (see WKInspectorViewController.mm) so that
+        // the extension inspector background page shares the same process as the inspector web view.
+        preferences._storageBlockingPolicy = _WKStorageBlockingPolicyAllowAll;
+    }
+
     return configuration;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
@@ -1402,4 +1402,53 @@ TEST(StorageSiteValidation, LoadWebArchive)
     EXPECT_FALSE(webContentProcessTerminated);
 }
 
+TEST(StorageSiteValidation, StorageBlockingPolicyAllowAll)
+{
+    HTTPServer server({
+        { "/setitem"_s, { "<script>window.localStorage.setItem('key', 'value')</script>"_s } },
+        { "/getitem"_s, { "<script>window.webkit.messageHandlers.testHandler.postMessage(localStorage.getItem('key'));</script>"_s } },
+        { "/webkit"_s, { "<iframe src='https://example.com/getitem'></iframe>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    [[configuration websiteDataStore] _setStorageSiteValidationEnabled:YES];
+    // _WKStorageBlockingPolicyAllowAll allows 3rd-party to use unpartitioned storage for WebStorage.
+    [[configuration preferences] _setStorageBlockingPolicy:_WKStorageBlockingPolicyAllowAll];
+    RetainPtr messageHandler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
+    RetainPtr sharedDelegate = adoptNS([TestNavigationDelegate new]);
+    [sharedDelegate allowAnyTLSCertificate];
+    RetainPtr setWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [setWebView setNavigationDelegate:sharedDelegate.get()];
+    RetainPtr getWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [getWebView setNavigationDelegate:sharedDelegate.get()];
+
+    [setWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/setitem"]]];
+    [sharedDelegate waitForDidFinishNavigation];
+
+    // Ensure item is stored by getting it from a different view.
+    receivedScriptMessage = false;
+    [getWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/getitem"]]];
+    TestWebKitAPI::Util::run(&receivedScriptMessage);
+    EXPECT_WK_STREQ(@"value", [lastScriptMessage body]);
+
+    RetainPtr validateDelegate = adoptNS([TestNavigationDelegate new]);
+    [validateDelegate allowAnyTLSCertificate];
+    __block bool webContentProcessTerminated = false;
+    validateDelegate.get().webContentProcessDidTerminate = ^(WKWebView *view, _WKProcessTerminationReason reason) {
+        // Setting receivedScriptMessage to end wait if web process is terminated.
+        receivedScriptMessage = true;
+        webContentProcessTerminated = true;
+    };
+    RetainPtr validateWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [validateWebView setNavigationDelegate:validateDelegate.get()];
+
+    // Validate that 3rd-party frame can get the item.
+    receivedScriptMessage = false;
+    [validateWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org/webkit"]]];
+    TestWebKitAPI::Util::run(&receivedScriptMessage);
+    EXPECT_WK_STREQ(@"value", [lastScriptMessage body]);
+    EXPECT_FALSE(webContentProcessTerminated);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### fca31e67e9f6ee2753de81cdde7b8585a70e05a1
<pre>
Skip site validation in WebStorage messages if StorageBlockingPolicy is AllowAll
<a href="https://rdar.apple.com/174127236">rdar://174127236</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311535">https://bugs.webkit.org/show_bug.cgi?id=311535</a>

Reviewed by Chris Dumez.

In current implementation, when StorageBlockingPolicy is AllowAll, third-party context will use non-partitioned storage
for WebStorage. For example, apple.com iframe embedded in webkit.org will have access to the same WebStorage data as
apple.com loaded in main frame. However, NetworkStorageManager::m_allowedSitesForConnections only records sites of
first-party context -- if a web process loads webkit.org that has an apple.com iframe, the web process will only have
access to webkit.org, but not apple.com; and when the process asks for data of apple.com, the process can get killed for
failing site validation.

To fix this, we may have UI process also send third-party context sites to network process; but StorageBlockingPolicy
AllowAll is not a common configuration (default value is BlockThirdParty), and this information will be only used for
WebStorage (other types all use partitioned storage). Therefore, this patch simply disables the validation in this case.

To make sure network process can check for StorageBlockingPolicy (which is uint32_t instead of bool), this patch also
modifies script that generates SharedPreferencesForWebProcess to support type uint32_t. With this change, some web
inspector tests like WKWebExtensionAPIDevTools.MessagePassingFromPanelToDevToolsBackground start to hit debug assertion
in WebExtensionContext::loadInspectorBackgroundPage. The direct cause is extension inspector background page no longer
uses same web process as web inspector page, and the root cause is their shared preferences don&apos;t match -- inspector
page uses AllowAll blocking policy, while extension page uses default BlockThirdParty policy, which causes the
hasSameGPUAndNetworkProcessPreferencesAs check in WebProcessPool::createWebPage to fail, even though the two pages are
marked as related page. To fix this, make sure the extension page also uses the AllowAll policy.

API test: StorageSiteValidation.StorageBlockingPolicyAllowAll

* Source/WTF/Scripts/GeneratePreferences.rb:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::canConnectionAccessSiteForWebStorage const):
(WebKit::NetworkStorageManager::connectToStorageArea):
(WebKit::NetworkStorageManager::cancelConnectToStorageArea):
(WebKit::NetworkStorageManager::disconnectFromStorageArea):
(WebKit::NetworkStorageManager::setItem):
(WebKit::NetworkStorageManager::removeItem):
(WebKit::NetworkStorageManager::clear):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.cpp.erb:
* Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.h.erb:
* Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.serialization.in.erb:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::webViewConfiguration):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm:
(TestWebKitAPI::(StorageSiteValidation, StorageBlockingPolicyAllowAll)):

Canonical link: <a href="https://commits.webkit.org/310806@main">https://commits.webkit.org/310806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abc09c1c6b5bed45fab0357de5a61feb7d8743f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21442 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163783 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156896 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28131 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119940 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139216 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100633 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/154343 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11609 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147073 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130954 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166259 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15854 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/9891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18668 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128042 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27827 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23364 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128180 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34777 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27751 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138852 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84460 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23057 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15647 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186810 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27443 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91547 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47866 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27021 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27252 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27094 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->