### PR TITLE
[GTK][WebRTC] Avoid gst_webrtc_error_quark() link failure in GStreamerIceAgent

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
@@ -119,6 +119,11 @@ typedef struct _WebKitGstIceAgentClass {
 GST_DEBUG_CATEGORY(webkit_webrtc_rice_debug);
 #define GST_CAT_DEFAULT webkit_webrtc_rice_debug
 
+static GQuark webkitGstWebRTCErrorQuark()
+{
+    return g_quark_from_static_string("gst-webrtc-error-quark");
+}
+
 WEBKIT_DEFINE_TYPE_WITH_CODE(WebKitGstIceAgent, webkit_gst_webrtc_ice_backend, GST_TYPE_WEBRTC_ICE, GST_DEBUG_CATEGORY_INIT(webkit_webrtc_rice_debug, "webkitwebrtcrice", 0, "WebRTC Rice ICE backend"))
 
 using namespace WebCore;
@@ -476,7 +481,7 @@ static void webkitGstWebRTCIceAgentAddCandidate(GstWebRTCICE* ice, GstWebRTCICES
         auto errorMessageString = errorMessage.utf8();
         GST_ERROR_OBJECT(ice, "%s", errorMessageString.data());
         if (promise) {
-            GUniquePtr<GError> error(g_error_new(GST_WEBRTC_ERROR, GST_WEBRTC_ERROR_INTERNAL_FAILURE, "%s", errorMessageString.data()));
+            GUniquePtr<GError> error(g_error_new(webkitGstWebRTCErrorQuark(), GST_WEBRTC_ERROR_INTERNAL_FAILURE, "%s", errorMessageString.data()));
             gst_promise_reply(promise, gst_structure_new("application/x-gst-promise", "error", G_TYPE_ERROR, error.get(), nullptr));
         }
         return;
@@ -488,7 +493,7 @@ static void webkitGstWebRTCIceAgentAddCandidate(GstWebRTCICE* ice, GstWebRTCICES
         auto errorMessageString = errorMessage.utf8();
         GST_ERROR_OBJECT(ice, "%s", errorMessageString.data());
         if (promise) {
-            GUniquePtr<GError> error(g_error_new(GST_WEBRTC_ERROR, GST_WEBRTC_ERROR_INTERNAL_FAILURE, "%s", errorMessageString.data()));
+            GUniquePtr<GError> error(g_error_new(webkitGstWebRTCErrorQuark(), GST_WEBRTC_ERROR_INTERNAL_FAILURE, "%s", errorMessageString.data()));
             gst_promise_reply(promise, gst_structure_new("application/x-gst-promise", "error", G_TYPE_ERROR, error.get(), nullptr));
         }
         return;
@@ -507,7 +512,7 @@ static void webkitGstWebRTCIceAgentAddCandidate(GstWebRTCICE* ice, GstWebRTCICES
             auto errorMessageString = errorMessage.utf8();
             GST_ERROR("%s", errorMessageString.data());
             if (promise) {
-                GUniquePtr<GError> error(g_error_new(GST_WEBRTC_ERROR, GST_WEBRTC_ERROR_INTERNAL_FAILURE, "%s", errorMessageString.data()));
+                GUniquePtr<GError> error(g_error_new(webkitGstWebRTCErrorQuark(), GST_WEBRTC_ERROR_INTERNAL_FAILURE, "%s", errorMessageString.data()));
                 gst_promise_reply(promise.get(), gst_structure_new("application/x-gst-promise", "error", G_TYPE_ERROR, error.get(), nullptr));
             }
             return;
@@ -526,7 +531,7 @@ static void webkitGstWebRTCIceAgentAddCandidate(GstWebRTCICE* ice, GstWebRTCICES
             auto errorMessage = "Unable to create Rice candidate from SDP"_s;
             GST_ERROR("%s", errorMessage.characters());
             if (promise) {
-                GUniquePtr<GError> error(g_error_new(GST_WEBRTC_ERROR, GST_WEBRTC_ERROR_INTERNAL_FAILURE, "%s", errorMessage.characters()));
+                GUniquePtr<GError> error(g_error_new(webkitGstWebRTCErrorQuark(), GST_WEBRTC_ERROR_INTERNAL_FAILURE, "%s", errorMessage.characters()));
                 gst_promise_reply(promise.get(), gst_structure_new("application/x-gst-promise", "error", G_TYPE_ERROR, error.get(), nullptr));
             }
         }


### PR DESCRIPTION
#### 051965b557800ec9707b36381de57feaf9a3a0d9
<pre>
[GTK][WebRTC] Avoid gst_webrtc_error_quark() link failure in GStreamerIceAgent
<a href="https://bugs.webkit.org/show_bug.cgi?id=311527">https://bugs.webkit.org/show_bug.cgi?id=311527</a>

Reviewed by NOBODY (OOPS!).

Replace the four uses of `GST_WEBRTC_ERROR` in `GStreamerIceAgent.cpp` with a
file-local helper that returns the WebRTC error-domain quark using
`g_quark_from_static_string(&quot;gst-webrtc-error-quark&quot;)`.

This avoids the `gst_webrtc_error_quark()` link failure seen when building the
GTK port with WebRTC and `USE_LIBRICE=ON` enabled.

No new tests were added because this is a build/link failure in the GTK
GStreamer WebRTC code path, and I do not have a practical regression test for
this specific linker issue.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp:
(webkitGstWebRTCErrorQuark):
(webkitGstWebRTCIceAgentAddCandidate):
Avoid `GST_WEBRTC_ERROR` at the four `g_error_new(...)` call sites and use a
file-local error-domain helper instead.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/051965b557800ec9707b36381de57feaf9a3a0d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163146 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107860 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156264 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27499 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119411 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84445 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157350 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138657 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100108 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20769 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18776 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10977 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130431 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16501 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165617 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8826 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18110 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127508 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22818 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127652 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27119 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138294 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/83772 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22545 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15086 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26809 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90912 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26390 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26621 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26463 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->