### PR TITLE
-webkit-perspective should accept bare numbers as pixel values and reject calc(<number>)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-perspective-invalid.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-perspective-invalid.tentative-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL e.style['-webkit-perspective'] = "calc(1000)" should not set the property value assert_equals: expected "" but got "calc(1000)"
-FAIL e.style['-webkit-perspective'] = "calc(25)" should not set the property value assert_equals: expected "" but got "calc(25)"
+PASS e.style['-webkit-perspective'] = "calc(1000)" should not set the property value
+PASS e.style['-webkit-perspective'] = "calc(25)" should not set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-perspective-valid.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-perspective-valid.tentative-expected.txt
@@ -5,8 +5,8 @@ PASS e.style['-webkit-perspective'] = "unset" should set the property value
 PASS e.style['-webkit-perspective'] = "revert" should set the property value
 PASS e.style['-webkit-perspective'] = "revert-layer" should set the property value
 PASS e.style['-webkit-perspective'] = "none" should set the property value
-FAIL e.style['-webkit-perspective'] = "1000" should set the property value assert_equals: serialization should be canonical expected "1000px" but got "1000"
-FAIL e.style['-webkit-perspective'] = "25" should set the property value assert_equals: serialization should be canonical expected "25px" but got "25"
+PASS e.style['-webkit-perspective'] = "1000" should set the property value
+PASS e.style['-webkit-perspective'] = "25" should set the property value
 PASS e.style['-webkit-perspective'] = "12px" should set the property value
 PASS e.style['-webkit-perspective'] = "3.5em" should set the property value
 

--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -1802,8 +1802,10 @@ inline bool PropertyParserCustom::consumeWebkitPerspectiveShorthand(CSSParserTok
         return range.atEnd();
     }
 
-    if (auto perspective = CSSPrimitiveValueResolver<Number<Nonnegative>>::consumeAndResolve(range, state)) {
-        result.addPropertyForCurrentShorthand(state, CSSPropertyPerspective, WTF::move(perspective));
+    // -webkit-perspective accepts bare <number [0,∞]> tokens (not calc) and interprets them as pixel lengths.
+    if (range.peek().type() == NumberToken && range.peek().numericValue() >= 0) {
+        auto value = CSSPrimitiveValue::create(range.consumeIncludingWhitespace().numericValue(), CSSUnitType::CSS_PX);
+        result.addPropertyForCurrentShorthand(state, CSSPropertyPerspective, WTF::move(value));
         return range.atEnd();
     }
 


### PR DESCRIPTION
#### 98e601691dc9bda0087a56d8d9c30b37cac49afc
<pre>
-webkit-perspective should accept bare numbers as pixel values and reject calc(&lt;number&gt;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=311537">https://bugs.webkit.org/show_bug.cgi?id=311537</a>
<a href="https://rdar.apple.com/174129183">rdar://174129183</a>

Reviewed by NOBODY (OOPS!).

-webkit-perspective supports &apos;&lt;number [0,∞]&gt;&apos; in addition to
&apos;none | &lt;length [0,∞]&gt;&apos;, interpreting bare numbers as pixel lengths.
However, calc(&lt;number&gt;) should not be accepted.

Replace the CSSPrimitiveValueResolver&lt;Number&lt;Nonnegative&gt;&gt; call with a direct
NumberToken check that converts the numeric value to CSS_PX. This ensures bare
number tokens like &quot;1000&quot; serialize as &quot;1000px&quot; while calc(1000) is rejected.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-perspective-invalid.tentative-expected.txt: Progressions
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/parsing/webkit-perspective-valid.tentative-expected.txt: Ditto
* Source/WebCore/css/parser/CSSPropertyParserCustom.h:
(WebCore::CSS::PropertyParserCustom::consumeWebkitPerspectiveShorthand):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98e601691dc9bda0087a56d8d9c30b37cac49afc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154392 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27650 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163147 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107861 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7a7662e4-57a8-42ae-84f0-9b9f4d1cef53) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156265 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27500 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119412 "Found 2 new test failures: fast/transforms/perspective-computed.html fast/transforms/perspective-valid.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84444 "3 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5200ed2a-e6de-402c-b93d-cc53118e6bc8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157351 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21680 "Found 2 new test failures: fast/transforms/perspective-computed.html fast/transforms/perspective-valid.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138658 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100109 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa730765-ce20-44d7-820d-4947f571e80c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20767 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18777 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10978 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130429 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16502 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165618 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8827 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18111 "Found 2 new test failures: fast/transforms/perspective-computed.html fast/transforms/perspective-valid.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127509 "Found 2 new test failures: fast/transforms/perspective-computed.html fast/transforms/perspective-valid.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27196 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22819 "Found 2 new test failures: fast/transforms/perspective-computed.html fast/transforms/perspective-valid.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127653 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27120 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138295 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83774 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22543 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15087 "Found 2 new test failures: fast/transforms/perspective-computed.html fast/transforms/perspective-valid.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26810 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90913 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26391 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26622 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26464 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->