### PR TITLE
Add a way for injected scripts with the AutoFill content world to dispatch events that are trusted only for bindings

### DIFF
--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp
@@ -23,6 +23,7 @@
 
 #include "ActiveDOMObject.h"
 #include "ContextDestructionObserverInlines.h"
+#include "DOMWrapperWorld.h"
 #include "ExtendedDOMClientIsoSubspaces.h"
 #include "ExtendedDOMIsoSubspaces.h"
 #include "JSDOMAttribute.h"
@@ -105,6 +106,22 @@ template<> ConversionResult<IDLDictionary<TestEventConstructor::Init>> convertDi
     auto composedConversionResult = convert<IDLBoolean>(lexicalGlobalObject, composedValue);
     if (composedConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
+    auto trustedForBindingsOnlyConversionResult = [&]() -> ConversionResult<IDLBoolean> {
+        if (worldForDOMObject(*&lexicalGlobalObject).allowAutofill()) {
+            JSValue trustedValue;
+            if (isNullOrUndefined)
+                trustedValue = jsUndefined();
+            else {
+                trustedValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "trusted"_s));
+                RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
+            }
+            return convert<IDLBoolean>(lexicalGlobalObject, trustedValue);
+        } else {
+            return ConversionResult<IDLBoolean> { Converter<IDLBoolean>::ReturnType { } };
+        }
+    }();
+    if (trustedForBindingsOnlyConversionResult.hasException(throwScope)) [[unlikely]]
+        return ConversionResultException { };
     JSValue attr2Value;
     if (isNullOrUndefined)
         attr2Value = jsUndefined();
@@ -132,6 +149,7 @@ template<> ConversionResult<IDLDictionary<TestEventConstructor::Init>> convertDi
             bubblesConversionResult.releaseReturnValue(),
             cancelableConversionResult.releaseReturnValue(),
             composedConversionResult.releaseReturnValue(),
+            trustedForBindingsOnlyConversionResult.releaseReturnValue(),
         },
         attr2ConversionResult.releaseReturnValue(),
 #if ENABLE(SPECIAL_EVENT)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp
@@ -24,6 +24,7 @@
 #include "ActiveDOMObject.h"
 #include "ContextDestructionObserverInlines.h"
 #include "DOMPromiseProxy.h"
+#include "DOMWrapperWorld.h"
 #include "ExtendedDOMClientIsoSubspaces.h"
 #include "ExtendedDOMIsoSubspaces.h"
 #include "JSDOMAttribute.h"
@@ -106,6 +107,22 @@ template<> ConversionResult<IDLDictionary<TestPromiseRejectionEvent::Init>> conv
     auto composedConversionResult = convert<IDLBoolean>(lexicalGlobalObject, composedValue);
     if (composedConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
+    auto trustedForBindingsOnlyConversionResult = [&]() -> ConversionResult<IDLBoolean> {
+        if (worldForDOMObject(*&lexicalGlobalObject).allowAutofill()) {
+            JSValue trustedValue;
+            if (isNullOrUndefined)
+                trustedValue = jsUndefined();
+            else {
+                trustedValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "trusted"_s));
+                RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
+            }
+            return convert<IDLBoolean>(lexicalGlobalObject, trustedValue);
+        } else {
+            return ConversionResult<IDLBoolean> { Converter<IDLBoolean>::ReturnType { } };
+        }
+    }();
+    if (trustedForBindingsOnlyConversionResult.hasException(throwScope)) [[unlikely]]
+        return ConversionResultException { };
     JSValue promiseValue;
     if (isNullOrUndefined)
         promiseValue = jsUndefined();
@@ -135,6 +152,7 @@ template<> ConversionResult<IDLDictionary<TestPromiseRejectionEvent::Init>> conv
             bubblesConversionResult.releaseReturnValue(),
             cancelableConversionResult.releaseReturnValue(),
             composedConversionResult.releaseReturnValue(),
+            trustedForBindingsOnlyConversionResult.releaseReturnValue(),
         },
         promiseConversionResult.releaseReturnValue(),
         reasonConversionResult.releaseReturnValue(),

--- a/Source/WebCore/dom/Event.cpp
+++ b/Source/WebCore/dom/Event.cpp
@@ -57,6 +57,7 @@ ALWAYS_INLINE Event::Event(MonotonicTime createTime, enum EventInterfaceType eve
     , m_defaultHandled { false }
     , m_isDefaultEventHandlerIgnored { false }
     , m_isTrusted { isTrusted == IsTrusted::Yes }
+    , m_isTrustedForBindingsOnly { false }
     , m_isExecutingPassiveEventListener { false }
     , m_currentTargetIsInShadowTree { false }
     , m_isAutofillEvent { false }
@@ -92,6 +93,7 @@ Event::Event(enum EventInterfaceType eventInterface, const AtomString& eventType
 {
     ASSERT(!eventType.isNull());
     m_isConstructedFromInitializer = true;
+    m_isTrustedForBindingsOnly = initializer.trustedForBindingsOnly;
 }
 
 Event::~Event() = default;

--- a/Source/WebCore/dom/Event.h
+++ b/Source/WebCore/dom/Event.h
@@ -147,6 +147,8 @@ public:
     bool isAutofillEvent() { return m_isAutofillEvent; }
     void setIsAutofillEvent() { m_isAutofillEvent = true; }
 
+    bool isTrustedForBindings() const { return m_isTrusted || m_isTrustedForBindingsOnly; }
+
 protected:
     explicit Event(enum EventInterfaceType, IsTrusted = IsTrusted::No);
     Event(enum EventInterfaceType, const AtomString& type, CanBubble, IsCancelable, IsComposed = IsComposed::No);
@@ -173,6 +175,7 @@ private:
     unsigned m_defaultHandled : 1;
     unsigned m_isDefaultEventHandlerIgnored : 1;
     unsigned m_isTrusted : 1;
+    unsigned m_isTrustedForBindingsOnly : 1;
     unsigned m_isExecutingPassiveEventListener : 1;
     unsigned m_currentTargetIsInShadowTree : 1;
     unsigned m_isAutofillEvent : 1;

--- a/Source/WebCore/dom/Event.idl
+++ b/Source/WebCore/dom/Event.idl
@@ -50,7 +50,7 @@ typedef double DOMHighResTimeStamp;
     readonly attribute boolean defaultPrevented;
     readonly attribute boolean composed;
 
-    [LegacyUnforgeable] readonly attribute boolean isTrusted;
+    [LegacyUnforgeable, ImplementedAs=isTrustedForBindings] readonly attribute boolean isTrusted;
     [CallWith=RelevantScriptExecutionContext, ImplementedAs=timeStampForBindings] readonly attribute DOMHighResTimeStamp timeStamp;
 
     undefined initEvent([AtomString] DOMString type, optional boolean bubbles = false, optional boolean cancelable = false); // Historical.

--- a/Source/WebCore/dom/EventInit.h
+++ b/Source/WebCore/dom/EventInit.h
@@ -31,6 +31,7 @@ struct EventInit {
     bool bubbles { false };
     bool cancelable { false };
     bool composed { false };
+    bool trustedForBindingsOnly { false };
 };
 
 }

--- a/Source/WebCore/dom/EventInit.idl
+++ b/Source/WebCore/dom/EventInit.idl
@@ -27,4 +27,7 @@ dictionary EventInit {
     boolean bubbles = false;
     boolean cancelable = false;
     boolean composed = false;
+
+    // Non-standard.
+    [EnabledForWorld=allowAutofill, ImplementedAs=trustedForBindingsOnly] boolean trusted = false;
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5017,6 +5017,7 @@ struct WebCore::EventInit {
     bool bubbles;
     bool cancelable;
     bool composed;
+    bool trustedForBindingsOnly;
 };
 
 struct WebCore::MessageWithMessagePorts {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm
@@ -1909,6 +1909,51 @@ TEST(WKUserContentController, AutoFillWorldTrustedEventHandler)
     EXPECT_EQ(pageWorldEventCount, 2);
 }
 
+TEST(WKUserContentController, DispatchTrustedEventForAutoFill)
+{
+    RetainPtr contentWorldConfiguration = adoptNS([[WKContentWorldConfiguration alloc] init]);
+    [contentWorldConfiguration setAutofillScriptingEnabled:YES];
+
+    __block int trustedOnlyEventCount = 0;
+    __block int regularEventCount = 0;
+    __block int isTrustedCount = 0;
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+
+    RetainPtr world = [WKContentWorld worldWithConfiguration:contentWorldConfiguration.get()];
+    RetainPtr autoFillHandler = adoptNS([[TestMessageHandler alloc] init]);
+    [autoFillHandler addMessage:@"trustedOnly" withHandler:^{
+        trustedOnlyEventCount++;
+    }];
+    [autoFillHandler addMessage:@"regular" withHandler:^{
+        regularEventCount++;
+    }];
+    [autoFillHandler addMessage:@"isTrusted" withHandler:^{
+        isTrustedCount++;
+    }];
+    [[configuration userContentController] addScriptMessageHandler:autoFillHandler.get() contentWorld:world.get() name:@"autofill"];
+
+    RetainPtr pageHandler = adoptNS([[TestMessageHandler alloc] init]);
+    [pageHandler addMessage:@"isTrusted" withHandler:^{
+        isTrustedCount++;
+    }];
+    [[configuration userContentController] addScriptMessageHandler:pageHandler.get() name:@"page"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    [webView synchronouslyLoadHTMLString:@"<input id='input' type='text'>"];
+
+    [webView objectByEvaluatingJavaScript:@"input.addEventListener('keydown', (e) => { window.webkit.messageHandlers.autofill.postMessage('trustedOnly'); }, { webkitTrustedOnly: true })" inFrame:nil inContentWorld:world.get()];
+    [webView objectByEvaluatingJavaScript:@"input.addEventListener('keydown', (e) => { window.webkit.messageHandlers.autofill.postMessage('regular'); })" inFrame:nil inContentWorld:world.get()];
+    [webView objectByEvaluatingJavaScript:@"input.addEventListener('keydown', (e) => { if (e.isTrusted) window.webkit.messageHandlers.page.postMessage('isTrusted'); window.webkit.messageHandlers.page.postMessage('done'); })"];
+    [webView objectByEvaluatingJavaScript:@"input.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', code: 'KeyA', keyCode: 65, which: 65, bubbles: true }))" inFrame:nil inContentWorld:world.get()];
+    [webView objectByEvaluatingJavaScript:@"input.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', code: 'KeyA', keyCode: 65, which: 65, bubbles: true, trusted: true }))" inFrame:nil inContentWorld:world.get()];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_EQ(isTrustedCount, 1);
+    EXPECT_EQ(regularEventCount, 2);
+    EXPECT_EQ(trustedOnlyEventCount, 0);
+}
+
 #endif
 
 TEST(WKUserContentController, WebKitSubmitEvent)


### PR DESCRIPTION
#### 87bc3a99dc381b20fe1b6839f97d9ca3d8178122
<pre>
Add a way for injected scripts with the AutoFill content world to dispatch events that are trusted only for bindings
<a href="https://bugs.webkit.org/show_bug.cgi?id=311538">https://bugs.webkit.org/show_bug.cgi?id=311538</a>
<a href="https://rdar.apple.com/174129268">rdar://174129268</a>

Reviewed by Ryosuke Niwa and Abrar Rahman Protyasha.

Currently, AutoFill dispatches synthetic key events through injected JavaScript when filling text.
These key events are untrusted; some websites detect this, and prevent login.

To improve compatibility with these websites, we add a way for clients (exposed only under the
AutoFill script world, for now) to create DOM events that are trusted only from the perspective of
bindings code, but remain untrusted from the perspective of the engine.

Test: WKUserContentController.DispatchTrustedEventForAutoFill

* Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp:
(WebCore::convertDictionary&lt;TestEventConstructor::Init&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp:
(WebCore::convertDictionary&lt;TestPromiseRejectionEvent::Init&gt;):

Rebaseline bindings generation tests.

* Source/WebCore/dom/Event.cpp:
* Source/WebCore/dom/Event.h:
(WebCore::Event::isTrustedForBindings const):

Split out `isTrusted` into `isTrustedForBindings` (which honors the new flag, and is only accessed
via script), and `isTrusted` (which the engine continues to use, and which only honors the true
`m_isTrusted` state).

* Source/WebCore/dom/Event.idl:
* Source/WebCore/dom/EventInit.h:
* Source/WebCore/dom/EventInit.idl:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm:
(TEST(WKUserContentController, DispatchTrustedEventForAutoFill)):

Canonical link: <a href="https://commits.webkit.org/310673@main">https://commits.webkit.org/310673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3855b9e9de97db5959895c5a7adc798aff4520f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163307 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/364dee82-83a8-4802-9bbd-e568fac25bc3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156422 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27941 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27657 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119538 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/98569e71-ef07-4b5e-b389-e8c2f08d05c5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138804 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100235 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/be29a29d-fbe5-43e0-872e-36f09ed857bd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20910 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11135 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130572 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165778 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/8984 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18257 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127639 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127783 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34673 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27277 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138441 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/83959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22680 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15233 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26967 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/91070 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26547 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/26778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26620 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->