### PR TITLE
[JSC] Use simple SIMD loop in x64 in GCMemoryOperations

### DIFF
--- a/Source/JavaScriptCore/heap/GCMemoryOperations.h
+++ b/Source/JavaScriptCore/heap/GCMemoryOperations.h
@@ -38,7 +38,6 @@ namespace JSC {
 // concurrent collector.
 
 constexpr size_t smallCutoff = 8 * 8;
-constexpr size_t mediumCutoff = 4 * 1024;
 
 // This is a forwards loop so gcSafeMemmove can rely on the direction.
 template <typename T>
@@ -48,102 +47,84 @@ ALWAYS_INLINE void gcSafeMemcpy(T* dst, const T* src, size_t bytes)
     RELEASE_ASSERT(bytes % 8 == 0);
 
 #if USE(JSVALUE64)
-
     auto slowPathForwardMemcpy = [&] {
         size_t count = bytes / 8;
         for (unsigned i = 0; i < count; ++i)
             std::bit_cast<volatile uint64_t*>(dst)[i] = std::bit_cast<volatile uint64_t*>(src)[i];
     };
 
-#if CPU(X86_64) || CPU(ARM64)
-    if (bytes <= smallCutoff)
+    if (bytes <= smallCutoff) {
         slowPathForwardMemcpy();
-    else if (isARM64() || bytes <= mediumCutoff) {
-#if CPU(X86_64)
-        size_t alignedBytes = (bytes / 64) * 64;
-        size_t tmp;
-        size_t offset = 0;
-        __asm__ volatile(
-            ".balign 32\t\n"
-            "1:\t\n"
-            "cmpq %q[offset], %q[alignedBytes]\t\n"
-            "je 2f\t\n"
-            "movups (%q[src], %q[offset], 1), %%xmm0\t\n"
-            "movups 16(%q[src], %q[offset], 1), %%xmm1\t\n"
-            "movups 32(%q[src], %q[offset], 1), %%xmm2\t\n"
-            "movups 48(%q[src], %q[offset], 1), %%xmm3\t\n"
-            "movups %%xmm0, (%q[dst], %q[offset], 1)\t\n"
-            "movups %%xmm1, 16(%q[dst], %q[offset], 1)\t\n"
-            "movups %%xmm2, 32(%q[dst], %q[offset], 1)\t\n"
-            "movups %%xmm3, 48(%q[dst], %q[offset], 1)\t\n"
-            "addq $64, %q[offset]\t\n"
-            "jmp 1b\t\n"
-
-            "2:\t\n"
-            "cmpq %q[offset], %q[bytes]\t\n"
-            "je 3f\t\n"
-            "movq (%q[src], %q[offset], 1), %q[tmp]\t\n"
-            "movq %q[tmp], (%q[dst], %q[offset], 1)\t\n"
-            "addq $8, %q[offset]\t\n"
-            "jmp 2b\t\n"
-
-            "3:\t\n"
-
-            : [alignedBytes] "+r" (alignedBytes), [bytes] "+r" (bytes), [tmp] "+r" (tmp), [offset] "+r" (offset), [dst] "+r" (dst), [src] "+r" (src)
-            :
-            : "xmm0", "xmm1", "xmm2", "xmm3", "memory", "cc"
-        );
-#elif CPU(ARM64) && !OS(WINDOWS)
-        // On Windows ARM64, LLVM has a bug (llvm/llvm-project#47432) that causes a
-        // fatal error "Failed to evaluate function length in SEH unwind info" when
-        // inline assembly contains alignment directives. Fall back to scalar code.
-        uint64_t alignedBytes = (static_cast<uint64_t>(bytes) / 64) * 64;
-
-        uint64_t dstPtr = static_cast<uint64_t>(std::bit_cast<uintptr_t>(dst));
-        uint64_t srcPtr = static_cast<uint64_t>(std::bit_cast<uintptr_t>(src));
-        uint64_t end = dstPtr + bytes;
-        uint64_t alignedEnd = dstPtr + alignedBytes;
-
-        __asm__ volatile(
-            "1:\t\n"
-            "cmp %x[dstPtr], %x[alignedEnd]\t\n"
-            "b.eq 2f\t\n"
-
-            "ldp q0, q1, [%x[srcPtr]], #0x20\t\n"
-            "ldp q2, q3, [%x[srcPtr]], #0x20\t\n"
-            "stp q0, q1, [%x[dstPtr]], #0x20\t\n"
-            "stp q2, q3, [%x[dstPtr]], #0x20\t\n"
-            "b 1b\t\n"
-
-            "2:\t\n"
-            "cmp %x[dstPtr], %x[end]\t\n"
-            "b.eq 3f\t\n"
-            "ldr d0, [%x[srcPtr]], #0x8\t\n"
-            "str d0, [%x[dstPtr]], #0x8\t\n"
-            "b 2b\t\n"
-
-            "3:\t\n"
-            : [end] "+r" (end), [alignedEnd] "+r" (alignedEnd), [dstPtr] "+r" (dstPtr), [srcPtr] "+r" (srcPtr)
-            :
-            : "d0", "d1", "d2", "d3", "memory", "cc"
-        );
-#endif // CPU(X86_64)
-    } else {
-        RELEASE_ASSERT(isX86_64());
-#if CPU(X86_64)
-        size_t count = bytes / 8;
-        __asm__ volatile(
-            ".balign 16\t\n"
-            "cld\t\n"
-            "rep movsq\t\n"
-            : "+D" (dst), "+S" (src), "+c" (count)
-            :
-            : "memory");
-#endif // CPU(X86_64)
+        return;
     }
+
+#if CPU(X86_64)
+    size_t alignedBytes = (bytes / 64) * 64;
+    size_t offset = 0;
+    __asm__ volatile(
+        ".balign 32\t\n"
+        "1:\t\n"
+        "cmpq %q[offset], %q[alignedBytes]\t\n"
+        "je 2f\t\n"
+        "movups (%q[src], %q[offset], 1), %%xmm0\t\n"
+        "movups 16(%q[src], %q[offset], 1), %%xmm1\t\n"
+        "movups 32(%q[src], %q[offset], 1), %%xmm2\t\n"
+        "movups 48(%q[src], %q[offset], 1), %%xmm3\t\n"
+        "movups %%xmm0, (%q[dst], %q[offset], 1)\t\n"
+        "movups %%xmm1, 16(%q[dst], %q[offset], 1)\t\n"
+        "movups %%xmm2, 32(%q[dst], %q[offset], 1)\t\n"
+        "movups %%xmm3, 48(%q[dst], %q[offset], 1)\t\n"
+        "addq $64, %q[offset]\t\n"
+        "jmp 1b\t\n"
+
+        "2:\t\n"
+        "cmpq %q[offset], %q[bytes]\t\n"
+        "je 3f\t\n"
+        "movq (%q[src], %q[offset], 1), %%xmm0\t\n"
+        "movq %%xmm0, (%q[dst], %q[offset], 1)\t\n"
+        "addq $8, %q[offset]\t\n"
+        "jmp 2b\t\n"
+
+        "3:\t\n"
+
+        : [offset] "+r" (offset)
+        : [alignedBytes] "r" (alignedBytes), [bytes] "r" (bytes), [dst] "r" (dst), [src] "r" (src)
+        : "xmm0", "xmm1", "xmm2", "xmm3", "memory", "cc"
+    );
+#elif CPU(ARM64)
+    uint64_t alignedBytes = (static_cast<uint64_t>(bytes) / 64) * 64;
+
+    uint64_t dstPtr = static_cast<uint64_t>(std::bit_cast<uintptr_t>(dst));
+    uint64_t srcPtr = static_cast<uint64_t>(std::bit_cast<uintptr_t>(src));
+    uint64_t end = dstPtr + bytes;
+    uint64_t alignedEnd = dstPtr + alignedBytes;
+
+    __asm__ volatile(
+        "1:\t\n"
+        "cmp %x[dstPtr], %x[alignedEnd]\t\n"
+        "b.eq 2f\t\n"
+
+        "ldp q0, q1, [%x[srcPtr]], #0x20\t\n"
+        "ldp q2, q3, [%x[srcPtr]], #0x20\t\n"
+        "stp q0, q1, [%x[dstPtr]], #0x20\t\n"
+        "stp q2, q3, [%x[dstPtr]], #0x20\t\n"
+        "b 1b\t\n"
+
+        "2:\t\n"
+        "cmp %x[dstPtr], %x[end]\t\n"
+        "b.eq 3f\t\n"
+        "ldr d0, [%x[srcPtr]], #0x8\t\n"
+        "str d0, [%x[dstPtr]], #0x8\t\n"
+        "b 2b\t\n"
+
+        "3:\t\n"
+        : [dstPtr] "+r" (dstPtr), [srcPtr] "+r" (srcPtr)
+        : [end] "r" (end), [alignedEnd] "r" (alignedEnd)
+        : "v0", "v1", "v2", "v3", "memory", "cc"
+    );
 #else
     slowPathForwardMemcpy();
-#endif // CPU(X86_64) || CPU(ARM64)
+#endif
 #else
     memcpy(dst, src, bytes);
 #endif // USE(JSVALUE64)
@@ -172,83 +153,80 @@ ALWAYS_INLINE void gcSafeMemmove(T* dst, const T* src, size_t bytes)
             std::bit_cast<volatile uint64_t*>(dst)[i] = std::bit_cast<volatile uint64_t*>(src)[i];
     };
 
-#if CPU(X86_64) || CPU(ARM64)
-    if (bytes <= smallCutoff)
+    if (bytes <= smallCutoff) {
         slowPathBackwardsMemmove();
-    else {
-#if CPU(X86_64)
-        size_t alignedBytes = (bytes / 64) * 64;
-
-        size_t tail = alignedBytes;
-        size_t tmp;
-        __asm__ volatile(
-            "2:\t\n"
-            "cmpq %q[tail], %q[bytes]\t\n"
-            "je 1f\t\n"
-            "addq $-8, %q[bytes]\t\n"
-            "movq (%q[src], %q[bytes], 1), %q[tmp]\t\n"
-            "movq %q[tmp], (%q[dst], %q[bytes], 1)\t\n"
-            "jmp 2b\t\n"
-
-            "1:\t\n"
-            "test %q[alignedBytes], %q[alignedBytes]\t\n"
-            "jz 3f\t\n"
-
-            ".balign 32\t\n"
-            "100:\t\n"
-
-            "movups -64(%q[src], %q[alignedBytes], 1), %%xmm0\t\n"
-            "movups -48(%q[src], %q[alignedBytes], 1), %%xmm1\t\n"
-            "movups -32(%q[src], %q[alignedBytes], 1), %%xmm2\t\n"
-            "movups -16(%q[src], %q[alignedBytes], 1), %%xmm3\t\n"
-            "movups %%xmm0, -64(%q[dst], %q[alignedBytes], 1)\t\n"
-            "movups %%xmm1, -48(%q[dst], %q[alignedBytes], 1)\t\n"
-            "movups %%xmm2, -32(%q[dst], %q[alignedBytes], 1)\t\n"
-            "movups %%xmm3, -16(%q[dst], %q[alignedBytes], 1)\t\n"
-            "addq $-64, %q[alignedBytes]\t\n"
-            "jnz 100b\t\n"
-
-            "3:\t\n"
-
-            : [alignedBytes] "+r" (alignedBytes), [tail] "+r" (tail), [bytes] "+r" (bytes), [tmp] "+r" (tmp), [dst] "+r" (dst), [src] "+r" (src)
-            :
-            : "xmm0", "xmm1", "xmm2", "xmm3", "memory", "cc"
-        );
-#elif CPU(ARM64) && !OS(WINDOWS)
-        uint64_t alignedBytes = (static_cast<uint64_t>(bytes) / 64) * 64;
-
-        uint64_t dstPtr = static_cast<uint64_t>(std::bit_cast<uintptr_t>(dst) + static_cast<uint64_t>(bytes));
-        uint64_t srcPtr = static_cast<uint64_t>(std::bit_cast<uintptr_t>(src) + static_cast<uint64_t>(bytes));
-
-        uint64_t alignedStart = std::bit_cast<uintptr_t>(dst) + (static_cast<uint64_t>(bytes) - alignedBytes);
-        uint64_t start = std::bit_cast<uintptr_t>(dst);
-
-        __asm__ volatile(
-            "1:\t\n"
-            "cmp %x[dstPtr], %x[alignedStart]\t\n"
-            "b.eq 2f\t\n"
-
-            "ldp q2, q3, [%x[srcPtr], #-0x20]!\t\n"
-            "ldp q0, q1, [%x[srcPtr], #-0x20]!\t\n"
-            "stp q2, q3, [%x[dstPtr], #-0x20]!\t\n"
-            "stp q0, q1, [%x[dstPtr], #-0x20]!\t\n"
-            "b 1b\t\n"
-
-            "2:\t\n"
-            "cmp %x[dstPtr], %x[start]\t\n"
-            "b.eq 3f\t\n"
-            "ldr d0, [%x[srcPtr], #-0x8]!\t\n"
-            "str d0, [%x[dstPtr], #-0x8]!\t\n"
-            "b 2b\t\n"
-
-            "3:\t\n"
-
-            : [alignedStart] "+r" (alignedStart), [start] "+r" (start), [dstPtr] "+r" (dstPtr), [srcPtr] "+r" (srcPtr)
-            :
-            : "d0", "d1", "d2", "d3", "memory", "cc"
-        );
-#endif // CPU(X86_64)
+        return;
     }
+
+#if CPU(X86_64)
+    size_t alignedBytes = (bytes / 64) * 64;
+    size_t tail = alignedBytes;
+    __asm__ volatile(
+        "2:\t\n"
+        "cmpq %q[tail], %q[bytes]\t\n"
+        "je 1f\t\n"
+        "addq $-8, %q[bytes]\t\n"
+        "movq (%q[src], %q[bytes], 1), %%xmm0\t\n"
+        "movq %%xmm0, (%q[dst], %q[bytes], 1)\t\n"
+        "jmp 2b\t\n"
+
+        "1:\t\n"
+        "test %q[alignedBytes], %q[alignedBytes]\t\n"
+        "jz 3f\t\n"
+
+        ".balign 32\t\n"
+        "100:\t\n"
+
+        "movups -64(%q[src], %q[alignedBytes], 1), %%xmm0\t\n"
+        "movups -48(%q[src], %q[alignedBytes], 1), %%xmm1\t\n"
+        "movups -32(%q[src], %q[alignedBytes], 1), %%xmm2\t\n"
+        "movups -16(%q[src], %q[alignedBytes], 1), %%xmm3\t\n"
+        "movups %%xmm0, -64(%q[dst], %q[alignedBytes], 1)\t\n"
+        "movups %%xmm1, -48(%q[dst], %q[alignedBytes], 1)\t\n"
+        "movups %%xmm2, -32(%q[dst], %q[alignedBytes], 1)\t\n"
+        "movups %%xmm3, -16(%q[dst], %q[alignedBytes], 1)\t\n"
+        "addq $-64, %q[alignedBytes]\t\n"
+        "jnz 100b\t\n"
+
+        "3:\t\n"
+
+        : [alignedBytes] "+r" (alignedBytes), [bytes] "+r" (bytes)
+        : [tail] "r" (tail), [dst] "r" (dst), [src] "r" (src)
+        : "xmm0", "xmm1", "xmm2", "xmm3", "memory", "cc"
+    );
+#elif CPU(ARM64)
+    uint64_t alignedBytes = (static_cast<uint64_t>(bytes) / 64) * 64;
+
+    uint64_t dstPtr = static_cast<uint64_t>(std::bit_cast<uintptr_t>(dst) + static_cast<uint64_t>(bytes));
+    uint64_t srcPtr = static_cast<uint64_t>(std::bit_cast<uintptr_t>(src) + static_cast<uint64_t>(bytes));
+
+    uint64_t alignedStart = std::bit_cast<uintptr_t>(dst) + (static_cast<uint64_t>(bytes) - alignedBytes);
+    uint64_t start = std::bit_cast<uintptr_t>(dst);
+
+    __asm__ volatile(
+        "1:\t\n"
+        "cmp %x[dstPtr], %x[alignedStart]\t\n"
+        "b.eq 2f\t\n"
+
+        "ldp q2, q3, [%x[srcPtr], #-0x20]!\t\n"
+        "ldp q0, q1, [%x[srcPtr], #-0x20]!\t\n"
+        "stp q2, q3, [%x[dstPtr], #-0x20]!\t\n"
+        "stp q0, q1, [%x[dstPtr], #-0x20]!\t\n"
+        "b 1b\t\n"
+
+        "2:\t\n"
+        "cmp %x[dstPtr], %x[start]\t\n"
+        "b.eq 3f\t\n"
+        "ldr d0, [%x[srcPtr], #-0x8]!\t\n"
+        "str d0, [%x[dstPtr], #-0x8]!\t\n"
+        "b 2b\t\n"
+
+        "3:\t\n"
+
+        : [dstPtr] "+r" (dstPtr), [srcPtr] "+r" (srcPtr)
+        : [alignedStart] "r" (alignedStart), [start] "r" (start)
+        : "v0", "v1", "v2", "v3", "memory", "cc"
+    );
 #else
     slowPathBackwardsMemmove();
 #endif // CPU(X86_64) || CPU(ARM64)
@@ -264,18 +242,36 @@ ALWAYS_INLINE void gcSafeZeroMemory(T* dst, size_t bytes)
     RELEASE_ASSERT(bytes % 8 == 0);
 #if USE(JSVALUE64)
 #if CPU(X86_64)
-    uint64_t zero = 0;
-    size_t count = bytes / 8;
-    __asm__ volatile (
-        "rep stosq\n\t"
-        : "+D"(dst), "+c"(count)
-        : "a"(zero)
-        : "memory"
+    size_t alignedBytes = (bytes / 64) * 64;
+    size_t offset = 0;
+    __asm__ volatile(
+        "xorps %%xmm0, %%xmm0\t\n"
+
+        ".balign 32\t\n"
+        "1:\t\n"
+        "cmpq %q[offset], %q[alignedBytes]\t\n"
+        "je 2f\t\n"
+        "movups %%xmm0, (%q[dst], %q[offset], 1)\t\n"
+        "movups %%xmm0, 16(%q[dst], %q[offset], 1)\t\n"
+        "movups %%xmm0, 32(%q[dst], %q[offset], 1)\t\n"
+        "movups %%xmm0, 48(%q[dst], %q[offset], 1)\t\n"
+        "addq $64, %q[offset]\t\n"
+        "jmp 1b\t\n"
+
+        "2:\t\n"
+        "cmpq %q[offset], %q[bytes]\t\n"
+        "je 3f\t\n"
+        "movq %%xmm0, (%q[dst], %q[offset], 1)\t\n"
+        "addq $8, %q[offset]\t\n"
+        "jmp 2b\t\n"
+
+        "3:\t\n"
+
+        : [offset] "+r" (offset)
+        : [alignedBytes] "r" (alignedBytes), [bytes] "r" (bytes), [dst] "r" (dst)
+        : "xmm0", "memory", "cc"
     );
-#elif CPU(ARM64) && !OS(WINDOWS)
-    // On Windows ARM64, LLVM has a bug (llvm/llvm-project#47432) that causes a
-    // fatal error "Failed to evaluate function length in SEH unwind info" when
-    // inline assembly contains alignment directives like .p2align.
+#elif CPU(ARM64)
     uint64_t alignedBytes = (static_cast<uint64_t>(bytes) / 64) * 64;
     uint64_t dstPtr = static_cast<uint64_t>(std::bit_cast<uintptr_t>(dst));
     uint64_t end = dstPtr + bytes;
@@ -284,7 +280,12 @@ ALWAYS_INLINE void gcSafeZeroMemory(T* dst, size_t bytes)
     __asm__ volatile(
         "movi v0.16b, #0\t\n"
 
+#if !OS(WINDOWS)
+        // On Windows ARM64, LLVM has a bug (llvm/llvm-project#47432) that causes a
+        // fatal error "Failed to evaluate function length in SEH unwind info" when
+        // inline assembly contains alignment directives like .p2align.
         ".p2align 4\t\n"
+#endif
         "1:\t\n"
         "cmp %x[dstPtr], %x[alignedEnd]\t\n"
         "b.eq 2f\t\n"


### PR DESCRIPTION
#### 861a6c6a08581e2b60c2e8488451baedf3be390c
<pre>
[JSC] Use simple SIMD loop in x64 in GCMemoryOperations
<a href="https://bugs.webkit.org/show_bug.cgi?id=311539">https://bugs.webkit.org/show_bug.cgi?id=311539</a>
<a href="https://rdar.apple.com/174131168">rdar://174131168</a>

Reviewed by Justin Michaud.

This patch cleans up the implementation of gcSafeMemcpy etc. on x64.
Also fixing Windows ARM64 bug.

1. Do not use `rep stosq` and always use manual SIMD loop. While `rep
   stosb` is specifically optimized by Intel cores, `rep stosq` is not.
   And we cannot use `rep stosb` here as we need to ensure that torn
   reads / writes do not happen.
2. Widen copying width as the same to 310580@main in ARM64.
3. 307443@main introduced a bug that it becomes nope when the size is
   larger than smallCutoff and ARM64 Windows, memcpy and memmove become nop.
   This patch fixes it.

* Source/JavaScriptCore/heap/GCMemoryOperations.h:
(JSC::gcSafeMemcpy):
(JSC::gcSafeMemmove):
(JSC::gcSafeZeroMemory):

Canonical link: <a href="https://commits.webkit.org/310652@main">https://commits.webkit.org/310652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1d08c54dff9e929406760f1cd931ee78855325a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154412 "24 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163167 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107881 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4745b09c-d613-4c1b-8cc5-9df6149d5ade) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27804 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27520 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119434 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84462 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ecdf906e-a70d-45b4-8dc4-3650d7078173) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157371 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21702 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138681 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100131 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/06d64006-0fca-4d9c-b085-12ae323daa60) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20789 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18798 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10998 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146461 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130451 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165638 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15243 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8847 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18134 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127531 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27216 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127675 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27140 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138318 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83797 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23578 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22565 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15110 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186048 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26830 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90933 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47707 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26411 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26642 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26484 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->