### PR TITLE
Fix inverted Y-axis comparison in RenderBox::positionForPoint

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-in-flex-container-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-in-flex-container-expected.txt
@@ -1,0 +1,7 @@
+AAA
+BBB
+
+PASS caretPositionFromPoint just inside a tall flex child resolves to that child
+PASS caretPositionFromPoint well inside a tall flex child resolves to that child
+PASS caretPositionFromPoint inside the short flex child resolves correctly
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-in-flex-container.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-in-flex-container.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>caretPositionFromPoint in flex/grid containers with tall children</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view-1/#dom-document-caretpositionfrompoint">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+  #container {
+    display: flex;
+    flex-direction: column;
+    width: 200px;
+  }
+  /*
+   * pointer-events:none on the children makes the hit-test return the flex
+   * container element.  The container's positionForPoint must then walk its
+   * children to find the one closest to the queried point.
+   */
+  .item {
+    pointer-events: none;
+    font: 16px/1 Ahem;
+  }
+</style>
+<div id="container">
+  <div id="short" class="item" style="height: 20px">AAA</div>
+  <div id="tall"  class="item" style="height: 300px">BBB</div>
+</div>
+<script>
+  test(() => {
+    const tall = document.getElementById("tall");
+    const rect = tall.getBoundingClientRect();
+    // 5 px below #tall's top edge – unambiguously inside #tall.
+    const pos = document.caretPositionFromPoint(rect.left + 10, rect.top + 5);
+    assert_not_equals(pos, null, "should return a CaretPosition");
+    assert_true(tall.contains(pos.offsetNode),
+      "caret near top of #tall must be inside #tall, not #short");
+  }, "caretPositionFromPoint just inside a tall flex child resolves to that child");
+
+  test(() => {
+    const tall = document.getElementById("tall");
+    const rect = tall.getBoundingClientRect();
+    // 100 px below #tall's top edge – well inside #tall.
+    const pos = document.caretPositionFromPoint(rect.left + 10, rect.top + 100);
+    assert_not_equals(pos, null, "should return a CaretPosition");
+    assert_true(tall.contains(pos.offsetNode),
+      "caret deep inside #tall must be inside #tall");
+  }, "caretPositionFromPoint well inside a tall flex child resolves to that child");
+
+  test(() => {
+    const short_ = document.getElementById("short");
+    const rect = short_.getBoundingClientRect();
+    // Vertically centred in #short – sanity check.
+    const pos = document.caretPositionFromPoint(rect.left + 10, rect.top + 10);
+    assert_not_equals(pos, null, "should return a CaretPosition");
+    assert_true(short_.contains(pos.offsetNode),
+      "caret inside #short must be inside #short");
+  }, "caretPositionFromPoint inside the short flex child resolves correctly");
+</script>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -4445,7 +4445,7 @@ PositionWithAffinity RenderBox::positionForPoint(const LayoutPoint& point, HitTe
         LayoutUnit left = renderer.borderLeft() + renderer.paddingLeft() + (is<RenderTableRow>(*this) ? 0_lu : renderer.x());
         LayoutUnit right = left + renderer.contentBoxWidth();
         
-        if (point.x() <= right && point.x() >= left && point.y() <= top && point.y() >= bottom) {
+        if (point.x() <= right && point.x() >= left && point.y() >= top && point.y() <= bottom) {
             if (is<RenderTableRow>(renderer))
                 return renderer.positionForPoint(point + adjustedPoint - renderer.locationOffset(), source, fragment);
             return renderer.positionForPoint(point - renderer.locationOffset(), source, fragment);


### PR DESCRIPTION
#### 9449d94cd8a3a294b2462c255d74e6f82b171e63
<pre>
Fix inverted Y-axis comparison in RenderBox::positionForPoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=311543">https://bugs.webkit.org/show_bug.cgi?id=311543</a>

Reviewed by Alan Baradlay.

The exact-hit check for whether a point falls inside a child&apos;s content
box had the Y comparisons swapped: it required point.y() &lt;= top AND
point.y() &gt;= bottom, which is impossible when bottom &gt; top (always true
since contentBoxHeight() is non-negative). This meant the early return
never fired, and the function always fell through to the distance-based
closest-child search.

The distance fallback computes the distance from the point to each
child&apos;s nearest edge. When the point is inside a tall child near its
top edge, the distance to that child&apos;s bottom edge can be very large,
while the distance to a short preceding sibling&apos;s bottom edge is small.
This causes the wrong child to be selected, misplacing the caret.

This is observable via caretPositionFromPoint on flex/grid containers
when the hit-test returns the container rather than a child (e.g. when
children have pointer-events: none).

Test: imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-in-flex-container.html
- This test is failing in shipping Safari but passing in Chrome and Firefox.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-in-flex-container-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-in-flex-container.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::positionForPoint):

Canonical link: <a href="https://commits.webkit.org/310626@main">https://commits.webkit.org/310626@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2300ae877f251930e58a05bbc2e19e8f67230ebb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27694 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163191 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107905 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/33232f56-5943-4bed-8947-48cdaa47aedb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27828 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27544 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119450 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84473 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3253d345-56ab-4129-95df-300c5d29877c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21720 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100147 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/af925479-6434-41cf-9faa-72fbaa323fa3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20807 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18818 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11022 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130469 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165662 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8871 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18153 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127544 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27240 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/22858 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127688 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34640 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27164 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138337 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83823 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22582 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15129 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26854 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90957 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26435 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26666 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26508 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->