### PR TITLE
SelectorQueryCache::add() should not evict cache entries unnecessarily

### DIFF
--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -700,14 +700,10 @@ SelectorQuery* SelectorQueryCache::add(const String& selectors, const Document& 
 {
     ASSERT(!selectors.isEmpty());
 
-    constexpr auto maximumSelectorQueryCacheSize = 512;
-    if (m_entries.size() == maximumSelectorQueryCacheSize)
-        m_entries.remove(m_entries.random());
-
     auto context = CSSSelectorParserContext { document };
     auto key = Key { selectors, context, document.securityOrigin().data() };
 
-    return m_entries.ensure(key, [&]() -> std::unique_ptr<SelectorQuery> {
+    auto result = m_entries.ensure(key, [&] -> std::unique_ptr<SelectorQuery> {
         auto tokenizer = CSSTokenizer { selectors };
         auto selectorList = parseCSSSelectorList(tokenizer.tokenRange(), context);
 
@@ -718,7 +714,17 @@ SelectorQuery* SelectorQueryCache::add(const String& selectors, const Document& 
             selectorList = CSSSelectorParser::resolveNestingParent(WTF::move(*selectorList), nullptr);
 
         return makeUnique<SelectorQuery>(WTF::move(*selectorList));
-    }).iterator->value.get();
+    });
+
+    auto* query = result.iterator->value.get();
+    constexpr auto maximumSelectorQueryCacheSize = 512;
+    while (m_entries.size() > maximumSelectorQueryCacheSize) {
+        auto it = m_entries.random();
+        if (it->key != result.iterator->key)
+            m_entries.remove(it);
+    }
+
+    return query;
 }
 
 void SelectorQueryCache::clear()


### PR DESCRIPTION
#### 6e66de4fdc3071e358812e15ebb1db5dbcc32790
<pre>
SelectorQueryCache::add() should not evict cache entries unnecessarily
<a href="https://bugs.webkit.org/show_bug.cgi?id=311547">https://bugs.webkit.org/show_bug.cgi?id=311547</a>

Reviewed by Anne van Kesteren.

Previously, a random cache entry was evicted before checking if the
selector was already cached. This could wastefully evict a valid entry
on cache hit, or even evict the very entry about to be looked up.

Move eviction after ensure() so it only happens when a new entry is
actually inserted.

* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::SelectorQueryCache::add):

Canonical link: <a href="https://commits.webkit.org/310632@main">https://commits.webkit.org/310632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0de3e34c3a0410d329ade7cde4f3cfb0acf8d7ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163200 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107914 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c0914e10-0651-48f9-8e56-a8710f7a253c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156318 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119457 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84481 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/356d765a-99a0-4ac3-af56-75d0ae8ccf51) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21731 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138708 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100154 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6b349c16-d063-4eac-a007-4c993743d24c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20818 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18828 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11031 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130480 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16552 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165671 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8880 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18161 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127552 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27249 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22868 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127696 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34646 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27173 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138345 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83836 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22592 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15137 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26863 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90966 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26444 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26675 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26517 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->