### PR TITLE
Remove redundant selectorClosest() in SelectorDataList

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5023,7 +5023,7 @@ ExceptionOr<bool> Element::matches(const String& selector)
     return query.releaseReturnValue().matches(*this);
 }
 
-ExceptionOr<Element*> Element::closest(const String& selector)
+ExceptionOr<RefPtr<Element>> Element::closest(const String& selector)
 {
     auto query = document().selectorQueryForString(selector);
     if (query.hasException())

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -646,7 +646,7 @@ public:
     virtual bool matchesIndeterminatePseudoClass() const;
     virtual bool matchesDefaultPseudoClass() const;
     WEBCORE_EXPORT ExceptionOr<bool> matches(const String& selectors);
-    WEBCORE_EXPORT ExceptionOr<Element*> closest(const String& selectors);
+    WEBCORE_EXPORT ExceptionOr<RefPtr<Element>> closest(const String& selectors);
 
     WEBCORE_EXPORT DOMTokenList& classList();
 

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -181,19 +181,6 @@ inline bool SelectorDataList::selectorMatches(const SelectorData& selectorData, 
     return selectorChecker.match(selectorData.selector, element, selectorCheckingContext);
 }
 
-inline Element* SelectorDataList::selectorClosest(const SelectorData& selectorData, Element& element, const ContainerNode& rootNode, Style::SelectorMatchingState* selectorMatchingState) const
-{
-    SelectorChecker selectorChecker(element.document());
-    SelectorChecker::CheckingContext selectorCheckingContext(SelectorChecker::Mode::QueryingRules);
-    selectorCheckingContext.scope = rootNode.isDocumentNode() ? nullptr : &rootNode;
-    // Providing SelectorMatchingState allows cross-element optimizations like caching for :has() matches.
-    selectorCheckingContext.selectorMatchingState = selectorMatchingState;
-
-    if (!selectorChecker.match(selectorData.selector, element, selectorCheckingContext))
-        return nullptr;
-    return &element;
-}
-
 bool SelectorDataList::matches(Element& targetElement) const
 {
     for (auto& selector : m_selectors) {
@@ -203,14 +190,14 @@ bool SelectorDataList::matches(Element& targetElement) const
     return false;
 }
 
-Element* SelectorDataList::closest(Element& targetElement) const
+RefPtr<Element> SelectorDataList::closest(Element& targetElement) const
 {
     Style::SelectorMatchingState selectorMatchingState;
 
     for (Ref currentElement : lineageOfType<Element>(targetElement)) {
         for (auto& selector : m_selectors) {
-            if (auto* candidateElement = selectorClosest(selector, currentElement, targetElement, &selectorMatchingState))
-                return candidateElement;
+            if (selectorMatches(selector, currentElement, targetElement, &selectorMatchingState))
+                return currentElement;
         }
     }
     return nullptr;

--- a/Source/WebCore/dom/SelectorQuery.h
+++ b/Source/WebCore/dom/SelectorQuery.h
@@ -50,7 +50,7 @@ class SelectorDataList {
 public:
     explicit SelectorDataList(const CSSSelectorList&);
     bool matches(Element&) const;
-    Element* closest(Element&) const;
+    RefPtr<Element> closest(Element&) const;
     Ref<NodeList> queryAll(ContainerNode& rootNode) const;
     Element* queryFirst(ContainerNode& rootNode) const;
 
@@ -66,7 +66,6 @@ private:
     };
 
     bool selectorMatches(const SelectorData&, Element&, const ContainerNode& rootNode, Style::SelectorMatchingState* = nullptr) const;
-    Element* selectorClosest(const SelectorData&, Element&, const ContainerNode& rootNode, Style::SelectorMatchingState* = nullptr) const;
 
     template <typename OutputType> void execute(ContainerNode& rootNode, OutputType&) const;
     template <typename OutputType> void executeFastPathForIdSelector(const ContainerNode& rootNode, const SelectorData&, const CSSSelector* idSelector, OutputType&) const;
@@ -107,7 +106,7 @@ class SelectorQuery {
 public:
     explicit SelectorQuery(CSSSelectorList&&);
     bool matches(Element&) const;
-    Element* closest(Element&) const;
+    RefPtr<Element> closest(Element&) const;
     Ref<NodeList> queryAll(ContainerNode& rootNode) const;
     Element* queryFirst(ContainerNode& rootNode) const;
 
@@ -137,7 +136,7 @@ inline bool SelectorQuery::matches(Element& element) const
     return m_selectors.matches(element);
 }
 
-inline Element* SelectorQuery::closest(Element& element) const
+inline RefPtr<Element> SelectorQuery::closest(Element& element) const
 {
     return m_selectors.closest(element);
 }


### PR DESCRIPTION
#### de120276f3ea149759f7b8a050460a443a08d247
<pre>
Remove redundant selectorClosest() in SelectorDataList
<a href="https://bugs.webkit.org/show_bug.cgi?id=311551">https://bugs.webkit.org/show_bug.cgi?id=311551</a>

Reviewed by Anne van Kesteren.

selectorClosest() was identical to selectorMatches() except it returned
Element* instead of bool. Rewrite closest() to use selectorMatches()
directly, eliminating the duplicated method. Update closest() to return
RefPtr&lt;Element&gt; instead of a raw pointer since the Ref local variable
used for the result is LIFETIME_BOUND.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::closest):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::SelectorDataList::closest const):
(WebCore::SelectorDataList::selectorClosest const): Deleted.
* Source/WebCore/dom/SelectorQuery.h:
(WebCore::SelectorQuery::closest const):

Canonical link: <a href="https://commits.webkit.org/310629@main">https://commits.webkit.org/310629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c02c34ab88d8bd3d62a6959396fa7cc1a2d7a507

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154439 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27697 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163194 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107908 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e80d81cb-d462-4dbe-9bbf-19f5d2d73721) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27831 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27547 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119452 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84479 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/11494d73-f10e-4778-8784-9181ccc322e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157398 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138701 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100149 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e228861f-1579-48d6-9e4f-5fa7311a9110) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20813 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18821 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11025 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130475 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165665 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8874 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18154 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127547 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22861 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127691 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34642 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27167 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138338 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83827 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22585 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15130 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26857 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90960 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26438 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26669 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26511 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->