### PR TITLE
Batch plain-text characters in HTML tokenizer DataState

### DIFF
--- a/Source/WebCore/html/parser/HTMLTokenizer.cpp
+++ b/Source/WebCore/html/parser/HTMLTokenizer.cpp
@@ -39,6 +39,24 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
+// https://html.spec.whatwg.org/multipage/parsing.html#data-state
+// In the Data state, '<' switches to TagOpenState, '&' switches to a character
+// reference, and '\0' is a parse error. '\r' and '\n' require special handling
+// for line counting and newline normalization in the input stream preprocessor.
+// Everything else is plain text that can be emitted as-is.
+static bool isDataStateSpecialCharacter(Latin1Character c)
+{
+    return c == '<' || c == '&' || c == '\r' || c == '\n' || c == '\0';
+}
+
+// Returns the leading prefix of `span` that contains only plain-text characters
+// (i.e. characters that don't require special handling in the Data state).
+static std::span<const Latin1Character> findPlainTextInDataState(std::span<const Latin1Character> span)
+{
+    auto it = std::ranges::find_if(span, isDataStateSpecialCharacter);
+    return span.first(it - span.begin());
+}
+
 static inline Latin1Character NODELETE convertASCIIAlphaToLower(char16_t character)
 {
     ASSERT(isASCIIAlpha(character));
@@ -216,6 +234,25 @@ bool HTMLTokenizer::processToken(SegmentedString& source)
         if (character == kEndOfFileMarker)
             return emitEndOfFile(source);
         bufferCharacter(character);
+        // Optimization: scan ahead for a run of plain-text characters in the
+        // current 8-bit substring and buffer them all at once, avoiding the
+        // per-character overhead of the main tokenizer loop.
+        {
+            auto span = source.currentSubstringSpan8();
+            if (span.size() > 2) {
+                // span[0] is the current character, already buffered above. We also
+                // stop before the last character because advancePastMultiple8()
+                // requires at least one character to remain in the span (it becomes
+                // the new current character for the next iteration).
+                auto plainText = findPlainTextInDataState(span.subspan(1, span.size() - 2));
+                if (!plainText.empty()) {
+                    bufferCharacters(plainText);
+                    // +1 to also advance past span[0] (the current character already buffered above).
+                    source.advancePastMultiple8(plainText.size() + 1);
+                    SWITCH_TO(DataState);
+                }
+            }
+        }
         ADVANCE_TO(DataState);
     END_STATE()
 

--- a/Source/WebCore/html/parser/InputStreamPreprocessor.h
+++ b/Source/WebCore/html/parser/InputStreamPreprocessor.h
@@ -42,6 +42,7 @@ public:
     }
 
     ALWAYS_INLINE char16_t nextInputCharacter() const { return m_nextInputCharacter; }
+    ALWAYS_INLINE bool skipNextNewLine() const { return m_skipNextNewLine; }
 
     // Returns whether we succeeded in peeking at the next character.
     // The only way we can fail to peek is if there are no more

--- a/Source/WebCore/platform/text/SegmentedString.h
+++ b/Source/WebCore/platform/text/SegmentedString.h
@@ -61,6 +61,9 @@ public:
     void advancePastNonNewline(); // Faster than calling advance when we know the current character is not a newline.
     void advancePastNewline(); // Faster than calling advance when we know the current character is a newline.
 
+    std::span<const Latin1Character> currentSubstringSpan8() const;
+    void advancePastMultiple8(unsigned count);
+
     enum AdvancePastResult { DidNotMatch, DidMatch, NotEnoughCharacters };
     AdvancePastResult advancePast(ASCIILiteral literal) { return advancePast<false>(literal); }
     AdvancePastResult advancePastLettersIgnoringASCIICase(ASCIILiteral literal) { return advancePast<true>(literal); }
@@ -290,6 +293,40 @@ inline void SegmentedString::advancePastNewline()
     }
 
     (this->*m_advanceAndUpdateLineNumberFunction)();
+}
+
+// Returns a span over the remaining characters in the current 8-bit substring,
+// starting from the current character. Returns an empty span if not 8-bit.
+inline std::span<const Latin1Character> SegmentedString::currentSubstringSpan8() const
+{
+    if (m_fastPathFlags & Use8BitAdvance)
+        return m_currentSubstring.s.currentCharacter8;
+    return { };
+}
+
+// Advances past `count` characters in the current 8-bit substring.
+// The caller must ensure at least one character remains after advancing
+// (i.e. count < currentSubstringSpan8().size()), as the function sets
+// the next remaining character as m_currentCharacter.
+inline void SegmentedString::advancePastMultiple8(unsigned count)
+{
+    ASSERT(m_fastPathFlags & Use8BitAdvance);
+    ASSERT(count < m_currentSubstring.s.currentCharacter8.size());
+
+    if (m_currentCharacter == '\n' && (m_fastPathFlags & Use8BitAdvanceAndUpdateLineNumbers)) {
+        // Must skip past the newline before calling startNewLine(), so that
+        // numberOfCharactersConsumed() reflects the position after the '\n'.
+        // This matches the ordering in advance().
+        skip(m_currentSubstring.s.currentCharacter8, 1);
+        startNewLine();
+        if (count > 1)
+            skip(m_currentSubstring.s.currentCharacter8, count - 1);
+    } else
+        skip(m_currentSubstring.s.currentCharacter8, count);
+
+    m_currentCharacter = m_currentSubstring.s.currentCharacter8[0];
+    if (m_currentSubstring.s.currentCharacter8.size() == 1) [[unlikely]]
+        updateAdvanceFunctionPointersForSingleCharacterSubstring();
 }
 
 inline unsigned SegmentedString::numberOfCharactersConsumed() const


### PR DESCRIPTION
#### 497d66f4b6748966084d33b847e333ff5b67c53f
<pre>
Batch plain-text characters in HTML tokenizer DataState
<a href="https://bugs.webkit.org/show_bug.cgi?id=311554">https://bugs.webkit.org/show_bug.cgi?id=311554</a>

Reviewed by Darin Adler.

The HTML tokenizer&apos;s DataState processes characters one at a time, paying
per-iteration overhead for each: advance() → peek() → 3 comparisons →
bufferCharacter() → goto. For text-heavy pages, this is the hottest path.

After buffering a character, scan ahead in the current 8-bit substring for
runs of plain text (stopping at &apos;&lt;&apos;, &apos;&amp;&apos;, &apos;\r&apos;, &apos;\n&apos;, &apos;\0&apos;). Buffer the
entire run at once via bufferCharacters() and advance the source with a
new SegmentedString::advancePastMultiple8() that skips multiple characters
without per-character function pointer dispatch.

Performance results (Parser/html-parser-text-heavy, 5000 paragraphs):
  Baseline: 54.0 ms median
  Patched:  38.0 ms median → 30% faster

On the tag-heavy HTML spec (Parser/html-parser):
  Baseline: 209.0 ms median
  Patched:  207.0 ms median → ~1% faster

Real-world pages fall between these extremes depending on the ratio of
text to markup.

* Source/WebCore/html/parser/HTMLTokenizer.cpp:
(WebCore::HTMLTokenizer::processToken):
* Source/WebCore/html/parser/InputStreamPreprocessor.h:
(WebCore::InputStreamPreprocessor::skipNextNewLine const):
* Source/WebCore/platform/text/SegmentedString.h:
(WebCore::SegmentedString::currentSubstringSpan8 const):
(WebCore::SegmentedString::advancePastMultiple8):

Canonical link: <a href="https://commits.webkit.org/310687@main">https://commits.webkit.org/310687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81d9117b3d2a48c5fd173847fddef416ad1ba1b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21026 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163366 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/17f83c46-16ad-4e1f-928a-cffd805a10e9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156481 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27716 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119586 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cbeb3f69-a846-4da7-a6ea-43b72e1ce369) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157567 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21875 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138855 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100283 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7b9f4e25-3bc5-4461-b9e6-fedfbcee8c21) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20960 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11194 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/130623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16699 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165838 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9043 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18308 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127687 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27412 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23015 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127830 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34689 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27336 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138492 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/84018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22725 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15285 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27028 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91130 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26606 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26837 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26679 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->