### PR TITLE
SVG getStartPositionOfChar/getEndPositionOfChar should not include dominant-baseline shift in returned position

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getstartpositionofchar-dominant-baseline-shift-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getstartpositionofchar-dominant-baseline-shift-expected.txt
@@ -1,0 +1,12 @@
+T
+T
+T
+T
+T
+T
+
+PASS Horizontal: getStartPositionOfChar/getEndPositionOfChar not affected by inherited dominant-baseline
+PASS Horizontal: getStartPositionOfChar/getEndPositionOfChar not affected by explicit dominant-baseline on tspan
+PASS Vertical: getStartPositionOfChar/getEndPositionOfChar not affected by dominant-baseline
+PASS Horizontal: x position unaffected by dominant-baseline
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getstartpositionofchar-dominant-baseline-shift.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getstartpositionofchar-dominant-baseline-shift.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>SVG getStartPositionOfChar with dominant-baseline should return unshifted position</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getStartPositionOfChar">
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=311553">
+<meta name="assert" content="getStartPositionOfChar and getEndPositionOfChar should return positions based on the y attribute value, not shifted by dominant-baseline.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg width="400" height="400" style="font-family: serif; font-size: 60px;">
+  <!-- Horizontal text: auto vs middle baseline -->
+  <text>
+    <tspan id="h-auto" x="20" y="80">T</tspan>
+  </text>
+  <text dominant-baseline="middle">
+    <tspan id="h-middle" x="20" y="80">T</tspan>
+  </text>
+
+  <!-- Horizontal text: explicit on tspan -->
+  <text>
+    <tspan id="h-explicit-auto" x="20" y="160">T</tspan>
+  </text>
+  <text>
+    <tspan id="h-explicit-middle" x="20" y="160" dominant-baseline="middle">T</tspan>
+  </text>
+
+  <!-- Vertical text: auto vs middle baseline -->
+  <text writing-mode="tb">
+    <tspan id="v-auto" x="300" y="20">T</tspan>
+  </text>
+  <text writing-mode="tb" dominant-baseline="middle">
+    <tspan id="v-middle" x="300" y="20">T</tspan>
+  </text>
+</svg>
+
+<script>
+test(() => {
+  const auto = document.getElementById('h-auto');
+  const middle = document.getElementById('h-middle');
+  assert_equals(auto.getStartPositionOfChar(0).y, middle.getStartPositionOfChar(0).y,
+    'getStartPositionOfChar().y should not depend on inherited dominant-baseline');
+  assert_equals(auto.getEndPositionOfChar(0).y, middle.getEndPositionOfChar(0).y,
+    'getEndPositionOfChar().y should not depend on inherited dominant-baseline');
+}, 'Horizontal: getStartPositionOfChar/getEndPositionOfChar not affected by inherited dominant-baseline');
+
+test(() => {
+  const auto = document.getElementById('h-explicit-auto');
+  const middle = document.getElementById('h-explicit-middle');
+  assert_equals(auto.getStartPositionOfChar(0).y, middle.getStartPositionOfChar(0).y,
+    'getStartPositionOfChar().y should not depend on explicit dominant-baseline');
+  assert_equals(auto.getEndPositionOfChar(0).y, middle.getEndPositionOfChar(0).y,
+    'getEndPositionOfChar().y should not depend on explicit dominant-baseline');
+}, 'Horizontal: getStartPositionOfChar/getEndPositionOfChar not affected by explicit dominant-baseline on tspan');
+
+test(() => {
+  const auto = document.getElementById('v-auto');
+  const middle = document.getElementById('v-middle');
+  assert_equals(auto.getStartPositionOfChar(0).x, middle.getStartPositionOfChar(0).x,
+    'getStartPositionOfChar().x should not depend on dominant-baseline in vertical text');
+  assert_equals(auto.getEndPositionOfChar(0).x, middle.getEndPositionOfChar(0).x,
+    'getEndPositionOfChar().x should not depend on dominant-baseline in vertical text');
+}, 'Vertical: getStartPositionOfChar/getEndPositionOfChar not affected by dominant-baseline');
+
+test(() => {
+  // Verify the x position is also unaffected in horizontal mode
+  const auto = document.getElementById('h-auto');
+  const middle = document.getElementById('h-middle');
+  assert_equals(auto.getStartPositionOfChar(0).x, middle.getStartPositionOfChar(0).x,
+    'getStartPositionOfChar().x should be the same regardless of dominant-baseline');
+}, 'Horizontal: x position unaffected by dominant-baseline');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getstartpositionofchar-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getstartpositionofchar-expected.txt
@@ -3,8 +3,8 @@ ABC
 ABC
 ABC
 
-FAIL vertical-rl assert_equals: expected 110 but got 100
-FAIL vertical-lr assert_equals: expected 110 but got 100
-FAIL sideways-rl assert_equals: expected 110 but got 100
-FAIL sideways-lr assert_equals: expected 90 but got 100
+FAIL vertical-rl assert_equals: expected 113 but got 103
+FAIL vertical-lr assert_equals: expected 113 but got 103
+FAIL sideways-rl assert_equals: expected 113 but got 103
+FAIL sideways-lr assert_equals: expected 93 but got 103
 

--- a/Source/WebCore/rendering/svg/SVGTextFragment.h
+++ b/Source/WebCore/rendering/svg/SVGTextFragment.h
@@ -25,18 +25,6 @@ namespace WebCore {
 
 // A SVGTextFragment describes a text fragment of a RenderSVGInlineText which can be rendered at once.
 struct SVGTextFragment {
-    SVGTextFragment()
-        : characterOffset(0)
-        , metricsListOffset(0)
-        , length(0)
-        , isTextOnPath(false)
-        , x(0)
-        , y(0)
-        , width(0)
-        , height(0)
-    {
-    }
-
     enum TransformType {
         TransformRespectingTextLength,
         TransformIgnoringTextLength
@@ -57,15 +45,20 @@ struct SVGTextFragment {
     }
 
     // The first rendered character starts at RenderSVGInlineText::characters() + characterOffset.
-    unsigned characterOffset;
-    unsigned metricsListOffset;
-    unsigned length : 31;
-    bool isTextOnPath : 1;
+    unsigned characterOffset { 0 };
+    unsigned metricsListOffset { 0 };
+    unsigned length : 31 { 0 };
+    bool isTextOnPath : 1 { false };
 
-    float x;
-    float y;
-    float width;
-    float height;
+    float x { 0 };
+    float y { 0 };
+    float width { 0 };
+    float height { 0 };
+
+    // Baseline shift from dominant-baseline / alignment-baseline / baseline-shift CSS properties.
+    // Stored separately so that query APIs (getStartPositionOfChar, getEndPositionOfChar, getExtentOfChar)
+    // return positions based on the y attribute value, while rendering applies this shift visually.
+    float baselineShift { 0 };
 
     // Includes rotation/glyph-orientation-(horizontal|vertical) transforms, as well as orientation related shifts
     // (see SVGTextLayoutEngine, which builds this transformation).

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
@@ -633,6 +633,9 @@ void SVGTextLayoutEngine::layoutTextOnLineOrPath(InlineIterator::SVGTextBoxItera
             m_currentTextFragment.metricsListOffset = m_visualMetricsListOffset;
             m_currentTextFragment.x = x;
             m_currentTextFragment.y = y;
+            // Record the baseline shift so query APIs can subtract it to return
+            // the unshifted position (matching Chrome/Firefox behavior).
+            m_currentTextFragment.baselineShift = baselineShift;
 
             // Build fragment transformation.
             if (angle)

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
@@ -62,6 +62,13 @@ AlignmentBaseline SVGTextLayoutEngineBaseline::dominantBaselineToAlignmentBaseli
 
     DominantBaseline baseline = textRenderer.style().dominantBaseline();
     if (baseline == DominantBaseline::Auto) {
+        // Per SVG2 and CSS Inline 3, auto maps to alphabetic in horizontal writing
+        // modes and to central in vertical writing modes. The CSS Inline 3 spec
+        // distinguishes text-orientation values for vertical text, but SVG2 says
+        // "the origin point of glyphs is always handled as for central in vertical
+        // writing modes" for backwards compatibility.
+        // https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline
+        // https://w3c.github.io/svgwg/svg2-draft/text.html#DominantBaselineProperty
         if (isVerticalText)
             baseline = DominantBaseline::Central;
         else

--- a/Source/WebCore/rendering/svg/SVGTextQuery.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextQuery.cpp
@@ -326,6 +326,15 @@ bool SVGTextQuery::startPositionOfCharacterCallback(Data* queryData, const SVGTe
 
     data->startPosition = FloatPoint(fragment.x, fragment.y);
 
+    // Subtract baseline shift so the returned position reflects the y attribute
+    // value, not the visually shifted position. This matches Chrome/Firefox behavior.
+    if (fragment.baselineShift) {
+        if (queryData->isVerticalText)
+            data->startPosition.move(-fragment.baselineShift, 0);
+        else
+            data->startPosition.move(0, fragment.baselineShift);
+    }
+
     if (startPosition) {
         SVGTextMetrics metrics = SVGTextMetrics::measureCharacterRange(*queryData->textRenderer, fragment.characterOffset, startPosition);
         if (queryData->isVerticalText)
@@ -378,6 +387,15 @@ bool SVGTextQuery::endPositionOfCharacterCallback(Data* queryData, const SVGText
         return false;
 
     data->endPosition = FloatPoint(fragment.x, fragment.y);
+
+    // Subtract baseline shift so the returned position reflects the y attribute
+    // value, not the visually shifted position. This matches Chrome/Firefox behavior.
+    if (fragment.baselineShift) {
+        if (queryData->isVerticalText)
+            data->endPosition.move(-fragment.baselineShift, 0);
+        else
+            data->endPosition.move(0, fragment.baselineShift);
+    }
 
     SVGTextMetrics metrics = SVGTextMetrics::measureCharacterRange(*queryData->textRenderer, fragment.characterOffset, startPosition + 1);
     if (queryData->isVerticalText)


### PR DESCRIPTION
#### 48ca57667b1e698e816ed42c69fc1e8eaaab05c1
<pre>
SVG getStartPositionOfChar/getEndPositionOfChar should not include dominant-baseline shift in returned position
<a href="https://bugs.webkit.org/show_bug.cgi?id=311553">https://bugs.webkit.org/show_bug.cgi?id=311553</a>
<a href="https://rdar.apple.com/174145885">rdar://174145885</a>

Reviewed by Nikolas Zimmermann.

This fix is a prerequisite for <a href="https://webkit.org/b/=297455">https://webkit.org/b/=297455</a>

getStartPositionOfChar and getEndPositionOfChar were returning positions
that included the visual baseline shift from dominant-baseline. They
should return positions based on the y attribute value instead.

Store the baseline shift in a new SVGTextFragment.baselineShift field
and subtract it in the query APIs only. All other consumers of
fragment.y (painting, hit testing, bounding boxes) are unchanged.

Test: imported/w3c/web-platform-tests/svg/text/scripted/getstartpositionofchar-dominant-baseline-shift.html

* LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getstartpositionofchar-dominant-baseline-shift-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getstartpositionofchar-dominant-baseline-shift.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getstartpositionofchar-expected.txt:
* Source/WebCore/rendering/svg/SVGTextFragment.h:
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp:
(WebCore::SVGTextLayoutEngine::layoutTextOnLineOrPath):
* Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp:
(WebCore::SVGTextLayoutEngineBaseline::dominantBaselineToAlignmentBaseline const):
* Source/WebCore/rendering/svg/SVGTextQuery.cpp:
(WebCore::SVGTextQuery::startPositionOfCharacterCallback const):
(WebCore::SVGTextQuery::endPositionOfCharacterCallback const):

Canonical link: <a href="https://commits.webkit.org/311450@main">https://commits.webkit.org/311450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65115fff1e4ec7c450fc684efe07286c69230655

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165832 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111091 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc89d488-2612-4351-a989-a244646eecf9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158880 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121594 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2feeb570-cc8e-418f-a920-8b96f7a1886c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140990 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102262 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22891 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21121 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13604 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132572 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18818 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168317 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12476 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20438 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129719 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29947 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25199 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129827 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35165 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29870 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140612 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87674 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24655 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17416 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29581 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93595 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29103 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29333 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29229 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->