### PR TITLE
Release animVal when animation ends in SVGAnimatedPropertyList and SVGAnimatedValueProperty

### DIFF
--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyList.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyList.h
@@ -93,7 +93,9 @@ public:
     void stopAnimation(SVGAttributeAnimator& animator) override
     {
         Base::stopAnimation(animator);
-        if (m_animVal)
+        if (!this->isAnimating())
+            m_animVal = nullptr;
+        else if (m_animVal)
             *m_animVal = m_baseVal;
     }
 

--- a/Source/WebCore/svg/properties/SVGAnimatedValueProperty.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedValueProperty.h
@@ -109,7 +109,9 @@ public:
     void stopAnimation(SVGAttributeAnimator& animator) override
     {
         Base::stopAnimation(animator);
-        if (m_animVal)
+        if (!this->isAnimating())
+            m_animVal = nullptr;
+        else if (m_animVal)
             m_animVal->setValue(m_baseVal->value());
     }
 


### PR DESCRIPTION
#### 393fc8204f770944fb1d811b90486c12a0cb42f2
<pre>
Release animVal when animation ends in SVGAnimatedPropertyList and SVGAnimatedValueProperty
<a href="https://bugs.webkit.org/show_bug.cgi?id=311559">https://bugs.webkit.org/show_bug.cgi?id=311559</a>

Reviewed by Darin Adler.

SVGAnimatedPrimitiveProperty::stopAnimation() already nulls m_animVal when
the last animator stops, freeing memory. SVGAnimatedPropertyList and
SVGAnimatedValueProperty were missing this — they unconditionally reset
animVal to baseVal, keeping the allocation alive indefinitely after
animation ended. For large lists (path segments, point lists), this is
wasted memory. Both classes already null m_animVal in
instanceStopAnimationImpl, so this makes stopAnimation consistent.

* Source/WebCore/svg/properties/SVGAnimatedPropertyList.h:
* Source/WebCore/svg/properties/SVGAnimatedValueProperty.h:

Canonical link: <a href="https://commits.webkit.org/310680@main">https://commits.webkit.org/310680@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26b9eec4f175c722c000b2bab668060a28a66441

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163215 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107928 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff0305be-2285-4cde-9764-9a263031536f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156332 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27567 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119469 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84495 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d7584e2-71d5-45c0-9d86-b87fca558376) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138723 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100166 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2a8951ea-d022-4701-b89c-6e55b935795b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20832 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18842 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11045 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130494 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165687 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8894 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18176 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127564 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127710 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34681 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27187 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138360 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83855 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22605 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15152 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26877 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90980 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26458 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26689 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26531 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->