### PR TITLE
HTMLFormElement::length() should use the cached HTMLFormControlsCollection

### DIFF
--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -153,18 +153,9 @@ void HTMLFormElement::removingSteps(RemovalType removalType, ContainerNode& oldP
       m_controlsCollection = nullptr; // Avoid leaks since HTMLCollection has a back Ref to this element.
 }
 
-unsigned HTMLFormElement::length() const
+unsigned HTMLFormElement::length()
 {
-    unsigned length = 0;
-    for (auto& weakElement : m_listedElements) {
-        auto* element = weakElement.get();
-        ASSERT(element);
-        auto* listedElement = element->asFormListedElement();
-        ASSERT(listedElement);
-        if (listedElement->isEnumeratable())
-            ++length;
-    }
-    return length;
+    return elements()->length();
 }
 
 HTMLElement* HTMLFormElement::item(unsigned index)

--- a/Source/WebCore/html/HTMLFormElement.h
+++ b/Source/WebCore/html/HTMLFormElement.h
@@ -54,8 +54,8 @@ public:
     Vector<Ref<Element>> namedElements(const AtomString&);
     bool isSupportedPropertyName(const AtomString&);
 
-    bool isSupportedPropertyIndex(unsigned index) const { return index < length(); }
-    WEBCORE_EXPORT unsigned NODELETE length() const;
+    bool isSupportedPropertyIndex(unsigned index) { return index < length(); }
+    WEBCORE_EXPORT unsigned length();
     HTMLElement* item(unsigned index);
     std::optional<Variant<Ref<RadioNodeList>, Ref<Element>>> namedItem(const AtomString&);
     Vector<AtomString> NODELETE supportedPropertyNames() const;


### PR DESCRIPTION
#### 3415adf7a9d658881a8246b91db3bc428069bc77
<pre>
HTMLFormElement::length() should use the cached HTMLFormControlsCollection
<a href="https://bugs.webkit.org/show_bug.cgi?id=311560">https://bugs.webkit.org/show_bug.cgi?id=311560</a>

Reviewed by Ryosuke Niwa and Anne van Kesteren.

HTMLFormElement::length() was manually iterating m_listedElements and
calling virtual isEnumeratable() on each element on every call.
HTMLFormControlsCollection already caches element count via
CollectionIndexCache, but length() was bypassing it entirely. This made
JavaScript patterns like for (i = 0; i &lt; form.length; i++) O(n^2).

Delegate to elements()-&gt;length() to benefit from the collection&apos;s
caching, matching how item() already delegates to elements()-&gt;item().

* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::length):
(WebCore::HTMLFormElement::length const): Deleted.
* Source/WebCore/html/HTMLFormElement.h:

Canonical link: <a href="https://commits.webkit.org/310685@main">https://commits.webkit.org/310685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b6f341476ca827c0e04227822f239543511e4df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154609 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163367 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/35f9eff9-7153-461d-a96e-66033f5d5f8f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156482 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28001 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27717 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/119587 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95f97dc9-8e1d-4cbc-8739-953d246caf62) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138857 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100284 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d22a9734-45f2-4813-90de-09a83ff231eb) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11195 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/130624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/16701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165839 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/9044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18310 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/127688 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27413 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127831 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34686 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138494 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/84019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22728 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15287 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27029 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91131 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26607 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/26838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26680 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->