### PR TITLE
Manage <select> RTL padding logic in popupInternalPaddingBox() as well

### DIFF
--- a/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-dimensions-expected.txt
+++ b/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-dimensions-expected.txt
@@ -18,6 +18,28 @@ PASS sidewaysRL.offsetHeight is horizontal.offsetWidth
 sideways-lr
 PASS sidewaysLR.offsetWidth is horizontal.offsetHeight
 PASS sidewaysLR.offsetHeight is horizontal.offsetWidth
+
+direction: rtl should not change dimensions
+
+horizontal rtl
+PASS horizontalRTL.offsetWidth is horizontal.offsetWidth
+PASS horizontalRTL.offsetHeight is horizontal.offsetHeight
+
+vertical-rl rtl
+PASS verticalRL_RTL.offsetWidth is verticalRL.offsetWidth
+PASS verticalRL_RTL.offsetHeight is verticalRL.offsetHeight
+
+vertical-lr rtl
+PASS verticalLR_RTL.offsetWidth is verticalLR.offsetWidth
+PASS verticalLR_RTL.offsetHeight is verticalLR.offsetHeight
+
+sideways-rl rtl
+PASS sidewaysRL_RTL.offsetWidth is sidewaysRL.offsetWidth
+PASS sidewaysRL_RTL.offsetHeight is sidewaysRL.offsetHeight
+
+sideways-lr rtl
+PASS sidewaysLR_RTL.offsetWidth is sidewaysLR.offsetWidth
+PASS sidewaysLR_RTL.offsetHeight is sidewaysLR.offsetHeight
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-dimensions.html
+++ b/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-dimensions.html
@@ -9,6 +9,12 @@
 <select id="verticalLR" style="writing-mode: vertical-lr"><option>Option 1</option></select>
 <select id="sidewaysRL" style="writing-mode: sideways-rl"><option>Option 1</option></select>
 <select id="sidewaysLR" style="writing-mode: sideways-lr"><option>Option 1</option></select>
+
+<select id="horizontalRTL" dir="rtl"><option>Option 1</option></select>
+<select id="verticalRL_RTL" style="writing-mode: vertical-rl; direction: rtl"><option>Option 1</option></select>
+<select id="verticalLR_RTL" style="writing-mode: vertical-lr; direction: rtl"><option>Option 1</option></select>
+<select id="sidewaysRL_RTL" style="writing-mode: sideways-rl; direction: rtl"><option>Option 1</option></select>
+<select id="sidewaysLR_RTL" style="writing-mode: sideways-lr; direction: rtl"><option>Option 1</option></select>
 </body>
 <script>
 
@@ -34,6 +40,34 @@ debug("");
 debug("sideways-lr");
 shouldBe("sidewaysLR.offsetWidth", "horizontal.offsetHeight");
 shouldBe("sidewaysLR.offsetHeight", "horizontal.offsetWidth");
+debug("");
+
+debug("direction: rtl should not change dimensions");
+debug("");
+
+debug("horizontal rtl");
+shouldBe("horizontalRTL.offsetWidth", "horizontal.offsetWidth");
+shouldBe("horizontalRTL.offsetHeight", "horizontal.offsetHeight");
+debug("");
+
+debug("vertical-rl rtl");
+shouldBe("verticalRL_RTL.offsetWidth", "verticalRL.offsetWidth");
+shouldBe("verticalRL_RTL.offsetHeight", "verticalRL.offsetHeight");
+debug("");
+
+debug("vertical-lr rtl");
+shouldBe("verticalLR_RTL.offsetWidth", "verticalLR.offsetWidth");
+shouldBe("verticalLR_RTL.offsetHeight", "verticalLR.offsetHeight");
+debug("");
+
+debug("sideways-rl rtl");
+shouldBe("sidewaysRL_RTL.offsetWidth", "sidewaysRL.offsetWidth");
+shouldBe("sidewaysRL_RTL.offsetHeight", "sidewaysRL.offsetHeight");
+debug("");
+
+debug("sideways-lr rtl");
+shouldBe("sidewaysLR_RTL.offsetWidth", "sidewaysLR.offsetWidth");
+shouldBe("sidewaysLR_RTL.offsetHeight", "sidewaysLR.offsetHeight");
 
 </script>
 </html>

--- a/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-rtl-expected.html
+++ b/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-rtl-expected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<style>
+
+.wrapper {
+    position: absolute;
+    display: inline-block;
+    transform: rotate(90deg) translate(0, -100%);
+    transform-origin: left top;
+}
+
+#first { left: 50px; top: 50px; }
+#second { left: 50px; top: 250px; }
+
+.cover {
+    position: absolute;
+    left: 0;
+    width: 200px;
+    height: 100px;
+    background: white;
+}
+
+#cover1 { top: 50px; }
+#cover2 { top: 250px; }
+
+</style>
+<div id="first" class="wrapper">
+    <select dir="rtl"><option>Option 1</option></select>
+</div>
+<div id="second" class="wrapper">
+    <select dir="rtl"><option>Option 1</option></select>
+</div>
+<div id="cover1" class="cover"></div>
+<div id="cover2" class="cover"></div>

--- a/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-rtl.html
+++ b/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-rtl.html
@@ -22,15 +22,15 @@
     background: white;
 }
 
-#cover1 { top: 90px; }
-#cover2 { top: 290px; }
+#cover1 { top: 50px; }
+#cover2 { top: 250px; }
 
 </style>
 <div id="first" class="wrapper">
-    <select style="writing-mode: vertical-rl"><option>Option 1</option></select>
+    <select style="writing-mode: vertical-rl; direction: rtl"><option>Option 1</option></select>
 </div>
 <div id="second" class="wrapper">
-    <select style="writing-mode: vertical-lr"><option>Option 1</option></select>
+    <select style="writing-mode: vertical-lr; direction: rtl"><option>Option 1</option></select>
 </div>
 <div id="cover1" class="cover"></div>
 <div id="cover2" class="cover"></div>

--- a/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-vertical-variants.html
+++ b/LayoutTests/fast/forms/vertical-writing-mode/select-menulist-vertical-variants.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<link rel="match" href="select-menulist-vertical-variants-expected.html">
+<meta name="fuzzy" content="maxDifference=0-170; totalPixels=0-284">
 <style>
 
 .wrapper {
@@ -16,8 +16,8 @@
     <select style="writing-mode: vertical-rl"><option>Option 1</option></select>
 </div>
 <div id="second" class="wrapper">
-    <select style="writing-mode: vertical-lr"><option>Option 1</option></select>
+    <select style="writing-mode: sideways-rl"><option>Option 1</option></select>
 </div>
 <div id="third" class="wrapper">
-    <select style="writing-mode: sideways-rl"><option>Option 1</option></select>
+    <select style="writing-mode: sideways-lr; transform: rotate(180deg)"><option>Option 1</option></select>
 </div>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -214,8 +214,10 @@ fast/forms/switch/zoom-approximates-transform.html [ Pass ]
 fast/forms/switch/zoom-computed-style.html [ Pass ]
 
 # Vertical <select> support needs some further changes.
+fast/forms/vertical-writing-mode/select-menulist-rtl.html [ Skip ]
 fast/forms/vertical-writing-mode/select-menulist-sideways-lr.html [ Skip ]
 fast/forms/vertical-writing-mode/select-menulist.html [ Skip ]
+fast/forms/vertical-writing-mode/select-menulist-vertical-variants.html [ Skip ]
 
 # Some Apple ports don't support RTL scrollbars.
 fast/scrolling/rtl-scrollbars-alternate-body-dir-attr-does-not-update-scrollbar-placement.html [ Pass ]

--- a/LayoutTests/platform/mac-sequoia/TestExpectations
+++ b/LayoutTests/platform/mac-sequoia/TestExpectations
@@ -20,6 +20,7 @@ fast/forms/datalist/datalist-fallback-content.html [ Pass ]
 fast/forms/appearance-default-button.html  [ Skip ]
 fast/forms/form-control-refresh [ Skip ]
 fast/forms/vertical-writing-mode/select-menulist.html [ Skip ]
+fast/forms/vertical-writing-mode/select-menulist-rtl.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-ui/button-author-level-padding-applies.html [ Skip ]
 
 # Tests which pass only with form control refresh disabled (support added in Tahoe)

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1697,13 +1697,19 @@ void RenderTheme::adjustSwitchStyle(RenderStyle& style, const Element*) const
 Style::PaddingBox RenderTheme::popupInternalPaddingBox(const RenderStyle& style) const
 {
     auto padding = platformPopupInternalPaddingBox(style);
-    if (!style.writingMode().isHorizontal()) {
-        if (style.writingMode().computedWritingMode() == StyleWritingMode::SidewaysLr)
-            padding = { padding.right(), padding.bottom(), padding.left(), padding.top() };
-        else
-            padding = { padding.left(), padding.top(), padding.right(), padding.bottom() };
+    auto mode = style.writingMode();
+    // Platform returns padding in horizontal-tb LTR.
+    Style::PaddingBox result { 0_css_px };
+    if (mode.isLineInverted()) {
+        result.after(mode) = padding.top();
+        result.before(mode) = padding.bottom();
+    } else {
+        result.before(mode) = padding.top();
+        result.after(mode) = padding.bottom();
     }
-    return padding;
+    result.start(mode) = padding.left();
+    result.end(mode) = padding.right();
+    return result;
 }
 
 Style::PaddingBox RenderTheme::platformPopupInternalPaddingBox(const RenderStyle&) const

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
@@ -358,14 +358,12 @@ Style::PaddingBox RenderThemeAdwaita::platformPopupInternalPaddingBox(const Rend
         return { 0_css_px };
 
     auto zoomedArrowSize = menuListButtonArrowSize * style.usedZoom();
-    int leftPadding = menuListButtonPadding + (style.writingMode().isBidiRTL() ? zoomedArrowSize : 0);
-    int rightPadding = menuListButtonPadding + (style.writingMode().isBidiLTR() ? zoomedArrowSize : 0);
 
     return {
         Style::PaddingEdge::Fixed { static_cast<float>(menuListButtonPadding) },
-        Style::PaddingEdge::Fixed { static_cast<float>(rightPadding) },
+        Style::PaddingEdge::Fixed { static_cast<float>(menuListButtonPadding + zoomedArrowSize) },
         Style::PaddingEdge::Fixed { static_cast<float>(menuListButtonPadding) },
-        Style::PaddingEdge::Fixed { static_cast<float>(leftPadding) },
+        Style::PaddingEdge::Fixed { static_cast<float>(menuListButtonPadding) },
     };
 }
 

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -387,16 +387,21 @@ Style::PaddingBox RenderThemeIOS::platformPopupInternalPaddingBox(const RenderSt
         // FIXME: Reduce code duplication with toTruncatedPaddingEdge.
         auto value = Style::PaddingEdge::Fixed { static_cast<float>(std::trunc(padding + Style::evaluate<float>(style.usedBorderTopWidth(),  Style::ZoomNeeded { }))) / style.usedZoom() };
 
-        bool padLeft = [&] {
-            auto textAlign = style.textAlign();
-            if (textAlign == Style::TextAlign::Start)
-                return style.writingMode().isBidiRTL();
-            if (textAlign == Style::TextAlign::End)
+        // Return in horizontal-tb LTR; popupInternalPaddingBox() handles conversion.
+        bool padStart = [&] {
+            switch (style.textAlign()) {
+            case Style::TextAlign::Start:
+                return false;
+            case Style::TextAlign::End:
+                return true;
+            case Style::TextAlign::Right:
                 return style.writingMode().isBidiLTR();
-            return textAlign == Style::TextAlign::Right;
+            default:
+                return style.writingMode().isBidiRTL();
+            }
         }();
 
-        if (padLeft)
+        if (padStart)
             return { 0_css_px, 0_css_px, 0_css_px, value };
         return { 0_css_px, value, 0_css_px, 0_css_px };
     }

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -876,21 +876,15 @@ static std::span<const IntSize, 4> NODELETE popupButtonSizes()
     return sizes;
 }
 
-static std::span<const int, 4> NODELETE popupButtonPadding(NSControlSize size, bool isRTL)
+static std::span<const int, 4> NODELETE popupButtonPadding(NSControlSize size)
 {
-    static constexpr std::array paddingLTR {
+    static constexpr std::array padding {
         std::array { 2, 26, 3, 8 },
         std::array { 2, 23, 3, 8 },
         std::array { 2, 22, 3, 10 },
         std::array { 2, 26, 3, 8 },
     };
-    static constexpr std::array paddingRTL {
-        std::array { 2, 8, 3, 26 },
-        std::array { 2, 8, 3, 23 },
-        std::array { 2, 8, 3, 22 },
-        std::array { 2, 8, 3, 26 },
-    };
-    return isRTL ? paddingRTL[size] : paddingLTR[size];
+    return padding[size];
 }
 
 // Checkboxes and radio buttons
@@ -1363,7 +1357,7 @@ static Style::PaddingEdge NODELETE toTruncatedPaddingEdge(auto value)
 Style::PaddingBox RenderThemeMac::platformPopupInternalPaddingBox(const RenderStyle& style) const
 {
     if (style.usedAppearance() == StyleAppearance::Menulist) {
-        auto padding = popupButtonPadding(controlSizeForFont(style), style.writingMode().isBidiRTL());
+        auto padding = popupButtonPadding(controlSizeForFont(style));
         return {
             toTruncatedPaddingEdge(padding[topPadding]),
             toTruncatedPaddingEdge(padding[rightPadding]),
@@ -1376,8 +1370,6 @@ Style::PaddingBox RenderThemeMac::platformPopupInternalPaddingBox(const RenderSt
         float arrowWidth = baseArrowWidth * (style.computedFontSize() / baseFontSize);
         float rightPadding = ceilf(arrowWidth + (arrowPaddingBefore + arrowPaddingAfter + paddingBeforeSeparator) * style.usedZoom());
         float leftPadding = styledPopupPaddingLeft;
-        if (style.writingMode().isBidiRTL())
-            std::swap(rightPadding, leftPadding);
 
         return {
             toTruncatedPaddingEdge(styledPopupPaddingTop),


### PR DESCRIPTION
#### a38e55c83134ff3099a27026c925f9decb86b7fd
<pre>
Manage &lt;select&gt; RTL padding logic in popupInternalPaddingBox() as well
<a href="https://bugs.webkit.org/show_bug.cgi?id=311564">https://bugs.webkit.org/show_bug.cgi?id=311564</a>

Reviewed by Elika Etemad and Darin Adler.

310622@main made it so we handle vertical logic in a central place, but
RTL was still embedded in the platform code, which was a bit confusing.

We also used computedWritingMode() which isn&apos;t idiomatic.

We also add some test coverage for RTL.

Test: fast/forms/vertical-writing-mode/select-menulist-rtl.html
Canonical link: <a href="https://commits.webkit.org/310786@main">https://commits.webkit.org/310786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41129eb49330b83373571e2d480b2c04c2205b8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163663 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108373 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28301 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119841 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84706 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157862 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22110 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139111 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100534 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21195 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19227 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11489 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130857 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16955 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166137 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9550 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127943 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128082 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27631 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138748 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84336 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23625 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22958 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15543 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27323 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91427 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26901 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27132 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26974 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->