### PR TITLE
Make auto outlines follow the border radii better

### DIFF
--- a/LayoutTests/fast/css/focus-ring-border-radius-outline-offset-expected.html
+++ b/LayoutTests/fast/css/focus-ring-border-radius-outline-offset-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+div {
+    position:absolute;
+    top:10px;
+    left:10px;
+    width: 16px;
+    height: 16px;
+    border-radius: 5px;
+    outline: auto;
+    outline-offset: 5px;
+}
+</style>
+<div></div>

--- a/LayoutTests/fast/css/focus-ring-border-radius-outline-offset.html
+++ b/LayoutTests/fast/css/focus-ring-border-radius-outline-offset.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url(../../resources/Ahem.ttf);
+}
+
+div {
+    position:absolute;
+    top:10px;
+    left:10px;
+    display:inline-block;
+    border-radius: 5px;
+    outline: auto;
+    outline-offset: 5px;
+    font: 16px/1 Ahem;
+    color:#fff;
+}
+</style>
+
+<div>X<div>

--- a/Source/WebCore/rendering/OutlinePainter.cpp
+++ b/Source/WebCore/rendering/OutlinePainter.cpp
@@ -287,15 +287,44 @@ void OutlinePainter::paintFocusRing(const RenderElement& renderer, const Vector<
     auto styleOptions = renderer.styleColorOptions();
     styleOptions.add(StyleColorOptions::UseSystemAppearance);
     auto focusRingColor = usePlatformFocusRingColorForOutlineStyleAuto() ? RenderTheme::singleton().focusRingColor(styleOptions) : style->visitedDependentOutlineColorApplyingColorFilter();
-    if (useShrinkWrappedFocusRingForOutlineStyleAuto() && style->border().hasBorderRadius()) {
-        auto path = pathWithShrinkWrappedRects(pixelSnappedFocusRingRects, style->border().radii, outlineOffset, style->writingMode(), zoom, deviceScaleFactor);
-        if (path.isEmpty()) {
-            for (auto rect : pixelSnappedFocusRingRects)
-                path.addRect(rect);
-        }
-        drawFocusRing(m_paintInfo.context(), path, style.get(), focusRingColor);
-    } else
+
+    if (!useShrinkWrappedFocusRingForOutlineStyleAuto() || !style->border().hasBorderRadius()) {
         drawFocusRing(m_paintInfo.context(), pixelSnappedFocusRingRects, style.get(), focusRingColor);
+        return;
+    }
+
+    // When all focus ring rects are contained within the first rect (the
+    // element's own rect for block elements with children), use BorderShape
+    // for correct radii computation. pathWithShrinkWrappedRects resolves radii
+    // against the already-inflated rect then further adjusts them via
+    // adjustedRadiiForHuggingCurve, producing incorrect rounding.
+    auto canUseBorderShape = [&] {
+        if (focusRingRects.isEmpty())
+            return false;
+        for (size_t i = 1; i < focusRingRects.size(); ++i) {
+            if (!focusRingRects[0].contains(focusRingRects[i]))
+                return false;
+        }
+        return true;
+    }();
+
+    if (canUseBorderShape) {
+        auto borderRect = focusRingRects[0];
+        auto outlineRect = borderRect;
+        outlineRect.inflate(LayoutUnit(outlineOffset));
+        auto outlineShape = BorderShape::shapeForOffsetRect(style.get(), borderRect, outlineRect, RectEdges<LayoutUnit> { }, RectEdges<bool> { true });
+        auto path = outlineShape.pathForOuterShape(deviceScaleFactor);
+        drawFocusRing(m_paintInfo.context(), path, style.get(), focusRingColor);
+        return;
+    }
+
+    // Multi-rect (inline spanning lines): shrink-wrap path.
+    auto path = pathWithShrinkWrappedRects(pixelSnappedFocusRingRects, style->border().radii, outlineOffset, style->writingMode(), zoom, deviceScaleFactor);
+    if (path.isEmpty()) {
+        for (auto rect : pixelSnappedFocusRingRects)
+            path.addRect(rect);
+    }
+    drawFocusRing(m_paintInfo.context(), path, style.get(), focusRingColor);
 }
 
 Vector<LayoutRect> OutlinePainter::collectFocusRingRects(const RenderElement& renderer, const LayoutPoint& additionalOffset, const RenderLayerModelObject* paintContainer)


### PR DESCRIPTION
#### 7a3ff16540bff913ee4b37e40116ea8dae35c7ea
<pre>
Make auto outlines follow the border radii better
<a href="https://bugs.webkit.org/show_bug.cgi?id=311567">https://bugs.webkit.org/show_bug.cgi?id=311567</a>

Reviewed by Simon Fraser.

Fixed paintFocusRing() to use BorderShape::shapeForOffsetRect instead
of pathWithShrinkWrappedRects when the focus ring rects resolve to a
single rectangle. The old path resolved border-radius against the
already-inflated rect (after outline-offset) then further adjusted via
adjustedRadiiForHuggingCurve, double-adjusting the radii.

The new path mirrors how non-auto outlines compute radii: resolve
against the original border box, then let BorderShape handle the offset
expansion/contraction. A containment check ensures block elements with
child rects (e.g., &lt;select&gt; buttons containing &lt;div&gt;/&lt;svg&gt;) also take
the corrected path, while genuine multi-rect cases (inline elements
spanning lines) still use the shrink-wrap path.

Also restructured the function to use early returns.

This improves this demo: <a href="https://codepen.io/argyleink/pen/wvYrZEV">https://codepen.io/argyleink/pen/wvYrZEV</a>

Test: fast/css/focus-ring-border-radius-outline-offset.html
Canonical link: <a href="https://commits.webkit.org/310900@main">https://commits.webkit.org/310900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fed6d52416a4c5008643d2ce7607b394affb8f11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155233 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163993 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f69a158-4870-4211-a2e7-d2c6f045aba4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157106 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28633 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120114 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0562dcb0-1c94-448d-a553-1700372bc4aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22367 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139404 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100809 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21453 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19512 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11819 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131118 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17240 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166471 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18849 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128221 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28037 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23546 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128358 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27961 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139033 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84670 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23672 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23221 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15830 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27654 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91758 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27232 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27462 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27305 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->