### PR TITLE
<audio> and <video> controls render strangely when rotated

### DIFF
--- a/LayoutTests/media/modern-media-controls/css/transformed-media-controls-update-expected.txt
+++ b/LayoutTests/media/modern-media-controls/css/transformed-media-controls-update-expected.txt
@@ -1,0 +1,11 @@
+Testing that media controls have correct dimensions when a CSS rotation is applied.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS mediaControls.style.width is "300px"
+PASS mediaControls.style.height is "150px"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/modern-media-controls/css/transformed-media-controls-update.html
+++ b/LayoutTests/media/modern-media-controls/css/transformed-media-controls-update.html
@@ -1,0 +1,28 @@
+<head>
+    <meta name="viewport" content="user-scalable=no, width=device-width">
+    <style type="text/css" media="screen">
+
+        video {
+            width: 300px;
+            height: 150px;
+            transform: rotate(45deg);
+            transform-origin: top left;
+        }
+
+    </style>
+</head>
+<body>
+    <video controls></video>
+    <script src="../../../resources/js-test.js"></script>
+    <script type="text/javascript">
+
+        description("Testing that media controls have correct dimensions when a CSS rotation is applied.");
+
+        const media = document.querySelector("video");
+        const shadowRoot = window.internals.shadowRoot(media);
+        const mediaControls = shadowRoot.querySelector(".media-controls");
+        shouldBeEqualToString("mediaControls.style.width", "300px");
+        shouldBeEqualToString("mediaControls.style.height", "150px");
+
+    </script>
+</body>

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -449,49 +449,13 @@ class MediaController
 
     _updateControlsSize()
     {
-        // To compute the bounds of the controls, we need to account for the computed transform applied
-        // to the media element, and apply the inverted transform to the bounds computed on the container
-        // element in the shadow root, which is naturally sized to match the metrics of its host,
-        // excluding borders.
-
-        // First, we traverse the node hierarchy up from the media element to compute the effective
-        // transform matrix applied to the media element.
-        let node = this.media;
-        let transform = new DOMMatrix;
-        while (node && node instanceof HTMLElement) {
-            transform = transform.multiply(new DOMMatrix(getComputedStyle(node).transform));
-            node = node.parentNode;
-        }
-
-        // Then, we take each corner of the container element in the shadow root and transform
-        // each with the inverted matrix we just computed so that we can compute the untransformed
-        // bounds of the media element.
-        const bounds = this.container.getBoundingClientRect();
-        const invertedTransform = transform.inverse();
-        let minX = Infinity;
-        let minY = Infinity;
-        let maxX = -Infinity;
-        let maxY = -Infinity;
-        [
-            new DOMPoint(bounds.left, bounds.top),
-            new DOMPoint(bounds.right, bounds.top),
-            new DOMPoint(bounds.right, bounds.bottom),
-            new DOMPoint(bounds.left, bounds.bottom)
-        ].forEach(corner => {
-            const point = corner.matrixTransform(invertedTransform);
-            if (point.x < minX)
-                minX = point.x;
-            if (point.x > maxX)
-                maxX = point.x;
-            if (point.y < minY)
-                minY = point.y;
-            if (point.y > maxY)
-                maxY = point.y;
-        });
-
-        // Finally, we factor in the scale factor of the controls themselves, which reflects the page's scale factor.
-        this.controls.width = Math.round((maxX - minX) * this.controls.scaleFactor);
-        this.controls.height = Math.round((maxY - minY) * this.controls.scaleFactor);
+        // Use offsetWidth/offsetHeight to get the untransformed layout dimensions of the
+        // container element in the shadow root, which is naturally sized to match the
+        // content box of its host (excluding borders). These properties are not affected
+        // by CSS transforms, so they give the correct dimensions regardless of any
+        // transform applied to the media element or its ancestors.
+        this.controls.width = Math.round(this.container.offsetWidth * this.controls.scaleFactor);
+        this.controls.height = Math.round(this.container.offsetHeight * this.controls.scaleFactor);
     }
 
     _updateTextTracksClassList()

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -461,49 +461,13 @@ class MediaController
 
     _updateControlsSize()
     {
-        // To compute the bounds of the controls, we need to account for the computed transform applied
-        // to the media element, and apply the inverted transform to the bounds computed on the container
-        // element in the shadow root, which is naturally sized to match the metrics of its host,
-        // excluding borders.
-
-        // First, we traverse the node hierarchy up from the media element to compute the effective
-        // transform matrix applied to the media element.
-        let node = this.media;
-        let transform = new DOMMatrix;
-        while (node && node instanceof HTMLElement) {
-            transform = transform.multiply(new DOMMatrix(getComputedStyle(node).transform));
-            node = node.parentNode;
-        }
-
-        // Then, we take each corner of the container element in the shadow root and transform
-        // each with the inverted matrix we just computed so that we can compute the untransformed
-        // bounds of the media element.
-        const bounds = this.container.getBoundingClientRect();
-        const invertedTransform = transform.inverse();
-        let minX = Infinity;
-        let minY = Infinity;
-        let maxX = -Infinity;
-        let maxY = -Infinity;
-        [
-            new DOMPoint(bounds.left, bounds.top),
-            new DOMPoint(bounds.right, bounds.top),
-            new DOMPoint(bounds.right, bounds.bottom),
-            new DOMPoint(bounds.left, bounds.bottom)
-        ].forEach(corner => {
-            const point = corner.matrixTransform(invertedTransform);
-            if (point.x < minX)
-                minX = point.x;
-            if (point.x > maxX)
-                maxX = point.x;
-            if (point.y < minY)
-                minY = point.y;
-            if (point.y > maxY)
-                maxY = point.y;
-        });
-
-        // Finally, we factor in the scale factor of the controls themselves, which reflects the page's scale factor.
-        this.controls.width = Math.round((maxX - minX) * this.controls.scaleFactor);
-        this.controls.height = Math.round((maxY - minY) * this.controls.scaleFactor);
+        // Use offsetWidth/offsetHeight to get the untransformed layout dimensions of the
+        // container element in the shadow root, which is naturally sized to match the
+        // content box of its host (excluding borders). These properties are not affected
+        // by CSS transforms, so they give the correct dimensions regardless of any
+        // transform applied to the media element or its ancestors.
+        this.controls.width = Math.round(this.container.offsetWidth * this.controls.scaleFactor);
+        this.controls.height = Math.round(this.container.offsetHeight * this.controls.scaleFactor);
     }
 
     _updateTextTracksClassList()

--- a/Source/WebCore/rendering/RenderMedia.cpp
+++ b/Source/WebCore/rendering/RenderMedia.cpp
@@ -68,6 +68,9 @@ void RenderMedia::styleDidChange(Style::Difference difference, const RenderStyle
 
     if (!oldStyle || style().dynamicRangeLimit() != oldStyle->dynamicRangeLimit())
         protect(mediaElement())->dynamicRangeLimitDidChange(style().dynamicRangeLimit().toPlatformDynamicRangeLimit());
+
+    if (oldStyle && style().transform() != oldStyle->transform())
+        protect(mediaElement())->layoutSizeChanged();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderMedia.cpp
+++ b/Source/WebCore/rendering/RenderMedia.cpp
@@ -68,6 +68,9 @@ void RenderMedia::styleDidChange(Style::Difference difference, const Style::Comp
 
     if (!oldStyle || style().dynamicRangeLimit() != oldStyle->dynamicRangeLimit())
         protect(mediaElement())->dynamicRangeLimitDidChange(style().dynamicRangeLimit().toPlatformDynamicRangeLimit());
+
+    if (oldStyle && style().transform() != oldStyle->transform())
+        protect(mediaElement())->layoutSizeChanged();
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### f706c72da85c5041afe03dbff2968fd9a2d82171
<pre>
&lt;audio&gt; and &lt;video&gt; controls render strangely when rotated
<a href="https://bugs.webkit.org/show_bug.cgi?id=182745">https://bugs.webkit.org/show_bug.cgi?id=182745</a>
<a href="https://rdar.apple.com/37516619">rdar://37516619</a>

Reviewed by Jer Noble.

The _updateControlsSize() method in MediaController used getBoundingClientRect()
with an inverse transform to compute untransformed control dimensions. This is
mathematically incorrect for rotations: getBoundingClientRect() returns the
axis-aligned bounding box of the rotated element, and inverse-transforming
that box&apos;s corners produces inflated dimensions (e.g. 450px instead of 300px
for a 300x150 element rotated 45 degrees).

Replace the complex inverse-transform approach with offsetWidth/offsetHeight,
which directly return the untransformed layout dimensions regardless of any
CSS transform applied.

Additionally, notify the media controls when the CSS transform property changes
by calling layoutSizeChanged() from RenderMedia::styleDidChange(), so the
controls are resized when a transform is dynamically applied or changed.

* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController.prototype._updateControlsSize):
* Source/WebCore/rendering/RenderMedia.cpp:
(WebCore::RenderMedia::styleDidChange):
* LayoutTests/media/modern-media-controls/css/transformed-media-controls-update-expected.txt: Added.
* LayoutTests/media/modern-media-controls/css/transformed-media-controls-update.html: Added.

Canonical link: <a href="https://commits.webkit.org/315718@main">https://commits.webkit.org/315718@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f4bbe5aa3f900415a5868bb40793b685b2b051f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170596 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118064 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b5aa43f7-d3d1-4484-88fa-c6fffd3d9458) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163562 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35168 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125447 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88370 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3907302e-f226-41d5-a4cb-73ab9f4aab0e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27755 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145236 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106043 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a5947141-f6cb-47b0-9b88-63281abb4a8c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26804 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25314 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18317 "Built successfully") | | 
| [⏳ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/JSC-Tests-x86-64-EWS "Waiting to run tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136497 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24632 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173084 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29406 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133739 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34841 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144786 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133744 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37878 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34825 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21619 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96826 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28277 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101780 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34335 "Built successfully") | [⏳ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Site-Isolation-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33835 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34078 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33984 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->