### PR TITLE
[JSC][WASM][Debugger] Fix SystemCall test and update documentation

### DIFF
--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -1533,6 +1533,7 @@ class SystemCallTestCase(BaseTestCase):
             try:
                 self.send_lldb_command_or_raise("c")
                 self.send_lldb_command_or_raise("process interrupt")
+                self.send_lldb_command_or_raise("dis", patterns=["error: read memory from 0x8000000000000000 failed"])
             except Exception as e:
                 raise Exception(f"Cycle {cycle} failed: {e}")
 
@@ -1546,7 +1547,6 @@ class SystemCallTestCase(BaseTestCase):
         self.send_lldb_command_or_raise("n", patterns=[])
         self.send_lldb_command_or_raise("process interrupt")
 
-        # FIXME: `dis` hangs LLDB when stop in the system call.
 
 
 class MultiVMSameModuleSameFunctionTestCase(BaseTestCase):

--- a/Source/JavaScriptCore/wasm/debugger/README.md
+++ b/Source/JavaScriptCore/wasm/debugger/README.md
@@ -103,29 +103,6 @@ Virtual Memory Layout:
 - 0x8000000000000000 - 0xFFFFFFFFFFFFFFFF: Invalid regions
 ```
 
-## Protocol Implementation
-
-### Execution Control
-
-- **[DONE]** `gdb-remote localhost:1234`: Attach to debugger
-- **[DONE]** `process interrupt`, `ctrl+C`: Stop execution at function entry
-- **[DONE]** `continue`: Resume WebAssembly execution
-- **[DONE]** `breakpoint set`: Set breakpoints at virtual addresses
-- **[DONE]** `step over`: Step over function calls
-- **[DONE]** `step in`: Step into function calls and exception handlers
-- **[DONE]** `step out`: Step out of current function
-- **[DONE]** `step instruction`: Single step through bytecode
-
-### Inspection
-
-- **[DONE]** `target modules list`: List loaded WebAssembly modules
-- **[DONE]** `disassemble`: Display WebAssembly bytecode
-- **[DONE]** `bt` (backtrace): Show WebAssembly call stack
-- **[DONE]** `frame variable`: List local variables
-- **[DONE]** `memory region --all`: List memory regions
-- **[DONE]** `memory read`: Read WebAssembly memory and module source
-- **[TODO]** `memory write`: Write to memory? source? or both?
-
 ## Testing
 
 ### Unit Tests
@@ -187,7 +164,7 @@ lldb -o 'log enable gdb-remote packets' -o 'process connect --plugin wasm connec
 
 See [RWI_ARCHITECTURE.md](./RWI_ARCHITECTURE.md) for complete setup instructions including:
 
-- Starting Safari/MiniBrowser with `--wasm-debugger` flag
+- Starting Safari/MiniBrowser with `__XPC_JSC_enableWasmDebugger=1 JSC_enableWasmDebugger=1` flag
 - Using WasmDebuggerRWIClient to relay LLDB commands
 - Debugging WebContent processes via Remote Web Inspector
 

--- a/Source/JavaScriptCore/wasm/debugger/RWI_ARCHITECTURE.md
+++ b/Source/JavaScriptCore/wasm/debugger/RWI_ARCHITECTURE.md
@@ -57,7 +57,7 @@ WebKit's WebAssembly debugging uses a **singleton `WasmDebugServer`** that manag
 ### UI Process (Safari)
 
 **WebProcessProxy** - Manages one WebContent process
-- Creates `WasmDebuggerDebuggable` on construction (if `--wasm-debugger` enabled)
+- Creates `WasmDebuggerDebuggable` on construction (if `enableWasmDebugger` enabled)
 - Forwards debugging commands via IPC
 - Routes responses back to LLDB
 


### PR DESCRIPTION
#### ad5fa4e3a647daf769ebefe266466b046dd93043
<pre>
[JSC][WASM][Debugger] Fix SystemCall test and update documentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=311573">https://bugs.webkit.org/show_bug.cgi?id=311573</a>
<a href="https://rdar.apple.com/174174390">rdar://174174390</a>

Reviewed by Yusuke Suzuki.

Fix the SystemCallTestCase to actually exercise `dis` after `process interrupt`
instead of skipping it with a FIXME comment — the hang is resolved so the
command now runs with an expected error pattern for reads from the invalid
address range (0x8000000000000000).

Also update README.md and RWI_ARCHITECTURE.md:
- Remove the now-stale &quot;Protocol Implementation&quot; checklist from README.md
  since they are all supported right now.
- Correct the flag name from `--wasm-debugger` to the actual env-var form
  (`__XPC_JSC_enableWasmDebugger=1 JSC_enableWasmDebugger=1`) in both files.

Canonical link: <a href="https://commits.webkit.org/310654@main">https://commits.webkit.org/310654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d50fea9b2dcad9c12d69cc7a96a81138a466aba2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27765 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/20925 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/163264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27615 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/163264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/460b3856-15f9-4aa0-a2d8-d59bbd2dcc06) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157466 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/21789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/138764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/163264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f3b58f8c-a0a5-4bfa-b34c-d683e0aafe5c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18883 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11093 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/146556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/130537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/16608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/165735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15338 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/8942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/18217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/165735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27311 "Failed to checkout and rebase branch from PR 62128") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22923 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/165735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/27235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/138401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/83918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23580 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/27235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/186215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26926 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/91028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/186215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/26506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/26737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26579 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->