### PR TITLE
[GFC][Cleanup] Remove unused avoidance reasons

### DIFF
--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -45,7 +45,6 @@ enum class ReasonCollectionMode : bool {
 };
 
 enum class GridAvoidanceReason : uint8_t {
-    GridHasNonFixedHeight,
     GridHasVerticalWritingMode,
     GridHasMarginTrim,
     GridNeedsBaseline,
@@ -54,11 +53,6 @@ enum class GridAvoidanceReason : uint8_t {
     GridItemIsReplacedElement,
     GridItemDoesNotHaveElement,
     GridIsEmpty,
-    GridHasNonInitialMinWidth,
-    GridHasNonInitialMaxWidth,
-    GridHasNonInitialMinHeight,
-    GridHasNonInitialMaxHeight,
-    GridHasNonZeroMinWidth,
     GridHasGridTemplateAreas,
     GridHasColumnAutoFlow,
     GridHasNonFixedGaps,
@@ -66,10 +60,7 @@ enum class GridAvoidanceReason : uint8_t {
     GridHasContainsSize,
     GridHasUnsupportedGridTemplateColumns,
     GridHasUnsupportedGridTemplateRows,
-    GridItemHasNonFixedWidth,
-    GridItemHasNonFixedHeight,
     GridItemHasNonInitialMaxWidth,
-    GridItemHasNonZeroMinHeight,
     GridItemHasNonInitialMaxHeight,
     GridItemHasBorder,
     GridItemHasPadding,
@@ -560,9 +551,6 @@ static void printReason(GridAvoidanceReason reason, TextStream& stream)
     case GridAvoidanceReason::GridFormattingContextIntegrationDisabled:
         stream << "grid formatting context integration is disabled";
         break;
-    case GridAvoidanceReason::GridHasNonFixedHeight:
-        stream << "grid has non-fixed height";
-        break;
     case GridAvoidanceReason::GridHasVerticalWritingMode:
         stream << "grid has vertical writing mode";
         break;
@@ -586,21 +574,6 @@ static void printReason(GridAvoidanceReason reason, TextStream& stream)
         break;
     case GridAvoidanceReason::GridIsEmpty:
         stream << "grid is empty";
-        break;
-    case GridAvoidanceReason::GridHasNonInitialMinWidth:
-        stream << "grid has non-initial min-width";
-        break;
-    case GridAvoidanceReason::GridHasNonInitialMaxWidth:
-        stream << "grid has non-initial max-width";
-        break;
-    case GridAvoidanceReason::GridHasNonInitialMinHeight:
-        stream << "grid has non-initial min-height";
-        break;
-    case GridAvoidanceReason::GridHasNonInitialMaxHeight:
-        stream << "grid has non-initial max-height";
-        break;
-    case GridAvoidanceReason::GridHasNonZeroMinWidth:
-        stream << "grid has non-zero min-width";
         break;
     case GridAvoidanceReason::GridHasGridTemplateAreas:
         stream << "grid has grid-template-areas";
@@ -635,14 +608,8 @@ static void printReason(GridAvoidanceReason reason, TextStream& stream)
     case GridAvoidanceReason::GridItemHasUnsupportedAutomaticBlockSizing:
         stream << "grid item has unsupported automatic block sizing";
         break;
-    case GridAvoidanceReason::GridItemHasNonFixedHeight:
-        stream << "grid item has non-fixed height";
-        break;
     case GridAvoidanceReason::GridItemHasNonInitialMaxWidth:
         stream << "grid item has non-initial max-width";
-        break;
-    case GridAvoidanceReason::GridItemHasNonZeroMinHeight:
-        stream << "grid item has non-zero min-height";
         break;
     case GridAvoidanceReason::GridItemHasNonInitialMaxHeight:
         stream << "grid item has non-initial max-height";


### PR DESCRIPTION
#### 8e89170e17a4c196a3a58d64bb141c348dff6401
<pre>
[GFC][Cleanup] Remove unused avoidance reasons
<a href="https://bugs.webkit.org/show_bug.cgi?id=311580">https://bugs.webkit.org/show_bug.cgi?id=311580</a>
<a href="https://rdar.apple.com/174178887">rdar://174178887</a>

Reviewed by Brandon Stewart, Vitor Roriz, and Alan Baradlay.

We have some GridAvoidanceReason values that are unused, aside from
being printed out, since we removed them as restrictions from not
running GFC earlier. Now they do not have any other purpose so we can
just delete these values.

Canonical link: <a href="https://commits.webkit.org/310714@main">https://commits.webkit.org/310714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e467a925530b320b924badf19ea64823cd1f1f6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154523 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163281 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107992 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3d86959-839e-42e7-9c75-e8a662c5a728) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119513 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84532 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157482 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21795 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138770 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100210 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/14c42e04-c59f-4b9e-8be3-7f328ca8aa27) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20881 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18896 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11109 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130543 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165751 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8958 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18223 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127615 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127759 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34708 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27251 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138407 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83933 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22655 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15199 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26941 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91044 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26521 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26752 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26594 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->