### PR TITLE
AX: WebKit fails to stitch text across inline element boundaries (e.g. abbr-element) and after atomic inlines (e.g. buttons)

### DIFF
--- a/LayoutTests/accessibility/text-stitching-across-inline-elements-expected.txt
+++ b/LayoutTests/accessibility/text-stitching-across-inline-elements-expected.txt
@@ -1,0 +1,33 @@
+This test ensures text after a link stitches with text inside inline formatting elements.
+
+Test 1 (italic):
+
+{AXRole: AXLink}
+
+{AXRole: AXStaticText AXValue: Easter}
+
+{AXRole: AXStaticText AXValue: . The text of the Shepherd Cantata was written by }
+
+{AXRole: AXLink}
+
+{AXRole: AXStaticText AXValue: Picander}
+
+Test 2 (span):
+
+{AXRole: AXLink}
+
+{AXRole: AXStaticText AXValue: Easter}
+
+{AXRole: AXStaticText AXValue: . The text of the Shepherd Cantata was written by }
+
+{AXRole: AXLink}
+
+{AXRole: AXStaticText AXValue: Picander}
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Easter. The text of the Shepherd Cantata was written by Picander
+
+Easter. The text of the Shepherd Cantata was written by Picander

--- a/LayoutTests/accessibility/text-stitching-across-inline-elements.html
+++ b/LayoutTests/accessibility/text-stitching-across-inline-elements.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ AccessibilityTextStitchingEnabled=true ] -->
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<!-- Text after a link boundary should stitch with text inside inline formatting elements. -->
+<p id="test1"><a href="#">Easter</a>. The text of the <i>Shepherd Cantata</i> was written by <a href="#">Picander</a></p>
+<p id="test2"><a href="#">Easter</a>. The text of the <span>Shepherd Cantata</span> was written by <a href="#">Picander</a></p>
+
+<script>
+var output = "This test ensures text after a link stitches with text inside inline formatting elements.\n\n";
+
+if (window.accessibilityController) {
+    output += "Test 1 (italic):\n";
+    output += dumpAXSearchTraversal(accessibilityController.accessibleElementById("test1"), { excludeRoles: ["group"] }) + "\n";
+    output += "Test 2 (span):\n";
+    output += dumpAXSearchTraversal(accessibilityController.accessibleElementById("test2"), { excludeRoles: ["group"] }) + "\n";
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/text-stitching-after-atomic-inline-expected.txt
+++ b/LayoutTests/accessibility/text-stitching-after-atomic-inline-expected.txt
@@ -1,0 +1,26 @@
+This test ensures text stitching works after atomic inline boxes (like buttons).
+
+Test 1: text after button
+
+{AXRole: AXButton}
+
+{AXRole: AXStaticText AXValue:  Hello team!}
+
+Test 2: text between multiple buttons
+
+{AXRole: AXStaticText AXValue: Before }
+
+{AXRole: AXButton}
+
+{AXRole: AXStaticText AXValue:  middle text here }
+
+{AXRole: AXButton}
+
+{AXRole: AXStaticText AXValue:  after end}
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Foo Hello team!
+Before A middle text here B after end

--- a/LayoutTests/accessibility/text-stitching-after-atomic-inline.html
+++ b/LayoutTests/accessibility/text-stitching-after-atomic-inline.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ AccessibilityTextStitchingEnabled=true ] -->
+<html>
+<head>
+<meta charset="utf-8"></meta>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<!-- Text after an atomic inline (button) should still be stitched. -->
+<div id="test1"><button>Foo</button> Hello <span>team!</span></div>
+
+<!-- Multiple atomic inlines shouldn't prevent stitching between them. -->
+<div id="test2">Before <button>A</button> middle <em>text</em> here <button>B</button> after <b>end</b></div>
+
+<script>
+var output = "This test ensures text stitching works after atomic inline boxes (like buttons).\n\n";
+
+if (window.accessibilityController) {
+    // Test 1: Text after a button should be stitched together.
+    var test1 = accessibilityController.accessibleElementById("test1");
+    output += "Test 1: text after button\n";
+    output += dumpAXSearchTraversal(test1) + "\n";
+
+    // Test 2: Text between and after multiple buttons should stitch separately.
+    var test2 = accessibilityController.accessibleElementById("test2");
+    output += "Test 2: text between multiple buttons\n";
+    output += dumpAXSearchTraversal(test2) + "\n";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -872,6 +872,8 @@ accessibility/aria-owns-text-stitching.html [ Skip ]
 accessibility/dynamic-text-stitching.html [ Skip ]
 accessibility/hit-test-on-stitched-text.html [ Skip ]
 accessibility/list-marker-text-stitching.html [ Skip ]
+accessibility/text-stitching-across-inline-elements.html [ Skip ]
+accessibility/text-stitching-after-atomic-inline.html [ Skip ]
 accessibility/text-stitching-end-text-marker.html [ Skip ]
 accessibility/text-stitching-inside-links.html [ Skip ]
 

--- a/Source/WebCore/accessibility/AXStitchUtilities.cpp
+++ b/Source/WebCore/accessibility/AXStitchUtilities.cpp
@@ -50,7 +50,7 @@ static bool hasStitchBreakingRole(Element& element)
 {
     return hasAnyRole(element, {
         // Cell roles
-        "gridcell"_s, "cell"_s, "columnheader"_s, "rowheader"_s
+        "gridcell"_s, "cell"_s, "columnheader"_s, "rowheader"_s,
         // Miscellaneous roles
         "suggestion"_s, "insertion"_s, "deletion"_s
     });
@@ -76,7 +76,7 @@ static bool isStitchBreakingElement(Element& element)
     || hasStitchBreakingTag(element);
 }
 
-bool shouldStopStitchingAt(const RenderObject& renderer, const AccessibilityObject& object, StitchingContext& context)
+StitchAction stitchActionFor(const RenderObject& renderer, const AccessibilityObject& object, StitchingContext& context)
 {
     auto isInsideLink = [] (const RenderObject& renderer) {
         return renderer.style().insideLink() != InsideLink::NotInside;
@@ -84,7 +84,7 @@ bool shouldStopStitchingAt(const RenderObject& renderer, const AccessibilityObje
 
     if (context.lastRenderer && isInsideLink(renderer) && !isInsideLink(*context.lastRenderer)) {
         // Stop the current stitch when entering a link.
-        return true;
+        return StitchAction::BreakAndSkip;
     }
 
     if (renderer.parent() && (renderer.parent()->isBeforeOrAfterContent() || renderer.parent()->isFirstLetter())) {
@@ -92,14 +92,14 @@ bool shouldStopStitchingAt(const RenderObject& renderer, const AccessibilityObje
         // some of our code that handles stitched text (e.g. stringValue) assumes
         // the presence of a Node. For now, stop stitching at generated content.
         // Ideally we remove this restriction in the future.
-        return true;
+        return StitchAction::BreakAndSkip;
     }
 
     if (hasEnclosingInputElement(renderer.node())) {
         // Don't stitch within text inputs. One example of why we want to avoid
         // this is otherwise the number values of the chosen dates will get stitched
         // with the "/"s that surround them, which is a poor user experience.
-        return true;
+        return StitchAction::BreakAndSkip;
     }
 
     RefPtr node = renderer.node();
@@ -128,7 +128,7 @@ bool shouldStopStitchingAt(const RenderObject& renderer, const AccessibilityObje
     while (currentAncestor) {
         if (currentAncestor->owners().size()) {
             stitchBreakingAncestor = nullptr;
-            return true;
+            return StitchAction::BreakAndSkip;
         }
 
         if (currentAncestor == context.containingBlockFlowObject) {
@@ -148,10 +148,11 @@ bool shouldStopStitchingAt(const RenderObject& renderer, const AccessibilityObje
 
     if (node && context.lastStitchBreakingAncestor && context.lastStitchBreakingAncestor != stitchBreakingAncestor) {
         // Breaking stitching across semantic boundaries, like cells, controls, etc.
-        return true;
+        // The current text is on the other side of the boundary and can start a new group.
+        return StitchAction::BreakAndAdd;
     }
 
-    return false;
+    return StitchAction::Continue;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AXStitchUtilities.h
+++ b/Source/WebCore/accessibility/AXStitchUtilities.h
@@ -43,6 +43,12 @@ struct StitchingContext {
     RefPtr<const AccessibilityNodeObject> containingBlockFlowObject { nullptr };
 };
 
-bool shouldStopStitchingAt(const RenderObject&, const AccessibilityObject&, StitchingContext&);
+enum class StitchAction : uint8_t {
+    Continue, // Add this text to the current group.
+    BreakAndSkip, // Finalize the current group; skip this text (link entry, re-ownership, generated content).
+    BreakAndAdd, // Finalize the current group; this text starts a new group (boundary crossing).
+};
+
+StitchAction stitchActionFor(const RenderObject&, const AccessibilityObject&, StitchingContext&);
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -4101,7 +4101,6 @@ Vector<AXStitchGroup> AccessibilityNodeObject::stitchGroups() const
     if (!cache)
         return { };
 
-    bool shouldStop = false;
     StitchingContext context { *this };
     Vector<AXStitchGroup> stitchGroups;
     Vector<AXID> currentGroup;
@@ -4112,7 +4111,14 @@ Vector<AXStitchGroup> AccessibilityNodeObject::stitchGroups() const
         if (currentGroup.isEmpty() || currentGroup.last() != axID)
             currentGroup.append(axID);
     };
-    for (auto lineBox = inlineLayout->firstLineBox(); lineBox && !shouldStop; lineBox.traverseNext()) {
+    auto finalizeCurrentGroup = [&] {
+        if (currentGroup.size() > 1 && representativeID)
+            stitchGroups.append(AXStitchGroup { std::exchange(currentGroup, { }), *representativeID });
+        else
+            currentGroup.clear();
+        representativeID = std::nullopt;
+    };
+    for (auto lineBox = inlineLayout->firstLineBox(); lineBox; lineBox.traverseNext()) {
         for (auto box = lineBox->logicalLeftmostLeafBox(); box; box.traverseLogicalRightwardOnLine()) {
             auto updateLastRenderer = makeScopeExit([&] {
                 context.lastRenderer = box->renderer();
@@ -4125,9 +4131,10 @@ Vector<AXStitchGroup> AccessibilityNodeObject::stitchGroups() const
             }
 
             if (box->isAtomicInlineBox()) {
-                // Non-list-marker atomic inline boxes (like buttons) should break up stitch groups.
-                shouldStop = true;
-                break;
+                // Non-list-marker atomic inline boxes (like buttons) should finalize
+                // the current stitch group. Text after the atomic inline can start a new group.
+                finalizeCurrentGroup();
+                continue;
             }
 
             // FIXME: We should also be able to stitch ellipsis-type boxes.
@@ -4138,34 +4145,33 @@ Vector<AXStitchGroup> AccessibilityNodeObject::stitchGroups() const
                     continue;
                 AXID axID = object->objectID();
 
-                if (shouldStopStitchingAt(renderer, *object, context)) {
-                    if (currentGroup.size() > 1 && representativeID)
-                        stitchGroups.append(AXStitchGroup { std::exchange(currentGroup, { }), *representativeID });
-                    else
-                        currentGroup.clear();
-
-                    representativeID = std::nullopt;
-                } else {
-                    CheckedPtr renderText = dynamicDowncast<RenderText>(renderer);
-
-                    // Avoid doing the wrong thing when !renderText->hasRenderedText() is only true
-                    // because it has dirty layout. We should not run this function when layout is dirty.
-                    AX_ASSERT(!renderText || !renderText->needsLayout() || !renderText->text().length());
-
-                    if (!renderText || !renderText->hasRenderedText())
+                auto action = stitchActionFor(renderer, *object, context);
+                if (action != StitchAction::Continue) {
+                    finalizeCurrentGroup();
+                    if (action == StitchAction::BreakAndSkip)
                         continue;
-
-                    if (currentGroup.isEmpty()) {
-                        if (renderText->text().containsOnly<isASCIIWhitespace>()) {
-                            // Do not start a stitch-group with whitspace.
-                            continue;
-                        }
-                    }
-
-                    if (!representativeID)
-                        representativeID = axID;
-                    appendToCurrentGroup(axID);
+                    // BreakAndAdd: fall through to add this text to a new group.
                 }
+
+                CheckedPtr renderText = dynamicDowncast<RenderText>(renderer);
+
+                // Avoid doing the wrong thing when !renderText->hasRenderedText() is only true
+                // because it has dirty layout. We should not run this function when layout is dirty.
+                AX_ASSERT(!renderText || !renderText->needsLayout() || !renderText->text().length());
+
+                if (!renderText || !renderText->hasRenderedText())
+                    continue;
+
+                if (currentGroup.isEmpty()) {
+                    if (renderText->text().containsOnly<isASCIIWhitespace>()) {
+                        // Do not start a stitch-group with whitspace.
+                        continue;
+                    }
+                }
+
+                if (!representativeID)
+                    representativeID = axID;
+                appendToCurrentGroup(axID);
             }
         }
     }


### PR DESCRIPTION
#### dcde9818cd6e96871b94e378fbaf7bd3a4308d70
<pre>
AX: WebKit fails to stitch text across inline element boundaries (e.g. abbr-element) and after atomic inlines (e.g. buttons)
<a href="https://bugs.webkit.org/show_bug.cgi?id=311581">https://bugs.webkit.org/show_bug.cgi?id=311581</a>
<a href="https://rdar.apple.com/174178906">rdar://174178906</a>

Reviewed by Joshua Hoffman.

Previously, shouldStopStitchingAt() returned a boolean. When stitching
stopped, the current text was always skipped. This prevented stitching
text that crosses inline element boundaries (e.g. i, abbr, span elements)
after a link, because the boundary crossing was treated as a hard stop
rather than a group separator.

Replace shouldStopStitchingAt() with stitchActionFor(), which returns a StitchAction:
- Continue: add this text to the current group
- BreakAndSkip: finalize the group and skip this text (link entry,
  generated content, re-ownership)
- BreakAndAdd: finalize the group, then start a new group with this
  text (semantic boundary crossing)

BreakAndAdd is the new additional behavior. It allows text after a boundary (like
a link exit) to begin a new stitch group rather than being dropped.

Also fix atomic inline handling: buttons and other atomic inlines
previously set shouldStop=true and broke out of the entire loop that
built stitch groups, preventing any text after the first atomic inline
from being stitched. Now they finalize the current group and continue,
so text between and after multiple atomic inlines stitches correctly.

* LayoutTests/accessibility/text-stitching-across-inline-elements-expected.txt: Added.
* LayoutTests/accessibility/text-stitching-across-inline-elements.html: Added.
* LayoutTests/accessibility/text-stitching-after-atomic-inline-expected.txt: Added.
* LayoutTests/accessibility/text-stitching-after-atomic-inline.html: Added.
* Source/WebCore/accessibility/AXStitchUtilities.cpp:
(WebCore::hasStitchBreakingRole):
(WebCore::stitchActionFor):
(WebCore::shouldStopStitchingAt): Deleted.
* Source/WebCore/accessibility/AXStitchUtilities.h:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::stitchGroups const):

Canonical link: <a href="https://commits.webkit.org/310683@main">https://commits.webkit.org/310683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70425beacf4cff70e820073989ccbbb2122dd671

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27790 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163290 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108001 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156405 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27640 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119522 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84537 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/68030af4-34e5-4627-b31f-b458651f9a04) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157491 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21807 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138786 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100219 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4ca72fbd-bea4-4b39-873a-439bc143a8c6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20893 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18907 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11118 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130555 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16630 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165760 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8967 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127623 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27336 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22947 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127767 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34684 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27260 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138423 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83942 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22669 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15215 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26950 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91053 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26530 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26761 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26603 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->