### PR TITLE
REGRESSION (iOS 26): Datalist options obscure text input

### DIFF
--- a/LayoutTests/fast/forms/ios/datalist-does-not-obscure-input-expected.txt
+++ b/LayoutTests/fast/forms/ios/datalist-does-not-obscure-input-expected.txt
@@ -1,0 +1,3 @@
+
+PASS: Datalist suggestions dropdown does not obscure the input field.
+

--- a/LayoutTests/fast/forms/ios/datalist-does-not-obscure-input.html
+++ b/LayoutTests/fast/forms/ios/datalist-does-not-obscure-input.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+input {
+    width: 300px;
+    height: 50px;
+}
+
+body {
+    margin: 0;
+}
+</style>
+</head>
+<body>
+
+<input id="fruit" list="fruits" type="text"/>
+<datalist id="fruits">
+    <option>Apple</option>
+    <option>Orange</option>
+    <option>Pear</option>
+</datalist>
+<pre id="output"></pre>
+
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+function log(msg) {
+    document.getElementById("output").textContent += msg + "\n";
+}
+
+(async () => {
+    const input = document.getElementById("fruit");
+
+    await UIHelper.activateElementAndWaitForInputSession(input);
+    await UIHelper.tapAt(290, 30);
+    await UIHelper.waitForDataListSuggestionsToChangeVisibility(true);
+
+    const menuRect = await UIHelper.contextMenuRect();
+    const inputBottom = input.offsetTop + input.offsetHeight;
+
+    if (menuRect.width === 0 && menuRect.height === 0)
+        log("FAIL: Could not retrieve suggestions menu rect.");
+    else if (menuRect.top < inputBottom)
+        log("FAIL: Datalist suggestions dropdown overlaps the input field.");
+    else
+        log("PASS: Datalist suggestions dropdown does not obscure the input field.");
+
+    await UIHelper.resignFirstResponder();
+    if (window.testRunner)
+        testRunner.notifyDone();
+})();
+</script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.h
+++ b/Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.h
@@ -31,7 +31,9 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/TZoneMalloc.h>
 
-@class WKCompactContextMenuPresenterButton;
+@protocol WKCompactContextMenuPresenter
+@property (nonatomic, weak) id<UIContextMenuInteractionDelegate> externalDelegate;
+@end
 
 namespace WebKit {
 
@@ -39,7 +41,9 @@ class CompactContextMenuPresenter {
     WTF_MAKE_TZONE_ALLOCATED(CompactContextMenuPresenter);
     WTF_MAKE_NONCOPYABLE(CompactContextMenuPresenter);
 public:
-    CompactContextMenuPresenter(UIView *rootView, id<UIContextMenuInteractionDelegate>);
+    enum class ShowsMenuFromSource : bool { No, Yes };
+
+    CompactContextMenuPresenter(UIView *rootView, id<UIContextMenuInteractionDelegate>, ShowsMenuFromSource = ShowsMenuFromSource::Yes);
     ~CompactContextMenuPresenter();
 
     void present(CGRect rectInRootView);
@@ -52,7 +56,7 @@ public:
 
 private:
     __weak UIView *m_rootView { nil };
-    RetainPtr<WKCompactContextMenuPresenterButton> m_button;
+    RetainPtr<UIControl<WKCompactContextMenuPresenter>> m_control;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.mm
+++ b/Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.mm
@@ -40,11 +40,55 @@
 @end
 #endif
 
-@interface WKCompactContextMenuPresenterButton : UIButton
-@property (nonatomic, weak) id<UIContextMenuInteractionDelegate> externalDelegate;
+@interface WKCompactContextMenuPresenterControl : UIControl <WKCompactContextMenuPresenter>
+@end
+
+@interface WKCompactContextMenuPresenterButton : UIButton <WKCompactContextMenuPresenter>
+@end
+
+@implementation WKCompactContextMenuPresenterControl
+@synthesize externalDelegate = _externalDelegate;
+
+- (UIContextMenuConfiguration *)contextMenuInteraction:(UIContextMenuInteraction *)interaction configurationForMenuAtLocation:(CGPoint)location
+{
+    RetainPtr externalDelegate = _externalDelegate;
+    if ([externalDelegate respondsToSelector:@selector(contextMenuInteraction:configurationForMenuAtLocation:)])
+        return [externalDelegate contextMenuInteraction:interaction configurationForMenuAtLocation:location];
+
+    return [super contextMenuInteraction:interaction configurationForMenuAtLocation:location];
+}
+
+- (UITargetedPreview *)contextMenuInteraction:(UIContextMenuInteraction *)interaction configuration:(UIContextMenuConfiguration *)configuration highlightPreviewForItemWithIdentifier:(id<NSCopying>)identifier
+{
+    RetainPtr externalDelegate = _externalDelegate;
+    if ([externalDelegate respondsToSelector:@selector(contextMenuInteraction:configuration:highlightPreviewForItemWithIdentifier:)])
+        return [externalDelegate contextMenuInteraction:interaction configuration:configuration highlightPreviewForItemWithIdentifier:identifier];
+
+    return [super contextMenuInteraction:interaction configuration:configuration highlightPreviewForItemWithIdentifier:identifier];
+}
+
+- (void)contextMenuInteraction:(UIContextMenuInteraction *)interaction willDisplayMenuForConfiguration:(UIContextMenuConfiguration *)configuration animator:(id<UIContextMenuInteractionAnimating>)animator
+{
+    [super contextMenuInteraction:interaction willDisplayMenuForConfiguration:configuration animator:animator];
+
+    RetainPtr externalDelegate = _externalDelegate;
+    if ([externalDelegate respondsToSelector:@selector(contextMenuInteraction:willDisplayMenuForConfiguration:animator:)])
+        [externalDelegate contextMenuInteraction:interaction willDisplayMenuForConfiguration:configuration animator:animator];
+}
+
+- (void)contextMenuInteraction:(UIContextMenuInteraction *)interaction willEndForConfiguration:(UIContextMenuConfiguration *)configuration animator:(id<UIContextMenuInteractionAnimating>)animator
+{
+    [super contextMenuInteraction:interaction willEndForConfiguration:configuration animator:animator];
+
+    RetainPtr externalDelegate = _externalDelegate;
+    if ([externalDelegate respondsToSelector:@selector(contextMenuInteraction:willEndForConfiguration:animator:)])
+        [externalDelegate contextMenuInteraction:interaction willEndForConfiguration:configuration animator:animator];
+}
+
 @end
 
 @implementation WKCompactContextMenuPresenterButton
+@synthesize externalDelegate = _externalDelegate;
 
 - (UIContextMenuConfiguration *)contextMenuInteraction:(UIContextMenuInteraction *)interaction configurationForMenuAtLocation:(CGPoint)location
 {
@@ -88,16 +132,20 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CompactContextMenuPresenter);
 
-CompactContextMenuPresenter::CompactContextMenuPresenter(UIView *rootView, id<UIContextMenuInteractionDelegate> delegate)
+CompactContextMenuPresenter::CompactContextMenuPresenter(UIView *rootView, id<UIContextMenuInteractionDelegate> delegate, ShowsMenuFromSource showsMenuFromSource)
     : m_rootView(rootView)
-    , m_button([WKCompactContextMenuPresenterButton buttonWithType:UIButtonTypeSystem])
 {
-    [m_button setExternalDelegate:delegate];
-    [m_button layer].zPosition = CGFLOAT_MIN;
-    [m_button setHidden:YES];
-    [m_button setUserInteractionEnabled:NO];
-    [m_button setContextMenuInteractionEnabled:YES];
-    [m_button setShowsMenuAsPrimaryAction:YES];
+    if (showsMenuFromSource == ShowsMenuFromSource::Yes)
+        m_control = [WKCompactContextMenuPresenterButton buttonWithType:UIButtonTypeSystem];
+    else
+        m_control = adoptNS([[WKCompactContextMenuPresenterControl alloc] init]);
+
+    [m_control setExternalDelegate:delegate];
+    [m_control layer].zPosition = CGFLOAT_MIN;
+    [m_control setHidden:YES];
+    [m_control setUserInteractionEnabled:NO];
+    [m_control setContextMenuInteractionEnabled:YES];
+    [m_control setShowsMenuAsPrimaryAction:YES];
 }
 
 CompactContextMenuPresenter::~CompactContextMenuPresenter()
@@ -105,7 +153,7 @@ CompactContextMenuPresenter::~CompactContextMenuPresenter()
     [UIView performWithoutAnimation:^{
         dismiss();
     }];
-    [m_button removeFromSuperview];
+    [m_control removeFromSuperview];
 }
 
 void CompactContextMenuPresenter::present(CGPoint locationInRootView)
@@ -115,7 +163,7 @@ void CompactContextMenuPresenter::present(CGPoint locationInRootView)
 
 UIContextMenuInteraction *CompactContextMenuPresenter::interaction() const
 {
-    return [m_button contextMenuInteraction];
+    return [m_control contextMenuInteraction];
 }
 
 void CompactContextMenuPresenter::present(CGRect rectInRootView)
@@ -124,14 +172,14 @@ void CompactContextMenuPresenter::present(CGRect rectInRootView)
     if (!rootView.get().window)
         return;
 
-    [m_button setFrame:rectInRootView];
-    if (![m_button superview])
-        [rootView addSubview:m_button.get()];
+    [m_control setFrame:rectInRootView];
+    if (![m_control superview])
+        [rootView addSubview:m_control.get()];
 
 #if HAVE(UI_BUTTON_PERFORM_PRIMARY_ACTION)
-    static BOOL canPerformPrimaryAction = [UIButton instancesRespondToSelector:@selector(performPrimaryAction)];
+    static BOOL canPerformPrimaryAction = [UIControl instancesRespondToSelector:@selector(performPrimaryAction)];
     if (canPerformPrimaryAction) {
-        [m_button performPrimaryAction];
+        [m_control performPrimaryAction];
         return;
     }
 #endif
@@ -141,7 +189,7 @@ void CompactContextMenuPresenter::present(CGRect rectInRootView)
 
 void CompactContextMenuPresenter::dismiss()
 {
-    [[m_button contextMenuInteraction] dismissMenu];
+    [[m_control contextMenuInteraction] dismissMenu];
 }
 
 void CompactContextMenuPresenter::updateVisibleMenu(UIMenu *(^updateBlock)(UIMenu *))

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
@@ -498,7 +498,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self _updateSuggestionsMenuElements];
 
     if (!_suggestionsContextMenuPresenter) {
-        _suggestionsContextMenuPresenter = makeUnique<WebKit::CompactContextMenuPresenter>(self.view, self);
+        _suggestionsContextMenuPresenter = makeUnique<WebKit::CompactContextMenuPresenter>(self.view, self, WebKit::CompactContextMenuPresenter::ShowsMenuFromSource::No);
         [self.view doAfterEditorStateUpdateAfterFocusingElement:[weakSelf = WeakObjCPtr<WKDataListSuggestionsDropdown>(self)] {
             auto strongSelf = weakSelf.get();
             if (!strongSelf)


### PR DESCRIPTION
#### 39156fa7001f9faa2e8d4a2184d5c4614bf6175d
<pre>
REGRESSION (iOS 26): Datalist options obscure text input
<a href="https://bugs.webkit.org/show_bug.cgi?id=305719">https://bugs.webkit.org/show_bug.cgi?id=305719</a>
<a href="https://rdar.apple.com/168475613">rdar://168475613</a>

Reviewed by Aditya Keerthi and Tim Horton.

In iOS 26, UIKit changed the behavior for UIButton. WebKit
used UIButton to programmatically trigger the
UIContextMenuInteraction and create/present the datalist.
As a consequence of the change, this overlap is the
expected behavior when using UIButton, even though it is not
expected behavior for datalists.

To fix this issue, WebKit now uses a UIControl for datalist
instead of a UIButton to trigger the UIContextMenuInteraction.
UIControl does not have this new expected behavior that the UIButton does.
For other CompactContextMenuPresenters, the UIButton is still used.

Alternatively, setting UIControl.showsMenuFromSource to NO would also
fix the issue but showsMenuFromSource is SPI, which WebKit cannot use.

Unfortunately, there isn&apos;t a straightforward way to make
WKCompactContextMenuPresenterButton (UIButton) subclass
WKCompactContextMenuPresenterControl (UIControl) even though UIButton is
a UIControl. As subclasses of UIControl respectively,
both need the minimum viable delegate implementation to be able to trigger
the UIContextMenuInteraction. As a result, the implementation has to be
duplicated for both.

Add an iOS layout test for datalists that check whether the datalist
overlaps with the text input or not.

* LayoutTests/fast/forms/ios/datalist-does-not-obscure-input-expected.txt: Added.
* LayoutTests/fast/forms/ios/datalist-does-not-obscure-input.html: Added.
* Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.h:
* Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.mm:
(-[WKCompactContextMenuPresenterControl contextMenuInteraction:configurationForMenuAtLocation:]):
(-[WKCompactContextMenuPresenterControl contextMenuInteraction:configuration:highlightPreviewForItemWithIdentifier:]):
(-[WKCompactContextMenuPresenterControl contextMenuInteraction:willDisplayMenuForConfiguration:animator:]):
(-[WKCompactContextMenuPresenterControl contextMenuInteraction:willEndForConfiguration:animator:]):
(WebKit::CompactContextMenuPresenter::CompactContextMenuPresenter):
(WebKit::CompactContextMenuPresenter::~CompactContextMenuPresenter):
(WebKit::CompactContextMenuPresenter::interaction const):
(WebKit::CompactContextMenuPresenter::present):
(WebKit::CompactContextMenuPresenter::dismiss):
* Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm:
(-[WKDataListSuggestionsDropdown _showSuggestions]):

Canonical link: <a href="https://commits.webkit.org/310733@main">https://commits.webkit.org/310733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd5c02e14c9958304bc9e53e79508e6bcb57908a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154722 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163482 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108191 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27830 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119686 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/84634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/177155ca-850d-4886-be4b-db297f8879d7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21975 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138957 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100380 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21061 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19079 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11308 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130723 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/16801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165956 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9188 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127788 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27526 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23119 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127927 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27450 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138594 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84155 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23606 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22823 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15388 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27142 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91244 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26720 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26951 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26793 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->