### PR TITLE
AX: If the buildIsolatedTreeTimer fires when the main-thread tree is only a scroll area + web area, the isolated tree can permanently be empty

### DIFF
--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -1021,7 +1021,15 @@ void AXIsolatedTree::updateChildren(AccessibilityObject& axObject, ResolveNodeCh
     // An example of this is when an empty element such as a <canvas> or <div>
     // has added a new child. So find the closest ancestor of axObject that has
     // an associated isolated object and update its children.
-    auto* axAncestor = &axObject;
+    //
+    // This behavior is important despite the isolated tree including ignored
+    // objects (and thus every object being "in-tree"). Without it, if we build
+    // the isolated tree from a main-thread tree that has only a scroll area and
+    // web area, the incremental tree updates that follow may not actually ever
+    // update the webarea's empty children, leaving the whole tree empty forever.
+    RefPtr axAncestor = &axObject;
+    while (axAncestor && !axAncestor->isDetached() && !m_nodeMap.contains(axAncestor->objectID()))
+        axAncestor = downcast<AccessibilityObject>(axAncestor->parentInCoreTree());
 
     if (!axAncestor || axAncestor->isDetached()) {
         // This update was triggered before the isolated tree has been repopulated.


### PR DESCRIPTION
#### d21fe886bee23ac8282e0b660dea3f4fd92ea0c9
<pre>
AX: If the buildIsolatedTreeTimer fires when the main-thread tree is only a scroll area + web area, the isolated tree can permanently be empty
<a href="https://bugs.webkit.org/show_bug.cgi?id=311582">https://bugs.webkit.org/show_bug.cgi?id=311582</a>
<a href="https://rdar.apple.com/174179484">rdar://174179484</a>

Reviewed by Joshua Hoffman.

In 286511@main when we implemented the feature to include ignored objects in the
isolated tree, we removed the walk-to-nearest-in-tree-ancestor behavior that
AXIsolatedTree::updateChidlren  had under the assumption that everything is now &quot;in-tree&quot;.

However, it has been observed via logging that sometimes the buildIsolatedTreeTimer
fires when the page loading progress has barely progressed (49%), and the isolated
tree is built from a main-thread tree that is only a scroll area and web area.
This is supposed to be fine -- incremental updates via AXIsolatedTree::updateChildren
should fill in the tree when the page loads further.

However, none of those incremental updates actually update the children of the webarea,
and because the webarea thinks it has no children, the entire tree remains empty forever.

Logging shows we do this ancestor crawl on pages even where web content doesn&apos;t remain empty,
meaning we were dropping potentially important updates in other scena

Re-add this behavior, fixing the bug.

* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateChildren):

Canonical link: <a href="https://commits.webkit.org/310712@main">https://commits.webkit.org/310712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3eda0b7a74852a4eb2b34c34ecd5a5285b74b16e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154604 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163362 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108073 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156477 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119583 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84573 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100280 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20963 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18972 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11190 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130626 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16696 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165834 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9039 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18305 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127684 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27408 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23012 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127827 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34705 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27332 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138489 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84014 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22723 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15282 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27024 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91126 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26602 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26833 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26675 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->