### PR TITLE
[css-anchor-position-1] Use UniqueRef in AnchorPositionedStates

### DIFF
--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -788,8 +788,8 @@ CheckedPtr<RenderBoxModelObject> AnchorPositionEvaluator::findAnchorForAnchorFun
 
     // PseudoElement nodes are created on-demand by render tree builder so dont' work as keys here.
     auto& anchorPositionedStates = *builderState.anchorPositionedStates();
-    auto& anchorPositionedState = *anchorPositionedStates.ensure({ elementOrHost.ptr(), style.pseudoElementIdentifier() }, [&] {
-        return WTF::makeUnique<AnchorPositionedState>();
+    auto& anchorPositionedState = anchorPositionedStates.ensure({ elementOrHost.ptr(), style.pseudoElementIdentifier() }, [&] {
+        return makeUniqueRef<AnchorPositionedState>();
     }).iterator->value.get();
 
     auto scopedAnchorName = [&] {
@@ -1300,7 +1300,7 @@ void AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayou
     auto anchorsForAnchorName = collectAnchorsForAnchorName(document);
 
     for (auto& elementAndState : anchorPositionedStates) {
-        auto& state = *elementAndState.value;
+        auto& state = elementAndState.value.get();
 
         switch (state.stage) {
         case AnchorPositionResolutionStage::FindAnchors: {
@@ -1362,17 +1362,17 @@ void AnchorPositionEvaluator::updateAnchorPositionedStateForDefaultAnchorAndPosi
     if (!shouldResolveDefaultAnchor && !hasPositionVisibilityNoOverflow)
         return;
 
-    auto* state = states.ensure({ &element, style.pseudoElementIdentifier() }, [&] {
-        return makeUnique<AnchorPositionedState>();
+    auto& state = states.ensure({ &element, style.pseudoElementIdentifier() }, [&] {
+        return makeUniqueRef<AnchorPositionedState>();
     }).iterator->value.get();
 
     if (shouldResolveDefaultAnchor) {
         // Always resolve the default anchor. Even if nothing is anchored to it we need it to compute the scroll compensation.
         auto resolvedDefaultAnchor = ResolvedScopedName::createFromScopedName(element, defaultAnchorName(style));
-        if (state->anchorNames.add(resolvedDefaultAnchor).isNewEntry) {
+        if (state.anchorNames.add(resolvedDefaultAnchor).isNewEntry) {
             // If anchor resolution has progressed past FindAnchors, and we pick up a new anchor name, set the
             // stage back to FindAnchors. This restarts the resolution process to resolve newly added names.
-            state->stage = AnchorPositionResolutionStage::FindAnchors;
+            state.stage = AnchorPositionResolutionStage::FindAnchors;
         }
     }
 }

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -156,7 +156,7 @@ struct AnchorPositionedState {
 };
 
 using AnchorPositionedKey = std::pair<RefPtr<const Element>, std::optional<PseudoElementIdentifier>>;
-using AnchorPositionedStates = HashMap<AnchorPositionedKey, std::unique_ptr<AnchorPositionedState>>;
+using AnchorPositionedStates = HashMap<AnchorPositionedKey, UniqueRef<AnchorPositionedState>>;
 
 using AnchorsForAnchorName = HashMap<ResolvedScopedName, Vector<SingleThreadWeakRef<const RenderBoxModelObject>>>;
 

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1541,11 +1541,8 @@ std::unique_ptr<Update> TreeResolver::resolve()
                 // reset the resolution stage to FindAnchor. This re-runs anchor resolution to
                 // pick up new anchor name changes.
                 AnchorPositionedKey anchorPositionedKey { anchorPositionedElement.ptr(), anchors.pseudoElementIdentifier };
-                auto stateIt = m_treeResolutionState.anchorPositionedStates.find(anchorPositionedKey);
-                if (stateIt != m_treeResolutionState.anchorPositionedStates.end()) {
-                    ASSERT(stateIt->value);
-                    stateIt->value->stage = AnchorPositionResolutionStage::FindAnchors;
-                }
+                if (auto* state = m_treeResolutionState.anchorPositionedStates.get(anchorPositionedKey))
+                    state->stage = AnchorPositionResolutionStage::FindAnchors;
             }
         }
 


### PR DESCRIPTION
#### fb8200366c4f2e4ee2e0b56ae8eda953703198cc
<pre>
[css-anchor-position-1] Use UniqueRef in AnchorPositionedStates
<a href="https://rdar.apple.com/174179610">rdar://174179610</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311583">https://bugs.webkit.org/show_bug.cgi?id=311583</a>

Reviewed by Antti Koivisto.

AnchorPositionedStates holds std::unique_ptr&lt;AnchorPositionedState&gt;. The
pointers are guaranteed to be non-null, so switch to using UniqueRef instead.

Simple refactoring, tested by existing anchor positioning tests.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::findAnchorForAnchorFunctionAndAttemptResolution):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout):
* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolve):

Canonical link: <a href="https://commits.webkit.org/310713@main">https://commits.webkit.org/310713@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7a55c432544c58f9fa3eb511bd7560d47b12acd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163291 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108002 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/981d5819-809f-466b-b346-4da2425b345d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156406 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27641 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119521 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84538 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/daf1736d-e2b0-4670-8352-f6b473aa13b2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21809 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138789 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100218 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/77b08b0e-4177-4a7f-b202-c69ef9cc1b1f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20895 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18909 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11119 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130557 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16633 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165761 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8968 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18242 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127625 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27337 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22949 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127769 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34706 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27261 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138426 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83943 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22668 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15218 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26951 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91054 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26531 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26762 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26604 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->