### PR TITLE
Use "= default" for constructor in WebKit code

### DIFF
--- a/Source/WebKit/Platform/IPC/MessageReceiverMap.cpp
+++ b/Source/WebKit/Platform/IPC/MessageReceiverMap.cpp
@@ -31,9 +31,7 @@
 
 namespace IPC {
 
-MessageReceiverMap::MessageReceiverMap()
-{
-}
+MessageReceiverMap::MessageReceiverMap() = default;
 
 MessageReceiverMap::~MessageReceiverMap() = default;
 

--- a/Source/WebKit/Shared/SharedStringHashTable.cpp
+++ b/Source/WebKit/Shared/SharedStringHashTable.cpp
@@ -33,9 +33,7 @@ namespace WebKit {
 
 using namespace WebCore;
 
-SharedStringHashTable::SharedStringHashTable()
-{
-}
+SharedStringHashTable::SharedStringHashTable() = default;
 
 SharedStringHashTable::~SharedStringHashTable() = default;
 

--- a/Source/WebKit/Shared/win/AuxiliaryProcessMainWin.cpp
+++ b/Source/WebKit/Shared/win/AuxiliaryProcessMainWin.cpp
@@ -33,7 +33,7 @@
 
 namespace WebKit {
 
-AuxiliaryProcessMainCommon::AuxiliaryProcessMainCommon() { }
+AuxiliaryProcessMainCommon::AuxiliaryProcessMainCommon() = default;
 
 void AuxiliaryProcess::platformInitialize(const AuxiliaryProcessInitializationParameters&)
 {

--- a/Source/WebKit/UIProcess/UserMediaProcessManager.cpp
+++ b/Source/WebKit/UIProcess/UserMediaProcessManager.cpp
@@ -53,9 +53,7 @@ UserMediaProcessManager& UserMediaProcessManager::singleton()
     return manager;
 }
 
-UserMediaProcessManager::UserMediaProcessManager()
-{
-}
+UserMediaProcessManager::UserMediaProcessManager() = default;
 
 #if ENABLE(SANDBOX_EXTENSIONS)
 static bool NODELETE needsAppleCameraService()

--- a/Source/WebKit/UIProcess/ViewSnapshotStore.cpp
+++ b/Source/WebKit/UIProcess/ViewSnapshotStore.cpp
@@ -39,9 +39,7 @@ static const size_t maximumSnapshotCacheSize = 400 * (1024 * 1024);
 namespace WebKit {
 using namespace WebCore;
 
-ViewSnapshotStore::ViewSnapshotStore()
-{
-}
+ViewSnapshotStore::ViewSnapshotStore() = default;
 
 ViewSnapshotStore::~ViewSnapshotStore()
 {

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.cpp
@@ -50,9 +50,7 @@ WebPasteboardProxy& WebPasteboardProxy::singleton()
     return proxy;
 }
 
-WebPasteboardProxy::WebPasteboardProxy()
-{
-}
+WebPasteboardProxy::WebPasteboardProxy() = default;
 
 void WebPasteboardProxy::addWebProcessProxy(WebProcessProxy& webProcessProxy)
 {

--- a/Source/WebKit/UIProcess/gtk/WebTextChecker.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebTextChecker.cpp
@@ -40,9 +40,7 @@ WebTextChecker* WebTextChecker::singleton()
     return textChecker;
 }
 
-WebTextChecker::WebTextChecker()
-{
-}
+WebTextChecker::WebTextChecker() = default;
 
 void WebTextChecker::setClient(const WKTextCheckerClientBase* client)
 {

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
@@ -37,9 +37,7 @@
 
 namespace WebKit {
 
-WebCacheStorageConnection::WebCacheStorageConnection()
-{
-}
+WebCacheStorageConnection::WebCacheStorageConnection() = default;
 
 WebCacheStorageConnection::~WebCacheStorageConnection() = default;
 


### PR DESCRIPTION
#### 9092a1156e3db0c77d9351fc0d996808140f230a
<pre>
Use &quot;= default&quot; for constructor in WebKit code
<a href="https://bugs.webkit.org/show_bug.cgi?id=311588">https://bugs.webkit.org/show_bug.cgi?id=311588</a>
<a href="https://rdar.apple.com/174182004">rdar://174182004</a>

Reviewed by Chris Dumez.

This extends our &quot;= default&quot; usage across few leftover empty constructors
in WebKit code.

* Source/WebKit/Platform/IPC/MessageReceiverMap.cpp:
(IPC::MessageReceiverMap::MessageReceiverMap): Deleted.
* Source/WebKit/Shared/SharedStringHashTable.cpp:
(WebKit::SharedStringHashTable::SharedStringHashTable): Deleted.
* Source/WebKit/Shared/win/AuxiliaryProcessMainWin.cpp:
(WebKit::AuxiliaryProcessMainCommon::AuxiliaryProcessMainCommon): Deleted.
* Source/WebKit/UIProcess/UserMediaProcessManager.cpp:
(WebKit::UserMediaProcessManager::UserMediaProcessManager): Deleted.
* Source/WebKit/UIProcess/ViewSnapshotStore.cpp:
(WebKit::ViewSnapshotStore::ViewSnapshotStore): Deleted.
* Source/WebKit/UIProcess/WebPasteboardProxy.cpp:
(WebKit::WebPasteboardProxy::WebPasteboardProxy): Deleted.
* Source/WebKit/UIProcess/gtk/WebTextChecker.cpp:
(WebKit::WebTextChecker::WebTextChecker): Deleted.
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp:
(WebKit::WebCacheStorageConnection::WebCacheStorageConnection): Deleted.

Canonical link: <a href="https://commits.webkit.org/310681@main">https://commits.webkit.org/310681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fe943df49fbc3684e5dd51db82696b7af39e260

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154534 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20952 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163292 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108003 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27642 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119523 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84539 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100220 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20900 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18908 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11120 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130562 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165762 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8969 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18243 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127624 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22948 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127768 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34682 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27262 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138427 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/83944 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22665 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15219 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26952 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91055 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26532 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26763 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26605 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->