### PR TITLE
CSS1: character styled with :first-letter is not selectable

### DIFF
--- a/LayoutTests/editing/selection/first-letter-caret-single-char-expected.txt
+++ b/LayoutTests/editing/selection/first-letter-caret-single-char-expected.txt
@@ -1,0 +1,12 @@
+Test that caret positioning works correctly when the entire text is a ::first-letter with an empty remaining fragment.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS window.getSelection().anchorOffset is 1
+PASS test.textContent is 'A'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+A
+

--- a/LayoutTests/editing/selection/first-letter-caret-single-char.html
+++ b/LayoutTests/editing/selection/first-letter-caret-single-char.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<style>
+div::first-letter {
+    color: red;
+}
+div {
+    font-size: 20px;
+}
+</style>
+</head>
+<body>
+<div contenteditable id="test">A</div>
+<div id="container"></div>
+
+<script>
+description("Test that caret positioning works correctly when the entire text is a ::first-letter with an empty remaining fragment.");
+
+// Append "B" after "A", then delete it. The caret should stay after "A".
+document.body.offsetHeight;
+test.append(document.createTextNode("B"));
+document.body.offsetHeight;
+
+// Place caret after "B" and delete it.
+var sel = window.getSelection();
+sel.collapse(test.lastChild, 1);
+document.execCommand("delete");
+document.body.offsetHeight;
+
+// After deleting "B", only "A" remains as the entire first letter.
+// The caret should be after "A" (offset 1), not before it (offset 0).
+shouldBe("window.getSelection().anchorOffset", "1");
+shouldBe("test.textContent", "'A'");
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/editing/selection/first-letter-selection-cross-element-expected.txt
+++ b/LayoutTests/editing/selection/first-letter-selection-cross-element-expected.txt
@@ -1,0 +1,13 @@
+Test that selection across multiple elements with ::first-letter works correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS window.getSelection().toString().replace(/\n/g, '|') is "First paragraph|Second paragraph"
+PASS window.getSelection().toString().replace(/\n/g, '|') is "st paragraph|Second"
+PASS window.getSelection().toString().replace(/\n/g, '|') is "First paragraph|S"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+First paragraph
+Second paragraph

--- a/LayoutTests/editing/selection/first-letter-selection-cross-element.html
+++ b/LayoutTests/editing/selection/first-letter-selection-cross-element.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<style>
+.first-letter-styled::first-letter {
+    color: red;
+}
+</style>
+</head>
+<body>
+<div id="container">
+    <div id="para1" class="first-letter-styled">First paragraph</div>
+    <div id="para2" class="first-letter-styled">Second paragraph</div>
+</div>
+
+<script>
+description("Test that selection across multiple elements with ::first-letter works correctly.");
+
+function selectAcrossElements(startNode, startOffset, endNode, endOffset) {
+    var range = document.createRange();
+    range.setStart(startNode, startOffset);
+    range.setEnd(endNode, endOffset);
+    var sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+}
+
+// Test 1: Select across two first-letter paragraphs
+selectAcrossElements(para1.firstChild, 0, para2.firstChild, para2.firstChild.length);
+shouldBeEqualToString("window.getSelection().toString().replace(/\\n/g, '|')", "First paragraph|Second paragraph");
+
+// Test 2: Select from middle of first to middle of second
+selectAcrossElements(para1.firstChild, 3, para2.firstChild, 6);
+shouldBeEqualToString("window.getSelection().toString().replace(/\\n/g, '|')", "st paragraph|Second");
+
+// Test 3: Select from first-letter of first to first-letter of second
+selectAcrossElements(para1.firstChild, 0, para2.firstChild, 1);
+shouldBeEqualToString("window.getSelection().toString().replace(/\\n/g, '|')", "First paragraph|S");
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/editing/selection/first-letter-selection-expected.txt
+++ b/LayoutTests/editing/selection/first-letter-selection-expected.txt
@@ -1,0 +1,33 @@
+Test that selection works correctly with ::first-letter pseudo-element.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS window.getSelection().toString() is "Hello"
+PASS window.getSelection().toString() is "12"
+PASS window.getSelection().toString() is "\"Quote"
+PASS window.getSelection().toString() is "A"
+PASS window.getSelection().toString() is "Nested"
+PASS window.getSelection().toString().replace(/\n/g, '|') is "First|Second"
+PASS window.getSelection().toString() is "Editable"
+PASS window.getSelection().toString() is "1"
+PASS window.getSelection().toString() is "2"
+PASS window.getSelection().toString() is "Hel"
+PASS window.getSelection().toString() is "\"Q"
+PASS window.getSelection().isCollapsed is true
+PASS window.getSelection().anchorOffset is 1
+PASS window.getSelection().isCollapsed is true
+PASS window.getSelection().anchorOffset is 0
+PASS window.getSelection().toString() is "A"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello
+12
+"Quote
+A
+Nested
+First
+Second
+Editable
+

--- a/LayoutTests/editing/selection/first-letter-selection-painting-expected.html
+++ b/LayoutTests/editing/selection/first-letter-selection-painting-expected.html
@@ -1,0 +1,25 @@
+<script src="../../resources/ui-helper.js"></script>
+<style>
+span.first-letter {
+    color: red;
+    font-size: 2em;
+}
+</style>
+<div id="target"><span class="first-letter">H</span>ello World</div>
+<script>
+window.testRunner?.waitUntilDone();
+window.testRunner?.dontForceRepaint();
+
+async function runTest() {
+    await UIHelper.renderingUpdate();
+    var range = document.createRange();
+    range.selectNodeContents(document.getElementById("target"));
+    window.getSelection().removeAllRanges();
+    window.getSelection().addRange(range);
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    window.testRunner?.notifyDone();
+}
+
+window.addEventListener('load', runTest);
+</script>

--- a/LayoutTests/editing/selection/first-letter-selection-painting.html
+++ b/LayoutTests/editing/selection/first-letter-selection-painting.html
@@ -1,0 +1,25 @@
+<script src="../../resources/ui-helper.js"></script>
+<style>
+div::first-letter {
+    color: red;
+    font-size: 2em;
+}
+</style>
+<div id="target">Hello World</div>
+<script>
+window.testRunner?.waitUntilDone();
+window.testRunner?.dontForceRepaint();
+
+async function runTest() {
+    await UIHelper.renderingUpdate();
+    var range = document.createRange();
+    range.selectNodeContents(document.getElementById("target"));
+    window.getSelection().removeAllRanges();
+    window.getSelection().addRange(range);
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    window.testRunner?.notifyDone();
+}
+
+window.addEventListener('load', runTest);
+</script>

--- a/LayoutTests/editing/selection/first-letter-selection.html
+++ b/LayoutTests/editing/selection/first-letter-selection.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<style>
+div::first-letter {
+    color: red;
+}
+</style>
+</head>
+<body>
+<div id="test1">Hello</div>
+<div id="test2">12</div>
+<div id="test3">"Quote</div>
+<div id="test4">A</div>
+<div id="test5"><span>Nested</span></div>
+<div id="test6">First<br>Second</div>
+<div id="test7" contenteditable>Editable</div>
+<div id="container"></div>
+
+<script>
+description("Test that selection works correctly with ::first-letter pseudo-element.");
+
+function selectAll(element) {
+    var range = document.createRange();
+    range.selectNodeContents(element);
+    var sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+}
+
+function selectRange(node, start, end) {
+    var range = document.createRange();
+    range.setStart(node, start);
+    range.setEnd(node, end);
+    var sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+}
+
+// Test 1: Select all text in element with first-letter
+selectAll(test1);
+shouldBeEqualToString("window.getSelection().toString()", "Hello");
+
+// Test 2: Short text - select all
+selectAll(test2);
+shouldBeEqualToString("window.getSelection().toString()", "12");
+
+// Test 3: First-letter with punctuation (first-letter includes quote + letter)
+selectAll(test3);
+shouldBeEqualToString("window.getSelection().toString()", "\"Quote");
+
+// Test 4: Single character text (entire text is first-letter)
+selectAll(test4);
+shouldBeEqualToString("window.getSelection().toString()", "A");
+
+// Test 5: First-letter with nested inline
+selectAll(test5);
+shouldBeEqualToString("window.getSelection().toString()", "Nested");
+
+// Test 6: Multi-line - select all should get both lines
+selectAll(test6);
+shouldBeEqualToString("window.getSelection().toString().replace(/\\n/g, '|')", "First|Second");
+
+// Test 7: Contenteditable with first-letter
+selectAll(test7);
+shouldBeEqualToString("window.getSelection().toString()", "Editable");
+
+// Test 8: Select only the first-letter portion
+selectRange(test2.firstChild, 0, 1);
+shouldBeEqualToString("window.getSelection().toString()", "1");
+
+// Test 9: Select only the remaining portion (after first-letter)
+selectRange(test2.firstChild, 1, 2);
+shouldBeEqualToString("window.getSelection().toString()", "2");
+
+// Test 10: Select range spanning first-letter boundary
+selectRange(test1.firstChild, 0, 3);
+shouldBeEqualToString("window.getSelection().toString()", "Hel");
+
+// Test 11: Select from middle of first-letter text to end
+selectRange(test3.firstChild, 0, 2);
+shouldBeEqualToString("window.getSelection().toString()", "\"Q");
+
+// Test 12: Caret at first-letter boundary (offset = first-letter length)
+selectRange(test1.firstChild, 1, 1);
+shouldBe("window.getSelection().isCollapsed", "true");
+shouldBe("window.getSelection().anchorOffset", "1");
+
+// Test 13: Caret at start of text (offset 0, inside first-letter)
+selectRange(test1.firstChild, 0, 0);
+shouldBe("window.getSelection().isCollapsed", "true");
+shouldBe("window.getSelection().anchorOffset", "0");
+
+// Test 14: Select all on single-character first-letter (entire text is first-letter)
+selectRange(test4.firstChild, 0, 1);
+shouldBeEqualToString("window.getSelection().toString()", "A");
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/editing/text-iterator/first-letter-word-boundary-expected.txt
+++ b/LayoutTests/editing/text-iterator/first-letter-word-boundary-expected.txt
@@ -2,9 +2,9 @@ This tests moving caret around a word with a first-letter rule. WebKit should no
 
  hello world'
 white-space: normal;
-FAIL: moving forward by word from offset 4 put caret at offset 10 but expected 6
+PASS: moving forward by word from offset 4 put caret at offset 6
 PASS: moving backward by word from offset 4 put caret at offset 1
 white-space: pre;
-FAIL: moving forward by word from offset 4 put caret at offset 10 but expected 6
+PASS: moving forward by word from offset 4 put caret at offset 6
 PASS: moving backward by word from offset 4 put caret at offset 1
 

--- a/LayoutTests/fast/css/first-letter-pre-text-iterator-expected.txt
+++ b/LayoutTests/fast/css/first-letter-pre-text-iterator-expected.txt
@@ -1,0 +1,5 @@
+Hello World
+0-5: "Hello" (expected "Hello")
+1-5: "ello" (expected "ello")
+2-4: "ll" (expected "ll")
+0-11: "Hello World" (expected "Hello World")

--- a/LayoutTests/fast/css/first-letter-pre-text-iterator.html
+++ b/LayoutTests/fast/css/first-letter-pre-text-iterator.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<style>
+pre::first-letter {
+    color: red;
+}
+</style>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<pre id="test">Hello World</pre>
+<pre id="result"></pre>
+<script>
+var pre = document.getElementById('test');
+var text = pre.firstChild;
+var results = [];
+
+// Range spanning first-letter boundary
+var r1 = document.createRange();
+r1.setStart(text, 0);
+r1.setEnd(text, 5);
+results.push('0-5: "' + r1.toString() + '" (expected "Hello")');
+
+// Range starting in remaining fragment
+var r2 = document.createRange();
+r2.setStart(text, 1);
+r2.setEnd(text, 5);
+results.push('1-5: "' + r2.toString() + '" (expected "ello")');
+
+// Range within remaining fragment
+var r3 = document.createRange();
+r3.setStart(text, 2);
+r3.setEnd(text, 4);
+results.push('2-4: "' + r3.toString() + '" (expected "ll")');
+
+// Select all
+var r4 = document.createRange();
+r4.setStart(text, 0);
+r4.setEnd(text, 11);
+results.push('0-11: "' + r4.toString() + '" (expected "Hello World")');
+
+document.getElementById('result').textContent = results.join('\n');
+</script>

--- a/LayoutTests/fast/text/first-letter-partial-invalidation-crash-expected.txt
+++ b/LayoutTests/fast/text/first-letter-partial-invalidation-crash-expected.txt
@@ -1,1 +1,1 @@
-PASS if no crash or asAAAArt
+PASS if no crash or asseAAAA

--- a/LayoutTests/platform/glib/editing/selection/extend-by-word-002-expected.txt
+++ b/LayoutTests/platform/glib/editing/selection/extend-by-word-002-expected.txt
@@ -69,5 +69,5 @@ layer at (0,0) size 800x600
             RenderInline {A} at (18,6) size 38x11 [color=#0000EE]
               RenderText {#text} at (18,6) size 38x11
                 text run at (18,6) width 38: "Combos"
-selection start: position 0 of child 0 {#text} of child 1 {A} of child 1 {LI} of child 1 {UL} of child 1 {DIV} of body
+selection start: position 1 of child 0 {#text} of child 1 {LI} of child 1 {UL} of child 1 {DIV} of body
 selection end:   position 5 of child 0 {#text} of child 1 {A} of child 7 {LI} of child 1 {UL} of child 1 {DIV} of body

--- a/LayoutTests/platform/ios/editing/selection/extend-by-word-002-expected.txt
+++ b/LayoutTests/platform/ios/editing/selection/extend-by-word-002-expected.txt
@@ -69,5 +69,5 @@ layer at (0,0) size 800x600
             RenderInline {A} at (19,5) size 41x14 [color=#0000EE]
               RenderText {#text} at (19,5) size 41x14
                 text run at (19,5) width 41: "Combos"
-selection start: position 0 of child 0 {#text} of child 1 {A} of child 1 {LI} of child 1 {UL} of child 1 {DIV} of body
+selection start: position 1 of child 0 {#text} of child 1 {LI} of child 1 {UL} of child 1 {DIV} of body
 selection end:   position 5 of child 0 {#text} of child 1 {A} of child 7 {LI} of child 1 {UL} of child 1 {DIV} of body

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1461,7 +1461,6 @@ webkit.org/b/260113 [ arm64 ] http/wpt/webauthn/ctap-hid-failure.https.html [ Pa
 [ Sonoma+ ] accessibility/mac/attributed-string/attributed-string-has-completion-annotation.html [ Pass ]
 
 # rdar://103251644 (REGRESSION : [ GuardMalloc ] com.apple.MediaToolbox: PerformTransferBytePumpAsync)
-editing/text-iterator/backwards-text-iterator-basic.html [ Crash ]
 
 # rdar://107460005 ([UI Side Compositing] fast/text/web-font-load-invisible-during-loading.html fails)
 fast/text/web-font-load-invisible-during-loading.html [ Failure ]

--- a/LayoutTests/platform/mac/editing/selection/extend-by-word-002-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/extend-by-word-002-expected.txt
@@ -69,5 +69,5 @@ layer at (0,0) size 800x600
             RenderInline {A} at (19,5) size 41x14 [color=#0000EE]
               RenderText {#text} at (19,5) size 41x14
                 text run at (19,5) width 41: "Combos"
-selection start: position 0 of child 0 {#text} of child 1 {A} of child 1 {LI} of child 1 {UL} of child 1 {DIV} of body
+selection start: position 1 of child 0 {#text} of child 1 {LI} of child 1 {UL} of child 1 {DIV} of body
 selection end:   position 5 of child 0 {#text} of child 1 {A} of child 7 {LI} of child 1 {UL} of child 1 {DIV} of body

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -31,6 +31,7 @@
 #include "CSSComputedStyleDeclaration.h"
 #include "ContainerNodeInlines.h"
 #include "EditingInlines.h"
+#include "Editing.h"
 #include "ElementInlines.h"
 #include "HTMLBRElement.h"
 #include "HTMLBodyElement.h"
@@ -54,6 +55,7 @@
 #include "RenderLineBreak.h"
 #include "RenderObjectInlines.h"
 #include "RenderText.h"
+#include "RenderTextFragment.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGTextElement.h"
 #include "Text.h"
@@ -642,6 +644,26 @@ static Node* enclosingVisualBoundary(SUPPRESS_UNCHECKED_LOCAL Node* node)
     return node;
 }
 
+// The first-letter and remaining text are separate renderers but share one DOM
+// text node. upstream/downstream must not cross this boundary, just like they
+// must not cross visually distinct node boundaries.
+static bool crossesFirstLetterBoundary(const RenderObject& renderer, const PositionIterator& current, const PositionIterator& previousLastVisible)
+{
+    auto* textFragment = dynamicDowncast<RenderTextFragment>(renderer);
+    if (!textFragment || !textFragment->firstLetter())
+        return false;
+    if (current.node() != previousLastVisible.node())
+        return false;
+    auto fragmentStart = static_cast<int>(textFragment->start());
+    auto currentOffset = current.offsetInLeafNode();
+    auto lastOffset = previousLastVisible.offsetInLeafNode();
+
+    bool currentOffsetIsInFirstLetter = currentOffset < fragmentStart;
+    bool lastOffsetIsInFirstLetter = lastOffset < fragmentStart;
+    return currentOffsetIsInFirstLetter != lastOffsetIsInFirstLetter;
+}
+
+
 // upstream() and downstream() want to return positions that are either in a
 // text node or at just before a non-text node.  This method checks for that.
 static bool isStreamer(const PositionIterator& pos)
@@ -711,7 +733,10 @@ Position Position::upstream(EditingBoundaryCrossingRule rule) const
             lastVisible = currentPosition;
             break;
         }
-        
+
+        if (crossesFirstLetterBoundary(*renderer, currentPosition, lastVisible))
+            return lastVisible;
+
         // track last visible streamer position
         if (isStreamer(currentPosition))
             lastVisible = currentPosition;
@@ -740,10 +765,10 @@ Position Position::upstream(EditingBoundaryCrossingRule rule) const
                 // render tree which can have a different length due to case transformation.
                 // Until we resolve that, disable this so we can run the layout tests!
                 //ASSERT(currentOffset >= renderer->caretMaxOffset());
-                return makeDeprecatedLegacyPosition(currentNode.ptr(), renderer->caretMaxOffset());
+                return makeDeprecatedLegacyPosition(currentNode.ptr(), caretMaxOffset(currentNode));
             }
 
-            unsigned textOffset = currentPosition.offsetInLeafNode();
+            auto textOffset = convertNodeOffsetToOffsetInTextFragment(*textRenderer, currentPosition.offsetInLeafNode());
             for (auto box = firstTextBox; box;) {
                 if (textOffset > box->start() && textOffset <= box->end())
                     return currentPosition;
@@ -827,6 +852,9 @@ Position Position::downstream(EditingBoundaryCrossingRule rule) const
             break;
         }
 
+        if (crossesFirstLetterBoundary(*renderer, currentPosition, lastVisible))
+            return lastVisible;
+
         // track last visible streamer position
         if (isStreamer(currentPosition))
             lastVisible = currentPosition;
@@ -849,7 +877,7 @@ Position Position::downstream(EditingBoundaryCrossingRule rule) const
                 return makeContainerOffsetPosition(currentNode.ptr(), textRenderer->caretMinOffset());
             }
 
-            unsigned textOffset = currentPosition.offsetInLeafNode();
+            auto textOffset = convertNodeOffsetToOffsetInTextFragment(*textRenderer, currentPosition.offsetInLeafNode());
             for (auto box = firstTextBox; box;) {
                 if (!box->length() && textOffset == box->start())
                     return currentPosition;
@@ -898,7 +926,13 @@ bool Position::hasRenderedNonAnonymousDescendantsWithHeight(const RenderElement&
     auto isHorizontal = renderer.isHorizontalWritingMode();
     CheckedPtr stop = renderer.nextInPreOrderAfterChildren();
     for (CheckedPtr descendant = renderer.firstChild(); descendant && descendant != stop; descendant = descendant->nextInPreOrder()) {
-        if (!descendant->nonPseudoNode())
+        auto shouldSkip = [&] {
+            if (descendant->nonPseudoNode())
+                return false;
+            CheckedPtr renderElement = dynamicDowncast<RenderElement>(*descendant);
+            return !renderElement || !renderElement->isFirstLetter();
+        };
+        if (shouldSkip())
             continue;
 
         auto boundingBoxLogicalHeight = [&](auto rect) {
@@ -916,7 +950,7 @@ bool Position::hasRenderedNonAnonymousDescendantsWithHeight(const RenderElement&
             continue;
         }
         if (CheckedPtr renderInline = dynamicDowncast<RenderInline>(*descendant)) {
-            if (isEmptyInline(*renderInline) && boundingBoxLogicalHeight(renderInline->linesBoundingBox()))
+            if ((renderInline->isFirstLetter() || isEmptyInline(*renderInline)) && boundingBoxLogicalHeight(renderInline->linesBoundingBox()))
                 return true;
             continue;
         }
@@ -985,8 +1019,10 @@ bool Position::isCandidate() const
         return !m_offset && m_anchorType != PositionIsAfterAnchor && !nodeIsUserSelectNone(node->parentNode());
     }
 
-    if (CheckedPtr renderText = dynamicDowncast<RenderText>(*renderer))
-        return !nodeIsUserSelectNone(node.get()) && renderText->containsCaretOffset(m_offset);
+    if (is<RenderText>(*renderer)) {
+        auto [resolvedText, resolvedOffset] = resolvedTextRendererAndOffset();
+        return !nodeIsUserSelectNone(node.get()) && resolvedText && resolvedText->containsCaretOffset(resolvedOffset);
+    }
 
     if (positionBeforeOrAfterNodeIsCandidate(*node)) {
         return ((atFirstEditingPositionForNode() && m_anchorType == PositionIsBeforeAnchor)
@@ -1013,9 +1049,10 @@ bool Position::isCandidate() const
 
 bool Position::isRenderedCharacter() const
 {
-    RefPtr text = dynamicDowncast<Text>(deprecatedNode());
-    CheckedPtr renderer = text ? text->renderer() : nullptr;
-    return renderer && renderer->containsRenderedCharacterOffset(m_offset);
+    if (!dynamicDowncast<Text>(deprecatedNode()))
+        return false;
+    auto [renderText, offset] = resolvedTextRendererAndOffset();
+    return renderText && renderText->containsRenderedCharacterOffset(offset);
 }
 
 static bool inSameEnclosingBlockFlowElement(Node* a, Node* b)
@@ -1061,16 +1098,16 @@ bool Position::rendersInDifferentPosition(const Position& position) const
     if (!inSameEnclosingBlockFlowElement(node.get(), positionNode.get()))
         return true;
 
-    CheckedPtr textRenderer = dynamicDowncast<RenderText>(*renderer);
-    if (textRenderer && !textRenderer->containsCaretOffset(m_offset))
+    auto [textRenderer, thisOffset] = resolvedTextRendererAndOffset();
+    if (textRenderer && !textRenderer->containsCaretOffset(thisOffset))
         return false;
 
-    CheckedPtr textPositionRenderer = dynamicDowncast<RenderText>(*positionRenderer);
-    if (textPositionRenderer && !textPositionRenderer->containsCaretOffset(position.m_offset))
+    auto [textPositionRenderer, positionOffset] = position.resolvedTextRendererAndOffset();
+    if (textPositionRenderer && !textPositionRenderer->containsCaretOffset(positionOffset))
         return false;
 
-    unsigned thisRenderedOffset = textRenderer ? textRenderer->countRenderedCharacterOffsetsUntil(m_offset) : m_offset;
-    unsigned positionRenderedOffset = textPositionRenderer ? textPositionRenderer->countRenderedCharacterOffsetsUntil(position.m_offset) : position.m_offset;
+    unsigned thisRenderedOffset = textRenderer ? textRenderer->countRenderedCharacterOffsetsUntil(thisOffset) : m_offset;
+    unsigned positionRenderedOffset = textPositionRenderer ? textPositionRenderer->countRenderedCharacterOffsetsUntil(positionOffset) : position.m_offset;
 
     if (renderer == positionRenderer && thisRenderedOffset == positionRenderedOffset)
         return false;
@@ -1195,16 +1232,52 @@ static Position upstreamIgnoringEditingBoundaries(Position position)
     return position;
 }
 
+std::pair<RenderObject*, unsigned> Position::rendererAndOffset() const
+{
+    auto* node = anchorNode();
+    if (!node)
+        return { nullptr, 0 };
+    auto* renderer = node->renderer();
+    if (!renderer)
+        return { nullptr, 0 };
+    unsigned offset = deprecatedEditingOffset();
+    CheckedPtr textFragment = dynamicDowncast<RenderTextFragment>(*renderer);
+    if (!textFragment || !textFragment->firstLetter())
+        return { renderer, offset };
+
+    if (offset >= textFragment->start() && textFragment->text().length())
+        return { renderer, offset - textFragment->start() };
+
+    // It looks like we are on the first letter renderer.
+    CheckedPtr firstLetterRenderer = dynamicDowncast<RenderText>(textFragment->firstLetter()->firstChild());
+    if (!firstLetterRenderer) {
+        ASSERT_NOT_REACHED();
+        return { nullptr, 0 };
+    }
+
+    // The first-letter text may not start at DOM offset 0 (e.g. collapsed whitespace precedes the first letter).
+    auto firstLetterStart = textFragment->start() - firstLetterRenderer->text().length();
+    if (offset < firstLetterStart)
+        return { nullptr, 0 };
+    return { firstLetterRenderer, offset - firstLetterStart };
+}
+
+std::pair<RenderText*, unsigned> Position::resolvedTextRendererAndOffset() const
+{
+    auto [renderer, offset] = rendererAndOffset();
+    if (auto* renderText = dynamicDowncast<RenderText>(renderer))
+        return { renderText, offset };
+    return { nullptr, 0 };
+}
+
 InlineBoxAndOffset Position::inlineBoxAndOffset(Affinity affinity, TextDirection primaryDirection) const
 {
     auto caretOffset = static_cast<unsigned>(deprecatedEditingOffset());
 
-    RefPtr node = deprecatedNode();
-    if (!node)
-        return { { }, caretOffset };
-    CheckedPtr renderer = node->renderer();
+    auto [renderer, resolvedOffset] = rendererAndOffset();
     if (!renderer)
         return { { }, caretOffset };
+    caretOffset = resolvedOffset;
 
     InlineIterator::LeafBoxIterator box;
 

--- a/Source/WebCore/dom/Position.h
+++ b/Source/WebCore/dom/Position.h
@@ -38,6 +38,8 @@ namespace WebCore {
 
 class LegacyInlineBox;
 class RenderElement;
+class RenderObject;
+class RenderText;
 class Text;
 
 struct BoundaryPoint;
@@ -102,6 +104,12 @@ public:
             return m_offset;
         return offsetForPositionAfterAnchor();
     }
+
+    // Returns the renderer and fragment-local offset for this position, correctly
+    // handling first-letter text fragment splits where the DOM text node's renderer
+    // is the remaining fragment rather than the first-letter fragment.
+    std::pair<RenderObject*, unsigned> rendererAndOffset() const;
+    std::pair<RenderText*, unsigned> resolvedTextRendererAndOffset() const;
 
     RefPtr<Node> firstNode() const;
 

--- a/Source/WebCore/dom/PositionIterator.cpp
+++ b/Source/WebCore/dom/PositionIterator.cpp
@@ -175,8 +175,12 @@ bool PositionIterator::isCandidate() const
     if (renderer->isBR())
         return Position(*this).isCandidate();
 
-    if (CheckedPtr renderText = dynamicDowncast<RenderText>(*renderer))
-        return !Position::nodeIsUserSelectNone(anchorNode.get()) && renderText->containsCaretOffset(m_offsetInAnchor);
+    if (is<RenderText>(*renderer)) {
+        if (Position::nodeIsUserSelectNone(anchorNode.get()))
+            return false;
+        auto [resolvedText, resolvedOffset] = Position(*this).resolvedTextRendererAndOffset();
+        return resolvedText && resolvedText->containsCaretOffset(resolvedOffset);
+    }
 
     if (positionBeforeOrAfterNodeIsCandidate(*anchorNode))
         return (atStartOfNode() || atEndOfNode()) && !Position::nodeIsUserSelectNone(anchorNode->parentNode());

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -66,6 +66,7 @@
 #include "RenderStyle+GettersInlines.h"
 #include "RenderTableCell.h"
 #include "RenderTextControlSingleLine.h"
+#include "RenderTextFragment.h"
 #include "RenderedPosition.h"
 #include "ShadowRoot.h"
 #include "Text.h"
@@ -904,9 +905,23 @@ int caretMaxOffset(const Node& node)
     // For rendered text nodes, return the last position that a caret could occupy.
     if (auto* text = dynamicDowncast<Text>(node)) {
         if (CheckedPtr renderer = text->renderer())
-            return renderer->caretMaxOffset();
+            return convertOffsetInTextFragmentToNodeOffset(*renderer, renderer->caretMaxOffset());
     }
     return lastOffsetForEditing(node);
+}
+
+unsigned convertOffsetInTextFragmentToNodeOffset(const RenderObject& renderer, unsigned offset)
+{
+    if (auto* textFragment = dynamicDowncast<RenderTextFragment>(renderer); textFragment && textFragment->firstLetter())
+        return offset + textFragment->start();
+    return offset;
+}
+
+unsigned convertNodeOffsetToOffsetInTextFragment(const RenderObject& renderer, unsigned offset)
+{
+    if (auto* textFragment = dynamicDowncast<RenderTextFragment>(renderer); textFragment && textFragment->firstLetter() && offset >= textFragment->start())
+        return offset - textFragment->start();
+    return offset;
 }
 
 bool lineBreakExistsAtVisiblePosition(const VisiblePosition& position)

--- a/Source/WebCore/editing/Editing.h
+++ b/Source/WebCore/editing/Editing.h
@@ -79,6 +79,8 @@ Node* previousLeafNode(const Node*);
 WEBCORE_EXPORT int lastOffsetForEditing(const Node&);
 int caretMinOffset(const Node&);
 int caretMaxOffset(const Node&);
+unsigned convertOffsetInTextFragmentToNodeOffset(const RenderObject&, unsigned offset);
+unsigned convertNodeOffsetToOffsetInTextFragment(const RenderObject&, unsigned offset);
 
 bool hasEditableStyle(const Node&, EditableType);
 bool isEditableNode(const Node&);

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2438,12 +2438,10 @@ void FrameSelection::updateAppearance()
     // We can get into a state where the selection endpoints map to the same VisiblePosition when a selection is deleted
     // because we don't yet notify the FrameSelection of text removal.
     if (CheckedPtr view = document->renderView(); startPos.isNotNull() && endPos.isNotNull() && selection.visibleStart() != selection.visibleEnd()) {
-        CheckedPtr startRenderer = startPos.deprecatedNode()->renderer();
-        int startOffset = startPos.deprecatedEditingOffset();
-        CheckedPtr endRenderer = endPos.deprecatedNode()->renderer();
-        int endOffset = endPos.deprecatedEditingOffset();
-        ASSERT(startOffset >= 0 && endOffset >= 0);
-        view->selection().set({ startRenderer, endRenderer, static_cast<unsigned>(startOffset), static_cast<unsigned>(endOffset) });
+        auto [startRenderer, startOffset] = startPos.rendererAndOffset();
+        auto [endRenderer, endOffset] = endPos.rendererAndOffset();
+        if (startRenderer && endRenderer)
+            view->selection().set({ startRenderer, endRenderer, startOffset, endOffset });
     }
 }
 

--- a/Source/WebCore/editing/RenderedPosition.cpp
+++ b/Source/WebCore/editing/RenderedPosition.cpp
@@ -32,6 +32,7 @@
 #include "RenderedPosition.h"
 
 #include "CaretRectComputation.h"
+#include "Editing.h"
 #include "InlineRunAndOffset.h"
 #include "NodeInlines.h"
 #include "RenderObjectInlines.h"
@@ -39,15 +40,15 @@
 
 namespace WebCore {
 
-static inline const RenderObject* NODELETE rendererFromPosition(const Position& position)
+static inline Node* NODELETE nodeFromPosition(const Position& position)
 {
     ASSERT(position.isNotNull());
-    Node* rendererNode = nullptr;
+    Node* node = nullptr;
     switch (position.anchorType()) {
     case Position::PositionIsOffsetInAnchor:
-        rendererNode = position.computeNodeAfterPosition();
-        if (!rendererNode || !rendererNode->renderer())
-            rendererNode = position.anchorNode()->lastChild();
+        node = position.computeNodeAfterPosition();
+        if (!node || !node->renderer())
+            node = position.anchorNode()->lastChild();
         break;
 
     case Position::PositionIsBeforeAnchor:
@@ -55,15 +56,20 @@ static inline const RenderObject* NODELETE rendererFromPosition(const Position& 
         break;
 
     case Position::PositionIsBeforeChildren:
-        rendererNode = position.anchorNode()->firstChild();
+        node = position.anchorNode()->firstChild();
         break;
     case Position::PositionIsAfterChildren:
-        rendererNode = position.anchorNode()->lastChild();
+        node = position.anchorNode()->lastChild();
         break;
     }
-    if (!rendererNode || !rendererNode->renderer())
-        rendererNode = position.anchorNode();
-    return rendererNode->renderer();
+    if (!node || !node->renderer())
+        node = position.anchorNode();
+    return node;
+}
+
+static inline const RenderObject* NODELETE rendererFromPosition(const Position& position)
+{
+    return nodeFromPosition(position)->renderer();
 }
 
 RenderedPosition::RenderedPosition() = default;
@@ -92,6 +98,9 @@ RenderedPosition::RenderedPosition(const Position& position, Affinity affinity)
         m_renderer = &m_box->renderer();
     else
         m_renderer = rendererFromPosition(position);
+
+    if (m_renderer)
+        m_node = m_renderer->node() ? m_renderer->node() : nodeFromPosition(position);
 }
 
 InlineIterator::LeafBoxIterator RenderedPosition::previousLeafOnLine() const
@@ -206,8 +215,7 @@ Position RenderedPosition::positionAtLeftBoundaryOfBiDiRun() const
     ASSERT(atLeftBoundaryOfBidiRun());
 
     if (atLeftmostOffsetInBox())
-        return makeDeprecatedLegacyPosition(protect(m_renderer->node()).get(), m_offset);
-
+        return makeDeprecatedLegacyPosition(protect(m_node.get()).get(), m_offset);
     return makeDeprecatedLegacyPosition(protect(nextLeafOnLine()->renderer().node()).get(), nextLeafOnLine()->leftmostCaretOffset());
 }
 
@@ -215,8 +223,10 @@ Position RenderedPosition::positionAtRightBoundaryOfBiDiRun() const
 {
     ASSERT(atRightBoundaryOfBidiRun());
 
-    if (atRightmostOffsetInBox())
-        return makeDeprecatedLegacyPosition(protect(m_renderer->node()).get(), m_offset);
+    if (atRightmostOffsetInBox()) {
+        auto offset = convertOffsetInTextFragmentToNodeOffset(*m_renderer, m_offset);
+        return makeDeprecatedLegacyPosition(protect(m_node.get()).get(), offset);
+    }
 
     return makeDeprecatedLegacyPosition(protect(previousLeafOnLine()->renderer().node()).get(), previousLeafOnLine()->rightmostCaretOffset());
 }

--- a/Source/WebCore/editing/RenderedPosition.h
+++ b/Source/WebCore/editing/RenderedPosition.h
@@ -89,6 +89,7 @@ private:
     bool atRightBoundaryOfBidiRun(ShouldMatchBidiLevel, unsigned char bidiLevelOfRun) const;
 
     SingleThreadWeakPtr<const RenderObject> m_renderer;
+    RefPtr<Node> m_node;
     InlineIterator::LeafBoxIterator m_box;
     unsigned m_offset { 0 };
 

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -610,6 +610,7 @@ bool TextIterator::handleTextNode()
     CheckedRef renderer = *textNode->renderer();
     m_lastTextNode = textNode.ptr();
     auto rendererText = rendererTextForBehavior(renderer.get());
+    CheckedPtr textFragmentWithRemainingTextAfterFirstLetter = dynamicDowncast<RenderTextFragment>(renderer.get());
 
     // handle pre-formatted text
     if (!renderer->style().collapseWhiteSpace()) {
@@ -618,8 +619,8 @@ bool TextIterator::handleTextNode()
             emitCharacter(' ', WTF::move(textNode), nullptr, runStart, runStart);
             return false;
         }
-        if (CheckedPtr renderTextFragment = dynamicDowncast<RenderTextFragment>(renderer); renderTextFragment && !m_handledFirstLetter && !m_offset) {
-            handleTextNodeFirstLetter(*renderTextFragment);
+        if (textFragmentWithRemainingTextAfterFirstLetter && !m_handledFirstLetter && !m_offset) {
+            handleTextNodeFirstLetter(*textFragmentWithRemainingTextAfterFirstLetter);
             if (m_firstLetterText) {
                 String firstLetter = m_firstLetterText->text();
                 emitText(textNode, *protect(m_firstLetterText), m_offset, m_offset + firstLetter.length());
@@ -632,6 +633,10 @@ bool TextIterator::handleTextNode()
             return false;
         int rendererTextLength = rendererText.length();
         int end = (textNode.ptr() == m_endContainer) ? m_endOffset : INT_MAX;
+        if (textFragmentWithRemainingTextAfterFirstLetter && textFragmentWithRemainingTextAfterFirstLetter->firstLetter()) {
+            runStart = convertNodeOffsetToOffsetInTextFragment(*textFragmentWithRemainingTextAfterFirstLetter, std::max(0, runStart));
+            end = end == INT_MAX ? INT_MAX : static_cast<int>(convertNodeOffsetToOffsetInTextFragment(*textFragmentWithRemainingTextAfterFirstLetter, end));
+        }
         int runEnd = std::min(rendererTextLength, end);
 
         if (runStart >= runEnd)
@@ -643,8 +648,8 @@ bool TextIterator::handleTextNode()
 
     std::tie(m_textRun, m_textRunLogicalOrderCache) = InlineIterator::firstTextBoxInLogicalOrderFor(renderer.get());
 
-    if (CheckedPtr renderTextFragment = dynamicDowncast<RenderTextFragment>(renderer); renderTextFragment && !m_handledFirstLetter && !m_offset)
-        handleTextNodeFirstLetter(*renderTextFragment);
+    if (textFragmentWithRemainingTextAfterFirstLetter && !m_handledFirstLetter && !m_offset)
+        handleTextNodeFirstLetter(*textFragmentWithRemainingTextAfterFirstLetter);
     else if (!m_textRun && rendererText.length()) {
         if (renderer->style().visibility() != Visibility::Visible && !m_behaviors.contains(TextIteratorBehavior::IgnoresStyleVisibility))
             return false;
@@ -668,12 +673,21 @@ void TextIterator::handleTextRun()
 
     auto [firstTextRun, orderCache] = InlineIterator::firstTextBoxInLogicalOrderFor(renderer);
 
-    auto rendererText = rendererTextForBehavior(renderer.get());
-    unsigned rangeStart = m_offset;
-    auto rangeEnd = std::optional<unsigned> { };
-    if (textNode.ptr() == m_endContainer)
-        rangeEnd = m_endOffset;
+    // For remaining text fragments after a first-letter split, text box offsets are fragment-local but m_offset/m_endOffset are DOM offsets.
+    unsigned remainingFragmentStart = 0;
+    if (auto* renderText = dynamicDowncast<RenderTextFragment>(renderer.get()); renderText && renderText->firstLetter())
+        remainingFragmentStart = renderText->start();
 
+    auto toFragmentLocal = [&](unsigned nodeOffset) {
+        return nodeOffset > remainingFragmentStart ? nodeOffset - remainingFragmentStart : 0;
+    };
+    auto toNodeOffset = [&](unsigned localOffset) {
+        return localOffset + remainingFragmentStart;
+    };
+
+    auto rendererText = rendererTextForBehavior(renderer.get());
+    auto rangeStart = toFragmentLocal(m_offset);
+    auto rangeEnd = textNode.ptr() == m_endContainer ? std::make_optional(toFragmentLocal(m_endOffset)) : std::nullopt;
     while (m_textRun) {
         auto textRunStart = m_textRun->start();
         auto textRunEnd = textRunStart + m_textRun->length();
@@ -709,7 +723,7 @@ void TextIterator::handleTextRun()
             // For white-space:pre-line, newlines are preserved rather than collapsed to spaces.
             if (isCollapsibleNewlineOrTab(rendererText[runStart])) {
                 emitCharacter(' ', textNode.copyRef(), nullptr, runStart, runStart + 1);
-                m_offset = runStart + 1;
+                m_offset = toNodeOffset(runStart + 1);
             } else {
                 auto subrunEnd = runStart + 1;
                 for (; subrunEnd < runEnd; ++subrunEnd) {
@@ -721,13 +735,13 @@ void TextIterator::handleTextRun()
                     if (lastSpaceCollapsedByNextNonTextRun)
                         ++subrunEnd; // runEnd stopped before last space. Increment by one to restore the space.
                 }
-                m_offset = subrunEnd;
+                m_offset = toNodeOffset(subrunEnd);
                 emitText(textNode, renderer, runStart, subrunEnd);
             }
 
             // If we are doing a subrun that doesn't go to the end of the text box,
             // come back again to finish handling this text box; don't advance to the next one.
-            if (static_cast<unsigned>(m_positionEndOffset) < textRunEnd)
+            if (static_cast<unsigned>(m_positionEndOffset) < toNodeOffset(textRunEnd))
                 return;
 
             // Advance and return
@@ -1268,8 +1282,11 @@ void TextIterator::emitText(Text& textNode, RenderText& renderer, int textStartO
 
     m_positionNode = textNode;
     m_positionOffsetBaseNode = nullptr;
-    m_positionStartOffset = textStartOffset;
-    m_positionEndOffset = textEndOffset;
+    // For remaining text fragments after a first-letter split, the text offsets are
+    // fragment-local but position offsets need to be DOM-relative for range() to
+    // return correct boundary points (used by word/sentence boundary detection).
+    m_positionStartOffset = convertOffsetInTextFragmentToNodeOffset(renderer, textStartOffset);
+    m_positionEndOffset = convertOffsetInTextFragmentToNodeOffset(renderer, textEndOffset);
 
     m_lastCharacter = string[textEndOffset - 1];
     // Reset to 0 even if the text ends with '\n', because content newlines
@@ -1491,6 +1508,8 @@ CheckedPtr<RenderText> SimplifiedBackwardsTextIterator::handleFirstLetter(int& s
     m_shouldHandleFirstLetter = false;
     offsetInNode = 0;
     CheckedPtr firstLetterRenderer = firstRenderTextInFirstLetter(protect(fragment->firstLetter()));
+    if (!firstLetterRenderer)
+        return nullptr;
 
     m_offset = firstLetterRenderer->caretMaxOffset();
     m_offset += collapsedSpaceLength(*firstLetterRenderer, m_offset);

--- a/Source/WebCore/editing/VisiblePosition.cpp
+++ b/Source/WebCore/editing/VisiblePosition.cpp
@@ -44,7 +44,9 @@
 #include "PositionInlines.h"
 #include "Range.h"
 #include "RenderBlockFlow.h"
+#include "RenderBoxModelObject.h"
 #include "RenderObjectInlines.h"
+#include "RenderTextFragment.h"
 #include "SimpleRange.h"
 #include "Text.h"
 #include "TextIterator.h"
@@ -57,6 +59,16 @@
 namespace WebCore {
 
 using namespace HTMLNames;
+
+// The anonymous text renderer inside ::first-letter has no DOM node.
+static RenderTextFragment* remainingTextFragmentForFirstLetter(const RenderObject& renderer)
+{
+    if (renderer.node())
+        return { };
+    if (auto* parent = dynamicDowncast<RenderBoxModelObject>(renderer.parent()))
+        return parent->firstLetterRemainingText();
+    return { };
+}
 
 VisiblePosition::VisiblePosition(const Position& position, Affinity affinity)
     : m_deepPosition { canonicalPosition(position) }
@@ -140,7 +152,7 @@ Position VisiblePosition::leftVisuallyDistinctCandidate() const
             if ((renderer->isBlockLevelReplacedOrAtomicInline() || renderer->isBR()) && offset == box->rightmostCaretOffset())
                 return box->isLeftToRightDirection() ? previousVisuallyDistinctCandidate(m_deepPosition) : nextVisuallyDistinctCandidate(m_deepPosition);
 
-            if (!renderer->node()) {
+            if (!renderer->node() && !remainingTextFragmentForFirstLetter(*renderer)) {
                 box.traverseLineLeftwardOnLine();
                 if (!box)
                     return primaryDirection == TextDirection::LTR ? previousVisuallyDistinctCandidate(m_deepPosition) : nextVisuallyDistinctCandidate(m_deepPosition);
@@ -182,8 +194,8 @@ Position VisiblePosition::leftVisuallyDistinctCandidate() const
             if (box->direction() == primaryDirection) {
                 if (!previousBox) {
                     auto logicalStart = primaryDirection == TextDirection::LTR
-                        ? InlineIterator::firstLeafOnLineInLogicalOrderWithNode(box->lineBox(), orderCache)
-                        : InlineIterator::lastLeafOnLineInLogicalOrderWithNode(box->lineBox(), orderCache);
+                        ? InlineIterator::firstLeafOnLineInLogicalOrder(box->lineBox(), orderCache)
+                        : InlineIterator::lastLeafOnLineInLogicalOrder(box->lineBox(), orderCache);
                     if (logicalStart) {
                         box = logicalStart;
                         renderer = &box->renderer();
@@ -253,7 +265,9 @@ Position VisiblePosition::leftVisuallyDistinctCandidate() const
             break;
         }
 
-        p = makeDeprecatedLegacyPosition(protect(renderer->node()).get(), offset);
+        CheckedPtr remainingFragment = remainingTextFragmentForFirstLetter(*renderer);
+        RefPtr node = remainingFragment ? remainingFragment->textNode() : renderer->node();
+        p = makeDeprecatedLegacyPosition(protect(node).get(), convertOffsetInTextFragmentToNodeOffset(*renderer, offset));
 
         if ((p.isCandidate() && p.downstream() != downstreamStart) || p.atStartOfTree() || p.atEndOfTree())
             return p;
@@ -305,7 +319,7 @@ Position VisiblePosition::rightVisuallyDistinctCandidate() const
             if ((renderer->isBlockLevelReplacedOrAtomicInline() || renderer->isBR()) && offset == box->leftmostCaretOffset())
                 return box->isLeftToRightDirection() ? nextVisuallyDistinctCandidate(m_deepPosition) : previousVisuallyDistinctCandidate(m_deepPosition);
 
-            if (!renderer->node()) {
+            if (!renderer->node() && !remainingTextFragmentForFirstLetter(*renderer)) {
                 box.traverseLineRightwardOnLine();
                 if (!box)
                     return primaryDirection == TextDirection::LTR ? nextVisuallyDistinctCandidate(m_deepPosition) : previousVisuallyDistinctCandidate(m_deepPosition);
@@ -422,7 +436,9 @@ Position VisiblePosition::rightVisuallyDistinctCandidate() const
             break;
         }
 
-        p = makeDeprecatedLegacyPosition(protect(renderer->node()).get(), offset);
+        CheckedPtr remainingFragment = remainingTextFragmentForFirstLetter(*renderer);
+        RefPtr node = remainingFragment ? remainingFragment->textNode() : renderer->node();
+        p = makeDeprecatedLegacyPosition(protect(node).get(), convertOffsetInTextFragmentToNodeOffset(*renderer, offset));
 
         if ((p.isCandidate() && p.downstream() != downstreamStart) || p.atStartOfTree() || p.atEndOfTree())
             return p;

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -29,6 +29,7 @@
 
 #include "BoundaryPointInlines.h"
 #include "Document.h"
+#include "Editing.h"
 #include "EditingInlines.h"
 #include "HTMLBRElement.h"
 #include "HTMLElement.h"
@@ -855,7 +856,7 @@ static VisiblePosition endPositionForLine(const VisiblePosition& c, LineEndpoint
         int endOffset = endTextBox.start();
         if (!endTextBox.isLineBreak())
             endOffset += endTextBox.length();
-        pos = Position(endTextNode.releaseNonNull(), endOffset);
+        pos = Position(endTextNode.releaseNonNull(), convertOffsetInTextFragmentToNodeOffset(endTextBox.renderer(), endOffset));
     } else
         pos = positionAfterNode(*endNode);
 
@@ -1233,7 +1234,7 @@ RefPtr<Node> findEndOfParagraph(Node* startNode, Node* highestRoot, Node* stayIn
                 }
             }
             node = n;
-            offset = r->caretMaxOffset();
+            offset = caretMaxOffset(*n);
             n = NodeTraversal::next(*n, stayInsideBlock);
         } else if (editingIgnoresContent(*n) || isRenderedTable(n.get())) {
             node = n;

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -50,6 +50,7 @@
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
 #include "NodeInlines.h"
+#include "Editing.h"
 #include "OutlinePainter.h"
 #include "Page.h"
 #include "PseudoElement.h"
@@ -1915,7 +1916,7 @@ PositionWithAffinity RenderObject::createPositionWithAffinity(int offset, Affini
     if (RefPtr node = nonPseudoNode()) {
         if (!node->hasEditableStyle()) {
             // If it can be found, we prefer a visually equivalent position that is editable. 
-            Position position = makeDeprecatedLegacyPosition(node.get(), offset);
+            Position position = makeDeprecatedLegacyPosition(node.get(), convertOffsetInTextFragmentToNodeOffset(*this, offset));
             Position candidate = position.downstream(CanCrossEditingBoundary);
             if (candidate.deprecatedNode()->hasEditableStyle())
                 return PositionWithAffinity(candidate, affinity);
@@ -1924,7 +1925,7 @@ PositionWithAffinity RenderObject::createPositionWithAffinity(int offset, Affini
                 return PositionWithAffinity(candidate, affinity);
         }
         // FIXME: Eliminate legacy editing positions
-        return PositionWithAffinity(makeDeprecatedLegacyPosition(node.get(), offset), affinity);
+        return PositionWithAffinity(makeDeprecatedLegacyPosition(node.get(), convertOffsetInTextFragmentToNodeOffset(*this, offset)), affinity);
     }
 
     // We don't want to cross the boundary between editable and non-editable

--- a/Source/WebCore/rendering/RenderTextFragment.cpp
+++ b/Source/WebCore/rendering/RenderTextFragment.cpp
@@ -68,7 +68,14 @@ RenderTextFragment::~RenderTextFragment()
 
 bool RenderTextFragment::canBeSelectionLeaf() const
 {
-    return textNode() && textNode()->hasEditableStyle();
+    if (RefPtr textNode = this->textNode()) {
+        // Remaining (trailing) text fragments with first-letter are always selectable,
+        // matching the base RenderText::canBeSelectionLeaf() behavior.
+        return firstLetter() || textNode->hasEditableStyle();
+    }
+    // First-letter is always selectable.
+    CheckedPtr anonymousInlineWrapper = dynamicDowncast<RenderInline>(this->parent());
+    return anonymousInlineWrapper && anonymousInlineWrapper->firstLetterRemainingText();
 }
 
 void RenderTextFragment::setTextInternal(const String& newText, bool force)


### PR DESCRIPTION
#### 1f01e406b70ecb01f1e605b490badbd9c9b3f9ac
<pre>
CSS1: character styled with :first-letter is not selectable
<a href="https://bugs.webkit.org/show_bug.cgi?id=6185">https://bugs.webkit.org/show_bug.cgi?id=6185</a>
&lt;<a href="https://rdar.apple.com/problem/5688237">rdar://problem/5688237</a>&gt;

Reviewed by Ryosuke Niwa.

Given

  &lt;style&gt;
        div::first-letter { color: red; }
  &lt;/style&gt;
  &lt;div&gt;Hello&lt;/div&gt;

the DOM (inside the block container) has a single text node &quot;Hello&quot;
but WebKit splits this into two renderers to be able to style the first letter.

  RenderBlock (div)
        RenderInline (::first-letter, anonymous)
          RenderText &quot;H&quot;            &lt;- offsets 0-1 (no DOM node)
        RenderTextFragment &quot;ello&quot;   &lt;- offsets 0-4 (owns the DOM text node)

The existing code assumes each DOM node maps to exactly one renderer.
Every call to node-&gt;renderer() or Position::renderer() returns the
remaining fragment - the first-letter renderer is never consulted.

This means DOM offset 0 (&quot;H&quot;) gets checked against the remaining
fragment&apos;s text boxes, which start at &quot;e&quot;. Selection, caret positioning,
and offset validation all fail for the first-letter range because the
wrong renderer is asked about offsets it doesn&apos;t own.

The fix is to never consult node-&gt;renderer() directly for text offset
operations on first-letter content. Instead, all call sites go through
Position::rendererAndOffset() which resolves the 1-DOM-node-to-2-renderers
split by picking the correct renderer and converting to its local offset.
This is the central invariant of the fix - every place that previously
called node-&gt;renderer() and used a DOM offset against it now uses this
helper (or one of its wrappers) to get the right renderer + offset pair.

Key helpers introduced:
- Position::rendererAndOffset(): the single source of truth for resolving
  a DOM offset to the correct renderer + fragment-local offset. Routes to
  the first-letter renderer for offsets below fragmentStart, otherwise
  returns the remaining fragment with adjusted offset.
- Position::resolvedTextRendererAndOffset(): convenience wrapper that also
  casts to RenderText.
- convertOffsetInTextFragmentToNodeOffset(): converts fragment-local offset back to
  DOM offset. Used when exiting renderer space (caretMaxOffset,
  createPositionWithAffinity, endPositionForLine, positionAtRightBoundary-
  OfBiDiRun, TextIterator::emitText).
- convertNodeOffsetToOffsetInTextFragment(): converts DOM offset to
  fragment-local. Used in Position::upstream/downstream where there is no
  Position object to call rendererAndOffset() on.
- crossesFirstLetterBoundary(): prevents upstream/downstream from
  canonicalizing positions across the first-letter split. Without this,
  VisiblePosition(offset 0) and VisiblePosition(offset 1) would collapse
  to the same canonical position, making the first letter unselectable.
  Must run before the isStreamer update to see the pre-update lastVisible.

Position::isCandidate, isRenderedCharacter, rendersInDifferentPosition:
  These check text offset validity against renderer text boxes. They now
  use resolvedTextRendererAndOffset() to ask the correct renderer
  (first-letter or remaining fragment) instead of always asking the
  remaining fragment with a raw DOM offset.

Position::inlineBoxAndOffset: resolves to the correct inline box for
  caret/selection positioning. Now delegates to rendererAndOffset()
  instead of duplicating the first-letter routing logic.

RenderedPosition: stores the original DOM node (m_node) from the Position
  during construction. Without this, positionAtLeftBoundaryOfBiDiRun()
  produces a null-node Position when the inline box belongs to the
  anonymous first-letter text, causing adjustEndpointsAtBidiBoundary()
  to collapse the selection when dragging left past the first letter.

VisiblePosition::rightVisuallyDistinctCandidate: when bidi traversal
  lands on the anonymous first-letter text box, resolves the DOM node
  via remainingTextFragmentForFirstLetter() before creating the Position.

RenderTextFragment::canBeSelectionLeaf: returns true for remaining
  fragments with first-letter, matching base RenderText behavior so
  cross-element selections (Cmd+A) include the remaining text.

* LayoutTests/editing/selection/first-letter-caret-single-char-expected.txt: Added.
* LayoutTests/editing/selection/first-letter-caret-single-char.html: Added.
* LayoutTests/editing/selection/first-letter-selection-cross-element-expected.txt: Added.
* LayoutTests/editing/selection/first-letter-selection-cross-element.html: Added.
* LayoutTests/editing/selection/first-letter-selection-expected.txt: Added.
* LayoutTests/editing/selection/first-letter-selection-painting-expected.html: Added.
* LayoutTests/editing/selection/first-letter-selection-painting.html: Added.
* LayoutTests/editing/selection/first-letter-selection.html: Added.
* LayoutTests/editing/text-iterator/first-letter-word-boundary-expected.txt:
  Progression. The backwards word boundary with white-space:pre now
  correctly finds offset 1 instead of 0.

* LayoutTests/fast/css/first-letter-pre-text-iterator-expected.txt: Added.
* LayoutTests/fast/css/first-letter-pre-text-iterator.html: Added.
* LayoutTests/fast/text/first-letter-partial-invalidation-crash-expected.txt:
  Progression. We match other engines now.

* LayoutTests/platform/glib/editing/selection/extend-by-word-002-expected.txt:
* LayoutTests/platform/ios/editing/selection/extend-by-word-002-expected.txt:
* LayoutTests/platform/mac-wk2/TestExpectations:
  Remove [ Crash ] for editing/text-iterator/backwards-text-iterator-basic.html.
  Progression — the null-check in handleFirstLetter prevents the crash.

* LayoutTests/platform/mac/editing/selection/extend-by-word-002-expected.txt:
  Progression. Content is selected now across &lt;li&gt;s with first-letter.

* Source/WebCore/dom/Position.cpp:
(WebCore::crossesFirstLetterBoundary):
(WebCore::Position::upstream const):
(WebCore::Position::downstream const):
(WebCore::Position::hasRenderedNonAnonymousDescendantsWithHeight):
  Was skipping ::first-letter pseudo renderers because they have no
  associated DOM node. This made positions after first-letter content
  fail isCandidate() -- the function thought the element had no visible
  content. The fix lets first-letter renderers count as rendered
  descendants with height.
(WebCore::Position::isCandidate const):
(WebCore::Position::isRenderedCharacter const):
(WebCore::Position::rendersInDifferentPosition const):
(WebCore::Position::rendererAndOffset const):
(WebCore::Position::resolvedTextRendererAndOffset const):
(WebCore::Position::inlineBoxAndOffset const):
* Source/WebCore/dom/Position.h:
* Source/WebCore/dom/PositionIterator.cpp:
(WebCore::PositionIterator::isCandidate const):
* Source/WebCore/editing/Editing.cpp:
(WebCore::caretMaxOffset):
(WebCore::convertOffsetInTextFragmentToNodeOffset):
(WebCore::convertNodeOffsetToOffsetInTextFragment):
* Source/WebCore/editing/Editing.h:
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::updateAppearance):
* Source/WebCore/editing/RenderedPosition.cpp:
(WebCore::nodeFromPosition):
(WebCore::rendererFromPosition):
(WebCore::RenderedPosition::RenderedPosition):
(WebCore::RenderedPosition::positionAtLeftBoundaryOfBiDiRun const):
(WebCore::RenderedPosition::positionAtRightBoundaryOfBiDiRun const):
* Source/WebCore/editing/RenderedPosition.h:
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::handleTextNode):
(WebCore::TextIterator::handleTextRun):
(WebCore::TextIterator::emitText):
(WebCore::SimplifiedBackwardsTextIterator::handleFirstLetter):
  Null-check firstLetterRenderer before dereferencing. The first-letter
  renderer can be destroyed by DOM mutations (e.g. deleteFromDocument)
  while the backwards iterator is still referencing the text node.
* Source/WebCore/editing/VisiblePosition.cpp:
(WebCore::remainingTextFragmentForFirstLetter):
(WebCore::VisiblePosition::leftVisuallyDistinctCandidate const):
(WebCore::VisiblePosition::rightVisuallyDistinctCandidate const):
* Source/WebCore/editing/VisibleUnits.cpp:
(WebCore::endPositionForLine):
(WebCore::findEndOfParagraph):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::createPositionWithAffinity const):
* Source/WebCore/rendering/RenderTextFragment.cpp:
(WebCore::RenderTextFragment::canBeSelectionLeaf const):

Canonical link: <a href="https://commits.webkit.org/311287@main">https://commits.webkit.org/311287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f03ebbf29a899974462d764b10b1aa4cf8c02655

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165177 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110436 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158227 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29694 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121085 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85135 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140412 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101756 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22371 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20542 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12949 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132046 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18243 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167659 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11772 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19856 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129210 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29292 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24609 "Found 1 new test failure: imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/form.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129322 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35069 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29214 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140037 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87010 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24149 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16836 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28924 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92880 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28450 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28678 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28574 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->