### PR TITLE
[macOS] Stop setting swatch size for color picker

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/NSPopoverColorWellSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSPopoverColorWellSPI.h
@@ -62,8 +62,10 @@ DECLARE_SYSTEM_HEADER
 
 @interface NSColorPickerMatrixView ()
 - (void)setColorList:(NSColorList *)list;
-- (void)setSwatchSize:(NSSize)size;
 - (void)setNumberOfColumns:(NSUInteger)columns;
+#if HAVE(NSCOLORPICKERMATRIXVIEW_CUSTOM_SWATCH_SIZE)
+- (void)setSwatchSize:(NSSize)size;
+#endif
 @end
 
 @interface NSColorPopoverController ()

--- a/Source/WebKit/UIProcess/mac/WebColorPickerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebColorPickerMac.mm
@@ -43,12 +43,8 @@
 #import <wtf/WeakPtr.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
-static const size_t maxColorSuggestions = 12;
-static const CGFloat colorPickerMatrixNumColumns = 12.0;
-static const CGFloat colorPickerMatrixBorderWidth = 1.0;
-
 // FIXME: <rdar://problem/41173525> We should not have to track changes in NSPopoverColorWell's implementation.
-static const CGFloat colorPickerMatrixSwatchWidth = 13.0;
+static constexpr CGFloat colorPickerMatrixNumColumns = 12.0;
 
 @protocol WKPopoverColorWellDelegate <NSObject>
 - (void)didClosePopover;
@@ -173,17 +169,24 @@ void WebColorPickerMac::showColorPicker(const WebCore::Color& color, const WebCo
     controller.get().delegate = self;
 
     if (_suggestedColors) {
-        NSUInteger numColors = [[_suggestedColors allKeys] count];
-        CGFloat swatchWidth = (colorPickerMatrixNumColumns * colorPickerMatrixSwatchWidth + (colorPickerMatrixNumColumns * colorPickerMatrixBorderWidth - numColors)) / numColors;
-        CGFloat swatchHeight = colorPickerMatrixSwatchWidth;
-
         // topBarMatrixView cannot be accessed until view has been loaded
         if (!controller.get().isViewLoaded)
             [controller loadView];
 
         RetainPtr<NSColorPickerMatrixView> topMatrix = controller.get().topBarMatrixView;
+        NSUInteger numColors = [[_suggestedColors allKeys] count];
         [topMatrix setNumberOfColumns:numColors];
+
+#if HAVE(NSCOLORPICKERMATRIXVIEW_CUSTOM_SWATCH_SIZE)
+        // FIXME: <rdar://problem/41173525> We should not have to track changes in NSPopoverColorWell's implementation.
+        static constexpr CGFloat colorPickerMatrixSwatchWidth = 13.0;
+        static constexpr CGFloat colorPickerMatrixBorderWidth = 1.0;
+
+        CGFloat swatchWidth = (colorPickerMatrixNumColumns * colorPickerMatrixSwatchWidth + (colorPickerMatrixNumColumns * colorPickerMatrixBorderWidth - numColors)) / numColors;
+        CGFloat swatchHeight = colorPickerMatrixSwatchWidth;
         [topMatrix setSwatchSize:NSMakeSize(swatchWidth, swatchHeight)];
+#endif
+
         [topMatrix setColorList:_suggestedColors.get()];
     }
 
@@ -241,7 +244,7 @@ void WebColorPickerMac::showColorPicker(const WebCore::Color& color, const WebCo
     RetainPtr<NSColorList> suggestedColors;
     if (suggestions.size()) {
         suggestedColors = adoptNS([[NSColorList alloc] init]);
-        for (size_t i = 0; i < std::min(suggestions.size(), maxColorSuggestions); i++)
+        for (size_t i = 0; i < std::min(suggestions.size(), clampTo<size_t>(colorPickerMatrixNumColumns)); i++)
             [suggestedColors insertColor:cocoaColor(suggestions.at(i)).get() key:retainPtr(@(i).stringValue).get() atIndex:i];
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ColorInputTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ColorInputTests.mm
@@ -81,6 +81,27 @@ TEST(ColorInputTests, SetColorWithAlphaUsingColorPicker)
     EXPECT_WK_STREQ(colorValue, "#0000ff");
 }
 
+TEST(ColorInputTests, ColorPickerWithSuggestionsDoesNotCrash)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView synchronouslyLoadHTMLString:
+        @"<input type='color' id='color' value='#ff0000' list='suggestions' style='width: 200px; height: 200px;'>"
+        "<datalist id='suggestions'><option value='#00ff00'></datalist>"];
+
+    [webView sendClickAtPoint:NSMakePoint(50, 350)];
+
+    bool appeared = Util::waitFor([&] {
+        return isShowingColorPicker(webView.get());
+    });
+    EXPECT_TRUE(appeared);
+
+    [webView stringByEvaluatingJavaScript:@"document.getElementById('color').blur()"];
+
+    Util::waitFor([&] {
+        return !isShowingColorPicker(webView.get());
+    });
+}
+
 } // namespace TestWebKitAPI
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 3f85e873fa7610e017dbc7a72d35f69f65fc6029
<pre>
[macOS] Stop setting swatch size for color picker
<a href="https://bugs.webkit.org/show_bug.cgi?id=311590">https://bugs.webkit.org/show_bug.cgi?id=311590</a>
<a href="https://rdar.apple.com/174068840">rdar://174068840</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

Stop setting the swatch size for NSColorPickerMatrixView if `setSwatchSize`
is unavailable.

Test: API test ColorInputTests.ColorPickerWithSuggestionsDoesNotCrash

* Source/WebCore/PAL/pal/spi/mac/NSPopoverColorWellSPI.h:
* Source/WebKit/UIProcess/mac/WebColorPickerMac.mm:
(-[WKPopoverColorWell _showPopover]):
(-[WKColorPopoverMac setAndShowPicker:withColor:supportsAlpha:suggestions:rect:]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ColorInputTests.mm:
(TestWebKitAPI::TEST(ColorInputTests, ColorPickerWithSuggestionsDoesNotCrash)):

Canonical link: <a href="https://commits.webkit.org/310828@main">https://commits.webkit.org/310828@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e465e2ef34c8a53f72cb20a8ea0d6c262c4f30e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155034 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163794 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/027000a4-9460-49ae-b928-46fc07b068ea) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156907 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28142 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119944 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157993 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100637 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21300 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19332 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11620 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130962 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166270 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/9942 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18674 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128046 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27838 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23371 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128184 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27762 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138858 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84471 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23642 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23060 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15653 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27454 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91558 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27033 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27263 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27105 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->