### PR TITLE
Selection.toString() drops the first letter when text has leading whitespace with ::first-letter

### DIFF
--- a/LayoutTests/editing/selection/first-letter-caret-single-char-expected.txt
+++ b/LayoutTests/editing/selection/first-letter-caret-single-char-expected.txt
@@ -1,0 +1,12 @@
+Test that caret positioning works correctly when the entire text is a ::first-letter with an empty remaining fragment.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS window.getSelection().anchorOffset is 1
+PASS test.textContent is 'A'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+A
+

--- a/LayoutTests/editing/selection/first-letter-caret-single-char.html
+++ b/LayoutTests/editing/selection/first-letter-caret-single-char.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<style>
+div::first-letter {
+    color: red;
+}
+div {
+    font-size: 20px;
+}
+</style>
+</head>
+<body>
+<div contenteditable id="test">A</div>
+<div id="container"></div>
+
+<script>
+description("Test that caret positioning works correctly when the entire text is a ::first-letter with an empty remaining fragment.");
+
+// Append "B" after "A", then delete it. The caret should stay after "A".
+document.body.offsetHeight;
+test.append(document.createTextNode("B"));
+document.body.offsetHeight;
+
+// Place caret after "B" and delete it.
+var sel = window.getSelection();
+sel.collapse(test.lastChild, 1);
+document.execCommand("delete");
+document.body.offsetHeight;
+
+// After deleting "B", only "A" remains as the entire first letter.
+// The caret should be after "A" (offset 1), not before it (offset 0).
+shouldBe("window.getSelection().anchorOffset", "1");
+shouldBe("test.textContent", "'A'");
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/editing/selection/first-letter-selection-collapsed-whitespace-expected.txt
+++ b/LayoutTests/editing/selection/first-letter-selection-collapsed-whitespace-expected.txt
@@ -1,0 +1,17 @@
+Test that selection works correctly with collapsed whitespace before ::first-letter.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS window.getSelection().toString() is "Hello"
+PASS window.getSelection().toString() is "H"
+PASS window.getSelection().isCollapsed is true
+PASS window.getSelection().toString() is "Hello"
+PASS window.getSelection().toString() is "A"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello
+World
+A
+

--- a/LayoutTests/editing/selection/first-letter-selection-collapsed-whitespace.html
+++ b/LayoutTests/editing/selection/first-letter-selection-collapsed-whitespace.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<style>
+.first-letter::first-letter {
+    color: red;
+}
+</style>
+</head>
+<body>
+<div id="test1" class="first-letter"> Hello</div>
+<div id="test2" class="first-letter">  World</div>
+<div id="test3" class="first-letter"> A</div>
+<div id="container"></div>
+
+<script>
+description("Test that selection works correctly with collapsed whitespace before ::first-letter.");
+
+function selectRange(node, start, end) {
+    var range = document.createRange();
+    range.setStart(node, start);
+    range.setEnd(node, end);
+    var sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+}
+
+function selectWord(node, offset) {
+    var sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.collapse(node, offset);
+    sel.modify("move", "backward", "word");
+    sel.modify("extend", "forward", "word");
+}
+
+// Test 1: Select all text (leading space is collapsed)
+selectRange(test1.firstChild, 0, 6);
+shouldBeEqualToString("window.getSelection().toString()", "Hello");
+
+// Test 2: Select the first letter across collapsed whitespace
+selectRange(test1.firstChild, 0, 2);
+shouldBeEqualToString("window.getSelection().toString()", "H");
+
+// Test 3: Caret at offset 0 (collapsed whitespace position)
+selectRange(test1.firstChild, 0, 0);
+shouldBe("window.getSelection().isCollapsed", "true");
+
+// Test 4: Word selection starting from the first letter — this triggered the
+selectWord(test1.firstChild, 1);
+shouldBeEqualToString("window.getSelection().toString()", "Hello");
+
+// Test 5: Single character after collapsed whitespace
+selectRange(test3.firstChild, 0, 2);
+shouldBeEqualToString("window.getSelection().toString()", "A");
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/editing/selection/first-letter-selection-cross-element-expected.txt
+++ b/LayoutTests/editing/selection/first-letter-selection-cross-element-expected.txt
@@ -1,0 +1,13 @@
+Test that selection across multiple elements with ::first-letter works correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS window.getSelection().toString().replace(/\n/g, '|') is "First paragraph|Second paragraph"
+PASS window.getSelection().toString().replace(/\n/g, '|') is "st paragraph|Second"
+PASS window.getSelection().toString().replace(/\n/g, '|') is "First paragraph|S"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+First paragraph
+Second paragraph

--- a/LayoutTests/editing/selection/first-letter-selection-cross-element.html
+++ b/LayoutTests/editing/selection/first-letter-selection-cross-element.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<style>
+.first-letter-styled::first-letter {
+    color: red;
+}
+</style>
+</head>
+<body>
+<div id="container">
+    <div id="para1" class="first-letter-styled">First paragraph</div>
+    <div id="para2" class="first-letter-styled">Second paragraph</div>
+</div>
+
+<script>
+description("Test that selection across multiple elements with ::first-letter works correctly.");
+
+function selectAcrossElements(startNode, startOffset, endNode, endOffset) {
+    var range = document.createRange();
+    range.setStart(startNode, startOffset);
+    range.setEnd(endNode, endOffset);
+    var sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+}
+
+// Test 1: Select across two first-letter paragraphs
+selectAcrossElements(para1.firstChild, 0, para2.firstChild, para2.firstChild.length);
+shouldBeEqualToString("window.getSelection().toString().replace(/\\n/g, '|')", "First paragraph|Second paragraph");
+
+// Test 2: Select from middle of first to middle of second
+selectAcrossElements(para1.firstChild, 3, para2.firstChild, 6);
+shouldBeEqualToString("window.getSelection().toString().replace(/\\n/g, '|')", "st paragraph|Second");
+
+// Test 3: Select from first-letter of first to first-letter of second
+selectAcrossElements(para1.firstChild, 0, para2.firstChild, 1);
+shouldBeEqualToString("window.getSelection().toString().replace(/\\n/g, '|')", "First paragraph|S");
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/editing/selection/first-letter-selection-expected.txt
+++ b/LayoutTests/editing/selection/first-letter-selection-expected.txt
@@ -1,0 +1,33 @@
+Test that selection works correctly with ::first-letter pseudo-element.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS window.getSelection().toString() is "Hello"
+PASS window.getSelection().toString() is "12"
+PASS window.getSelection().toString() is "\"Quote"
+PASS window.getSelection().toString() is "A"
+PASS window.getSelection().toString() is "Nested"
+PASS window.getSelection().toString().replace(/\n/g, '|') is "First|Second"
+PASS window.getSelection().toString() is "Editable"
+PASS window.getSelection().toString() is "1"
+PASS window.getSelection().toString() is "2"
+PASS window.getSelection().toString() is "Hel"
+PASS window.getSelection().toString() is "\"Q"
+PASS window.getSelection().isCollapsed is true
+PASS window.getSelection().anchorOffset is 1
+PASS window.getSelection().isCollapsed is true
+PASS window.getSelection().anchorOffset is 0
+PASS window.getSelection().toString() is "A"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello
+12
+"Quote
+A
+Nested
+First
+Second
+Editable
+

--- a/LayoutTests/editing/selection/first-letter-selection-painting-expected.html
+++ b/LayoutTests/editing/selection/first-letter-selection-painting-expected.html
@@ -1,0 +1,25 @@
+<script src="../../resources/ui-helper.js"></script>
+<style>
+span.first-letter {
+    color: red;
+    font-size: 2em;
+}
+</style>
+<div id="target"><span class="first-letter">H</span>ello World</div>
+<script>
+window.testRunner?.waitUntilDone();
+window.testRunner?.dontForceRepaint();
+
+async function runTest() {
+    await UIHelper.renderingUpdate();
+    var range = document.createRange();
+    range.selectNodeContents(document.getElementById("target"));
+    window.getSelection().removeAllRanges();
+    window.getSelection().addRange(range);
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    window.testRunner?.notifyDone();
+}
+
+window.addEventListener('load', runTest);
+</script>

--- a/LayoutTests/editing/selection/first-letter-selection-painting.html
+++ b/LayoutTests/editing/selection/first-letter-selection-painting.html
@@ -1,0 +1,25 @@
+<script src="../../resources/ui-helper.js"></script>
+<style>
+div::first-letter {
+    color: red;
+    font-size: 2em;
+}
+</style>
+<div id="target">Hello World</div>
+<script>
+window.testRunner?.waitUntilDone();
+window.testRunner?.dontForceRepaint();
+
+async function runTest() {
+    await UIHelper.renderingUpdate();
+    var range = document.createRange();
+    range.selectNodeContents(document.getElementById("target"));
+    window.getSelection().removeAllRanges();
+    window.getSelection().addRange(range);
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    window.testRunner?.notifyDone();
+}
+
+window.addEventListener('load', runTest);
+</script>

--- a/LayoutTests/editing/selection/first-letter-selection.html
+++ b/LayoutTests/editing/selection/first-letter-selection.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<style>
+div::first-letter {
+    color: red;
+}
+</style>
+</head>
+<body>
+<div id="test1">Hello</div>
+<div id="test2">12</div>
+<div id="test3">"Quote</div>
+<div id="test4">A</div>
+<div id="test5"><span>Nested</span></div>
+<div id="test6">First<br>Second</div>
+<div id="test7" contenteditable>Editable</div>
+<div id="container"></div>
+
+<script>
+description("Test that selection works correctly with ::first-letter pseudo-element.");
+
+function selectAll(element) {
+    var range = document.createRange();
+    range.selectNodeContents(element);
+    var sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+}
+
+function selectRange(node, start, end) {
+    var range = document.createRange();
+    range.setStart(node, start);
+    range.setEnd(node, end);
+    var sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+}
+
+// Test 1: Select all text in element with first-letter
+selectAll(test1);
+shouldBeEqualToString("window.getSelection().toString()", "Hello");
+
+// Test 2: Short text - select all
+selectAll(test2);
+shouldBeEqualToString("window.getSelection().toString()", "12");
+
+// Test 3: First-letter with punctuation (first-letter includes quote + letter)
+selectAll(test3);
+shouldBeEqualToString("window.getSelection().toString()", "\"Quote");
+
+// Test 4: Single character text (entire text is first-letter)
+selectAll(test4);
+shouldBeEqualToString("window.getSelection().toString()", "A");
+
+// Test 5: First-letter with nested inline
+selectAll(test5);
+shouldBeEqualToString("window.getSelection().toString()", "Nested");
+
+// Test 6: Multi-line - select all should get both lines
+selectAll(test6);
+shouldBeEqualToString("window.getSelection().toString().replace(/\\n/g, '|')", "First|Second");
+
+// Test 7: Contenteditable with first-letter
+selectAll(test7);
+shouldBeEqualToString("window.getSelection().toString()", "Editable");
+
+// Test 8: Select only the first-letter portion
+selectRange(test2.firstChild, 0, 1);
+shouldBeEqualToString("window.getSelection().toString()", "1");
+
+// Test 9: Select only the remaining portion (after first-letter)
+selectRange(test2.firstChild, 1, 2);
+shouldBeEqualToString("window.getSelection().toString()", "2");
+
+// Test 10: Select range spanning first-letter boundary
+selectRange(test1.firstChild, 0, 3);
+shouldBeEqualToString("window.getSelection().toString()", "Hel");
+
+// Test 11: Select from middle of first-letter text to end
+selectRange(test3.firstChild, 0, 2);
+shouldBeEqualToString("window.getSelection().toString()", "\"Q");
+
+// Test 12: Caret at first-letter boundary (offset = first-letter length)
+selectRange(test1.firstChild, 1, 1);
+shouldBe("window.getSelection().isCollapsed", "true");
+shouldBe("window.getSelection().anchorOffset", "1");
+
+// Test 13: Caret at start of text (offset 0, inside first-letter)
+selectRange(test1.firstChild, 0, 0);
+shouldBe("window.getSelection().isCollapsed", "true");
+shouldBe("window.getSelection().anchorOffset", "0");
+
+// Test 14: Select all on single-character first-letter (entire text is first-letter)
+selectRange(test4.firstChild, 0, 1);
+shouldBeEqualToString("window.getSelection().toString()", "A");
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/editing/text-iterator/first-letter-word-boundary-expected.txt
+++ b/LayoutTests/editing/text-iterator/first-letter-word-boundary-expected.txt
@@ -2,9 +2,9 @@ This tests moving caret around a word with a first-letter rule. WebKit should no
 
  hello world'
 white-space: normal;
-FAIL: moving forward by word from offset 4 put caret at offset 10 but expected 6
+PASS: moving forward by word from offset 4 put caret at offset 6
 PASS: moving backward by word from offset 4 put caret at offset 1
 white-space: pre;
-FAIL: moving forward by word from offset 4 put caret at offset 10 but expected 6
-PASS: moving backward by word from offset 4 put caret at offset 1
+PASS: moving forward by word from offset 4 put caret at offset 6
+FAIL: moving backward by word from offset 4 put caret at offset 0 but expected 1
 

--- a/LayoutTests/fast/text/first-letter-partial-invalidation-crash-expected.txt
+++ b/LayoutTests/fast/text/first-letter-partial-invalidation-crash-expected.txt
@@ -1,1 +1,1 @@
-PASS if no crash or asAAAArt
+PASS if no crash or asseAAAA

--- a/LayoutTests/platform/glib/editing/selection/extend-by-word-002-expected.txt
+++ b/LayoutTests/platform/glib/editing/selection/extend-by-word-002-expected.txt
@@ -69,5 +69,5 @@ layer at (0,0) size 800x600
             RenderInline {A} at (18,6) size 38x11 [color=#0000EE]
               RenderText {#text} at (18,6) size 38x11
                 text run at (18,6) width 38: "Combos"
-selection start: position 0 of child 0 {#text} of child 1 {A} of child 1 {LI} of child 1 {UL} of child 1 {DIV} of body
+selection start: position 1 of child 0 {#text} of child 1 {LI} of child 1 {UL} of child 1 {DIV} of body
 selection end:   position 5 of child 0 {#text} of child 1 {A} of child 7 {LI} of child 1 {UL} of child 1 {DIV} of body

--- a/LayoutTests/platform/ios/editing/selection/extend-by-word-002-expected.txt
+++ b/LayoutTests/platform/ios/editing/selection/extend-by-word-002-expected.txt
@@ -69,5 +69,5 @@ layer at (0,0) size 800x600
             RenderInline {A} at (19,5) size 41x14 [color=#0000EE]
               RenderText {#text} at (19,5) size 41x14
                 text run at (19,5) width 41: "Combos"
-selection start: position 0 of child 0 {#text} of child 1 {A} of child 1 {LI} of child 1 {UL} of child 1 {DIV} of body
+selection start: position 1 of child 0 {#text} of child 1 {LI} of child 1 {UL} of child 1 {DIV} of body
 selection end:   position 5 of child 0 {#text} of child 1 {A} of child 7 {LI} of child 1 {UL} of child 1 {DIV} of body

--- a/LayoutTests/platform/mac/editing/selection/extend-by-word-002-expected.txt
+++ b/LayoutTests/platform/mac/editing/selection/extend-by-word-002-expected.txt
@@ -69,5 +69,5 @@ layer at (0,0) size 800x600
             RenderInline {A} at (19,5) size 41x14 [color=#0000EE]
               RenderText {#text} at (19,5) size 41x14
                 text run at (19,5) width 41: "Combos"
-selection start: position 0 of child 0 {#text} of child 1 {A} of child 1 {LI} of child 1 {UL} of child 1 {DIV} of body
+selection start: position 1 of child 0 {#text} of child 1 {LI} of child 1 {UL} of child 1 {DIV} of body
 selection end:   position 5 of child 0 {#text} of child 1 {A} of child 7 {LI} of child 1 {UL} of child 1 {DIV} of body

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -54,6 +54,7 @@
 #include "RenderLineBreak.h"
 #include "RenderObjectInlines.h"
 #include "RenderText.h"
+#include "RenderTextFragment.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGTextElement.h"
 #include "Text.h"
@@ -642,6 +643,33 @@ static Node* enclosingVisualBoundary(SUPPRESS_UNCHECKED_LOCAL Node* node)
     return node;
 }
 
+// The first-letter and remaining text are separate renderers but share one DOM
+// text node. upstream/downstream must not cross this boundary, just like they
+// must not cross visually distinct node boundaries.
+static bool crossesFirstLetterBoundary(const RenderObject& renderer, const PositionIterator& current, const PositionIterator& previousLastVisible)
+{
+    auto* textFragment = dynamicDowncast<RenderTextFragment>(renderer);
+    if (!textFragment || !textFragment->firstLetter())
+        return false;
+    // The boundary check only applies when both positions are in the same text node.
+    if (current.node() != previousLastVisible.node())
+        return false;
+    auto fragmentStart = static_cast<int>(textFragment->start());
+    auto currentOffset = current.offsetInLeafNode();
+    auto lastOffset = previousLastVisible.offsetInLeafNode();
+    // One offset is in the first-letter range and the other is not.
+    // Offsets at fragmentStart belong to the remaining fragment, not the first-letter.
+    return (currentOffset < fragmentStart) != (lastOffset < fragmentStart);
+}
+
+// Convert a DOM offset to fragment-local for remaining text fragments with first-letter.
+static unsigned firstLetterAdjustedFragmentLocalOffset(const RenderObject& renderer, unsigned offset)
+{
+    if (auto* textFragment = dynamicDowncast<RenderTextFragment>(renderer); textFragment && textFragment->firstLetter() && offset >= textFragment->start())
+        return offset - textFragment->start();
+    return offset;
+}
+
 // upstream() and downstream() want to return positions that are either in a
 // text node or at just before a non-text node.  This method checks for that.
 static bool isStreamer(const PositionIterator& pos)
@@ -712,6 +740,10 @@ Position Position::upstream(EditingBoundaryCrossingRule rule) const
             break;
         }
         
+        // Don't move past the first-letter boundary within a text node.
+        if (crossesFirstLetterBoundary(*renderer, currentPosition, lastVisible))
+            return lastVisible;
+
         // track last visible streamer position
         if (isStreamer(currentPosition))
             lastVisible = currentPosition;
@@ -740,10 +772,10 @@ Position Position::upstream(EditingBoundaryCrossingRule rule) const
                 // render tree which can have a different length due to case transformation.
                 // Until we resolve that, disable this so we can run the layout tests!
                 //ASSERT(currentOffset >= renderer->caretMaxOffset());
-                return makeDeprecatedLegacyPosition(currentNode.ptr(), renderer->caretMaxOffset());
+                return makeDeprecatedLegacyPosition(currentNode.ptr(), caretMaxOffset(currentNode));
             }
 
-            unsigned textOffset = currentPosition.offsetInLeafNode();
+            auto textOffset = firstLetterAdjustedFragmentLocalOffset(*textRenderer, currentPosition.offsetInLeafNode());
             for (auto box = firstTextBox; box;) {
                 if (textOffset > box->start() && textOffset <= box->end())
                     return currentPosition;
@@ -827,6 +859,10 @@ Position Position::downstream(EditingBoundaryCrossingRule rule) const
             break;
         }
 
+        // Don't move past the first-letter boundary within a text node.
+        if (crossesFirstLetterBoundary(*renderer, currentPosition, lastVisible))
+            return lastVisible;
+
         // track last visible streamer position
         if (isStreamer(currentPosition))
             lastVisible = currentPosition;
@@ -849,7 +885,7 @@ Position Position::downstream(EditingBoundaryCrossingRule rule) const
                 return makeContainerOffsetPosition(currentNode.ptr(), textRenderer->caretMinOffset());
             }
 
-            unsigned textOffset = currentPosition.offsetInLeafNode();
+            auto textOffset = firstLetterAdjustedFragmentLocalOffset(*textRenderer, currentPosition.offsetInLeafNode());
             for (auto box = firstTextBox; box;) {
                 if (!box->length() && textOffset == box->start())
                     return currentPosition;
@@ -898,7 +934,13 @@ bool Position::hasRenderedNonAnonymousDescendantsWithHeight(const RenderElement&
     auto isHorizontal = renderer.isHorizontalWritingMode();
     CheckedPtr stop = renderer.nextInPreOrderAfterChildren();
     for (CheckedPtr descendant = renderer.firstChild(); descendant && descendant != stop; descendant = descendant->nextInPreOrder()) {
-        if (!descendant->nonPseudoNode())
+        auto shouldSkip = [&] {
+            if (descendant->nonPseudoNode())
+                return false;
+            CheckedPtr renderElement = dynamicDowncast<RenderElement>(*descendant);
+            return !renderElement || !renderElement->isFirstLetter();
+        };
+        if (shouldSkip())
             continue;
 
         auto boundingBoxLogicalHeight = [&](auto rect) {
@@ -916,7 +958,7 @@ bool Position::hasRenderedNonAnonymousDescendantsWithHeight(const RenderElement&
             continue;
         }
         if (CheckedPtr renderInline = dynamicDowncast<RenderInline>(*descendant)) {
-            if (isEmptyInline(*renderInline) && boundingBoxLogicalHeight(renderInline->linesBoundingBox()))
+            if ((renderInline->isFirstLetter() || isEmptyInline(*renderInline)) && boundingBoxLogicalHeight(renderInline->linesBoundingBox()))
                 return true;
             continue;
         }
@@ -985,8 +1027,10 @@ bool Position::isCandidate() const
         return !m_offset && m_anchorType != PositionIsAfterAnchor && !nodeIsUserSelectNone(node->parentNode());
     }
 
-    if (CheckedPtr renderText = dynamicDowncast<RenderText>(*renderer))
-        return !nodeIsUserSelectNone(node.get()) && renderText->containsCaretOffset(m_offset);
+    if (CheckedPtr renderText = dynamicDowncast<RenderText>(*renderer)) {
+        auto [resolvedText, resolvedOffset] = resolvedTextRendererAndOffset();
+        return !nodeIsUserSelectNone(node.get()) && resolvedText && resolvedText->containsCaretOffset(resolvedOffset);
+    }
 
     if (positionBeforeOrAfterNodeIsCandidate(*node)) {
         return ((atFirstEditingPositionForNode() && m_anchorType == PositionIsBeforeAnchor)
@@ -1013,9 +1057,10 @@ bool Position::isCandidate() const
 
 bool Position::isRenderedCharacter() const
 {
-    RefPtr text = dynamicDowncast<Text>(deprecatedNode());
-    CheckedPtr renderer = text ? text->renderer() : nullptr;
-    return renderer && renderer->containsRenderedCharacterOffset(m_offset);
+    if (!dynamicDowncast<Text>(deprecatedNode()))
+        return false;
+    auto [renderText, offset] = resolvedTextRendererAndOffset();
+    return renderText && renderText->containsRenderedCharacterOffset(offset);
 }
 
 static bool inSameEnclosingBlockFlowElement(Node* a, Node* b)
@@ -1061,16 +1106,16 @@ bool Position::rendersInDifferentPosition(const Position& position) const
     if (!inSameEnclosingBlockFlowElement(node.get(), positionNode.get()))
         return true;
 
-    CheckedPtr textRenderer = dynamicDowncast<RenderText>(*renderer);
-    if (textRenderer && !textRenderer->containsCaretOffset(m_offset))
+    auto [textRenderer, thisOffset] = resolvedTextRendererAndOffset();
+    if (textRenderer && !textRenderer->containsCaretOffset(thisOffset))
         return false;
 
-    CheckedPtr textPositionRenderer = dynamicDowncast<RenderText>(*positionRenderer);
-    if (textPositionRenderer && !textPositionRenderer->containsCaretOffset(position.m_offset))
+    auto [textPositionRenderer, positionOffset] = position.resolvedTextRendererAndOffset();
+    if (textPositionRenderer && !textPositionRenderer->containsCaretOffset(positionOffset))
         return false;
 
-    unsigned thisRenderedOffset = textRenderer ? textRenderer->countRenderedCharacterOffsetsUntil(m_offset) : m_offset;
-    unsigned positionRenderedOffset = textPositionRenderer ? textPositionRenderer->countRenderedCharacterOffsetsUntil(position.m_offset) : position.m_offset;
+    unsigned thisRenderedOffset = textRenderer ? textRenderer->countRenderedCharacterOffsetsUntil(thisOffset) : m_offset;
+    unsigned positionRenderedOffset = textPositionRenderer ? textPositionRenderer->countRenderedCharacterOffsetsUntil(positionOffset) : position.m_offset;
 
     if (renderer == positionRenderer && thisRenderedOffset == positionRenderedOffset)
         return false;
@@ -1195,16 +1240,52 @@ static Position upstreamIgnoringEditingBoundaries(Position position)
     return position;
 }
 
+std::pair<RenderObject*, unsigned> Position::rendererAndOffset() const
+{
+    auto* node = deprecatedNode();
+    if (!node)
+        return { { }, { } };
+    auto* renderer = node->renderer();
+    if (!renderer)
+        return { { }, { } };
+    unsigned offset = deprecatedEditingOffset();
+    CheckedPtr textFragment = dynamicDowncast<RenderTextFragment>(*renderer);
+    if (!textFragment || !textFragment->firstLetter())
+        return { renderer, offset };
+
+    // When the remaining fragment is empty (entire text is the first letter),
+    // route to the first-letter renderer's end position so "after the last character" is a valid caret position.
+    if (offset >= textFragment->start() && textFragment->text().length())
+        return { renderer, offset - textFragment->start() };
+
+    // It looks like we are on the first letter renderer.
+    CheckedPtr firstLetterRenderer = dynamicDowncast<RenderText>(textFragment->firstLetter()->firstChild());
+    if (!firstLetterRenderer) {
+        ASSERT_NOT_REACHED();
+        return { { }, { } };
+    }
+
+    // The first-letter text may not start at DOM offset 0 (e.g. collapsed whitespace precedes the first letter).
+    auto firstLetterStart = textFragment->start() - firstLetterRenderer->text().length();
+    return offset >= firstLetterStart ? std::make_pair(firstLetterRenderer, offset - firstLetterStart) : std::make_pair(nullptr, 0);
+}
+
+std::pair<RenderText*, unsigned> Position::resolvedTextRendererAndOffset() const
+{
+    auto [renderer, offset] = rendererAndOffset();
+    if (auto* renderText = dynamicDowncast<RenderText>(renderer))
+        return { renderText, offset };
+    return { nullptr, 0 };
+}
+
 InlineBoxAndOffset Position::inlineBoxAndOffset(Affinity affinity, TextDirection primaryDirection) const
 {
     auto caretOffset = static_cast<unsigned>(deprecatedEditingOffset());
 
-    RefPtr node = deprecatedNode();
-    if (!node)
-        return { { }, caretOffset };
-    CheckedPtr renderer = node->renderer();
+    auto [renderer, resolvedOffset] = rendererAndOffset();
     if (!renderer)
         return { { }, caretOffset };
+    caretOffset = resolvedOffset;
 
     InlineIterator::LeafBoxIterator box;
 

--- a/Source/WebCore/dom/Position.h
+++ b/Source/WebCore/dom/Position.h
@@ -38,6 +38,8 @@ namespace WebCore {
 
 class LegacyInlineBox;
 class RenderElement;
+class RenderObject;
+class RenderText;
 class Text;
 
 struct BoundaryPoint;
@@ -102,6 +104,12 @@ public:
             return m_offset;
         return offsetForPositionAfterAnchor();
     }
+
+    // Returns the renderer and fragment-local offset for this position, correctly
+    // handling first-letter text fragment splits where the DOM text node's renderer
+    // is the remaining fragment rather than the first-letter fragment.
+    std::pair<RenderObject*, unsigned> rendererAndOffset() const;
+    std::pair<RenderText*, unsigned> resolvedTextRendererAndOffset() const;
 
     RefPtr<Node> firstNode() const;
 

--- a/Source/WebCore/dom/PositionIterator.cpp
+++ b/Source/WebCore/dom/PositionIterator.cpp
@@ -175,8 +175,12 @@ bool PositionIterator::isCandidate() const
     if (renderer->isBR())
         return Position(*this).isCandidate();
 
-    if (CheckedPtr renderText = dynamicDowncast<RenderText>(*renderer))
-        return !Position::nodeIsUserSelectNone(anchorNode.get()) && renderText->containsCaretOffset(m_offsetInAnchor);
+    if (CheckedPtr renderText = dynamicDowncast<RenderText>(*renderer)) {
+        if (Position::nodeIsUserSelectNone(anchorNode.get()))
+            return false;
+        auto [resolvedText, resolvedOffset] = Position(*this).resolvedTextRendererAndOffset();
+        return resolvedText && resolvedText->containsCaretOffset(resolvedOffset);
+    }
 
     if (positionBeforeOrAfterNodeIsCandidate(*anchorNode))
         return (atStartOfNode() || atEndOfNode()) && !Position::nodeIsUserSelectNone(anchorNode->parentNode());

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -66,6 +66,7 @@
 #include "RenderStyle+GettersInlines.h"
 #include "RenderTableCell.h"
 #include "RenderTextControlSingleLine.h"
+#include "RenderTextFragment.h"
 #include "RenderedPosition.h"
 #include "ShadowRoot.h"
 #include "Text.h"
@@ -904,9 +905,16 @@ int caretMaxOffset(const Node& node)
     // For rendered text nodes, return the last position that a caret could occupy.
     if (auto* text = dynamicDowncast<Text>(node)) {
         if (CheckedPtr renderer = text->renderer())
-            return renderer->caretMaxOffset();
+            return firstLetterAdjustedDOMOffset(*renderer, renderer->caretMaxOffset());
     }
     return lastOffsetForEditing(node);
+}
+
+unsigned firstLetterAdjustedDOMOffset(const RenderObject& renderer, unsigned offset)
+{
+    if (auto* textFragment = dynamicDowncast<RenderTextFragment>(renderer); textFragment && textFragment->firstLetter())
+        return offset + textFragment->start();
+    return offset;
 }
 
 bool lineBreakExistsAtVisiblePosition(const VisiblePosition& position)

--- a/Source/WebCore/editing/Editing.h
+++ b/Source/WebCore/editing/Editing.h
@@ -79,6 +79,7 @@ Node* previousLeafNode(const Node*);
 WEBCORE_EXPORT int lastOffsetForEditing(const Node&);
 int caretMinOffset(const Node&);
 int caretMaxOffset(const Node&);
+unsigned firstLetterAdjustedDOMOffset(const RenderObject&, unsigned offset);
 
 bool hasEditableStyle(const Node&, EditableType);
 bool isEditableNode(const Node&);

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2436,12 +2436,10 @@ void FrameSelection::updateAppearance()
     // We can get into a state where the selection endpoints map to the same VisiblePosition when a selection is deleted
     // because we don't yet notify the FrameSelection of text removal.
     if (CheckedPtr view = document->renderView(); startPos.isNotNull() && endPos.isNotNull() && selection.visibleStart() != selection.visibleEnd()) {
-        CheckedPtr startRenderer = startPos.deprecatedNode()->renderer();
-        int startOffset = startPos.deprecatedEditingOffset();
-        CheckedPtr endRenderer = endPos.deprecatedNode()->renderer();
-        int endOffset = endPos.deprecatedEditingOffset();
-        ASSERT(startOffset >= 0 && endOffset >= 0);
-        view->selection().set({ startRenderer, endRenderer, static_cast<unsigned>(startOffset), static_cast<unsigned>(endOffset) });
+        auto [startRenderer, startOffset] = startPos.rendererAndOffset();
+        auto [endRenderer, endOffset] = endPos.rendererAndOffset();
+        if (startRenderer && endRenderer)
+            view->selection().set({ startRenderer, endRenderer, startOffset, endOffset });
     }
 }
 

--- a/Source/WebCore/editing/RenderedPosition.cpp
+++ b/Source/WebCore/editing/RenderedPosition.cpp
@@ -32,6 +32,7 @@
 #include "RenderedPosition.h"
 
 #include "CaretRectComputation.h"
+#include "Editing.h"
 #include "InlineRunAndOffset.h"
 #include "NodeInlines.h"
 #include "RenderObjectInlines.h"
@@ -85,6 +86,7 @@ RenderedPosition::RenderedPosition(const Position& position, Affinity affinity)
     if (position.isNull())
         return;
 
+    m_node = position.deprecatedNode();
     auto boxAndOffset = position.inlineBoxAndOffset(affinity);
     m_box = boxAndOffset.box;
     m_offset = boxAndOffset.offset;
@@ -206,7 +208,7 @@ Position RenderedPosition::positionAtLeftBoundaryOfBiDiRun() const
     ASSERT(atLeftBoundaryOfBidiRun());
 
     if (atLeftmostOffsetInBox())
-        return makeDeprecatedLegacyPosition(protect(m_renderer->node()).get(), m_offset);
+        return makeDeprecatedLegacyPosition(protect(m_node.get()).get(), m_offset);
 
     return makeDeprecatedLegacyPosition(protect(nextLeafOnLine()->renderer().node()).get(), nextLeafOnLine()->leftmostCaretOffset());
 }
@@ -215,8 +217,10 @@ Position RenderedPosition::positionAtRightBoundaryOfBiDiRun() const
 {
     ASSERT(atRightBoundaryOfBidiRun());
 
-    if (atRightmostOffsetInBox())
-        return makeDeprecatedLegacyPosition(protect(m_renderer->node()).get(), m_offset);
+    if (atRightmostOffsetInBox()) {
+        auto offset = firstLetterAdjustedDOMOffset(*m_renderer, m_offset);
+        return makeDeprecatedLegacyPosition(protect(m_node.get()).get(), offset);
+    }
 
     return makeDeprecatedLegacyPosition(protect(previousLeafOnLine()->renderer().node()).get(), previousLeafOnLine()->rightmostCaretOffset());
 }

--- a/Source/WebCore/editing/RenderedPosition.h
+++ b/Source/WebCore/editing/RenderedPosition.h
@@ -89,6 +89,7 @@ private:
     bool atRightBoundaryOfBidiRun(ShouldMatchBidiLevel, unsigned char bidiLevelOfRun) const;
 
     SingleThreadWeakPtr<const RenderObject> m_renderer;
+    RefPtr<Node> m_node;
     InlineIterator::LeafBoxIterator m_box;
     unsigned m_offset { 0 };
 

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -648,9 +648,15 @@ bool TextIterator::handleTextNode()
 
     std::tie(m_textRun, m_textRunLogicalOrderCache) = InlineIterator::firstTextBoxInLogicalOrderFor(renderer.get());
 
-    if (textFragment && !m_handledFirstLetter && !m_offset)
+    if (textFragment && !m_handledFirstLetter && static_cast<unsigned>(m_offset) < textFragment->start()) {
         handleTextNodeFirstLetter(*textFragment);
-    else if (!m_textRun && rendererText.length()) {
+        if (m_firstLetterText) {
+            // m_offset is a DOM offset but handleTextRun works in renderer-local coordinates.
+            // Convert to first-letter local offset.
+            auto firstLetterStart = static_cast<int>(textFragment->start() - m_firstLetterText->text().length());
+            m_offset = std::max(0, m_offset - firstLetterStart);
+        }
+    } else if (!m_textRun && rendererText.length()) {
         if (renderer->style().visibility() != Visibility::Visible && !m_behaviors.contains(TextIteratorBehavior::IgnoresStyleVisibility))
             return false;
         m_lastTextNodeEndedWithCollapsedSpace = true; // entire block is collapsed space

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -607,6 +607,8 @@ bool TextIterator::handleTextNode()
     CheckedRef renderer = *textNode->renderer();
     m_lastTextNode = textNode.ptr();
     auto rendererText = rendererTextForBehavior(renderer.get());
+    // textFragment is the renderer that holds the trailing content and has a reference to the first letter renderer.
+    CheckedPtr textFragment = dynamicDowncast<RenderTextFragment>(renderer.get());
 
     // handle pre-formatted text
     if (!renderer->style().collapseWhiteSpace()) {
@@ -615,8 +617,8 @@ bool TextIterator::handleTextNode()
             emitCharacter(' ', WTF::move(textNode), nullptr, runStart, runStart);
             return false;
         }
-        if (CheckedPtr renderTextFragment = dynamicDowncast<RenderTextFragment>(renderer); renderTextFragment && !m_handledFirstLetter && !m_offset) {
-            handleTextNodeFirstLetter(*renderTextFragment);
+        if (textFragment && !m_handledFirstLetter && !m_offset) {
+            handleTextNodeFirstLetter(*textFragment);
             if (m_firstLetterText) {
                 String firstLetter = m_firstLetterText->text();
                 emitText(textNode, *protect(m_firstLetterText), m_offset, m_offset + firstLetter.length());
@@ -627,9 +629,15 @@ bool TextIterator::handleTextNode()
         }
         if (renderer->style().visibility() != Visibility::Visible && !m_behaviors.contains(TextIteratorBehavior::IgnoresStyleVisibility))
             return false;
-        int rendererTextLength = rendererText.length();
-        int end = (textNode.ptr() == m_endContainer) ? m_endOffset : INT_MAX;
-        int runEnd = std::min(rendererTextLength, end);
+        auto rendererTextLength = static_cast<int>(rendererText.length());
+        auto end = (textNode.ptr() == m_endContainer) ? m_endOffset : INT_MAX;
+        if (textFragment && textFragment->firstLetter()) {
+            // The remaining text fragment's text is fragment-local. Convert DOM offsets to fragment-local so we can compare against the renderer's text length.
+            auto fragmentStart = static_cast<int>(textFragment->start());
+            runStart = std::max(0, runStart - fragmentStart);
+            end = end == INT_MAX ? INT_MAX : std::max(0, end - fragmentStart);
+        }
+        auto runEnd = std::min(rendererTextLength, end);
 
         if (runStart >= runEnd)
             return true;
@@ -640,8 +648,8 @@ bool TextIterator::handleTextNode()
 
     std::tie(m_textRun, m_textRunLogicalOrderCache) = InlineIterator::firstTextBoxInLogicalOrderFor(renderer.get());
 
-    if (CheckedPtr renderTextFragment = dynamicDowncast<RenderTextFragment>(renderer); renderTextFragment && !m_handledFirstLetter && !m_offset)
-        handleTextNodeFirstLetter(*renderTextFragment);
+    if (textFragment && !m_handledFirstLetter && !m_offset)
+        handleTextNodeFirstLetter(*textFragment);
     else if (!m_textRun && rendererText.length()) {
         if (renderer->style().visibility() != Visibility::Visible && !m_behaviors.contains(TextIteratorBehavior::IgnoresStyleVisibility))
             return false;
@@ -665,12 +673,21 @@ void TextIterator::handleTextRun()
 
     auto [firstTextRun, orderCache] = InlineIterator::firstTextBoxInLogicalOrderFor(renderer);
 
-    auto rendererText = rendererTextForBehavior(renderer.get());
-    unsigned rangeStart = m_offset;
-    auto rangeEnd = std::optional<unsigned> { };
-    if (textNode.ptr() == m_endContainer)
-        rangeEnd = m_endOffset;
+    // For remaining text fragments after a first-letter split, text box offsets are fragment-local but m_offset/m_endOffset are DOM offsets.
+    unsigned remainingFragmentStart = 0;
+    if (auto* renderText = dynamicDowncast<RenderTextFragment>(renderer.get()); renderText && renderText->firstLetter())
+        remainingFragmentStart = renderText->start();
 
+    auto toFragmentLocal = [&](unsigned domOffset) {
+        return domOffset > remainingFragmentStart ? domOffset - remainingFragmentStart : 0;
+    };
+    auto toDOMOffset = [&](unsigned localOffset) {
+        return localOffset + remainingFragmentStart;
+    };
+
+    auto rendererText = rendererTextForBehavior(renderer.get());
+    auto rangeStart = toFragmentLocal(m_offset);
+    auto rangeEnd = textNode.ptr() == m_endContainer ? std::make_optional(toFragmentLocal(m_endOffset)) : std::nullopt;
     while (m_textRun) {
         auto textRunStart = m_textRun->start();
         auto textRunEnd = textRunStart + m_textRun->length();
@@ -704,7 +721,7 @@ void TextIterator::handleTextRun()
             // This effectively translates newlines and tabs to spaces without copying the text.
             if (isNewlineOrTab(rendererText[runStart])) {
                 emitCharacter(' ', textNode.copyRef(), nullptr, runStart, runStart + 1);
-                m_offset = runStart + 1;
+                m_offset = toDOMOffset(runStart + 1);
             } else {
                 auto subrunEnd = runStart + 1;
                 for (; subrunEnd < runEnd; ++subrunEnd) {
@@ -716,13 +733,13 @@ void TextIterator::handleTextRun()
                     if (lastSpaceCollapsedByNextNonTextRun)
                         ++subrunEnd; // runEnd stopped before last space. Increment by one to restore the space.
                 }
-                m_offset = subrunEnd;
+                m_offset = toDOMOffset(subrunEnd);
                 emitText(textNode, renderer, runStart, subrunEnd);
             }
 
             // If we are doing a subrun that doesn't go to the end of the text box,
             // come back again to finish handling this text box; don't advance to the next one.
-            if (static_cast<unsigned>(m_positionEndOffset) < textRunEnd)
+            if (static_cast<unsigned>(m_positionEndOffset) < toDOMOffset(textRunEnd))
                 return;
 
             // Advance and return
@@ -1201,8 +1218,11 @@ void TextIterator::emitText(Text& textNode, RenderText& renderer, int textStartO
 
     m_positionNode = textNode;
     m_positionOffsetBaseNode = nullptr;
-    m_positionStartOffset = textStartOffset;
-    m_positionEndOffset = textEndOffset;
+    // For remaining text fragments after a first-letter split, the text offsets are
+    // fragment-local but position offsets need to be DOM-relative for range() to
+    // return correct boundary points (used by word/sentence boundary detection).
+    m_positionStartOffset = firstLetterAdjustedDOMOffset(renderer, textStartOffset);
+    m_positionEndOffset = firstLetterAdjustedDOMOffset(renderer, textEndOffset);
 
     m_lastCharacter = string[textEndOffset - 1];
     m_copyableText.set(WTF::move(string), textStartOffset, textEndOffset - textStartOffset);
@@ -1361,70 +1381,52 @@ bool SimplifiedBackwardsTextIterator::handleTextNode()
 {
     m_lastTextNode = downcast<Text>(m_node.get());
 
-    int startOffset;
-    int offsetInNode;
-    CheckedPtr renderer = handleFirstLetter(startOffset, offsetInNode);
-    if (!renderer)
-        return true;
+    CheckedRef renderer = downcast<RenderText>(*m_node->renderer());
+    auto startOffset = (m_node == m_startContainer) ? m_startOffset : 0;
 
-    String text = renderer->text();
+    auto text = renderer->text();
     if (!renderer->hasRenderedText() && text.length())
         return true;
 
-    if (startOffset + offsetInNode == m_offset) {
-        ASSERT(!m_shouldHandleFirstLetter);
+    if (startOffset == m_offset)
         return true;
-    }
+
+    // Nothing to emit when the renderer text is empty (e.g. the remaining text
+    // fragment after a first-letter split covers no characters).
+    if (!text.length())
+        return true;
 
     m_positionEndOffset = m_offset;
-    m_offset = startOffset + offsetInNode;
+    m_offset = startOffset;
     m_positionNode = m_node;
     m_positionStartOffset = m_offset;
 
-    ASSERT(m_positionStartOffset < m_positionEndOffset);
-    ASSERT(m_positionStartOffset - offsetInNode >= 0);
-    ASSERT(m_positionEndOffset - offsetInNode > 0);
-    ASSERT(m_positionEndOffset - offsetInNode <= static_cast<int>(text.length()));
+    // For remaining text fragments after a first-letter split, DOM offsets (m_positionStartOffset,
+    // m_positionEndOffset) differ from fragment-local offsets used to index into renderer text.
+    // Convert to fragment-local for text access, keeping DOM offsets for range().
+    unsigned fragmentStart = 0;
+    if (auto* renderText = dynamicDowncast<RenderTextFragment>(renderer.get()); renderText && renderText->firstLetter() && startOffset >= static_cast<int>(renderText->start()))
+        fragmentStart = renderText->start();
 
-    m_lastCharacter = text[m_positionEndOffset - offsetInNode - 1];
-    m_copyableText.set(WTF::move(text), m_positionStartOffset - offsetInNode, m_positionEndOffset - m_positionStartOffset);
+    // After editing mutations (e.g. deleting the last character),
+    // m_positionEndOffset can exceed the text node's current length in DOM space.
+    auto textLengthInDOMSpace = static_cast<int>(text.length() + fragmentStart);
+    if (m_positionEndOffset > textLengthInDOMSpace)
+        m_positionEndOffset = textLengthInDOMSpace;
+
+    int localStart = m_positionStartOffset - fragmentStart;
+    int localEnd = m_positionEndOffset - fragmentStart;
+
+    ASSERT(m_positionStartOffset < m_positionEndOffset);
+    ASSERT(localStart >= 0);
+    ASSERT(localEnd > 0);
+    ASSERT(localEnd <= static_cast<int>(text.length()));
+
+    m_lastCharacter = text[localEnd - 1];
+    m_copyableText.set(WTF::move(text), localStart, m_positionEndOffset - m_positionStartOffset);
     m_text = m_copyableText.text();
 
-    return !m_shouldHandleFirstLetter;
-}
-
-CheckedPtr<RenderText> SimplifiedBackwardsTextIterator::handleFirstLetter(int& startOffset, int& offsetInNode)
-{
-    CheckedRef renderer = downcast<RenderText>(*m_node->renderer());
-    startOffset = (m_node == m_startContainer) ? m_startOffset : 0;
-
-    CheckedPtr fragment = dynamicDowncast<RenderTextFragment>(renderer);
-    if (!fragment) {
-        offsetInNode = 0;
-        return renderer;
-    }
-
-    int offsetAfterFirstLetter = fragment->start();
-    if (startOffset >= offsetAfterFirstLetter) {
-        ASSERT(!m_shouldHandleFirstLetter);
-        offsetInNode = offsetAfterFirstLetter;
-        return renderer;
-    }
-
-    if (!m_shouldHandleFirstLetter && startOffset + offsetAfterFirstLetter < m_offset) {
-        m_shouldHandleFirstLetter = true;
-        offsetInNode = offsetAfterFirstLetter;
-        return renderer;
-    }
-
-    m_shouldHandleFirstLetter = false;
-    offsetInNode = 0;
-    CheckedPtr firstLetterRenderer = firstRenderTextInFirstLetter(protect(fragment->firstLetter()));
-
-    m_offset = firstLetterRenderer->caretMaxOffset();
-    m_offset += collapsedSpaceLength(*firstLetterRenderer, m_offset);
-
-    return firstLetterRenderer;
+    return true;
 }
 
 bool SimplifiedBackwardsTextIterator::handleReplacedElement()

--- a/Source/WebCore/editing/TextIterator.h
+++ b/Source/WebCore/editing/TextIterator.h
@@ -201,7 +201,6 @@ public:
 private:
     void exitNode();
     bool handleTextNode();
-    CheckedPtr<RenderText> handleFirstLetter(int& startOffset, int& offsetInNode);
     bool handleReplacedElement();
     bool handleNonTextNode();
     void emitCharacter(char16_t, RefPtr<Node>&&, int startOffset, int endOffset);
@@ -236,8 +235,6 @@ private:
     // Whether m_node has advanced beyond the iteration range (i.e. m_startContainer).
     bool m_havePassedStartContainer { false };
 
-    // Should handle first-letter renderer in the next call to handleTextNode.
-    bool m_shouldHandleFirstLetter { false };
 };
 
 // Builds on the text iterator, adding a character position so we can walk one

--- a/Source/WebCore/editing/VisiblePosition.cpp
+++ b/Source/WebCore/editing/VisiblePosition.cpp
@@ -44,7 +44,9 @@
 #include "PositionInlines.h"
 #include "Range.h"
 #include "RenderBlockFlow.h"
+#include "RenderBoxModelObject.h"
 #include "RenderObjectInlines.h"
+#include "RenderTextFragment.h"
 #include "SimpleRange.h"
 #include "Text.h"
 #include "TextIterator.h"
@@ -57,6 +59,16 @@
 namespace WebCore {
 
 using namespace HTMLNames;
+
+// The anonymous text renderer inside ::first-letter has no DOM node.
+static RenderTextFragment* remainingTextFragmentForFirstLetter(const RenderObject& renderer)
+{
+    if (renderer.node())
+        return { };
+    if (auto* parent = dynamicDowncast<RenderBoxModelObject>(renderer.parent()))
+        return parent->firstLetterRemainingText();
+    return { };
+}
 
 VisiblePosition::VisiblePosition(const Position& position, Affinity affinity)
     : m_deepPosition { canonicalPosition(position) }
@@ -140,7 +152,7 @@ Position VisiblePosition::leftVisuallyDistinctCandidate() const
             if ((renderer->isBlockLevelReplacedOrAtomicInline() || renderer->isBR()) && offset == box->rightmostCaretOffset())
                 return box->isLeftToRightDirection() ? previousVisuallyDistinctCandidate(m_deepPosition) : nextVisuallyDistinctCandidate(m_deepPosition);
 
-            if (!renderer->node()) {
+            if (!renderer->node() && !remainingTextFragmentForFirstLetter(*renderer)) {
                 box.traverseLineLeftwardOnLine();
                 if (!box)
                     return primaryDirection == TextDirection::LTR ? previousVisuallyDistinctCandidate(m_deepPosition) : nextVisuallyDistinctCandidate(m_deepPosition);
@@ -182,8 +194,8 @@ Position VisiblePosition::leftVisuallyDistinctCandidate() const
             if (box->direction() == primaryDirection) {
                 if (!previousBox) {
                     auto logicalStart = primaryDirection == TextDirection::LTR
-                        ? InlineIterator::firstLeafOnLineInLogicalOrderWithNode(box->lineBox(), orderCache)
-                        : InlineIterator::lastLeafOnLineInLogicalOrderWithNode(box->lineBox(), orderCache);
+                        ? InlineIterator::firstLeafOnLineInLogicalOrder(box->lineBox(), orderCache)
+                        : InlineIterator::lastLeafOnLineInLogicalOrder(box->lineBox(), orderCache);
                     if (logicalStart) {
                         box = logicalStart;
                         renderer = &box->renderer();
@@ -253,7 +265,9 @@ Position VisiblePosition::leftVisuallyDistinctCandidate() const
             break;
         }
 
-        p = makeDeprecatedLegacyPosition(protect(renderer->node()).get(), offset);
+        auto* remainingFragment = remainingTextFragmentForFirstLetter(*renderer);
+        auto* node = remainingFragment ? remainingFragment->textNode() : renderer->node();
+        p = makeDeprecatedLegacyPosition(protect(node).get(), firstLetterAdjustedDOMOffset(*renderer, offset));
 
         if ((p.isCandidate() && p.downstream() != downstreamStart) || p.atStartOfTree() || p.atEndOfTree())
             return p;
@@ -305,7 +319,7 @@ Position VisiblePosition::rightVisuallyDistinctCandidate() const
             if ((renderer->isBlockLevelReplacedOrAtomicInline() || renderer->isBR()) && offset == box->leftmostCaretOffset())
                 return box->isLeftToRightDirection() ? nextVisuallyDistinctCandidate(m_deepPosition) : previousVisuallyDistinctCandidate(m_deepPosition);
 
-            if (!renderer->node()) {
+            if (!renderer->node() && !remainingTextFragmentForFirstLetter(*renderer)) {
                 box.traverseLineRightwardOnLine();
                 if (!box)
                     return primaryDirection == TextDirection::LTR ? nextVisuallyDistinctCandidate(m_deepPosition) : previousVisuallyDistinctCandidate(m_deepPosition);
@@ -422,7 +436,9 @@ Position VisiblePosition::rightVisuallyDistinctCandidate() const
             break;
         }
 
-        p = makeDeprecatedLegacyPosition(protect(renderer->node()).get(), offset);
+        auto* remainingFragment = remainingTextFragmentForFirstLetter(*renderer);
+        auto* node = remainingFragment ? remainingFragment->textNode() : renderer->node();
+        p = makeDeprecatedLegacyPosition(protect(node).get(), firstLetterAdjustedDOMOffset(*renderer, offset));
 
         if ((p.isCandidate() && p.downstream() != downstreamStart) || p.atStartOfTree() || p.atEndOfTree())
             return p;

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -29,6 +29,7 @@
 
 #include "BoundaryPointInlines.h"
 #include "Document.h"
+#include "Editing.h"
 #include "EditingInlines.h"
 #include "HTMLBRElement.h"
 #include "HTMLElement.h"
@@ -855,7 +856,7 @@ static VisiblePosition endPositionForLine(const VisiblePosition& c, LineEndpoint
         int endOffset = endTextBox.start();
         if (!endTextBox.isLineBreak())
             endOffset += endTextBox.length();
-        pos = Position(endTextNode.releaseNonNull(), endOffset);
+        pos = Position(endTextNode.releaseNonNull(), firstLetterAdjustedDOMOffset(endTextBox.renderer(), endOffset));
     } else
         pos = positionAfterNode(*endNode);
 
@@ -1233,7 +1234,7 @@ RefPtr<Node> findEndOfParagraph(Node* startNode, Node* highestRoot, Node* stayIn
                 }
             }
             node = n;
-            offset = r->caretMaxOffset();
+            offset = caretMaxOffset(*n);
             n = NodeTraversal::next(*n, stayInsideBlock);
         } else if (editingIgnoresContent(*n) || isRenderedTable(n.get())) {
             node = n;

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -50,6 +50,7 @@
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
 #include "NodeInlines.h"
+#include "Editing.h"
 #include "OutlinePainter.h"
 #include "Page.h"
 #include "PseudoElement.h"
@@ -1914,7 +1915,7 @@ PositionWithAffinity RenderObject::createPositionWithAffinity(int offset, Affini
     if (RefPtr node = nonPseudoNode()) {
         if (!node->hasEditableStyle()) {
             // If it can be found, we prefer a visually equivalent position that is editable. 
-            Position position = makeDeprecatedLegacyPosition(node.get(), offset);
+            Position position = makeDeprecatedLegacyPosition(node.get(), firstLetterAdjustedDOMOffset(*this, offset));
             Position candidate = position.downstream(CanCrossEditingBoundary);
             if (candidate.deprecatedNode()->hasEditableStyle())
                 return PositionWithAffinity(candidate, affinity);
@@ -1923,7 +1924,7 @@ PositionWithAffinity RenderObject::createPositionWithAffinity(int offset, Affini
                 return PositionWithAffinity(candidate, affinity);
         }
         // FIXME: Eliminate legacy editing positions
-        return PositionWithAffinity(makeDeprecatedLegacyPosition(node.get(), offset), affinity);
+        return PositionWithAffinity(makeDeprecatedLegacyPosition(node.get(), firstLetterAdjustedDOMOffset(*this, offset)), affinity);
     }
 
     // We don't want to cross the boundary between editable and non-editable

--- a/Source/WebCore/rendering/RenderTextFragment.cpp
+++ b/Source/WebCore/rendering/RenderTextFragment.cpp
@@ -68,7 +68,14 @@ RenderTextFragment::~RenderTextFragment()
 
 bool RenderTextFragment::canBeSelectionLeaf() const
 {
-    return textNode() && textNode()->hasEditableStyle();
+    if (auto* textNode = this->textNode()) {
+        // Remaining (trailing) text fragments with first-letter are always selectable,
+        // matching the base RenderText::canBeSelectionLeaf() behavior.
+        return firstLetter() ? true : textNode->hasEditableStyle();
+    }
+    // First-letter is always selectable.
+    auto* anonymousInlineWrapper = dynamicDowncast<RenderInline>(this->parent());
+    return anonymousInlineWrapper && anonymousInlineWrapper->firstLetterRemainingText();
 }
 
 void RenderTextFragment::setTextInternal(const String& newText, bool force)


### PR DESCRIPTION
#### f9fcbb5d21b6379d6d016b4af23dcd85d70e4473
<pre>
Selection.toString() drops the first letter when text has leading whitespace with ::first-letter
<a href="https://bugs.webkit.org/show_bug.cgi?id=311439">https://bugs.webkit.org/show_bug.cgi?id=311439</a>
&lt;<a href="https://rdar.apple.com/174184379">rdar://174184379</a>&gt;

Reviewed by NOBODY (OOPS!).

Text &quot; Hello&quot; with ::first-letter splits into two renderers: first-letter
has &quot;H&quot;, remaining fragment has &quot;ello&quot; starting at DOM offset 2.

When you select from DOM offset 1 (the &quot;H&quot;), TextIterator needs to visit
the first-letter renderer to emit &quot;H&quot;. But it only did that when m_offset
was exactly 0. Since the selection starts at offset 1, it skipped the
first-letter renderer entirely and only visited the remaining fragment --
giving &quot;ello&quot; instead of &quot;Hello&quot;.

The fix: enter the first-letter path whenever m_offset &lt; fragmentStart
(i.e. the offset is anywhere in the first-letter&apos;s range), not just when
it is 0. Then convert m_offset from DOM coordinates to the first-letter
renderer&apos;s local coordinates so handleTextRun finds the right text box.

* LayoutTests/editing/selection/first-letter-selection-collapsed-whitespace-expected.txt: Added.
* LayoutTests/editing/selection/first-letter-selection-collapsed-whitespace.html: Added.
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::handleTextNode):
</pre>
----------------------------------------------------------------------
#### ff06033a3f6a6a74ae3a8c1f43c61fd63581c8a9
<pre>
Need a short description (OOPS!).
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

Tests: editing/selection/first-letter-caret-single-char.html
       editing/selection/first-letter-selection-cross-element.html
       editing/selection/first-letter-selection-painting.html
       editing/selection/first-letter-selection.html

* LayoutTests/editing/selection/first-letter-caret-single-char-expected.txt: Added.
* LayoutTests/editing/selection/first-letter-caret-single-char.html: Added.
* LayoutTests/editing/selection/first-letter-selection-cross-element-expected.txt: Added.
* LayoutTests/editing/selection/first-letter-selection-cross-element.html: Added.
* LayoutTests/editing/selection/first-letter-selection-expected.txt: Added.
* LayoutTests/editing/selection/first-letter-selection-painting-expected.html: Added.
* LayoutTests/editing/selection/first-letter-selection-painting.html: Added.
* LayoutTests/editing/selection/first-letter-selection.html: Added.
* LayoutTests/editing/text-iterator/first-letter-word-boundary-expected.txt:
* LayoutTests/fast/text/first-letter-partial-invalidation-crash-expected.txt:
* LayoutTests/platform/glib/editing/selection/extend-by-word-002-expected.txt:
* LayoutTests/platform/ios/editing/selection/extend-by-word-002-expected.txt:
* LayoutTests/platform/mac/editing/selection/extend-by-word-002-expected.txt:
* Source/WebCore/dom/Position.cpp:
(WebCore::crossesFirstLetterBoundary):
(WebCore::firstLetterAdjustedFragmentLocalOffset):
(WebCore::Position::upstream const):
(WebCore::Position::downstream const):
(WebCore::Position::hasRenderedNonAnonymousDescendantsWithHeight):
(WebCore::Position::isCandidate const):
(WebCore::Position::isRenderedCharacter const):
(WebCore::Position::rendersInDifferentPosition const):
(WebCore::Position::rendererAndOffset const):
(WebCore::Position::resolvedTextRendererAndOffset const):
(WebCore::Position::inlineBoxAndOffset const):
* Source/WebCore/dom/Position.h:
* Source/WebCore/dom/PositionIterator.cpp:
(WebCore::PositionIterator::isCandidate const):
* Source/WebCore/editing/Editing.cpp:
(WebCore::caretMaxOffset):
(WebCore::firstLetterAdjustedDOMOffset):
* Source/WebCore/editing/Editing.h:
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::updateAppearance):
* Source/WebCore/editing/RenderedPosition.cpp:
(WebCore::RenderedPosition::RenderedPosition):
(WebCore::RenderedPosition::positionAtLeftBoundaryOfBiDiRun const):
(WebCore::RenderedPosition::positionAtRightBoundaryOfBiDiRun const):
* Source/WebCore/editing/RenderedPosition.h:
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::handleTextNode):
(WebCore::TextIterator::handleTextRun):
(WebCore::TextIterator::emitText):
(WebCore::SimplifiedBackwardsTextIterator::handleTextNode):
(WebCore::SimplifiedBackwardsTextIterator::handleFirstLetter): Deleted.
* Source/WebCore/editing/TextIterator.h:
* Source/WebCore/editing/VisiblePosition.cpp:
(WebCore::remainingTextFragmentForFirstLetter):
(WebCore::VisiblePosition::leftVisuallyDistinctCandidate const):
(WebCore::VisiblePosition::rightVisuallyDistinctCandidate const):
* Source/WebCore/editing/VisibleUnits.cpp:
(WebCore::endPositionForLine):
(WebCore::findEndOfParagraph):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::createPositionWithAffinity const):
* Source/WebCore/rendering/RenderTextFragment.cpp:
(WebCore::RenderTextFragment::canBeSelectionLeaf const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9fcbb5d21b6379d6d016b4af23dcd85d70e4473

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163297 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108008 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9bedb46b-7df6-49a7-9f15-59d4123b1b31) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156412 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27647 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119527 "Found 4 new test failures: accessibility/crash-while-adding-text-child-with-transform.html editing/inserting/insert-character-in-first-letter-crash.html editing/selection/select-bidi-run.html fast/css/first-letter-capitalized-edit-select-crash.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84542 "3 flakes 4 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157498 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21817 "Found 1 new test failure: fast/css/first-letter-capitalized-edit-select-crash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138798 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100224 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20903 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18914 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11125 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130565 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16642 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165767 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8974 "Found 9 new failures in rendering/RenderTextFragment.cpp, editing/VisiblePosition.cpp and found 1 fixed file: rendering/RenderTextFragment.cpp") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18251 "Found 3 new test failures: accessibility/crash-while-adding-text-child-with-transform.html editing/inserting/insert-character-in-first-letter-crash.html fast/css/first-letter-capitalized-edit-select-crash.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127629 "Found 3 new test failures: accessibility/crash-while-adding-text-child-with-transform.html editing/inserting/insert-character-in-first-letter-crash.html fast/css/first-letter-capitalized-edit-select-crash.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27343 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22954 "Found 3 new test failures: accessibility/crash-while-adding-text-child-with-transform.html editing/inserting/insert-character-in-first-letter-crash.html fast/css/first-letter-capitalized-edit-select-crash.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127773 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27267 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138435 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83949 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22675 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15227 "Found 3 new test failures: accessibility/crash-while-adding-text-child-with-transform.html editing/inserting/insert-character-in-first-letter-crash.html fast/css/first-letter-capitalized-edit-select-crash.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26957 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91060 "Found 9 new failures in editing/VisiblePosition.cpp, rendering/RenderTextFragment.cpp and found 1 fixed file: rendering/RenderTextFragment.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26537 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26768 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26610 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->