### PR TITLE
[JSC][WASM][Debugger] Fix active thread selection in multi-VM stops and add step tests

### DIFF
--- a/JSTests/wasm/debugger/resources/wasm/multi-vm-same-module-different-funcs.js
+++ b/JSTests/wasm/debugger/resources/wasm/multi-vm-same-module-different-funcs.js
@@ -24,7 +24,7 @@ const wasm = new Uint8Array([
     // Export function 2 as "func3"
     0x05, 0x66, 0x75, 0x6e, 0x63, 0x33, 0x00, 0x02,
 
-    // [0x30] Code section
+    // [0x2f] Code section
     0x0a,                   // section id=10
     0x22,                   // section size=34
     0x03,                   // 3 functions
@@ -32,38 +32,38 @@ const wasm = new Uint8Array([
     // Function 0: func1 (body size=10)
     0x0a,                   // body size
     0x00,                   // 0 local declarations
-    0x01,                   // [0x35] nop
-    0x41, 0x0a,             // [0x36] i32.const 10
-    0x1a,                   // [0x38] drop
-    0x01,                   // [0x39] nop
-    0x41, 0x14,             // [0x3a] i32.const 20
-    0x1a,                   // [0x3c] drop
-    0x0b,                   // [0x3d] end
+    0x01,                   // [0x34] nop
+    0x41, 0x0a,             // [0x35] i32.const 10
+    0x1a,                   // [0x37] drop
+    0x01,                   // [0x38] nop
+    0x41, 0x14,             // [0x39] i32.const 20
+    0x1a,                   // [0x3b] drop
+    0x0b,                   // [0x3c] end
 
     // Function 1: func2 (body size=10)
     0x0a,                   // body size
     0x00,                   // 0 local declarations
-    0x01,                   // [0x40] nop
-    0x41, 0x1e,             // [0x41] i32.const 30
-    0x1a,                   // [0x43] drop
-    0x01,                   // [0x44] nop
-    0x41, 0x28,             // [0x45] i32.const 40
-    0x1a,                   // [0x47] drop
-    0x0b,                   // [0x48] end
+    0x01,                   // [0x3f] nop
+    0x41, 0x1e,             // [0x40] i32.const 30
+    0x1a,                   // [0x42] drop
+    0x01,                   // [0x43] nop
+    0x41, 0x28,             // [0x44] i32.const 40
+    0x1a,                   // [0x46] drop
+    0x0b,                   // [0x47] end
 
     // Function 2: func3 (body size=10)
     0x0a,                   // body size
     0x00,                   // 0 local declarations
-    0x01,                   // [0x4b] nop
-    0x41, 0x32,             // [0x4c] i32.const 50
-    0x1a,                   // [0x4e] drop
-    0x01,                   // [0x4f] nop
-    0x41, 0x3c,             // [0x50] i32.const 60
-    0x1a,                   // [0x52] drop
-    0x0b                    // [0x53] end
+    0x01,                   // [0x4a] nop
+    0x41, 0x32,             // [0x4b] i32.const 50
+    0x1a,                   // [0x4d] drop
+    0x01,                   // [0x4e] nop
+    0x41, 0x3c,             // [0x4f] i32.const 60
+    0x1a,                   // [0x51] drop
+    0x0b                    // [0x52] end
 ]);
 
-const NUM_WORKERS = 2;
+const NUM_WORKERS = 1;
 const PRINT_INTERVAL = 1e7;
 
 print("=== Multi-VM Different Functions Test ===");
@@ -88,19 +88,18 @@ const workerScript = (workerId, funcName) => `
     }
 `;
 
-// Start workers, each running a different function
-const functions = ['func2', 'func3'];
+// Main thread runs func1
+print("Main thread starting func1 execution...");
+const mainModule = new WebAssembly.Module(wasm);
+const mainInstance = new WebAssembly.Instance(mainModule, {});
+const func1 = mainInstance.exports.func1;
+
+// Worker runs func2 (different from main thread's func1)
+const functions = ['func2'];
 for (let i = 0; i < NUM_WORKERS; i++) {
     $.agent.start(workerScript(i + 1, functions[i]));
     print(`Started worker ${i + 1}/${NUM_WORKERS} running ${functions[i]}`);
 }
-
-// Main thread runs func1
-print("Main thread starting func1 execution...");
-print("");
-const mainModule = new WebAssembly.Module(wasm);
-const mainInstance = new WebAssembly.Instance(mainModule, {});
-const func1 = mainInstance.exports.func1;
 
 let iteration = 0;
 for (; ;) {

--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -1567,7 +1567,17 @@ class MultiVMSameModuleSameFunctionTestCase(BaseTestCase):
             raise Exception(f"Test failed: {e}")
 
     def stepTest(self):
-        # FIXME: Add tests when thread select is full supported
+        self.send_lldb_command_or_raise("th list", patterns=["thread #1", "thread #2", "thread #3"])
+        self.send_lldb_command_or_raise("b 0x4000000100000024")
+        self.send_lldb_command_or_raise("c", patterns=["->  0x4000000100000024: nop"])
+        patterns = [
+            ["->  0x4000000100000025: i32.const 42"],
+            ["->  0x4000000100000027: drop"],
+            ["->  0x4000000100000028: nop"],
+            ["->  0x4000000100000029: end"],
+        ]
+        for pattern in patterns:
+            self.send_lldb_command_or_raise("si", patterns=pattern)
         return
 
 
@@ -1589,7 +1599,40 @@ class MultiVMSameModuleDifferentFunctionsTestCase(BaseTestCase):
             raise Exception(f"Test failed: {e}")
 
     def stepTest(self):
-        # FIXME: Add tests when thread select is full supported
+        self.send_lldb_command_or_raise("th list", patterns=["thread #1", "thread #2"])
+
+        self.send_lldb_command_or_raise("b 0x4000000000000034")
+        self.send_lldb_command_or_raise("c", patterns=["->  0x4000000000000034: nop"])
+        patterns = [
+            ["->  0x4000000000000035: i32.const 10"],
+            ["->  0x4000000000000037: drop"],
+            ["->  0x4000000000000038: nop"],
+            ["->  0x4000000000000039: i32.const 20"],
+            ["->  0x400000000000003b: drop"],
+            ["->  0x400000000000003c: end"],
+        ]
+        for pattern in patterns:
+            self.send_lldb_command_or_raise("si", patterns=pattern)
+        self.send_lldb_command_or_raise(
+            "br del -f", patterns=["All breakpoints removed. (1 breakpoint)"]
+        )
+
+        self.send_lldb_command_or_raise("b 0x400000010000003f")
+        self.send_lldb_command_or_raise("c", patterns=["->  0x400000010000003f: nop"])
+        patterns = [
+            ["->  0x4000000100000040: i32.const 30"],
+            ["->  0x4000000100000042: drop"],
+            ["->  0x4000000100000043: nop"],
+            ["->  0x4000000100000044: i32.const 40"],
+            ["->  0x4000000100000046: drop"],
+            ["->  0x4000000100000047: end"],
+        ]
+        for pattern in patterns:
+            self.send_lldb_command_or_raise("si", patterns=pattern)
+        self.send_lldb_command_or_raise(
+            "br del -f", patterns=["All breakpoints removed. (1 breakpoint)"]
+        )
+
         return
 
 

--- a/Source/JavaScriptCore/wasm/debugger/README.md
+++ b/Source/JavaScriptCore/wasm/debugger/README.md
@@ -196,11 +196,6 @@ See [RWI_ARCHITECTURE.md](./RWI_ARCHITECTURE.md) for complete setup instructions
 - **Location**: `WasmDebugServer.cpp:348-349`
 - **Solution**: Introduce various stop states and proper termination handling
 
-### Multi-Thread Display in LLDB
-
-- **Issue**: Thread select and stop reply protocol handlers need improvement to correctly display multi-VM data in LLDB
-- **Current Status**: Multi-VM stop-the-world is implemented, but thread information may not display correctly in LLDB UI
-
 ### X86_64 Support
 
 - **Issue**: The WebAssembly debugger is currently restricted to ARM64 platforms only

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
@@ -752,22 +752,6 @@ struct ThreadInfo {
     StringView stopReason;
 };
 
-static Vector<ThreadInfo> collectAllStoppedThreads()
-{
-    Vector<ThreadInfo> threads;
-    VMManager::forEachVM([&](VM& vm) {
-        auto* state = vm.debugState();
-        if (!state->isStopped())
-            return IterationStatus::Continue;
-
-        uint64_t threadId = ExecutionHandler::threadId(vm);
-        auto stopInfo = stopReasonToInfo(*state);
-        threads.append({ threadId, getStopPC(*state), getThreadName(*state, threadId), stopInfo.reasonSuffix });
-        return IterationStatus::Continue;
-    });
-    return threads;
-}
-
 void ExecutionHandler::sendStopReply(AbstractLocker& locker) WTF_REQUIRES_LOCK(m_lock)
 {
     sendStopReplyForThread(locker, threadId(*m_debuggee));
@@ -776,8 +760,14 @@ void ExecutionHandler::sendStopReply(AbstractLocker& locker) WTF_REQUIRES_LOCK(m
 void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t threadId) WTF_REQUIRES_LOCK(m_lock)
 {
     VM* vm = findVM(threadId);
+    if (!vm) {
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] sendStopReplyForThread: thread ", threadId, " not found");
+        sendErrorReply(ProtocolError::InvalidAddress);
+        return;
+    }
+
     DebugState* state = vm->debugState();
-    if (!vm || !state) {
+    if (!state) {
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] sendStopReplyForThread: thread ", threadId, " not found");
         sendErrorReply(ProtocolError::InvalidAddress);
         return;
@@ -785,11 +775,28 @@ void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t t
 
     RELEASE_ASSERT(state->isStopped());
 
-    // Gather information for the target thread
-    Vector<ThreadInfo> allThreads = collectAllStoppedThreads();
+    // Collect all stopped threads; swap event thread to index 0 so thread-pcs[i] aligns with threads[i].
+    Vector<ThreadInfo> allThreads;
+    VMManager::forEachVM([&](VM& vm) {
+        auto* state = vm.debugState();
+        if (!state->isStopped())
+            return IterationStatus::Continue;
+        uint64_t tid = ExecutionHandler::threadId(vm);
+        allThreads.append({ tid, getStopPC(*state), getThreadName(*state, tid), stopReasonToInfo(*state).reasonSuffix });
+        if (tid == threadId)
+            std::swap(allThreads[0], allThreads.last());
+        return IterationStatus::Continue;
+    });
 
-    // FIXME: Report different stop reasons for active vs passive threads (currently all use same code).
-    auto stopInfo = stopReasonToInfo(*state);
+    // A "passive thread" is a VM that was collaterally stopped when the world was halted (its
+    // stopReason set to Interrupted by setStopped()), as opposed to the debuggee thread that
+    // actually triggered the stop event (breakpoint/step/trap/interrupt/new-module-load).
+    // Passive threads get signal 0 so LLDB's ShouldSelect() returns false for them, allowing
+    // the event thread to win thread selection in HandleProcessStateChangedEvent.
+    bool isPassiveThread = state->stopReason == DebugState::Reason::Interrupted && m_debuggee && threadId != ExecutionHandler::threadId(*m_debuggee);
+    auto stopInfo = isPassiveThread
+        ? StopReasonInfo { signalStopString(0), "signal"_s }
+        : stopReasonToInfo(*state);
 
     // Build packet with target thread
     StringBuilder reply;


### PR DESCRIPTION
#### 121f967d4c90c2de1a5ba9647a260461ddcdd2ad
<pre>
[JSC][WASM][Debugger] Fix active thread selection in multi-VM stops and add step tests
<a href="https://rdar.apple.com/174187067">rdar://174187067</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311594">https://bugs.webkit.org/show_bug.cgi?id=311594</a>

Reviewed by Keith Miller.

LLDB always selected the wrong thread when multiple VMs stopped simultaneously.
Root cause: LLDB resets m_selected_tid on every stop and falls back to m_threads[0]
(lowest IndexID). Passive threads had StopInfoSignal(SIGSTOP) with ShouldSelect()=true,
causing the selection loop to be skipped. Fix by sending signal 0 for passive threads
so ShouldSelect()=false and the event thread wins selection.

Also inline collectAllStoppedThreads into sendStopReplyForThread with event-thread-first
ordering, fix a null-deref before vm null check, fix off-by-1 WASM offset comments in
multi-vm-same-module-different-funcs.js, add step test coverage for multi-VM test cases,
and remove the stale known issue from README.md.

Tests:
* JSTests/wasm/debugger/tests/tests.py:
(MultiVMSameModuleSameFunctionTestCase.stepTest)
(MultiVMSameModuleDifferentFunctionsTestCase.stepTest)

Canonical link: <a href="https://commits.webkit.org/310847@main">https://commits.webkit.org/310847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23600f09131129e31c7ea0db03e0923c6318b7fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28489 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/21648 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163989 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 62147") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157102 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28337 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/163989 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 62147") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158188 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/22364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/139399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/163989 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 62147") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/11815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/147279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/17235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166467 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/16060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/18844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/128216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/28033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/23540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/128353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/27957 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/139028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/84666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23649 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/27957 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187114 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/27650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/91754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/47983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/27228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/27458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/27301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->