### PR TITLE
[Site Isolation] Web Inspector: Add frame target test coverage for cancelling provisional page loading

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation-expected.txt
@@ -1,5 +1,6 @@
 CONSOLE MESSAGE: Hello from leaf-iframe http://localhost:8000/site-isolation/inspector/target/resources/leaf-iframe.html
 CONSOLE MESSAGE: Hello from leaf-iframe http://127.0.0.1:8000/site-isolation/inspector/target/resources/leaf-iframe.html
+CONSOLE MESSAGE: Hello from leaf-iframe http://localhost:8000/site-isolation/inspector/target/resources/leaf-iframe.html
 Test that frame targets are properly destroyed and created during a cross-origin page navigation.
 
 
@@ -21,4 +22,12 @@ http://127.0.0.1:8000/site-isolation/inspector/target/resources/leaf-iframe.html
 http://localhost:8000/site-isolation/inspector/target/resources/middle-iframe.html
 http://localhost:8000/site-isolation/inspector/target/target-cross-origin-page-navigation.html
 PASS: Frame targets should be new despite the same page structure.
+
+-- Running test case: SiteIsolation.Target.CrossOriginPageNavigation.ProvisionalLoadCancelsPreviousLoad
+Navigating cross-origin slowly...
+PASS: First provisional frame target was created.
+Navigating cross-origin again to cancel previous load...
+PASS: First provisional frame target was removed.
+PASS: Second provisional frame target was committed.
+PASS: Committed target should not be the first provisional.
 

--- a/LayoutTests/http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation.html
@@ -2,6 +2,17 @@
 <script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
 
 <script>
+    function navigateCrossOrigin() {
+        location.hostname = location.hostname === "127.0.0.1" ? "localhost" : "127.0.0.1";
+    }
+
+    function navigateCrossOriginSlowly() {
+        let crossOriginHost = location.hostname === "127.0.0.1" ? "localhost" : "127.0.0.1";
+        let path = location.pathname;
+        // Delay the response, giving time to cancel the provisional load.
+        location.href = `http://${crossOriginHost}:8000/resources/network-simulator.py?test=inspector-target-cancel-nav&path=${path}&initialdelay=10000`;
+    }
+
     function test() {
         let suite = InspectorTest.createAsyncSuite("SiteIsolation.Target.CrossOriginPageNavigation");
 
@@ -41,7 +52,7 @@
 
                 InspectorTest.log("Navigating cross-origin...");
                 InspectorTest.deferOutputUntilTestPageIsReloaded();
-                InspectorTest.evaluateInPage(`location.hostname = "localhost";`);
+                InspectorTest.evaluateInPage(`navigateCrossOrigin();`);
 
                 // Wait for the log from leaf-iframe to ensure all loading has completed.
                 await WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded);
@@ -61,6 +72,62 @@
                 let oldIds = oldFrameTargets.map((t) => t.identifier);
                 let targetsHaveNewIds = newFrameTargets.every((t) => !oldIds.includes(t.identifier));
                 InspectorTest.expectThat(targetsHaveNewIds, "Frame targets should be new despite the same page structure.");
+            },
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.Target.CrossOriginPageNavigation.ProvisionalLoadCancelsPreviousLoad",
+            description: "Two consecutive cross-origin navigations cancel the first provisional frame target and commit the second.",
+            async test() {
+                let firstProvisionalFrameTargetAdded = new Promise(function (resolve) {
+                    function handle(event) {
+                        let { target } = event.data;
+                        if (target.type === WI.TargetType.Frame && target.isProvisional) {
+                            WI.targetManager.removeEventListener(WI.TargetManager.Event.TargetAdded, handle);
+                            resolve(target);
+                        }
+                    }
+                    WI.targetManager.addEventListener(WI.TargetManager.Event.TargetAdded, handle);
+                });
+
+                InspectorTest.log("Navigating cross-origin slowly...");
+                InspectorTest.deferOutputUntilTestPageIsReloaded();
+                InspectorTest.evaluateInPage(`navigateCrossOriginSlowly();`);
+
+                let firstProvisionalTarget = await firstProvisionalFrameTargetAdded;
+                InspectorTest.pass("First provisional frame target was created.");
+
+                let frameTargetRemoved = new Promise(function (resolve) {
+                    function handle(event) {
+                        let { target } = event.data;
+                        if (target.type === WI.TargetType.Frame) {
+                            WI.targetManager.removeEventListener(WI.TargetManager.Event.TargetRemoved, handle);
+                            resolve(target);
+                        }
+                    }
+                    WI.targetManager.addEventListener(WI.TargetManager.Event.TargetRemoved, handle);
+                });
+                let provisionalFrameTargetCommitted = new Promise(function (resolve) {
+                    function handle(event) {
+                        let { target } = event.data;
+                        if (target.type === WI.TargetType.Frame) {
+                            WI.targetManager.removeEventListener(WI.TargetManager.Event.DidCommitProvisionalTarget, handle);
+                            resolve(target);
+                        }
+                    }
+                    WI.targetManager.addEventListener(WI.TargetManager.Event.DidCommitProvisionalTarget, handle);
+                });
+
+                InspectorTest.log("Navigating cross-origin again to cancel previous load...");
+                InspectorTest.deferOutputUntilTestPageIsReloaded();
+                InspectorTest.evaluateInPage(`navigateCrossOrigin();`);
+
+                let removedTarget = await frameTargetRemoved;
+                InspectorTest.expectEqual(removedTarget.identifier, firstProvisionalTarget.identifier, "First provisional frame target was removed.");
+
+                let committedTarget = await provisionalFrameTargetCommitted;
+                InspectorTest.pass("Second provisional frame target was committed.");
+                InspectorTest.expectNotEqual(committedTarget.identifier, firstProvisionalTarget.identifier, "Committed target should not be the first provisional.");
             },
         });
 


### PR DESCRIPTION
#### bd64dde4ccccaa886c7294ac9b79fe1439935f7c
<pre>
[Site Isolation] Web Inspector: Add frame target test coverage for cancelling provisional page loading
<a href="https://bugs.webkit.org/show_bug.cgi?id=310567">https://bugs.webkit.org/show_bug.cgi?id=310567</a>
<a href="https://rdar.apple.com/173716937">rdar://173716937</a>

Reviewed by BJ Burg.

Add a test case covering the provisional main frame target&apos;s lifetime
in the event of a cancelled page-level cross-origin navigation.

* LayoutTests/http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation-expected.txt:
* LayoutTests/http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation.html:

Canonical link: <a href="https://commits.webkit.org/311211@main">https://commits.webkit.org/311211@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09151e556779a408cad66284783d1652cdd803a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/156360 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/29695 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/22877 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/165181 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/29828 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/29698 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/165181 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/159318 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/29828 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/22877 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/165181 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/29828 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/29698 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/12953 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/29828 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/22877 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/167663 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/22877 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/167663 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/29698 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/167663 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/29218 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/22877 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23802 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/29218 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/22877 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/28928 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/28682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/28578 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->