### PR TITLE
[JSC] Tag allocated memory with name on Linux too

### DIFF
--- a/Source/WTF/wtf/OSAllocator.h
+++ b/Source/WTF/wtf/OSAllocator.h
@@ -40,9 +40,6 @@ public:
         FastMallocPages = VM_TAG_FOR_TCMALLOC_MEMORY,
         JSJITCodePages = VM_TAG_FOR_EXECUTABLEALLOCATOR_MEMORY,
         StructureAllocatorPages = VM_TAG_FOR_STRUCTUREALLOCATOR_MEMORY,
-#if OS(LINUX) || OS(HAIKU)
-        UncommittedPages = -2,
-#endif
     };
 
     // The requested alignment must be a power of two and greater than the system page size.
@@ -90,6 +87,9 @@ public:
     WTF_EXPORT_PRIVATE static bool tryProtect(void*, size_t, bool readable, bool writable);
 
     WTF_EXPORT_PRIVATE static void zeroFill(void* base, size_t);
+
+private:
+    static void* tryReserveAndCommitImpl(size_t, Usage, void* address, bool writable, bool executable, bool jitCageEnabled, unsigned numGuardPagesToAddOnEachEnd, bool uncommitted);
 };
 
 inline void* OSAllocator::reserveAndCommit(size_t reserveSize, size_t commitSize, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled)

--- a/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
+++ b/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
@@ -54,9 +54,26 @@
 #include <wtf/spi/cocoa/MachVMSPI.h>
 #endif
 
+#if OS(LINUX)
+#include <sys/prctl.h>
+
+#ifndef PR_SET_VMA
+#define PR_SET_VMA 0x53564d41
+#endif
+
+#ifndef PR_SET_VMA_ANON_NAME
+#define PR_SET_VMA_ANON_NAME 0
+#endif
+#endif
+
 namespace WTF {
 
 void* OSAllocator::tryReserveAndCommit(size_t bytes, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled, unsigned numGuardPagesToAddOnEachEnd)
+{
+    return tryReserveAndCommitImpl(bytes, usage, address, writable, executable, jitCageEnabled, numGuardPagesToAddOnEachEnd, /* uncommitted */ false);
+}
+
+void* OSAllocator::tryReserveAndCommitImpl(size_t bytes, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled, unsigned numGuardPagesToAddOnEachEnd, bool uncommitted)
 {
     // All POSIX reservations start out logically committed.
     int protection = PROT_READ;
@@ -67,6 +84,7 @@ void* OSAllocator::tryReserveAndCommit(size_t bytes, Usage usage, void* address,
 
     int flags = MAP_PRIVATE | MAP_ANON;
 #if OS(DARWIN)
+    UNUSED_PARAM(uncommitted);
     if (executable) {
         if (jitCageEnabled)
             flags |= MAP_EXECUTABLE_FOR_JIT_WITH_JIT_CAGE;
@@ -75,18 +93,14 @@ void* OSAllocator::tryReserveAndCommit(size_t bytes, Usage usage, void* address,
     }
 #elif OS(LINUX) || OS(HAIKU)
     UNUSED_PARAM(jitCageEnabled);
-    if (usage == OSAllocator::UncommittedPages)
+    if (uncommitted)
         flags |= MAP_NORESERVE;
 #else
     UNUSED_PARAM(jitCageEnabled);
+    UNUSED_PARAM(uncommitted);
 #endif
 
-#if OS(DARWIN)
-    int fd = usage;
-#else
-    UNUSED_PARAM(usage);
-    int fd = -1;
-#endif
+    int fd = vmTagFd(static_cast<bmalloc::VMTag>(usage));
 
     size_t guardSize = 0;
     if (numGuardPagesToAddOnEachEnd) {
@@ -100,6 +114,11 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     auto result = MmapSpan<uint8_t>::mmap(address, bytes, protection, flags, fd);
     if (!result)
         return result.leakSpan().data();
+
+#if OS(LINUX)
+    if (const char* name = vmTagName(static_cast<bmalloc::VMTag>(usage)))
+        prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, result.mutableSpan().data(), bytes, name);
+#endif
 
     if (numGuardPagesToAddOnEachEnd) {
         // We use mmap to remap the guardpages rather than using mprotect as
@@ -118,7 +137,7 @@ void* OSAllocator::tryReserveUncommitted(size_t bytes, Usage usage, void* addres
 {
 #if OS(LINUX) || OS(HAIKU)
     UNUSED_PARAM(usage);
-    void* result = tryReserveAndCommit(bytes, OSAllocator::UncommittedPages, address, writable, executable, jitCageEnabled, numGuardPagesToAddOnEachEnd);
+    void* result = tryReserveAndCommitImpl(bytes, usage, address, writable, executable, jitCageEnabled, numGuardPagesToAddOnEachEnd, /* uncommitted */ true);
     if (result)
         while (madvise(result, bytes, MADV_DONTNEED) == -1 && errno == EAGAIN) { }
 #else // not OS(LINUX) || OS(HAIKU)
@@ -333,8 +352,13 @@ void OSAllocator::zeroFill(void* base, size_t size)
     }
 #endif
 
+#if OS(LINUX)
+    int result = madvise(base, size, MADV_DONTNEED);
+    RELEASE_ASSERT(!result);
+#else
     void* result = mmap(base, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | MAP_FIXED, -1, 0);
     RELEASE_ASSERT(result != MAP_FAILED);
+#endif
 }
 
 } // namespace WTF

--- a/Source/bmalloc/bmalloc/BVMTags.h
+++ b/Source/bmalloc/bmalloc/BVMTags.h
@@ -75,11 +75,11 @@
 
 #else // BOS(DARWIN)
 
-#define VM_TAG_FOR_TCMALLOC_MEMORY -1
-#define VM_TAG_FOR_GIGACAGE_MEMORY -1
-#define VM_TAG_FOR_STRUCTUREALLOCATOR_MEMORY -1
-#define VM_TAG_FOR_EXECUTABLEALLOCATOR_MEMORY -1
-#define VM_TAG_FOR_ISOHEAP_MEMORY -1
+#define VM_TAG_FOR_TCMALLOC_MEMORY -3
+#define VM_TAG_FOR_GIGACAGE_MEMORY -4
+#define VM_TAG_FOR_STRUCTUREALLOCATOR_MEMORY -5
+#define VM_TAG_FOR_EXECUTABLEALLOCATOR_MEMORY -6
+#define VM_TAG_FOR_ISOHEAP_MEMORY -7
 
 #endif // BOS(DARWIN)
 
@@ -93,6 +93,34 @@ enum class VMTag {
     JSGigacage = VM_TAG_FOR_GIGACAGE_MEMORY,
     JSStructureHeap = VM_TAG_FOR_STRUCTUREALLOCATOR_MEMORY,
 };
+
+inline const char* vmTagName(VMTag tag)
+{
+#if BOS(DARWIN)
+    static_assert(VMTag::JSStructureHeap == VMTag::JSGigacage);
+#endif
+    switch (tag) {
+    case VMTag::Malloc: return "WKFastMalloc";
+    case VMTag::IsoHeap: return "WKIsoHeap";
+    case VMTag::JSJITCode: return "JSJITCode";
+    case VMTag::JSGigacage: return "JSGigacage";
+#if !BOS(DARWIN)
+    case VMTag::JSStructureHeap: return "JSStructureHeap";
+#endif
+    default:
+        return nullptr;
+    }
+}
+
+inline int vmTagFd(VMTag tag)
+{
+    BUNUSED_PARAM(tag);
+#if BOS(DARWIN) || (BPLATFORM(PLAYSTATION) && defined(VM_MAKE_TAG))
+    return static_cast<int>(tag);
+#else
+    return -1;
+#endif
+}
 
 } // namespace bmalloc
 

--- a/Source/bmalloc/bmalloc/Gigacage.cpp
+++ b/Source/bmalloc/bmalloc/Gigacage.cpp
@@ -187,7 +187,7 @@ void ensureGigacage()
                     const vm_inherit_t childProcessInheritance = VM_INHERIT_DEFAULT;
                     const bool copy = false;
                     const vm_prot_t protections = VM_PROT_WRITE | VM_PROT_READ;
-                    auto kernResult = mach_vm_map(mach_task_self(), (mach_vm_address_t*)&base, size, vmPageSize() - 1, VM_FLAGS_FIXED | VM_FLAGS_OVERWRITE | (int)VMTag::JSGigacage, MEMORY_OBJECT_NULL, 0, copy, protections, protections, childProcessInheritance);
+                    auto kernResult = mach_vm_map(mach_task_self(), (mach_vm_address_t*)&base, size, vmPageSize() - 1, VM_FLAGS_FIXED | VM_FLAGS_OVERWRITE | vmTagFd(VMTag::JSGigacage), MEMORY_OBJECT_NULL, 0, copy, protections, protections, childProcessInheritance);
                     RELEASE_BASSERT(kernResult == KERN_SUCCESS);
                 }
             }

--- a/Source/bmalloc/bmalloc/VMAllocate.h
+++ b/Source/bmalloc/bmalloc/VMAllocate.h
@@ -55,6 +55,18 @@
 #define BMALLOC_USE_MADV_ZERO 0
 #endif
 
+#if BOS(LINUX)
+#include <sys/prctl.h>
+
+#ifndef PR_SET_VMA
+#define PR_SET_VMA 0x53564d41
+#endif
+
+#ifndef PR_SET_VMA_ANON_NAME
+#define PR_SET_VMA_ANON_NAME 0
+#endif
+#endif
+
 BALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace bmalloc {
@@ -248,9 +260,12 @@ inline size_t vmPageSizePhysical()
 inline void* tryVMAllocate(size_t vmSize, VMTag usage)
 {
     vmValidate(vmSize);
-    void* result = mmap(0, vmSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | BMALLOC_NORESERVE, static_cast<int>(usage), 0);
+    void* result = mmap(0, vmSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | BMALLOC_NORESERVE, vmTagFd(usage), 0);
     if (result == MAP_FAILED)
         return nullptr;
+#if BOS(LINUX)
+    prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, result, vmSize, vmTagName(usage));
+#endif
     return result;
 }
 
@@ -274,7 +289,7 @@ inline void vmZeroAndPurge(void* p, size_t vmSize, VMTag usage)
 {
     vmValidate(p, vmSize);
     int flags = MAP_PRIVATE | MAP_ANON | MAP_FIXED | BMALLOC_NORESERVE;
-    int tag = static_cast<int>(usage);
+    int tag = vmTagFd(usage);
 #if BMALLOC_USE_MADV_ZERO
     if (isMadvZeroSupported()) {
         int rc = madvise(p, vmSize, MADV_ZERO);
@@ -287,10 +302,18 @@ inline void vmZeroAndPurge(void* p, size_t vmSize, VMTag usage)
     if (tryVmZeroAndPurgeMTECase(p, vmSize, usage))
         return;
 #endif // BENABLE(MTE) && BOS(DARWIN)
+
+#if BOS(LINUX)
+    BUNUSED(flags);
+    BUNUSED(tag);
+    int result = madvise(p, vmSize, MADV_DONTNEED);
+    RELEASE_BASSERT(!result);
+#else
     // MAP_ANON guarantees the memory is zeroed. This will also cause
     // page faults on accesses to this range following this call.
     void* result = mmap(p, vmSize, PROT_READ | PROT_WRITE, flags, tag, 0);
     RELEASE_BASSERT(result == p);
+#endif
 }
 
 inline void vmDeallocatePhysicalPages(void* p, size_t vmSize)

--- a/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
@@ -41,6 +41,9 @@
 #include <mach/vm_page_size.h>
 #include <mach/vm_statistics.h>
 #endif
+#if PAS_OS(LINUX)
+#include <sys/prctl.h>
+#endif
 
 #include "pas_internal_config.h"
 #include "pas_log.h"
@@ -79,9 +82,19 @@ static bool madv_zero_supported = false;
 #else
 #define PAS_VM_TAG -1
 #endif
+#define PAS_VM_TAG_NAME "WKFastMalloc"
 
 #if PAS_OS(LINUX)
 #define PAS_NORESERVE MAP_NORESERVE
+
+#ifndef PR_SET_VMA
+#define PR_SET_VMA 0x53564d41
+#endif
+
+#ifndef PR_SET_VMA_ANON_NAME
+#define PR_SET_VMA_ANON_NAME 0
+#endif
+
 #else
 #define PAS_NORESERVE 0
 #endif
@@ -172,6 +185,10 @@ pas_page_malloc_try_map_pages(size_t size, bool may_contain_small_or_medium)
         return NULL;
     } else
         PAS_RECORD_STAT(page_alloc_counts, size, may_contain_small_or_medium, false);
+
+#if PAS_OS(LINUX)
+    prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, mmap_result, size, PAS_VM_TAG_NAME);
+#endif
 
     return mmap_result;
 #endif
@@ -300,6 +317,7 @@ void pas_page_malloc_zero_fill(void* base, size_t size)
 #else
     size_t page_size;
     void* result_ptr;
+    int result;
 
     page_size = pas_page_malloc_alignment();
     
@@ -318,10 +336,18 @@ void pas_page_malloc_zero_fill(void* base, size_t size)
     }
 #endif /* PAS_USE_MADV_ZERO */
 
+    PAS_UNUSED_PARAM(result_ptr);
+    PAS_UNUSED_PARAM(result);
+
     PAS_PROFILE(ZERO_FILL_PAGE, base, size, flags, tag);
     PAS_MTE_HANDLE(ZERO_FILL_PAGE, base, size, flags, tag);
+#if PAS_OS(LINUX)
+    result = madvise(base, size, MADV_DONTNEED);
+    PAS_ASSERT(!result);
+#else
     result_ptr = mmap(base, size, PROT_READ | PROT_WRITE, flags, tag, 0);
     PAS_ASSERT(result_ptr == base, (uintptr_t)result_ptr, (uintptr_t)base);
+#endif
 #endif /* PAS_OS(WINDOWS) */
 }
 


### PR DESCRIPTION
#### b651d820ecaab692e24ee2b2f2b915e8a04908cf
<pre>
[JSC] Tag allocated memory with name on Linux too
<a href="https://bugs.webkit.org/show_bug.cgi?id=311606">https://bugs.webkit.org/show_bug.cgi?id=311606</a>
<a href="https://rdar.apple.com/174202713">rdar://174202713</a>

Reviewed by Justin Michaud.

Using `prctl` system call when allocating pages. This allows Linux to
tag pages with names like what Darwin VMTag is doing. smaps can have
these names for debugging.

We also uses MADV_DONTNEED for page-based zero-clearing on Linux. mmap
with MAP_FIXED will create a new VMA which clears an attached name &amp; VMA.
madvise + MADV_DONTNEED offers page-based zero-clearing while keeping VMA.

```
7cd00514a000-7cd005170000 rw-p 00000000 00:00 0                          [anon:JSGigacage]
Size:                152 kB
KernelPageSize:        4 kB
MMUPageSize:           4 kB
Rss:                 152 kB
Pss:                 152 kB
Pss_Dirty:           152 kB
Shared_Clean:          0 kB
Shared_Dirty:          0 kB
Private_Clean:         0 kB
Private_Dirty:       152 kB
Referenced:          152 kB
Anonymous:           152 kB
KSM:                   0 kB
LazyFree:              0 kB
AnonHugePages:         0 kB
ShmemPmdMapped:        0 kB
FilePmdMapped:         0 kB
Shared_Hugetlb:        0 kB
Private_Hugetlb:       0 kB
Swap:                  0 kB
SwapPss:               0 kB
Locked:                0 kB
THPeligible:           0
VmFlags: rd wr mr mw me nr sd
```

* Source/WTF/wtf/OSAllocator.h:
* Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp:
(WTF::OSAllocator::tryReserveAndCommit):
(WTF::OSAllocator::tryReserveAndCommitImpl):
(WTF::OSAllocator::tryReserveUncommitted):
(WTF::OSAllocator::zeroFill):
* Source/bmalloc/bmalloc/BVMTags.h:
(bmalloc::vmTagName):
(bmalloc::vmTagFd):
* Source/bmalloc/bmalloc/Gigacage.cpp:
(Gigacage::ensureGigacage):
* Source/bmalloc/bmalloc/VMAllocate.h:
(bmalloc::tryVMAllocate):
(bmalloc::vmZeroAndPurge):
* Source/bmalloc/libpas/src/libpas/pas_page_malloc.c:
(pas_page_malloc_try_map_pages):
(pas_page_malloc_zero_fill):

Canonical link: <a href="https://commits.webkit.org/310721@main">https://commits.webkit.org/310721@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7753e235464af1498f4b48e30be1f9e801f08a64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163345 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108056 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9a7305e-a31c-4efa-b432-480894d3a7ac) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27979 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119571 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84566 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7562e00b-0e90-4d7d-b085-b8d1631297d8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21859 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138838 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100268 "Found 2 new API test failures: TestWebCore:MIMETypeRegistry.CanShowMIMEType, TestWebCore:GStreamerTest.gstStructureGetters (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f557e1c3-49aa-4597-8951-c40ea5ff6383) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20945 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18957 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11173 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146637 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130608 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165817 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15418 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9022 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18291 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127672 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27391 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127815 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138475 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83997 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23603 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22714 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15267 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186294 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27006 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91109 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47743 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26585 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26816 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26658 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->