### PR TITLE
Facebook: Unable to drag volume slider in video's media control.

### DIFF
--- a/LayoutTests/fast/events/touch/ios/slider-touch-drag-quirk-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/slider-touch-drag-quirk-expected.txt
@@ -1,0 +1,17 @@
+Tests that touch-dragging a [role='slider'] element on facebook.com dispatches synthetic mouse events, and that non-slider elements do not receive them (rdar://174179871)
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS mouseDownFired is true
+PASS mouseDownTrusted is true
+PASS mouseMoveCount > 0 is true
+PASS mouseMoveTrusted is true
+PASS mouseUpFired is true
+PASS mouseUpTrusted is true
+PASS nonSliderMouseDownFired is false
+PASS nonSliderMouseMoveFired is false
+PASS nonSliderMouseUpFired is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/touch/ios/slider-touch-drag-quirk.html
+++ b/LayoutTests/fast/events/touch/ios/slider-touch-drag-quirk.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width">
+    <script src="../../../../resources/js-test.js"></script>
+    <script src="../../../../resources/ui-helper.js"></script>
+    <style>
+        #slider {
+            width: 300px;
+            height: 30px;
+            background: #ccc;
+            position: relative;
+        }
+        #non-slider {
+            width: 300px;
+            height: 30px;
+            background: #eee;
+            margin-top: 10px;
+        }
+    </style>
+    <script>
+        jsTestIsAsync = true;
+        let mouseDownFired = false;
+        let mouseDownTrusted = false;
+        let mouseMoveCount = 0;
+        let mouseMoveTrusted = false;
+        let mouseUpFired = false;
+        let mouseUpTrusted = false;
+        let nonSliderMouseDownFired = false;
+        let nonSliderMouseMoveFired = false;
+        let nonSliderMouseUpFired = false;
+
+        window.internals?.setTopDocumentURLForQuirks("https://www.facebook.com");
+
+        addEventListener("load", async () => {
+            description("Tests that touch-dragging a [role='slider'] element on facebook.com dispatches synthetic mouse events, and that non-slider elements do not receive them (rdar://174179871)");
+
+            if (!window.testRunner || !testRunner.runUIScript) {
+                debug("This test requires WebKitTestRunner.");
+                finishJSTest();
+                return;
+            }
+
+            const slider = document.getElementById("slider");
+            const sliderRect = slider.getBoundingClientRect();
+
+            slider.addEventListener("mousedown", (event) => {
+                mouseDownFired = true;
+                mouseDownTrusted = event.isTrusted;
+            });
+            slider.addEventListener("mousemove", (event) => {
+                mouseMoveCount++;
+                mouseMoveTrusted = event.isTrusted;
+            });
+            slider.addEventListener("mouseup", (event) => {
+                mouseUpFired = true;
+                mouseUpTrusted = event.isTrusted;
+            });
+
+            const nonSlider = document.getElementById("non-slider");
+            const nonSliderRect = nonSlider.getBoundingClientRect();
+
+            nonSlider.addEventListener("mousedown", () => {
+                nonSliderMouseDownFired = true;
+            });
+            nonSlider.addEventListener("mousemove", () => {
+                nonSliderMouseMoveFired = true;
+            });
+            nonSlider.addEventListener("mouseup", () => {
+                nonSliderMouseUpFired = true;
+            });
+
+            const startX = sliderRect.left + sliderRect.width * 0.25;
+            const startY = sliderRect.top + sliderRect.height / 2;
+            const endX = sliderRect.left + sliderRect.width * 0.75;
+
+            await UIHelper.dragFromPointToPoint(startX, startY, endX, startY, 0.5);
+
+            shouldBeTrue("mouseDownFired");
+            shouldBeTrue("mouseDownTrusted");
+            shouldBeTrue("mouseMoveCount > 0");
+            shouldBeTrue("mouseMoveTrusted");
+            shouldBeTrue("mouseUpFired");
+            shouldBeTrue("mouseUpTrusted");
+
+            const nsStartX = nonSliderRect.left + nonSliderRect.width * 0.25;
+            const nsStartY = nonSliderRect.top + nonSliderRect.height / 2;
+            const nsEndX = nonSliderRect.left + nonSliderRect.width * 0.75;
+
+            await UIHelper.dragFromPointToPoint(nsStartX, nsStartY, nsEndX, nsStartY, 0.5);
+
+            shouldBeFalse("nonSliderMouseDownFired");
+            shouldBeFalse("nonSliderMouseMoveFired");
+            shouldBeFalse("nonSliderMouseUpFired");
+
+            finishJSTest();
+        });
+    </script>
+</head>
+<body>
+<div id="slider" role="slider" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+<div id="non-slider"></div>
+<div id="description"></div>
+<div id="console"></div>
+</body>
+</html>

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -497,6 +497,9 @@ bool Quirks::shouldDispatchSimulatedMouseEvents(const EventTarget* target) const
             return QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
         if (m_quirksData.isSoundCloud)
             return QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
+        // facebook.com rdar://174179871
+        if (m_quirksData.isFacebook)
+            return QuirksData::ShouldDispatchSimulatedMouseEvents::DependingOnTargetForFacebook;
 
         const URL& topDocumentURL = this->topDocumentURL();
         const auto registrableDomainString = RegistrableDomain(topDocumentURL).string();
@@ -542,6 +545,13 @@ bool Quirks::shouldDispatchSimulatedMouseEvents(const EventTarget* target) const
         return false;
 
     case QuirksData::ShouldDispatchSimulatedMouseEvents::No:
+        return false;
+
+    case QuirksData::ShouldDispatchSimulatedMouseEvents::DependingOnTargetForFacebook:
+        for (RefPtr node = dynamicDowncast<Node>(target); node; node = node->parentNode()) {
+            if (RefPtr element = dynamicDowncast<Element>(*node); element && element->attributeWithoutSynchronization(HTMLNames::roleAttr) == "slider"_s)
+                return true;
+        }
         return false;
 
     case QuirksData::ShouldDispatchSimulatedMouseEvents::DependingOnTargetFor_mybinder_org:

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -295,6 +295,7 @@ struct QuirksData {
     enum class ShouldDispatchSimulatedMouseEvents : uint8_t {
         Unknown,
         No,
+        DependingOnTargetForFacebook,
         DependingOnTargetFor_mybinder_org,
         Yes,
     };


### PR DESCRIPTION
#### 7c622cdabaac4b0533013ce441c2268072fbd3e7
<pre>
Facebook: Unable to drag volume slider in video&apos;s media control.
<a href="https://bugs.webkit.org/show_bug.cgi?id=311586">https://bugs.webkit.org/show_bug.cgi?id=311586</a>
<a href="https://rdar.apple.com/174179871">rdar://174179871</a>

Reviewed by Tim Nguyen and Abrar Rahman Protyasha.

The problem: On iPad Safari, Facebook&apos;s video volume slider
only responds to taps and not drags because it is expecting mousemove events.
While there is a existing Quirk that synthesizes
mouse events from touch, I thought it was too broad to apply
that to every touch event on all of facebook.com. Possible consequences
being double handling in React components that work
fine currently.

The fix: Inject a JS quirk for facebook.com that converts touch
events into mouse events only on [role=&quot;slider&quot;] elements.
The mousedown is deferred to the first touchmove to
avoid interfering with tap interactions. Also applies
touch:action to prevent page scrolling during slider drag.

* LayoutTests/fast/events/touch/ios/slider-touch-drag-quirk-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/slider-touch-drag-quirk.html: Added.
* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/311328@main">https://commits.webkit.org/311328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/638c5279ffc948939b8a0f9072ec4f6e5c6950a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165406 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110664 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158454 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121279 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85208 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23512 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140610 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101946 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22568 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20749 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13177 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132247 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167888 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12009 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20057 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129394 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29520 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129504 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35094 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140234 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87245 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24329 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17036 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29151 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93116 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28677 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28906 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28802 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->