### PR TITLE
Use default constructors and assignment operators more

### DIFF
--- a/Source/JavaScriptCore/bytecode/DeleteByVariant.cpp
+++ b/Source/JavaScriptCore/bytecode/DeleteByVariant.cpp
@@ -45,21 +45,8 @@ DeleteByVariant::DeleteByVariant(CacheableIdentifier identifier, bool result, St
 }
 
 DeleteByVariant::~DeleteByVariant() = default;
-
-DeleteByVariant::DeleteByVariant(const DeleteByVariant& other)
-{
-    *this = other;
-}
-
-DeleteByVariant& DeleteByVariant::operator=(const DeleteByVariant& other)
-{
-    m_identifier = other.m_identifier;
-    m_result = other.m_result;
-    m_oldStructure = other.m_oldStructure;
-    m_newStructure = other.m_newStructure;
-    m_offset = other.m_offset;
-    return *this;
-}
+DeleteByVariant::DeleteByVariant(const DeleteByVariant&) = default;
+DeleteByVariant& DeleteByVariant::operator=(const DeleteByVariant&) = default;
 
 bool DeleteByVariant::attemptToMerge(const DeleteByVariant& other)
 {

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -61,10 +61,7 @@ public:
         ResetStubAndFireWatchpoints // We found out some data that makes us want to start over fresh with this stub. Currently, this happens when we detect poly proto.
     };
 
-
     AccessGenerationResult() = default;
-    AccessGenerationResult(AccessGenerationResult&&) = default;
-    AccessGenerationResult& operator=(AccessGenerationResult&&) = default;
 
     AccessGenerationResult(Kind kind)
         : m_kind(kind)

--- a/Source/JavaScriptCore/bytecode/Operands.h
+++ b/Source/JavaScriptCore/bytecode/Operands.h
@@ -49,7 +49,6 @@ public:
     static_assert(maxBits == 34);
 
     Operand() = default;
-    Operand(const Operand&) = default;
 
     Operand(VirtualRegister operand)
         : Operand(operand.isLocal() ? OperandKind::Local : OperandKind::Argument, operand.offset())
@@ -67,8 +66,6 @@ public:
         ASSERT(kind == OperandKind::Tmp || VirtualRegister(operand).isLocal() == (kind == OperandKind::Local));
     }
     static Operand tmp(uint32_t index) { return Operand(OperandKind::Tmp, index); }
-
-    Operand& operator=(const Operand&) = default;
 
     OperandKind kind() const { return m_kind; }
     int value() const { return m_operand; }

--- a/Source/JavaScriptCore/runtime/CacheableIdentifier.h
+++ b/Source/JavaScriptCore/runtime/CacheableIdentifier.h
@@ -38,6 +38,7 @@ class JSCell;
 class CacheableIdentifier {
 public:
     CacheableIdentifier() = default;
+    constexpr CacheableIdentifier(std::nullptr_t) { }
 
     static inline CacheableIdentifier createFromCell(JSCell* identifier);
     template <typename CodeBlockType>
@@ -47,13 +48,6 @@ public:
     static inline CacheableIdentifier createFromImmortalIdentifier(UniquedStringImpl*);
     static inline CacheableIdentifier createFromSharedStub(UniquedStringImpl*);
     static constexpr CacheableIdentifier createFromRawBits(uintptr_t rawBits) { return CacheableIdentifier(rawBits); }
-
-    CacheableIdentifier(const CacheableIdentifier&) = default;
-    CacheableIdentifier(CacheableIdentifier&&) = default;
-
-    CacheableIdentifier(std::nullptr_t)
-        : m_bits(0)
-    { }
 
     bool isUid() const { return m_bits & s_uidTag; }
     bool isCell() const { return !isUid(); }
@@ -70,9 +64,6 @@ public:
     explicit operator bool() const { return m_bits; }
 
     unsigned hash() const { return uid()->symbolAwareHash(); }
-
-    CacheableIdentifier& operator=(const CacheableIdentifier&) = default;
-    CacheableIdentifier& operator=(CacheableIdentifier&&) = default;
 
     bool operator==(const CacheableIdentifier&) const;
     bool operator==(const Identifier&) const;

--- a/Source/JavaScriptCore/yarr/RegularExpression.cpp
+++ b/Source/JavaScriptCore/yarr/RegularExpression.cpp
@@ -95,18 +95,11 @@ RegularExpression::RegularExpression(StringView pattern, OptionSet<Flags> flags,
 {
 }
 
-RegularExpression::RegularExpression(const RegularExpression& re)
-    : d(re.d)
-{
-}
-
+RegularExpression::RegularExpression(const RegularExpression&) = default;
 RegularExpression::~RegularExpression() = default;
-
-RegularExpression& RegularExpression::operator=(const RegularExpression& re)
-{
-    d = re.d;
-    return *this;
-}
+RegularExpression& RegularExpression::operator=(const RegularExpression&) = default;
+RegularExpression::RegularExpression(RegularExpression&&) = default;
+RegularExpression& RegularExpression::operator=(RegularExpression&&) = default;
 
 int RegularExpression::match(StringView str, unsigned startFrom, int* matchLength) const
 {

--- a/Source/JavaScriptCore/yarr/RegularExpression.h
+++ b/Source/JavaScriptCore/yarr/RegularExpression.h
@@ -45,6 +45,8 @@ public:
 
     RegularExpression(const RegularExpression&);
     RegularExpression& operator=(const RegularExpression&);
+    RegularExpression(RegularExpression&&);
+    RegularExpression& operator=(RegularExpression&&);
 
     int match(StringView, unsigned startFrom = 0, int* matchLength = nullptr) const;
     int searchRev(StringView) const;

--- a/Source/WebCore/Modules/webdatabase/DatabaseDetails.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseDetails.h
@@ -39,33 +39,6 @@ class DatabaseDetails {
 public:
     DatabaseDetails() = default;
 
-    DatabaseDetails(const DatabaseDetails& details)
-        : m_name(details.m_name)
-        , m_displayName(details.m_displayName)
-        , m_expectedUsage(details.m_expectedUsage)
-        , m_currentUsage(details.m_currentUsage)
-        , m_creationTime(details.m_creationTime)
-        , m_modificationTime(details.m_modificationTime)
-#if ASSERT_ENABLED
-        , m_thread(details.m_thread.copyRef())
-#endif
-    {
-    }
-
-    DatabaseDetails& operator=(const DatabaseDetails& details)
-    {
-        m_name = details.m_name;
-        m_displayName = details.m_displayName;
-        m_expectedUsage = details.m_expectedUsage;
-        m_currentUsage = details.m_currentUsage;
-        m_creationTime = details.m_creationTime;
-        m_modificationTime = details.m_modificationTime;
-#if ASSERT_ENABLED
-        m_thread = details.m_thread.copyRef();
-#endif
-        return *this;
-    }
-
     DatabaseDetails(const String& databaseName, const String& displayName, uint64_t expectedUsage, uint64_t currentUsage, std::optional<WallTime> creationTime, std::optional<WallTime> modificationTime)
         : m_name(databaseName)
         , m_displayName(displayName)

--- a/Source/WebCore/contentextensions/MutableRange.h
+++ b/Source/WebCore/contentextensions/MutableRange.h
@@ -33,7 +33,6 @@ namespace ContentExtensions {
 
 template <typename CharacterType, typename DataType>
 class MutableRange {
-    typedef MutableRange<CharacterType, DataType> TypedMutableRange;
 public:
     MutableRange(uint32_t nextRangeIndex, CharacterType first, CharacterType last)
         : nextRangeIndex(nextRangeIndex)
@@ -59,24 +58,6 @@ public:
         , last(last)
     {
         ASSERT(first <= last);
-    }
-
-    MutableRange(MutableRange&& other)
-        : data(WTF::move(other.data))
-        , nextRangeIndex(other.nextRangeIndex)
-        , first(other.first)
-        , last(other.last)
-    {
-        ASSERT(first <= last);
-    }
-
-    TypedMutableRange& operator=(TypedMutableRange&& other)
-    {
-        data = WTF::move(other.data);
-        nextRangeIndex = WTF::move(other.nextRangeIndex);
-        first = WTF::move(other.first);
-        last = WTF::move(other.last);
-        return *this;
     }
 
     DataType data;

--- a/Source/WebCore/css/calc/CSSCalcTree.h
+++ b/Source/WebCore/css/calc/CSSCalcTree.h
@@ -263,9 +263,7 @@ struct Children {
 
     Vector<Child> value;
 
-    Children(Children&&);
     Children(Vector<Child>&&);
-    Children& operator=(Children&&);
     Children& operator=(Vector<Child>&&);
 
     iterator begin() LIFETIME_BOUND;
@@ -1204,20 +1202,9 @@ inline ChildOrNone::ChildOrNone(CSS::Keyword::None none)
 
 // MARK: Children Definition
 
-inline Children::Children(Children&& other)
-    : value(WTF::move(other.value))
-{
-}
-
 inline Children::Children(Vector<Child>&& other)
     : value(WTF::move(other))
 {
-}
-
-inline Children& Children::operator=(Children&& other)
-{
-    value = WTF::move(other.value);
-    return *this;
 }
 
 inline Children& Children::operator=(Vector<Child>&& other)

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumeric.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumeric.h
@@ -88,30 +88,6 @@ template<NumericRaw RawType> struct PrimitiveNumeric {
     {
     }
 
-    // MARK: Copy/Move Construction/Assignment
-
-    PrimitiveNumeric(const PrimitiveNumeric& other)
-        : m_data { other.m_data }
-    {
-    }
-
-    PrimitiveNumeric(PrimitiveNumeric&& other)
-        : m_data { WTF::move(other.m_data) }
-    {
-    }
-
-    PrimitiveNumeric& operator=(const PrimitiveNumeric& other)
-    {
-        m_data = other.m_data;
-        return *this;
-    }
-
-    PrimitiveNumeric& operator=(PrimitiveNumeric&& other)
-    {
-        m_data = WTF::move(other.m_data);
-        return *this;
-    }
-
     // MARK: Equality
 
     bool operator==(const PrimitiveNumeric& other) const

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericOrKeyword.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericOrKeyword.h
@@ -90,30 +90,6 @@ template<Numeric NumericType, PrimitiveKeyword... Ks> struct PrimitiveNumericOrK
     {
     }
 
-    // MARK: Copy/Move Construction/Assignment
-
-    PrimitiveNumericOrKeyword(const PrimitiveNumericOrKeyword& other)
-        : m_data { other.m_data }
-    {
-    }
-
-    PrimitiveNumericOrKeyword(PrimitiveNumericOrKeyword&& other)
-        : m_data { WTF::move(other.m_data) }
-    {
-    }
-
-    PrimitiveNumericOrKeyword& operator=(const PrimitiveNumericOrKeyword& other)
-    {
-        m_data = other.m_data;
-        return *this;
-    }
-
-    PrimitiveNumericOrKeyword& operator=(PrimitiveNumericOrKeyword&& other)
-    {
-        m_data = WTF::move(other.m_data);
-        return *this;
-    }
-
     // MARK: Construction/Assignment from `NumericType`
 
     PrimitiveNumericOrKeyword(const NumericType& other)

--- a/Source/WebCore/dom/SerializedNode.h
+++ b/Source/WebCore/dom/SerializedNode.h
@@ -56,10 +56,6 @@ struct SerializedNode {
 
         QualifiedName(const WebCore::QualifiedName&);
         WEBCORE_EXPORT QualifiedName(String&&, String&&, String&&);
-        QualifiedName(const QualifiedName&) = default;
-        QualifiedName(QualifiedName&&) = default;
-        QualifiedName& operator=(const QualifiedName&) = default;
-        QualifiedName& operator=(QualifiedName&&) = default;
         WebCore::QualifiedName qualifiedName() &&;
     };
     struct Attr {

--- a/Source/WebCore/dom/ViewportArguments.h
+++ b/Source/WebCore/dom/ViewportArguments.h
@@ -93,11 +93,6 @@ struct ViewportArguments {
     {
     }
 
-    ViewportArguments(ViewportArguments&&) = default;
-    ViewportArguments(const ViewportArguments&) = default;
-    ViewportArguments& operator=(ViewportArguments&&) = default;
-    ViewportArguments& operator=(const ViewportArguments&) = default;
-
     ViewportArguments(Type type, float width, float height, float zoom, float minZoom, float maxZoom, float userZoom, float orientation, float shrinkToFit, ViewportFit viewportFit, bool widthWasExplicit, InteractiveWidget interactiveWidget)
         : type(type)
         , width(width)

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h
@@ -39,10 +39,6 @@ public:
         : m_rootInlineBox(rootInlineBox)
     {
     }
-    LineBoxIteratorLegacyPath(LineBoxIteratorLegacyPath&&) = default;
-    LineBoxIteratorLegacyPath(const LineBoxIteratorLegacyPath&) = default;
-    LineBoxIteratorLegacyPath& operator=(const LineBoxIteratorLegacyPath&) = default;
-    LineBoxIteratorLegacyPath& operator=(LineBoxIteratorLegacyPath&&) = default;
 
     float contentLogicalTop() const { return m_rootInlineBox->lineTop().toFloat(); }
     float contentLogicalBottom() const { return m_rootInlineBox->lineBottom().toFloat(); }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
@@ -42,10 +42,6 @@ public:
     {
         ASSERT(lineIndex <= lines().size());
     }
-    LineBoxIteratorModernPath(LineBoxIteratorModernPath&&) = default;
-    LineBoxIteratorModernPath(const LineBoxIteratorModernPath&) = default;
-    LineBoxIteratorModernPath& operator=(const LineBoxIteratorModernPath&) = default;
-    LineBoxIteratorModernPath& operator=(LineBoxIteratorModernPath&&) = default;
 
     float contentLogicalTop() const { return line().enclosingContentLogicalTop(); }
     float contentLogicalBottom() const { return line().enclosingContentLogicalBottom(); }

--- a/Source/WebCore/page/LinkDecorationFilteringData.h
+++ b/Source/WebCore/page/LinkDecorationFilteringData.h
@@ -45,24 +45,6 @@ struct LinkDecorationFilteringData {
         : LinkDecorationFilteringData(RegistrableDomain { URL { WTF::move(domain) } }, WTF::move(path), WTF::move(linkDecoration))
     {
     }
-
-    LinkDecorationFilteringData(const LinkDecorationFilteringData&) = default;
-    LinkDecorationFilteringData& operator=(const LinkDecorationFilteringData&) = default;
-
-    LinkDecorationFilteringData(LinkDecorationFilteringData&& data)
-        : domain(WTF::move(data.domain))
-        , path(WTF::move(data.path))
-        , linkDecoration(WTF::move(data.linkDecoration))
-    {
-    }
-
-    LinkDecorationFilteringData& operator=(LinkDecorationFilteringData&& data)
-    {
-        domain = WTF::move(data.domain);
-        path = WTF::move(data.path);
-        linkDecoration = WTF::move(data.linkDecoration);
-        return *this;
-    }
 };
 
 }

--- a/Source/WebCore/platform/LayoutUnit.h
+++ b/Source/WebCore/platform/LayoutUnit.h
@@ -86,7 +86,7 @@ public:
     }
 
     LayoutUnit& operator=(const LayoutUnit&) = default;
-    LayoutUnit& operator=(const float& other) { return *this = LayoutUnit(other); }
+    LayoutUnit& operator=(float other) { return *this = LayoutUnit(other); }
 
     friend auto operator<=>(LayoutUnit, LayoutUnit) = default;
 

--- a/Source/WebCore/platform/PasteboardCustomData.cpp
+++ b/Source/WebCore/platform/PasteboardCustomData.cpp
@@ -175,12 +175,7 @@ void PasteboardCustomData::clear(const String& type)
     });
 }
 
-PasteboardCustomData& PasteboardCustomData::operator=(const PasteboardCustomData& other)
-{
-    m_origin = other.origin();
-    m_data = other.m_data;
-    return *this;
-}
+PasteboardCustomData& PasteboardCustomData::operator=(const PasteboardCustomData&) = default;
 
 Vector<String> PasteboardCustomData::orderedTypes() const
 {

--- a/Source/WebCore/platform/Site.h
+++ b/Source/WebCore/platform/Site.h
@@ -37,9 +37,6 @@ public:
     WEBCORE_EXPORT explicit Site(String&& protocol, RegistrableDomain&&);
     WEBCORE_EXPORT explicit Site(const SecurityOriginData&);
 
-    Site(const Site&) = default;
-    Site& operator=(const Site&) = default;
-
     WEBCORE_EXPORT const String& protocol() const;
     const RegistrableDomain& domain() const LIFETIME_BOUND { return m_domain; }
     WEBCORE_EXPORT String toString() const;

--- a/Source/WebCore/platform/graphics/ImageFrame.cpp
+++ b/Source/WebCore/platform/graphics/ImageFrame.cpp
@@ -52,25 +52,8 @@ const ImageFrame& ImageFrame::defaultFrame()
     return sharedInstance;
 }
 
-ImageFrame& ImageFrame::operator=(const ImageFrame& other)
-{
-    if (this == &other)
-        return *this;
-
-    m_decodingStatus = other.m_decodingStatus;
-
-    m_size = other.m_size;
-    m_densityCorrectedSize = other.m_densityCorrectedSize;
-    m_subsamplingLevel = other.m_subsamplingLevel;
-
-    m_orientation = other.m_orientation;
-    m_duration = other.m_duration;
-    m_hasAlpha = other.m_hasAlpha;
-
-    m_source = other.m_source;
-    m_hdrSource = other.m_hdrSource;
-    return *this;
-}
+ImageFrame::ImageFrame(const ImageFrame&) = default;
+ImageFrame& ImageFrame::operator=(const ImageFrame&) = default;
 
 void ImageFrame::setDecodingStatus(DecodingStatus decodingStatus)
 {

--- a/Source/WebCore/platform/graphics/ImageFrame.h
+++ b/Source/WebCore/platform/graphics/ImageFrame.h
@@ -44,13 +44,13 @@ public:
 
     ImageFrame();
     ImageFrame(Ref<NativeImage>&&);
-    ImageFrame(const ImageFrame& other) { operator=(other); }
+    ImageFrame(const ImageFrame&);
 
     ~ImageFrame();
 
     static const ImageFrame& NODELETE defaultFrame();
 
-    ImageFrame& operator=(const ImageFrame& other);
+    ImageFrame& operator=(const ImageFrame&);
 
     unsigned clearSourceImage(ShouldDecodeToHDR);
     unsigned clearImage(std::optional<ShouldDecodeToHDR> = std::nullopt);

--- a/Source/WebCore/platform/graphics/Path.h
+++ b/Source/WebCore/platform/graphics/Path.h
@@ -51,11 +51,6 @@ public:
     explicit Path(const Vector<FloatPoint>& points);
     WEBCORE_EXPORT Path(Ref<PathImpl>&&);
 
-    Path(const Path&) = default;
-    Path(Path&&) = default;
-    Path& operator=(const Path&) = default;
-    Path& operator=(Path&&) = default;
-
     WEBCORE_EXPORT bool definitelyEqual(const Path&) const;
 
     void moveTo(const FloatPoint&);

--- a/Source/WebCore/platform/graphics/Region.cpp
+++ b/Source/WebCore/platform/graphics/Region.cpp
@@ -57,11 +57,7 @@ Region::Region(const Region& other)
 {
 }
 
-Region::Region(Region&& other)
-    : m_bounds(WTF::move(other.m_bounds))
-    , m_shape(WTF::move(other.m_shape))
-{
-}
+Region::Region(Region&&) = default;
 
 Region::~Region() = default;
 
@@ -72,12 +68,7 @@ Region& Region::operator=(const Region& other)
     return *this;
 }
 
-Region& Region::operator=(Region&& other)
-{
-    m_bounds = WTF::move(other.m_bounds);
-    m_shape = WTF::move(other.m_shape);
-    return *this;
-}
+Region& Region::operator=(Region&&) = default;
 
 Vector<IntRect, 1> Region::rects() const
 {

--- a/Source/WebCore/platform/graphics/cg/ShareableSpatialImage.h
+++ b/Source/WebCore/platform/graphics/cg/ShareableSpatialImage.h
@@ -37,11 +37,7 @@ namespace WebCore {
 
 class ShareableSpatialImage {
 public:
-    ShareableSpatialImage(ShareableSpatialImage&&) = default;
-    ShareableSpatialImage(const ShareableSpatialImage&) = default;
     WEBCORE_EXPORT ShareableSpatialImage(ShareableBitmap::Handle&&, ShareableBitmap::Handle&&, const SpatialImageEyeProperties&, const SpatialImageEyeProperties&);
-
-    ShareableSpatialImage& operator=(ShareableSpatialImage&&) = default;
 
     WEBCORE_EXPORT static std::optional<ShareableSpatialImage> create(BitmapImage&);
 

--- a/Source/WebCore/platform/graphics/iso/ISOVTTCue.h
+++ b/Source/WebCore/platform/graphics/iso/ISOVTTCue.h
@@ -48,9 +48,6 @@ public:
     WEBCORE_EXPORT ISOWebVTTCue(ISOWebVTTCue&&);
     WEBCORE_EXPORT ~ISOWebVTTCue();
 
-    ISOWebVTTCue& operator=(const ISOWebVTTCue&) = default;
-    ISOWebVTTCue& operator=(ISOWebVTTCue&&) = default;
-
     static FourCC boxTypeName() { return std::span { "vttc" }; }
 
     const MediaTime& presentationTime() const LIFETIME_BOUND { return m_presentationTime; }

--- a/Source/WebCore/rendering/HitTestLocation.cpp
+++ b/Source/WebCore/rendering/HitTestLocation.cpp
@@ -64,29 +64,11 @@ HitTestLocation::HitTestLocation(const HitTestLocation& other, const LayoutSize&
     move(offset);
 }
 
-HitTestLocation::HitTestLocation(const HitTestLocation& other)
-    : m_point(other.m_point)
-    , m_boundingBox(other.m_boundingBox)
-    , m_transformedPoint(other.m_transformedPoint)
-    , m_transformedRect(other.m_transformedRect)
-    , m_isRectBased(other.m_isRectBased)
-    , m_isRectilinear(other.m_isRectilinear)
-{
-}
+HitTestLocation::HitTestLocation(const HitTestLocation&) = default;
 
 HitTestLocation::~HitTestLocation() = default;
 
-HitTestLocation& HitTestLocation::operator=(const HitTestLocation& other)
-{
-    m_point = other.m_point;
-    m_boundingBox = other.m_boundingBox;
-    m_transformedPoint = other.m_transformedPoint;
-    m_transformedRect = other.m_transformedRect;
-    m_isRectBased = other.m_isRectBased;
-    m_isRectilinear = other.m_isRectilinear;
-
-    return *this;
-}
+HitTestLocation& HitTestLocation::operator=(const HitTestLocation&) = default;
 
 void HitTestLocation::move(const LayoutSize& offset)
 {

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -208,7 +208,7 @@ public:
     {
         m_element = nullptr;
         m_pseudoElementIdentifier = Style::PseudoElementIdentifier();
-        m_pseudoElementIdentifier->nameOrPart = name;
+        m_pseudoElementIdentifier->nameOrPart = WTF::move(name);
     }
 
     explicit operator bool() const { return !!m_element; }

--- a/Source/WebCore/style/calc/StyleCalculationTree.h
+++ b/Source/WebCore/style/calc/StyleCalculationTree.h
@@ -197,9 +197,9 @@ struct Children {
 
     Vector<Child> value;
 
-    Children(Children&&);
+    Children(Children&&) = default;
     Children(Vector<Child>&&);
-    Children& operator=(Children&&);
+    Children& operator=(Children&&) = default;
     Children& operator=(Vector<Child>&&);
 
     iterator begin() LIFETIME_BOUND;
@@ -821,20 +821,9 @@ inline ChildOrNone::ChildOrNone(CSS::Keyword::None none)
 
 // MARK: Children Definition
 
-inline Children::Children(Children&& other)
-    : value(WTF::move(other.value))
-{
-}
-
 inline Children::Children(Vector<Child>&& other)
     : value(WTF::move(other))
 {
-}
-
-inline Children& Children::operator=(Children&& other)
-{
-    value = WTF::move(other.value);
-    return *this;
 }
 
 inline Children& Children::operator=(Vector<Child>&& other)


### PR DESCRIPTION
#### 2b9732f54c5ebdee73f07ff84eb0d3cc618733f9
<pre>
Use default constructors and assignment operators more
<a href="https://bugs.webkit.org/show_bug.cgi?id=311607">https://bugs.webkit.org/show_bug.cgi?id=311607</a>
<a href="https://rdar.apple.com/174203280">rdar://174203280</a>

Reviewed by Chris Dumez.

* Source/JavaScriptCore/bytecode/DeleteByVariant.cpp: Use default
for copy constructor and assignment operator.

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.h: Removed
explicit default move constructor and assignment operator since
they will be generated if we don&apos;t declare them.

* Source/JavaScriptCore/bytecode/Operands.h: Removed explicit
default copy constructor and assignment operator since they
will be generated if we don&apos;t declare them.

* Source/JavaScriptCore/runtime/CacheableIdentifier.h: Simplified
the std::nullptr_t constructor. Removed explicit default copy and
move constructors and assignment operators since they will be
generated if we don&apos;t declare them.

* Source/JavaScriptCore/yarr/RegularExpression.cpp: Use default
for the copy and move constructors and assignment operators.

* Source/JavaScriptCore/yarr/RegularExpression.h: Added declaration
of move constructor and assignment operator so we can avoid
reference count churn.

* Source/WebCore/Modules/webdatabase/DatabaseDetails.h: Removed
copy constructor and assigment operator since they will be
generated if we don&apos;t declare them.

* Source/WebCore/contentextensions/MutableRange.h: Removed unused
TypedMutableRange typedef. Removed move constructor and assignment
operator since they will be generated if we don&apos;t declare them.

* Source/WebCore/css/calc/CSSCalcTree.h: Removed move constructor
and assignment operator since they will be generated if we don&apos;t
declare them.

* Source/WebCore/css/values/primitives/CSSPrimitiveNumeric.h:
Removed copy and move constructors and assignment operators since
they will be generated if we don&apos;t declare them.

* Source/WebCore/css/values/primitives/CSSPrimitiveNumericOrKeyword.h:
Removed copy and move constructors and assignment operators since
they will be generated if we don&apos;t declare them.

* Source/WebCore/dom/SerializedNode.h: Removed explicit default copy and
move constructors and assignment operators since they will be generated if
we don&apos;t declare them.

* Source/WebCore/dom/ViewportArguments.h: Removed explicit default copy
and move constructors and assignment operators since they will be generated
if we don&apos;t declare them.

* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h:
Removed explicit default copy and move constructors and assignment
operators since they will be generated if we don&apos;t declare them.

* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h:
Removed explicit default copy and move constructors and assignment
operators since they will be generated if we don&apos;t declare them.

* Source/WebCore/page/LinkDecorationFilteringData.h:
Removed explicit default copy constructor and assignment operator and
move constructor and assignment operator since they will be generated
if we don&apos;t declare them.

* Source/WebCore/platform/LayoutUnit.h: Removed unusual and unnecessary
const float&amp; argument type.

* Source/WebCore/platform/PasteboardCustomData.cpp: Use default for copy
constructor.

* Source/WebCore/platform/Site.h: Removed explicit default copy constructor
and assignment operator since they will be generated if we don&apos;t declare them.

* Source/WebCore/platform/graphics/ImageFrame.cpp: Use default for copy
constructor and assignment operator.

* Source/WebCore/platform/graphics/ImageFrame.h: Removed inline definition of
copy constructor.

* Source/WebCore/platform/graphics/Path.h: Removed copy and move constructors
and assignment operators since they will be generated if we don&apos;t declare them.

* Source/WebCore/platform/graphics/Region.cpp: Use default for move
constructor and assignment operator.

* Source/WebCore/platform/graphics/cg/ShareableSpatialImage.h: Removed explicit
default copy and move constructors and assignment operators since they will be
generated if we don&apos;t declare them.

* Source/WebCore/platform/graphics/iso/ISOVTTCue.h: Removed explicit
default copy and move assignment operators since they will be generated if we
don&apos;t declare them.

* Source/WebCore/rendering/HitTestLocation.cpp: Use default copy constructor
and assignment operator.

* Source/WebCore/style/Styleable.h: Use WTF::move.

* Source/WebCore/style/calc/StyleCalculationTree.h: Use default for move
constructor and assignment operator.

Canonical link: <a href="https://commits.webkit.org/310840@main">https://commits.webkit.org/310840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/444145c31a97e077dd540876c904338ba82137a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163884 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156997 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28232 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120026 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22271 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139300 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100719 "Passed tests") | | ⏳ 🛠 vision-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/154444 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21356 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19409 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11710 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147174 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131018 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17142 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166362 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15955 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18751 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128130 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27928 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23447 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128268 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34798 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27852 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138935 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84561 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23128 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15730 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186911 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27545 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91648 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47895 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27123 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27353 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27196 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->