### PR TITLE
Avoid some String allocations in WebKit by leveraging StringView more

### DIFF
--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -152,8 +152,7 @@ public:
     StringView left(unsigned length) const { return substring(0, length); }
     StringView right(unsigned length) const { return substring(this->length() - length, length); }
 
-    template<typename MatchedCharacterPredicate>
-    StringView trim(const MatchedCharacterPredicate&) const;
+    StringView trim(CodeUnitMatchFunction) const;
 
     class SplitResult;
     SplitResult split(char16_t) const;
@@ -1249,8 +1248,7 @@ inline StringView StringView::trim(std::span<const CharacterType> characters, co
     return result;
 }
 
-template<typename MatchedCharacterPredicate>
-StringView StringView::trim(const MatchedCharacterPredicate& predicate) const
+inline StringView StringView::trim(CodeUnitMatchFunction predicate) const
 {
     if (is8Bit())
         return trim<Latin1Character>(span8(), predicate);

--- a/Source/WebCore/Modules/fetch/IPAddressSpace.cpp
+++ b/Source/WebCore/Modules/fetch/IPAddressSpace.cpp
@@ -64,12 +64,13 @@ IPAddressSpace determineIPAddressSpace(const URL& url)
             host = host.substring(7);
             if (!host.contains('.')) {
                 // Parse hex representation like "c0a8:101" -> "192.168.1.1"
-                Vector<String> halves = host.split(':');
-                if (halves.size() != 2)
+                StringView hostView { host };
+                auto colonPosition = hostView.find(':');
+                if (colonPosition == notFound || hostView.find(':', colonPosition + 1) != notFound)
                     return IPAddressSpace::Public;
 
-                auto value1 = parseInteger<uint16_t>(halves[0], 16);
-                auto value2 = parseInteger<uint16_t>(halves[1], 16);
+                auto value1 = parseInteger<uint16_t>(hostView.left(colonPosition), 16);
+                auto value2 = parseInteger<uint16_t>(hostView.substring(colonPosition + 1), 16);
 
                 if (!value1.has_value() || !value2.has_value())
                     return IPAddressSpace::Public;
@@ -88,17 +89,18 @@ IPAddressSpace determineIPAddressSpace(const URL& url)
         }
     }
     if (host.contains('.')) {
-        Vector<String> octets = host.split('.');
-        if (octets.size() != 4)
-            return IPAddressSpace::Public;
-
         std::array<uint8_t, 4> parts;
-        for (size_t i = 0; i < 4; i++) {
-            auto value = parseInteger<uint8_t>(octets[i]);
+        size_t i = 0;
+        for (auto octet : StringView(host).split('.')) {
+            if (i >= 4)
+                return IPAddressSpace::Public;
+            auto value = parseInteger<uint8_t>(octet);
             if (!value)
                 return IPAddressSpace::Public;
-            parts[i] = *value;
+            parts[i++] = *value;
         }
+        if (i != 4)
+            return IPAddressSpace::Public;
 
         // Check IPv4 address blocks according to spec table:
 

--- a/Source/WebCore/accessibility/AXUtilities.cpp
+++ b/Source/WebCore/accessibility/AXUtilities.cpp
@@ -137,11 +137,8 @@ bool hasAccNameAttribute(Element& element)
 
     // For title, check that it's not whitespace-only.
     const auto& titleValue = element.attributeWithoutSynchronization(titleAttr);
-    if (!titleValue.isEmpty()) {
-        auto titleCopy = titleValue.string();
-        if (!titleCopy.trim(isASCIIWhitespace).isEmpty())
-            return true;
-    }
+    if (!titleValue.string().containsOnly<isASCIIWhitespace>())
+        return true;
 
     return false;
 }

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -178,7 +178,7 @@ std::optional<ScriptType> ScriptElement::determineScriptType(const String& type,
         return ScriptType::Classic; // Assume text/javascript.
 
     // Step 9. If the script block's type string is a JavaScript MIME type essence match, then set el's type to "classic".
-    if (MIMETypeRegistry::isSupportedJavaScriptMIMEType(type.trim(isASCIIWhitespace)))
+    if (MIMETypeRegistry::isSupportedJavaScriptMIMEType(StringView(type).trim(isASCIIWhitespace)))
         return ScriptType::Classic;
 
     // FIXME: XHTML spec defines "defer" attribute. But WebKit does not implement it for a long time.

--- a/Source/WebCore/dom/TextDecoder.cpp
+++ b/Source/WebCore/dom/TextDecoder.cpp
@@ -42,7 +42,7 @@ TextDecoder::~TextDecoder() = default;
 
 ExceptionOr<Ref<TextDecoder>> TextDecoder::create(const String& label, Options options)
 {
-    auto trimmedLabel = label.trim(isASCIIWhitespace);
+    auto trimmedLabel = StringView(label).trim(isASCIIWhitespace);
     const char16_t nullCharacter = '\0';
     if (trimmedLabel.contains(nullCharacter))
         return Exception { ExceptionCode::RangeError };

--- a/Source/WebCore/html/EmailInputType.cpp
+++ b/Source/WebCore/html/EmailInputType.cpp
@@ -117,12 +117,13 @@ ValueOrReference<String> EmailInputType::sanitizeValue(const String& proposedVal
     ASSERT(element());
     if (!protect(element())->multiple())
         return noLineBreakValue.trim(isASCIIWhitespace);
-    Vector<String> addresses = noLineBreakValue.splitAllowingEmptyEntries(',');
     StringBuilder strippedValue;
-    for (unsigned i = 0; i < addresses.size(); ++i) {
-        if (i > 0)
+    bool first = true;
+    for (auto address : StringView(noLineBreakValue).splitAllowingEmptyEntries(',')) {
+        if (!first)
             strippedValue.append(',');
-        strippedValue.append(addresses[i].trim(isASCIIWhitespace));
+        first = false;
+        strippedValue.append(address.trim(isASCIIWhitespace));
     }
     return String { strippedValue.toString() };
 }

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -551,7 +551,7 @@ void HTMLAnchorElement::handleClick(Event& event)
         return;
 
     StringBuilder url;
-    url.append(attributeWithoutSynchronization(hrefAttr).string().trim(isASCIIWhitespace));
+    url.append(StringView(attributeWithoutSynchronization(hrefAttr).string()).trim(isASCIIWhitespace));
     appendServerMapMousePosition(url, event);
     URL completedURL = document->completeURL(url.toString());
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -824,8 +824,8 @@ static AtomString extractContentLanguageFromHeader(const String& header)
 {
     auto commaIndex = header.find(',');
     if (commaIndex == notFound)
-        return AtomString { header.trim(isASCIIWhitespace) };
-    return StringView(header).left(commaIndex).trim(isASCIIWhitespace<char16_t>).toAtomString();
+        return StringView(header).trim(isASCIIWhitespace).toAtomString();
+    return StringView(header).left(commaIndex).trim(isASCIIWhitespace).toAtomString();
 }
 
 void FrameLoader::didBeginDocument(bool dispatch, LocalDOMWindow* previousWindow)

--- a/Source/WebCore/page/CaptionUserPreferences.cpp
+++ b/Source/WebCore/page/CaptionUserPreferences.cpp
@@ -223,7 +223,7 @@ static String trackDisplayName(const TextTrack& track)
     if (&track == &TextTrack::captionMenuAutomaticItemSingleton())
         return textTrackAutomaticMenuItemText();
 
-    if (auto label = track.label().string().trim(isASCIIWhitespace); !label.isEmpty())
+    if (!track.label().string().containsOnly<isASCIIWhitespace>())
         return track.label();
     if (auto languageIdentifier = track.validBCP47Language(); !languageIdentifier.isEmpty())
         return languageIdentifier;
@@ -294,7 +294,7 @@ Vector<Ref<TextTrack>> CaptionUserPreferences::sortedTrackListForMenu(TextTrackL
 
 static String trackDisplayName(const AudioTrack& track)
 {
-    if (auto label = track.label().string().trim(isASCIIWhitespace); !label.isEmpty())
+    if (!track.label().string().containsOnly<isASCIIWhitespace>())
         return track.label();
     if (auto languageIdentifier = track.validBCP47Language(); !languageIdentifier.isEmpty())
         return languageIdentifier;

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -619,12 +619,12 @@ static String searchableTextForTarget(Element& target)
     size_t longestLength = 0;
     TextIterator iterator { makeRangeSelectingNodeContents(target), { TextIteratorBehavior::EmitsTextsWithoutTranscoding } };
     for (; !iterator.atEnd(); iterator.advance()) {
-        auto text = iterator.copyableText().text().toString().trim(isASCIIWhitespace);
+        auto text = iterator.copyableText().text().trim(isASCIIWhitespace);
         if (text.length() <= longestLength)
             continue;
 
         longestLength = text.length();
-        longestText = WTF::move(text);
+        longestText = text.toString();
     }
 
     auto documentElements = collectDocumentElementsFromChildFrames(target);

--- a/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -518,7 +518,7 @@ bool MIMETypeRegistry::isSupportedImageMIMETypeForEncoding(const String& mimeTyp
     return threadGlobalDataSingleton().mimeTypeRegistryThreadGlobalData().supportedImageMIMETypesForEncoding().contains(mimeType);
 }
 
-bool MIMETypeRegistry::isSupportedJavaScriptMIMEType(const String& mimeType)
+bool MIMETypeRegistry::isSupportedJavaScriptMIMEType(StringView mimeType)
 {
     return supportedJavaScriptMIMETypes.contains(mimeType);
 }

--- a/Source/WebCore/platform/MIMETypeRegistry.h
+++ b/Source/WebCore/platform/MIMETypeRegistry.h
@@ -74,7 +74,7 @@ public:
     WEBCORE_EXPORT static bool isSupportedImageMIMETypeForEncoding(const String& mimeType);
 
     // Check to see if a MIME type is suitable for being loaded as a JavaScript or JSON resource.
-    WEBCORE_EXPORT static bool isSupportedJavaScriptMIMEType(const String& mimeType);
+    WEBCORE_EXPORT static bool isSupportedJavaScriptMIMEType(StringView mimeType);
     WEBCORE_EXPORT static bool isSupportedJSONMIMEType(const String& mimeType);
 
     // Check to see if a MIME type is suitable for being loaded as a WebAssembly module.

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
@@ -371,7 +371,7 @@ static gboolean wpeDisplayDRMSetup(WPEDisplayDRM* displayDRM, const char* device
     std::optional<double> scaleFromEnvironment;
     if (const auto scaleString = StringView::fromLatin1(getenv("WPE_DRM_SCALE"))) {
         RELEASE_ASSERT(scaleString.is8Bit());
-        auto trimmedScaleString = scaleString.trim(isASCIIWhitespace<Latin1Character>);
+        auto trimmedScaleString = scaleString.trim(isASCIIWhitespace);
         size_t parsedLength = 0;
         auto scale = parseDouble(trimmedScaleString, parsedLength);
         if (parsedLength == trimmedScaleString.length() && scaleIsInBounds(scale))


### PR DESCRIPTION
#### 133ad0e516b642c1220e3bcd6e9cbb967a54a392
<pre>
Avoid some String allocations in WebKit by leveraging StringView more
<a href="https://bugs.webkit.org/show_bug.cgi?id=311608">https://bugs.webkit.org/show_bug.cgi?id=311608</a>

Reviewed by Anne van Kesteren.

* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::trim const):
* Source/WebCore/Modules/fetch/IPAddressSpace.cpp:
(WebCore::determineIPAddressSpace):
* Source/WebCore/accessibility/AXUtilities.cpp:
(WebCore::hasAccNameAttribute):
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::determineScriptType):
* Source/WebCore/dom/TextDecoder.cpp:
(WebCore::TextDecoder::create):
* Source/WebCore/html/EmailInputType.cpp:
(WebCore::EmailInputType::sanitizeValue const):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::handleClick):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::extractContentLanguageFromHeader):
* Source/WebCore/page/CaptionUserPreferences.cpp:
(WebCore::trackDisplayName):
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::searchableTextForTarget):
* Source/WebCore/platform/MIMETypeRegistry.cpp:
(WebCore::MIMETypeRegistry::isSupportedJavaScriptMIMEType):
* Source/WebCore/platform/MIMETypeRegistry.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp:
(wpeDisplayDRMSetup):

Canonical link: <a href="https://commits.webkit.org/310703@main">https://commits.webkit.org/310703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a80ec3ba0d0775f5243eb24c7e99d619887b82d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163411 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108121 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f1864e4f-5816-4f03-9566-1846a428427a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119632 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/84596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f0ab34ef-b010-4702-a686-98e31e7acb5d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157611 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21919 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138902 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100326 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1f2ff43b-538f-4c5d-96cd-fdc7b5b13737) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21004 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19022 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11238 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146702 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130667 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165885 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15483 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9096 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18355 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127733 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/154052 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23062 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127872 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34698 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27380 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138539 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84062 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22776 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15333 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186386 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27072 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91174 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47782 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26650 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26881 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26723 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->