### PR TITLE
AX: Add helper to AXTextMarkerRange to get the text-run form of the start and end markers, allowing for code de-duplication

### DIFF
--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -569,12 +569,10 @@ String AXTextMarkerRange::toString(IncludeListMarkerText includeListMarkerText, 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     if (!isMainThread()) {
         // Traverses from m_start to m_end, collecting all text along the way.
-        auto start = m_start.toTextRunMarker();
-        if (!start.isValid())
+        auto markers = toValidTextRunMarkers();
+        if (!markers)
             return emptyString();
-        auto end = m_end.toTextRunMarker();
-        if (!end.isValid())
-            return emptyString();
+        auto& [start, end] = *markers;
 
         StringBuilder result;
         if (includeListMarkerText == IncludeListMarkerText::Yes)
@@ -1019,16 +1017,25 @@ static FloatRect viewportRelativeFrameFromRuns(Ref<AXIsolatedObject> object, uns
     return viewportRelativeFrameFromRuns(object, offset, runs->totalLength());
 }
 
+std::optional<std::pair<AXTextMarker, AXTextMarker>> AXTextMarkerRange::toValidTextRunMarkers() const
+{
+    auto start = m_start.toTextRunMarker();
+    if (!start.isValid())
+        return std::nullopt;
+    auto end = m_end.toTextRunMarker();
+    if (!end.isValid())
+        return std::nullopt;
+    return { { WTF::move(start), WTF::move(end) } };
+}
+
 FloatRect AXTextMarkerRange::viewportRelativeFrame() const
 {
     AX_ASSERT(!isMainThread());
 
-    auto start = m_start.toTextRunMarker();
-    if (!start.isValid())
+    auto markers = toValidTextRunMarkers();
+    if (!markers)
         return { };
-    auto end = m_end.toTextRunMarker();
-    if (!end.isValid())
-        return { };
+    auto& [start, end] = *markers;
 
     if (*start.objectID() == *end.objectID()) {
         // The range is self-contained.

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -421,6 +421,7 @@ public:
     String toString(IncludeListMarkerText = IncludeListMarkerText::Yes, IncludeImageAltText = IncludeImageAltText::No) const;
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    std::optional<std::pair<AXTextMarker, AXTextMarker>> toValidTextRunMarkers() const;
     // Returns the bounds (frame) of the text in this range relative to the viewport.
     // Analagous to AXCoreObject::relativeFrame().
     FloatRect viewportRelativeFrame() const;

--- a/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
@@ -79,12 +79,10 @@ RetainPtr<NSAttributedString> AXTextMarkerRange::toAttributedString(AXCoreObject
 {
     AX_ASSERT(!isMainThread());
 
-    auto start = m_start.toTextRunMarker();
-    if (!start.isValid())
+    auto markers = toValidTextRunMarkers();
+    if (!markers)
         return nil;
-    auto end = m_end.toTextRunMarker();
-    if (!end.isValid())
-        return nil;
+    auto& [start, end] = *markers;
 
     String listMarkerText = listMarkerTextOnSameLine(start);
 


### PR DESCRIPTION
#### 3bad0b8aef8c2bd017702f73c807d846a62a1dff
<pre>
AX: Add helper to AXTextMarkerRange to get the text-run form of the start and end markers, allowing for code de-duplication
<a href="https://bugs.webkit.org/show_bug.cgi?id=311610">https://bugs.webkit.org/show_bug.cgi?id=311610</a>
<a href="https://rdar.apple.com/174209754">rdar://174209754</a>

Reviewed by Joshua Hoffman.

* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarkerRange::toString const):
(WebCore::AXTextMarkerRange::toValidTextRunMarkers const):
(WebCore::AXTextMarkerRange::viewportRelativeFrame const):
* Source/WebCore/accessibility/AXTextMarker.h:
* Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm:
(WebCore::AXTextMarkerRange::toAttributedString const):

Canonical link: <a href="https://commits.webkit.org/310707@main">https://commits.webkit.org/310707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10658f931b266c1e59e194ae5303f095b283b0a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27864 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21024 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163364 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108075 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/234d1324-4c06-4f0f-827b-a09f4c1d6f25) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156479 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27714 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119585 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84576 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/001d5745-f898-4dfa-8cf5-3b0a741fa584) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157565 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21873 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138854 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100282 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/432a5bb7-9bd2-4f6d-bfc9-e8ff0c456b9a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20958 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18973 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11192 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130621 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16698 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165836 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9041 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18307 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127686 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27410 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127829 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34701 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138491 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84016 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22726 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15284 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27026 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91128 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26604 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26835 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26677 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->