### PR TITLE
[YARR] `quantifyAtom` should handle `nullopt` from `copyTerm` on stack exhaustion

### DIFF
--- a/JSTests/stress/regexp-quantify-atom-copy-term-out-of-stack.js
+++ b/JSTests/stress/regexp-quantify-atom-copy-term-out-of-stack.js
@@ -1,0 +1,19 @@
+//@ requireOptions("-e", "let depth=25000") if $memoryLimited
+
+depth = typeof(depth) === 'undefined' ? 50000 : depth;
+
+let expectedException = "SyntaxError: Invalid regular expression: regular expression too large";
+
+function test(source)
+{
+    try {
+        new RegExp(source);
+    } catch (e) {
+        if (e != expectedException)
+            throw "Expected \"" + expectedException + "\", but got \"" + e + "\" for: " + source.slice(0, 30) + "...";
+    }
+}
+
+test("(?:".repeat(depth) + "a" + ")".repeat(depth) + "{1,2}");
+
+test("(?<=" + "(?:".repeat(depth) + "a" + ")".repeat(depth) + "{1,2}" + ")");

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1731,7 +1731,10 @@ public:
         else {
             if (term.matchDirection() == Forward) {
                 term.quantify(min, min, QuantifierType::FixedCount);
-                m_alternative->m_terms.append(*copyTerm(term, /* filterStartsWithBOL */ false));
+                auto copied = copyTerm(term, /* filterStartsWithBOL */ false);
+                if (!copied) [[unlikely]]
+                    return;
+                m_alternative->m_terms.append(WTF::move(*copied));
                 // NOTE: this term is interesting from an analysis perspective, in that it can be ignored.....
                 m_alternative->lastTerm().quantify((max == quantifyInfinite) ? max : max - min, greedy ? QuantifierType::Greedy : QuantifierType::NonGreedy);
                 if (m_alternative->lastTerm().type == PatternTerm::Type::ParenthesesSubpattern)
@@ -1740,7 +1743,10 @@ public:
                 term.quantify((max == quantifyInfinite) ? max : max - min, greedy ? QuantifierType::Greedy : QuantifierType::NonGreedy);
                 if (term.type == PatternTerm::Type::ParenthesesSubpattern)
                     term.parentheses.isCopy = true;
-                m_alternative->m_terms.append(*copyTerm(term, /* filterStartsWithBOL */ false));
+                auto copied = copyTerm(term, /* filterStartsWithBOL */ false);
+                if (!copied) [[unlikely]]
+                    return;
+                m_alternative->m_terms.append(WTF::move(*copied));
                 m_alternative->lastTerm().quantify(min, min, QuantifierType::FixedCount);
                 if (m_alternative->lastTerm().type == PatternTerm::Type::ParenthesesSubpattern)
                     m_alternative->lastTerm().parentheses.isCopy = false;


### PR DESCRIPTION
#### f30b516527da60431a24666782722d4d8a781298
<pre>
[YARR] `quantifyAtom` should handle `nullopt` from `copyTerm` on stack exhaustion
<a href="https://bugs.webkit.org/show_bug.cgi?id=311612">https://bugs.webkit.org/show_bug.cgi?id=311612</a>

Reviewed by Yusuke Suzuki.

288897@main made copyTerm() return std::optional&lt;PatternTerm&gt; and updated
copyDisjunction() to check it, but the two callers in quantifyAtom() were
left dereferencing the result unconditionally. The assumption was that
filterStartsWithBOL=false makes copyTerm() infallible, but copyDisjunction()
also returns nullptr when isSafeToRecurse() fails while recursing through
deeply nested parentheses, which propagates as nullopt and triggers a
libc++ hardening trap (SIGTRAP) even in Release builds.

    new RegExp(&quot;(?:&quot;.repeat(50000) + &quot;a&quot; + &quot;)&quot;.repeat(50000) + &quot;{1,2}&quot;)

Fix by checking the optional and returning early; m_error is already set to
PatternTooLarge by copyDisjunction(), so YarrPattern::compile() reports the
error normally.

Test: JSTests/stress/regexp-quantify-atom-copy-term-out-of-stack.js

* JSTests/stress/regexp-quantify-atom-copy-term-out-of-stack.js: Added.
(test):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::quantifyAtom):

Canonical link: <a href="https://commits.webkit.org/310888@main">https://commits.webkit.org/310888@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/471b58476f744ee0f25b3e04b36cd90541a0f052

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21057 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163398 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108108 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27747 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119617 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84589 "3 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157598 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21907 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138884 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100311 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20992 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19006 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11225 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146689 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130655 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16728 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165872 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15470 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9077 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18337 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127717 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27443 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127857 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34828 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27367 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138521 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84049 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22752 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15315 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186373 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27059 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91161 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47779 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26637 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26868 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26710 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->