### PR TITLE
Add nullptr checks for m_objectStore.get() in WebCore::IDBServer::MemoryIndex

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp
@@ -123,8 +123,14 @@ IDBGetResult MemoryIndex::getResultForKeyRange(IndexedDB::IndexRecordType type, 
     if (!keyValue)
         return { };
 
+    if (type == IndexedDB::IndexRecordType::Key)
+        return IDBGetResult(*keyValue);
+
     RefPtr objectStore = m_objectStore.get();
-    return type == IndexedDB::IndexRecordType::Key ? IDBGetResult(*keyValue) : IDBGetResult(*keyValue, objectStore->valueForKeyRange(*keyValue), objectStore->info().keyPath());
+    if (!objectStore)
+        return { };
+
+    return IDBGetResult(*keyValue, objectStore->valueForKeyRange(*keyValue), objectStore->info().keyPath());
 }
 
 uint64_t MemoryIndex::countForKeyRange(const IDBKeyRangeData& inRange)
@@ -156,6 +162,11 @@ void MemoryIndex::getAllRecords(const IDBKeyRangeData& keyRangeData, std::option
     LOG(IndexedDB, "MemoryIndex::getAllRecords");
 
     RefPtr objectStore = m_objectStore.get();
+    if (!objectStore) {
+        result = { };
+        return;
+    }
+
     result = { type, objectStore->info().keyPath() };
 
     CheckedPtr records = m_records.get();


### PR DESCRIPTION
#### 51448cf8aa9525ff45b74e8d8e450351e8602905
<pre>
Add nullptr checks for m_objectStore.get() in WebCore::IDBServer::MemoryIndex
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=311611">https://bugs.webkit.org/show_bug.cgi?id=311611</a>&gt;
&lt;<a href="https://rdar.apple.com/174209893">rdar://174209893</a>&gt;

Reviewed by Geoffrey Garen.

`m_objectStore` is a `WeakPtr&lt;MemoryObjectStore&gt;`.  If the object store
is deallocated, `WeakPtr::get()` returns nullptr.  Add nullptr checks to
`getResultForKeyRange()` and `getAllRecords()` to prevent crashes.

Unable to create a test case.

* Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp:
(WebCore::IDBServer::MemoryIndex::getResultForKeyRange):
(WebCore::IDBServer::MemoryIndex::getAllRecords):

Canonical link: <a href="https://commits.webkit.org/310716@main">https://commits.webkit.org/310716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb2a385abf55ca3e2455aafac3e0591aedb359fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154614 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163372 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108083 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/816c9e06-4df3-42ad-bed1-c120a1d7a725) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156487 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28006 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119591 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84577 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/74b27807-7eb9-4cb9-bb4f-5a90e7f4de40) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21881 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100288 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20966 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18981 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11200 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130629 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16705 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165844 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9049 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18314 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127693 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27418 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23021 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127836 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27342 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138498 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84024 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23601 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22732 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15292 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27034 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91136 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26612 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26843 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26685 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->