### PR TITLE
Composited layers flash blank when window.scrollTo() is called synchronously with a DOM layout change on iOS

### DIFF
--- a/LayoutTests/fast/scrolling/ios/programmatic-scroll-updates-exposed-content-rect-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/programmatic-scroll-updates-exposed-content-rect-expected.txt
@@ -1,0 +1,37 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Composited
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 2210.00)
+  (visible rect 0.00, 1610.00 800.00 x 600.00)
+  (coverage rect 0.00, 1610.00 800.00 x 600.00)
+  (intersects coverage rect 1)
+  (contentsScale 2.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 2210.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (visible rect 0.00, 1610.00 800.00 x 600.00)
+      (coverage rect 0.00, 1610.00 800.00 x 600.00)
+      (intersects coverage rect 1)
+      (contentsScale 2.00)
+      (children 1
+        (GraphicsLayer
+          (position 0.00 2010.00)
+          (bounds 800.00 200.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+          (visible rect 0.00, 0.00 800.00 x 200.00)
+          (coverage rect 0.00, -400.00 800.00 x 600.00)
+          (intersects coverage rect 1)
+          (contentsScale 2.00)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/fast/scrolling/ios/programmatic-scroll-updates-exposed-content-rect.html
+++ b/LayoutTests/fast/scrolling/ios/programmatic-scroll-updates-exposed-content-rect.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body {
+        margin: 0;
+        height: 400px;
+        background-image: repeating-linear-gradient(white, silver 300px);
+    }
+        
+    #composited {
+        position: absolute;
+        top: 10px;
+        width: 100%;
+        height: 200px;
+        background-color: green;
+        will-change: transform;
+    }
+    </style>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<script>
+    jsTestIsAsync = true;
+
+    window.addEventListener('load', async () => {
+        await UIHelper.ensurePresentationUpdate();
+
+        const scrollAmount = 2000;
+        document.getElementById('composited').style.top = `${scrollAmount + 10}px`;
+        window.scrollTo(0, scrollAmount);
+
+        document.getElementById('layers').innerText = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_VISIBLE_RECTS | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+        
+        finishJSTest();
+    });
+</script>
+</head>
+<body>
+    <div id="composited">Composited</div>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/platform/ios/compositing/visible-rect/scrolled-expected.txt
+++ b/LayoutTests/platform/ios/compositing/visible-rect/scrolled-expected.txt
@@ -1,16 +1,16 @@
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 1508.00 2008.00)
-  (visible rect 0.00, 0.00 800.00 x 600.00)
-  (coverage rect 0.00, 0.00 800.00 x 600.00)
+  (visible rect 25.00, 200.00 800.00 x 600.00)
+  (coverage rect 25.00, 200.00 800.00 x 600.00)
   (intersects coverage rect 1)
   (contentsScale 2.00)
   (children 1
     (GraphicsLayer
       (bounds 1508.00 2008.00)
       (contentsOpaque 1)
-      (visible rect 0.00, 0.00 800.00 x 600.00)
-      (coverage rect 0.00, 0.00 800.00 x 600.00)
+      (visible rect 25.00, 200.00 800.00 x 600.00)
+      (coverage rect 25.00, 200.00 800.00 x 600.00)
       (intersects coverage rect 1)
       (contentsScale 2.00)
       (children 1
@@ -19,8 +19,8 @@
           (bounds 200.00 500.00)
           (contentsOpaque 1)
           (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 1.00 1.00])
-          (visible rect 0.00, 0.00 200.00 x 500.00)
-          (coverage rect -8.00, 0.00 800.00 x 600.00)
+          (visible rect 17.00, 200.00 183.00 x 300.00)
+          (coverage rect 17.00, 200.00 800.00 x 600.00)
           (intersects coverage rect 1)
           (contentsScale 2.00)
         )

--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -182,6 +182,10 @@ interaction-region/interaction-layers-culling.html [ Failure ]
 platform/visionos/transforms/separated-update.html [ Failure ]
 platform/visionos/transforms/separated-video.html [ Failure ]
 
+overlay-region/full-page-scrolling.html [ Failure ]
+overlay-region/overlay-element.html [ Failure ]
+overlay-region/sticky.html [ Failure ]
+
 ### END OF Triaged failures
 ###################################################################################################
 
@@ -209,11 +213,9 @@ platform/visionos/transforms/separated-video.html [ Failure ]
 ###################################################################################################
 ### START OF Flaky tests
 
-# webkit.org/b/309297 overlay-region/clipping.html
-overlay-region/full-page-horizontal.html [ Pass Failure ]
+webkit.org/b/309297 overlay-region/full-page-horizontal.html [ Pass Failure ]
+webkit.org/b/305613 overlay-region/clipping.html [ Pass Failure ]
 
-# webkit.org/b/305613 overlay-region/clipping.html
-overlay-region/clipping.html [ Pass Failure ]
 
 ### END OF Flaky tests
 ###################################################################################################

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -410,6 +410,10 @@ bool AsyncScrollingCoordinator::requestScrollToPosition(ScrollableArea& scrollab
                 .updateLayerPositionAction = ScrollingLayerPositionAction::Set,
             },
         };
+
+        if (scrollingNodeID == frameView->scrollingNodeID())
+            frameView->adjustExposedContentRectForProgrammaticScroll(adjustedScrollPosition);
+
         applyScrollUpdate(WTF::move(scrollUpdate), ScrollType::Programmatic);
     }
 

--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -252,6 +252,21 @@ void ScrollView::setExposedContentRect(const FloatRect& rect)
     m_delegatedScrollingGeometry->exposedContentRect = rect;
 }
 
+void ScrollView::adjustExposedContentRectForProgrammaticScroll(ScrollPosition newPosition)
+{
+    if (!m_delegatedScrollingGeometry)
+        return;
+
+    if (parent())
+        return;
+
+    FloatSize delta = newPosition - scrollPosition();
+    if (delta.isZero())
+        return;
+
+    m_delegatedScrollingGeometry->exposedContentRect.move(delta);
+}
+
 FloatSize ScrollView::unobscuredContentSize() const
 {
     ASSERT(m_delegatedScrollingGeometry);

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -218,6 +218,8 @@ public:
     // The given rects are only used if there is no platform widget.
     WEBCORE_EXPORT void NODELETE setExposedContentRect(const FloatRect&);
 
+    void adjustExposedContentRectForProgrammaticScroll(ScrollPosition);
+
     WEBCORE_EXPORT FloatSize NODELETE unobscuredContentSize() const;
     WEBCORE_EXPORT void setUnobscuredContentSize(const FloatSize&);
 


### PR DESCRIPTION
#### 46fb2414dbc9d58182d393b10571742b1e32d1d5
<pre>
Composited layers flash blank when window.scrollTo() is called synchronously with a DOM layout change on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=310087">https://bugs.webkit.org/show_bug.cgi?id=310087</a>
<a href="https://rdar.apple.com/173197381">rdar://173197381</a>

Reviewed by Matt Woodrow.

GraphicsLayer visible rect computations take `frameView-&gt;exposedContentRect()` as input,
and this is updated when we get VisibleContentRect updates from the UI process.

However, on a programmatic scroll, we commit a layer tree using the existing
exposedContentRect, which does not account for the new scroll position, resulting in
a frame of missing layer backing stores, which causes a flicker.

Fix this by updating exposedContentRect for programmatic scrolls on the root frame.
This may not be exactly correct with UI-side geometry changes that happen on scrolling,
but the web process will get a new value on the next update.

Test: fast/scrolling/ios/programmatic-scroll-updates-exposed-content-rect.html

* LayoutTests/fast/scrolling/ios/programmatic-scroll-updates-exposed-content-rect-expected.txt: Added.
* LayoutTests/fast/scrolling/ios/programmatic-scroll-updates-exposed-content-rect.html: Added.
* LayoutTests/platform/ios/compositing/visible-rect/scrolled-expected.txt: Update results.
* LayoutTests/platform/visionos/TestExpectations:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::requestScrollToPosition):
* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::adjustExposedContentRectForProgrammaticScroll):
* Source/WebCore/platform/ScrollView.h:

Canonical link: <a href="https://commits.webkit.org/310864@main">https://commits.webkit.org/310864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c99e2913e60b9b973827a6890ccd063b097c94af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155269 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164032 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/54f3c457-5c06-4fd7-9f99-9e4767c75aa5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157142 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28669 "Hash c99e2913 for PR 62166 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28377 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120154 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d22faa82-fcfb-4939-9998-af2bf1526363) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158228 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/28669 "Hash c99e2913 for PR 62166 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139438 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100849 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2ad610c9-aaaa-4f9a-a50c-d8317fc0b69b) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/28669 "Hash c99e2913 for PR 62166 does not build (failure)") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11855 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/28669 "Hash c99e2913 for PR 62166 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166508 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128256 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28073 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23574 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128393 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34811 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27997 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139065 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84706 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23251 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15862 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27691 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91794 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27268 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27498 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27341 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->