### PR TITLE
[git-webkit] Allow using gh CLI for GitHub authentication

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
@@ -30,7 +30,8 @@ from collections import defaultdict
 from datetime import datetime
 from webkitbugspy import User
 from webkitbugspy.github import Tracker
-from webkitcorepy import decorators, string_utils, CallByNeed
+import webkitcorepy.credentials
+from webkitcorepy import decorators, run, string_utils, CallByNeed
 from webkitscmpy import Commit, Contributor, PullRequest
 from webkitscmpy.remote.scm import Scm
 from xml.dom import minidom
@@ -513,6 +514,21 @@ class GitHub(Scm):
         self.tracker = Tracker(url, users=users, session=self.session)
 
     def credentials(self, required=True, validate=False, save_in_keyring=None):
+        if not self._cached_credentials and run(
+            ['git', 'config', '--get', 'webkitscmpy.use-gh-cli'], capture_output=True, encoding='utf-8',
+        ).stdout.strip() == 'true':
+            try:
+                token = run(['gh', 'auth', 'token', '--hostname', self.domain], capture_output=True, encoding='utf-8').stdout.strip()
+                login = run(['gh', 'api', 'user', '--hostname', self.domain, '--jq', '.login'], capture_output=True, encoding='utf-8').stdout.strip() if token else None
+                if token and login:
+                    self._cached_credentials = (login, token)
+                    sys.modules['webkitcorepy.credentials']._cache[self.domain.replace('.', '_').upper()] = self._cached_credentials
+                else:
+                    sys.stderr.write("'webkitscmpy.use-gh-cli' is set, but failed to get credentials from gh CLI for {}\n".format(self.domain))
+            except FileNotFoundError:
+                sys.stderr.write("'webkitscmpy.use-gh-cli' is set, but 'gh' was not found in PATH\n")
+        if self._cached_credentials:
+            return self._cached_credentials
         return self.tracker.credentials(required=required, validate=validate, save_in_keyring=save_in_keyring)
 
     @property


### PR DESCRIPTION
#### 97d43eb5aa03056d794de9c653a05232c59c006e
<pre>
[git-webkit] Allow using gh CLI for GitHub authentication
<a href="https://bugs.webkit.org/show_bug.cgi?id=311614">https://bugs.webkit.org/show_bug.cgi?id=311614</a>

Reviewed by NOBODY (OOPS!).

Currently `git-webkit pr` requires generating a Personal Access Token via
the web UI and storing it in the system keyring. For contributors who
already use the `gh` CLI, this is redundant.

This change adds an opt-in `webkitscmpy.use-gh-cli` git config option.
When set to `true`, `git-webkit` obtains the GitHub username and token
from `gh auth token` / `gh api user` instead of prompting. If `gh` is
not installed or not authenticated, it falls back to the existing flow.

Usage: git config webkitscmpy.use-gh-cli true

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97d43eb5aa03056d794de9c653a05232c59c006e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163379 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27729 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119595 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157580 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/21894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/138869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100292 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/153941 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11207 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/130642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/16713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165851 "Built successfully") | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/18322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/127699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/154021 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27425 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23028 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127842 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27349 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/138506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/84031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22735 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27041 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26619 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/26850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26692 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->