### PR TITLE
SVGLengthValue::valueAsPercentage() should resolve absolute units to pixels for objectBoundingBox

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/gradient-objectBoundingBox-absolute-units-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/gradient-objectBoundingBox-absolute-units-expected.svg
@@ -1,0 +1,18 @@
+<svg width="200" height="200"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <g id="testmeta">
+    <title>Reference: objectBoundingBox gradient with unitless x2="96",
+           equivalent to x2="1in" (since 1in = 96px).</title>
+  </g>
+
+  <defs>
+    <linearGradient id="grad" gradientUnits="objectBoundingBox"
+                    x1="0" y1="0" x2="96" y2="0">
+      <stop offset="0" stop-color="blue"/>
+      <stop offset="1" stop-color="lime"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="200" height="200" fill="url(#grad)"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/gradient-objectBoundingBox-absolute-units.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/gradient-objectBoundingBox-absolute-units.svg
@@ -1,0 +1,25 @@
+<svg width="200" height="200"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <g id="testmeta">
+    <title>Gradient with objectBoundingBox and absolute length units</title>
+    <html:link rel="help"
+          href="https://www.w3.org/TR/SVG2/pservers.html#LinearGradientElementX2Attribute"/>
+    <html:link rel="match" href="reference/gradient-objectBoundingBox-absolute-units-ref.svg" />
+  </g>
+
+  <!-- Test: In objectBoundingBox mode, absolute units like "in" should be
+       resolved to their CSS pixel equivalent (1in = 96px) and used as the
+       coordinate in the objectBoundingBox space. So x2="1in" should behave
+       like x2="96" (unitless), NOT like x2="1". -->
+
+  <defs>
+    <linearGradient id="grad" gradientUnits="objectBoundingBox"
+                    x1="0" y1="0" x2="1in" y2="0">
+      <stop offset="0" stop-color="blue"/>
+      <stop offset="1" stop-color="lime"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="200" height="200" fill="url(#grad)"/>
+</svg>

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -83,7 +83,7 @@ FloatPoint SVGLengthContext::resolvePoint(const SVGElement* context, SVGUnitType
         return FloatPoint(x.value(lengthContext), y.value(lengthContext));
     }
 
-    // FIXME: valueAsPercentage() won't be correct for eg. cm units. They need to be resolved in user space and then be considered in objectBoundingBox space.
+    // FIXME: valueAsPercentage() won't be correct for relative units (e.g. em, ex). They need to be resolved in user space and then be considered in objectBoundingBox space.
     return FloatPoint(x.valueAsPercentage(), y.valueAsPercentage());
 }
 
@@ -95,7 +95,7 @@ float SVGLengthContext::resolveLength(const SVGElement* context, SVGUnitTypes::S
         return x.value(lengthContext);
     }
 
-    // FIXME: valueAsPercentage() won't be correct for eg. cm units. They need to be resolved in user space and then be considered in objectBoundingBox space.
+    // FIXME: valueAsPercentage() won't be correct for relative units (e.g. em, ex). They need to be resolved in user space and then be considered in objectBoundingBox space.
     return x.valueAsPercentage();
 }
 

--- a/Source/WebCore/svg/SVGLengthValue.cpp
+++ b/Source/WebCore/svg/SVGLengthValue.cpp
@@ -31,6 +31,7 @@
 #include "CSSPropertyParserConsumer+NumberDefinitions.h"
 #include "CSSToLengthConversionData.h"
 #include "CSSTokenizer.h"
+#include "CSSUnits.h"
 #include "ExceptionOr.h"
 #include "SVGElement.h"
 #include "SVGLengthContext.h"
@@ -208,6 +209,28 @@ float SVGLengthValue::value(const SVGLengthContext& context) const
     return result.releaseReturnValue();
 }
 
+static float convertToPixels(float value, CSS::LengthPercentageUnit unit)
+{
+    switch (unit) {
+    case CSS::LengthPercentageUnit::Px:
+        return value;
+    case CSS::LengthPercentageUnit::Cm:
+        return value * CSS::pixelsPerCm;
+    case CSS::LengthPercentageUnit::Mm:
+        return value * CSS::pixelsPerMm;
+    case CSS::LengthPercentageUnit::Q:
+        return value * CSS::pixelsPerQ;
+    case CSS::LengthPercentageUnit::In:
+        return value * CSS::pixelsPerInch;
+    case CSS::LengthPercentageUnit::Pt:
+        return value * CSS::pixelsPerPt;
+    case CSS::LengthPercentageUnit::Pc:
+        return value * CSS::pixelsPerPc;
+    default:
+        return value;
+    }
+}
+
 float SVGLengthValue::valueAsPercentage() const
 {
     return WTF::switchOn(m_value,
@@ -222,7 +245,7 @@ float SVGLengthValue::valueAsPercentage() const
                 if (raw->unit == CSS::LengthPercentageUnit::Percentage)
                     return raw->value / 100.0f;
 
-                return raw->value;
+                return convertToPixels(raw->value, raw->unit);
             }
 
             return 0.0f;


### PR DESCRIPTION
#### 5bff2eb26e59dd23485d7482aacc3a08f7df0974
<pre>
SVGLengthValue::valueAsPercentage() should resolve absolute units to pixels for objectBoundingBox
<a href="https://bugs.webkit.org/show_bug.cgi?id=311615">https://bugs.webkit.org/show_bug.cgi?id=311615</a>

Reviewed by Anne van Kesteren.

SVGLengthValue::valueAsPercentage() is used to resolve coordinates for
SVG elements with objectBoundingBox units (gradients, filters, masks,
patterns). Previously, it returned the raw numeric value for all
non-percentage units, so &quot;1in&quot; was treated as the value 1.0 rather
than 96.0 (its CSS pixel equivalent). This caused incorrect rendering
when absolute length units (cm, mm, in, pt, pc) were used with
objectBoundingBox.

This aligns WebKit&apos;s behavior with Blink and Gecko, which both resolve
absolute CSS units to their pixel equivalents before using them as
objectBoundingBox coordinates.

Test: imported/w3c/web-platform-tests/svg/pservers/reftests/gradient-objectBoundingBox-absolute-units.svg
- This test is failing in shipping Safari but passing in both Chrome and Firefox.

* LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/gradient-objectBoundingBox-absolute-units-expected.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/gradient-objectBoundingBox-absolute-units.svg: Added.
* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::resolvePoint):
(WebCore::SVGLengthContext::resolveLength):
* Source/WebCore/svg/SVGLengthValue.cpp:
(WebCore::convertToPixels):
(WebCore::SVGLengthValue::valueAsPercentage const):

Canonical link: <a href="https://commits.webkit.org/310698@main">https://commits.webkit.org/310698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e489ebafe25b55159e9ea60815f8e68974884c6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163410 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ee77f70b-ff76-4a13-9a51-9ad7c1fe0d3c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156524 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27759 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119628 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/92ac67b0-dfc3-42ac-9e2c-4bc62449c3d5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157610 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21912 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138898 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100322 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/225bd5b7-fa3a-4da5-a6f6-9c02f0a24344) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20997 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11237 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130660 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165884 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9106 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18351 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127729 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127868 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34697 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27379 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138535 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84061 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22761 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15329 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27071 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91173 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26649 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26880 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26722 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->