### PR TITLE
CanvasPath.roundRect() should not require the radii argument

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/path-objects/2d.path.roundrect.radius.noargument-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/path-objects/2d.path.roundrect.radius.noargument-expected.txt
@@ -2,5 +2,5 @@
 Check that roundRect draws a rectangle when no radii are provided.
 Actual output:
 
-FAIL Check that roundRect draws a rectangle when no radii are provided. Not enough arguments
+PASS Check that roundRect draws a rectangle when no radii are provided.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/path-objects/2d.path.roundrect.radius.noarugment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/path-objects/2d.path.roundrect.radius.noarugment-expected.txt
@@ -2,5 +2,5 @@
 Check that roundRect draws a rectangle when no radii are provided.
 Actual output:
 
-FAIL Check that roundRect draws a rectangle when no radii are provided. Not enough arguments
+PASS Check that roundRect draws a rectangle when no radii are provided.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.roundrect.radius.noargument-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.roundrect.radius.noargument-expected.txt
@@ -3,5 +3,5 @@
 Check that roundRect draws a rectangle when no radii are provided.
 
 
-FAIL Check that roundRect draws a rectangle when no radii are provided. Not enough arguments
+PASS Check that roundRect draws a rectangle when no radii are provided.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.roundrect.radius.noargument.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.roundrect.radius.noargument.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Check that roundRect draws a rectangle when no radii are provided. Not enough arguments
+PASS Check that roundRect draws a rectangle when no radii are provided.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
@@ -310,7 +310,7 @@ PASS Path2D interface: operation quadraticCurveTo(unrestricted double, unrestric
 PASS Path2D interface: operation bezierCurveTo(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS Path2D interface: operation arcTo(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS Path2D interface: operation rect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
-FAIL Path2D interface: operation roundRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double, optional (unrestricted double or DOMPointInit or sequence<(unrestricted double or DOMPointInit)>)) assert_equals: property has wrong .length expected 4 but got 5
+PASS Path2D interface: operation roundRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double, optional (unrestricted double or DOMPointInit or sequence<(unrestricted double or DOMPointInit)>))
 PASS Path2D interface: operation arc(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, optional boolean)
 PASS Path2D interface: operation ellipse(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, optional boolean)
 PASS ImageBitmapRenderingContext interface: existence and properties of interface object
@@ -419,7 +419,7 @@ PASS OffscreenCanvasRenderingContext2D interface: operation quadraticCurveTo(unr
 PASS OffscreenCanvasRenderingContext2D interface: operation bezierCurveTo(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation arcTo(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation rect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
-FAIL OffscreenCanvasRenderingContext2D interface: operation roundRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double, optional (unrestricted double or DOMPointInit or sequence<(unrestricted double or DOMPointInit)>)) assert_equals: property has wrong .length expected 4 but got 5
+PASS OffscreenCanvasRenderingContext2D interface: operation roundRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double, optional (unrestricted double or DOMPointInit or sequence<(unrestricted double or DOMPointInit)>))
 PASS OffscreenCanvasRenderingContext2D interface: operation arc(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, optional boolean)
 PASS OffscreenCanvasRenderingContext2D interface: operation ellipse(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, optional boolean)
 PASS CustomElementRegistry interface: existence and properties of interface object

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
@@ -310,7 +310,7 @@ PASS Path2D interface: operation quadraticCurveTo(unrestricted double, unrestric
 PASS Path2D interface: operation bezierCurveTo(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS Path2D interface: operation arcTo(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS Path2D interface: operation rect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
-FAIL Path2D interface: operation roundRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double, optional (unrestricted double or DOMPointInit or sequence<(unrestricted double or DOMPointInit)>)) assert_equals: property has wrong .length expected 4 but got 5
+PASS Path2D interface: operation roundRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double, optional (unrestricted double or DOMPointInit or sequence<(unrestricted double or DOMPointInit)>))
 PASS Path2D interface: operation arc(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, optional boolean)
 PASS Path2D interface: operation ellipse(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, optional boolean)
 PASS ImageBitmapRenderingContext interface: existence and properties of interface object
@@ -419,7 +419,7 @@ PASS OffscreenCanvasRenderingContext2D interface: operation quadraticCurveTo(unr
 PASS OffscreenCanvasRenderingContext2D interface: operation bezierCurveTo(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation arcTo(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation rect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
-FAIL OffscreenCanvasRenderingContext2D interface: operation roundRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double, optional (unrestricted double or DOMPointInit or sequence<(unrestricted double or DOMPointInit)>)) assert_equals: property has wrong .length expected 4 but got 5
+PASS OffscreenCanvasRenderingContext2D interface: operation roundRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double, optional (unrestricted double or DOMPointInit or sequence<(unrestricted double or DOMPointInit)>))
 PASS OffscreenCanvasRenderingContext2D interface: operation arc(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, optional boolean)
 PASS OffscreenCanvasRenderingContext2D interface: operation ellipse(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, optional boolean)
 PASS CustomElementRegistry interface: existence and properties of interface object

--- a/Source/WebCore/html/canvas/CanvasPath.cpp
+++ b/Source/WebCore/html/canvas/CanvasPath.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2008, 2010 Nokia Corporation and/or its subsidiary(-ies)
  * Copyright (C) 2007 Alp Toker <alp@atoker.com>
  * Copyright (C) 2008 Eric Seidel <eric@webkit.org>
@@ -242,9 +242,16 @@ void CanvasPath::rect(float x, float y, float width, float height)
     m_path.addRect(FloatRect(x, y, width, height));
 }
 
-ExceptionOr<void> CanvasPath::roundRect(float x, float y, float width, float height, const RadiusVariant& radii)
+ExceptionOr<void> CanvasPath::roundRect(float x, float y, float width, float height, float radii)
 {
-    return roundRect(x, y, width, height, singleElementSpan(radii));
+    RadiusVariant radiusVariant { static_cast<double>(radii) };
+    return roundRect(x, y, width, height, singleElementSpan(radiusVariant));
+}
+
+ExceptionOr<void> CanvasPath::roundRect(float x, float y, float width, float height, const DOMPointInit& radii)
+{
+    RadiusVariant radiusVariant { radii };
+    return roundRect(x, y, width, height, singleElementSpan(radiusVariant));
 }
 
 ExceptionOr<void> CanvasPath::roundRect(float x, float y, float width, float height, std::span<const RadiusVariant> radii)

--- a/Source/WebCore/html/canvas/CanvasPath.h
+++ b/Source/WebCore/html/canvas/CanvasPath.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006, 2007, 2009, 2010, 2011, 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2012, 2013 Adobe Systems Incorporated. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -50,7 +50,8 @@ public:
     ExceptionOr<void> arc(float x, float y, float r, float sa, float ea, bool anticlockwise);
     ExceptionOr<void> ellipse(float x, float y, float radiusX, float radiusY, float rotation, float startAngle, float endAngled, bool anticlockwise);
     void rect(float x, float y, float width, float height);
-    ExceptionOr<void> roundRect(float x, float y, float width, float height, const RadiusVariant& radii);
+    ExceptionOr<void> roundRect(float x, float y, float width, float height, float radii);
+    ExceptionOr<void> roundRect(float x, float y, float width, float height, const DOMPointInit& radii);
     ExceptionOr<void> roundRect(float x, float y, float width, float height, std::span<const RadiusVariant> radii);
 
     float currentX() const;

--- a/Source/WebCore/html/canvas/CanvasPath.idl
+++ b/Source/WebCore/html/canvas/CanvasPath.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
  */
 
 // https://html.spec.whatwg.org/multipage/canvas.html#canvaspath
+
 interface mixin CanvasPath {
     // shared path API methods
     undefined closePath();
@@ -36,8 +37,9 @@ interface mixin CanvasPath {
     undefined arcTo(unrestricted double x1, unrestricted double y1, unrestricted double x2, unrestricted double y2, unrestricted double radius);
     // undefined arcTo(unrestricted double x1, unrestricted double y1, unrestricted double x2, unrestricted double y2, unrestricted double radiusX, unrestricted double radiusY, unrestricted double rotation);
     undefined rect(unrestricted double x, unrestricted double y, unrestricted double w, unrestricted double h);
+    undefined roundRect(unrestricted double x, unrestricted double y, unrestricted double w, unrestricted double h, optional unrestricted double radii = 0);
+    undefined roundRect(unrestricted double x, unrestricted double y, unrestricted double w, unrestricted double h, DOMPointInit radii);
     undefined roundRect(unrestricted double x, unrestricted double y, unrestricted double w, unrestricted double h, sequence<(unrestricted double or DOMPointInit)> radii);
-    undefined roundRect(unrestricted double x, unrestricted double y, unrestricted double w, unrestricted double h, (unrestricted double or DOMPointInit) radii);
     undefined arc(unrestricted double x, unrestricted double y, unrestricted double radius, unrestricted double startAngle, unrestricted double endAngle, optional boolean anticlockwise = false);
     undefined ellipse(unrestricted double x, unrestricted double y, unrestricted double radiusX, unrestricted double radiusY, unrestricted double rotation, unrestricted double startAngle, unrestricted double endAngle, optional boolean anticlockwise = false);
 };

--- a/Source/WebCore/inspector/InspectorCanvasArguments.cpp
+++ b/Source/WebCore/inspector/InspectorCanvasArguments.cpp
@@ -64,6 +64,12 @@ auto InspectorCanvasArgumentProcessor<IDLDictionary<ImageDataSettings>>::operato
     return std::nullopt;
 }
 
+auto InspectorCanvasArgumentProcessor<IDLDictionary<DOMPointInit>>::operator()(InspectorCanvas&, const DOMPointInit&) -> std::optional<InspectorCanvasProcessedArgument>
+{
+    // FIXME: Implement. See https://webkit.org/b/233255.
+    return std::nullopt;
+}
+
 // MARK: - Strings
 
 auto InspectorCanvasArgumentProcessor<IDLDOMString>::operator()(InspectorCanvas& context, const String& argument) -> std::optional<InspectorCanvasProcessedArgument>

--- a/Source/WebCore/inspector/InspectorCanvasArguments.h
+++ b/Source/WebCore/inspector/InspectorCanvasArguments.h
@@ -138,6 +138,10 @@ template<> struct InspectorCanvasArgumentProcessor<IDLDictionary<ImageDataSettin
     std::optional<InspectorCanvasProcessedArgument> NODELETE operator()(InspectorCanvas&, const ImageDataSettings&);
 };
 
+template<> struct InspectorCanvasArgumentProcessor<IDLDictionary<DOMPointInit>> {
+    std::optional<InspectorCanvasProcessedArgument> operator()(InspectorCanvas&, const DOMPointInit&);
+};
+
 // MARK: - Strings
 
 template<> struct InspectorCanvasArgumentProcessor<IDLDOMString> {


### PR DESCRIPTION
#### 7d000e2d1c1d26ce3ef59f2c22ca87873202f37a
<pre>
CanvasPath.roundRect() should not require the radii argument
<a href="https://bugs.webkit.org/show_bug.cgi?id=311618">https://bugs.webkit.org/show_bug.cgi?id=311618</a>
<a href="https://rdar.apple.com/174216935">rdar://174216935</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Per [1], roundRect is defined with `optional ... radii = 0`, meaning
calling roundRect(x, y, w, h) without radii should draw a plain
rectangle. WebKit had two overloads both requiring radii, causing
a &quot;Not enough arguments&quot; error when radii was omitted, and
roundRect.length incorrectly reported 5 instead of 4.

Split into three overloads (optional double, DOMPointInit, sequence)
to avoid the union type and enable future per-type optimization.

[1] <a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-roundrect">https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-roundrect</a>

* Source/WebCore/html/canvas/CanvasPath.cpp:
(WebCore::CanvasPath::roundRect):
* Source/WebCore/html/canvas/CanvasPath.h:
* Source/WebCore/html/canvas/CanvasPath.idl:
* Source/WebCore/inspector/InspectorCanvasArguments.cpp:
(WebCore::InspectorCanvasArgumentProcessor&lt;IDLDictionary&lt;DOMPointInit&gt;&gt;::operator):
* Source/WebCore/inspector/InspectorCanvasArguments.h:

&gt; Progressions:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/path-objects/2d.path.roundrect.radius.noargument-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/path-objects/2d.path.roundrect.radius.noarugment-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.roundrect.radius.noargument-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.roundrect.radius.noargument.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d000e2d1c1d26ce3ef59f2c22ca87873202f37a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154879 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28138 "Hash 7d000e2d for PR 62172 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21301 "Hash 7d000e2d for PR 62172 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163639 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108349 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/76491692-7ef4-424c-a425-4a8b0e581579) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156752 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28280 "Hash 7d000e2d for PR 62172 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27987 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119817 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84692 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac060324-1ff8-461a-a32d-dde139626cf2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157838 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/28280 "Hash 7d000e2d for PR 62172 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139089 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100510 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e6dfc217-7b14-4efa-89fb-a97da6e85d87) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/28280 "Hash 7d000e2d for PR 62172 does not build (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19204 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11465 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146929 "Build is in progress. Recent messages:") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/28280 "Hash 7d000e2d for PR 62172 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16933 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166113 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9498 "Failed to build and analyze WebKit") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18542 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127920 "Passed tests") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27683 "Hash 7d000e2d for PR 62172 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23244 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128059 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27607 "Hash 7d000e2d for PR 62172 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138726 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84312 "Built successfully") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/27607 "Hash 7d000e2d for PR 62172 does not build (failure)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15521 "Passed tests") | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27299 "Hash 7d000e2d for PR 62172 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91401 "Failed to build and analyze WebKit") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26877 "Hash 7d000e2d for PR 62172 does not build (failure)") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27108 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26950 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->