### PR TITLE
Batch plain-text characters in HTML tokenizer quoted attribute value states

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/newline-normalization-cr-then-lf-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/newline-normalization-cr-then-lf-expected.txt
@@ -1,0 +1,8 @@
+
+PASS Text content: \r followed by plain text then \n produces two newlines
+PASS Double-quoted attribute: \r followed by plain text then \n produces two newlines
+PASS Single-quoted attribute: \r followed by plain text then \n produces two newlines
+PASS Text content: \r\n collapses to single newline
+PASS Double-quoted attribute: \r\n collapses to single newline
+PASS Single-quoted attribute: \r\n collapses to single newline
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/newline-normalization-cr-then-lf.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/newline-normalization-cr-then-lf.html
@@ -1,0 +1,54 @@
+<meta charset="UTF-8">
+<title>Newline normalization: \r followed by plain text then \n</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<script>
+function parseHTML(html) {
+    var parser = new DOMParser();
+    return parser.parseFromString(html, "text/html");
+}
+
+// \r followed by non-newline characters followed by \n should produce two
+// separate newlines: the \r is normalized to \n per the spec, and the
+// subsequent \n must be preserved since they are NOT a \r\n pair.
+// DOMParser is used so that raw \r bytes reach the input stream preprocessor.
+
+test(function() {
+    var doc = parseHTML("<body><div>before\rABCDEF\nafter</div></body>");
+    var div = doc.querySelector("div");
+    assert_equals(div.textContent, "before\nABCDEF\nafter");
+}, "Text content: \\r followed by plain text then \\n produces two newlines");
+
+test(function() {
+    var doc = parseHTML('<body><input value="before\rABCDEF\nafter"></body>');
+    var input = doc.querySelector("input");
+    assert_equals(input.getAttribute("value"), "before\nABCDEF\nafter");
+}, "Double-quoted attribute: \\r followed by plain text then \\n produces two newlines");
+
+test(function() {
+    var doc = parseHTML("<body><input value='before\rABCDEF\nafter'></body>");
+    var input = doc.querySelector("input");
+    assert_equals(input.getAttribute("value"), "before\nABCDEF\nafter");
+}, "Single-quoted attribute: \\r followed by plain text then \\n produces two newlines");
+
+// Verify that actual \r\n pairs still collapse to a single \n.
+
+test(function() {
+    var doc = parseHTML("<body><div>before\r\nafter</div></body>");
+    var div = doc.querySelector("div");
+    assert_equals(div.textContent, "before\nafter");
+}, "Text content: \\r\\n collapses to single newline");
+
+test(function() {
+    var doc = parseHTML('<body><input value="before\r\nafter"></body>');
+    var input = doc.querySelector("input");
+    assert_equals(input.getAttribute("value"), "before\nafter");
+}, "Double-quoted attribute: \\r\\n collapses to single newline");
+
+test(function() {
+    var doc = parseHTML("<body><input value='before\r\nafter'></body>");
+    var input = doc.querySelector("input");
+    assert_equals(input.getAttribute("value"), "before\nafter");
+}, "Single-quoted attribute: \\r\\n collapses to single newline");
+</script>

--- a/Source/WebCore/html/parser/HTMLTokenizer.cpp
+++ b/Source/WebCore/html/parser/HTMLTokenizer.cpp
@@ -57,6 +57,25 @@ static std::span<const Latin1Character> findPlainTextInDataState(std::span<const
     return span.first(it - span.begin());
 }
 
+// https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(double-quoted)-state
+// https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(single-quoted)-state
+// In quoted attribute value states, the closing quote ends the value, '&' starts
+// a character reference, and '\0' is a parse error. '\r' and '\n' require special
+// handling for line counting and newline normalization. Everything else is plain
+// text that can be appended to the attribute value as-is.
+template<Latin1Character quoteCharacter>
+static bool isQuotedAttributeValueSpecialCharacter(Latin1Character c)
+{
+    return c == quoteCharacter || c == '&' || c == '\r' || c == '\n' || c == '\0';
+}
+
+template<Latin1Character quoteCharacter>
+static std::span<const Latin1Character> findPlainTextInQuotedAttributeValue(std::span<const Latin1Character> span)
+{
+    auto it = std::ranges::find_if(span, isQuotedAttributeValueSpecialCharacter<quoteCharacter>);
+    return span.first(it - span.begin());
+}
+
 static inline Latin1Character NODELETE convertASCIIAlphaToLower(char16_t character)
 {
     ASSERT(isASCIIAlpha(character));
@@ -237,9 +256,14 @@ bool HTMLTokenizer::processToken(SegmentedString& source)
         // Optimization: scan ahead for a run of plain-text characters in the
         // current 8-bit substring and buffer them all at once, avoiding the
         // per-character overhead of the main tokenizer loop.
+        // We skip batching when m_preprocessor.skipNextNewLine() is true (i.e.
+        // the current character was a '\r'). The preprocessor expects the very
+        // next peek to check whether a '\n' follows (for \r\n normalization);
+        // batching would bypass that check and cause a subsequent '\n' to be
+        // incorrectly skipped.
         {
             auto span = source.currentSubstringSpan8();
-            if (span.size() > 2) {
+            if (span.size() > 2 && !m_preprocessor.skipNextNewLine()) {
                 // span[0] is the current character, already buffered above. We also
                 // stop before the last character because advancePastMultiple8()
                 // requires at least one character to remain in the span (it becomes
@@ -830,6 +854,25 @@ bool HTMLTokenizer::processToken(SegmentedString& source)
             RECONSUME_IN(DataState);
         }
         m_token.appendToAttributeValue(character);
+        // Optimization: scan ahead for a run of plain-text characters in the
+        // current 8-bit substring and append them all at once, avoiding the
+        // per-character overhead of the main tokenizer loop.
+        // We skip batching when m_preprocessor.skipNextNewLine() is true (i.e.
+        // the current character was a '\r'). The preprocessor expects the very
+        // next peek to check whether a '\n' follows (for \r\n normalization);
+        // batching would bypass that check and cause a subsequent '\n' to be
+        // incorrectly skipped.
+        {
+            auto span = source.currentSubstringSpan8();
+            if (span.size() > 2 && !m_preprocessor.skipNextNewLine()) {
+                auto plainText = findPlainTextInQuotedAttributeValue<'"'>(span.subspan(1, span.size() - 2));
+                if (!plainText.empty()) {
+                    m_token.appendToAttributeValue(plainText);
+                    source.advancePastMultiple8(plainText.size() + 1);
+                    SWITCH_TO(AttributeValueDoubleQuotedState);
+                }
+            }
+        }
         ADVANCE_TO(AttributeValueDoubleQuotedState);
     END_STATE()
 
@@ -848,6 +891,25 @@ bool HTMLTokenizer::processToken(SegmentedString& source)
             RECONSUME_IN(DataState);
         }
         m_token.appendToAttributeValue(character);
+        // Optimization: scan ahead for a run of plain-text characters in the
+        // current 8-bit substring and append them all at once, avoiding the
+        // per-character overhead of the main tokenizer loop.
+        // We skip batching when m_preprocessor.skipNextNewLine() is true (i.e.
+        // the current character was a '\r'). The preprocessor expects the very
+        // next peek to check whether a '\n' follows (for \r\n normalization);
+        // batching would bypass that check and cause a subsequent '\n' to be
+        // incorrectly skipped.
+        {
+            auto span = source.currentSubstringSpan8();
+            if (span.size() > 2 && !m_preprocessor.skipNextNewLine()) {
+                auto plainText = findPlainTextInQuotedAttributeValue<'\''>(span.subspan(1, span.size() - 2));
+                if (!plainText.empty()) {
+                    m_token.appendToAttributeValue(plainText);
+                    source.advancePastMultiple8(plainText.size() + 1);
+                    SWITCH_TO(AttributeValueSingleQuotedState);
+                }
+            }
+        }
         ADVANCE_TO(AttributeValueSingleQuotedState);
     END_STATE()
 


### PR DESCRIPTION
#### 5778396ee19cedd3b67401af44bb2af02f99745b
<pre>
Batch plain-text characters in HTML tokenizer quoted attribute value states
<a href="https://bugs.webkit.org/show_bug.cgi?id=311620">https://bugs.webkit.org/show_bug.cgi?id=311620</a>

Reviewed by Darin Adler.

Apply the same batching optimization from 310687@main (DataState) to
AttributeValueDoubleQuotedState and AttributeValueSingleQuotedState.

After appending a character, scan ahead in the current 8-bit substring
for runs of plain text (stopping at the closing quote, &apos;&amp;&apos;, &apos;\r&apos;, &apos;\n&apos;,
or &apos;\0&apos;). Append the entire run at once via the span overload of
appendToAttributeValue() and advance the source with
advancePastMultiple8(), avoiding per-character tokenizer loop overhead.

Performance results on attribute-heavy benchmark
(Parser/html-parser-attribute-heavy, 3000 elements with long inline
styles, data URIs, and URLs):
  Baseline: 58.0 ms median
  Patched:  53.0 ms median → ~9% faster

On the tag-heavy HTML spec (Parser/html-parser):
  Baseline: 207.0 ms median
  Patched:  204.5 ms median → ~1% faster

* LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/newline-normalization-cr-then-lf-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/newline-normalization-cr-then-lf.html: Added.
No behavior change compared to shipping but I&apos;m extending test coverage since I found a bug while working
on this PR that wasn&apos;t caught by WPT tests.

* Source/WebCore/html/parser/HTMLTokenizer.cpp:
(WebCore::isQuotedAttributeValueSpecialCharacter):
(WebCore::findPlainTextInQuotedAttributeValue):
(WebCore::HTMLTokenizer::processToken):

Canonical link: <a href="https://commits.webkit.org/310747@main">https://commits.webkit.org/310747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95deef01de864cb8ed42a73d6adedcba84df58da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163415 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108125 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bf471df9-3c09-4fbe-858d-0a64b2d602e0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156529 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28049 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119633 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84597 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/556f2cfa-31af-4007-b8cd-b66e590b47b3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21920 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138897 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100327 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9194387f-6e09-4656-b32a-04800033bd6a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21005 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19023 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11242 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130668 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165889 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9100 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18350 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127734 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27460 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23063 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127873 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34731 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138534 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84066 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22768 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15328 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27076 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91178 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26654 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26885 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26727 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->