### PR TITLE
Move common WebContent entitlements to shared function

### DIFF
--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -14,34 +14,12 @@ function mac_process_webcontent_entitlements()
 {
     plistbuddy Add :com.apple.security.cs.allow-jit bool YES
 
-    if [[ "${WK_USE_FATAL_EXCEPTIONS}" == YES ]]
-    then
-        plistbuddy Add :com.apple.security.fatal-exceptions array
-        plistbuddy Add :com.apple.security.fatal-exceptions:0 string jit
-    fi
-
     if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
     then
-        plistbuddy Add :com.apple.private.webkit.use-xpc-endpoint bool YES
-        plistbuddy Add :com.apple.rootless.storage.WebKitWebContentSandbox bool YES
-        plistbuddy Add :com.apple.QuartzCore.webkit-end-points bool YES
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
+        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 ))
         then
-            plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
-            plistbuddy Add :com.apple.developer.videotoolbox.client-sandboxed-decoder bool YES
-            plistbuddy Add :com.apple.pac.shared_region_id string WebContent
-            plistbuddy Add :com.apple.private.security.message-filter bool YES
-            plistbuddy Add :com.apple.avfoundation.allow-system-wide-context bool YES
-            plistbuddy add :com.apple.QuartzCore.webkit-limited-types bool YES
-
-            if [[ "${WK_USE_FATAL_EXCEPTIONS}" == YES ]]
-            then
-                plistbuddy Add :com.apple.private.pac.exception bool YES
-            fi
-        fi
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 130000 ))
-        then
-            plistbuddy Add :com.apple.private.gpu-restricted bool YES
+            plistbuddy Add :com.apple.private.verified-jit bool YES
+            plistbuddy Add :com.apple.security.cs.single-jit bool YES
         fi
     fi
 
@@ -50,42 +28,13 @@ function mac_process_webcontent_entitlements()
 
 function mac_process_webcontent_captiveportal_entitlements()
 {
-    if [[ "${WK_USE_FATAL_EXCEPTIONS}" == YES ]]
-    then
-        plistbuddy Add :com.apple.security.fatal-exceptions array
-        plistbuddy Add :com.apple.security.fatal-exceptions:0 string jit
-    fi
-
     if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
     then
-        plistbuddy Add :com.apple.private.webkit.use-xpc-endpoint bool YES
-        plistbuddy Add :com.apple.rootless.storage.WebKitWebContentSandbox bool YES
-        plistbuddy Add :com.apple.QuartzCore.webkit-end-points bool YES
-
         plistbuddy Add :com.apple.imageio.allowabletypes array
         plistbuddy Add :com.apple.imageio.allowabletypes:0 string org.webmproject.webp
         plistbuddy Add :com.apple.imageio.allowabletypes:1 string public.jpeg
         plistbuddy Add :com.apple.imageio.allowabletypes:2 string public.png
         plistbuddy Add :com.apple.imageio.allowabletypes:3 string com.compuserve.gif
-
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
-        then
-            plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
-            plistbuddy Add :com.apple.developer.videotoolbox.client-sandboxed-decoder bool YES
-            plistbuddy Add :com.apple.pac.shared_region_id string WebContent
-            plistbuddy Add :com.apple.private.security.message-filter bool YES
-            plistbuddy Add :com.apple.avfoundation.allow-system-wide-context bool YES
-            plistbuddy add :com.apple.QuartzCore.webkit-limited-types bool YES
-
-            if [[ "${WK_USE_FATAL_EXCEPTIONS}" == YES ]]
-            then
-                plistbuddy Add :com.apple.private.pac.exception bool YES
-            fi
-        fi
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 130000 ))
-        then
-            plistbuddy Add :com.apple.private.gpu-restricted bool YES
-        fi
     fi
 
     mac_process_webcontent_shared_entitlements
@@ -93,33 +42,6 @@ function mac_process_webcontent_captiveportal_entitlements()
 
 function mac_process_webcontent_enhancedsecurity_entitlements()
 {
-    if [[ "${WK_USE_FATAL_EXCEPTIONS}" == YES ]]
-    then
-        plistbuddy Add :com.apple.security.fatal-exceptions array
-        plistbuddy Add :com.apple.security.fatal-exceptions:0 string jit
-    fi
-
-    if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
-    then
-        plistbuddy Add :com.apple.private.webkit.use-xpc-endpoint bool YES
-        plistbuddy Add :com.apple.rootless.storage.WebKitWebContentSandbox bool YES
-        plistbuddy Add :com.apple.QuartzCore.webkit-end-points bool YES
-        
-        plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
-        plistbuddy Add :com.apple.developer.videotoolbox.client-sandboxed-decoder bool YES
-        plistbuddy Add :com.apple.pac.shared_region_id string WebContent
-        plistbuddy Add :com.apple.private.security.message-filter bool YES
-        plistbuddy Add :com.apple.avfoundation.allow-system-wide-context bool YES
-        plistbuddy add :com.apple.QuartzCore.webkit-limited-types bool YES
-    
-        plistbuddy Add :com.apple.private.gpu-restricted bool YES
-
-        if [[ "${WK_USE_FATAL_EXCEPTIONS}" == YES ]]
-        then
-            plistbuddy Add :com.apple.private.pac.exception bool YES
-        fi
-    fi
-
     mac_process_webcontent_shared_entitlements
 }
 
@@ -336,11 +258,6 @@ function mac_process_webcontent_shared_entitlements()
 
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 ))
         then
-            if [[ "${PRODUCT_NAME}" != com.apple.WebKit.WebContent.EnhancedSecurity && "${PRODUCT_NAME}" != com.apple.WebKit.WebContent.CaptivePortal ]]
-            then
-                plistbuddy Add :com.apple.private.verified-jit bool YES
-                plistbuddy Add :com.apple.security.cs.single-jit bool YES
-            fi
             plistbuddy add :com.apple.coreaudio.allow-vorbis-decode bool YES
         fi
 
@@ -361,6 +278,28 @@ function mac_process_webcontent_shared_entitlements()
             plistbuddy Add :com.apple.security.hardened-process.checked-allocations.no-tagged-receive bool YES
         fi
         plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES # FIXME: Should be removed before release <rdar://171909082>
+
+        plistbuddy Add :com.apple.private.webkit.use-xpc-endpoint bool YES
+        plistbuddy Add :com.apple.rootless.storage.WebKitWebContentSandbox bool YES
+        plistbuddy Add :com.apple.QuartzCore.webkit-end-points bool YES
+        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
+        then
+            plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
+            plistbuddy Add :com.apple.developer.videotoolbox.client-sandboxed-decoder bool YES
+            plistbuddy Add :com.apple.pac.shared_region_id string WebContent
+            plistbuddy Add :com.apple.private.security.message-filter bool YES
+            plistbuddy Add :com.apple.avfoundation.allow-system-wide-context bool YES
+            plistbuddy add :com.apple.QuartzCore.webkit-limited-types bool YES
+
+            if [[ "${WK_USE_FATAL_EXCEPTIONS}" == YES ]]
+            then
+                plistbuddy Add :com.apple.private.pac.exception bool YES
+            fi
+        fi
+        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 130000 ))
+        then
+            plistbuddy Add :com.apple.private.gpu-restricted bool YES
+        fi
     fi
 
     if [[ "${WK_XPC_SERVICE_VARIANT}" == Development ]]
@@ -371,6 +310,12 @@ function mac_process_webcontent_shared_entitlements()
     if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" > 140000 ))
     then
         notify_entitlements
+    fi
+
+    if [[ "${WK_USE_FATAL_EXCEPTIONS}" == YES ]]
+    then
+        plistbuddy Add :com.apple.security.fatal-exceptions array
+        plistbuddy Add :com.apple.security.fatal-exceptions:0 string jit
     fi
 }
 


### PR DESCRIPTION
#### eb466700acafb0a4e0823b232fb9d7e8b54c4771
<pre>
Move common WebContent entitlements to shared function
<a href="https://bugs.webkit.org/show_bug.cgi?id=311624">https://bugs.webkit.org/show_bug.cgi?id=311624</a>
<a href="https://rdar.apple.com/174220367">rdar://174220367</a>

Reviewed by Basuke Suzuki and Ben Nham.

* Source/WebKit/Scripts/process-entitlements.sh:

Canonical link: <a href="https://commits.webkit.org/310764@main">https://commits.webkit.org/310764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d1c2673a03434849e2f47b2f847e396772e77ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154746 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163506 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108216 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28142 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27854 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119699 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84644 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f247457b-653f-48ac-96ae-8438d287fcc9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157705 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21987 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138978 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100392 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6423ad27-b559-4ece-ac02-40090bb74d23) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/154066 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21073 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19092 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11332 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130735 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165980 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9221 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127800 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27550 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23132 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127942 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138615 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84179 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23620 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22841 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15409 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27166 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91268 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26744 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26975 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26817 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->