### PR TITLE
Fix radii for non-auto outline

### DIFF
--- a/LayoutTests/fast/css/outline-border-radius-negative-offset-expected.html
+++ b/LayoutTests/fast/css/outline-border-radius-negative-offset-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0;
+    overflow: hidden;
+}
+
+div {
+    margin: 57px;
+    width: 200px;
+    height: 200px;
+    border-radius: 20px;
+    outline: 3px solid black;
+    outline-offset: 0px;
+}
+</style>
+<div></div>

--- a/LayoutTests/fast/css/outline-border-radius-negative-offset.html
+++ b/LayoutTests/fast/css/outline-border-radius-negative-offset.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0;
+    overflow: hidden;
+}
+
+div {
+    margin: 50px;
+    width: 214px;
+    height: 214px;
+    border-radius: 27px;
+    outline: 3px solid black;
+    outline-offset: -7px;
+}
+</style>
+<div></div>

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -908,17 +908,14 @@ void BackgroundPainter::paintBoxShadow(const LayoutRect& paintRect, const Render
                 if (!shadowSpread)
                     return borderShape;
 
-                if (shadowSpread > 0) {
-                    auto spreadRect = paintRect;
-                    spreadRect.inflate(shadowSpread);
-                    return BorderShape::shapeForOutsetRect(style, paintRect, spreadRect, { }, closedEdges);
-                }
-
                 auto spreadRect = paintRect;
-                auto inflateX = std::max(shadowSpread, -paintRect.width() / 2);
-                auto inflateY = std::max(shadowSpread, -paintRect.height() / 2);
-                spreadRect.inflate(LayoutSize { inflateX, inflateY });
-                return BorderShape::shapeForInsetRect(style, paintRect, spreadRect /* , closedEdges*/);
+                if (shadowSpread < 0) {
+                    auto inflateX = std::max(shadowSpread, -paintRect.width() / 2);
+                    auto inflateY = std::max(shadowSpread, -paintRect.height() / 2);
+                    spreadRect.inflate(LayoutSize { inflateX, inflateY });
+                } else
+                    spreadRect.inflate(shadowSpread);
+                return BorderShape::shapeForOffsetRect(style, paintRect, spreadRect, { }, closedEdges);
             }();
 
             if (shadowShape.isEmpty())

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -41,6 +41,36 @@
 
 namespace WebCore {
 
+static void zeroRadiiForOpenEdges(LayoutRoundedRectRadii& radii, RectEdges<bool> closedEdges)
+{
+    if (!closedEdges.top()) {
+        radii.setTopLeft({ });
+        radii.setTopRight({ });
+    }
+    if (!closedEdges.right()) {
+        radii.setTopRight({ });
+        radii.setBottomRight({ });
+    }
+    if (!closedEdges.bottom()) {
+        radii.setBottomRight({ });
+        radii.setBottomLeft({ });
+    }
+    if (!closedEdges.left()) {
+        radii.setBottomLeft({ });
+        radii.setTopLeft({ });
+    }
+}
+
+static RectEdges<LayoutUnit> applyClosedEdges(const RectEdges<LayoutUnit>& widths, RectEdges<bool> closedEdges)
+{
+    return {
+        LayoutUnit(closedEdges.top() ? widths.top() : 0_lu),
+        LayoutUnit(closedEdges.right() ? widths.right() : 0_lu),
+        LayoutUnit(closedEdges.bottom() ? widths.bottom() : 0_lu),
+        LayoutUnit(closedEdges.left() ? widths.left() : 0_lu),
+    };
+}
+
 BorderShape BorderShape::shapeForBorderRect(const RenderStyle& style, const LayoutRect& borderRect, RectEdges<bool> closedEdges)
 {
     auto borderWidths = RectEdges<LayoutUnit>::map(style.usedBorderWidths(), [&](auto width) {
@@ -51,34 +81,12 @@ BorderShape BorderShape::shapeForBorderRect(const RenderStyle& style, const Layo
 
 BorderShape BorderShape::shapeForBorderRect(const RenderStyle& style, const LayoutRect& borderRect, const RectEdges<LayoutUnit>& overrideBorderWidths, RectEdges<bool> closedEdges)
 {
-    // top, right, bottom, left.
-    auto usedBorderWidths = RectEdges<LayoutUnit> {
-        LayoutUnit(closedEdges.top() ? overrideBorderWidths.top() : 0_lu),
-        LayoutUnit(closedEdges.right() ? overrideBorderWidths.right() : 0_lu),
-        LayoutUnit(closedEdges.bottom() ? overrideBorderWidths.bottom() : 0_lu),
-        LayoutUnit(closedEdges.left() ? overrideBorderWidths.left() : 0_lu),
-    };
+    auto usedBorderWidths = applyClosedEdges(overrideBorderWidths, closedEdges);
 
     if (style.border().hasBorderRadius()) {
         auto radii = Style::evaluate<LayoutRoundedRectRadii>(style.borderRadii(), borderRect.size(), style.usedZoomForLength());
         radii.scale(calcBorderRadiiConstraintScaleFor(borderRect, radii));
-
-        if (!closedEdges.top()) {
-            radii.setTopLeft({ });
-            radii.setTopRight({ });
-        }
-        if (!closedEdges.right()) {
-            radii.setTopRight({ });
-            radii.setBottomRight({ });
-        }
-        if (!closedEdges.bottom()) {
-            radii.setBottomRight({ });
-            radii.setBottomLeft({ });
-        }
-        if (!closedEdges.left()) {
-            radii.setBottomLeft({ });
-            radii.setTopLeft({ });
-        }
+        zeroRadiiForOpenEdges(radii, closedEdges);
 
         if (!radii.areRenderableInRect(borderRect))
             radii.makeRenderableInRect(borderRect);
@@ -89,72 +97,28 @@ BorderShape BorderShape::shapeForBorderRect(const RenderStyle& style, const Layo
     return BorderShape { borderRect, usedBorderWidths };
 }
 
-BorderShape BorderShape::shapeForOutsetRect(const RenderStyle& style, const LayoutRect& borderRect, const LayoutRect& outlineBoxRect, const RectEdges<LayoutUnit>& outlineWidths, RectEdges<bool> closedEdges)
+BorderShape BorderShape::shapeForOffsetRect(const RenderStyle& style, const LayoutRect& borderRect, const LayoutRect& offsetRect, const RectEdges<LayoutUnit>& edgeWidths, RectEdges<bool> closedEdges)
 {
-    // top, right, bottom, left.
-    auto usedOutlineWidths = RectEdges<LayoutUnit> {
-        LayoutUnit(closedEdges.top() ? outlineWidths.top() : 0_lu),
-        LayoutUnit(closedEdges.right() ? outlineWidths.right() : 0_lu),
-        LayoutUnit(closedEdges.bottom() ? outlineWidths.bottom() : 0_lu),
-        LayoutUnit(closedEdges.left() ? outlineWidths.left() : 0_lu),
-    };
+    auto usedEdgeWidths = applyClosedEdges(edgeWidths, closedEdges);
 
     if (style.border().hasBorderRadius()) {
         auto radii = Style::evaluate<LayoutRoundedRectRadii>(style.borderRadii(), borderRect.size(), style.usedZoomForLength());
 
-        auto leftOutset = std::max(borderRect.x() - outlineBoxRect.x(), 0_lu);
-        auto topOutset = std::max(borderRect.y() - outlineBoxRect.y(), 0_lu);
-        auto rightOutset = std::max(outlineBoxRect.maxX() - borderRect.maxX(), 0_lu);
-        auto bottomOutset = std::max(outlineBoxRect.maxY() - borderRect.maxY(), 0_lu);
+        auto leftDelta = borderRect.x() - offsetRect.x();
+        auto topDelta = borderRect.y() - offsetRect.y();
+        auto rightDelta = offsetRect.maxX() - borderRect.maxX();
+        auto bottomDelta = offsetRect.maxY() - borderRect.maxY();
 
-        radii.expand(topOutset, bottomOutset, leftOutset, rightOutset);
+        radii.expand(topDelta, bottomDelta, leftDelta, rightDelta);
+        zeroRadiiForOpenEdges(radii, closedEdges);
 
-        // FIXME: Share
-        if (!closedEdges.top()) {
-            radii.setTopLeft({ });
-            radii.setTopRight({ });
-        }
-        if (!closedEdges.right()) {
-            radii.setTopRight({ });
-            radii.setBottomRight({ });
-        }
-        if (!closedEdges.bottom()) {
-            radii.setBottomRight({ });
-            radii.setBottomLeft({ });
-        }
-        if (!closedEdges.left()) {
-            radii.setBottomLeft({ });
-            radii.setTopLeft({ });
-        }
+        if (!radii.areRenderableInRect(offsetRect))
+            radii.makeRenderableInRect(offsetRect);
 
-        if (!radii.areRenderableInRect(outlineBoxRect))
-            radii.makeRenderableInRect(outlineBoxRect);
-
-        return BorderShape { outlineBoxRect, usedOutlineWidths, radii };
+        return BorderShape { offsetRect, usedEdgeWidths, radii };
     }
 
-    return BorderShape { outlineBoxRect, usedOutlineWidths };
-}
-
-BorderShape BorderShape::shapeForInsetRect(const RenderStyle& style, const LayoutRect& borderRect, const LayoutRect& insetRect)
-{
-    if (style.border().hasBorderRadius()) {
-        auto radii = Style::evaluate<LayoutRoundedRectRadii>(style.borderRadii(), borderRect.size(), style.usedZoomForLength());
-
-        auto leftInset = std::max(insetRect.x() - borderRect.x(), 0_lu);
-        auto topInset = std::max(insetRect.y()- borderRect.y(), 0_lu);
-        auto rightInset = std::max(borderRect.maxX() - insetRect.maxX(), 0_lu);
-        auto bottomInset = std::max(borderRect.maxY() - insetRect.maxY(), 0_lu);
-
-        auto insetWidths = RectEdges<LayoutUnit> { topInset, rightInset, bottomInset, leftInset };
-        auto roundedRect = LayoutRoundedRect { borderRect, radii };
-
-        auto insetRoundedRect = computeInnerEdgeRoundedRect(roundedRect, insetWidths);
-
-        return BorderShape { insetRect, { }, insetRoundedRect.radii() };
-    }
-
-    return BorderShape { insetRect, { } };
+    return BorderShape { offsetRect, usedEdgeWidths };
 }
 
 BorderShape::BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths)

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -51,11 +51,10 @@ public:
     // overrideBorderWidths describe custom insets from the border box, used instead of the border widths from the style.
     static BorderShape shapeForBorderRect(const RenderStyle&, const LayoutRect& borderRect, const RectEdges<LayoutUnit>& overrideBorderWidths, RectEdges<bool> closedEdges = { true });
 
-    // Create a BorderShape suitable for rendering an outline or outset shadow. borderRect is provided to allow for scaling the corner radii.
-    static BorderShape shapeForOutsetRect(const RenderStyle&, const LayoutRect& borderRect, const LayoutRect& outlineBoxRect, const RectEdges<LayoutUnit>& outlineWidths, RectEdges<bool> closedEdges = { true });
-
-    // Create a BorderShape suitable for rendering a shape inset from the box. borderRect is provided to allow for scaling the corner radii.
-    static BorderShape shapeForInsetRect(const RenderStyle&, const LayoutRect& borderRect, const LayoutRect& insetRect);
+    // Create a BorderShape suitable for rendering an outline or shadow. borderRect is provided to
+    // allow for scaling the corner radii; radii expand outward or shrink inward based on the offset
+    // between borderRect and offsetRect.
+    static BorderShape shapeForOffsetRect(const RenderStyle&, const LayoutRect& borderRect, const LayoutRect& offsetRect, const RectEdges<LayoutUnit>& edgeWidths, RectEdges<bool> closedEdges = { true });
 
     BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths);
     BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths, const LayoutRoundedRectRadii&);

--- a/Source/WebCore/rendering/OutlinePainter.cpp
+++ b/Source/WebCore/rendering/OutlinePainter.cpp
@@ -104,7 +104,7 @@ void OutlinePainter::paintOutline(const RenderElement& renderer, const LayoutRec
     auto closedEdges = RectEdges<bool> { true };
 
     auto outlineEdgeWidths = RectEdges<LayoutUnit> { outlineWidth };
-    auto outlineShape = BorderShape::shapeForOutsetRect(styleToUse.get(), paintRect, outerRect, outlineEdgeWidths, closedEdges);
+    auto outlineShape = BorderShape::shapeForOffsetRect(styleToUse.get(), paintRect, outerRect, outlineEdgeWidths, closedEdges);
 
     auto bleedAvoidance = BleedAvoidance::ShrinkBackground;
     auto appliedClipAlready = false;


### PR DESCRIPTION
#### 4894d8539f316ce6239325ff37bf5a93f31817cf
<pre>
Fix radii for non-auto outline
<a href="https://bugs.webkit.org/show_bug.cgi?id=311627">https://bugs.webkit.org/show_bug.cgi?id=311627</a>

Reviewed by Simon Fraser.

Non-auto outlines with negative outline-offset and border-radius kept
the full border-box radii instead of shrinking them inward. The root
cause was BorderShape::shapeForOutsetRect clamping per-side deltas to
zero, which meant inward offsets had no effect on radii.

Since radii.expand() already clamps each component to zero internally,
the fix is removing the std::max(..., 0) on the deltas. This also makes
shapeForInsetRect redundant — its only caller (BackgroundPainter for
negative box-shadow spread) now uses the unified method. Renamed to
shapeForOffsetRect and extracted shared helpers zeroRadiiForOpenEdges
and applyClosedEdges.

Test: fast/css/outline-border-radius-negative-offset.html
Canonical link: <a href="https://commits.webkit.org/310784@main">https://commits.webkit.org/310784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7ecf0f00ba582b2890b8935409878c795fc81b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21067 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163408 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108118 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156522 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27757 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119625 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84594 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4e39763f-b693-4d99-82fc-93774fbffb99) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138894 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100319 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2a16fbce-1fd1-4fef-98cb-25be0d5a3897) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20999 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19014 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11235 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130662 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16738 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165882 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9090 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18347 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127726 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23054 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127866 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34761 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27377 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138531 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84059 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22774 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15325 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27069 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91171 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26647 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26878 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26720 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->