### PR TITLE
!important should override CSS animations even when CSS transitions are also running

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-important-with-transition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-important-with-transition-expected.txt
@@ -1,0 +1,11 @@
+Test
+Test
+Test
+Test
+
+PASS !important overrides animation when no transition is running
+PASS !important overrides animation even when a CSS transition is concurrently running
+PASS !important does not override a running CSS transition
+PASS !important overrides animation but not transition on the same element
+PASS !important overrides multiple animated properties even with a concurrent transition
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-important-with-transition.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-important-with-transition.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<title>!important declarations interact correctly with animations and transitions per cascade level</title>
+<link rel="help" href="https://drafts.csswg.org/css-cascade-5/#importance">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+@keyframes changeColor {
+    from { color: rgb(0, 0, 255); }
+    to { color: rgb(0, 0, 255); }
+}
+
+@keyframes changeColorAndOpacity {
+    from { color: rgb(0, 0, 255); opacity: 0; }
+    to { color: rgb(0, 0, 255); opacity: 0; }
+}
+
+#target1 {
+    color: rgb(255, 0, 0) !important;
+    opacity: 1;
+    transition: opacity 1000s steps(1);
+    animation: changeColor 1000s forwards;
+}
+
+#target2 {
+    transition: color 1000s linear;
+}
+
+#target2.green {
+    color: rgb(0, 128, 0) !important;
+}
+
+#target2.red {
+    color: rgb(255, 0, 0) !important;
+}
+
+#target3 {
+    color: rgb(255, 0, 0) !important;
+    transition: opacity 1000s linear;
+    animation: changeColor 1000s forwards;
+}
+
+#target3.start {
+    opacity: 1 !important;
+}
+
+#target3.end {
+    opacity: 0.5 !important;
+}
+
+#target4 {
+    color: rgb(255, 0, 0) !important;
+    opacity: 1 !important;
+    background-color: white;
+    transition: background-color 1000s steps(1);
+    animation: changeColorAndOpacity 1000s forwards;
+}
+</style>
+<div id="target1">Test</div>
+<div id="target2" class="green">Test</div>
+<div id="target3" class="start">Test</div>
+<div id="target4">Test</div>
+<script>
+test(() => {
+    // Before any transition, !important correctly overrides the animation.
+    assert_equals(getComputedStyle(target1).color, 'rgb(255, 0, 0)',
+        'color should be red before transition starts');
+}, '!important overrides animation when no transition is running');
+
+promise_test(async t => {
+    // Trigger a transition on opacity.
+    target1.style.opacity = '0.5';
+
+    // Now both a CSS animation and a CSS transition are running.
+    // getAnimations() returns them in composite order: transitions before animations.
+    const allAnimations = target1.getAnimations();
+    assert_equals(allAnimations.length, 2, 'Should have exactly two animations');
+    assert_true(allAnimations[0] instanceof CSSTransition, 'First animation should be a CSSTransition');
+    assert_true(allAnimations[1] instanceof CSSAnimation, 'Second animation should be a CSSAnimation');
+
+    // Per CSS cascade spec, !important declarations override CSS animations.
+    // This must remain true even when a CSS transition is also running.
+    assert_equals(getComputedStyle(target1).color, 'rgb(255, 0, 0)',
+        'color: red !important should still override the animation while a transition is running');
+}, '!important overrides animation even when a CSS transition is concurrently running');
+
+promise_test(async t => {
+    // target2 starts with class "green" giving it color: green !important.
+    assert_equals(getComputedStyle(target2).color, 'rgb(0, 128, 0)');
+
+    // Switch to class "red" to change computed color to red !important,
+    // triggering a transition from green to red.
+    target2.className = 'red';
+
+    const animations = target2.getAnimations();
+    assert_equals(animations.length, 1, 'Should have exactly one animation');
+    assert_true(animations[0] instanceof CSSTransition, 'The animation should be a CSSTransition');
+
+    // The transition is running on color. Per CSS cascade spec, transitions
+    // sit above !important in the cascade. The mid-transition value must NOT
+    // be snapped to the !important target; the transition must animate.
+    const color = getComputedStyle(target2).color;
+    assert_not_equals(color, 'rgb(255, 0, 0)',
+        'transition on color should not be overridden by !important');
+}, '!important does not override a running CSS transition');
+
+promise_test(async t => {
+    // target3 has an animation on color and a transition on opacity.
+    // Trigger the transition by switching !important opacity values.
+    target3.className = 'end';
+
+    const animations = target3.getAnimations();
+    assert_equals(animations.length, 2, 'Should have exactly two animations');
+    assert_true(animations.some(a => a instanceof CSSTransition), 'Should have a CSSTransition');
+    assert_true(animations.some(a => a instanceof CSSAnimation), 'Should have a CSSAnimation');
+
+    // !important should override the animation on color.
+    assert_equals(getComputedStyle(target3).color, 'rgb(255, 0, 0)',
+        'color: red !important should override the animation on color');
+
+    // The transition on opacity should NOT be overridden by !important.
+    const opacity = getComputedStyle(target3).opacity;
+    assert_not_equals(opacity, '0.5',
+        'opacity transition should not be snapped to the !important target value');
+}, '!important overrides animation but not transition on the same element');
+
+promise_test(async t => {
+    // target4 animates both color and opacity, with !important on both.
+    // A transition runs on background-color (a non-animated property).
+    target4.style.backgroundColor = 'rgb(0, 128, 0)';
+
+    const animations = target4.getAnimations();
+    assert_true(animations.some(a => a instanceof CSSTransition), 'Should have a CSSTransition on background-color');
+    assert_true(animations.some(a => a instanceof CSSAnimation), 'Should have a CSSAnimation');
+
+    // !important should override the animation on both color and opacity.
+    assert_equals(getComputedStyle(target4).color, 'rgb(255, 0, 0)',
+        'color: red !important should override animation');
+    assert_equals(getComputedStyle(target4).opacity, '1',
+        'opacity: 1 !important should override animation');
+}, '!important overrides multiple animated properties even with a concurrent transition');
+</script>

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -43,7 +43,7 @@ namespace Style {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PropertyCascade);
 
-PropertyCascade::PropertyCascade(const MatchResult& matchResult, IncludedProperties&& includedProperties, const HashSet<AnimatableCSSProperty>* animatedProperties, const StyleProperties* positionTryFallbackProperties)
+PropertyCascade::PropertyCascade(const MatchResult& matchResult, IncludedProperties&& includedProperties, const HashMap<AnimatableCSSProperty, EnumSet<AnimationSource>>* animatedProperties, const StyleProperties* positionTryFallbackProperties)
     : m_matchResult(matchResult)
     , m_includedProperties(WTF::move(includedProperties))
     , m_maximumOrigin(positionTryFallbackProperties ? PropertyCascade::Origin::PositionFallback : PropertyCascade::Origin::Author)
@@ -85,12 +85,15 @@ PropertyCascade::PropertyCascade(const PropertyCascade& parent, RevertRuleTag)
 
 PropertyCascade::~PropertyCascade() = default;
 
-PropertyCascade::AnimationLayer::AnimationLayer(const HashSet<AnimatableCSSProperty>& properties)
+PropertyCascade::AnimationLayer::AnimationLayer(const HashMap<AnimatableCSSProperty, EnumSet<AnimationSource>>& properties)
     : properties(properties)
 {
-    hasCustomProperties = std::ranges::find_if(properties, [](auto& property) {
-        return std::holds_alternative<AtomString>(property);
-    }) != properties.end();
+    for (auto& key : properties.keys()) {
+        if (std::holds_alternative<AtomString>(key)) {
+            hasCustomProperties = true;
+            break;
+        }
+    }
 
     hasFontSize = properties.contains(CSSPropertyFontSize);
     hasLineHeight = properties.contains(CSSPropertyLineHeight);
@@ -306,7 +309,7 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Origi
             if (mayOverrideExistingProperty(propertyID, *current.value()))
                 return true;
 
-            if (m_includedProperties.types.containsAny({ PropertyType::AfterAnimation, PropertyType::AfterTransition })) {
+            if (m_includedProperties.types.contains(PropertyType::AfterAnimation)) {
                 if (shouldApplyAfterAnimation(current)) {
                     m_animationLayer->overriddenProperties.add(propertyID);
                     return true;
@@ -346,16 +349,13 @@ bool PropertyCascade::shouldApplyAfterAnimation(const StyleProperties::PropertyR
     auto id = property.id();
     RefPtr customProperty = dynamicDowncast<CSSCustomPropertyValue>(*property.value());
 
-    auto isAnimatedProperty = [&] {
-        if (customProperty)
-            return m_animationLayer->properties.contains(customProperty->name());
-        return m_animationLayer->properties.contains(id);
-    }();
-
-    if (isAnimatedProperty) {
+    auto animationSource = m_animationLayer->properties.getOptional(customProperty ? AnimatableCSSProperty { customProperty->name() } : id);
+    if (animationSource) {
         // "Important declarations from all origins take precedence over animations."
         // https://drafts.csswg.org/css-cascade-5/#importance
-        return m_includedProperties.types.contains(PropertyType::AfterAnimation) && property.isImportant();
+        // But transitions take precedence over !important, so only allow the
+        // override for properties not animated by a transition.
+        return !animationSource->contains(AnimationSource::CSSTransition) && property.isImportant();
     }
 
     // If we are animating custom properties they may affect other properties so we need to re-resolve them.

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -28,6 +28,7 @@
 #include "MatchResult.h"
 #include "WebAnimationTypes.h"
 #include <wtf/BitSet.h>
+#include <wtf/EnumSet.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ValueOrReference.h>
 
@@ -42,14 +43,18 @@ class PropertyCascade {
 public:
     using PropertyBitSet = WTF::BitSet<lastLowPriorityProperty + 1>;
 
+    enum class AnimationSource : uint8_t {
+        CSSAnimation,
+        CSSTransition,
+    };
+
     enum class PropertyType : uint8_t {
         NonInherited = 1 << 0,
         Inherited = 1 << 1,
         ExplicitlyInherited = 1 << 2,
         AfterAnimation = 1 << 3,
-        AfterTransition = 1 << 4,
-        StartingStyle = 1 << 5,
-        NonCacheable = 1 << 6,
+        StartingStyle = 1 << 4,
+        NonCacheable = 1 << 5,
     };
 
     enum class Origin : uint8_t {
@@ -72,7 +77,7 @@ public:
 
     static IncludedProperties normalProperties() { return { normalPropertyTypes() }; }
 
-    PropertyCascade(const MatchResult&, IncludedProperties&&, const HashSet<AnimatableCSSProperty>* = nullptr, const StyleProperties* positionTryFallbackProperties = nullptr);
+    PropertyCascade(const MatchResult&, IncludedProperties&&, const HashMap<AnimatableCSSProperty, EnumSet<AnimationSource>>* animatedProperties = nullptr, const StyleProperties* positionTryFallbackProperties = nullptr);
     PropertyCascade(const PropertyCascade&, Origin, std::optional<ScopeOrdinal> rollbackScope = { }, std::optional<CascadeLayerPriority> maximumCascadeLayerPriorityForRollback = { });
     enum RevertRuleTag { RevertRule };
     PropertyCascade(const PropertyCascade&, RevertRuleTag);
@@ -139,9 +144,9 @@ private:
     const unsigned m_ruleRollbackDepth { 0 };
 
     struct AnimationLayer {
-        AnimationLayer(const HashSet<AnimatableCSSProperty>&);
+        explicit AnimationLayer(const HashMap<AnimatableCSSProperty, EnumSet<AnimationSource>>&);
 
-        const HashSet<AnimatableCSSProperty>& properties;
+        const HashMap<AnimatableCSSProperty, EnumSet<AnimationSource>>& properties;
         HashSet<AnimatableCSSProperty> overriddenProperties;
         bool hasCustomProperties { false };
         bool hasFontSize { false };

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -98,8 +98,8 @@ static const StyleProperties* NODELETE positionTryFallbackProperties(const Build
     return context.positionTryFallback ? context.positionTryFallback->properties.get() : nullptr;
 }
 
-Builder::Builder(RenderStyle& style, BuilderContext&& context, const MatchResult& matchResult, PropertyCascade::IncludedProperties&& includedProperties, const HashSet<AnimatableCSSProperty>* animatedPropertes)
-    : m_cascade(matchResult, WTF::move(includedProperties), animatedPropertes, positionTryFallbackProperties(context))
+Builder::Builder(RenderStyle& style, BuilderContext&& context, const MatchResult& matchResult, PropertyCascade::IncludedProperties&& includedProperties, const HashMap<AnimatableCSSProperty, EnumSet<PropertyCascade::AnimationSource>>* animatedProperties)
+    : m_cascade(matchResult, WTF::move(includedProperties), animatedProperties, positionTryFallbackProperties(context))
     , m_state(BuilderState::create(style, WTF::move(context)))
 {
 }

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -42,7 +42,7 @@ class CustomProperty;
 class Builder {
     WTF_MAKE_TZONE_ALLOCATED(Builder);
 public:
-    Builder(RenderStyle&, BuilderContext&&, const MatchResult&, PropertyCascade::IncludedProperties&& = PropertyCascade::normalProperties(), const HashSet<AnimatableCSSProperty>* animatedProperties = nullptr);
+    Builder(RenderStyle&, BuilderContext&&, const MatchResult&, PropertyCascade::IncludedProperties&& = PropertyCascade::normalProperties(), const HashMap<AnimatableCSSProperty, EnumSet<PropertyCascade::AnimationSource>>* animatedProperties = nullptr);
     ~Builder();
 
     void applyAllProperties();

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -783,6 +783,20 @@ const RenderStyle* TreeResolver::parentBoxStyleForPseudoElement(const ElementUpd
     }
 }
 
+static HashMap<AnimatableCSSProperty, EnumSet<PropertyCascade::AnimationSource>> animatedPropertySources(const Styleable& styleable, const HashSet<AnimatableCSSProperty>& animatedProperties)
+{
+    HashMap<AnimatableCSSProperty, EnumSet<PropertyCascade::AnimationSource>> result;
+    for (auto& property : animatedProperties)
+        result.add(property, PropertyCascade::AnimationSource::CSSAnimation);
+    if (auto* runningTransitionsByProperty = styleable.runningTransitionsByProperty()) {
+        for (auto& property : runningTransitionsByProperty->keys()) {
+            auto& sources = result.add(property, EnumSet<PropertyCascade::AnimationSource> { }).iterator->value;
+            sources.add(PropertyCascade::AnimationSource::CSSTransition);
+        }
+    }
+    return result;
+}
+
 ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolvedStyle, const Styleable& styleable, OptionSet<Change> parentChanges, const ResolutionContext& resolutionContext, IsInDisplayNoneTree isInDisplayNoneTree)
 {
     Ref element = styleable.element;
@@ -882,8 +896,7 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
         if (resolvedStyle.matchResult) {
             auto animatedStyleBeforeCascadeApplication = RenderStyle::clonePtr(*animatedStyle);
             // The cascade may override animated properties and have dependencies to them.
-            // FIXME: This is wrong if there are both transitions and animations running on the same element.
-            auto overriddenAnimatedProperties = applyCascadeAfterAnimation(*animatedStyle, animatedProperties, styleable.hasRunningTransitions(), *resolvedStyle.matchResult, element, resolutionContext);
+            auto overriddenAnimatedProperties = applyCascadeAfterAnimation(*animatedStyle, animatedPropertySources(styleable, animatedProperties), *resolvedStyle.matchResult, element, resolutionContext);
             ASSERT(styleable.keyframeEffectStack());
             styleable.keyframeEffectStack()->cascadeDidOverrideProperties(overriddenAnimatedProperties, document);
             styleable.setHasPropertiesOverridenAfterAnimation(!overriddenAnimatedProperties.isEmpty());
@@ -1049,7 +1062,7 @@ const RenderStyle& TreeResolver::parentAfterChangeStyle(const Styleable& styleab
     return *resolutionContext.parentStyle;
 }
 
-HashSet<AnimatableCSSProperty> TreeResolver::applyCascadeAfterAnimation(RenderStyle& animatedStyle, const HashSet<AnimatableCSSProperty>& animatedProperties, bool isTransition, const MatchResult& matchResult, const Element& element, const ResolutionContext& resolutionContext)
+HashSet<AnimatableCSSProperty> TreeResolver::applyCascadeAfterAnimation(RenderStyle& animatedStyle, const HashMap<AnimatableCSSProperty, EnumSet<PropertyCascade::AnimationSource>>& animatedProperties, const MatchResult& matchResult, const Element& element, const ResolutionContext& resolutionContext)
 {
     auto builderContext = BuilderContext {
         m_document.get(),
@@ -1063,7 +1076,7 @@ HashSet<AnimatableCSSProperty> TreeResolver::applyCascadeAfterAnimation(RenderSt
         animatedStyle,
         WTF::move(builderContext),
         matchResult,
-        { isTransition ? PropertyCascade::PropertyType::AfterTransition : PropertyCascade::PropertyType::AfterAnimation },
+        { PropertyCascade::PropertyType::AfterAnimation },
         &animatedProperties
     };
 

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -101,7 +101,7 @@ private:
     std::unique_ptr<RenderStyle> resolveAgainInDifferentContext(const ResolvedStyle&, const Styleable&, const RenderStyle& parentStyle,  OptionSet<PropertyCascade::PropertyType>, std::optional<BuilderPositionTryFallback>&&, const ResolutionContext&);
     const RenderStyle& parentAfterChangeStyle(const Styleable&, const ResolutionContext&) const;
 
-    HashSet<AnimatableCSSProperty> applyCascadeAfterAnimation(RenderStyle&, const HashSet<AnimatableCSSProperty>&, bool isTransition, const MatchResult&, const Element&, const ResolutionContext&);
+    HashSet<AnimatableCSSProperty> applyCascadeAfterAnimation(RenderStyle&, const HashMap<AnimatableCSSProperty, EnumSet<PropertyCascade::AnimationSource>>&, const MatchResult&, const Element&, const ResolutionContext&);
 
     std::optional<ElementUpdate> resolvePseudoElement(Element&, const PseudoElementIdentifier&, const ElementUpdate&, IsInDisplayNoneTree, const RenderStyle*);
     std::optional<ElementUpdate> resolveAncestorPseudoElement(Element&, const PseudoElementIdentifier&, const ElementUpdate&);

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -123,6 +123,11 @@ struct Styleable {
         return element.hasRunningTransitions(pseudoElementIdentifier);
     }
 
+    const AnimatableCSSPropertyToTransitionMap* runningTransitionsByProperty() const
+    {
+        return element.runningTransitionsByProperty(pseudoElementIdentifier);
+    }
+
     AnimationCollection& ensureAnimations() const
     {
         return element.ensureAnimations(pseudoElementIdentifier);


### PR DESCRIPTION
#### 8da2ffcdc7dc113b0f0a195063316b39819c1653
<pre>
!important should override CSS animations even when CSS transitions are also running
<a href="https://bugs.webkit.org/show_bug.cgi?id=311628">https://bugs.webkit.org/show_bug.cgi?id=311628</a>

Reviewed by Antti Koivisto.

Previously, applyCascadeAfterAnimation used a single bool to choose
between AfterTransition and AfterAnimation cascade types. When an
element had both running transitions and animations, AfterTransition
was selected, which prevented !important declarations from overriding
CSS animation values.

Per <a href="https://drafts.csswg.org/css-cascade-5/#importance">https://drafts.csswg.org/css-cascade-5/#importance</a>, &quot;important
declarations from all origins take precedence over animations.&quot; However,
transition declarations take precedence over important declarations
per the cascade sorting order. When both are present, each animated
property must be handled according to whether it is animated by a
transition or an animation.

The fix introduces a PropertyCascade::AnimationSource enum with
CSSAnimation and CSSTransition flags. Instead of passing two separate
HashSets of animated properties, we now pass a single
HashMap&lt;AnimatableCSSProperty, EnumSet&lt;AnimationSource&gt;&gt; so that
shouldApplyAfterAnimation can distinguish per-property whether it is
animated by a transition, an animation, or both. This also removes the
now-unused PropertyType::AfterTransition enum value.

Test: imported/w3c/web-platform-tests/css/css-animations/animation-important-with-transition.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-important-with-transition-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-important-with-transition.html: Added.
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::PropertyCascade):
(WebCore::Style::PropertyCascade::AnimationLayer::AnimationLayer):
(WebCore::Style::PropertyCascade::shouldApplyAfterAnimation):
* Source/WebCore/style/PropertyCascade.h:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::Builder):
* Source/WebCore/style/StyleBuilder.h:
* Source/WebCore/style/Styleable.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):
(WebCore::Style::TreeResolver::applyCascadeAfterAnimation):
* Source/WebCore/style/StyleTreeResolver.h:

Canonical link: <a href="https://commits.webkit.org/310810@main">https://commits.webkit.org/310810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44c70b2aa242b69bb5999a1d57266dbf980f7e08

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155104 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28364 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/21523 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163864 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8c11d791-f417-41ec-8b67-5447e75875b4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156977 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/28504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28212 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/120003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/924b4d5f-54da-4db3-b351-ef1740910bfe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158063 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/28504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/139281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100696 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/63df07a4-55a3-4bd5-b121-2067c286bbea) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/28504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/11690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/28504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/17124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166341 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/18733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/128105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/27908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/23429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/128243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34782 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/27832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/138917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/84541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/27832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/27525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/91628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/27103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/27333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/27176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->