### PR TITLE
Use protect() instead of Ref { } in Source/WebCore/Modules/WebGPU

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
@@ -125,7 +125,7 @@ void GPUAdapter::requestDevice(ScriptExecutionContext& scriptExecutionContext, c
         return;
     }
 
-    m_backing->requestDevice(convertToBacking(deviceDescriptor), [protectedThis = Ref { *this }, deviceDescriptor, promise = WTF::move(promise), scriptExecutionContextRef = Ref { scriptExecutionContext }](RefPtr<WebGPU::Device>&& device) mutable {
+    m_backing->requestDevice(convertToBacking(deviceDescriptor), [protectedThis = protect(*this), deviceDescriptor, promise = WTF::move(promise), scriptExecutionContextRef = protect(scriptExecutionContext)](RefPtr<WebGPU::Device>&& device) mutable {
         if (!device.get())
             promise.reject(Exception(ExceptionCode::OperationError));
         else {

--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
@@ -68,7 +68,7 @@ void GPUBuffer::mapAsync(GPUMapModeFlags mode, GPUSize64 offset, std::optional<G
 
     m_pendingMapPromise = makeUnique<MapAsyncPromise>(promise);
     // FIXME: Should this capture a weak pointer to |this| instead?
-    m_backing->mapAsync(convertMapModeFlagsToBacking(mode), offset, size, [promise = WTF::move(promise), protectedThis = Ref { *this }, offset, size](bool success) mutable {
+    m_backing->mapAsync(convertMapModeFlagsToBacking(mode), offset, size, [promise = WTF::move(promise), protectedThis = protect(*this), offset, size](bool success) mutable {
         if (!protectedThis->m_pendingMapPromise) {
             if (protectedThis->m_destroyed)
                 promise.reject(Exception { ExceptionCode::OperationError, "buffer destroyed during mapAsync"_s });

--- a/Source/WebCore/Modules/WebGPU/GPUCommandBuffer.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandBuffer.cpp
@@ -35,7 +35,7 @@ String GPUCommandBuffer::label() const
 
 void GPUCommandBuffer::setLabel(String&& label)
 {
-    Ref { m_backing }->setLabel(WTF::move(label));
+    protect(m_backing)->setLabel(WTF::move(label));
 }
 
 void GPUCommandBuffer::setOverrideLabel(String&& label)

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -86,7 +86,7 @@ GPUDevice::GPUDevice(ScriptExecutionContext* scriptExecutionContext, Ref<WebGPU:
     : ActiveDOMObject { scriptExecutionContext }
     , m_lostPromise(makeUniqueRef<LostPromise>())
     , m_backing(WTF::move(backing))
-    , m_queue(GPUQueue::create(Ref { m_backing->queue() }, this->backing()))
+    , m_queue(GPUQueue::create(m_backing->queue(), this->backing()))
     , m_autoPipelineLayout(createAutoPipelineLayout())
     , m_features(GPUSupportedFeatures::create(m_backing->features()))
     , m_limits(GPUSupportedLimits::create(m_backing->limits()))

--- a/Source/WebCore/Modules/WebGPU/GPUPipelineLayoutDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUPipelineLayoutDescriptor.h
@@ -39,7 +39,7 @@ struct GPUPipelineLayoutDescriptor : public GPUObjectDescriptorBase {
         return {
             { label },
             bindGroupLayouts.map([&](const auto& bindGroupLayout) -> Ref<WebGPU::BindGroupLayout> {
-                return bindGroupLayout ? Ref { bindGroupLayout->backing() } : device.emptyBindGroupLayout();
+                return bindGroupLayout ? protect(bindGroupLayout->backing()) : device.emptyBindGroupLayout();
             }),
         };
     }

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp
@@ -299,7 +299,7 @@ void AdapterImpl::requestDevice(const DeviceDescriptor& descriptor, CompletionHa
         limits.maxStorageTexturesInVertexStage);
 
     auto requestedFeatures = supportedFeatures(features);
-    auto blockPtr = makeBlockPtr([protectedThis = Ref { *this }, convertToBackingContext = m_convertToBackingContext.copyRef(), callback = WTF::move(callback), requestedLimits, requestedFeatures](WGPURequestDeviceStatus status, WGPUDevice device, const char*) mutable {
+    auto blockPtr = makeBlockPtr([protectedThis = protect(*this), convertToBackingContext = m_convertToBackingContext.copyRef(), callback = WTF::move(callback), requestedLimits, requestedFeatures](WGPURequestDeviceStatus status, WGPUDevice device, const char*) mutable {
         callback(DeviceImpl::create(adoptWebGPU(device), status == WGPURequestDeviceStatus_Success ? WTF::move(requestedFeatures) : SupportedFeatures::create({ }), WTF::move(requestedLimits), convertToBackingContext));
     });
     wgpuAdapterRequestDevice(m_backing.get(), &backingDescriptor, &requestDeviceCallback, Block_copy(blockPtr.get())); // Block_copy is matched with Block_release above in requestDeviceCallback().

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
@@ -560,7 +560,7 @@ static void createComputePipelineAsyncCallback(WGPUCreatePipelineAsyncStatus sta
 void DeviceImpl::createComputePipelineAsync(const ComputePipelineDescriptor& descriptor, CompletionHandler<void(RefPtr<ComputePipeline>&&, String&&)>&& callback)
 {
     convertToBacking(descriptor, m_convertToBackingContext, [backing = m_backing.copyRef(), &convertToBackingContext = m_convertToBackingContext.get(), callback = WTF::move(callback)](const WGPUComputePipelineDescriptor& backingDescriptor) mutable {
-        auto blockPtr = makeBlockPtr([convertToBackingContext = Ref { convertToBackingContext }, callback = WTF::move(callback)](WGPUCreatePipelineAsyncStatus status, WGPUComputePipeline pipeline, String&& message) mutable {
+        auto blockPtr = makeBlockPtr([convertToBackingContext = protect(convertToBackingContext), callback = WTF::move(callback)](WGPUCreatePipelineAsyncStatus status, WGPUComputePipeline pipeline, String&& message) mutable {
             if (status == WGPUCreatePipelineAsyncStatus_Success)
                 callback(ComputePipelineImpl::create(adoptWebGPU(pipeline), convertToBackingContext), ""_s);
             else
@@ -639,7 +639,7 @@ RefPtr<QuerySet> DeviceImpl::createQuerySet(const QuerySetDescriptor& descriptor
 
 void DeviceImpl::pushErrorScope(ErrorFilter errorFilter)
 {
-    wgpuDevicePushErrorScope(m_backing.get(), Ref { m_convertToBackingContext }->convertToBacking(errorFilter));
+    wgpuDevicePushErrorScope(m_backing.get(), protect(m_convertToBackingContext)->convertToBacking(errorFilter));
 }
 
 static void popErrorScopeCallback(WGPUErrorType type, const char* message, void* userdata)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.cpp
@@ -93,7 +93,7 @@ static WTF::Function<void(CompletionHandler<void()>&&)> convert(WGPUOnSubmittedW
 
 RefPtr<PresentationContext> GPUImpl::createPresentationContext(const PresentationContextDescriptor& presentationContextDescriptor)
 {
-    Ref compositorIntegration = m_convertToBackingContext->convertToBacking(Ref { presentationContextDescriptor.compositorIntegration }.get());
+    Ref compositorIntegration = m_convertToBackingContext->convertToBacking(protect(presentationContextDescriptor.compositorIntegration).get());
 
     auto registerCallbacksBlock = makeBlockPtr([&](WGPURenderBuffersWereRecreatedBlockCallback renderBuffersWereRecreatedCallback, WGPUOnSubmittedWorkScheduledCallback onSubmittedWorkScheduledCallback) {
         compositorIntegration->registerCallbacks(makeBlockPtr(WTF::move(renderBuffersWereRecreatedCallback)), convert(WTF::move(onSubmittedWorkScheduledCallback)));

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
@@ -51,7 +51,7 @@ QueueImpl::~QueueImpl() = default;
 void QueueImpl::submit(Vector<Ref<WebGPU::CommandBuffer>>&& commandBuffers)
 {
     auto backingCommandBuffers = commandBuffers.map([&](auto commandBuffer) {
-        return Ref { m_convertToBackingContext }->convertToBacking(commandBuffer);
+        return protect(m_convertToBackingContext)->convertToBacking(commandBuffer);
     });
 
     wgpuQueueSubmit(m_backing.get(), backingCommandBuffers.size(), backingCommandBuffers.span().data());
@@ -98,7 +98,7 @@ void QueueImpl::writeBufferNoCopy(
     Size64 dataOffset,
     std::optional<Size64> size)
 {
-    wgpuQueueWriteBuffer(m_backing.get(), Ref { m_convertToBackingContext }->convertToBacking(buffer), bufferOffset, source.subspan(dataOffset, size.value_or(source.size() - dataOffset)));
+    wgpuQueueWriteBuffer(m_backing.get(), protect(m_convertToBackingContext)->convertToBacking(buffer), bufferOffset, source.subspan(dataOffset, size.value_or(source.size() - dataOffset)));
 }
 
 void QueueImpl::writeTexture(

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRBindingImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRBindingImpl.cpp
@@ -65,7 +65,7 @@ RefPtr<XRSubImage> XRBindingImpl::getSubImage(XRProjectionLayer&, WebCore::WebXR
 RefPtr<XRSubImage> XRBindingImpl::getViewSubImage(XRProjectionLayer& projectionLayer)
 {
     auto& projectionLayerImpl = downcast<XRProjectionLayerImpl>(projectionLayer);
-    return XRSubImageImpl::create(adoptWebGPU(wgpuBindingGetViewSubImage(m_backing.get(), projectionLayerImpl.backing())), Ref { m_convertToBackingContext });
+    return XRSubImageImpl::create(adoptWebGPU(wgpuBindingGetViewSubImage(m_backing.get(), projectionLayerImpl.backing())), protect(m_convertToBackingContext));
 }
 
 TextureFormat XRBindingImpl::getPreferredColorFormat()


### PR DESCRIPTION
#### 568ffc2322503818f7cb67b0a77e6580666d545b
<pre>
Use protect() instead of Ref { } in Source/WebCore/Modules/WebGPU
<a href="https://bugs.webkit.org/show_bug.cgi?id=311634">https://bugs.webkit.org/show_bug.cgi?id=311634</a>
<a href="https://rdar.apple.com/174226028">rdar://174226028</a>

Reviewed by Mike Wyrzykowski.

Mechanical migration from Ref { expr } to protect(expr) in WebCore&apos;s WebGPU
DOM binding and Implementation layers, aligning with the codebase-wide
transition away from brace-initialized smart pointer temporaries.

For GPUDevice::GPUDevice, the Ref { } wrapper around m_backing-&gt;queue() was
removed entirely since queue() already returns Ref&lt;Queue&gt; by value.

No new tests needed (no behavioral change, style-only refactor).

* Source/WebCore/Modules/WebGPU/GPUAdapter.cpp:
(WebCore::GPUAdapter::requestDevice):
* Source/WebCore/Modules/WebGPU/GPUBuffer.cpp:
(WebCore::GPUBuffer::mapAsync):
* Source/WebCore/Modules/WebGPU/GPUCommandBuffer.cpp:
(WebCore::GPUCommandBuffer::setLabel):
* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
(WebCore::GPUDevice::GPUDevice):
* Source/WebCore/Modules/WebGPU/GPUPipelineLayoutDescriptor.h:
(WebCore::GPUPipelineLayoutDescriptor::convertToBacking const):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp:
(WebCore::WebGPU::AdapterImpl::requestDevice):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp:
(WebCore::WebGPU::DeviceImpl::createComputePipelineAsync):
(WebCore::WebGPU::DeviceImpl::pushErrorScope):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.cpp:
(WebCore::WebGPU::GPUImpl::createPresentationContext):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp:
(WebCore::WebGPU::QueueImpl::submit):
(WebCore::WebGPU::QueueImpl::writeBufferNoCopy):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRBindingImpl.cpp:
(WebCore::WebGPU::XRBindingImpl::getViewSubImage):

Canonical link: <a href="https://commits.webkit.org/310728@main">https://commits.webkit.org/310728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/760e10d2fc62e6c9802253a81e05ea719cb68d46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163425 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108135 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/97e84053-dddc-40fc-9241-cf2d9e2dfb53) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27774 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119639 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84601 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb81fa83-f277-4260-966f-5abfe398f65b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21926 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138906 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100333 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5c14f597-500d-4bd8-b738-df72890dd90c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21012 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19030 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11252 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130674 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16750 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165899 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9112 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18359 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127741 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23070 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127880 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34718 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138543 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84076 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22777 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15337 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27086 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91188 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26664 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26895 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26737 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->