### PR TITLE
REGRESSION (STP 239-240): MediaStreamTrack DataCloneError: The object can not be cloned

### DIFF
--- a/LayoutTests/http/wpt/mediastream/serialize-mediastreamtrack-to-worker-expected.txt
+++ b/LayoutTests/http/wpt/mediastream/serialize-mediastreamtrack-to-worker-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Serialize MediaStreamTrack to dedicated worker and use MediaStreamTrackProcessor
+

--- a/LayoutTests/http/wpt/mediastream/serialize-mediastreamtrack-to-worker.html
+++ b/LayoutTests/http/wpt/mediastream/serialize-mediastreamtrack-to-worker.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<canvas id=canvas width=640 height=480></canvas>
+<script>
+
+async function createWorker(script)
+{
+    script += "self.postMessage('ready');";
+    const blob = new Blob([script], { type: 'text/javascript' });
+    const url = URL.createObjectURL(blob);
+    const worker = new Worker(url);
+    await new Promise(resolve => worker.onmessage = () => {
+        resolve();
+    });
+    URL.revokeObjectURL(url);
+    return worker;
+}
+
+async function getFrameFromTrack(test, worker, track)
+{
+    worker.postMessage({ track });
+
+    const result = await new Promise(resolve => worker.onmessage = e => resolve(e.data));
+    test.add_cleanup(() => result.value.close());
+
+    assert_equals(result.value.codedWidth, 640);
+    assert_equals(result.value.codedHeight, 480);
+}
+
+promise_test(async test => {
+    if (!window.internals)
+        return;
+
+    window.internals.setTopDocumentURLForQuirks("https://zoom.us");
+
+    const stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640, height: 480 } });
+
+    const worker = await createWorker(`
+        self.onmessage = async (event) => {
+            const processor = new MediaStreamTrackProcessor({ track: event.data.track });
+            const data = await processor.readable.getReader().read();
+            self.postMessage(data);
+            data.value.close();
+        }
+    `);
+    test.add_cleanup(() => worker.terminate());
+    const track = stream.getVideoTracks()[0];
+
+    await getFrameFromTrack(test, worker, track);
+
+    assert_equals(track.readyState, "live");
+
+    await getFrameFromTrack(test, worker, track);
+}, "Serialize MediaStreamTrack to dedicated worker and use MediaStreamTrackProcessor");
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -1186,7 +1186,7 @@ public:
             Vector<RefPtr<WebCodecsAudioData>>& serializedAudioData,
 #endif
 #if ENABLE(MEDIA_STREAM)
-            const Vector<Ref<MediaStreamTrack>>& detachedMediaStreamTracks,
+            Vector<Ref<MediaStreamTrack>>& detachedMediaStreamTracks,
             const Vector<Ref<MediaStreamTrackHandle>>& detachedMediaStreamTrackHandles,
 #endif
 #if ENABLE(WEBASSEMBLY)
@@ -1234,6 +1234,10 @@ public:
 #endif
             blobHandles, out, context, sharedBuffers, forStorage);
         auto code = serializer.serialize(value);
+#if ENABLE(MEDIA_STREAM)
+        for (auto& track : std::exchange(serializer.m_serializedMediaStreamTracks , { }))
+            detachedMediaStreamTracks.append(track.releaseNonNull());
+#endif
 #if ASSERT_ENABLED
         RETURN_IF_EXCEPTION(scope, code);
         validateSerializedResult(serializer, code, out, lexicalGlobalObject, messagePorts, sharedBuffers, sharedBuffers, inMemoryMessagePorts);
@@ -1960,13 +1964,23 @@ private:
     void dumpMediaStreamTrack(JSObject* obj, SerializationReturnCode& code)
     {
         auto index = m_transferredMediaStreamTracks.find(obj);
-        if (index != m_transferredMediaStreamTracks.end()) {
-            write(MediaStreamTrackTag);
-            write(index->value);
-            return;
+        if (index == m_transferredMediaStreamTracks.end()) {
+            bool shouldAllowMediaStreamTrackSerialization = [&] {
+                RefPtr context = jsCast<JSDOMGlobalObject*>(m_lexicalGlobalObject)->scriptExecutionContext();
+                RefPtr document = dynamicDowncast<Document>(context);
+                return document && document->quirks().shouldAllowMediaStreamTrackSerializationQuirk();
+            }();
+            if (!shouldAllowMediaStreamTrackSerialization) {
+                code = SerializationReturnCode::DataCloneError;
+                return;
+            }
+
+            m_serializedMediaStreamTracks.append(protect(jsCast<JSMediaStreamTrack*>(obj)->wrapped())->clone());
+            index = m_transferredMediaStreamTracks.add(obj, m_transferredMediaStreamTracks.size()).iterator;
         }
 
-        code = SerializationReturnCode::DataCloneError;
+        write(MediaStreamTrackTag);
+        write(index->value);
     }
     void dumpMediaStreamTrackHandle(JSObject* obj, SerializationReturnCode& code)
     {
@@ -2902,6 +2916,7 @@ private:
 #endif
 #if ENABLE(MEDIA_STREAM)
     ObjectPoolMap m_transferredMediaStreamTracks;
+    Vector<RefPtr<MediaStreamTrack>> m_serializedMediaStreamTracks;
     ObjectPoolMap m_transferredMediaStreamTrackHandles;
 #endif
     SerializationForStorage m_forStorage;

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1150,6 +1150,13 @@ bool Quirks::shouldDisableImageCaptureQuirk() const
     return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldDisableImageCaptureQuirk);
 }
 
+bool Quirks::shouldAllowMediaStreamTrackSerializationQuirk() const
+{
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldAllowMediaStreamTrackSerializationQuirk);
+}
+
 bool Quirks::shouldEnableCameraAndMicrophonePermissionStateQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
@@ -3576,6 +3583,7 @@ static void handleZoomQuirks(QuirksData& quirksData, const URL& /* quirksURL */,
 #if ENABLE(MEDIA_STREAM)
         // zoom.us rdar://118185086
         QuirksData::SiteSpecificQuirk::ShouldDisableImageCaptureQuirk,
+        QuirksData::SiteSpecificQuirk::ShouldAllowMediaStreamTrackSerializationQuirk
 #endif
     });
 }

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -164,6 +164,7 @@ public:
     Ref<NodeList> applyFacebookFlagQuirk(Document&, NodeList&);
     bool shouldEnableLegacyGetUserMediaQuirk() const;
     bool shouldDisableImageCaptureQuirk() const;
+    bool shouldAllowMediaStreamTrackSerializationQuirk() const;
     bool shouldEnableSpeakerSelectionPermissionsPolicyQuirk() const;
     bool shouldEnableEnumerateDeviceQuirk() const;
     bool shouldEnableCameraAndMicrophonePermissionStateQuirk() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -158,6 +158,7 @@ struct QuirksData {
 #endif
 #if ENABLE(MEDIA_STREAM)
         ShouldDisableImageCaptureQuirk,
+        ShouldAllowMediaStreamTrackSerializationQuirk,
 #endif
         ShouldDisableLazyIframeLoadingQuirk,
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 3bf2b90a001e19959ef3f1f05cf61ee8addf92e4
<pre>
REGRESSION (STP 239-240): MediaStreamTrack DataCloneError: The object can not be cloned
<a href="https://rdar.apple.com/173891803">rdar://173891803</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311156">https://bugs.webkit.org/show_bug.cgi?id=311156</a>

Reviewed by Eric Carlson.

We add a quirk that allows to serialize MediaStreamTrack via postMessage.
Basically, any track that is not in the transfer list is cloned and the clone is added to the transfer list.
This ensures that the serialized track is not stopped as part of postMessage.

We enable this quirk for Zoom.
This quirk is only enabled for document&apos;s contexts, not workers, since this is sufficient to unbreak Zoom.

Test: http/wpt/mediastream/serialize-mediastreamtrack-to-worker.html
Canonical link: <a href="https://commits.webkit.org/310717@main">https://commits.webkit.org/310717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1e563d62129768542eba42f35092d35a5f87179

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163429 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108138 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27777 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119643 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/84604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157628 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138912 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100337 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/33ce20ab-4825-438e-a4e9-90fe578dd85b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21018 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19034 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11255 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130680 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16756 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165903 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9115 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18365 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127745 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27473 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23074 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127884 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34709 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27397 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138549 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84079 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22783 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15343 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27089 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91191 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26667 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26898 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26740 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->