### PR TITLE
[GTK4] Mark old favicon API as deprecated

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
@@ -85,23 +85,16 @@ WEBKIT_DEFINE_FINAL_TYPE(WebKitFaviconDatabase, webkit_favicon_database, G_TYPE_
 static void webkit_favicon_database_class_init(WebKitFaviconDatabaseClass* faviconDatabaseClass)
 {
 #if PLATFORM(GTK)
-    /**
-     * WebKitFaviconDatabase::favicon-changed:
-     * @database: the object on which the signal is emitted
-     * @page_uri: the URI of the Web page containing the icon
-     * @favicon_uri: the URI of the favicon
-     *
-     * This signal is emitted when the favicon URI of @page_uri has
-     * been changed to @favicon_uri in the database. You can connect
-     * to this signal and call webkit_favicon_database_get_favicon()
-     * to get the favicon. If you are interested in the favicon of a
-     * #WebKitWebView it's easier to use the #WebKitWebView:favicon
-     * property. See webkit_web_view_get_favicon() for more details.
-     */
+#if USE(GTK4)
+    static constexpr auto faviconChangedSignalFlags =
+        static_cast<GSignalFlags>(G_SIGNAL_RUN_LAST | G_SIGNAL_DEPRECATED);
+#else
+    static constexpr auto faviconChangedSignalFlags = G_SIGNAL_RUN_LAST;
+#endif // USE(GTK4)
     signals[FAVICON_CHANGED] = g_signal_new(
         "favicon-changed",
         G_TYPE_FROM_CLASS(faviconDatabaseClass),
-        G_SIGNAL_RUN_LAST,
+        faviconChangedSignalFlags,
         0, nullptr, nullptr,
         g_cclosure_marshal_generic,
         G_TYPE_NONE, 2,
@@ -221,25 +214,6 @@ void webkitFaviconDatabaseGetFaviconInternal(WebKitFaviconDatabase* database, co
         });
 }
 
-/**
- * webkit_favicon_database_get_favicon:
- * @database: a #WebKitFaviconDatabase
- * @page_uri: URI of the page for which we want to retrieve the favicon
- * @cancellable: (allow-none): A #GCancellable or %NULL.
- * @callback: (scope async) (nullable): A #GAsyncReadyCallback to call when the request is
- *            satisfied or %NULL if you don't care about the result.
- * @user_data: The data to pass to @callback.
- *
- * Asynchronously obtains a favicon image.
- *
- * Asynchronously obtains an image of the favicon for the
- * given page URI. It returns the cached icon if it's in the database
- * asynchronously waiting for the icon to be read from the database.
- *
- * This is an asynchronous method. When the operation is finished, callback will
- * be invoked. You can then call webkit_favicon_database_get_favicon_finish()
- * to get the result of the operation.
- */
 void webkit_favicon_database_get_favicon(WebKitFaviconDatabase* database, const gchar* pageURI, GCancellable* cancellable, GAsyncReadyCallback callback, gpointer userData)
 {
     g_return_if_fail(WEBKIT_IS_FAVICON_DATABASE(database));
@@ -248,16 +222,6 @@ void webkit_favicon_database_get_favicon(WebKitFaviconDatabase* database, const 
     webkitFaviconDatabaseGetFaviconInternal(database, pageURI, false, cancellable, callback, userData);
 }
 
-/**
- * webkit_favicon_database_get_favicon_finish:
- * @database: a #WebKitFaviconDatabase
- * @result: A #GAsyncResult obtained from the #GAsyncReadyCallback passed to webkit_favicon_database_get_favicon()
- * @error: (allow-none): Return location for error or %NULL.
- *
- * Finishes an operation started with webkit_favicon_database_get_favicon().
- *
- * Returns: (transfer full): a new favicon image, or %NULL in case of error.
- */
 #if USE(GTK4)
 GdkTexture* webkit_favicon_database_get_favicon_finish(WebKitFaviconDatabase* database, GAsyncResult* result, GError** error)
 #else
@@ -283,16 +247,6 @@ cairo_surface_t* webkit_favicon_database_get_favicon_finish(WebKitFaviconDatabas
 #endif
 }
 
-/**
- * webkit_favicon_database_get_favicon_uri:
- * @database: a #WebKitFaviconDatabase
- * @page_uri: URI of the page containing the icon
- *
- * Obtains the URI of the favicon for the given @page_uri.
- *
- * Returns: a newly allocated URI for the favicon, or %NULL if the
- * database doesn't have a favicon for @page_uri.
- */
 gchar* webkit_favicon_database_get_favicon_uri(WebKitFaviconDatabase* database, const gchar* pageURL)
 {
     g_return_val_if_fail(WEBKIT_IS_FAVICON_DATABASE(database), nullptr);

--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.h.in
@@ -124,4 +124,132 @@ webkit_favicon_database_clear              (WebKitFaviconDatabase *database);
 
 G_END_DECLS
 
+#if USE(GTK4)
+/**
+ * WebKitFaviconDatabase::favicon-changed:
+ * @database: the object on which the signal is emitted
+ * @page_uri: the URI of the Web page containing the icon
+ * @favicon_uri: the URI of the favicon
+ *
+ * This signal is emitted when the favicon URI of @page_uri has
+ * been changed to @favicon_uri in the database. You can connect
+ * to this signal and call webkit_favicon_database_get_favicon()
+ * to get the favicon. If you are interested in the favicon of a
+ * #WebKitWebView it's easier to use the #WebKitWebView:favicon
+ * property. See webkit_web_view_get_favicon() for more details.
+ *
+ * Deprecated: 2.54
+ */
+
+/**
+ * webkit_favicon_database_get_favicon:
+ * @database: a #WebKitFaviconDatabase
+ * @page_uri: URI of the page for which we want to retrieve the favicon
+ * @cancellable: (allow-none): A #GCancellable or %NULL.
+ * @callback: (scope async) (nullable): A #GAsyncReadyCallback to call when the request is
+ *            satisfied or %NULL if you don't care about the result.
+ * @user_data: The data to pass to @callback.
+ *
+ * Asynchronously obtains a favicon image.
+ *
+ * Asynchronously obtains an image of the favicon for the
+ * given page URI. It returns the cached icon if it's in the database
+ * asynchronously waiting for the icon to be read from the database.
+ *
+ * This is an asynchronous method. When the operation is finished, callback will
+ * be invoked. You can then call webkit_favicon_database_get_favicon_finish()
+ * to get the result of the operation.
+ *
+ * New applications should use [method@FaviconDatabase.get_page_icons] and
+ * [method@FaviconDatabase.get_page_icons_finish] instead.
+ *
+ * Deprecated: 2.54
+ */
+
+/**
+ * webkit_favicon_database_get_favicon_finish:
+ * @database: a #WebKitFaviconDatabase
+ * @result: A #GAsyncResult obtained from the #GAsyncReadyCallback passed to webkit_favicon_database_get_favicon()
+ * @error: (allow-none): Return location for error or %NULL.
+ *
+ * Finishes an operation started with webkit_favicon_database_get_favicon().
+ *
+ * New applications should use [method@FaviconDatabase.get_page_icons] and
+ * [method@FaviconDatabase.get_page_icons_finish] instead.
+ *
+ * Returns: (transfer full): a new favicon image, or %NULL in case of error.
+ *
+ * Deprecated: 2.54
+ */
+
+/**
+ * webkit_favicon_database_get_favicon_uri:
+ * @database: a #WebKitFaviconDatabase
+ * @page_uri: URI of the page containing the icon
+ *
+ * Obtains the URI of the favicon for the given @page_uri.
+ *
+ * Returns: a newly allocated URI for the favicon, or %NULL if the
+ * database doesn't have a favicon for @page_uri.
+ *
+ * Deprecated: 2.54
+ */
+#else
+/**
+ * WebKitFaviconDatabase::favicon-changed:
+ * @database: the object on which the signal is emitted
+ * @page_uri: the URI of the Web page containing the icon
+ * @favicon_uri: the URI of the favicon
+ *
+ * This signal is emitted when the favicon URI of @page_uri has
+ * been changed to @favicon_uri in the database. You can connect
+ * to this signal and call webkit_favicon_database_get_favicon()
+ * to get the favicon. If you are interested in the favicon of a
+ * #WebKitWebView it's easier to use the #WebKitWebView:favicon
+ * property. See webkit_web_view_get_favicon() for more details.
+ */
+
+/**
+ * webkit_favicon_database_get_favicon:
+ * @database: a #WebKitFaviconDatabase
+ * @page_uri: URI of the page for which we want to retrieve the favicon
+ * @cancellable: (allow-none): A #GCancellable or %NULL.
+ * @callback: (scope async) (nullable): A #GAsyncReadyCallback to call when the request is
+ *            satisfied or %NULL if you don't care about the result.
+ * @user_data: The data to pass to @callback.
+ *
+ * Asynchronously obtains a favicon image.
+ *
+ * Asynchronously obtains an image of the favicon for the
+ * given page URI. It returns the cached icon if it's in the database
+ * asynchronously waiting for the icon to be read from the database.
+ *
+ * This is an asynchronous method. When the operation is finished, callback will
+ * be invoked. You can then call webkit_favicon_database_get_favicon_finish()
+ * to get the result of the operation.
+ */
+
+/**
+ * webkit_favicon_database_get_favicon_finish:
+ * @database: a #WebKitFaviconDatabase
+ * @result: A #GAsyncResult obtained from the #GAsyncReadyCallback passed to webkit_favicon_database_get_favicon()
+ * @error: (allow-none): Return location for error or %NULL.
+ *
+ * Finishes an operation started with webkit_favicon_database_get_favicon().
+ *
+ * Returns: (transfer full): a new favicon image, or %NULL in case of error.
+ */
+
+/**
+ * webkit_favicon_database_get_favicon_uri:
+ * @database: a #WebKitFaviconDatabase
+ * @page_uri: URI of the page containing the icon
+ *
+ * Obtains the URI of the favicon for the given @page_uri.
+ *
+ * Returns: a newly allocated URI for the favicon, or %NULL if the
+ * database doesn't have a favicon for @page_uri.
+ */
+#endif // USE(GTK4)
+
 #endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -1485,12 +1485,6 @@ static void webkit_web_view_class_init(WebKitWebViewClass* webViewClass)
             WEBKIT_PARAM_READABLE);
 
 #if PLATFORM(GTK)
-    /**
-     * WebKitWebView:favicon:
-     *
-     * The favicon currently associated to the #WebKitWebView.
-     * See webkit_web_view_get_favicon() for more details.
-     */
     sObjProperties[PROP_FAVICON] =
 #if USE(GTK4)
         g_param_spec_object(
@@ -3985,19 +3979,6 @@ const gchar* webkit_web_view_get_uri(WebKitWebView* webView)
 }
 
 #if PLATFORM(GTK)
-/**
- * webkit_web_view_get_favicon:
- * @web_view: a #WebKitWebView
- *
- * Returns favicon currently associated to @web_view.
- *
- * Returns favicon currently associated to @web_view, if any. You can
- * connect to notify::favicon signal of @web_view to be notified when
- * the favicon is available.
- *
- * Returns: (transfer none): the favicon image or %NULL if there's no
- *    icon associated with @web_view.
- */
 #if USE(GTK4)
 GdkTexture* webkit_web_view_get_favicon(WebKitWebView* webView)
 #else

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -1097,6 +1097,60 @@ webkit_web_view_leave_immersive_mode                 (WebKitWebView             
  */
 #endif
 
+#if PLATFORM(GTK)
+#if USE(GTK4)
+/**
+ * WebKitWebView:favicon:
+ *
+ * The favicon currently associated to the #WebKitWebView.
+ * See webkit_web_view_get_favicon() for more details.
+ *
+ * New applications should use [property@WebView:page-icons] instead.
+ *
+ * Deprecated: 2.54
+ */
+
+/**
+ * webkit_web_view_get_favicon:
+ * @web_view: a #WebKitWebView
+ *
+ * Returns favicon currently associated to @web_view.
+ *
+ * Returns favicon currently associated to @web_view, if any. You can
+ * connect to notify::favicon signal of @web_view to be notified when
+ * the favicon is available.
+ *
+ * New applications should use [method@WebView.get_page_icons] instead.
+ *
+ * Returns: (transfer none): the favicon image or %NULL if there's no
+ *    icon associated with @web_view.
+ *
+ * Deprecated: 2.54
+ */
+#else
+/**
+ * WebKitWebView:favicon:
+ *
+ * The favicon currently associated to the #WebKitWebView.
+ * See webkit_web_view_get_favicon() for more details.
+ */
+
+/**
+ * webkit_web_view_get_favicon:
+ * @web_view: a #WebKitWebView
+ *
+ * Returns favicon currently associated to @web_view.
+ *
+ * Returns favicon currently associated to @web_view, if any. You can
+ * connect to notify::favicon signal of @web_view to be notified when
+ * the favicon is available.
+ *
+ * Returns: (transfer none): the favicon image or %NULL if there's no
+ *    icon associated with @web_view.
+ */
+#endif // USE(GTK4)
+#endif // PLATFORM(GTK)
+
 G_END_DECLS
 
 #endif


### PR DESCRIPTION
#### 848a9b915e9b3a6742bc32cf79e2eac51a136333
<pre>
[GTK4] Mark old favicon API as deprecated
<a href="https://bugs.webkit.org/show_bug.cgi?id=311225">https://bugs.webkit.org/show_bug.cgi?id=311225</a>

Reviewed by Patrick Griffis.

Deprecate the old favicon public API, and edit the documentation
comments to refer to the new functions that may be used instead.

* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp:
(webkit_favicon_database_class_init):
* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkit_web_view_class_init):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:

Canonical link: <a href="https://commits.webkit.org/318964@main">https://commits.webkit.org/318964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ff72f071df96a9a26f2378acc7edf51a9a23ccc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/47661 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190131 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144238 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/53581 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140305 "Found 1 new test failure: fast/dom/lazy-image-loading-document-leak.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182875 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161083 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120756 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/42627 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40944 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153029 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40610 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1287 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/46464 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192062 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/53531 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/149637 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54218 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149366 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27328 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44013 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/126481 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/121538 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/52735 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/15596 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52117 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52355 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52181 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->