### PR TITLE
REGRESSION(310695@main) Some idlharness tests are failing after SVGElementInstance removal

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/idlharness-expected.txt
@@ -3,7 +3,6 @@ PASS idl_test setup
 PASS idl_test validation
 PASS Partial interface Element: member names are unique
 PASS SVGElement includes GlobalEventHandlers: member names are unique
-PASS SVGElement includes SVGElementInstance: member names are unique
 PASS SVGElement includes HTMLOrSVGElement: member names are unique
 PASS Element includes ParentNode: member names are unique
 PASS Element includes NonDocumentTypeChildNode: member names are unique

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/idlharness-expected.txt
@@ -14,7 +14,6 @@ PASS HTMLElement includes ElementCSSInlineStyle: member names are unique
 PASS SVGElement includes ElementCSSInlineStyle: member names are unique
 PASS MathMLElement includes ElementCSSInlineStyle: member names are unique
 PASS SVGElement includes GlobalEventHandlers: member names are unique
-PASS SVGElement includes SVGElementInstance: member names are unique
 PASS SVGElement includes HTMLOrSVGElement: member names are unique
 PASS HTMLElement includes GlobalEventHandlers: member names are unique
 PASS HTMLElement includes ElementContentEditable: member names are unique

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/idlharness-expected.txt
@@ -19,7 +19,6 @@ PASS HTMLElement includes ElementCSSInlineStyle: member names are unique
 PASS SVGElement includes ElementCSSInlineStyle: member names are unique
 PASS MathMLElement includes ElementCSSInlineStyle: member names are unique
 PASS SVGElement includes GlobalEventHandlers: member names are unique
-PASS SVGElement includes SVGElementInstance: member names are unique
 PASS SVGElement includes HTMLOrSVGElement: member names are unique
 PASS SVGStyleElement includes LinkStyle: member names are unique
 PASS HTMLElement includes GlobalEventHandlers: member names are unique

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/idlharness.any-expected.txt
@@ -22,7 +22,6 @@ PASS SVGFESpecularLightingElement includes SVGFilterPrimitiveStandardAttributes:
 PASS SVGFETileElement includes SVGFilterPrimitiveStandardAttributes: member names are unique
 PASS SVGFETurbulenceElement includes SVGFilterPrimitiveStandardAttributes: member names are unique
 PASS SVGElement includes GlobalEventHandlers: member names are unique
-PASS SVGElement includes SVGElementInstance: member names are unique
 PASS SVGElement includes HTMLOrSVGElement: member names are unique
 PASS Element includes ParentNode: member names are unique
 PASS Element includes NonDocumentTypeChildNode: member names are unique

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/idlharness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/idlharness.any.worker-expected.txt
@@ -22,7 +22,6 @@ PASS SVGFESpecularLightingElement includes SVGFilterPrimitiveStandardAttributes:
 PASS SVGFETileElement includes SVGFilterPrimitiveStandardAttributes: member names are unique
 PASS SVGFETurbulenceElement includes SVGFilterPrimitiveStandardAttributes: member names are unique
 PASS SVGElement includes GlobalEventHandlers: member names are unique
-PASS SVGElement includes SVGElementInstance: member names are unique
 PASS SVGElement includes HTMLOrSVGElement: member names are unique
 PASS Element includes ParentNode: member names are unique
 PASS Element includes NonDocumentTypeChildNode: member names are unique

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/idlharness.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/idlharness.tentative-expected.txt
@@ -20,7 +20,6 @@ PASS Element includes NonDocumentTypeChildNode: member names are unique
 PASS Element includes ChildNode: member names are unique
 PASS Element includes Slottable: member names are unique
 PASS SVGElement includes GlobalEventHandlers: member names are unique
-PASS SVGElement includes SVGElementInstance: member names are unique
 PASS SVGElement includes HTMLOrSVGElement: member names are unique
 PASS SVGGraphicsElement includes SVGTests: member names are unique
 PASS SVGAElement includes SVGURIReference: member names are unique


### PR DESCRIPTION
#### 36a09f9e259ebb2be70161a76ef1445187a832bf
<pre>
REGRESSION(<a href="https://commits.webkit.org/310695@main">310695@main</a>) Some idlharness tests are failing after SVGElementInstance removal
<a href="https://bugs.webkit.org/show_bug.cgi?id=311646">https://bugs.webkit.org/show_bug.cgi?id=311646</a>

Unreviewed test gardening.

Update baselines.

* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/idlharness-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/idlharness-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/idlharness-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/idlharness.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/idlharness.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/idlharness.tentative-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36a09f9e259ebb2be70161a76ef1445187a832bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154680 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163440 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27788 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/119651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157639 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/21940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/138920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/100345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11266 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/130688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/16764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165914 "Built successfully") | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/18373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/127753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27484 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/23082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/127892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27408 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/138557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84093 "Built successfully") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/22789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27100 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26678 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26909 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26751 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->