### PR TITLE
ANGLE: Enable ANGLE test expectations in ANGLEEnd2EndTests runner

### DIFF
--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
@@ -469,6 +469,11 @@
 		7B81955C28CF63D800C7ABCD /* MemoryShaderCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B81955A28CF63D800C7ABCD /* MemoryShaderCache.h */; };
 		7B820C562DE992CD00DAC5E4 /* libtranslator.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7BF5549B2C81EDE0002B101E /* libtranslator.a */; };
 		7B820C792DE9956000DAC5E4 /* End2EndTestsSourcesPlatform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B820C762DE9956000DAC5E4 /* End2EndTestsSourcesPlatform.cpp */; };
+		7B8C09092F7E843B007E37DE /* TestSuite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B8C09082F7E843B007E37DE /* TestSuite.cpp */; };
+		7B8C09152F84EAB1007E37DE /* TestSuite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B8C09082F7E843B007E37DE /* TestSuite.cpp */; };
+		7B8C091A2F84EC49007E37DE /* GPUTestConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4D72DE49CE200327F7F /* GPUTestConfig.cpp */; };
+		7B8C091B2F84EC83007E37DE /* GPUTestExpectationsParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BFAF4DD2DE49CE200327F7F /* GPUTestExpectationsParser.cpp */; };
+		7B8C091C2F84EC9D007E37DE /* OSWindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BB971EB2DE468FE00455D13 /* OSWindow.cpp */; };
 		7B8EC8402DF1BC9100105EB6 /* ImageTestMetal.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7B8EC83F2DF1BC9100105EB6 /* ImageTestMetal.mm */; };
 		7B8EC8412DF1BC9100105EB6 /* GLSLUBTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B8EC83E2DF1BC9100105EB6 /* GLSLUBTest.cpp */; };
 		7B8EC8462DF2E5FC00105EB6 /* EnsureLoopForwardProgress.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B8EC8452DF2E5FC00105EB6 /* EnsureLoopForwardProgress.cpp */; };
@@ -2147,6 +2152,8 @@
 		7B81955928CF63D800C7ABCD /* MemoryShaderCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryShaderCache.cpp; sourceTree = "<group>"; };
 		7B81955A28CF63D800C7ABCD /* MemoryShaderCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MemoryShaderCache.h; sourceTree = "<group>"; };
 		7B820C762DE9956000DAC5E4 /* End2EndTestsSourcesPlatform.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = End2EndTestsSourcesPlatform.cpp; path = WebKit/End2EndTestsSourcesPlatform.cpp; sourceTree = "<group>"; };
+		7B8C09072F7E843B007E37DE /* TestSuite.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestSuite.h; sourceTree = "<group>"; };
+		7B8C09082F7E843B007E37DE /* TestSuite.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TestSuite.cpp; sourceTree = "<group>"; };
 		7B8EC83E2DF1BC9100105EB6 /* GLSLUBTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GLSLUBTest.cpp; sourceTree = "<group>"; };
 		7B8EC83F2DF1BC9100105EB6 /* ImageTestMetal.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ImageTestMetal.mm; sourceTree = "<group>"; };
 		7B8EC8442DF2E5FC00105EB6 /* EnsureLoopForwardProgress.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EnsureLoopForwardProgress.h; sourceTree = "<group>"; };
@@ -3806,6 +3813,15 @@
 			path = shader_translator;
 			sourceTree = "<group>";
 		};
+		7B8C09062F7E8348007E37DE /* runner */ = {
+			isa = PBXGroup;
+			children = (
+				7B8C09082F7E843B007E37DE /* TestSuite.cpp */,
+				7B8C09072F7E843B007E37DE /* TestSuite.h */,
+			);
+			path = runner;
+			sourceTree = "<group>";
+		};
 		7BB971C22DE4577C00455D13 /* tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -4026,6 +4042,7 @@
 		7BFAF4B02DE4947900327F7F /* test_utils */ = {
 			isa = PBXGroup;
 			children = (
+				7B8C09062F7E8348007E37DE /* runner */,
 				7BFAF4B12DE494CF00327F7F /* angle_test_configs.cpp */,
 				7BFAF4CD2DE49C3B00327F7F /* angle_test_configs.h */,
 				7BFAF4B22DE494CF00327F7F /* angle_test_instantiate.cpp */,
@@ -5990,6 +6007,7 @@
 				7BFAF5E22DE59E0900327F7F /* StateChangeTest.cpp in Sources */,
 				7BFAF5BD2DE59E0900327F7F /* SwizzleTest.cpp in Sources */,
 				7BFAF6672DE5A7A200327F7F /* system_info_util.cpp in Sources */,
+				7B8C09092F7E843B007E37DE /* TestSuite.cpp in Sources */,
 				7BFAF5C92DE59E0900327F7F /* TextureExternalUpdateTest.cpp in Sources */,
 				7BFAF6042DE59E0900327F7F /* TextureFixedRateCompressionTest.cpp in Sources */,
 				7BFAF5CC2DE59E0900327F7F /* TextureMultisampleTest.cpp in Sources */,
@@ -6240,6 +6258,8 @@
 				7BFAF8ED2DE6EDE400327F7F /* FixedQueue_unittest.cpp in Sources */,
 				7BFAF8E02DE6EDE400327F7F /* FixedVector_unittest.cpp in Sources */,
 				7BFAF8812DE6ECA700327F7F /* FloatLex_test.cpp in Sources */,
+				7B8C091A2F84EC49007E37DE /* GPUTestConfig.cpp in Sources */,
+				7B8C091B2F84EC83007E37DE /* GPUTestExpectationsParser.cpp in Sources */,
 				7BFAF8E52DE6EDE400327F7F /* hash_utils_unittest.cpp in Sources */,
 				7BFAF8B12DE6ECA700327F7F /* ImmutableString_test.cpp in Sources */,
 				7BFAF8B62DE6ECA700327F7F /* ImmutableString_test_autogen.cpp in Sources */,
@@ -6250,12 +6270,14 @@
 				7BFAF8EC2DE6EDE400327F7F /* MemoryBuffer_unittest.cpp in Sources */,
 				7BFAF8A72DE6ECA700327F7F /* MSLOutput_test.cpp in Sources */,
 				7BFAF8E62DE6EDE400327F7F /* Optional_unittest.cpp in Sources */,
+				7B8C091C2F84EC9D007E37DE /* OSWindow.cpp in Sources */,
 				7BFAF8F02DE6EDE400327F7F /* PoolAlloc_unittest.cpp in Sources */,
 				7BFAF8F12DE6EDE400327F7F /* SimpleMutex_unittest.cpp in Sources */,
 				7BFAF8E12DE6EDE400327F7F /* span_unittest.cpp in Sources */,
 				7BFAF8E42DE6EDE400327F7F /* string_utils_unittest.cpp in Sources */,
 				7BFAF8E32DE6EDE400327F7F /* system_utils_unittest.cpp in Sources */,
 				7BFAF8F32DE6EE4500327F7F /* SystemInfo_unittest.cpp in Sources */,
+				7B8C09152F84EAB1007E37DE /* TestSuite.cpp in Sources */,
 				7BFAF8C12DE6ECA700327F7F /* Type_test.cpp in Sources */,
 				7BFAF8BB2DE6ECA700327F7F /* VariablePacker_test.cpp in Sources */,
 				7BFAF8E22DE6EDE400327F7F /* vector_utils_unittest.cpp in Sources */,

--- a/Source/ThirdParty/ANGLE/src/tests/angle_deqp_tests_main.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/angle_deqp_tests_main.cpp
@@ -19,7 +19,7 @@ int RunGLCTSTests(int *argc, char **argv);
 
 int main(int argc, char **argv)
 {
-#if defined(ANGLE_PLATFORM_MACOS)
+#if defined(ANGLE_PLATFORM_MACOS) && defined(ANGLE_OUTSIDE_WEBKIT)
     // By default, we should hook file API functions on macOS to avoid slow Metal shader caching
     // file access.
     angle::InitMetalFileAPIHooking(argc, argv);

--- a/Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests_main.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests_main.cpp
@@ -9,9 +9,7 @@
 #endif
 
 #include "gtest/gtest.h"
-#if defined(ANGLE_HAS_RAPIDJSON)
-#    include "test_utils/runner/TestSuite.h"
-#endif  // defined(ANGLE_HAS_RAPIDJSON)
+#include "test_utils/runner/TestSuite.h"
 #include "util/OSWindow.h"
 
 void ANGLEProcessTestArgs(int *argc, char *argv[]);
@@ -50,9 +48,6 @@ int main(int argc, char **argv)
         return EXIT_FAILURE;
     }
 
-    // TODO(b/279980674): TestSuite depends on rapidjson which we don't have in aosp builds,
-    // for now disable both TestSuite and expectations.
-#if defined(ANGLE_HAS_RAPIDJSON)
     ANGLEProcessTestArgs(&argc, argv);
 
     auto registerTestsCallback = [] {
@@ -83,8 +78,4 @@ int main(int argc, char **argv)
     }
 
     return testSuite.run();
-#else
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-#endif  // defined(ANGLE_HAS_RAPIDJSON)
 }

--- a/Source/ThirdParty/ANGLE/src/tests/angle_unittest_main.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/angle_unittest_main.cpp
@@ -10,9 +10,7 @@
 
 #include "GLSLANG/ShaderLang.h"
 #include "gtest/gtest.h"
-#if defined(ANGLE_HAS_RAPIDJSON)
-#    include "test_utils/runner/TestSuite.h"
-#endif
+#include "test_utils/runner/TestSuite.h"
 
 class CompilerTestEnvironment : public testing::Environment
 {
@@ -46,13 +44,7 @@ int main(int argc, char **argv)
             gVerbose = true;
         }
     }
-#if defined(ANGLE_HAS_RAPIDJSON)
     angle::TestSuite testSuite(&argc, argv);
     testing::AddGlobalTestEnvironment(new CompilerTestEnvironment());
     return testSuite.run();
-#else
-    testing::AddGlobalTestEnvironment(new CompilerTestEnvironment());
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-#endif  // defined(ANGLE_HAS_RAPIDJSON)
 }

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/ContextLostTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/ContextLostTest.cpp
@@ -226,7 +226,9 @@ ANGLE_INSTANTIATE_TEST(ContextLostTest,
                        WithRobustness(ES2_D3D11()),
                        WithRobustness(ES3_D3D11()),
                        WithRobustness(ES2_VULKAN()),
-                       WithRobustness(ES3_VULKAN()));
+                       WithRobustness(ES3_VULKAN()),
+                       WithRobustness(ES2_METAL()),
+                       WithRobustness(ES3_METAL()));
 
 ANGLE_INSTANTIATE_TEST(ContextLostSkipValidationTest,
                        WithRobustness(ES2_NULL()),
@@ -234,7 +236,10 @@ ANGLE_INSTANTIATE_TEST(ContextLostSkipValidationTest,
                        WithRobustness(ES2_D3D11()),
                        WithRobustness(ES3_D3D11()),
                        WithRobustness(ES2_VULKAN()),
-                       WithRobustness(ES3_VULKAN()));
+                       WithRobustness(ES3_VULKAN()),
+                       WithRobustness(ES2_METAL()),
+                       WithRobustness(ES3_METAL()));
+
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(ContextLostTestES32);
 ANGLE_INSTANTIATE_TEST(ContextLostTestES32, WithRobustness(ES32_VULKAN()));

--- a/Source/ThirdParty/ANGLE/src/tests/test_utils/ANGLETest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/test_utils/ANGLETest.cpp
@@ -29,9 +29,7 @@
 #    include <VersionHelpers.h>
 #endif  // defined(ANGLE_PLATFORM_WINDOWS)
 
-#if defined(ANGLE_HAS_RAPIDJSON)
-#    include "test_utils/runner/TestSuite.h"
-#endif  // defined(ANGLE_HAS_RAPIDJSON)
+#include "test_utils/runner/TestSuite.h"
 
 namespace angle
 {
@@ -712,9 +710,6 @@ void ANGLETestBase::ANGLETestSetUp()
     fullTestNameStr << testInfo->test_suite_name() << "." << testInfo->name();
     std::string fullTestName = fullTestNameStr.str();
 
-    // TODO(b/279980674): TestSuite depends on rapidjson which we don't have in aosp builds,
-    // for now disable both TestSuite and expectations.
-#if defined(ANGLE_HAS_RAPIDJSON)
     TestSuite *testSuite = TestSuite::GetInstance();
     int32_t testExpectation =
         testSuite->getTestExpectationWithConfigAndUpdateTimeout(testConfig, fullTestName);
@@ -723,7 +718,6 @@ void ANGLETestBase::ANGLETestSetUp()
     {
         GTEST_SKIP() << "Test skipped on this config";
     }
-#endif
 
     if (IsWindows())
     {

--- a/Source/ThirdParty/ANGLE/src/tests/test_utils/runner/TestSuite.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/test_utils/runner/TestSuite.cpp
@@ -28,16 +28,20 @@
 #include <unordered_map>
 
 #include <gtest/gtest.h>
+#if defined(ANGLE_HAS_RAPIDJSON)
 #include <rapidjson/document.h>
 #include <rapidjson/filewritestream.h>
 #include <rapidjson/istreamwrapper.h>
 #include <rapidjson/prettywriter.h>
+#endif
 
 // We directly call into a function to register the parameterized tests. This saves spinning up
 // a subprocess with a new gtest filter.
-#include <gtest/../../src/gtest-internal-inl.h>
+#include <gtest/src/gtest-internal-inl.h>
 
+#if defined(ANGLE_HAS_RAPIDJSON)
 namespace js = rapidjson;
+#endif
 
 namespace angle
 {
@@ -143,6 +147,7 @@ const char *ResultTypeToString(TestResultType type)
     }
 }
 
+#if defined(ANGLE_HAS_RAPIDJSON)
 TestResultType GetResultTypeFromString(const std::string &str)
 {
     if (str == "CRASH")
@@ -159,12 +164,14 @@ TestResultType GetResultTypeFromString(const std::string &str)
         return TestResultType::Timeout;
     return TestResultType::Unknown;
 }
+#endif
 
 bool IsFailedResult(TestResultType resultType)
 {
     return resultType != TestResultType::Pass && resultType != TestResultType::Skip;
 }
 
+#if defined(ANGLE_HAS_RAPIDJSON)
 js::Value ResultTypeToJSString(TestResultType type, js::Document::AllocatorType *allocator)
 {
     js::Value jsName;
@@ -354,6 +361,7 @@ void WriteHistogramJson(const HistogramWriter &histogramWriter, const std::strin
         printf("Error writing histogram json file.\n");
     }
 }
+#endif  // defined(ANGLE_HAS_RAPIDJSON)
 
 void UpdateCurrentTestResult(const testing::TestResult &resultIn, TestResults *resultsOut)
 {
@@ -469,6 +477,7 @@ std::string GetTestFilter(const std::vector<TestIdentifier> &tests)
     return filterStream.str();
 }
 
+#if defined(ANGLE_HAS_RAPIDJSON)
 bool GetTestArtifactsFromJSON(const js::Value::ConstObject &obj,
                               std::vector<std::string> *testArtifactPathsOut)
 {
@@ -653,6 +662,7 @@ bool GetTestResultsFromJSON(const js::Document &document, TestResults *resultsOu
 
     return true;
 }
+#endif  // defined(ANGLE_HAS_RAPIDJSON)
 
 bool MergeTestResults(TestResults *input, TestResults *output, int flakyRetries)
 {
@@ -1048,7 +1058,7 @@ TestSuite::TestSuite(int *argc, char **argv, std::function<void()> registerTests
     Optional<int> filterArgIndex;
     bool alsoRunDisabledTests = false;
 
-#if defined(ANGLE_PLATFORM_MACOS)
+#if defined(ANGLE_PLATFORM_MACOS) && defined(ANGLE_OUTSIDE_WEBKIT)
     // By default, we should hook file API functions on macOS to avoid slow Metal shader caching
     // file access.
     angle::InitMetalFileAPIHooking(*argc, argv);
@@ -1135,7 +1145,6 @@ TestSuite::TestSuite(int *argc, char **argv, std::function<void()> registerTests
         SetEnvironmentVar(kVkLoaderDisableDLLUnloadingEnvVar, "1");
     }
 #endif
-
     registerTestsCallback();
 
     std::string envShardIndex = angle::GetEnvironmentVar("GTEST_SHARD_INDEX");
@@ -1957,7 +1966,9 @@ void TestSuite::addHistogramSample(const std::string &measurement,
                                    double value,
                                    const std::string &units)
 {
+#if defined(ANGLE_HAS_RAPIDJSON)
     mHistogramWriter.addSample(measurement, story, value, units);
+#endif  // defined(ANGLE_HAS_RAPIDJSON)
 }
 
 bool TestSuite::hasTestArtifactsDirectory() const
@@ -1981,6 +1992,7 @@ std::string TestSuite::reserveTestArtifactPath(const std::string &artifactName)
 
 bool GetTestResultsFromFile(const char *fileName, TestResults *resultsOut)
 {
+#if defined(ANGLE_HAS_RAPIDJSON)
     std::ifstream ifs(fileName);
     if (!ifs.is_open())
     {
@@ -2005,6 +2017,9 @@ bool GetTestResultsFromFile(const char *fileName, TestResults *resultsOut)
     }
 
     return true;
+#else
+    return false;
+#endif  // defined(ANGLE_HAS_RAPIDJSON)
 }
 
 void TestSuite::dumpTestExpectationsErrorMessages()
@@ -2085,6 +2100,7 @@ int TestSuite::getSlowTestTimeout() const
 
 void TestSuite::writeOutputFiles(bool interrupted)
 {
+#if defined(ANGLE_HAS_RAPIDJSON)
     if (!mResultsFile.empty())
     {
         WriteResultsFile(interrupted, mTestResults, mResultsFile);
@@ -2094,6 +2110,7 @@ void TestSuite::writeOutputFiles(bool interrupted)
     {
         WriteHistogramJson(mHistogramWriter, mHistogramJsonFile);
     }
+#endif  // defined(ANGLE_HAS_RAPIDJSON)
 
     mMetricWriter.close();
 }

--- a/Source/ThirdParty/ANGLE/src/tests/test_utils/runner/TestSuite.h
+++ b/Source/ThirdParty/ANGLE/src/tests/test_utils/runner/TestSuite.h
@@ -16,9 +16,12 @@
 #include <string>
 #include <thread>
 
-#include "HistogramWriter.h"
 #include "tests/test_expectations/GPUTestExpectationsParser.h"
 #include "util/test_utils.h"
+
+#if defined(ANGLE_HAS_RAPIDJSON)
+#include "HistogramWriter.h"
+#endif
 
 namespace angle
 {
@@ -231,7 +234,9 @@ class TestSuite
     std::map<TestIdentifier, FileLine> mTestFileLines;
     std::vector<ProcessInfo> mCurrentProcesses;
     std::thread mWatchdogThread;
+#if defined(ANGLE_HAS_RAPIDJSON)
     HistogramWriter mHistogramWriter;
+#endif
     MetricWriter mMetricWriter;
     std::string mTestArtifactDirectory;
     GPUTestExpectationsParser mTestExpectationsParser;

--- a/Source/ThirdParty/ANGLE/util/OSWindow.cpp
+++ b/Source/ThirdParty/ANGLE/util/OSWindow.cpp
@@ -472,7 +472,8 @@ bool FindTestDataPath(const char *searchPath, char *dataPathOut, size_t maxDataP
 #else
     const std::string searchPaths[] = {
         GetExecutableDirectory(), GetExecutableDirectory() + "/../..", ".",
-        GetExecutableDirectory() + "/../../third_party/angle", "third_party/angle"};
+        GetExecutableDirectory() + "/../../third_party/angle", "third_party/angle",
+        GetExecutableDirectory() + "/../../Source/ThirdParty/ANGLE", "Source/ThirdParty/ANGLE"};
 #endif  // defined(ANGLE_PLATFORM_ANDROID)
 
     for (const std::string &path : searchPaths)

--- a/Source/ThirdParty/gtest/xcode/gtest.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/gtest/xcode/gtest.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -85,6 +85,8 @@
 		4539C9340EC280AE00A70F4C /* gtest-param-test.h in Headers */ = {isa = PBXBuildFile; fileRef = 4539C9330EC280AE00A70F4C /* gtest-param-test.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4539C93A0EC280E200A70F4C /* gtest-param-util.h in Copy Headers Internal */ = {isa = PBXBuildFile; fileRef = 4539C9370EC280E200A70F4C /* gtest-param-util.h */; };
 		4567C8181264FF71007740BE /* gtest-printers.h in Headers */ = {isa = PBXBuildFile; fileRef = 4567C8171264FF71007740BE /* gtest-printers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7B8C090E2F7E8A27007E37DE /* gtest-internal-inl.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B8C090D2F7E8A27007E37DE /* gtest-internal-inl.h */; };
+		7B8C090F2F7E8A27007E37DE /* gtest-internal-inl.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B8C090D2F7E8A27007E37DE /* gtest-internal-inl.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A3A1248A2BCF8BE400ACB2A0 /* gtest-assertion-result.h in Headers */ = {isa = PBXBuildFile; fileRef = A3A124892BCF8BE300ACB2A0 /* gtest-assertion-result.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A3C10BE0260952C60023155D /* gtest-matchers.h in Headers */ = {isa = PBXBuildFile; fileRef = A3C10BDF260952C50023155D /* gtest-matchers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F67D4F3E1C7F5D8B0017C729 /* gtest-port-arch.h in Headers */ = {isa = PBXBuildFile; fileRef = F67D4F3D1C7F5D8B0017C729 /* gtest-port-arch.h */; };
@@ -100,7 +102,7 @@
 		3171513E2D8250F500D53C18 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
-			filePatterns = "*.h";
+			filePatterns = "*/include/**/*.h";
 			fileType = pattern.proxy;
 			inputFiles = (
 			);
@@ -109,6 +111,19 @@
 				"$(HEADER_OUTPUT_DIR)/$(SRCROOT:dir:relativeto=$(INPUT_FILE_PATH))",
 			);
 			runOncePerArchitecture = 0;
+			script = "cp \"${INPUT_FILE_PATH}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+		};
+		7B8C09142F7E91CE007E37DE /* PBXBuildRule */ = {
+			isa = PBXBuildRule;
+			compilerSpec = com.apple.compilers.proxy.script;
+			filePatterns = "*/src/*.h";
+			fileType = pattern.proxy;
+			inputFiles = (
+			);
+			isEditable = 1;
+			outputFiles = (
+				"$(HEADER_OUTPUT_DIR)/include/gtest/$(SRCROOT:dir:relativeto=$(INPUT_FILE_PATH))",
+			);
 			script = "cp \"${INPUT_FILE_PATH}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 		};
 /* End PBXBuildRule section */
@@ -294,6 +309,7 @@
 		4539C9330EC280AE00A70F4C /* gtest-param-test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "gtest-param-test.h"; sourceTree = "<group>"; };
 		4539C9370EC280E200A70F4C /* gtest-param-util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "gtest-param-util.h"; sourceTree = "<group>"; };
 		4567C8171264FF71007740BE /* gtest-printers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "gtest-printers.h"; sourceTree = "<group>"; };
+		7B8C090D2F7E8A27007E37DE /* gtest-internal-inl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "gtest-internal-inl.h"; sourceTree = "<group>"; };
 		A3A124892BCF8BE300ACB2A0 /* gtest-assertion-result.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "gtest-assertion-result.h"; sourceTree = "<group>"; };
 		A3C10BDF260952C50023155D /* gtest-matchers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "gtest-matchers.h"; sourceTree = "<group>"; };
 		F67D4F3D1C7F5D8B0017C729 /* gtest-port-arch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "gtest-port-arch.h"; sourceTree = "<group>"; };
@@ -447,6 +463,7 @@
 			isa = PBXGroup;
 			children = (
 				224A12A10E9EADA700BD17FD /* gtest-all.cc */,
+				7B8C090D2F7E8A27007E37DE /* gtest-internal-inl.h */,
 				4048840D0E2F799B00CF7658 /* gtest_main.cc */,
 			);
 			name = src;
@@ -506,6 +523,7 @@
 				4048843B0E2F799B00CF7658 /* gtest.h in Headers */,
 				A3A1248A2BCF8BE400ACB2A0 /* gtest-assertion-result.h in Headers */,
 				404884380E2F799B00CF7658 /* gtest-death-test.h in Headers */,
+				7B8C090E2F7E8A27007E37DE /* gtest-internal-inl.h in Headers */,
 				A3C10BE0260952C60023155D /* gtest-matchers.h in Headers */,
 				404884390E2F799B00CF7658 /* gtest-message.h in Headers */,
 				4539C9340EC280AE00A70F4C /* gtest-param-test.h in Headers */,
@@ -531,6 +549,7 @@
 				317151502D83285B00D53C18 /* gtest-death-test-internal.h in Headers */,
 				317151592D83287900D53C18 /* gtest-death-test.h in Headers */,
 				317151512D83285E00D53C18 /* gtest-filepath.h in Headers */,
+				7B8C090F2F7E8A27007E37DE /* gtest-internal-inl.h in Headers */,
 				317151522D83286500D53C18 /* gtest-internal.h in Headers */,
 				3171515A2D83287D00D53C18 /* gtest-matchers.h in Headers */,
 				3171515B2D83287F00D53C18 /* gtest-message.h in Headers */,
@@ -598,6 +617,7 @@
 				40C848F7101A209C0083642A /* Sources */,
 			);
 			buildRules = (
+				7B8C09142F7E91CE007E37DE /* PBXBuildRule */,
 				3171513E2D8250F500D53C18 /* PBXBuildRule */,
 			);
 			dependencies = (


### PR DESCRIPTION
#### 659c76126a285b0608a5c511ffe1ec232aafb446
<pre>
ANGLE: Enable ANGLE test expectations in ANGLEEnd2EndTests runner
<a href="https://bugs.webkit.org/show_bug.cgi?id=311647">https://bugs.webkit.org/show_bug.cgi?id=311647</a>
<a href="https://rdar.apple.com/174233237">rdar://174233237</a>

Reviewed by Elliott Williams and Mike Wyrzykowski.

ANGLEEnd2EndTests test runner would run all the tests in normal gtest
mode. Upstream ANGLE has further result lists in angle_end2end_tests.txt
test expectations. Without the expectations, the full clean test runs
are hard to run since the skips are not applied and few test suites
cause crashes.

Compile the full upstraem test result functionality from TestSuite.cpp.
The complication was that TestSuite.cpp depends on RapidJSON which
we do not want to import unless explicitly needed. Use ifdefs to
further carve out RapidJSON use. Currently in upstream it is used in
&quot;bot&quot; mode to report subprocess results to main test runner process and
to export the bot results.

Disable incompatible test runner code with existing
!ANGLE_OUTSIDE_WEBKIT define. This mainly disables the feature upstream
uses to disable Metal shader cache to speed up the test runs. We do not
compile the dylib used to do this, and instead should improve Metal
until the runs are fast enough.

GTest changes:
Change the gtest exported headers to export one implementation header:
gtest/src/gtest-internal-inl.h. This is used to evaluate the gtest
filter pattern against the test list compiled from the test
expectations file.

Previously the project file would mark headers exported and have a
copy rule to copy *.h files to framework export headers path.
The change here adds a pattern */include/**/*.h to this rule.
The change here also adds a pattern */src/*.h to copy the
implementation private header to gtest/src/.

* Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj:
* Source/ThirdParty/ANGLE/src/tests/angle_deqp_tests_main.cpp:
(main):
* Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests_main.cpp:
(main):
* Source/ThirdParty/ANGLE/src/tests/angle_unittest_main.cpp:
(main):
* Source/ThirdParty/ANGLE/src/tests/gl_tests/ContextLostTest.cpp:
* Source/ThirdParty/ANGLE/src/tests/test_utils/ANGLETest.cpp:
(ANGLETestBase::ANGLETestSetUp):
* Source/ThirdParty/ANGLE/src/tests/test_utils/runner/TestSuite.cpp:
(angle::TestSuite::TestSuite):
* Source/ThirdParty/ANGLE/src/tests/test_utils/runner/TestSuite.h:
* Source/ThirdParty/ANGLE/util/OSWindow.cpp:
(angle::FindTestDataPath):
* Source/ThirdParty/gtest/xcode/gtest.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/311423@main">https://commits.webkit.org/311423@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eeada97271c40f7348e289c759ae3d233a66a9e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163656 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108366 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28004 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119834 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84700 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/19fd4496-69c2-40a4-94c9-31b8462f03ce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157855 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22102 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139103 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100527 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9fe30196-5a64-481a-9c7f-1cf8021585d9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21187 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19219 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11482 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130849 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16947 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166130 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18556 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127933 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128072 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35148 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27624 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138740 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84329 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22960 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15535 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27316 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26894 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27125 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26967 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->