### PR TITLE
Remove SVGElementInstance from SVG2

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/idlharness-expected.txt
@@ -3,7 +3,6 @@ PASS idl_test setup
 PASS idl_test validation
 PASS Partial interface Element: member names are unique
 PASS SVGElement includes GlobalEventHandlers: member names are unique
-PASS SVGElement includes SVGElementInstance: member names are unique
 PASS SVGElement includes HTMLOrSVGElement: member names are unique
 PASS Element includes ParentNode: member names are unique
 PASS Element includes NonDocumentTypeChildNode: member names are unique

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/idlharness-expected.txt
@@ -14,7 +14,6 @@ PASS HTMLElement includes ElementCSSInlineStyle: member names are unique
 PASS SVGElement includes ElementCSSInlineStyle: member names are unique
 PASS MathMLElement includes ElementCSSInlineStyle: member names are unique
 PASS SVGElement includes GlobalEventHandlers: member names are unique
-PASS SVGElement includes SVGElementInstance: member names are unique
 PASS SVGElement includes HTMLOrSVGElement: member names are unique
 PASS HTMLElement includes GlobalEventHandlers: member names are unique
 PASS HTMLElement includes ElementContentEditable: member names are unique

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/idlharness-expected.txt
@@ -19,7 +19,6 @@ PASS HTMLElement includes ElementCSSInlineStyle: member names are unique
 PASS SVGElement includes ElementCSSInlineStyle: member names are unique
 PASS MathMLElement includes ElementCSSInlineStyle: member names are unique
 PASS SVGElement includes GlobalEventHandlers: member names are unique
-PASS SVGElement includes SVGElementInstance: member names are unique
 PASS SVGElement includes HTMLOrSVGElement: member names are unique
 PASS SVGStyleElement includes LinkStyle: member names are unique
 PASS HTMLElement includes GlobalEventHandlers: member names are unique

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/idlharness.any-expected.txt
@@ -22,7 +22,6 @@ PASS SVGFESpecularLightingElement includes SVGFilterPrimitiveStandardAttributes:
 PASS SVGFETileElement includes SVGFilterPrimitiveStandardAttributes: member names are unique
 PASS SVGFETurbulenceElement includes SVGFilterPrimitiveStandardAttributes: member names are unique
 PASS SVGElement includes GlobalEventHandlers: member names are unique
-PASS SVGElement includes SVGElementInstance: member names are unique
 PASS SVGElement includes HTMLOrSVGElement: member names are unique
 PASS Element includes ParentNode: member names are unique
 PASS Element includes NonDocumentTypeChildNode: member names are unique

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/idlharness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/idlharness.any.worker-expected.txt
@@ -22,7 +22,6 @@ PASS SVGFESpecularLightingElement includes SVGFilterPrimitiveStandardAttributes:
 PASS SVGFETileElement includes SVGFilterPrimitiveStandardAttributes: member names are unique
 PASS SVGFETurbulenceElement includes SVGFilterPrimitiveStandardAttributes: member names are unique
 PASS SVGElement includes GlobalEventHandlers: member names are unique
-PASS SVGElement includes SVGElementInstance: member names are unique
 PASS SVGElement includes HTMLOrSVGElement: member names are unique
 PASS Element includes ParentNode: member names are unique
 PASS Element includes NonDocumentTypeChildNode: member names are unique

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/idlharness.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/idlharness.tentative-expected.txt
@@ -20,7 +20,6 @@ PASS Element includes NonDocumentTypeChildNode: member names are unique
 PASS Element includes ChildNode: member names are unique
 PASS Element includes Slottable: member names are unique
 PASS SVGElement includes GlobalEventHandlers: member names are unique
-PASS SVGElement includes SVGElementInstance: member names are unique
 PASS SVGElement includes HTMLOrSVGElement: member names are unique
 PASS SVGGraphicsElement includes SVGTests: member names are unique
 PASS SVGAElement includes SVGURIReference: member names are unique

--- a/LayoutTests/imported/w3c/web-platform-tests/interfaces/SVG.idl
+++ b/LayoutTests/imported/w3c/web-platform-tests/interfaces/SVG.idl
@@ -13,7 +13,6 @@ interface SVGElement : Element {
 };
 
 SVGElement includes GlobalEventHandlers;
-SVGElement includes SVGElementInstance;
 SVGElement includes HTMLOrSVGElement;
 
 dictionary SVGBoundingBoxOptions {
@@ -307,11 +306,6 @@ SVGUseElement includes SVGURIReference;
 
 [Exposed=Window]
 interface SVGUseElementShadowRoot : ShadowRoot {
-};
-
-interface mixin SVGElementInstance {
-  [SameObject] readonly attribute SVGElement? correspondingElement;
-  [SameObject] readonly attribute SVGUseElement? correspondingUseElement;
 };
 
 [Exposed=Window]

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt
@@ -13,7 +13,6 @@ PASS Partial interface Element: member names are unique
 PASS Partial interface ShadowRoot: member names are unique
 PASS Partial interface Document[4]: member names are unique
 PASS SVGElement includes GlobalEventHandlers: member names are unique
-PASS SVGElement includes SVGElementInstance: member names are unique
 PASS SVGElement includes HTMLOrSVGElement: member names are unique
 PASS SVGGraphicsElement includes SVGTests: member names are unique
 PASS SVGSVGElement includes SVGFitToViewBox: member names are unique
@@ -57,8 +56,6 @@ PASS SVGElement interface: existence and properties of interface prototype objec
 PASS SVGElement interface: attribute className
 PASS SVGElement interface: attribute ownerSVGElement
 PASS SVGElement interface: attribute viewportElement
-FAIL SVGElement interface: attribute correspondingElement assert_true: The prototype object must have a property "correspondingElement" expected true got false
-FAIL SVGElement interface: attribute correspondingUseElement assert_true: The prototype object must have a property "correspondingUseElement" expected true got false
 PASS SVGGraphicsElement interface: existence and properties of interface object
 PASS SVGGraphicsElement interface object length
 PASS SVGGraphicsElement interface object name
@@ -484,8 +481,6 @@ PASS SVGGraphicsElement interface: objects.svg must inherit property "systemLang
 PASS SVGElement interface: objects.svg must inherit property "className" with the proper type
 PASS SVGElement interface: objects.svg must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.svg must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.svg must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.svg must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGGElement interface: existence and properties of interface object
 PASS SVGGElement interface object length
 PASS SVGGElement interface object name
@@ -504,8 +499,6 @@ PASS SVGGraphicsElement interface: objects.g must inherit property "systemLangua
 PASS SVGElement interface: objects.g must inherit property "className" with the proper type
 PASS SVGElement interface: objects.g must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.g must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.g must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.g must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGDefsElement interface: existence and properties of interface object
 PASS SVGDefsElement interface object length
 PASS SVGDefsElement interface object name
@@ -524,8 +517,6 @@ PASS SVGGraphicsElement interface: objects.defs must inherit property "systemLan
 PASS SVGElement interface: objects.defs must inherit property "className" with the proper type
 PASS SVGElement interface: objects.defs must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.defs must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.defs must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.defs must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGDescElement interface: existence and properties of interface object
 PASS SVGDescElement interface object length
 PASS SVGDescElement interface object name
@@ -537,8 +528,6 @@ PASS Stringification of objects.desc
 PASS SVGElement interface: objects.desc must inherit property "className" with the proper type
 PASS SVGElement interface: objects.desc must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.desc must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.desc must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.desc must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGMetadataElement interface: existence and properties of interface object
 PASS SVGMetadataElement interface object length
 PASS SVGMetadataElement interface object name
@@ -550,8 +539,6 @@ PASS Stringification of objects.metadata
 PASS SVGElement interface: objects.metadata must inherit property "className" with the proper type
 PASS SVGElement interface: objects.metadata must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.metadata must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.metadata must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.metadata must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGTitleElement interface: existence and properties of interface object
 PASS SVGTitleElement interface object length
 PASS SVGTitleElement interface object name
@@ -563,8 +550,6 @@ PASS Stringification of objects.title
 PASS SVGElement interface: objects.title must inherit property "className" with the proper type
 PASS SVGElement interface: objects.title must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.title must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.title must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.title must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGSymbolElement interface: existence and properties of interface object
 PASS SVGSymbolElement interface object length
 PASS SVGSymbolElement interface object name
@@ -587,8 +572,6 @@ PASS SVGGraphicsElement interface: objects.symbol must inherit property "systemL
 PASS SVGElement interface: objects.symbol must inherit property "className" with the proper type
 PASS SVGElement interface: objects.symbol must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.symbol must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.symbol must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.symbol must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGUseElement interface: existence and properties of interface object
 PASS SVGUseElement interface object length
 PASS SVGUseElement interface object name
@@ -621,8 +604,6 @@ PASS SVGGraphicsElement interface: objects.use must inherit property "systemLang
 PASS SVGElement interface: objects.use must inherit property "className" with the proper type
 PASS SVGElement interface: objects.use must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.use must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.use must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.use must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 FAIL SVGUseElementShadowRoot interface: existence and properties of interface object assert_own_property: self does not have own property "SVGUseElementShadowRoot" expected property "SVGUseElementShadowRoot" missing
 FAIL SVGUseElementShadowRoot interface object length assert_own_property: self does not have own property "SVGUseElementShadowRoot" expected property "SVGUseElementShadowRoot" missing
 FAIL SVGUseElementShadowRoot interface object name assert_own_property: self does not have own property "SVGUseElementShadowRoot" expected property "SVGUseElementShadowRoot" missing
@@ -654,8 +635,6 @@ PASS SVGGraphicsElement interface: objects.switch must inherit property "systemL
 PASS SVGElement interface: objects.switch must inherit property "className" with the proper type
 PASS SVGElement interface: objects.switch must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.switch must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.switch must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.switch must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGStyleElement interface: existence and properties of interface object
 PASS SVGStyleElement interface object length
 PASS SVGStyleElement interface object name
@@ -675,8 +654,6 @@ PASS SVGStyleElement interface: objects.style must inherit property "disabled" w
 PASS SVGElement interface: objects.style must inherit property "className" with the proper type
 PASS SVGElement interface: objects.style must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.style must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.style must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.style must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGTransform interface: existence and properties of interface object
 PASS SVGTransform interface object length
 PASS SVGTransform interface object name
@@ -883,8 +860,6 @@ PASS SVGGraphicsElement interface: objects.rect must inherit property "systemLan
 PASS SVGElement interface: objects.rect must inherit property "className" with the proper type
 PASS SVGElement interface: objects.rect must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.rect must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.rect must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.rect must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGCircleElement interface: existence and properties of interface object
 PASS SVGCircleElement interface object length
 PASS SVGCircleElement interface object name
@@ -917,8 +892,6 @@ PASS SVGGraphicsElement interface: objects.circle must inherit property "systemL
 PASS SVGElement interface: objects.circle must inherit property "className" with the proper type
 PASS SVGElement interface: objects.circle must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.circle must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.circle must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.circle must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGEllipseElement interface: existence and properties of interface object
 PASS SVGEllipseElement interface object length
 PASS SVGEllipseElement interface object name
@@ -953,8 +926,6 @@ PASS SVGGraphicsElement interface: objects.ellipse must inherit property "system
 PASS SVGElement interface: objects.ellipse must inherit property "className" with the proper type
 PASS SVGElement interface: objects.ellipse must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.ellipse must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.ellipse must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.ellipse must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGLineElement interface: existence and properties of interface object
 PASS SVGLineElement interface object length
 PASS SVGLineElement interface object name
@@ -989,8 +960,6 @@ PASS SVGGraphicsElement interface: objects.line must inherit property "systemLan
 PASS SVGElement interface: objects.line must inherit property "className" with the proper type
 PASS SVGElement interface: objects.line must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.line must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.line must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.line must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGPointList interface: existence and properties of interface object
 PASS SVGPointList interface object length
 PASS SVGPointList interface object name
@@ -1053,8 +1022,6 @@ PASS SVGGraphicsElement interface: objects.polyline must inherit property "syste
 PASS SVGElement interface: objects.polyline must inherit property "className" with the proper type
 PASS SVGElement interface: objects.polyline must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.polyline must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.polyline must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.polyline must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGPolygonElement interface: existence and properties of interface object
 PASS SVGPolygonElement interface object length
 PASS SVGPolygonElement interface object name
@@ -1085,8 +1052,6 @@ PASS SVGGraphicsElement interface: objects.polygon must inherit property "system
 PASS SVGElement interface: objects.polygon must inherit property "className" with the proper type
 PASS SVGElement interface: objects.polygon must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.polygon must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.polygon must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.polygon must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGTextContentElement interface: existence and properties of interface object
 PASS SVGTextContentElement interface object length
 PASS SVGTextContentElement interface object name
@@ -1165,8 +1130,6 @@ PASS SVGGraphicsElement interface: objects.text must inherit property "systemLan
 PASS SVGElement interface: objects.text must inherit property "className" with the proper type
 PASS SVGElement interface: objects.text must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.text must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.text must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.text must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGTSpanElement interface: existence and properties of interface object
 PASS SVGTSpanElement interface object length
 PASS SVGTSpanElement interface object name
@@ -1211,8 +1174,6 @@ PASS SVGGraphicsElement interface: objects.tspan must inherit property "systemLa
 PASS SVGElement interface: objects.tspan must inherit property "className" with the proper type
 PASS SVGElement interface: objects.tspan must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.tspan must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.tspan must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.tspan must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGTextPathElement interface: existence and properties of interface object
 PASS SVGTextPathElement interface object length
 PASS SVGTextPathElement interface object name
@@ -1278,8 +1239,6 @@ PASS SVGGraphicsElement interface: objects.textPath must inherit property "syste
 PASS SVGElement interface: objects.textPath must inherit property "className" with the proper type
 PASS SVGElement interface: objects.textPath must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.textPath must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.textPath must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.textPath must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGImageElement interface: existence and properties of interface object
 PASS SVGImageElement interface object length
 PASS SVGImageElement interface object name
@@ -1312,8 +1271,6 @@ PASS SVGGraphicsElement interface: objects.image must inherit property "systemLa
 PASS SVGElement interface: objects.image must inherit property "className" with the proper type
 PASS SVGElement interface: objects.image must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.image must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.image must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.image must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGForeignObjectElement interface: existence and properties of interface object
 PASS SVGForeignObjectElement interface object length
 PASS SVGForeignObjectElement interface object name
@@ -1340,8 +1297,6 @@ PASS SVGGraphicsElement interface: objects.foreignObject must inherit property "
 PASS SVGElement interface: objects.foreignObject must inherit property "className" with the proper type
 PASS SVGElement interface: objects.foreignObject must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.foreignObject must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.foreignObject must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.foreignObject must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGMarkerElement interface: existence and properties of interface object
 PASS SVGMarkerElement interface object length
 PASS SVGMarkerElement interface object name
@@ -1399,8 +1354,6 @@ PASS SVGMarkerElement interface: objects.marker must inherit property "preserveA
 PASS SVGElement interface: objects.marker must inherit property "className" with the proper type
 PASS SVGElement interface: objects.marker must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.marker must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.marker must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.marker must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGGradientElement interface: existence and properties of interface object
 PASS SVGGradientElement interface object length
 PASS SVGGradientElement interface object name
@@ -1446,8 +1399,6 @@ PASS SVGGradientElement interface: objects.linearGradient must inherit property 
 PASS SVGElement interface: objects.linearGradient must inherit property "className" with the proper type
 PASS SVGElement interface: objects.linearGradient must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.linearGradient must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.linearGradient must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.linearGradient must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGRadialGradientElement interface: existence and properties of interface object
 PASS SVGRadialGradientElement interface object length
 PASS SVGRadialGradientElement interface object name
@@ -1479,8 +1430,6 @@ PASS SVGGradientElement interface: objects.radialGradient must inherit property 
 PASS SVGElement interface: objects.radialGradient must inherit property "className" with the proper type
 PASS SVGElement interface: objects.radialGradient must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.radialGradient must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.radialGradient must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.radialGradient must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGStopElement interface: existence and properties of interface object
 PASS SVGStopElement interface object length
 PASS SVGStopElement interface object name
@@ -1494,8 +1443,6 @@ PASS SVGStopElement interface: objects.stop must inherit property "offset" with 
 PASS SVGElement interface: objects.stop must inherit property "className" with the proper type
 PASS SVGElement interface: objects.stop must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.stop must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.stop must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.stop must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGPatternElement interface: existence and properties of interface object
 PASS SVGPatternElement interface object length
 PASS SVGPatternElement interface object name
@@ -1527,8 +1474,6 @@ PASS SVGPatternElement interface: objects.pattern must inherit property "href" w
 PASS SVGElement interface: objects.pattern must inherit property "className" with the proper type
 PASS SVGElement interface: objects.pattern must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.pattern must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.pattern must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.pattern must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGScriptElement interface: existence and properties of interface object
 PASS SVGScriptElement interface object length
 PASS SVGScriptElement interface object name
@@ -1546,8 +1491,6 @@ PASS SVGScriptElement interface: objects.script must inherit property "href" wit
 PASS SVGElement interface: objects.script must inherit property "className" with the proper type
 PASS SVGElement interface: objects.script must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.script must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.script must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.script must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGAElement interface: existence and properties of interface object
 PASS SVGAElement interface object length
 PASS SVGAElement interface object name
@@ -1604,8 +1547,6 @@ PASS SVGGraphicsElement interface: objects.a must inherit property "systemLangua
 PASS SVGElement interface: objects.a must inherit property "className" with the proper type
 PASS SVGElement interface: objects.a must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.a must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.a must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.a must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGViewElement interface: existence and properties of interface object
 PASS SVGViewElement interface object length
 PASS SVGViewElement interface object name
@@ -1621,8 +1562,6 @@ PASS SVGViewElement interface: objects.view must inherit property "preserveAspec
 PASS SVGElement interface: objects.view must inherit property "className" with the proper type
 PASS SVGElement interface: objects.view must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.view must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.view must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.view must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 FAIL TimeEvent interface: existence and properties of interface object assert_own_property: self does not have own property "TimeEvent" expected property "TimeEvent" missing
 FAIL TimeEvent interface object length assert_own_property: self does not have own property "TimeEvent" expected property "TimeEvent" missing
 FAIL TimeEvent interface object name assert_own_property: self does not have own property "TimeEvent" expected property "TimeEvent" missing
@@ -1677,8 +1616,6 @@ PASS SVGAnimationElement interface: objects.animate must inherit property "syste
 PASS SVGElement interface: objects.animate must inherit property "className" with the proper type
 PASS SVGElement interface: objects.animate must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.animate must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.animate must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.animate must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGSetElement interface: existence and properties of interface object
 PASS SVGSetElement interface object length
 PASS SVGSetElement interface object name
@@ -1705,8 +1642,6 @@ PASS SVGAnimationElement interface: objects.set must inherit property "systemLan
 PASS SVGElement interface: objects.set must inherit property "className" with the proper type
 PASS SVGElement interface: objects.set must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.set must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.set must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.set must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGAnimateMotionElement interface: existence and properties of interface object
 PASS SVGAnimateMotionElement interface object length
 PASS SVGAnimateMotionElement interface object name
@@ -1733,8 +1668,6 @@ PASS SVGAnimationElement interface: objects.animateMotion must inherit property 
 PASS SVGElement interface: objects.animateMotion must inherit property "className" with the proper type
 PASS SVGElement interface: objects.animateMotion must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.animateMotion must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.animateMotion must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.animateMotion must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGMPathElement interface: existence and properties of interface object
 PASS SVGMPathElement interface object length
 PASS SVGMPathElement interface object name
@@ -1748,8 +1681,6 @@ PASS SVGMPathElement interface: objects.mpath must inherit property "href" with 
 PASS SVGElement interface: objects.mpath must inherit property "className" with the proper type
 PASS SVGElement interface: objects.mpath must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.mpath must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.mpath must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.mpath must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS SVGAnimateTransformElement interface: existence and properties of interface object
 PASS SVGAnimateTransformElement interface object length
 PASS SVGAnimateTransformElement interface object name
@@ -1776,7 +1707,5 @@ PASS SVGAnimationElement interface: objects.animateTransform must inherit proper
 PASS SVGElement interface: objects.animateTransform must inherit property "className" with the proper type
 PASS SVGElement interface: objects.animateTransform must inherit property "ownerSVGElement" with the proper type
 PASS SVGElement interface: objects.animateTransform must inherit property "viewportElement" with the proper type
-FAIL SVGElement interface: objects.animateTransform must inherit property "correspondingElement" with the proper type assert_inherits: property "correspondingElement" not found in prototype chain
-FAIL SVGElement interface: objects.animateTransform must inherit property "correspondingUseElement" with the proper type assert_inherits: property "correspondingUseElement" not found in prototype chain
 PASS Document interface: attribute rootElement
 


### PR DESCRIPTION
#### 3b6d79bc5d4a27bc776da0eba2552b1515af230a
<pre>
Remove SVGElementInstance from SVG2
<a href="https://bugs.webkit.org/show_bug.cgi?id=311630">https://bugs.webkit.org/show_bug.cgi?id=311630</a>
<a href="https://rdar.apple.com/174223805">rdar://174223805</a>

Reviewed by Anne van Kesteren.

SVG2 working has decided to remove the SVGElementInstance from SVG2
including correspondingElement/correspondingUseElement.
<a href="https://www.w3.org/2026/03/19-svg-minutes.html#8e49">https://www.w3.org/2026/03/19-svg-minutes.html#8e49</a>
w3c/svgwg#1070

* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/idlharness-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/idlharness-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/idlharness-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/idlharness.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/idlharness.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/idlharness.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/interfaces/SVG.idl:
* LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt:

Canonical link: <a href="https://commits.webkit.org/310739@main">https://commits.webkit.org/310739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6976bc731717e41bc7f0ab2cc7a5d9fe95a2bd24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21102 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108153 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f1baaa57-a398-418a-a3bd-4b7f19aaaf4d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27792 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119653 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84612 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d0cc658-194f-4b67-b505-4b707f5d07b3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138923 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100347 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e5cd71fe-1632-4c37-aedc-2aaf9ee91aee) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21029 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19045 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11270 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130691 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165918 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127755 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27488 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23085 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127894 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34726 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138560 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84098 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22792 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15354 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27104 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26682 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26913 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26755 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->