### PR TITLE
Disable display property transitions for popover & <dialog>

### DIFF
--- a/LayoutTests/transitions/no-display-transition-top-layer-expected.txt
+++ b/LayoutTests/transitions/no-display-transition-top-layer-expected.txt
@@ -1,0 +1,4 @@
+Regular
+PASS: popover hide does not create display transition
+PASS: dialog close does not create display transition
+PASS: regular element gets display transition

--- a/LayoutTests/transitions/no-display-transition-top-layer.html
+++ b/LayoutTests/transitions/no-display-transition-top-layer.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<style>
+.target {
+    transition: display 0.3s allow-discrete;
+}
+#regular {
+    display: block;
+    width: 50px;
+    height: 50px;
+}
+#regular.hidden {
+    display: none;
+}
+</style>
+
+<div id="popover" popover class="target">Popover</div>
+<dialog id="dialog" class="target">Dialog</dialog>
+<div id="regular" class="target">Regular</div>
+<pre id="results"></pre>
+
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function hasDisplayTransition(element) {
+    return element.getAnimations().some(a => a instanceof CSSTransition && a.transitionProperty === "display");
+}
+
+async function runTests() {
+    const results = [];
+
+    const popover = document.getElementById("popover");
+    const dialog = document.getElementById("dialog");
+    const regular = document.getElementById("regular");
+
+    // Test 1: Popover should NOT get display transition when hidden.
+    popover.showPopover();
+    popover.offsetTop;
+    popover.hidePopover();
+    popover.offsetTop;
+    results.push((hasDisplayTransition(popover) ? "FAIL" : "PASS") + ": popover hide does not create display transition");
+
+    // Test 2: Dialog should NOT get display transition when closed.
+    dialog.showModal();
+    dialog.offsetTop;
+    dialog.close();
+    dialog.offsetTop;
+    results.push((hasDisplayTransition(dialog) ? "FAIL" : "PASS") + ": dialog close does not create display transition");
+
+    // Test 3: Regular element SHOULD get display transition.
+    regular.offsetTop;
+    regular.classList.add("hidden");
+    regular.offsetTop;
+    results.push((hasDisplayTransition(regular) ? "PASS" : "FAIL") + ": regular element gets display transition");
+
+    document.getElementById("results").textContent = results.join("\n");
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+runTests();
+</script>

--- a/Source/WebCore/animation/WebAnimationUtilities.cpp
+++ b/Source/WebCore/animation/WebAnimationUtilities.cpp
@@ -37,6 +37,7 @@
 #include "CSSTransitionEvent.h"
 #include "Element.h"
 #include "EventTargetInlines.h"
+#include "HTMLDialogElement.h"
 #include "KeyframeEffectStack.h"
 #include "NodeDocument.h"
 #include "RenderStyle.h"
@@ -407,8 +408,13 @@ AtomString animatablePropertyAsString(AnimatableCSSProperty property)
     );
 }
 
-bool styleHasDisplayTransition(const RenderStyle& style)
+bool styleHasDisplayTransition(const RenderStyle& style, const Element& element)
 {
+    // FIXME: Best-effort disablement of this feature for elements participating in the top layer as
+    // that requires some more specification design work that has not happened yet.
+    if (element.popoverState() != PopoverState::None || is<HTMLDialogElement>(element))
+        return false;
+
     if (style.transitions().isInitial())
         return false;
 

--- a/Source/WebCore/animation/WebAnimationUtilities.h
+++ b/Source/WebCore/animation/WebAnimationUtilities.h
@@ -69,7 +69,7 @@ AtomString animatablePropertyAsString(AnimatableCSSProperty);
 bool animatablePropertiesContainTransformRelatedProperty(const HashSet<AnimatableCSSProperty>&);
 
 // Determines whether a RenderStyle specifies a transition on `display` property.
-bool styleHasDisplayTransition(const RenderStyle&);
+bool styleHasDisplayTransition(const RenderStyle&, const Element&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -864,7 +864,7 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
             // to the old value. To remedy this, we manually patch display to be the old value if:
             // 1. the old style's display is not none, and
             // 2. the new style has display: none and specifies a transition on display.
-            if (oldStyle && !oldStyle->transitions().isInitial() && oldStyle->display() != DisplayType::None && styleHasDisplayTransition(*newStyle) && newStyle->display() == DisplayType::None)
+            if (oldStyle && !oldStyle->transitions().isInitial() && oldStyle->display() != DisplayType::None && styleHasDisplayTransition(*newStyle, element) && newStyle->display() == DisplayType::None)
                 newStyle->setDisplay(oldStyle->display());
             return { WTF::move(newStyle), OptionSet<AnimationImpact> { } };
         }

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -775,7 +775,7 @@ void Styleable::updateCSSTransitions(const RenderStyle& currentStyle, const Rend
 
     // In case this element is newly getting a "display: none" we need to cancel all of its transitions and disregard new ones,
     // unless it will transition the "display" property itself.
-    if (!currentStyle.transitions().isInitial() && currentStyle.display() != Style::DisplayType::None && newStyle.display() == Style::DisplayType::None && !styleHasDisplayTransition(newStyle)) {
+    if (!currentStyle.transitions().isInitial() && currentStyle.display() != Style::DisplayType::None && newStyle.display() == Style::DisplayType::None && !styleHasDisplayTransition(newStyle, element)) {
         if (hasRunningTransitions()) {
             auto runningTransitions = ensureRunningTransitionsByProperty();
             for (const auto& cssTransitionsByAnimatableCSSPropertyMapItem : runningTransitions)


### PR DESCRIPTION
#### 7031d1f1b39d86e88f7d3c03de72451aa7845cf6
<pre>
Disable display property transitions for popover &amp; &lt;dialog&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=311648">https://bugs.webkit.org/show_bug.cgi?id=311648</a>
<a href="https://rdar.apple.com/171454696">rdar://171454696</a>

Reviewed by Tim Nguyen.

The standardization story for these kind of transitions is not entirely
finished:

    <a href="https://github.com/w3c/csswg-drafts/issues/13595">https://github.com/w3c/csswg-drafts/issues/13595</a>
    <a href="https://github.com/w3c/csswg-drafts/issues/13200">https://github.com/w3c/csswg-drafts/issues/13200</a>

And because of that these transitions end up looking janky for various
customizable &lt;select&gt; demos:

    <a href="https://codepen.io/utilitybend/pen/MWdaMxm">https://codepen.io/utilitybend/pen/MWdaMxm</a>
    <a href="https://cdpn.io/pen/debug/wvYrZEV">https://cdpn.io/pen/debug/wvYrZEV</a>
    <a href="https://codepen.io/sakupi01/pen/KwPBBNg">https://codepen.io/sakupi01/pen/KwPBBNg</a>

And as those demos demonstrate what eventually might make it into
production we should disable support now until we figure out the
correct solution.

Test: transitions/no-display-transition-top-layer.html
Canonical link: <a href="https://commits.webkit.org/310725@main">https://commits.webkit.org/310725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/260e01bb7970c51366554095166198459b49af61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163445 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108154 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/639db8aa-bf7d-4fcc-a0f0-54bf1ae8dac2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27793 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119654 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84613 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/92d40c12-f896-4e48-8125-ec0d3d8872a8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138924 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100348 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bd599688-6b35-41b0-83d8-0613fd496836) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21030 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19047 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11271 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130692 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165919 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9135 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18377 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127756 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27489 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23087 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127895 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27413 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138561 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84100 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23604 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22793 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15355 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27105 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91207 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26683 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26914 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26756 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->