### PR TITLE
[macOS Debug] TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedCloseByItself is a flaky failure

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h
@@ -175,6 +175,7 @@ class Color;
 @interface TestMessageHandler : NSObject <WKScriptMessageHandler>
 - (void)addMessage:(NSString *)message withHandler:(dispatch_block_t)handler;
 @property (nonatomic, copy) void (^didReceiveScriptMessage)(NSString *);
+@property (nonatomic, readonly) NSArray<NSString *> *receivedMessages;
 @end
 
 @interface TestWKWebView : WKWebView
@@ -186,6 +187,7 @@ class Color;
 - (void)performAfterReceivingAnyMessage:(void (^)(NSString *))action;
 - (void)waitForMessage:(NSString *)message;
 - (void)waitForMessages:(NSArray<NSString *> *)messages;
+- (void)waitForMessagesUnordered:(NSArray<NSString *> *)messages;
 
 // This function waits until a DOM load event is fired.
 // FIXME: Rename this function to better describe what "after loading" means.

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm
@@ -865,6 +865,7 @@ static IterationStatus forEachCALayer(CALayer *layer, IterationStatus(^visitor)(
 
 @implementation TestMessageHandler {
     NSMutableDictionary<NSString *, dispatch_block_t> *_messageHandlers;
+    RetainPtr<NSMutableArray<NSString *>> _receivedMessages;
 }
 
 - (void)addMessage:(NSString *)message withHandler:(dispatch_block_t)handler
@@ -882,10 +883,19 @@ static IterationStatus forEachCALayer(CALayer *layer, IterationStatus(^visitor)(
 
 - (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
 {
+    if (!_receivedMessages)
+        _receivedMessages = adoptNS([[NSMutableArray alloc] init]);
+    [_receivedMessages addObject:message.body];
+
     if (dispatch_block_t handler = _messageHandlers[message.body])
         handler();
     if (_didReceiveScriptMessage)
         _didReceiveScriptMessage(message.body);
+}
+
+- (NSArray<NSString *> *)receivedMessages
+{
+    return _receivedMessages.get();
 }
 
 @end
@@ -1193,6 +1203,18 @@ static UIWindowScene *windowScene()
         EXPECT_WK_STREQ(receivedMessages.takeFirst().get(), expectedMessage);
     }
     [self.configuration.userContentController removeScriptMessageHandlerForName:@"testHandler"];
+}
+
+- (void)waitForMessagesUnordered:(NSArray<NSString *> *)expectedMessages
+{
+    if (!_testHandler) {
+        _testHandler = adoptNS([[TestMessageHandler alloc] init]);
+        [[self.configuration userContentController] addScriptMessageHandler:_testHandler.get() name:@"testHandler"];
+    }
+
+    RetainPtr expected = [NSCountedSet setWithArray:expectedMessages];
+    while (![expected isSubsetOfSet:[NSCountedSet setWithArray:[_testHandler receivedMessages]]])
+        TestWebKitAPI::Util::spinRunLoop();
 }
 
 - (void)performAfterLoading:(dispatch_block_t)actions

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm
@@ -2168,12 +2168,7 @@ TEST(SOAuthorizationPopUp, InterceptionCancel)
     Util::run(&allMessagesReceived);
 }
 
-// FIXME when webkit.org/b/309196 is resolved.
-#if PLATFORM(MAC) && !defined(NDEBUG)
-TEST(SOAuthorizationPopUp, DISABLED_InterceptionSucceedCloseByItself)
-#else
 TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByItself)
-#endif
 {
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
@@ -2182,12 +2177,8 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByItself)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateOpenerHTML(openerTemplate, testURL.string());
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"Hello.", @"WindowClosed."]]);
-    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
@@ -2203,12 +2194,12 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByItself)
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
-    auto resonseHtmlCString = generateHTML(newWindowResponseTemplate, "window.close();"_s).utf8(); // The pop up closes itself.
+    auto responseHtmlCString = generateHTML(newWindowResponseTemplate, "window.close();"_s).utf8();
     // The secret WKWebView needs to be destroyed right the way.
     @autoreleasepool {
-        [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:resonseHtmlCString.data() length:resonseHtmlCString.length()]).get()];
+        [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:responseHtmlCString.data() length:responseHtmlCString.length()]).get()];
     }
-    Util::run(&allMessagesReceived);
+    [webView waitForMessagesUnordered:@[@"Hello.", @"WindowClosed."]];
 }
 
 TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByParent)


### PR DESCRIPTION
#### 7dd830ffb65b9b60b0502f281638964acc193eea
<pre>
[macOS Debug] TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedCloseByItself is a flaky failure
<a href="https://rdar.apple.com/171756017">rdar://171756017</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309196">https://bugs.webkit.org/show_bug.cgi?id=309196</a>

Reviewed by Abrar Rahman Protyasha.

The popup runs `postMessage(&apos;Hello.&apos;, &apos;*&apos;); window.close()` synchronously, but the opener
detects `newWindow.closed` via a 200ms polling interval. Because `window.close()` sets
`page-&gt;isClosing()` synchronously while postMessage is delivered asynchronously, the poll
can fire between the two — observing closure before &quot;Hello.&quot; arrives.

The test only needs to verify that both events occur, not their order. Add
`waitForMessagesUnordered:` to TestWKWebView, which buffers messages in TestMessageHandler
and asserts with NSCountedSet equality. Re-enable the test unconditionally.

* Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm:
(-[TestMessageHandler userContentController:didReceiveScriptMessage:]):
(-[TestMessageHandler receivedMessages]):
(-[TestWKWebView waitForMessagesUnordered:]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm:
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByItself)):

Canonical link: <a href="https://commits.webkit.org/310750@main">https://commits.webkit.org/310750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6718b5095fce3af3eb907216d2242aa174e79f56

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154716 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163476 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108185 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b46f2b25-3a7f-4d2c-ad77-a374d6588ea0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156589 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27824 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119681 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84630 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5a544788-65ae-4e3e-a966-183034ee4f2d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21973 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138952 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100375 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ae291c2-7c7b-4a0e-86db-908a477ccc53) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21059 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19072 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11302 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130721 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16796 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165950 "Built successfully") | | 
| | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18405 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127785 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27520 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127924 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34733 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27444 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138589 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84149 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22818 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15383 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27136 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26714 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26945 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26787 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->