### PR TITLE
[Gardening]: REGRESSION(macOS 13.3): [ Ventura ] http/tests/media/hls/track-in-band-hls-metadata-cue-duration.html is a constant text failure

### DIFF
--- a/LayoutTests/http/tests/media/hls/track-in-band-hls-metadata-cue-duration-expected.txt
+++ b/LayoutTests/http/tests/media/hls/track-in-band-hls-metadata-cue-duration-expected.txt
@@ -5,7 +5,6 @@ Test that metadata cues have valid duration.
 ** Set video.src, wait for media data to load
 RUN(video.src = "http://127.0.0.1:8000/media/resources/hls/metadata/prog_index.m3u8")
 EVENT(canplaythrough)
-
 EVENT(addtrack)
 RUN(track = video.textTracks[0])
 RUN(track.mode = "hidden")

--- a/LayoutTests/http/tests/media/hls/track-in-band-hls-metadata-cue-duration.html
+++ b/LayoutTests/http/tests/media/hls/track-in-band-hls-metadata-cue-duration.html
@@ -42,8 +42,6 @@
 
                 await waitFor(video, 'canplaythrough');
                 await video.play();
-
-                consoleWrite('');
             }
         </script>
     </head>


### PR DESCRIPTION
#### 5fe38c4b065b319a3c3f404387ca6ef2fc2d66aa
<pre>
[Gardening]: REGRESSION(macOS 13.3): [ Ventura ] http/tests/media/hls/track-in-band-hls-metadata-cue-duration.html is a constant text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=255697">https://bugs.webkit.org/show_bug.cgi?id=255697</a>
<a href="https://rdar.apple.com/108290413">rdar://108290413</a>

Unreviewed test Gardening

* LayoutTests/http/tests/media/hls/track-in-band-hls-metadata-cue-duration-expected.txt: Remove newline.
* LayoutTests/http/tests/media/hls/track-in-band-hls-metadata-cue-duration.html: Remove racey newline.

Canonical link: <a href="https://commits.webkit.org/310720@main">https://commits.webkit.org/310720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c90bc9529e194e18ab8bbc7c1afe000126174577

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27976 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/21135 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163477 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1af59638-89e6-4912-b556-15f309aa58a5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27825 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/119682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/28619e6e-dba4-4706-b918-45728e48069e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157676 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/21969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/138951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/100376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/11303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/130717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/16795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165951 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/18404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/127783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27521 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/23113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/127922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27445 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/138588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84150 "Failed to checkout and rebase branch from PR 62203") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23602 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/22815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27137 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26715 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/26946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/26788 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->