### PR TITLE
Add LOOA check for user script and user style interning

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -139,6 +139,7 @@ enum class SDKAlignedBehavior {
     SuppressKeypressForModifierShortcuts,
     ScrollColorExtensionGrowsDuringRubberBanding,
     ManagedRefreshControlAppearance,
+    EnableUserScriptAndUserStyleInterning,
 
     NumberOfBehaviors
 };

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -242,6 +242,10 @@ static SDKAlignedBehaviors computeSDKAlignedBehaviors()
     if (linkedBefore(dyld_2025_SU_B_os_versions, DYLD_IOS_VERSION_26_1, DYLD_MACOSX_VERSION_26_1))
         disableBehavior(SDKAlignedBehavior::GetBoundingClientRectZoomed);
 
+    // This should be disabled unconditionally until WTF::String is made thread-safe. See the comment in UserScript.cpp.
+    // It's only enabled for clients that purposely enable all LOOA checks.
+    disableBehavior(SDKAlignedBehavior::EnableUserScriptAndUserStyleInterning);
+
     disableAdditionalSDKAlignedBehaviors(behaviors);
 
     return behaviors;

--- a/Source/WebCore/page/UserScript.cpp
+++ b/Source/WebCore/page/UserScript.cpp
@@ -28,9 +28,14 @@
 #include "UserScript.h"
 
 #include <wtf/HashCountedSet.h>
+#include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
+
+#if PLATFORM(COCOA)
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#endif
 
 namespace WebCore {
 
@@ -42,6 +47,13 @@ static WTF::URL generateUserScriptUniqueURL()
     return { { }, makeString("user-script:"_s, ++identifier) };
 }
 
+#if PLATFORM(COCOA)
+NO_RETURN_DUE_TO_CRASH NEVER_INLINE static void crashDueToApplicationCreatingUserScriptFromBackgroundThread()
+{
+    RELEASE_ASSERT_NOT_REACHED("Terminating process due to improper usage of WebKit APIs off the main thread.");
+}
+#endif
+
 static HashCountedSet<String>& sourceStrings()
 {
     static NeverDestroyed<HashCountedSet<String>> set;
@@ -50,11 +62,30 @@ static HashCountedSet<String>& sourceStrings()
 
 static String internedSourceString(const String& string)
 {
+#if PLATFORM(COCOA)
+    if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::EnableUserScriptAndUserStyleInterning))
+        return string;
+
+    // FIXME: replace this main thread check with a locked HashCountedSet once String becomes fully thread-safe.
+    if (!isMainRunLoop())
+        crashDueToApplicationCreatingUserScriptFromBackgroundThread();
+#endif
+
     if (string.isEmpty())
         return emptyString();
 
     auto result = sourceStrings().add(string);
     return result.iterator->key;
+}
+
+static void removeSourceString(const String& string)
+{
+#if PLATFORM(COCOA)
+    if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::EnableUserScriptAndUserStyleInterning))
+        return;
+#endif
+
+    sourceStrings().remove(string);
 }
 
 UserScript::UserScript(String&& source, URL&& url, Vector<String>&& allowlist, Vector<String>&& blocklist, UserScriptInjectionTime injectionTime, UserContentInjectedFrames injectedFrames, UserContentMatchParentFrame matchParentFrame)
@@ -70,7 +101,7 @@ UserScript::UserScript(String&& source, URL&& url, Vector<String>&& allowlist, V
 
 UserScript::~UserScript()
 {
-    sourceStrings().remove(m_source);
+    removeSourceString(m_source);
 }
 
 String UserScript::debugDescription() const

--- a/Source/WebCore/page/UserStyleSheet.cpp
+++ b/Source/WebCore/page/UserStyleSheet.cpp
@@ -28,9 +28,14 @@
 #include "UserStyleSheet.h"
 
 #include <wtf/HashCountedSet.h>
+#include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
+
+#if PLATFORM(COCOA)
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#endif
 
 namespace WebCore {
 
@@ -42,6 +47,13 @@ static WTF::URL generateUserStyleUniqueURL()
     return { { }, makeString("user-style:"_s, ++identifier) };
 }
 
+#if PLATFORM(COCOA)
+NO_RETURN_DUE_TO_CRASH NEVER_INLINE static void crashDueToApplicationCreatingUserStyleSheetFromBackgroundThread()
+{
+    RELEASE_ASSERT_NOT_REACHED("Terminating process due to improper usage of WebKit APIs off the main thread.");
+}
+#endif
+
 static HashCountedSet<String>& styleStrings()
 {
     static NeverDestroyed<HashCountedSet<String>> set;
@@ -50,11 +62,30 @@ static HashCountedSet<String>& styleStrings()
 
 static String internedStyleString(const String& string)
 {
+#if PLATFORM(COCOA)
+    if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::EnableUserScriptAndUserStyleInterning))
+        return string;
+
+    // FIXME: replace this main thread check with a locked HashCountedSet once String becomes fully thread-safe.
+    if (!isMainRunLoop())
+        crashDueToApplicationCreatingUserStyleSheetFromBackgroundThread();
+#endif
+
     if (string.isEmpty())
         return emptyString();
 
     auto result = styleStrings().add(string);
     return result.iterator->key;
+}
+
+static void removeStyleString(const String& string)
+{
+#if PLATFORM(COCOA)
+    if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::EnableUserScriptAndUserStyleInterning))
+        return;
+#endif
+
+    styleStrings().remove(string);
 }
 
 UserStyleSheet::UserStyleSheet(const String& source, const URL& url, Vector<String>&& allowlist, Vector<String>&& blocklist, UserContentInjectedFrames injectedFrames, UserContentMatchParentFrame matchParentFrame, UserStyleLevel level, std::optional<PageIdentifier> pageID)
@@ -71,7 +102,7 @@ UserStyleSheet::UserStyleSheet(const String& source, const URL& url, Vector<Stri
 
 UserStyleSheet::~UserStyleSheet()
 {
-    styleStrings().remove(m_source);
+    removeStyleString(m_source);
 }
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
@@ -53,6 +53,10 @@
 #include "WebExtensionMatchPattern.h"
 #endif
 
+#if PLATFORM(COCOA)
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#endif
+
 namespace WebKit {
 
 using namespace WebCore;
@@ -98,6 +102,14 @@ void WebUserContentControllerProxy::removeNetworkProcess(NetworkProcessProxy& pr
 
 IPC::TransferString WebUserContentControllerProxy::cachedTransferString(const String& string) const
 {
+#if PLATFORM(COCOA)
+    if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::EnableUserScriptAndUserStyleInterning)) {
+        auto result = IPC::TransferString::create(string);
+        RELEASE_ASSERT(result);
+        return *result;
+    }
+#endif
+
     if (auto maybeTransferString = m_transferStringCache.getOptional(string))
         return *maybeTransferString;
 


### PR DESCRIPTION
#### 595877325542edd0b428c38b1aa03fa2752d3977
<pre>
Add LOOA check for user script and user style interning
<a href="https://bugs.webkit.org/show_bug.cgi?id=311658">https://bugs.webkit.org/show_bug.cgi?id=311658</a>
<a href="https://rdar.apple.com/174250486">rdar://174250486</a>

Reviewed by Per Arne Vollan.

Some apps create WKUserScript and WKUserStyleSheet objects off the main thread. This was never safe,
but clients could sometimes get away with this thread safety issue in the past. But apps are much
less likely to get away with this issue after 310050@main, since that patch interns source strings
in to a non-thread-safe HashCountedSet.

To give devs some time to get used to this behavior, put the interning behind a LOOA check.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebCore/page/UserScript.cpp:
(WebCore::crashDueToApplicationCreatingUserScriptFromBackgroundThread):
(WebCore::internedSourceString):
(WebCore::removeSourceString):
(WebCore::UserScript::~UserScript):
* Source/WebCore/page/UserStyleSheet.cpp:
(WebCore::crashDueToApplicationCreatingUserStyleSheetFromBackgroundThread):
(WebCore::internedStyleString):
(WebCore::removeStyleString):
(WebCore::UserStyleSheet::~UserStyleSheet):
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp:
(WebKit::WebUserContentControllerProxy::cachedTransferString const):

Canonical link: <a href="https://commits.webkit.org/310850@main">https://commits.webkit.org/310850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c17654ac0214e38b383ddc68060b40803e68b923

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163829 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108540 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156942 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28177 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119971 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84775 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139258 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100664 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/170033d1-694c-4997-81eb-0d97ae1ef609) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21321 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19359 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11655 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147119 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130983 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17101 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166305 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15900 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10063 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18710 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128074 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27873 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23398 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128212 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34803 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27797 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138894 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84506 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23088 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15689 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186856 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27489 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91593 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47880 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27068 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27298 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27140 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->