### PR TITLE
AX: Quad and cubic Bézier curve conversions aren't handled correctly in WebAccessibilityObjectWrapperMac, causing incorrect paths to be returned

### DIFF
--- a/LayoutTests/accessibility/mac/bezier-path-curves-expected.txt
+++ b/LayoutTests/accessibility/mac/bezier-path-curves-expected.txt
@@ -1,0 +1,9 @@
+This test verifies that quadratic and cubic curves in SVG paths are correctly converted to NSBezierPath for the AXPath attribute.
+
+PASS: quadCurveCount > 0 === true
+PASS: cubicCurveCount > 0 === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/bezier-path-curves.html
+++ b/LayoutTests/accessibility/mac/bezier-path-curves.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<!-- SVG path with quadratic Bézier curve (Q command). -->
+<svg width="100" height="100">
+  <path role="button" id="quad-curve" d="M0,50 Q50,0 100,50 Q50,100 0,50 Z" />
+</svg>
+
+<!-- SVG path with cubic Bézier curve (C command). -->
+<svg width="100" height="100">
+  <path role="button" id="cubic-curve" d="M0,50 C25,0 75,0 100,50 C75,100 25,100 0,50 Z" />
+</svg>
+
+<script>
+var output = "This test verifies that quadratic and cubic curves in SVG paths are correctly converted to NSBezierPath for the AXPath attribute.\n\n";
+
+if (window.accessibilityController) {
+    // Quadratic curves (Q) should be promoted to cubic and appear as "Curve to".
+    var quadCurveCount = pathSegmentCountOfID("quad-curve", "Curve to");
+    output += expect("quadCurveCount > 0", "true");
+
+    // Cubic curves (C) should appear as "Curve to".
+    var cubicCurveCount = pathSegmentCountOfID("cubic-curve", "Curve to");
+    output += expect("cubicCurveCount > 0", "true");
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/resources/accessibility-helper.js
+++ b/LayoutTests/resources/accessibility-helper.js
@@ -290,6 +290,23 @@ async function waitForElementById(id) {
     return element;
 }
 
+async function waitUntilIDHasPathWith(id, minimumCount, pathComponent) {
+    await waitFor(() => {
+        var element = accessibilityController.accessibleElementById(id);
+        if (!element)
+            return false;
+        var matches = element.pathDescription.match(new RegExp(pathComponent, "g"));
+        return matches && matches.length >= minimumCount;
+    });
+}
+
+function pathSegmentCountOfID(id, segmentType) {
+    var element = accessibilityController.accessibleElementById(id);
+    if (!element)
+        return 0;
+    return (element.pathDescription.match(new RegExp(segmentType, "g")) || []).length;
+}
+
 // Executes the operation and waits until an accessibility notification of the provided
 // `notificationName` is received. A notification listener is added to the passed
 // AccessibilityUIElement if not null, or a global listener is installed, before

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -579,7 +579,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         [additional addObject:NSAccessibilityMathPostscriptsAttribute];
     }
 
-    // isStaticText() objects already note their support for path in `accessibilityAttributeNames`.
+    // isStaticText() objects already include AXPath in their base attribute set above.
     if (!backingObject->isStaticText() && backingObject->supportsPath())
         [additional addObject:NSAccessibilityPathAttribute];
 
@@ -1096,14 +1096,27 @@ static void WebTransformCGPathToNSBezierPath(void* info, const CGPathElement *el
     case kCGPathElementAddLineToPoint:
         [bezierPath lineToPoint:NSPointFromCGPoint(points[0])];
         break;
+    case kCGPathElementAddQuadCurveToPoint: {
+        // Promote quad curve to cubic. points[0] = control point, points[1] = endpoint.
+        // NSBezierPath has no quad curve method, so convert to cubic:
+        //   cp1 = currentPoint + 2/3 * (quadCP - currentPoint)
+        //   cp2 = endpoint + 2/3 * (quadCP - endpoint)
+        NSPoint currentPoint = [bezierPath currentPoint];
+        CGPoint qp = points[0];
+        CGPoint ep = points[1];
+        NSPoint cp1 = NSMakePoint(currentPoint.x + (2.0 / 3.0) * (qp.x - currentPoint.x), currentPoint.y + (2.0 / 3.0) * (qp.y - currentPoint.y));
+        NSPoint cp2 = NSMakePoint(ep.x + (2.0 / 3.0) * (qp.x - ep.x), ep.y + (2.0 / 3.0) * (qp.y - ep.y));
+        [bezierPath curveToPoint:NSPointFromCGPoint(ep) controlPoint1:cp1 controlPoint2:cp2];
+        break;
+    }
     case kCGPathElementAddCurveToPoint: {
-        [bezierPath curveToPoint:NSPointFromCGPoint(points[0]) controlPoint1:NSPointFromCGPoint(points[1]) controlPoint2:NSPointFromCGPoint(points[2])];
+        // points[0] = cp1, points[1] = cp2, points[2] = endpoint.
+        // curveToPoint: takes the endpoint first, then control points.
+        [bezierPath curveToPoint:NSPointFromCGPoint(points[2]) controlPoint1:NSPointFromCGPoint(points[0]) controlPoint2:NSPointFromCGPoint(points[1])];
         break;
     }
     case kCGPathElementCloseSubpath:
         [bezierPath closePath];
-        break;
-    default:
         break;
     }
 }


### PR DESCRIPTION
#### 622e178d0c644289f4b9e51305047e4fa62a4fc3
<pre>
AX: Quad and cubic Bézier curve conversions aren&apos;t handled correctly in WebAccessibilityObjectWrapperMac, causing incorrect paths to be returned
<a href="https://bugs.webkit.org/show_bug.cgi?id=311662">https://bugs.webkit.org/show_bug.cgi?id=311662</a>
<a href="https://rdar.apple.com/174252190">rdar://174252190</a>

Reviewed by Joshua Hoffman.

WebTransformCGPathToNSBezierPath had two bugs that caused incorrect
VoiceOver cursor paths:

1. Quadratic Bézier curves (kCGPathElementAddQuadCurveToPoint) were
 silently dropped by the default switch case. NSBezierPath has no
 quad curve method, so promote them to cubic curves using the
 standard 2/3 conversion formula.

2. Cubic Bézier curves (kCGPathElementAddCurveToPoint) had the wrong
 argument order: points[0] (cp1) was passed as the endpoint to
 curveToPoint:controlPoint1:controlPoint2:, which expects the
 endpoint first. Reorder to points[2], points[0], points[1].

Remove the default case since all CGPathElementType values are now
handled explicitly.

* LayoutTests/accessibility/mac/bezier-path-curves-expected.txt: Added.
* LayoutTests/accessibility/mac/bezier-path-curves.html: Added.
* LayoutTests/resources/accessibility-helper.js:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper _additionalAccessibilityAttributeNames:]):
(WebTransformCGPathToNSBezierPath):

Canonical link: <a href="https://commits.webkit.org/310752@main">https://commits.webkit.org/310752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3719d09fb713cd028ff6dc0fffb2948e573d0b32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21162 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163504 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108214 "Failed to checkout and rebase branch from PR 62207") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156617 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27852 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119698 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/108214 "Failed to checkout and rebase branch from PR 62207") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157703 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138976 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100391 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21068 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19094 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11330 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130730 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16820 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165978 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9215 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18429 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127799 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27548 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23134 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127938 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34737 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27472 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138613 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84177 "Failed to checkout and rebase branch from PR 62207") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22839 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15407 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27164 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91266 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26742 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26973 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26815 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->