### PR TITLE
Handles 401s for AppSSO redirect flows

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.mm
@@ -69,8 +69,8 @@ void RedirectSOAuthorizationSession::completeInternal(const ResourceResponse& re
     RefPtr navigationAction = this->navigationAction();
     ASSERT(navigationAction);
     RefPtr page = this->page();
-    // FIXME: Enable the useRedirectionForCurrentNavigation code path for all redirections.
-    if ((response.httpStatusCode() != httpStatus302Found && response.httpStatusCode() != httpStatus200OK && !(response.httpStatusCode() == httpStatus307TemporaryRedirect && navigationAction->request().httpMethod() == "POST"_s)) || !page) {
+
+    if (!page) {
         AUTHORIZATIONSESSION_RELEASE_LOG("completeInternal: httpState=%d page=%d, so falling back to web path.", response.httpStatusCode(), !!page);
         fallBackToWebPathInternal();
         return;
@@ -95,6 +95,7 @@ void RedirectSOAuthorizationSession::completeInternal(const ResourceResponse& re
         page->loadRequest(ResourceRequest(response.httpHeaderFields().get(HTTPHeaderName::Location)));
         return;
     }
+
     if (response.httpStatusCode() == httpStatus200OK) {
         invokeCallback(true);
         page->setShouldSuppressSOAuthorizationInNextNavigationPolicyDecision();
@@ -102,9 +103,28 @@ void RedirectSOAuthorizationSession::completeInternal(const ResourceResponse& re
         return;
     }
 
-    ASSERT(response.httpStatusCode() == httpStatus307TemporaryRedirect && navigationAction->request().httpMethod() == "POST"_s);
-    page->useRedirectionForCurrentNavigation(response);
-    invokeCallback(false);
+    // FIXME: Enable the useRedirectionForCurrentNavigation code path for all redirections.
+    if (response.httpStatusCode() == httpStatus307TemporaryRedirect
+        && navigationAction->request().httpMethod() == "POST"_s) {
+        page->useRedirectionForCurrentNavigation(response);
+        invokeCallback(false);
+        return;
+    }
+
+    // When the SSO extension completes with a 401 response and non-empty body data,
+    // load the response body so the page can continue the authentication flow.
+    // The extension chose didCompleteWithHTTPResponse: over authorizationDidNotHandle:,
+    // indicating it has meaningful content for the browser to render. rdar://145336725
+    if (response.httpStatusCode() == httpStatus401Unauthorized && data.length) {
+        AUTHORIZATIONSESSION_RELEASE_LOG("completeInternal: loading 401 response body (%zu bytes)", static_cast<size_t>(data.length));
+        invokeCallback(true);
+        page->setShouldSuppressSOAuthorizationInNextNavigationPolicyDecision();
+        page->loadData(SharedBuffer::create(data), "text/html"_s, "UTF-8"_s, response.url().string(), nullptr, navigationAction->shouldOpenExternalURLsPolicy());
+        return;
+    }
+
+    AUTHORIZATIONSESSION_RELEASE_LOG("completeInternal: httpState=%d, so falling back to web path.", response.httpStatusCode());
+    fallBackToWebPathInternal();
 }
 
 void RedirectSOAuthorizationSession::beforeStart()

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
@@ -74,7 +74,7 @@ public:
     void abort();
     // Only responses that meet all of the following requirements will be processed:
     // 1) it has the same origin as the request;
-    // 2) it has a status code of 302 or 200.
+    // 2) it has a status code of 200, 302, 307 (POST only), or 401 (with non-empty body).
     // Otherwise, it falls back to the web path.
     // Only the following HTTP headers will be processed:
     // { Set-Cookie, Location }.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm
@@ -813,6 +813,61 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithOtherHttpStatusCode)
     EXPECT_WK_STREQ(testURL.get().absoluteString, finalURL);
 }
 
+TEST(SOAuthorizationRedirect, InterceptionSucceedWith401AndBody)
+{
+    resetState();
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
+
+    RetainPtr testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"DeviceAuth"]]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
+    Util::run(&authorizationPerformed);
+    checkAuthorizationOptions(false, emptyString(), 0);
+    EXPECT_TRUE(policyForAppSSOPerformed);
+
+    // Pass a HTTP 401 response with HTML body to mimic a device authentication challenge.
+    static constexpr auto deviceAuthResponse =
+        "<html>"
+        "<script>"
+        "window.webkit.messageHandlers.testHandler.postMessage('DeviceAuth');"
+        "</script>"
+        "</html>";
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:401 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:deviceAuthResponse length:strlen(deviceAuthResponse)]).get()];
+    Util::run(&allMessagesReceived);
+}
+
+TEST(SOAuthorizationRedirect, InterceptionFallbackWith401AndEmptyBody)
+{
+    resetState();
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
+
+    RetainPtr testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
+    Util::run(&authorizationPerformed);
+    checkAuthorizationOptions(false, emptyString(), 0);
+    EXPECT_TRUE(policyForAppSSOPerformed);
+
+    // A 401 with empty body should fall back to web path, same as other unhandled status codes.
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:401 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
+    Util::run(&navigationCompleted);
+    EXPECT_WK_STREQ(testURL.get().absoluteString, finalURL);
+}
+
 TEST(SOAuthorizationRedirect, InterceptionSucceedWith302POST)
 {
     resetState();


### PR DESCRIPTION
#### 20d4ad126aa3b75e75fba77bc85690c88e0ffcb2
<pre>
Handles 401s for AppSSO redirect flows
<a href="https://rdar.apple.com/145336725">rdar://145336725</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311665">https://bugs.webkit.org/show_bug.cgi?id=311665</a>

Reviewed by Brent Fulgham.

An SSO extension may return an HTTP 401 response with body data via
didCompleteWithHTTPResponse:httpBody: during a login flow. Previously,
completeInternal only accepted 200, 302, and 307-POST — everything else
called fallBackToWebPathInternal(), which dropped the body. Now, 401
responses with non-empty body data are loaded as HTML (same as the 200
path), allowing the authentication flow to continue. The method was also
restructured to check each status code individually with a final fallback,
replacing the compound guard condition and trailing ASSERT.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm

* Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.mm:
(WebKit::RedirectSOAuthorizationSession::completeInternal):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm:
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWith401AndBody)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionFallbackWith401AndEmptyBody)):

Canonical link: <a href="https://commits.webkit.org/311205@main">https://commits.webkit.org/311205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0df52344f05795325577fe21ed76f4cc28d9c4b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164909 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157959 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29556 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29424 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120856 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159046 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23079 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140178 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101539 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22159 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20297 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12681 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131819 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167388 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11504 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19622 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128972 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29024 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129101 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35023 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28946 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139804 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86713 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23930 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16602 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28655 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92612 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28182 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28410 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28306 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->