### PR TITLE
[JSC] Fold string length as much as possible in DFG / FTL

### DIFF
--- a/JSTests/stress/constant-string-length-folding.js
+++ b/JSTests/stress/constant-string-length-folding.js
@@ -1,0 +1,62 @@
+// Tests that constant string length is folded in DFG/FTL.
+// No output on success, throws on failure.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("Expected " + expected + " but got " + actual);
+}
+
+// .length
+function testLength() {
+    return "hello".length;
+}
+
+// .charCodeAt
+function testCharCodeAt() {
+    return "hello".charCodeAt(1);
+}
+
+// .codePointAt
+function testCodePointAt() {
+    return "hello".codePointAt(0);
+}
+
+// .slice
+function testSlice() {
+    return "hello world".slice(6);
+}
+
+// .at (negative index uses length internally)
+function testAt() {
+    return "hello".at(-1);
+}
+
+// .toUpperCase
+function testToUpperCase() {
+    return "HELLO".toUpperCase();
+}
+
+// .toLowerCase
+function testToLowerCase() {
+    return "hello".toLowerCase();
+}
+
+// Long string > 10000 chars to exercise the dynamicCastConstant fallback
+// (tryGetString returns null for strings > 10000 chars)
+var longStr = "";
+for (var i = 0; i < 10001; i++)
+    longStr += "a";
+// Use eval to make the string a compile-time constant in the function
+var testLongLength = new Function("return " + JSON.stringify(longStr) + ".length;");
+
+// Run enough iterations to trigger FTL
+for (var i = 0; i < 1e5; i++) {
+    shouldBe(testLength(), 5);
+    shouldBe(testCharCodeAt(), 101); // 'e'
+    shouldBe(testCodePointAt(), 104); // 'h'
+    shouldBe(testSlice(), "world");
+    shouldBe(testAt(), "o");
+    shouldBe(testToUpperCase(), "HELLO");
+    shouldBe(testToLowerCase(), "hello");
+    shouldBe(testLongLength(), 10001);
+}

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -1940,7 +1940,10 @@ void SpeculativeJIT::compileStringCodePointAt(Node* node)
     GPRReg scratch4GPR = scratch4.gpr();
 
     loadPtr(Address(stringGPR, JSString::offsetOfValue()), scratch1GPR);
-    load32(Address(scratch1GPR, StringImpl::lengthMemoryOffset()), scratch2GPR);
+    if (auto stringLength = tryGetConstantStringLength(node->child1()))
+        move(TrustedImm32(*stringLength), scratch2GPR);
+    else
+        load32(Address(scratch1GPR, StringImpl::lengthMemoryOffset()), scratch2GPR);
 
     // unsigned comparison so we can filter out negative indices and indices that are too large
     speculationCheck(Uncountable, JSValueRegs(), nullptr, branch32(AboveOrEqual, indexGPR, scratch2GPR));
@@ -2631,9 +2634,12 @@ void SpeculativeJIT::compileGetCharCodeAt(Node* node)
     GPRReg scratchReg = scratch.gpr();
 
     loadPtr(Address(stringReg, JSString::offsetOfValue()), scratchReg);
-    
+
     // unsigned comparison so we can filter out negative indices and indices that are too large
-    speculationCheck(Uncountable, JSValueRegs(), nullptr, branch32(AboveOrEqual, indexReg, Address(scratchReg, StringImpl::lengthMemoryOffset())));
+    if (auto stringLength = tryGetConstantStringLength(node->child1()))
+        speculationCheck(Uncountable, JSValueRegs(), nullptr, branch32(AboveOrEqual, indexReg, TrustedImm32(*stringLength)));
+    else
+        speculationCheck(Uncountable, JSValueRegs(), nullptr, branch32(AboveOrEqual, indexReg, Address(scratchReg, StringImpl::lengthMemoryOffset())));
 
     // Load the character into scratchReg
     Jump is16Bit = branchTest32(Zero, Address(scratchReg, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit()));
@@ -2674,21 +2680,30 @@ void SpeculativeJIT::compileGetByValOnString(Node* node, const ScopedLambda<std:
 
     move(propertyReg, propertyTempReg);
 
+    auto stringLength = tryGetConstantStringLength(m_graph.child(node, 0));
+
     if (node->op() == StringAt) {
         Jump isNotNegativeIndex = branch32(GreaterThanOrEqual, propertyTempReg, TrustedImm32(0));
 
-        loadPtr(Address(baseReg, JSString::offsetOfValue()), scratchReg);
-        load32(Address(scratchReg, StringImpl::lengthMemoryOffset()), scratchReg);
-        add32(scratchReg, propertyTempReg, propertyTempReg);
+        if (stringLength)
+            add32(TrustedImm32(*stringLength), propertyTempReg, propertyTempReg);
+        else {
+            loadPtr(Address(baseReg, JSString::offsetOfValue()), scratchReg);
+            load32(Address(scratchReg, StringImpl::lengthMemoryOffset()), scratchReg);
+            add32(scratchReg, propertyTempReg, propertyTempReg);
+        }
 
         isNotNegativeIndex.link(this);
     }
 
     // unsigned comparison so we can filter out negative indices and indices that are too large
     loadPtr(Address(baseReg, JSString::offsetOfValue()), scratchReg);
-    Jump outOfBounds = branch32(
-        AboveOrEqual, propertyTempReg,
-        Address(scratchReg, StringImpl::lengthMemoryOffset()));
+    Jump outOfBounds;
+    if (stringLength)
+        outOfBounds = branch32(AboveOrEqual, propertyTempReg, TrustedImm32(*stringLength));
+    else
+        outOfBounds = branch32(AboveOrEqual, propertyTempReg, Address(scratchReg, StringImpl::lengthMemoryOffset()));
+
     if (node->op() != StringCharAt && node->arrayMode().isInBounds())
         speculationCheck(OutOfBounds, JSValueRegs(), nullptr, outOfBounds);
 
@@ -8381,6 +8396,18 @@ bool SpeculativeJIT::canBeRope(Edge edge)
     return true;
 }
 
+std::optional<unsigned> SpeculativeJIT::tryGetConstantStringLength(Edge edge)
+{
+    String string = edge->tryGetString(m_graph);
+    if (!!string)
+        return string.length();
+    if (JSValue value = m_state.forNode(edge).m_value) {
+        if (value.isCell() && value.asCell()->type() == StringType)
+            return asString(value)->length();
+    }
+    return std::nullopt;
+}
+
 void SpeculativeJIT::compileGetArrayLength(Node* node)
 {
     switch (node->arrayMode().type()) {
@@ -8411,6 +8438,16 @@ void SpeculativeJIT::compileGetArrayLength(Node* node)
         break;
     }
     case Array::String: {
+        if (auto stringLength = tryGetConstantStringLength(node->child1())) {
+            SpeculateCellOperand base(this, node->child1());
+            GPRTemporary result(this, Reuse, base);
+            base.gpr(); // Perform Cell speculation.
+            GPRReg resultGPR = result.gpr();
+            move(TrustedImm32(*stringLength), resultGPR);
+            strictInt32Result(resultGPR, node);
+            break;
+        }
+
         SpeculateCellOperand base(this, node->child1());
         GPRTemporary result(this, Reuse, base);
         GPRTemporary temp(this);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -571,6 +571,7 @@ public:
     bool isKnownNotOther(Node* node) { return !(m_state.forNode(node).m_type & SpecOther); }
 
     bool canBeRope(Edge);
+    std::optional<unsigned> tryGetConstantStringLength(Edge);
 
     UniquedStringImpl* identifierUID(unsigned index)
     {

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -662,11 +662,16 @@ private:
         }
 
         case GetArrayLength: {
-            if (m_node->arrayMode().type() == Array::Generic
-                || m_node->arrayMode().type() == Array::String) {
+            if (m_node->arrayMode().type() == Array::Generic || m_node->arrayMode().type() == Array::String) {
                 String string = m_node->child1()->tryGetString(m_graph);
                 if (!!string) {
                     m_graph.convertToConstant(m_node, jsNumber(string.length()));
+                    m_changed = true;
+                    break;
+                }
+
+                if (JSString* jsString = m_node->child1()->dynamicCastConstant<JSString*>()) {
+                    m_graph.convertToConstant(m_node, jsNumber(jsString->length()));
                     m_changed = true;
                     break;
                 }

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -6101,6 +6101,11 @@ IGNORE_CLANG_WARNINGS_END
         case Array::String: {
             LValue string = lowCell(m_node->child1());
 
+            if (auto stringLength = tryGetConstantStringLength(m_node->child1())) {
+                setInt32(m_out.constInt32(*stringLength));
+                return;
+            }
+
             LBasicBlock ropePath = m_out.newBlock();
             LBasicBlock nonRopePath = m_out.newBlock();
             LBasicBlock continuation = m_out.newBlock();
@@ -11354,7 +11359,11 @@ IGNORE_CLANG_WARNINGS_END
         LValue originalIndex = lowInt32(m_graph.child(m_node, 1));
 
         LValue stringImpl = m_out.loadPtr(base, m_heaps.JSString_value);
-        LValue stringLength = m_out.load32NonNegative(stringImpl, m_heaps.StringImpl_length);
+        LValue stringLength;
+        if (auto constantStringLength = tryGetConstantStringLength(m_graph.child(m_node, 0)))
+            stringLength = m_out.constInt32(*constantStringLength);
+        else
+            stringLength = m_out.load32NonNegative(stringImpl, m_heaps.StringImpl_length);
 
         LValue index = m_node->op() == StringAt ? m_out.select(m_out.lessThan(originalIndex, m_out.int32Zero), m_out.add(stringLength, originalIndex), originalIndex) : originalIndex;
 
@@ -11486,10 +11495,14 @@ IGNORE_CLANG_WARNINGS_END
         LValue data = m_out.loadPtr(stringImpl, m_heaps.StringImpl_data);
 
         if (!m_node->arrayMode().isInBounds()) {
+            LValue length;
+            if (auto stringLength = tryGetConstantStringLength(m_node->child1()))
+                length = m_out.constInt32(*stringLength);
+            else
+                length = m_out.load32NonNegative(stringImpl, m_heaps.StringImpl_length);
             speculate(
                 Uncountable, noValue(), nullptr,
-                m_out.aboveOrEqual(
-                    index, m_out.load32NonNegative(stringImpl, m_heaps.StringImpl_length)));
+                m_out.aboveOrEqual(index, length));
         }
 
         m_out.branch(
@@ -11525,7 +11538,11 @@ IGNORE_CLANG_WARNINGS_END
         LValue index = lowInt32(m_node->child2());
 
         LValue stringImpl = m_out.loadPtr(base, m_heaps.JSString_value);
-        LValue length = m_out.load32NonNegative(stringImpl, m_heaps.StringImpl_length);
+        LValue length;
+        if (auto stringLength = tryGetConstantStringLength(m_node->child1()))
+            length = m_out.constInt32(*stringLength);
+        else
+            length = m_out.load32NonNegative(stringImpl, m_heaps.StringImpl_length);
 
         speculate(Uncountable, noValue(), nullptr, m_out.aboveOrEqual(index, length));
 
@@ -19538,7 +19555,11 @@ IGNORE_CLANG_WARNINGS_END
 
         LBasicBlock lastNext = m_out.appendTo(lengthCheckCase, emptyCase);
         LValue stringImpl = m_out.loadPtr(string, m_heaps.JSString_value);
-        LValue length = m_out.load32NonNegative(stringImpl, m_heaps.StringImpl_length);
+        LValue length;
+        if (auto stringLength = tryGetConstantStringLength(m_node->child1()))
+            length = m_out.constInt32(*stringLength);
+        else
+            length = m_out.load32NonNegative(stringImpl, m_heaps.StringImpl_length);
         auto range = populateSliceRange(start, end, length);
         LValue from = range.first;
         LValue to = range.second;
@@ -19635,7 +19656,11 @@ IGNORE_CLANG_WARNINGS_END
             unsure(slowPath), unsure(is8Bit));
 
         m_out.appendTo(is8Bit, loopTop);
-        LValue length = m_out.load32(impl, m_heaps.StringImpl_length);
+        LValue length;
+        if (auto stringLength = tryGetConstantStringLength(m_node->child1()))
+            length = m_out.constInt32(*stringLength);
+        else
+            length = m_out.load32(impl, m_heaps.StringImpl_length);
         LValue buffer = m_out.loadPtr(impl, m_heaps.StringImpl_data);
         ValueFromBlock fastResult = m_out.anchor(string);
         m_out.jump(loopTop);
@@ -19691,7 +19716,11 @@ IGNORE_CLANG_WARNINGS_END
             unsure(slowPath), unsure(is8Bit));
 
         m_out.appendTo(is8Bit, loopTop);
-        LValue length = m_out.load32(impl, m_heaps.StringImpl_length);
+        LValue length;
+        if (auto stringLength = tryGetConstantStringLength(m_node->child1()))
+            length = m_out.constInt32(*stringLength);
+        else
+            length = m_out.load32(impl, m_heaps.StringImpl_length);
         LValue buffer = m_out.loadPtr(impl, m_heaps.StringImpl_data);
         ValueFromBlock fastResult = m_out.anchor(string);
         m_out.jump(loopTop);
@@ -22106,7 +22135,11 @@ IGNORE_CLANG_WARNINGS_END
         LBasicBlock lastNext = m_out.appendTo(hasImplBlock, is8BitBlock);
 
         LValue stringImpl = m_out.loadPtr(string, m_heaps.JSString_value);
-        LValue length = m_out.load32(stringImpl, m_heaps.StringImpl_length);
+        LValue length;
+        if (auto stringLength = tryGetConstantStringLength(edge))
+            length = m_out.constInt32(*stringLength);
+        else
+            length = m_out.load32(stringImpl, m_heaps.StringImpl_length);
 
         m_out.branch(
             m_out.testIsZero32(
@@ -22129,7 +22162,11 @@ IGNORE_CLANG_WARNINGS_END
 
         m_out.appendTo(isRopeBlock, slowBlock);
         const UnlinkedStringJumpTable& unlinkedTable = m_graph.unlinkedStringSwitchJumpTable(data->switchTableIndex);
-        LValue ropeLength = m_out.load32NonNegative(string, m_heaps.JSRopeString_length);
+        LValue ropeLength;
+        if (auto stringLength = tryGetConstantStringLength(edge))
+            ropeLength = m_out.constInt32(*stringLength);
+        else
+            ropeLength = m_out.load32NonNegative(string, m_heaps.JSRopeString_length);
         m_out.branch(m_out.belowOrEqual(m_out.sub(ropeLength, m_out.constInt32(unlinkedTable.minLength())), m_out.constInt32(unlinkedTable.maxLength() - unlinkedTable.minLength())), unsure(slowBlock), unsure(lowBlock(data->fallThrough.block)));
 
         m_out.appendTo(slowBlock, lastNext);
@@ -24184,6 +24221,16 @@ IGNORE_CLANG_WARNINGS_END
         if (!canBeRope(edge))
             return m_out.booleanFalse;
         return m_out.testNonZeroPtr(m_out.loadPtr(string, m_heaps.JSString_value), m_out.constIntPtr(JSString::isRopeInPointer));
+    }
+
+    std::optional<unsigned> tryGetConstantStringLength(Edge edge)
+    {
+        String string = edge->tryGetString(m_graph);
+        if (!!string)
+            return string.length();
+        if (JSString* jsString = edge->dynamicCastConstant<JSString*>())
+            return jsString->length();
+        return std::nullopt;
     }
 
     LValue isNotRopeString(LValue string, Edge edge = Edge())


### PR DESCRIPTION
#### 7aea7dd35f02e4dea28a15e47ee9ff486da0aeda
<pre>
[JSC] Fold string length as much as possible in DFG / FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=311666">https://bugs.webkit.org/show_bug.cgi?id=311666</a>
<a href="https://rdar.apple.com/174257984">rdar://174257984</a>

Reviewed by Keith Miller and Yijia Huang.

Add helper function to fold string length as much as possible in DFG and
FTL. This potentially skips unnecessary loading or removing dead code.

Test: JSTests/stress/constant-string-length-folding.js

* JSTests/stress/constant-string-length-folding.js: Added.
(shouldBe):
(testLength):
(testCharCodeAt):
(testCodePointAt):
(testSlice):
(testAt):
(testToUpperCase):
(testToLowerCase):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileStringCodePointAt):
(JSC::DFG::SpeculativeJIT::compileGetCharCodeAt):
(JSC::DFG::SpeculativeJIT::compileGetByValOnString):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileGetArrayLength):
(JSC::FTL::DFG::LowerDFGToB3::compileStringCharAtImpl):
(JSC::FTL::DFG::LowerDFGToB3::compileStringCharCodeAt):
(JSC::FTL::DFG::LowerDFGToB3::compileStringCodePointAt):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Canonical link: <a href="https://commits.webkit.org/310753@main">https://commits.webkit.org/310753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9b0e75a615f7909939069caa8da591dc41b4a5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163523 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/83567daa-7d3e-4e81-934e-92ad4cbf1154) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28159 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27871 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119716 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21998 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138988 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100409 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21084 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19109 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11349 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146813 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130746 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16832 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165997 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15594 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9246 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18441 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127818 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27567 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23149 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127958 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27491 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138625 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84196 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23614 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22851 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15419 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186497 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27183 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91285 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47804 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26761 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26992 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26834 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->