### PR TITLE
[libpas] Fix TestHarness.cpp fd handling for child processes

### DIFF
--- a/Source/bmalloc/libpas/src/test/TestHarness.cpp
+++ b/Source/bmalloc/libpas/src/test/TestHarness.cpp
@@ -286,7 +286,7 @@ void iterateForward(TestScopeImpl* scope, const Func& func)
 }
 
 string currentSuite;
-bool runningOneTest;
+bool runningOneTestInProcess;
 
 struct Test {
     Test() = default;
@@ -362,8 +362,15 @@ unsigned testsPassed;
 unsigned testsRan;
 
 static constexpr char successByte = 'S';
-
-int resultPipe[2];
+int childSuccessReportingPipe = -1;
+[[noreturn]] void reportSuccessAndExitForkedProcess()
+{
+    PAS_ASSERT(childSuccessReportingPipe > 0);
+    ssize_t writeResult = write(childSuccessReportingPipe, &successByte, 1);
+    PAS_ASSERT(writeResult == 1);
+    exit(0);
+    PAS_ASSERT(!"Should have exited");
+}
 
 } // anonymous namespace
 
@@ -403,7 +410,7 @@ void addViewCacheTests();
 
 void testSucceeded()
 {
-    if (runningOneTest) {
+    if (runningOneTestInProcess) {
         cout << "    PASS!" << endl;
         cout << endl;
         cout << "Exiting early due to test success." << endl;
@@ -412,10 +419,7 @@ void testSucceeded()
         exit(0);
     }
 
-    ssize_t writeResult = write(resultPipe[1], &successByte, 1);
-    PAS_ASSERT(writeResult == 1);
-    exit(0);
-    PAS_ASSERT(!"Should have exited");
+    reportSuccessAndExitForkedProcess();
 }
 
 unsigned deterministicRandomNumber(unsigned exclusiveUpperBound)
@@ -671,9 +675,9 @@ unsigned computeTestConcurrency(std::optional<int> childProcesses)
 }
 
 
-void runOneTest(const Test& test)
+void runOneTestInProcess(const Test& test)
 {
-    runningOneTest = true;
+    runningOneTestInProcess = true;
     cout << "Running " << test.fullName() << "..." << endl;
     test.run();
     testSucceeded();
@@ -699,11 +703,9 @@ RunningTest startForkedTest(const Test& test, size_t testIndex)
     if (!forkResult) {
         // Child process
         close(pipefd[0]);
+        childSuccessReportingPipe = pipefd[1];
         test.run();
-        ssize_t writeResult = write(pipefd[1], &successByte, 1);
-        PAS_ASSERT(writeResult == 1);
-        exit(0);
-        PAS_ASSERT(!"Should have exited");
+        reportSuccessAndExitForkedProcess();
     }
 
     // Parent process
@@ -779,7 +781,7 @@ void runTests(const vector<Test>& tests, std::optional<int> childProcesses)
     CHECK(tests.size());
 
     if (tests.size() == 1) {
-        runOneTest(tests[0]);
+        runOneTestInProcess(tests[0]);
         return;
     }
 


### PR DESCRIPTION
#### 7c6ba4f49874c598fc04e5a09c1926b7cdb0009d
<pre>
[libpas] Fix TestHarness.cpp fd handling for child processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=311668">https://bugs.webkit.org/show_bug.cgi?id=311668</a>
<a href="https://rdar.apple.com/174260027">rdar://174260027</a>

Reviewed by Keith Miller.

Normally, success should be reported through the local pipefd in
startForkedTest. However, there’s some old code which uses a global
resultPipe instead, which is 0-initialized, thus passing through to
stdin and thus apparently the terminal.
E.g.:
```
Running
(1115):&lt;...&gt;/OpenSource/Source/bmalloc/libpas/src/test/ThingyAndUtilityHeapAllocationTests.cpp:2503/ThingyAndUtilityHeapAllocation/force-exclusives/force-tlas/epoch-is-counter/small-and-medium/disable-bitfit/testSmallDoubleFree()...
    Failed deallocation: Alloc bit not set in
    pas_segregated_page_deallocate_with_page: 0x10f000130
    S    FAIL: unexpected exit with code 0
```
This patch fixes that by consolidating the two fds.

Canonical link: <a href="https://commits.webkit.org/310745@main">https://commits.webkit.org/310745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd0006ca0289d0ae3ffec2349593a5d355726fa8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163518 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ccf90688-a6fe-48c7-8751-2e2eac4d4e06) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27866 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119710 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e624a04d-0580-4deb-99b7-04450deb1f1a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138974 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100403 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b90d3fb9-600d-42be-b305-1e520949e7c9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21083 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11344 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146808 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130745 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16818 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165992 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15589 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18427 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127813 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27562 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23143 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127953 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34729 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27486 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138611 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84191 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22846 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15405 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186492 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27178 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47800 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26756 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26987 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26829 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->