### PR TITLE
Skip full-page anchor scan for conservative-only speculation rules

### DIFF
--- a/LayoutTests/http/wpt/prefetch/speculation-rules-conservative-lazy-match.https-expected.txt
+++ b/LayoutTests/http/wpt/prefetch/speculation-rules-conservative-lazy-match.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Conservative document rule with selector_matches lazily matches on pointerdown
+PASS Conservative document rule with href_matches pattern lazily matches on pointerdown
+PASS Dynamically added link with conservative document rule lazily matches on pointerdown
+

--- a/LayoutTests/http/wpt/prefetch/speculation-rules-conservative-lazy-match.https.html
+++ b/LayoutTests/http/wpt/prefetch/speculation-rules-conservative-lazy-match.https.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SpeculationRulesPrefetchEnabled=true ] -->
+<meta charset="utf-8">
+<meta name="timeout" content="long">
+<title>Conservative document rules lazy matching on interaction</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<body>
+<script>
+
+setup(() => {
+  assert_implements(
+      'supports' in HTMLScriptElement,
+      'HTMLScriptElement.supports must be supported');
+  assert_implements(
+      HTMLScriptElement.supports('speculationrules'),
+      '<script type="speculationrules"> must be supported');
+});
+
+const PREFETCH_RESOURCE_URL = new URL('/speculation-rules/prefetch/resources/prefetch.py', location.href);
+
+function getPrefetchUrl(extra_params = {}) {
+  let params = new URLSearchParams({ uuid: token(), ...extra_params });
+  return new URL(`${PREFETCH_RESOURCE_URL}?${params}`);
+}
+
+async function isUrlPrefetched(url) {
+  let response = await fetch(url, { redirect: 'follow' });
+  return response.json();
+}
+
+// Poll until prefetch arrives or timeout. Use for positive assertions instead
+// of fixed delays.
+async function waitForPrefetch(url, timeout = 5000) {
+  const start = performance.now();
+  while (performance.now() - start < timeout) {
+    if (await isUrlPrefetched(url) > 0)
+      return true;
+    await new Promise(r => setTimeout(r, 50));
+  }
+  return false;
+}
+
+// Yield to the event loop so that any synchronously-initiated prefetch
+// network requests have a chance to reach the server. Two round-trips:
+// one to flush the event loop, one to let the server process the request.
+async function flushNetworking() {
+  await fetch('/resources/blank.html');
+  await fetch('/resources/blank.html');
+}
+
+function insertSpeculationRules(body) {
+  let script = document.createElement('script');
+  script.type = 'speculationrules';
+  script.textContent = JSON.stringify(body);
+  document.head.appendChild(script);
+  return script;
+}
+
+function addLink(href, className, parent = document.body) {
+  const a = document.createElement('a');
+  a.href = href;
+  a.textContent = 'link';
+  if (className)
+    a.className = className;
+  parent.appendChild(a);
+  return a;
+}
+
+function triggerPointerDown(element) {
+  const rect = element.getBoundingClientRect();
+  const x = rect.left + rect.width / 2;
+  const y = rect.top + rect.height / 2;
+
+  element.dispatchEvent(new PointerEvent('pointerdown', {
+    bubbles: true, cancelable: true, view: window,
+    clientX: x, clientY: y, button: 0, pointerType: 'mouse'
+  }));
+  element.dispatchEvent(new MouseEvent('mousedown', {
+    bubbles: true, cancelable: true, view: window,
+    clientX: x, clientY: y, button: 0
+  }));
+}
+
+function triggerHover(element) {
+  const rect = element.getBoundingClientRect();
+  const x = rect.left + rect.width / 2;
+  const y = rect.top + rect.height / 2;
+
+  element.dispatchEvent(new PointerEvent('pointerover', {
+    bubbles: true, cancelable: true, view: window,
+    clientX: x, clientY: y, pointerType: 'mouse'
+  }));
+  element.dispatchEvent(new MouseEvent('mouseover', {
+    bubbles: true, cancelable: true, view: window,
+    clientX: x, clientY: y
+  }));
+  element.dispatchEvent(new PointerEvent('pointermove', {
+    bubbles: true, cancelable: true, view: window,
+    clientX: x, clientY: y, pointerType: 'mouse'
+  }));
+  element.dispatchEvent(new MouseEvent('mousemove', {
+    bubbles: true, cancelable: true, view: window,
+    clientX: x, clientY: y
+  }));
+}
+
+// Test: Conservative document rule with selector_matches is lazily matched
+// on pointerdown (not during style recalc / anchor scan).
+promise_test(async t => {
+  const matchUrl = getPrefetchUrl({ test: 'selector-match' });
+  const noMatchUrl = getPrefetchUrl({ test: 'selector-no-match' });
+
+  const matchLink = addLink(matchUrl, 'prefetch-me');
+  const noMatchLink = addLink(noMatchUrl, 'do-not-prefetch');
+  matchLink.addEventListener('click', e => e.preventDefault());
+  noMatchLink.addEventListener('click', e => e.preventDefault());
+  t.add_cleanup(() => { matchLink.remove(); noMatchLink.remove(); });
+
+  const rules = insertSpeculationRules({
+    prefetch: [{
+      source: 'document',
+      eagerness: 'conservative',
+      where: { selector_matches: '.prefetch-me' }
+    }]
+  });
+  t.add_cleanup(() => rules.remove());
+
+  // With the optimization, the anchor scan is skipped for conservative-only
+  // rules, so m_prefetchEagerness stays "none" instead of being set to
+  // "conservative" by the scan.
+  if (window.internals)
+    assert_equals(internals.anchorPrefetchEagerness(matchLink), 'none', 'eagerness should be none (scan skipped for conservative-only rules)');
+
+  // Hover should not trigger conservative prefetch.
+  triggerHover(matchLink);
+  await flushNetworking();
+  assert_equals(await isUrlPrefetched(matchUrl), 0, 'matching link should not be prefetched on hover');
+  assert_equals(await isUrlPrefetched(noMatchUrl), 0, 'non-matching link should not be prefetched on hover');
+
+  // Pointerdown on matching link should trigger lazy match and prefetch.
+  triggerPointerDown(matchLink);
+  assert_true(await waitForPrefetch(matchUrl), 'matching link should be prefetched after pointerdown');
+
+  // Pointerdown on non-matching link should NOT trigger prefetch.
+  triggerPointerDown(noMatchLink);
+  await flushNetworking();
+  assert_equals(await isUrlPrefetched(noMatchUrl), 0, 'non-matching link should not be prefetched after pointerdown');
+}, 'Conservative document rule with selector_matches lazily matches on pointerdown');
+
+// Test: Conservative document rule with href_matches pattern lazily matches.
+promise_test(async t => {
+  const url = getPrefetchUrl({ test: 'href-pattern' });
+
+  const link = addLink(url);
+  link.addEventListener('click', e => e.preventDefault());
+  t.add_cleanup(() => link.remove());
+
+  const rules = insertSpeculationRules({
+    prefetch: [{
+      source: 'document',
+      eagerness: 'conservative',
+      where: { href_matches: '/speculation-rules/prefetch/resources/prefetch.py*' }
+    }]
+  });
+  t.add_cleanup(() => rules.remove());
+
+  if (window.internals)
+    assert_equals(internals.anchorPrefetchEagerness(link), 'none', 'eagerness should be none (scan skipped)');
+
+  // Hover should not trigger conservative prefetch.
+  triggerHover(link);
+  await flushNetworking();
+  assert_equals(await isUrlPrefetched(url), 0, 'should not be prefetched on hover');
+
+  triggerPointerDown(link);
+  assert_true(await waitForPrefetch(url), 'should be prefetched after pointerdown');
+}, 'Conservative document rule with href_matches pattern lazily matches on pointerdown');
+
+// Test: Dynamically added link is lazily matched on pointerdown without
+// needing a style recalc anchor scan.
+promise_test(async t => {
+  const url = getPrefetchUrl({ test: 'dynamic-link' });
+
+  // Insert rules first, before the link exists.
+  const rules = insertSpeculationRules({
+    prefetch: [{
+      source: 'document',
+      eagerness: 'conservative',
+      where: { selector_matches: '.late-addition' }
+    }]
+  });
+  t.add_cleanup(() => rules.remove());
+
+  // Add link after rules are already in place.
+  const link = addLink(url, 'late-addition');
+  link.addEventListener('click', e => e.preventDefault());
+  t.add_cleanup(() => link.remove());
+
+  if (window.internals)
+    assert_equals(internals.anchorPrefetchEagerness(link), 'none', 'dynamically added link eagerness should be none');
+
+  // Hover should not trigger conservative prefetch.
+  triggerHover(link);
+  await flushNetworking();
+  assert_equals(await isUrlPrefetched(url), 0, 'dynamically added link should not be prefetched on hover');
+
+  triggerPointerDown(link);
+  assert_true(await waitForPrefetch(url), 'dynamically added link should be prefetched after pointerdown');
+}, 'Dynamically added link with conservative document rule lazily matches on pointerdown');
+
+</script>
+</body>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4780,12 +4780,17 @@ void Document::processSpeculationRules()
     RefPtr frame = this->frame();
     ASSERT(frame);
 
-    auto anchors = links();
-    auto iterator = anchors->createIterator(this);
-    for (RefPtr element = iterator.next(); element; element = iterator.next()) {
-        if (RefPtr anchorElement = dynamicDowncast<HTMLAnchorElement>(element.get())) {
-            if (auto prefetchRule = SpeculationRulesMatcher::hasMatchingRule(*this, *anchorElement))
-                anchorElement->setShouldBePrefetched(prefetchRule->eagerness, WTF::move(prefetchRule->tags), WTF::move(prefetchRule->referrerPolicy));
+    // Only scan all anchors if there are rules requiring eager matching
+    // (Immediate/Eager/Moderate). Conservative rules are matched lazily
+    // on user interaction in HTMLAnchorElement::defaultEventHandler().
+    if (speculationRules().hasNonConservativePrefetchRules()) {
+        auto anchors = links();
+        auto iterator = anchors->createIterator(this);
+        for (RefPtr element = iterator.next(); element; element = iterator.next()) {
+            if (RefPtr anchorElement = dynamicDowncast<HTMLAnchorElement>(element.get())) {
+                if (auto prefetchRule = SpeculationRulesMatcher::hasMatchingRule(*this, *anchorElement))
+                    anchorElement->setShouldBePrefetched(prefetchRule->eagerness, WTF::move(prefetchRule->tags), WTF::move(prefetchRule->referrerPolicy));
+            }
         }
     }
     // Prefetch all the URL lists that need to be prefetched immediately

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -165,6 +165,16 @@ void HTMLAnchorElement::defaultEventHandler(Event& event)
 {
     if (m_prefetchEagerness == PrefetchEagerness::Conservative && (event.type() == eventNames().keydownEvent || event.type() == eventNames().mousedownEvent || event.type() == eventNames().pointerdownEvent))
         protect(document())->prefetch(href(), m_speculationRulesTags, m_prefetchReferrerPolicy);
+    else if (m_prefetchEagerness == PrefetchEagerness::None
+        && document().settings().speculationRulesPrefetchEnabled()
+        && (event.type() == eventNames().keydownEvent || event.type() == eventNames().mousedownEvent || event.type() == eventNames().pointerdownEvent)) {
+        // Lazy matching for conservative rules: evaluate at interaction time
+        // instead of scanning all links on every style recalculation.
+        if (auto prefetchRule = SpeculationRulesMatcher::hasMatchingRule(protect(document()), *this)) {
+            if (prefetchRule->eagerness != SpeculationRules::Eagerness::Immediate)
+                protect(document())->prefetch(href(), prefetchRule->tags, prefetchRule->referrerPolicy);
+        }
+    }
 
     if (isLink()) {
         if (focused() && isEnterKeyKeydownEvent(event) && treatLinkAsLiveForEventType(NonMouseEvent)) {
@@ -748,10 +758,30 @@ void HTMLAnchorElement::setShouldBePrefetched(SpeculationRules::Eagerness eagern
         protect(document())->prefetch(href(), m_speculationRulesTags, m_prefetchReferrerPolicy, true);
 }
 
+String HTMLAnchorElement::prefetchEagernessForTesting() const
+{
+    switch (m_prefetchEagerness) {
+    case PrefetchEagerness::None:
+        return "none"_s;
+    case PrefetchEagerness::Conservative:
+        return "conservative"_s;
+    case PrefetchEagerness::Immediate:
+        return "immediate"_s;
+    }
+    return "none"_s;
+}
+
 void HTMLAnchorElement::checkForSpeculationRules()
 {
     if (!document().settings().speculationRulesPrefetchEnabled())
         return;
+    // For conservative-only rules, defer matching to interaction time.
+    if (!document().speculationRules().hasNonConservativePrefetchRules()) {
+        m_prefetchEagerness = PrefetchEagerness::None;
+        m_speculationRulesTags.clear();
+        m_prefetchReferrerPolicy = std::nullopt;
+        return;
+    }
     if (auto prefetchRule = SpeculationRulesMatcher::hasMatchingRule(protect(document()), *this))
         setShouldBePrefetched(prefetchRule->eagerness, WTF::move(prefetchRule->tags), WTF::move(prefetchRule->referrerPolicy));
     else {

--- a/Source/WebCore/html/HTMLAnchorElement.h
+++ b/Source/WebCore/html/HTMLAnchorElement.h
@@ -89,6 +89,8 @@ public:
 
     void setShouldBePrefetched(SpeculationRules::Eagerness, Vector<String>&& tags, std::optional<ReferrerPolicy>&&);
 
+    WEBCORE_EXPORT String prefetchEagernessForTesting() const;
+
 protected:
     HTMLAnchorElement(const QualifiedName&, Document&);
 

--- a/Source/WebCore/loader/SpeculationRules.cpp
+++ b/Source/WebCore/loader/SpeculationRules.cpp
@@ -384,6 +384,17 @@ bool SpeculationRules::parseSpeculationRules(Node& sourceNode, const StringView&
     return true;
 }
 
+bool SpeculationRules::hasNonConservativePrefetchRules() const
+{
+    for (auto [node, rules] : m_prefetchRulesByNode) {
+        for (const auto& rule : rules) {
+            if (rule.eagerness != Eagerness::Conservative)
+                return true;
+        }
+    }
+    return false;
+}
+
 // https://html.spec.whatwg.org/C#unregister-speculation-rules
 Vector<URL> SpeculationRules::unregisterSpeculationRules(Node& sourceNode)
 {

--- a/Source/WebCore/loader/SpeculationRules.h
+++ b/Source/WebCore/loader/SpeculationRules.h
@@ -110,6 +110,8 @@ public:
 
     const WeakHashMap<Node, Vector<Rule>, WeakPtrImplWithEventTargetData>& prefetchRules() const LIFETIME_BOUND { return m_prefetchRulesByNode; }
 
+    bool NODELETE hasNonConservativePrefetchRules() const;
+
 private:
     SpeculationRules() = default;
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1765,6 +1765,13 @@ String Internals::visiblePlaceholder(Element& element)
     return String();
 }
 
+String Internals::anchorPrefetchEagerness(Element& element)
+{
+    if (auto* anchor = dynamicDowncast<HTMLAnchorElement>(element))
+        return anchor->prefetchEagernessForTesting();
+    return String();
+}
+
 void Internals::setCanShowPlaceholder(Element& element, bool canShowPlaceholder)
 {
     if (auto* textFormControlElement = dynamicDowncast<HTMLTextFormControlElement>(element))

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -358,6 +358,7 @@ public:
     Node* NODELETE parentTreeScope(Node&);
 
     String visiblePlaceholder(Element&);
+    String anchorPrefetchEagerness(Element&);
     void setCanShowPlaceholder(Element&, bool);
 
     RefPtr<Element> insertTextPlaceholder(int width, int height);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -594,6 +594,7 @@ enum ContentsFormat {
     double preferredRenderingUpdateInterval();
 
     DOMString visiblePlaceholder(Element element);
+    DOMString anchorPrefetchEagerness(Element element);
     undefined selectColorInColorChooser(HTMLInputElement element, DOMString colorValue);
     sequence<[AtomString] DOMString> formControlStateOfPreviousHistoryItem();
     undefined setFormControlStateOfPreviousHistoryItem(sequence<[AtomString] DOMString> values);


### PR DESCRIPTION
#### 5cf7b15948ed07e78ad873f8c51418831a949d2b
<pre>
Skip full-page anchor scan for conservative-only speculation rules
<a href="https://bugs.webkit.org/show_bug.cgi?id=311672">https://bugs.webkit.org/show_bug.cgi?id=311672</a>
<a href="https://rdar.apple.com/173520903">rdar://173520903</a>

Reviewed by Chris Dumez.

processSpeculationRules() scans all links on every style recalculation,
performing pattern/selector evaluations per anchor. For conservative rules,
the result is only consumed at user interaction time. This is wasted work
on pages with many links.

Defer matching for conservative-only rules to interaction time in
HTMLAnchorElement::defaultEventHandler(), skipping the full-page anchor
scan when all rules are conservative.

Test: http/wpt/prefetch/speculation-rules-conservative-lazy-match.https.html
* LayoutTests/http/wpt/prefetch/speculation-rules-conservative-lazy-match.https-expected.txt: Added.
* LayoutTests/http/wpt/prefetch/speculation-rules-conservative-lazy-match.https.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::processSpeculationRules):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::defaultEventHandler):
(WebCore::HTMLAnchorElement::prefetchEagernessForTesting const):
(WebCore::HTMLAnchorElement::checkForSpeculationRules):
* Source/WebCore/html/HTMLAnchorElement.h:
* Source/WebCore/loader/SpeculationRules.cpp:
(WebCore::SpeculationRules::hasNonConservativePrefetchRules const):
* Source/WebCore/loader/SpeculationRules.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::anchorPrefetchEagerness):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/310814@main">https://commits.webkit.org/310814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ee6733c867d814b470235274bd42a2185e8a230

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163606 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108316 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/039ebb11-830e-4ba3-bbe2-0cdec1bbd727) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156719 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28242 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27954 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119785 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84677 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/08faf17a-1140-40f6-af3c-43d285719f3e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157805 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100478 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4b88738f-cee4-43d2-a2a4-48a021d27196) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21148 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19174 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11432 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130810 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166080 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9446 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18510 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127887 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27650 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23214 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128027 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34786 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27574 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138694 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84279 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22912 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15488 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27266 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91368 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26844 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27075 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26917 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->