### PR TITLE
[Smart Lists] Smart Lists should not activate until the second list-like line

### DIFF
--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -1607,27 +1607,8 @@ VisibleSelection CompositeEditCommand::shouldBreakOutOfEmptyListItem() const
     return VisibleSelection(endingSelection().start().previous(BackwardDeletion), endingSelection().end());
 }
 
-bool CompositeEditCommand::hasSmartListMarkerAttribute() const
-{
-#if PLATFORM(COCOA)
-    if (shouldBreakOutOfEmptyListItem().isNone())
-        return false;
-
-    RefPtr emptyListItem = enclosingEmptyListItem(endingSelection().visibleStart());
-    ASSERT(emptyListItem);
-
-    RefPtr listNode = emptyListItem->parentElement();
-    ASSERT(listNode);
-
-    auto attribute = listNode->getAttribute(HTMLNames::webkitsmartlistmarkerAttr);
-    return !attribute.isEmpty() && parseTextList(attribute);
-#else
-    return false;
-#endif
-}
-
 // FIXME: Send an appropriate shouldDeleteRange call.
-bool CompositeEditCommand::breakOutOfEmptyListItem(ReconstitutePlainTextListIfNeeded reconstitutePlainTextListIfNeeded)
+bool CompositeEditCommand::breakOutOfEmptyListItem()
 {
     if (shouldBreakOutOfEmptyListItem().isNone())
         return false;
@@ -1682,11 +1663,6 @@ bool CompositeEditCommand::breakOutOfEmptyListItem(ReconstitutePlainTextListIfNe
 
     appendBlockPlaceholder(newBlock.copyRef());
     setEndingSelection(VisibleSelection(firstPositionInNode(newBlock), Affinity::Downstream, endingSelection().directionality()));
-
-    if (reconstitutePlainTextListIfNeeded == ReconstitutePlainTextListIfNeeded::Yes) {
-        if (auto smartListMarker = downcast<Element>(*listNode).getAttribute(HTMLNames::webkitsmartlistmarkerAttr); !smartListMarker.isEmpty())
-            inputText(WTF::makeString(smartListMarker, " "_s));
-    }
 
     style->prepareToApplyAt(endingSelection().start());
     if (!style->isEmpty())

--- a/Source/WebCore/editing/CompositeEditCommand.h
+++ b/Source/WebCore/editing/CompositeEditCommand.h
@@ -216,11 +216,8 @@ protected:
     void cloneParagraphUnderNewElement(const Position& start, const Position& end, Node* outerNode, Element* blockElement);
     void cleanupAfterDeletion(VisiblePosition destination = VisiblePosition());
 
-    enum class ReconstitutePlainTextListIfNeeded : bool { No, Yes };
-
     VisibleSelection shouldBreakOutOfEmptyListItem() const;
-    bool hasSmartListMarkerAttribute() const;
-    bool breakOutOfEmptyListItem(ReconstitutePlainTextListIfNeeded = ReconstitutePlainTextListIfNeeded::No);
+    bool breakOutOfEmptyListItem();
     bool breakOutOfEmptyMailBlockquotedParagraph();
     
     Position positionAvoidingSpecialElementBoundary(const Position&);

--- a/Source/WebCore/editing/InsertTextCommand.cpp
+++ b/Source/WebCore/editing/InsertTextCommand.cpp
@@ -144,34 +144,85 @@ bool InsertTextCommand::applySmartListsIfNeeded()
     if (!selectionAllowsSmartLists(m_text, endingSelection()))
         return false;
 
+    // Get the start of the current line
+
     auto lineStart = logicalStartOfLine(endingSelection().visibleBase());
     if (lineStart.isNull() || lineStart.isOrphan()) {
         ASSERT_NOT_REACHED();
         return false;
     }
 
-    // Get the range from the beginning of the line up until the current caret position,
-    // before `m_text` has been applied.
-    VisibleSelection line { lineStart, endingSelection().visibleExtent() };
-    auto range = line.firstRange();
-    if (!range) {
-        ASSERT_NOT_REACHED();
-        return false;
-    }
+    // Create and parse the smart list for the current line, if possible.
 
-    // First, convert the SimpleRange to a String, and then convert the String to a Style::ListStyleType
+    auto smartListRangeForCurrentLine = [&] -> std::optional<SimpleRange> {
+        // Get the range from the beginning of the line up until the current caret position,
+        // before `m_text` has been applied.
+        VisibleSelection line { lineStart, endingSelection().visibleExtent() };
+        return line.firstRange();
+    };
+
+    auto currentRange = smartListRangeForCurrentLine();
+    if (!currentRange)
+        return false;
+
+    // Convert the SimpleRange to a String, and then convert the String to a Style::ListStyleType
     // (which itself is later converted to a CSSValue).
 
-    auto lineText = plainText(*range);
-    auto smartList = parseTextList(lineText);
-    if (!smartList) {
+    auto currentLineText = plainText(*currentRange);
+    auto currentSmartList = parseTextList(currentLineText);
+    if (!currentSmartList) {
         // The line content does not match the Smart List marker criteria.
         return false;
     }
 
+    // Create and parse the smart list for the previous line, if possible.
+
+    auto smartListRangeForPreviousLine = [&] -> std::optional<SimpleRange> {
+        auto positionBeforeStartOfCurrentLine = lineStart.previous();
+        auto previousLineStart = logicalStartOfLine(positionBeforeStartOfCurrentLine);
+        if (previousLineStart.isNull() || previousLineStart.isOrphan())
+            return std::nullopt;
+
+        auto previousLineEnd = logicalEndOfLine(positionBeforeStartOfCurrentLine);
+        if (previousLineEnd.isNull() || previousLineEnd.isOrphan())
+            return std::nullopt;
+
+        VisibleSelection previousLine { previousLineStart, previousLineEnd };
+        return previousLine.firstRange();
+    };
+
+    auto previousRange = smartListRangeForPreviousLine();
+    if (!previousRange)
+        return false;
+
+    auto previousLineText = plainText(*previousRange);
+    auto previousSmartList = parseTextList(previousLineText);
+    if (!previousSmartList) {
+        // The line content does not match the Smart List marker criteria.
+        return false;
+    }
+
+    // Ensure there are no mismatches between the current and previous line list markers
+
+    if (!areCompatibleListMarkers(*currentSmartList, *previousSmartList))
+        return false;
+
     Ref document = this->document();
-    auto listType = smartList->ordered ? InsertListCommand::Type::OrderedList : InsertListCommand::Type::UnorderedList;
-    applyCommandToComposite(InsertListCommand::create(document.copyRef(), listType, smartList->styleType), *range);
+
+    // Insert a list for the previous line
+
+    auto listType = previousSmartList->ordered ? InsertListCommand::Type::OrderedList : InsertListCommand::Type::UnorderedList;
+    applyCommandToComposite(InsertListCommand::create(document.copyRef(), listType, previousSmartList->styleType), *previousRange);
+
+    // And delete the marker from that line.
+
+    if (RefPtr prevListChild = enclosingListChild(endingSelection().base().anchorNode())) {
+        if (RefPtr textNode = dynamicDowncast<Text>(prevListChild->firstDescendant())) {
+            auto spaceIndex = previousLineText.find(' ');
+            if (spaceIndex != WTF::notFound && spaceIndex + 1 <= textNode->length())
+                deleteTextFromNode(*textNode, 0, spaceIndex + 1);
+        }
+    }
 
     // This list is the one that was just created or modified.
     RefPtr listElement = enclosingList(endingSelection().base().anchorNode());
@@ -180,11 +231,20 @@ bool InsertTextCommand::applySmartListsIfNeeded()
         return false;
     }
 
-    auto attributes = nodeAttributesForSmartList(*listElement, *smartList, lineText);
+    // Apply the relevant attributes to the current list element
+
+    auto attributes = nodeAttributesForSmartList(*listElement, *previousSmartList);
     for (const auto& [attribute, value] : attributes)
         setNodeAttribute(*listElement, attribute, value);
 
+    // Insert a list for the current line, which will get merged into the prior line.
+
+    applyCommandToComposite(InsertListCommand::create(document.copyRef(), listType, currentSmartList->styleType), *currentRange);
+
+    // And delete the marker from the current line.
+
     deleteSelection();
+
     return true;
 }
 #endif // PLATFORM(COCOA)

--- a/Source/WebCore/editing/TextListParser.cpp
+++ b/Source/WebCore/editing/TextListParser.cpp
@@ -208,6 +208,9 @@ static AtomString startingOrdinalForList(const StyledElement& element, const Tex
 
 std::optional<TextList> parseTextList(StringView input)
 {
+    auto spaceIndex = input.find(' ');
+    auto upToSpace = spaceIndex == WTF::notFound ? input : input.left(spaceIndex);
+
     // The input is parsed to a TextList using these rules:
     //
     //  <U+002A | U+2022>EOF                        |= <U+2022>          (unordered, disc)
@@ -215,15 +218,27 @@ std::optional<TextList> parseTextList(StringView input)
     //  <ordinal><U+002E | U+0029>EOF , ordinal > 0 |= <ordinal><U+002E> (ordered, start=ordinal)
     //  otherwise                                   |= invalid
 
-    return WTF::readCharactersForParsing(input, [](auto buffer) -> std::optional<TextList> {
+    return WTF::readCharactersForParsing(upToSpace, [](auto buffer) -> std::optional<TextList> {
         return consumeTextList(buffer);
     });
 }
 
-Vector<std::pair<const QualifiedName&, AtomString>> nodeAttributesForSmartList(const StyledElement& element, const TextList& list, const String& input)
+bool areCompatibleListMarkers(const TextList& a, const TextList& b)
 {
-    ASSERT(!input.isEmpty());
+    // If one is ordered and the other one isn't, they're incompatible.
+    if (a.ordered != b.ordered)
+        return false;
 
+    // If both are ordered, they're compatible, even if their starting item numbers differ.
+    if (a.ordered)
+        return true;
+
+    // For unordered, style types must match.
+    return a.styleType == b.styleType;
+}
+
+Vector<std::pair<const QualifiedName&, AtomString>> nodeAttributesForSmartList(const StyledElement& element, const TextList& list)
+{
     Vector<std::pair<const QualifiedName&, AtomString>> result;
 
     if (auto start = startingOrdinalForList(element, list); !start.isNull())
@@ -234,12 +249,6 @@ Vector<std::pair<const QualifiedName&, AtomString>> nodeAttributesForSmartList(c
 
     if (auto className = classNameForSmartList(list); !className.isNull())
         result.append({ HTMLNames::classAttr, className });
-
-    // The conversion from plain-text list markers (like "*") to styled list markers may be lossy
-    // as there is not a 1:1 relationship. Therefore, this is needed so that the original
-    // plain-text list can be reconstituted if needed. See `CompositeEditCommand::breakOutOfEmptyListItem`
-    // for more details.
-    result.append({ HTMLNames::webkitsmartlistmarkerAttr, AtomString { input } });
 
     return result;
 }

--- a/Source/WebCore/editing/TextListParser.h
+++ b/Source/WebCore/editing/TextListParser.h
@@ -36,8 +36,9 @@ class QualifiedName;
 class VisibleSelection;
 
 std::optional<TextList> parseTextList(StringView);
+bool areCompatibleListMarkers(const TextList&, const TextList&);
 
-Vector<std::pair<const QualifiedName&, AtomString>> nodeAttributesForSmartList(const StyledElement&, const TextList&, const String& input);
+Vector<std::pair<const QualifiedName&, AtomString>> nodeAttributesForSmartList(const StyledElement&, const TextList&);
 
 bool selectionAllowsSmartLists(const String&, const VisibleSelection&);
 

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -682,11 +682,11 @@ void TypingCommand::deleteKeyPressed(TextGranularity granularity, bool shouldAdd
         const VisiblePosition& previousPosition = visibleStart.previous(CannotCrossEditingBoundary);
         RefPtr enclosingTableCell = enclosingNodeOfType(visibleStart.deepEquivalent(), &isTableCell);
         RefPtr enclosingTableCellForPreviousPosition = enclosingNodeOfType(previousPosition.deepEquivalent(), &isTableCell);
-        if (previousPosition.isNull() || enclosingTableCell != enclosingTableCellForPreviousPosition || hasSmartListMarkerAttribute()) {
+        if (previousPosition.isNull() || enclosingTableCell != enclosingTableCellForPreviousPosition) {
             // When the caret is at the start of the editable area in an empty list item, break out of the list item.
             if (auto deleteListSelection = shouldBreakOutOfEmptyListItem(); !deleteListSelection.isNone()) {
                 if (willAddTypingToOpenCommand(Type::DeleteKey, granularity, { }, deleteListSelection.firstRange())) {
-                    breakOutOfEmptyListItem(ReconstitutePlainTextListIfNeeded::Yes);
+                    breakOutOfEmptyListItem();
                     typingAddedToOpenCommand(Type::DeleteKey);
                 }
                 return;

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -450,7 +450,6 @@ webkitattachmentid
 webkitattachmentpath
 webkitdirectory
 webkitdropzone
-webkitsmartlistmarker
 width
 wrap
 writingsuggestions

--- a/Tools/TestWebKitAPI/Helpers/cocoa/SmartListsSupport.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/SmartListsSupport.h
@@ -60,7 +60,6 @@ NS_SWIFT_UI_ACTOR
 
 + (void)processConfiguration:(SmartListsTestConfiguration *)configuration completionHandler:(NS_SWIFT_UI_ACTOR void(^)(SmartListsTestResult * NS_NULLABLE_RESULT, NSError * _Nullable))completionHandler;
 
-+ (void)testBackspaceWithInvalidWebKitSmartListMarkerAttributeDoesNotApplyWithCompletionHandler:(NS_SWIFT_UI_ACTOR void(^)(SmartListsTestResult * NS_NULLABLE_RESULT, NSError * _Nullable))completionHandler;
 
 @end
 

--- a/Tools/TestWebKitAPI/Helpers/cocoa/SmartListsSupport.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/SmartListsSupport.swift
@@ -136,61 +136,6 @@ extension SmartListsSupport {
             actualHTML: actualHTML
         )
     }
-
-    open class func testBackspaceWithInvalidWebKitSmartListMarkerAttributeDoesNotApply() async throws -> SmartListsTestResult {
-        let page = WebPage()
-
-        page.setWebFeature("SmartListsAvailable", enabled: true)
-
-        #if os(macOS)
-        page.smartListsEnabled = true
-        #endif
-
-        let html = """
-            <head>
-                <meta charset="UTF-8">
-            </head>
-            <body contenteditable>
-                Hello
-                <ul class="Apple-disc-list" style="list-style-type: disc;" webkitsmartlistmarker="INVALID">
-                    <li>A</li>
-                </ul>
-            </body>
-            """
-
-        try await page.load(html: html).wait()
-        try await page.callJavaScript("document.body.focus()")
-
-        try await page.setCaretSelection(path: "//body/ul/li/text()", offset: 1)
-
-        await page.executeEditCommand(.deleteBackward) // delete "A"
-        await page.executeEditCommand(.deleteBackward) // then break out of the list
-
-        guard let actualHTML = try await page.callJavaScript("return document.body.outerHTML") as? String else {
-            fatalError()
-        }
-
-        let actualTree = try await page.renderTree()
-
-        let expectedHTML = """
-            <body contenteditable>
-                Hello
-            </body>
-            """
-
-        try await page.load(html: expectedHTML).wait()
-
-        try await page.setCaretSelection(path: "//body/text()", offset: 10)
-
-        let expectedTree = try await page.renderTree()
-
-        return .init(
-            expectedRenderTree: expectedTree,
-            actualRenderTree: actualTree,
-            expectedHTML: expectedHTML,
-            actualHTML: actualHTML
-        )
-    }
 }
 
 extension WebPage {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SmartLists.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SmartLists.mm
@@ -228,17 +228,18 @@ TEST(SmartLists, ContextMenuItemStateIsConsistentWithAvailability)
 TEST(SmartLists, InsertingSpaceAndTextAfterBulletPointGeneratesListWithText)
 {
     static constexpr auto expectedHTML = R"""(
-    <body>
+    <body contenteditable="">
         <ul>
             <li>Hello</li>
+            <li>World</li>
         </ul>
     </body>
     )"""_s;
 
-    runTest(@"* Hello", expectedHTML.createNSString().get(), @"//body/ul/li/text()", @"Hello".length);
+    runTest(@"* Hello\n* World", expectedHTML.createNSString().get(), @"//body/ul/li[2]/text()", @"World".length);
 
-    RetainPtr inputWithBullet = makeString(WTF::Unicode::bullet, " Hello"_s).createNSString();
-    runTest(inputWithBullet.get(), expectedHTML.createNSString().get(), @"//body/ul/li/text()", @"Hello".length);
+    RetainPtr inputWithBullet = makeString(WTF::Unicode::bullet, " Hello\n"_s, WTF::Unicode::bullet, " World"_s).createNSString();
+    runTest(inputWithBullet.get(), expectedHTML.createNSString().get(), @"//body/ul/li[2]/text()", @"World".length);
 }
 
 TEST(SmartLists, InsertingSpaceAndTextAfterHyphenGeneratesDashedList)
@@ -246,16 +247,17 @@ TEST(SmartLists, InsertingSpaceAndTextAfterHyphenGeneratesDashedList)
     auto marker = WTF::makeString(WTF::Unicode::emDash, WTF::Unicode::noBreakSpace, WTF::Unicode::noBreakSpace);
 
     static constexpr auto expectedHTMLTemplate = R"""(
-    <body>
+    <body contenteditable="">
         <ul style="list-style-type: '<MARKER>';">
             <li>Hello</li>
+            <li>World</li>
         </ul>
     </body>
     )"""_s;
 
     RetainPtr expectedHTML = WTF::makeStringByReplacingAll(expectedHTMLTemplate, "<MARKER>"_s, marker).createNSString();
 
-    runTest(@"- Hello", expectedHTML.get(), @"//body/ul/li/text()", @"Hello".length);
+    runTest(@"- Hello\n- World", expectedHTML.get(), @"//body/ul/li[2]/text()", @"World".length);
 }
 
 TEST(SmartLists, InsertingSpaceAfterBulletPointGeneratesEmptyList)
@@ -263,12 +265,13 @@ TEST(SmartLists, InsertingSpaceAfterBulletPointGeneratesEmptyList)
     static constexpr auto expectedHTML = R"""(
     <body>
         <ul style="list-style-type: disc;">
+            <li>A</li>
             <li><br></li>
         </ul>
     </body>
     )"""_s;
 
-    runTest(@"* ", expectedHTML.createNSString().get(), @"//body/ul/li/br", 0);
+    runTest(@"* A\n* ", expectedHTML.createNSString().get(), @"//body/ul/li[2]/br", 0);
 }
 
 TEST(SmartLists, InsertingSpaceAfterBulletPointInMiddleOfSentenceDoesNotGenerateList)
@@ -296,29 +299,31 @@ TEST(SmartLists, InsertingSpaceAfterPeriodAtStartOfSentenceDoesNotGenerateList)
 TEST(SmartLists, InsertingSpaceAfterNumberGeneratesOrderedList)
 {
     static constexpr auto expectedHTML = R"""(
-    <body>
+    <body contenteditable="">
         <ol>
             <li>Hello</li>
+            <li>World</li>
         </ol>
     </body>
     )"""_s;
 
-    runTest(@"1. Hello", expectedHTML.createNSString().get(), @"//body/ol/li/text()", @"Hello".length);
+    runTest(@"1. Hello\n2. World", expectedHTML.createNSString().get(), @"//body/ol/li[2]/text()", @"World".length);
 
-    runTest(@"1) Hello", expectedHTML.createNSString().get(), @"//body/ol/li/text()", @"Hello".length);
+    runTest(@"1) Hello\n2) World", expectedHTML.createNSString().get(), @"//body/ol/li[2]/text()", @"World".length);
 }
 
 TEST(SmartLists, InsertingSpaceAfterMultipleDigitNumberGeneratesOrderedList)
 {
     static constexpr auto expectedHTML = R"""(
-    <body>
+    <body contenteditable="">
         <ol start="1234" style="list-style-type: decimal;">
             <li>Hello</li>
+            <li>World</li>
         </ol>
     </body>
     )"""_s;
 
-    runTest(@"1234. Hello", expectedHTML.createNSString().get(), @"//body/ol/li/text()", @"Hello".length);
+    runTest(@"1234. Hello\n1235. World", expectedHTML.createNSString().get(), @"//body/ol/li[2]/text()", @"World".length);
 }
 
 TEST(SmartLists, InsertingSpaceAfterInvalidNumberDoesNotGenerateOrderedList)
@@ -359,22 +364,24 @@ TEST(SmartLists, InsertingDifferentListStylesDoesNotMergeLists)
 
     static constexpr auto expectedHTMLTemplate = R"""(
     <body contenteditable="">
-        <ul style="list-style-type: disc;" class="Apple-disc-list" webkitsmartlistmarker="*">
+        <ul style="list-style-type: disc;" class="Apple-disc-list">
             <li>A</li>
             <li>B</li>
             <li>C</li>
             <li>D</li>
+            <li>E</li>
         </ul>
         <div>
-            <ul class="Apple-dash-list" style="list-style-type: '<DASH_MARKER>';" webkitsmartlistmarker="-">
+            <ul class="Apple-dash-list" style="list-style-type: '<DASH_MARKER>';">
                 <li>A</li>
+                <li>B</li>
             </ul>
         </div>
     </body>)"""_s;
 
     RetainPtr expectedHTML = WTF::makeStringByReplacingAll(expectedHTMLTemplate, "<DASH_MARKER>"_s, dashMarker).createNSString();
 
-    runTest(@"* A\nB\nC\n\n* D\n\n- A", expectedHTML.get(), @"//body/div/ul/li[1]/text()", @"A".length);
+    runTest(@"* A\n* B\nC\n\n* D\n* E\n\n- A\n- B", expectedHTML.get(), @"//body/div/ul/li[2]/text()", @"B".length);
 }
 
 TEST(SmartLists, InsertingListMergesWithPreviousListIfPossible)
@@ -385,17 +392,21 @@ TEST(SmartLists, InsertingListMergesWithPreviousListIfPossible)
             <li>A</li>
             <li>B</li>
             <li>C</li>
+            <li>D</li>
+            <li>E</li>
         </ol>
     </body>)"""_s;
 
     RetainPtr input = @""
     "1. A\n"
-    "B\n"
+    "2. B\n"
+    "C\n"
     "\n"
-    "5. C"
+    "5. D\n"
+    "6. E"
     "";
 
-    runTest(input.get(), expectedHTML.createNSString().get(), @"//body/ol/li[3]/text()", 1);
+    runTest(input.get(), expectedHTML.createNSString().get(), @"//body/ol/li[5]/text()", 1);
 }
 
 TEST(SmartLists, InsertingSpaceInsideListElementDoesNotActivateSmartLists)
@@ -404,140 +415,140 @@ TEST(SmartLists, InsertingSpaceInsideListElementDoesNotActivateSmartLists)
     <body contenteditable="">
         <ul style="list-style-type: disc;" class="Apple-disc-list">
             <li>A</li>
+            <li>B</li>
             <li>1. Hi</li>
         </ul>
     </body>)"""_s;
 
-    runTest(@"* A\n1. Hi", expectedHTML.createNSString().get(), @"//body/ul/li[2]/text()", @"1. Hi".length);
-}
-
-TEST(SmartLists, BackspaceOnEmptyListElementShouldKeepPlainTextMarkers)
-{
-    static constexpr auto expectedBulletHTML = R"""(
-    <body contenteditable="" webkitsmartlistmarker="*">
-        <div>* ABC</div>
-    </body>)"""_s;
-
-    runTest(@"* ⌫ABC", expectedBulletHTML.createNSString().get(), @"//body/div/text()", @"* ABC".length);
-
-    static constexpr auto expectedDashHTML = R"""(
-    <body contenteditable="" webkitsmartlistmarker="-">
-        <div>- ABC</div>
-    </body>)"""_s;
-
-    runTest(@"- ⌫ABC", expectedDashHTML.createNSString().get(), @"//body/div/text()", @"- ABC".length);
-
-    static constexpr auto expectedNumberHTML = R"""(
-    <body contenteditable="" webkitsmartlistmarker="1.">
-        <div>1. ABC</div>
-    </body>)"""_s;
-
-    runTest(@"1. ⌫ABC", expectedNumberHTML.createNSString().get(), @"//body/div/text()", @"1. ABC".length);
-}
-
-TEST(SmartLists, BackspaceOnNonEmptyListElementShouldPreserveList)
-{
-    static constexpr auto expectedHTML = R"""(
-    <body contenteditable="">
-        <ul style="list-style-type: disc;" class="Apple-disc-list">
-            <li>Worl</li>
-        </ul>
-    </body>)"""_s;
-
-    runTest(@"* World⌫", expectedHTML.createNSString().get(), @"//body/ul/li/text()", @"Worl".length);
-}
-
-TEST(SmartLists, BackspaceOnEmptyNonFirstListElementShouldKeepPlainTextMarkers)
-{
-    static constexpr auto expectedBulletHTML = R"""(
-    <body contenteditable="" webkitsmartlistmarker="*">
-        <ul class="Apple-disc-list" style="list-style-type: disc;">
-            <li>A</li>
-        </ul>
-        <div>* B</div>
-    </body>)"""_s;
-
-    runTest(@"* A\n⌫B", expectedBulletHTML.createNSString().get(), @"//body/div/text()", @"* B".length);
-}
-
-TEST(SmartLists, BackspaceWithInvalidWebKitSmartListMarkerAttributeDoesNotApply)
-{
-    __block bool finished = false;
-    __block RetainPtr<SmartListsTestResult> result;
-    [SmartListsSupport testBackspaceWithInvalidWebKitSmartListMarkerAttributeDoesNotApplyWithCompletionHandler:^(SmartListsTestResult *testResult, NSError *error) {
-        if (error) {
-            TextStream errorMessage;
-            errorMessage << error;
-            EXPECT_NULL(error) << errorMessage.release().utf8().data();
-        }
-        result = testResult;
-        finished = true;
-    }];
-
-    TestWebKitAPI::Util::run(&finished);
-
-    TextStream stream;
-    stream << "expected " << [result actualHTML] << " to equal " << [result expectedHTML];
-    EXPECT_WK_STREQ([result expectedRenderTree], [result actualRenderTree]) << stream.release().utf8().data();
+    runTest(@"* A\n* B\n1. Hi", expectedHTML.createNSString().get(), @"//body/ul/li[3]/text()", @"1. Hi".length);
 }
 
 TEST(SmartLists, NewlineOnEmptyListElementShouldRemovePlainTextMarkers)
 {
     static constexpr auto expectedHTML = R"""(
-    <body contenteditable="" webkitsmartlistmarker="*">
+    <body contenteditable="">
         <ul class="Apple-disc-list" style="list-style-type: disc;">
             <li>A</li>
+            <li>B</li>
         </ul>
-        <div>B</div>
+        <div>C</div>
     </body>)"""_s;
 
-    runTest(@"* A\n\nB", expectedHTML.createNSString().get(), @"//body/div/text()", 1);
-}
-
-TEST(SmartLists, GeneratedSmartListsHaveAssociatedClassNames)
-{
-    auto dashMarker = WTF::makeString(WTF::Unicode::emDash, WTF::Unicode::noBreakSpace, WTF::Unicode::noBreakSpace);
-
-    static constexpr auto expectedHTMLTemplate = R"""(
-    <body contenteditable>
-        <ul class="Apple-disc-list" style="list-style-type: disc;">
-            <li>A</li>
-        </ul>
-        <div>
-            <ol class="Apple-decimal-list" start="1" style="list-style-type: decimal;">
-                <li>B</li>
-            </ol>
-            <div>
-                <ul class="Apple-dash-list" style="list-style-type: '<DASH_MARKER>';">
-                    <li>C</li>
-                </ul>
-            </div>
-        </div>
-    </body>
-    )"""_s;
-
-    static constexpr auto css = R"""(
-    <style>
-        .Apple-disc-list { color: red }
-        .Apple-dash-list { color: green }
-        .Apple-decimal-list { color: blue }
-    </style>
-    )"""_s;
-
-    RetainPtr expectedHTML = WTF::makeStringByReplacingAll(expectedHTMLTemplate, "<DASH_MARKER>"_s, dashMarker).createNSString();
-
-    runTest(@"* A\n\n1. B\n\n- C", expectedHTML.get(), @"//body/div/div/ul/li/text()", 1, css.createNSString().get());
+    runTest(@"* A\n* B\n\nC", expectedHTML.createNSString().get(), @"//body/div/text()", 1);
 }
 
 TEST(SmartLists, OrderedSmartListWithRTL)
 {
     RetainPtr expectedHTML = @"<body dir=\"rtl\" contenteditable=\"\">"
-    "<ol start=\"1\" style=\"list-style-type: decimal;\" class=\"Apple-decimal-list\" webkitsmartlistmarker=\"1.\">"
+    "<ol start=\"1\" style=\"list-style-type: decimal;\" class=\"Apple-decimal-list\">"
         "<li>تفاحة</li>"
+        "<li>برتقال</li>"
     "</ol>"
     "</body>";
 
-    runTest(@"1. تفاحة", expectedHTML.get(), @"//body/ol/li[1]/text()", @"تفاحة".length, nullptr, true);
+    runTest(@"1. تفاحة\n2. برتقال", expectedHTML.get(), @"//body/ol/li[2]/text()", @"برتقال".length, nullptr, true);
+}
+
+TEST(SmartLists, SingleLineMarkerDoesNotTriggerConversion)
+{
+    static constexpr auto expectedHTML = R"""(
+    <body contenteditable="">
+        * Hello
+    </body>
+    )"""_s;
+
+    runTest(@"* Hello", expectedHTML.createNSString().get(), @"//body/text()", @"* Hello".length);
+}
+
+TEST(SmartLists, MismatchedMarkersDoNotTriggerConversion)
+{
+    static constexpr auto expectedHTML = R"""(
+    <body contenteditable="">
+        * Hello
+        <div>- World</div>
+    </body>
+    )"""_s;
+
+    runTest(@"* Hello\n- World", expectedHTML.createNSString().get(), @"//body/div/text()", @"- World".length);
+}
+
+TEST(SmartLists, MarkersSeparatedByBlankLineDoNotTriggerConversion)
+{
+    static constexpr auto expectedHTML = R"""(
+    <body contenteditable="">
+        * A
+        <div><br></div>
+        <div>* B</div>
+    </body>
+    )"""_s;
+
+    runTest(@"* A\n\n* B", expectedHTML.createNSString().get(), @"//body/div[2]/text()", @"* B".length);
+}
+
+TEST(SmartLists, OrderedAndUnorderedMismatchDoesNotTriggerConversion)
+{
+    {
+        static constexpr auto expectedHTML = R"""(
+        <body contenteditable="">
+            1. Hello
+            <div>* World</div>
+        </body>
+        )"""_s;
+
+        runTest(@"1. Hello\n* World", expectedHTML.createNSString().get(), @"//body/div/text()", @"* World".length);
+    }
+
+    {
+        static constexpr auto expectedHTML = R"""(
+        <body contenteditable="">
+            * Hello
+            <div>1. World</div>
+        </body>
+        )"""_s;
+
+        runTest(@"* Hello\n1. World", expectedHTML.createNSString().get(), @"//body/div/text()", @"1. World".length);
+    }
+}
+
+TEST(SmartLists, MatchingOrderedMarkersWithDifferentDelimitersGenerateList)
+{
+    static constexpr auto expectedHTML = R"""(
+    <body contenteditable="">
+        <ol>
+            <li>A</li>
+            <li>B</li>
+        </ol>
+    </body>
+    )"""_s;
+
+    runTest(@"1. A\n2) B", expectedHTML.createNSString().get(), @"//body/ol/li[2]/text()", @"B".length);
+}
+
+TEST(SmartLists, OrderedListStartingFromNonOneGeneratesCorrectStartAttribute)
+{
+    static constexpr auto expectedHTML = R"""(
+    <body contenteditable="">
+        <ol start="5" style="list-style-type: decimal;">
+            <li>A</li>
+            <li>B</li>
+        </ol>
+    </body>
+    )"""_s;
+
+    runTest(@"5. A\n6. B", expectedHTML.createNSString().get(), @"//body/ol/li[2]/text()", @"B".length);
+}
+
+TEST(SmartLists, OrderedMarkersSeparatedByBlankLineDoNotTriggerConversion)
+{
+    static constexpr auto expectedHTML = R"""(
+    <body contenteditable="">
+        1. A
+        <div><br></div>
+        <div>2. B</div>
+    </body>
+    )"""_s;
+
+    runTest(@"1. A\n\n2. B", expectedHTML.createNSString().get(), @"//body/div[2]/text()", @"2. B".length);
 }
 
 #endif // ENABLE_SWIFTUI


### PR DESCRIPTION
#### e72d37f15e4e444e15bc63f5e497be503654a1d4
<pre>
[Smart Lists] Smart Lists should not activate until the second list-like line
<a href="https://rdar.apple.com/169692253">rdar://169692253</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311682">https://bugs.webkit.org/show_bug.cgi?id=311682</a>

Reviewed by Tim Horton.

Modify the activation logic of Smart Lists to be more limited; specifically, only if the current line is list-like,
and the previous line is _also_ list-like. This makes it more difficult to accidentally create a Smart List when one
is not desired.

As part of this, revert 307373@main since that behavior is now nonsensical with this new activation logic.

Tests: Tools/TestWebKitAPI/Helpers/cocoa/SmartListsSupport.swift
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SmartLists.mm

* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::moveParagraphs):
* Source/WebCore/editing/CompositeEditCommand.h:
* Source/WebCore/editing/InsertTextCommand.cpp:
(WebCore::InsertTextCommand::applySmartListsIfNeeded):
* Source/WebCore/editing/TextListParser.cpp:
(WebCore::parseTextList):
(WebCore::areCompatibleListMarkers):
(WebCore::nodeAttributesForSmartList):
* Source/WebCore/editing/TextListParser.h:
* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommand::deleteKeyPressed):
* Source/WebCore/html/HTMLAttributeNames.in:
* Tools/TestWebKitAPI/Helpers/cocoa/SmartListsSupport.h:
* Tools/TestWebKitAPI/Helpers/cocoa/SmartListsSupport.swift:
(SmartListsSupport.processConfiguration(_:)):
(SmartListsSupport.testBackspaceWithInvalidWebKitSmartListMarkerAttributeDoesNotApply): Deleted.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SmartLists.mm:
(TEST(SmartLists, InsertingSpaceAndTextAfterBulletPointGeneratesListWithText)):
(InsertingSpaceAndTextAfterHyphenGeneratesDashedList)):
((SmartLists, InsertingSpaceAfterBulletPointGeneratesEmptyList)):
((SmartLists, InsertingSpaceAfterNumberGeneratesOrderedList)):
((SmartLists, InsertingSpaceAfterMultipleDigitNumberGeneratesOrderedList)):
((SmartLists, InsertingDifferentListStylesDoesNotMergeLists)):
((SmartLists, InsertingListMergesWithPreviousListIfPossible)):
((SmartLists, InsertingSpaceInsideListElementDoesNotActivateSmartLists)):
((SmartLists, NewlineOnEmptyListElementShouldRemovePlainTextMarkers)):
((SmartLists, OrderedSmartListWithRTL)):
((SmartLists, SingleLineMarkerDoesNotTriggerConversion)):
((SmartLists, MismatchedMarkersDoNotTriggerConversion)):
((SmartLists, MarkersSeparatedByBlankLineDoNotTriggerConversion)):
((SmartLists, OrderedAndUnorderedMismatchDoesNotTriggerConversion)):
((SmartLists, MatchingOrderedMarkersWithDifferentDelimitersGenerateList)):
((SmartLists, OrderedListStartingFromNonOneGeneratesCorrectStartAttribute)):
((SmartLists, OrderedMarkersSeparatedByBlankLineDoNotTriggerConversion)):
((SmartLists, BackspaceOnEmptyListElementShouldKeepPlainTextMarkers)):
((SmartLists, BackspaceOnNonEmptyListElementShouldPreserveList)):
((SmartLists, BackspaceOnEmptyNonFirstListElementShouldKeepPlainTextMarkers)):
((SmartLists, BackspaceWithInvalidWebKitSmartListMarkerAttributeDoesNotApply)): Deleted.
((SmartLists, GeneratedSmartListsHaveAssociatedClassNames)):

Canonical link: <a href="https://commits.webkit.org/310881@main">https://commits.webkit.org/310881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c8252a6174d9865c3f5f60349a23b8072558920

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155166 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163926 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157039 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28566 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28274 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120061 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158125 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22312 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139346 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100756 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21398 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19449 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11752 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131060 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166404 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18795 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128163 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27970 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23485 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128300 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34825 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27894 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138979 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84603 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23165 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15775 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27587 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91691 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27165 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27395 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27238 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->