### PR TITLE
Constructing a hash table deleted value of WeakStyleable involves assigning a deleted value of AtomString

### DIFF
--- a/Source/WebCore/animation/AcceleratedEffectStackUpdater.h
+++ b/Source/WebCore/animation/AcceleratedEffectStackUpdater.h
@@ -47,7 +47,7 @@ public:
     bool hasTargetsPendingUpdate() const { return !m_targetsPendingUpdate.isEmpty(); }
 
 private:
-    WeakStyleableHashSet m_targetsPendingUpdate;
+    HashSet<WeakStyleable> m_targetsPendingUpdate;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -204,12 +204,14 @@ class WeakStyleable {
 public:
     WeakStyleable() = default;
 
-    WeakStyleable(AtomString name)
-    {
-        m_element = nullptr;
-        m_pseudoElementIdentifier = Style::PseudoElementIdentifier();
-        m_pseudoElementIdentifier->nameOrPart = WTF::move(name);
-    }
+    WeakStyleable(WTF::HashTableDeletedValueType) : m_element(WTF::HashTableDeletedValue) { }
+    bool isHashTableDeletedValue() const { return m_element.isHashTableDeletedValue(); }
+
+    WeakStyleable(WTF::HashTableEmptyValueType) : m_element(WTF::HashTableEmptyValue) { }
+    bool isHashTableEmptyValue() const { return m_element.isHashTableEmptyValue(); }
+
+    // WeakPtr is not safe to compare.
+    static constexpr bool isSafeToCompareToHashTableEmptyOrDeletedValue = false;
 
     explicit operator bool() const { return !!m_element; }
 
@@ -243,28 +245,28 @@ private:
     std::optional<Style::PseudoElementIdentifier> m_pseudoElementIdentifier;
 };
 
-// FIXME: using PairHashTraits would give us constructDeletedValue() and isDeletedValue() for free.
-struct WeakStyleableHashTraits : HashTraits<WeakStyleable> {
-    static constexpr bool hasIsWeakNullValueFunction = true;
-    static bool isWeakNullValue(const WeakStyleable& value) { return !value; }
-    static void constructDeletedValue(WeakStyleable& slot) { slot = { AtomString { WTF::HashTableDeletedValue } }; }
-    static bool isDeletedValue(const WeakStyleable& value) { return !value.element() && value.pseudoElementIdentifier() && value.pseudoElementIdentifier()->nameOrPart.isHashTableDeletedValue(); }
-};
-
-struct WeakStyleableHash {
-    static unsigned hash(const WeakStyleable& styleable) { return WTF::PairHash<Element*, std::optional<Style::PseudoElementIdentifier>>::hash({ styleable.element().get(), styleable.pseudoElementIdentifier() }); }
-    static bool equal(const WeakStyleable& a, const WeakStyleable& b)
-    {
-        if (!a || !b)
-            return false;
-        return a.element().get() == b.element().get() && a.pseudoElementIdentifier() == b.pseudoElementIdentifier();
-    }
-    static constexpr bool safeToCompareToEmptyOrDeleted = false;
-};
-
-using WeakStyleableHashSet = HashSet<WeakStyleable, WeakStyleableHash, WeakStyleableHashTraits>;
+// This lets HasherBasedHash define a DefaultHash<WeakStyleable> for us.
+inline void add(Hasher& hasher, const WeakStyleable& weakStyleable)
+{
+    add(hasher, weakStyleable.element());
+    add(hasher, weakStyleable.pseudoElementIdentifier());
+}
 
 WTF::TextStream& operator<<(WTF::TextStream&, const Styleable&);
 WTF::TextStream& operator<<(WTF::TextStream&, const WeakStyleable&);
 
 } // namespace WebCore
+
+namespace WTF {
+
+template<> struct HashTraits<WebCore::WeakStyleable> : SimpleClassHashTraits<WebCore::WeakStyleable> {
+    static const bool emptyValueIsZero = false;
+    static constexpr bool hasIsEmptyValueFunction = true;
+    static WebCore::WeakStyleable emptyValue() { return { WTF::HashTableEmptyValue }; }
+    static bool isEmptyValue(const WebCore::WeakStyleable& value) { return value.isHashTableEmptyValue(); }
+
+    static constexpr bool hasIsWeakNullValueFunction = true;
+    static bool isWeakNullValue(const WebCore::WeakStyleable& value) { return !value; }
+};
+
+} // namespace WTF


### PR DESCRIPTION
#### 0339b91d5f538645e0801d34a2bc0365a4cfb746
<pre>
Constructing a hash table deleted value of WeakStyleable involves assigning a deleted value of AtomString
<a href="https://rdar.apple.com/174260083">rdar://174260083</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311669">https://bugs.webkit.org/show_bug.cgi?id=311669</a>

Reviewed by Ryosuke Niwa.

constructDeletedValue() turns a WeakStyleable into a hash table deleted value:

    constructDeletedValue(WeakStyleable&amp; slot) { slot = { AtomString { WTF::HashTableDeletedValue } }; }

It calls into this constructor:

    WeakStyleable(AtomString name)
    {
        [...]
        m_pseudoElementIdentifier-&gt;nameOrPart = name;
    }

The hash table deleted value of AtomString gets copied around, but as noted in
the source, the deleted value is not meant to be copied, and will crash if so:

    // Hash table deleted values, which are only constructed and never copied or destroyed.
    AtomString(WTF::HashTableDeletedValueType) : m_string(WTF::HashTableDeletedValue) { }

This patch fixes this by utilizing WeakPtr m_element to mark a WeakStyleable as
deleted/empty instead. WeakPtr already supports deleted/empty constructions, so
we simply add new WeakStyleable constructions that constructs the WeakPtr as
deleted/empty.

Additionally this patch simplifies the hash traits/default hash implementation
of WeakStyleable:
* Defines add(Hasher&amp;, WeakStyleable&amp;) to get DefaultHash&lt;WeakStyleable&gt; for free
  from HasherBasedHash
* Derives the hash trait from SimpleClassHashTraits to get constructDeleteValue and
  isDeletedValue for free
* Make the hash trait struct an initialization of WTF::HashTrait&lt;&gt;, so WeakStyleable
  can be used with HashSet/HashMap without explicitly specifying the hash trait struct

* Source/WebCore/animation/AcceleratedEffectStackUpdater.h:
* Source/WebCore/style/Styleable.h:
(WebCore::WeakStyleable::WeakStyleable):
(WebCore::WeakStyleable::isHashTableDeletedValue const):
(WebCore::WeakStyleable::isHashTableEmptyValue const):
(WebCore::add):
(WTF::HashTraits&lt;WebCore::WeakStyleable&gt;::emptyValue):
(WTF::HashTraits&lt;WebCore::WeakStyleable&gt;::isEmptyValue):
(WTF::HashTraits&lt;WebCore::WeakStyleable&gt;::isWeakNullValue):
(WebCore::WeakStyleableHashTraits::isWeakNullValue): Deleted.
(WebCore::WeakStyleableHashTraits::constructDeletedValue): Deleted.
(WebCore::WeakStyleableHashTraits::isDeletedValue): Deleted.
(WebCore::WeakStyleableHash::hash): Deleted.
(WebCore::WeakStyleableHash::equal): Deleted.

Canonical link: <a href="https://commits.webkit.org/310898@main">https://commits.webkit.org/310898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d12e5f35375853aeb0a8c56b494cb8eefcf56e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155332 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164093 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a6c2a636-8636-437c-9c4b-d614e5e3644f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28732 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28442 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120208 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/72d434b2-0794-4f23-b2cc-e5a9837e8bb6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22414 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139497 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100897 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/643a97b2-1fe8-4ae1-9d9a-24ddfdd43f35) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21500 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11923 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131168 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17329 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166571 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18939 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128317 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28136 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128448 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34840 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28060 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139122 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85445 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23300 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15919 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27754 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91857 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27331 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27561 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27404 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->