### PR TITLE
Add LIBPAS_ENABLED_MINIMALLY for non-pas builds

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_config.h
@@ -67,6 +67,7 @@
 #if !BENABLE(LIBPAS)
 #undef LIBPAS_ENABLED
 #define LIBPAS_ENABLED 0
+#define LIBPAS_ENABLED_MINIMALLY 1
 #endif
 #endif
 

--- a/Source/bmalloc/libpas/src/libpas/pas_lock.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_lock.c
@@ -25,7 +25,7 @@
 
 #include "pas_config.h"
 
-#if LIBPAS_ENABLED
+#if LIBPAS_ENABLED || LIBPAS_ENABLED_MINIMALLY
 
 #include "pas_lock.h"
 #if PAS_OS(DARWIN)

--- a/Source/bmalloc/libpas/src/libpas/pas_log.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_log.c
@@ -25,7 +25,7 @@
 
 #include "pas_config.h"
 
-#if LIBPAS_ENABLED
+#if LIBPAS_ENABLED || LIBPAS_ENABLED_MINIMALLY
 
 #include "pas_log.h"
 

--- a/Source/bmalloc/libpas/src/libpas/pas_race_test_hooks.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_race_test_hooks.c
@@ -25,7 +25,7 @@
 
 #include "pas_config.h"
 
-#if LIBPAS_ENABLED
+#if LIBPAS_ENABLED || LIBPAS_ENABLED_MINIMALLY
 
 #include "pas_race_test_hooks.h"
 

--- a/Source/bmalloc/libpas/src/libpas/pas_runtime_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_runtime_config.h
@@ -49,13 +49,13 @@ typedef uint64_t Slot;
 #ifdef __cplusplus
 extern "C" {
 #endif
-#if LIBPAS_ENABLED
+#if LIBPAS_ENABLED || LIBPAS_ENABLED_MINIMALLY
 #if defined(PAS_BMALLOC)
 BEXPORT extern Slot g_config[];
 #else // !defined(PAS_BMALLOC)
 extern Slot g_config[];
 #endif // defined(PAS_BMALLOC)
-#endif // LIBPAS_ENABLED
+#endif // LIBPAS_ENABLED || LIBPAS_ENABLED_MINIMALLY
 #ifdef __cplusplus
 }
 #endif

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_suspend_lock.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_suspend_lock.c
@@ -25,7 +25,7 @@
 
 #include "pas_config.h"
 
-#if LIBPAS_ENABLED
+#if LIBPAS_ENABLED || LIBPAS_ENABLED_MINIMALLY
 
 #include "pas_thread_suspend_lock.h"
 

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.c
@@ -25,7 +25,7 @@
 
 #include "pas_config.h"
 
-#if LIBPAS_ENABLED
+#if LIBPAS_ENABLED || LIBPAS_ENABLED_MINIMALLY
 
 #include "pas_utils.h"
 


### PR DESCRIPTION
#### 530970d630313570dbe478582c634ea1ab796788
<pre>
Add LIBPAS_ENABLED_MINIMALLY for non-pas builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=311686">https://bugs.webkit.org/show_bug.cgi?id=311686</a>

Reviewed by NOBODY (OOPS!).

This essentially forms two cases:
1) The happy path, where everything sits in libas in peace and harmony
2) The sad path, where we need this functionality in bmalloc even when
   pas is not built.

One alternative to this approach would be to add a new library under
libpas that bmalloc and libpas could both share. This is logically
the best approach, but breaks two nice properties:

1) libpas is self-contained
2) libpas can continue to use pas idioms for everything, instead of
   adopting another layer of macros and settings.

A follow-up patch will move functionality from WTF to pas using this
fallback mechanism to support armv7 and watchos.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9ede6239fceed44b7ff30f5cbd5a8a724abe321

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163730 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108441 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28078 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119897 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84742 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157929 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22176 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139185 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100590 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21261 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19295 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11556 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147020 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130923 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166205 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15801 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18638 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127996 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23334 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128135 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27698 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138822 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84407 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23027 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15617 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186757 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27390 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47856 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26968 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27199 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27041 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->