### PR TITLE
[JSC] More JSString::view call adoption

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -2018,7 +2018,7 @@ JSC_DEFINE_JIT_OPERATION(operationToNumberString, EncodedJSValue, (JSGlobalObjec
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto view = string->value(globalObject);
+    auto view = string->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     unsigned size = view->length();
@@ -3334,10 +3334,10 @@ JSC_DEFINE_JIT_OPERATION(operationStringLocaleCompare, UCPUStrictInt32, (JSGloba
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto string = base->value(globalObject);
+    auto string = base->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, 0);
 
-    auto that = argument->value(globalObject);
+    auto that = argument->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, 0);
 
     auto* collator = globalObject->defaultCollator();
@@ -4112,7 +4112,7 @@ JSC_DEFINE_JIT_OPERATION(operationCompareStringLess, uintptr_t, (JSGlobalObject*
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    OPERATION_RETURN(scope, codePointCompareLessThan(asString(a)->value(globalObject), asString(b)->value(globalObject)));
+    OPERATION_RETURN(scope, codePointCompareLessThan(asString(a)->view(globalObject), asString(b)->view(globalObject)));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationCompareStringLessEq, uintptr_t, (JSGlobalObject* globalObject, JSString* a, JSString* b))
@@ -4122,7 +4122,7 @@ JSC_DEFINE_JIT_OPERATION(operationCompareStringLessEq, uintptr_t, (JSGlobalObjec
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    OPERATION_RETURN(scope, !codePointCompareLessThan(asString(b)->value(globalObject), asString(a)->value(globalObject)));
+    OPERATION_RETURN(scope, !codePointCompareLessThan(asString(b)->view(globalObject), asString(a)->view(globalObject)));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationCompareStringGreater, uintptr_t, (JSGlobalObject* globalObject, JSString* a, JSString* b))
@@ -4132,7 +4132,7 @@ JSC_DEFINE_JIT_OPERATION(operationCompareStringGreater, uintptr_t, (JSGlobalObje
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    OPERATION_RETURN(scope, codePointCompareLessThan(asString(b)->value(globalObject), asString(a)->value(globalObject)));
+    OPERATION_RETURN(scope, codePointCompareLessThan(asString(b)->view(globalObject), asString(a)->view(globalObject)));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationCompareStringGreaterEq, uintptr_t, (JSGlobalObject* globalObject, JSString* a, JSString* b))
@@ -4142,7 +4142,7 @@ JSC_DEFINE_JIT_OPERATION(operationCompareStringGreaterEq, uintptr_t, (JSGlobalOb
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    OPERATION_RETURN(scope, !codePointCompareLessThan(asString(a)->value(globalObject), asString(b)->value(globalObject)));
+    OPERATION_RETURN(scope, !codePointCompareLessThan(asString(a)->view(globalObject), asString(b)->view(globalObject)));
 }
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationNotifyWrite, void, (VM* vmPointer, WatchpointSet* set))

--- a/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp
@@ -54,7 +54,7 @@ void JSModuleNamespaceObject::finishCreation(JSGlobalObject* globalObject, Abstr
     //
     // Sort the exported names by the code point order.
     std::ranges::sort(resolutions, WTF::codePointCompareLessThan, [](const auto& resolution) {
-        return resolution.first.impl();
+        return StringView(resolution.first.impl());
     });
 
     m_moduleRecord.set(vm, this, moduleRecord);

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -1966,20 +1966,20 @@ JSC_DEFINE_HOST_FUNCTION(jsonProtoFuncRawJSON, (JSGlobalObject* globalObject, Ca
         return character == 0x0009 || character == 0x000A || character == 0x000D || character == 0x0020;
     };
 
-    String string = jsString->value(globalObject);
+    auto view = jsString->view(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
-    if (string.isEmpty()) [[unlikely]] {
+    if (view->isEmpty()) [[unlikely]] {
         throwSyntaxError(globalObject, scope, "JSON.rawJSON cannot accept empty string"_s);
         return { };
     }
 
-    char16_t firstCharacter = string[0];
+    char16_t firstCharacter = view->codeUnitAt(0);
     if (isJSONWhitespace(firstCharacter)) [[unlikely]] {
         throwSyntaxError(globalObject, scope, makeString("JSON.rawJSON cannot accept string starting with '"_s, firstCharacter, "'"_s));
         return { };
     }
 
-    char16_t lastCharacter = string[string.length() - 1];
+    char16_t lastCharacter = view->codeUnitAt(view->length() - 1);
     if (isJSONWhitespace(lastCharacter)) [[unlikely]] {
         throwSyntaxError(globalObject, scope, makeString("JSON.rawJSON cannot accept string ending with '"_s, lastCharacter, "'"_s));
         return { };
@@ -1987,8 +1987,8 @@ JSC_DEFINE_HOST_FUNCTION(jsonProtoFuncRawJSON, (JSGlobalObject* globalObject, Ca
 
     {
         JSValue result;
-        if (string.is8Bit()) {
-            LiteralParser<Latin1Character, JSONReviverMode::Disabled> jsonParser(globalObject, string.span8(), StrictJSON);
+        if (view->is8Bit()) {
+            LiteralParser<Latin1Character, JSONReviverMode::Disabled> jsonParser(globalObject, view->span8(), StrictJSON);
             result = jsonParser.tryLiteralParsePrimitiveValue();
             RETURN_IF_EXCEPTION(scope, { });
             if (!result) [[unlikely]] {
@@ -1996,7 +1996,7 @@ JSC_DEFINE_HOST_FUNCTION(jsonProtoFuncRawJSON, (JSGlobalObject* globalObject, Ca
                 return { };
             }
         } else {
-            LiteralParser<char16_t, JSONReviverMode::Disabled> jsonParser(globalObject, string.span16(), StrictJSON);
+            LiteralParser<char16_t, JSONReviverMode::Disabled> jsonParser(globalObject, view->span16(), StrictJSON);
             result = jsonParser.tryLiteralParsePrimitiveValue();
             RETURN_IF_EXCEPTION(scope, { });
             if (!result) [[unlikely]] {

--- a/Source/JavaScriptCore/runtime/Operations.h
+++ b/Source/JavaScriptCore/runtime/Operations.h
@@ -309,9 +309,9 @@ ALWAYS_INLINE JSBigInt::ComparisonResult compareBigIntToOtherPrimitive(JSGlobalO
     ASSERT(!primValue.isBigInt());
 
     if (primValue.isString()) {
-        auto string = asString(primValue)->value(globalObject);
+        auto string = asString(primValue)->view(globalObject);
         RETURN_IF_EXCEPTION(scope, JSBigInt::ComparisonResult::Undefined);
-        JSValue bigIntValue = JSBigInt::stringToBigInt(globalObject, WTF::move(string));
+        JSValue bigIntValue = JSBigInt::stringToBigInt(globalObject, string);
         RETURN_IF_EXCEPTION(scope, JSBigInt::ComparisonResult::Undefined);
         if (!bigIntValue)
             return JSBigInt::ComparisonResult::Undefined;
@@ -349,9 +349,9 @@ ALWAYS_INLINE JSBigInt::ComparisonResult compareBigInt32ToOtherPrimitive(JSGloba
     };
 
     if (primValue.isString()) {
-        auto string = asString(primValue)->value(globalObject);
+        auto string = asString(primValue)->view(globalObject);
         RETURN_IF_EXCEPTION(scope, JSBigInt::ComparisonResult::Undefined);
-        JSValue bigIntValue = JSBigInt::stringToBigInt(globalObject, WTF::move(string));
+        JSValue bigIntValue = JSBigInt::stringToBigInt(globalObject, string);
         RETURN_IF_EXCEPTION(scope, JSBigInt::ComparisonResult::Undefined);
         if (!bigIntValue)
             return JSBigInt::ComparisonResult::Undefined;
@@ -455,9 +455,9 @@ ALWAYS_INLINE bool jsLess(JSGlobalObject* globalObject, JSValue v1, JSValue v2)
         return v1.asNumber() < v2.asNumber();
 
     if (isJSString(v1) && isJSString(v2)) {
-        auto s1 = asString(v1)->value(globalObject);
+        auto s1 = asString(v1)->view(globalObject);
         RETURN_IF_EXCEPTION(scope, false);
-        auto s2 = asString(v2)->value(globalObject);
+        auto s2 = asString(v2)->view(globalObject);
         RETURN_IF_EXCEPTION(scope, false);
         return codePointCompareLessThan(s1, s2);
     }
@@ -486,7 +486,7 @@ ALWAYS_INLINE bool jsLess(JSGlobalObject* globalObject, JSValue v1, JSValue v2)
         return n1 < n2;
     }
 
-    return codePointCompareLessThan(asString(p1)->value(globalObject), asString(p2)->value(globalObject));
+    return codePointCompareLessThan(asString(p1)->view(globalObject), asString(p2)->view(globalObject));
 }
 
 // See ES5 11.8.3/11.8.4/11.8.5 for definition of leftFirst, this value ensures correct
@@ -505,9 +505,9 @@ ALWAYS_INLINE bool jsLessEq(JSGlobalObject* globalObject, JSValue v1, JSValue v2
         return v1.asNumber() <= v2.asNumber();
 
     if (isJSString(v1) && isJSString(v2)) {
-        auto s1 = asString(v1)->value(globalObject);
+        auto s1 = asString(v1)->view(globalObject);
         RETURN_IF_EXCEPTION(scope, false);
-        auto s2 = asString(v2)->value(globalObject);
+        auto s2 = asString(v2)->view(globalObject);
         RETURN_IF_EXCEPTION(scope, false);
         return !codePointCompareLessThan(s2, s1);
     }
@@ -535,7 +535,7 @@ ALWAYS_INLINE bool jsLessEq(JSGlobalObject* globalObject, JSValue v1, JSValue v2
 
         return n1 <= n2;
     }
-    return !codePointCompareLessThan(asString(p2)->value(globalObject), asString(p1)->value(globalObject));
+    return !codePointCompareLessThan(asString(p2)->view(globalObject), asString(p1)->view(globalObject));
 }
 
 // Fast-path choices here are based on frequency data from SunSpider:

--- a/Source/JavaScriptCore/runtime/RegExpConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpConstructor.cpp
@@ -110,19 +110,19 @@ JSC_DEFINE_HOST_FUNCTION(regExpConstructorEscape, (JSGlobalObject* globalObject,
     if (!value.isString()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "RegExp.escape requires a string"_s);
 
-    auto string = asString(value)->value(globalObject);
+    auto view = asString(value)->view(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
     StringBuilder builder(OverflowPolicy::RecordOverflow);
-    builder.reserveCapacity(string->length());
+    builder.reserveCapacity(view->length());
 
-    for (unsigned i = 0; i < string->length() && !builder.hasOverflowed();) {
+    for (unsigned i = 0; i < view->length() && !builder.hasOverflowed();) {
         char32_t codePoint;
-        if (string->is8Bit())
-            codePoint = string->span8()[i++];
+        if (view->is8Bit())
+            codePoint = view->span8()[i++];
         else {
-            auto characters = string->span16();
-            U16_NEXT(characters, i, string->length(), codePoint);
+            auto characters = view->span16();
+            U16_NEXT(characters, i, view->length(), codePoint);
         }
 
         if (builder.isEmpty() && isASCIIAlphanumeric(codePoint)) {

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -319,11 +319,6 @@ inline bool equalIgnoringASCIICase(const AtomString& a, ASCIILiteral b)
     return equalIgnoringASCIICase(a.string(), b);
 }
 
-inline std::strong_ordering codePointCompare(const AtomString& a, const AtomString& b)
-{
-    return codePointCompare(a.string(), b.string());
-}
-
 [[nodiscard]] ALWAYS_INLINE String makeStringByReplacingAll(const AtomString& string, char16_t target, char16_t replacement)
 {
     return makeStringByReplacingAll(string.string(), target, replacement);

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -653,8 +653,7 @@ size_t NODELETE reverseFind(std::span<const Latin1Character>, char16_t matchChar
 template<size_t inlineCapacity> bool NODELETE equalIgnoringNullity(const Vector<char16_t, inlineCapacity>&, StringImpl*);
 
 template<typename CharacterType1, typename CharacterType2>
-std::strong_ordering NODELETE odePointCompare(std::span<const CharacterType1> characters1, std::span<const CharacterType2> characters2);
-std::strong_ordering NODELETE codePointCompare(const StringImpl* string1, const StringImpl* string2);
+SUPPRESS_NODELETE std::strong_ordering NODELETE codePointCompare(std::span<const CharacterType1> characters1, std::span<const CharacterType2> characters2);
 
 bool NODELETE isUnicodeWhitespace(char16_t);
 
@@ -783,7 +782,8 @@ template<size_t inlineCapacity> inline bool equalIgnoringNullity(const Vector<ch
 }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-template<typename CharacterType1, typename CharacterType2> inline std::strong_ordering codePointCompare(std::span<const CharacterType1> characters1, std::span<const CharacterType2> characters2)
+template<typename CharacterType1, typename CharacterType2>
+inline std::strong_ordering codePointCompare(std::span<const CharacterType1> characters1, std::span<const CharacterType2> characters2)
 {
     size_t commonLength = std::min(characters1.size(), characters2.size());
 
@@ -837,26 +837,6 @@ template<typename CharacterType1, typename CharacterType2> inline std::strong_or
     return (characters1.size() > characters2.size()) ? std::strong_ordering::greater : std::strong_ordering::less;
 }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-
-SUPPRESS_NODELETE inline std::strong_ordering codePointCompare(const StringImpl* string1, const StringImpl* string2)
-{
-    // FIXME: Should null strings compare as less than empty strings rather than equal to them?
-    if (!string1)
-        return (string2 && string2->length()) ? std::strong_ordering::less : std::strong_ordering::equal;
-    if (!string2)
-        return string1->length() ? std::strong_ordering::greater : std::strong_ordering::equal;
-
-    bool string1Is8Bit = string1->is8Bit();
-    bool string2Is8Bit = string2->is8Bit();
-    if (string1Is8Bit) {
-        if (string2Is8Bit)
-            return codePointCompare(string1->span8(), string2->span8());
-        return codePointCompare(string1->span8(), string2->span16());
-    }
-    if (string2Is8Bit)
-        return codePointCompare(string1->span16(), string2->span8());
-    return codePointCompare(string1->span16(), string2->span16());
-}
 
 // FIXME: For Latin1Character, isUnicodeCompatibleASCIIWhitespace(character) || character == 0x0085 || character == noBreakSpace would be enough
 SUPPRESS_NODELETE inline bool isUnicodeWhitespace(char16_t character)

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -473,7 +473,7 @@ String makeStringByReplacingAll(StringView string, char16_t target, char16_t rep
     return StringImpl::createByReplacingInCharacters(characters, target, replacement, i);
 }
 
-std::strong_ordering codePointCompare(StringView lhs, StringView rhs)
+SUPPRESS_NODELETE std::strong_ordering codePointCompare(StringView lhs, StringView rhs)
 {
     bool lhsIs8Bit = lhs.is8Bit();
     bool rhsIs8Bit = rhs.is8Bit();

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -288,6 +288,12 @@ WTF_EXPORT_PRIVATE String normalizedNFC(const String&);
 inline StringView nullStringView() { return { }; }
 inline StringView emptyStringView() { return ""_span; }
 
+WTF_EXPORT_PRIVATE NODELETE std::strong_ordering codePointCompare(StringView, StringView);
+inline bool NODELETE codePointCompareLessThan(StringView a, StringView b)
+{
+    return codePointCompare(a, b) < 0;
+}
+
 } // namespace WTF
 
 #include <wtf/ValueOrReference.h>
@@ -1271,8 +1277,6 @@ inline bool equalIgnoringNullity(StringView a, StringView b)
     return equal(a, b);
 }
 
-WTF_EXPORT_PRIVATE std::strong_ordering codePointCompare(StringView, StringView);
-
 inline bool hasUnpairedSurrogate(StringView string)
 {
     // Fast path for 8-bit strings; they can't have any surrogates.
@@ -1585,3 +1589,5 @@ using WTF::StringViewWithUnderlyingString;
 using WTF::hasUnpairedSurrogate;
 using WTF::nullStringView;
 using WTF::emptyStringView;
+using WTF::codePointCompare;
+using WTF::codePointCompareLessThan;

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -69,11 +69,6 @@ String::String(const char* nullTerminatedString)
 {
 }
 
-std::strong_ordering codePointCompare(const String& a, const String& b)
-{
-    return codePointCompare(a.impl(), b.impl());
-}
-
 char32_t String::codePointAt(unsigned i) const
 {
     if (!m_impl || i >= m_impl->length())

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -355,9 +355,6 @@ RetainPtr<NSString> nsStringNilIfNull(const String&);
 
 #endif
 
-WTF_EXPORT_PRIVATE std::strong_ordering NODELETE codePointCompare(const String&, const String&);
-bool codePointCompareLessThan(const String&, const String&);
-
 // Shared global empty and null string.
 struct StaticString {
     constexpr StaticString(StringImpl::StaticStringImpl* pointer)
@@ -541,11 +538,6 @@ inline RetainPtr<NSString> nsStringNilIfNull(const String& string)
 
 #endif
 
-inline bool codePointCompareLessThan(const String& a, const String& b)
-{
-    return codePointCompare(a.impl(), b.impl()) < 0;
-}
-
 template<typename Predicate>
 String String::removeCharacters(const Predicate& findMatch) const
 {
@@ -601,6 +593,5 @@ using WTF::equal;
 using WTF::find;
 using WTF::containsOnly;
 using WTF::reverseFind;
-using WTF::codePointCompareLessThan;
 
 #include <wtf/text/AtomString.h>


### PR DESCRIPTION
#### 8084e23a05dde736384f08c8a090625ea0f58134
<pre>
[JSC] More JSString::view call adoption
<a href="https://bugs.webkit.org/show_bug.cgi?id=311687">https://bugs.webkit.org/show_bug.cgi?id=311687</a>
<a href="https://rdar.apple.com/problem/174301504">rdar://problem/174301504</a>

Reviewed by Mark Lam and Sosuke Suzuki.

Apply JSString::view more broadly in various JS operations to avoid
resolving ropes unnecessarily.

* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp:
(JSC::JSModuleNamespaceObject::finishCreation):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/Operations.h:
(JSC::compareBigIntToOtherPrimitive):
(JSC::compareBigInt32ToOtherPrimitive):
(JSC::jsLess):
(JSC::jsLessEq):
* Source/JavaScriptCore/runtime/RegExpConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WTF/wtf/text/AtomString.h:
(WTF::codePointCompare): Deleted.
* Source/WTF/wtf/text/StringImpl.h:
(WTF::codePointCompare):
* Source/WTF/wtf/text/StringView.cpp:
(WTF::codePointCompare):
* Source/WTF/wtf/text/StringView.h:
(WTF::codePointCompareLessThan):
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::codePointCompare): Deleted.
* Source/WTF/wtf/text/WTFString.h:
(WTF::codePointCompareLessThan): Deleted.

Canonical link: <a href="https://commits.webkit.org/310816@main">https://commits.webkit.org/310816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57c2a348cab8d96ce83ff7849af8cbda9f6536f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163805 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/896e337f-612a-43aa-84f9-f88f2e858488) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28153 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119962 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158004 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139242 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100655 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d463d041-b76d-48dd-aad5-f50353e9f907) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21308 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11631 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147095 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130970 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17085 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166281 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15876 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/9984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18694 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128064 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27849 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23387 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128202 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27773 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138878 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84482 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23634 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23077 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15673 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186832 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27465 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91569 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47874 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27044 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27274 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27116 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->