### PR TITLE
[macOS iOS] http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change.html is flaky

### DIFF
--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change.html
@@ -63,6 +63,12 @@
         video.currentTime = 0.6;
         watcher = new EventWatcher(t, video, [ 'seeking', 'seeked' ]);
         await watcher.wait_for([ 'seeking', 'seeked' ]);
+        // The demuxing of webm samples is asynchronous and may not have completed by the time the seek completed.
+        // wait for duration to be known.
+        if (Number.isNaN(video.duration)) {
+            let watcher = new EventWatcher(t, video, [ 'durationchange' ]);
+            await watcher.wait_for([ 'durationchange' ]);
+        }
         assert_greater_than(video.duration, 0.5, "video got recorded past change of sample rate");
     }, "Recorder WebM with sampling rate change");
 </script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8612,5 +8612,3 @@ webkit.org/b/311222 [ Release ] imported/w3c/web-platform-tests/navigation-api/n
 
 # rdar://173890240 ([iOS] imported/w3c/web-platform-tests/css/css-images/gradient/gradient-analogous-missing-components-003.html has 2 component pixel difference)
 imported/w3c/web-platform-tests/css/css-images/gradient/gradient-analogous-missing-components-003.html [ Pass ImageOnlyFailure ]
-
-webkit.org/b/311378 http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change.html [ Pass Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2467,8 +2467,6 @@ webkit.org/b/309850 [ Debug ] imported/w3c/web-platform-tests/uievents/mouse/mou
 
 webkit.org/b/308334 [ Debug ] http/tests/webgpu/webgpu/api/validation/gpu_external_texture_expiration.html [ Skip ]
 
-webkit.org/b/311378 http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change.html [ Pass Failure ]
-
 webkit.org/b/311677 [ Tahoe+ Release ] imported/w3c/web-platform-tests/svg/animations/svglength-animation-invalid-value-5.html [ Pass Failure ]
 webkit.org/b/311677 [ Tahoe+ Release ] imported/w3c/web-platform-tests/svg/animations/svglength-animation-invalid-value-7.html [ Pass Failure ]
 webkit.org/b/311677 [ Tahoe+ Release ] imported/w3c/web-platform-tests/svg/animations/svglength-animation-invalid-value-9.html [ Pass Failure ]


### PR DESCRIPTION
#### 4775179da61b9e0a4da8fbd2e02638cfdcbb12fd
<pre>
[macOS iOS] http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change.html is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=311378">https://bugs.webkit.org/show_bug.cgi?id=311378</a>
<a href="https://rdar.apple.com/173975629">rdar://173975629</a>

Reviewed by Eric Carlson.

In 309373@main, the WebM player was made to run in parallel by no longer operating
on the main thread.
As a consequence, some operations happen faster than it used to, such as reading
the media&apos;s init segment.
Prior 309373@main, the readyState would have moved past HAVE_METADATA only once
all the samples had been demuxed and playback start would have been delayed until then.
Following the changes, the main thread is no longer blocked while waiting on all
the samples to be read, and so occasionally, the duration wouldn&apos;t be known
at the time the readyState had progressed.
We need to wait for the durationchange event before the duration is guaranteed to be valid.

Re-enabling test.

* LayoutTests/http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/310758@main">https://commits.webkit.org/310758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/183076a1d374a686646c0189145b2b27ca1e2d1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163568 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/10f63f8d-c63f-4986-bfee-fb9480f5d501) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27916 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119753 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/afdbe3b9-910a-4e16-a5a5-2f7d5a6cce71) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139028 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100446 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b60d6871-0085-4520-af4a-7bb8d4513b9c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11394 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/130783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16872 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166042 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18481 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127857 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23185 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127997 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34742 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27536 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138665 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84241 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22887 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15459 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27228 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26806 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27037 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26879 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->