### PR TITLE
Cred Man: Define which types are allowed in the same get() request

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/credential-management/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/credential-management/WEB_FEATURES.yml
@@ -1,0 +1,12 @@
+features:
+- name: credential-management
+  files:
+    - '*'
+    - '!federatedcredential-framed-get.sub.https.html'
+    - '!passwordcredential-framed-get.sub.https.html'
+- name: federated-credentials
+  files:
+    - 'federatedcredential-framed-get.sub.https.html'
+- name: password-credentials
+  files:
+    - 'passwordcredential-framed-get.sub.https.html'

--- a/LayoutTests/imported/w3c/web-platform-tests/credential-management/credentialscontainer-create-basics.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/credential-management/credentialscontainer-create-basics.https-expected.txt
@@ -1,19 +1,25 @@
 
 PASS navigator.credentials.create() with no argument.
 PASS navigator.credentials.create() with empty argument.
-FAIL navigator.credentials.create() with valid PasswordCredentialData promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'credential.id')"
-FAIL navigator.credentials.create() with valid HTMLFormElement promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'credential.id')"
-FAIL navigator.credentials.create() with bogus password data assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL navigator.credentials.create() with valid FederatedCredentialData promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'credential.id')"
-FAIL navigator.credentials.create() with bogus federated data assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL navigator.credentials.create() with valid PasswordCredentialData promise_test: Unhandled rejection with value: object "NotSupportedError: No credential type was specified."
+FAIL navigator.credentials.create() with valid HTMLFormElement promise_test: Unhandled rejection with value: object "NotSupportedError: No credential type was specified."
+FAIL navigator.credentials.create() with bogus password data promise_rejects_js: function "function() { throw e; }" threw object "NotSupportedError: No credential type was specified." ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL navigator.credentials.create() with valid FederatedCredentialData promise_test: Unhandled rejection with value: object "NotSupportedError: No credential type was specified."
+FAIL navigator.credentials.create() with bogus federated data promise_rejects_js: function "function() { throw e; }" threw object "NotSupportedError: No credential type was specified." ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
 PASS navigator.credentials.create() with bogus publicKey data
-FAIL navigator.credentials.create() with both PasswordCredentialData and FederatedCredentialData assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL navigator.credentials.create() with bogus password and federated data assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS navigator.credentials.create() with both PasswordCredentialData and FederatedCredentialData
+FAIL navigator.credentials.create() with bogus password and federated data promise_rejects_js: function "function() { throw e; }" threw object "NotSupportedError: No credential type was specified." ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
 PASS navigator.credentials.create() with bogus federated and publicKey data
 PASS navigator.credentials.create() with bogus password and publicKey data
 PASS navigator.credentials.create() with bogus password, federated, and publicKey data
-FAIL navigator.credentials.create() with bogus data assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS navigator.credentials.create() with bogus data
 PASS navigator.credentials.create() aborted with custom reason
 PASS navigator.credentials.create() aborted with different objects
-FAIL navigator.credentials.create() rejects when aborted after the promise creation assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL navigator.credentials.create() rejects when aborted after the promise creation promise_rejects_exactly: function "function() { throw e; }" threw object "NotSupportedError: No credential type was specified." but we expected it to throw object "Error: custom error"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/credential-management/credentialscontainer-create-basics.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/credential-management/credentialscontainer-create-basics.https.html
@@ -3,14 +3,14 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-promise_test(async function(t) {
-    const result = await navigator.credentials.create();
-    assert_equals(result, null, "By default algorithm, it returns null");
+promise_test(function(t) {
+    return promise_rejects_dom(t, "NotSupportedError",
+            navigator.credentials.create());
 }, "navigator.credentials.create() with no argument.");
 
-promise_test(async function(t) {
-    const result = await navigator.credentials.create({});
-    assert_equals(result, null, "By default algorithm, it returns null");
+promise_test(function(t) {
+    return promise_rejects_dom(t, "NotSupportedError",
+            navigator.credentials.create({}));
 }, "navigator.credentials.create() with empty argument.");
 
 promise_test(function(t) {

--- a/LayoutTests/imported/w3c/web-platform-tests/credential-management/credentialscontainer-get-basics.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/credential-management/credentialscontainer-get-basics.https-expected.txt
@@ -1,6 +1,8 @@
 
 PASS Calling navigator.credentials.get() without a valid matching interface.
+PASS Calling navigator.credentials.get() with invalid combinations of credential types.
+PASS Calling navigator.credentials.get() with valid combination (password + federated).
 PASS navigator.credentials.get() aborted with custom reason
 PASS navigator.credentials.get() aborted with different objects
-FAIL navigator.credentials.get() rejects when aborted after the promise creation promise_rejects_exactly: function "function() { throw e; }" threw object "NotSupportedError: Missing request type." but we expected it to throw object "Error: custom error"
+PASS navigator.credentials.get() rejects when aborted after the promise creation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/credential-management/credentialscontainer-get-basics.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/credential-management/credentialscontainer-get-basics.https.html
@@ -55,6 +55,36 @@
     );
   }, "Calling navigator.credentials.get() without a valid matching interface.");
 
+  promise_test(async (t) => {
+    const invalidCombinations = [
+      { password: true, publicKey: { challenge: new Uint8Array() } },
+      { password: true, otp: { transport: ["sms"] } },
+      { password: true, identity: { providers: [] } },
+      { federated: { providers: ['https://idp.example.com'] }, publicKey: { challenge: new Uint8Array() } },
+      { federated: { providers: ['https://idp.example.com'] }, otp: { transport: ["sms"] } },
+      { federated: { providers: ['https://idp.example.com'] }, identity: { providers: [] } },
+      { publicKey: { challenge: new Uint8Array() }, otp: { transport: ["sms"] } },
+      { publicKey: { challenge: new Uint8Array() }, identity: { providers: [] } },
+      { otp: { transport: ["sms"] }, identity: { providers: [] } },
+    ];
+
+    for (const options of invalidCombinations) {
+      await promise_rejects_dom(
+        t,
+        "NotSupportedError",
+        navigator.credentials.get(options)
+      );
+    }
+  }, "Calling navigator.credentials.get() with invalid combinations of credential types.");
+
+  promise_test(async (t) => {
+    const result = await navigator.credentials.get({
+      password: true,
+      federated: { providers: ['https://idp.example.com'] }
+    });
+    assert_equals(result, null);
+  }, "Calling navigator.credentials.get() with valid combination (password + federated).");
+
   promise_test(function(t) {
     const controller = new AbortController();
     controller.abort("custom reason");
@@ -76,7 +106,10 @@
     const error = new Error("custom error");
     const controller = new AbortController();
 
-    const result = navigator.credentials.get({ signal: controller.signal });
+    const result = navigator.credentials.get({
+      signal: controller.signal,
+      publicKey: { challenge: new Uint8Array() },
+    });
     controller.abort(error); // aborted after the promise is created
 
     return promise_rejects_exactly(t, error, result);

--- a/LayoutTests/imported/w3c/web-platform-tests/credential-management/historical.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/credential-management/historical.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Credential.willRequestConditionalCreation should not exist
+

--- a/LayoutTests/imported/w3c/web-platform-tests/credential-management/historical.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/credential-management/historical.https.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Credential Management historical tests</title>
+<link rel="help" href="https://github.com/w3c/webappsec-credential-management/pull/282">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(() => {
+  assert_false("willRequestConditionalCreation" in Credential);
+}, "Credential.willRequestConditionalCreation should not exist");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/credential-management/non-fully-active.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/credential-management/non-fully-active.https.html
@@ -26,7 +26,7 @@
     const iframe = document.querySelector("iframe");
 
     // The signal check happens after the fully active check.
-    // This allows us to confirm the the right error is thrown
+    // This allows us to confirm the right error is thrown
     // and in the right order.
     const controller = new iframe.contentWindow.AbortController();
     const signal = controller.signal;

--- a/LayoutTests/imported/w3c/web-platform-tests/credential-management/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/credential-management/w3c-import.log
@@ -15,11 +15,13 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/credential-management/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/credential-management/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/credential-management/credentialscontainer-create-basics.https.html
 /LayoutTests/imported/w3c/web-platform-tests/credential-management/credentialscontainer-frame-basics.https.html
 /LayoutTests/imported/w3c/web-platform-tests/credential-management/credentialscontainer-get-basics.https.html
 /LayoutTests/imported/w3c/web-platform-tests/credential-management/credentialscontainer-prevent-silent-access.https.html
 /LayoutTests/imported/w3c/web-platform-tests/credential-management/federatedcredential-framed-get.sub.https.html
+/LayoutTests/imported/w3c/web-platform-tests/credential-management/historical.https.html
 /LayoutTests/imported/w3c/web-platform-tests/credential-management/idlharness.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/credential-management/non-fully-active.https.html
 /LayoutTests/imported/w3c/web-platform-tests/credential-management/otpcredential-get-basics.https.html

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/create.disabled-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/create.disabled-by-permissions-policy.https.sub-expected.txt
@@ -2,7 +2,7 @@
 
 Harness Error (TIMEOUT), message = null
 
-FAIL Permissions-Policy header digital-credentials-create=() disallows the top-level document. assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Permissions-Policy header digital-credentials-create=() disallows the top-level document. promise_rejects_dom: function "function() { throw e; }" threw object "NotSupportedError: No credential type was specified." that is not a DOMException NotAllowedError: property "code" is equal to 9, expected 0
 FAIL Permissions-Policy header digital-credentials-create=() disallows same-origin iframes. assert_false: Digital Credential API expected false got undefined
 TIMEOUT Permissions-Policy header digital-credentials-create=() cannot be overridden using the allow attribute. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/default-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/default-permissions-policy.https.sub-expected.txt
@@ -1,5 +1,7 @@
 
 
 PASS Permissions-Policy is by default 'self' for get().
-FAIL Permissions-Policy is by default 'self' for create(). assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Permissions-Policy is by default 'self' for create(). promise_rejects_js: function "function() { throw e; }" threw object "NotSupportedError: No credential type was specified." ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8636,6 +8636,9 @@ webgl/2.0.y/conformance/textures/image_bitmap_from_image_bitmap/tex-2d-rgba-rgba
 
 webkit.org/b/311222 [ Release ] imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-window-stop-after-intercept.html [ Skip ]
 
+# WebAuthn authenticator setup races against abort under stress mode; can timeout or produce wrong rejection
+webkit.org/b/312120 imported/w3c/web-platform-tests/credential-management/credentialscontainer-get-basics.https.html [ Pass Failure Timeout ]
+
 # rdar://173890240 ([iOS] imported/w3c/web-platform-tests/css/css-images/gradient/gradient-analogous-missing-components-003.html has 2 component pixel difference)
 imported/w3c/web-platform-tests/css/css-images/gradient/gradient-analogous-missing-components-003.html [ Pass ImageOnlyFailure ]
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -390,7 +390,10 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/credentialmanagement/CredentialMediationRequirement.idl
     Modules/credentialmanagement/CredentialRequestOptions.idl
     Modules/credentialmanagement/CredentialsContainer.idl
+    Modules/credentialmanagement/FederatedCredentialRequestOptions.idl
+    Modules/credentialmanagement/IdentityCredentialRequestOptions.idl
     Modules/credentialmanagement/Navigator+Credentials.idl
+    Modules/credentialmanagement/OTPCredentialRequestOptions.idl
 
     Modules/encryptedmedia/MediaKeyEncryptionScheme.idl
     Modules/encryptedmedia/MediaKeyMessageEventInit.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -443,7 +443,10 @@ $(PROJECT_DIR)/Modules/credentialmanagement/CredentialCreationOptions.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/CredentialMediationRequirement.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/CredentialRequestOptions.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/CredentialsContainer.idl
+$(PROJECT_DIR)/Modules/credentialmanagement/FederatedCredentialRequestOptions.idl
+$(PROJECT_DIR)/Modules/credentialmanagement/IdentityCredentialRequestOptions.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/Navigator+Credentials.idl
+$(PROJECT_DIR)/Modules/credentialmanagement/OTPCredentialRequestOptions.idl
 $(PROJECT_DIR)/Modules/encryptedmedia/MediaKeyEncryptionScheme.idl
 $(PROJECT_DIR)/Modules/encryptedmedia/MediaKeyMessageEvent.idl
 $(PROJECT_DIR)/Modules/encryptedmedia/MediaKeyMessageEventInit.idl
@@ -1142,8 +1145,8 @@ $(PROJECT_DIR)/Modules/webxr/WebXRRenderState+Layers.idl
 $(PROJECT_DIR)/Modules/webxr/WebXRRenderState.idl
 $(PROJECT_DIR)/Modules/webxr/WebXRRigidTransform.idl
 $(PROJECT_DIR)/Modules/webxr/WebXRSession+AR.idl
-$(PROJECT_DIR)/Modules/webxr/WebXRSession+Layers.idl
 $(PROJECT_DIR)/Modules/webxr/WebXRSession+HitTest.idl
+$(PROJECT_DIR)/Modules/webxr/WebXRSession+Layers.idl
 $(PROJECT_DIR)/Modules/webxr/WebXRSession.idl
 $(PROJECT_DIR)/Modules/webxr/WebXRSpace.idl
 $(PROJECT_DIR)/Modules/webxr/WebXRSystem.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1096,6 +1096,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFakeXRViewInit.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFakeXRViewInit.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFakeXRWorldInit.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFakeXRWorldInit.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFederatedCredentialRequestOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFederatedCredentialRequestOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchBody.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchBody.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchEvent.cpp
@@ -1752,6 +1754,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIIRFilterOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIIRFilterOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIPAddressSpace.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIPAddressSpace.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdentityCredentialRequestOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdentityCredentialRequestOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdleDeadline.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdleDeadline.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdleRequestCallback.cpp
@@ -2189,6 +2193,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSOESTextureHalfFloatLinear.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSOESTextureHalfFloatLinear.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSOESVertexArrayObject.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSOESVertexArrayObject.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSOTPCredentialRequestOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSOTPCredentialRequestOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSObservable.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSObservable.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSObservableInspector.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -308,7 +308,10 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/credentialmanagement/CredentialMediationRequirement.idl \
     $(WebCore)/Modules/credentialmanagement/CredentialRequestOptions.idl \
     $(WebCore)/Modules/credentialmanagement/CredentialsContainer.idl \
+    $(WebCore)/Modules/credentialmanagement/FederatedCredentialRequestOptions.idl \
+    $(WebCore)/Modules/credentialmanagement/IdentityCredentialRequestOptions.idl \
     $(WebCore)/Modules/credentialmanagement/Navigator+Credentials.idl \
+    $(WebCore)/Modules/credentialmanagement/OTPCredentialRequestOptions.idl \
     $(WebCore)/Modules/encryptedmedia/MediaKeyEncryptionScheme.idl \
     $(WebCore)/Modules/encryptedmedia/MediaKeyMessageEventInit.idl \
     $(WebCore)/Modules/encryptedmedia/MediaKeyMessageEvent.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -394,7 +394,10 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     Modules/credentialmanagement/BasicCredential.h
     Modules/credentialmanagement/CredentialRequestOptions.h
+    Modules/credentialmanagement/FederatedCredentialRequestOptions.h
+    Modules/credentialmanagement/IdentityCredentialRequestOptions.h
     Modules/credentialmanagement/MediationRequirement.h
+    Modules/credentialmanagement/OTPCredentialRequestOptions.h
 
     Modules/encryptedmedia/CDM.h
     Modules/encryptedmedia/CDMClient.h

--- a/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h
@@ -29,7 +29,10 @@
 #if ENABLE(WEB_AUTHN)
 
 #include <WebCore/DigitalCredentialRequestOptions.h>
+#include <WebCore/FederatedCredentialRequestOptions.h>
+#include <WebCore/IdentityCredentialRequestOptions.h>
 #include <WebCore/MediationRequirement.h>
+#include <WebCore/OTPCredentialRequestOptions.h>
 #include <WebCore/PublicKeyCredentialRequestOptions.h>
 #include <wtf/RefCounted.h>
 
@@ -41,6 +44,10 @@ using CredentialMediationRequirement = MediationRequirement;
 struct CredentialRequestOptions {
     MediationRequirement mediation;
     RefPtr<AbortSignal> signal;
+    bool password { false };
+    std::optional<FederatedCredentialRequestOptions> federated;
+    std::optional<IdentityCredentialRequestOptions> identity;
+    std::optional<OTPCredentialRequestOptions> otp;
     std::optional<PublicKeyCredentialRequestOptions> publicKey;
 #if ENABLE(WEB_AUTHN)
     std::optional<DigitalCredentialRequestOptions> digital;

--- a/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.idl
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.idl
@@ -29,6 +29,14 @@
 ] dictionary CredentialRequestOptions {
     CredentialMediationRequirement mediation = "optional";
     AbortSignal signal;
+    // https://www.w3.org/TR/credential-management-1/#passwordcredential-interface
+    boolean password = false;
+    // https://www.w3.org/TR/credential-management-1/#federatedcredential-interface
+    FederatedCredentialRequestOptions federated;
+    // https://fedidcg.github.io/FedCM/#dictdef-identitycredentialrequestoptions
+    IdentityCredentialRequestOptions identity;
+    // https://wicg.github.io/web-otp/#dictdef-otpcredentialrequestoptions
+    OTPCredentialRequestOptions otp;
     PublicKeyCredentialRequestOptions publicKey;
     // https://wicg.github.io/digital-identities/#extensions-to-credentialrequestoptions-dictionary
     [EnabledBySetting=DigitalCredentialsEnabled] DigitalCredentialRequestOptions digital;

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
@@ -42,12 +42,70 @@
 #include "LocalFrame.h"
 #include "Navigator.h"
 #include "Page.h"
+#include <wtf/OptionSet.h>
 
 namespace WebCore {
 
 CredentialsContainer::CredentialsContainer(WeakPtr<Document, WeakPtrImplWithEventTargetData>&& document)
     : m_document(WTF::move(document))
 {
+}
+
+// https://w3c.github.io/webappsec-credential-management/#credential-type-registry
+static bool checkCredentialTypeCombinations(const CredentialRequestOptions& options, CredentialPromise& promise)
+{
+    enum class CredentialType : uint8_t {
+        Password  = 1 << 0,
+        Federated = 1 << 1,
+        Identity  = 1 << 2,
+        OTP       = 1 << 3,
+        PublicKey = 1 << 4,
+        Digital   = 1 << 5,
+    };
+
+    OptionSet<CredentialType> requestedTypes;
+    if (options.password)
+        requestedTypes.add(CredentialType::Password);
+    if (options.federated)
+        requestedTypes.add(CredentialType::Federated);
+    if (options.identity)
+        requestedTypes.add(CredentialType::Identity);
+    if (options.otp)
+        requestedTypes.add(CredentialType::OTP);
+    if (options.publicKey)
+        requestedTypes.add(CredentialType::PublicKey);
+    if (options.digital)
+        requestedTypes.add(CredentialType::Digital);
+
+    if (requestedTypes.isEmpty()) {
+        promise.reject(Exception { ExceptionCode::NotSupportedError, "No credential type was specified."_s });
+        return false;
+    }
+
+    // NOTE: allowedWith() must be symmetric — if type A lists B, then B must
+    // also list A. Asymmetry causes inconsistent rejection depending on
+    // iteration order. See https://w3c.github.io/webappsec-credential-management/#credential-type-registry
+    auto allowedWith = [](CredentialType type) -> OptionSet<CredentialType> {
+        switch (type) {
+        case CredentialType::Password:  return { CredentialType::Federated };
+        case CredentialType::Federated: return { CredentialType::Password };
+        case CredentialType::Identity:
+        case CredentialType::OTP:
+        case CredentialType::PublicKey:
+        case CredentialType::Digital:   return { };
+        }
+        ASSERT_NOT_REACHED();
+        return { };
+    };
+
+    for (auto type : requestedTypes) {
+        auto others = requestedTypes - type;
+        if (!others.isEmpty() && !allowedWith(type).containsAll(others)) {
+            promise.reject(Exception { ExceptionCode::NotSupportedError, "The credential type combination is not supported."_s });
+            return false;
+        }
+    }
+    return true;
 }
 
 template<typename Options>
@@ -70,15 +128,8 @@ static bool performCommonChecks(const Document& document, const Options& options
 
     if constexpr (std::is_same_v<Options, CredentialRequestOptions>) {
 #if ENABLE(WEB_AUTHN)
-        if (!options.publicKey && !options.digital) {
-            promise.reject(Exception { ExceptionCode::NotSupportedError, "Missing request type."_s });
+        if (!checkCredentialTypeCombinations(options, promise))
             return false;
-        }
-
-        if (options.publicKey && options.digital) {
-            promise.reject(Exception { ExceptionCode::NotSupportedError, "Only one request type is supported at a time."_s });
-            return false;
-        }
 #else
         if (!options.publicKey) {
             promise.reject(Exception { ExceptionCode::NotSupportedError, "Missing request type."_s });
@@ -93,8 +144,7 @@ static bool performCommonChecks(const Document& document, const Options& options
 
 void CredentialsContainer::get(CredentialRequestOptions&& options, CredentialPromise&& promise)
 {
-    // The following implements https://www.w3.org/TR/credential-management-1/#algorithm-request as of 4 August 2017
-    // with enhancement from 14 November 2017 Editor's Draft.
+    // https://w3c.github.io/webappsec-credential-management/#algorithm-request
     RefPtr document = this->document();
     if (!document) {
         promise.reject(Exception { ExceptionCode::NotSupportedError });
@@ -112,6 +162,12 @@ void CredentialsContainer::get(CredentialRequestOptions&& options, CredentialPro
 #endif
         return;
     }
+
+    if (!options.publicKey) {
+        promise.resolve(nullptr);
+        return;
+    }
+
     document->page()->authenticatorCoordinator().discoverFromExternalSource(*document, WTF::move(options), WTF::move(promise));
 }
 
@@ -142,7 +198,7 @@ void CredentialsContainer::isCreate(CredentialCreationOptions&& options, Credent
         return;
     }
 
-    promise.resolve(nullptr);
+    promise.reject(Exception { ExceptionCode::NotSupportedError, "No credential type was specified."_s });
 }
 
 void CredentialsContainer::preventSilentAccess(DOMPromiseDeferred<void>&& promise) const

--- a/Source/WebCore/Modules/credentialmanagement/FederatedCredentialRequestOptions.h
+++ b/Source/WebCore/Modules/credentialmanagement/FederatedCredentialRequestOptions.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+struct FederatedCredentialRequestOptions {
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/credentialmanagement/FederatedCredentialRequestOptions.idl
+++ b/Source/WebCore/Modules/credentialmanagement/FederatedCredentialRequestOptions.idl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://www.w3.org/TR/credential-management-1/#federatedcredential-interface
+// NOTE: Members are not implemented; this stub exists solely to enable
+// combination-type checking in CredentialsContainer.get().
+dictionary FederatedCredentialRequestOptions {
+};

--- a/Source/WebCore/Modules/credentialmanagement/IdentityCredentialRequestOptions.h
+++ b/Source/WebCore/Modules/credentialmanagement/IdentityCredentialRequestOptions.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+struct IdentityCredentialRequestOptions {
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/credentialmanagement/IdentityCredentialRequestOptions.idl
+++ b/Source/WebCore/Modules/credentialmanagement/IdentityCredentialRequestOptions.idl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://fedidcg.github.io/FedCM/#dictdef-identitycredentialrequestoptions
+// NOTE: Members are not implemented; this stub exists solely to enable
+// combination-type checking in CredentialsContainer.get().
+dictionary IdentityCredentialRequestOptions {
+};

--- a/Source/WebCore/Modules/credentialmanagement/OTPCredentialRequestOptions.h
+++ b/Source/WebCore/Modules/credentialmanagement/OTPCredentialRequestOptions.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+struct OTPCredentialRequestOptions {
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/credentialmanagement/OTPCredentialRequestOptions.idl
+++ b/Source/WebCore/Modules/credentialmanagement/OTPCredentialRequestOptions.idl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://wicg.github.io/web-otp/#dictdef-otpcredentialrequestoptions
+// NOTE: Members are not implemented; this stub exists solely to enable
+// combination-type checking in CredentialsContainer.get().
+dictionary OTPCredentialRequestOptions {
+};

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -4024,6 +4024,9 @@ JSCredentialMediationRequirement.cpp
 JSCredentialPropertiesOutput.cpp
 JSCredentialRequestOptions.cpp
 JSCredentialsContainer.cpp
+JSFederatedCredentialRequestOptions.cpp
+JSIdentityCredentialRequestOptions.cpp
+JSOTPCredentialRequestOptions.cpp
 JSCrypto.cpp
 JSCryptoAesKeyAlgorithm.cpp
 JSCryptoAlgorithmParameters.cpp


### PR DESCRIPTION
#### 906bdfad2925e9db82b1da7caee954c1dac89710
<pre>
Cred Man: Define which types are allowed in the same get() request

<a href="https://rdar.apple.com/173918198">rdar://173918198</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310788">https://bugs.webkit.org/show_bug.cgi?id=310788</a>

Reviewed by Pascoe.

Implements the credential type registry check from the Credential Management
spec (<a href="https://www.w3.org/TR/credential-management-1/#credential-type-registry)">https://www.w3.org/TR/credential-management-1/#credential-type-registry)</a>,
as added by <a href="https://github.com/w3c/webappsec-credential-management/pull/261.">https://github.com/w3c/webappsec-credential-management/pull/261.</a>

navigator.credentials.get() now rejects with NotSupportedError when called
with an invalid combination of credential types (e.g. publicKey + password),
and rejects with NotSupportedError when called with no credential type at all.
The only valid multi-type combination is password + federated, which resolves
with null (no stored credentials).

To support the combination check, three stub dictionaries are added:
FederatedCredentialRequestOptions, IdentityCredentialRequestOptions, and
OTPCredentialRequestOptions. These have no members; they exist solely to make
the credential types recognizable to the WebIDL bindings so the combination
check can fire.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/b592ce44eb85d5276d5743c731a8fb8e33508faf">https://github.com/web-platform-tests/wpt/commit/b592ce44eb85d5276d5743c731a8fb8e33508faf</a>

Canonical link: <a href="https://commits.webkit.org/311988@main">https://commits.webkit.org/311988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f501bde1b2e348676a027aed9324502eed96670b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167319 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112574 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32001 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122750 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86145 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25009 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142367 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103420 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24066 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15090 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133753 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20147 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169809 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15554 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21771 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130940 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31605 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131054 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35496 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31551 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141940 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89427 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25746 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18746 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31062 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97076 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30582 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30855 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30736 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->