### PR TITLE
REGRESSION (292858@main): Pasting HTML renders sans-serif font as Times

### DIFF
--- a/LayoutTests/editing/pasteboard/paste-style-block-generic-font-family-expected.html
+++ b/LayoutTests/editing/pasteboard/paste-style-block-generic-font-family-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div contenteditable><p style="font-family: Helvetica;">This text should be sans-serif.</p></div>
+</body>
+</html>

--- a/LayoutTests/editing/pasteboard/paste-style-block-generic-font-family.html
+++ b/LayoutTests/editing/pasteboard/paste-style-block-generic-font-family.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="source">Source</div>
+<div id="destination" contenteditable></div>
+<script>
+if (window.testRunner && window.internals) {
+    internals.settings.setCustomPasteboardDataEnabled(true);
+
+    const source = document.getElementById("source");
+    const destination = document.getElementById("destination");
+
+    source.addEventListener("copy", event => {
+        event.clipboardData.setData("text/html",
+            "<html><head><style>p { font-family: sans-serif; }</style></head>"
+            + "<body><p>This text should be sans-serif.</p></body></html>");
+        event.clipboardData.setData("text/plain", "This text should be sans-serif.");
+        event.preventDefault();
+    });
+
+    getSelection().selectAllChildren(source);
+    testRunner.execCommand("Copy");
+
+    destination.focus();
+    testRunner.execCommand("Paste");
+
+    destination.blur();
+
+    source.remove();
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -205,6 +205,7 @@ Ref<Page> createPageForSanitizingWebContent(Document* destinationDocument)
 {
     bool useDarkAppearance = false;
     bool useElevatedUserInterfaceLevel = false;
+    std::optional<FontGenericFamilies> fontGenericFamilies;
 
     if (destinationDocument) {
         if (RefPtr destinationPage = destinationDocument->page()) {
@@ -217,6 +218,7 @@ Ref<Page> createPageForSanitizingWebContent(Document* destinationDocument)
 
             useDarkAppearance = documentNeedsDarkAppearance && destinationPage->useDarkAppearance();
             useElevatedUserInterfaceLevel = destinationPage->useElevatedUserInterfaceLevel();
+            fontGenericFamilies = destinationPage->settings().fontGenericFamilies();
         }
     }
 
@@ -231,6 +233,9 @@ Ref<Page> createPageForSanitizingWebContent(Document* destinationDocument)
     page->settings().setHTMLParserScriptingFlagPolicy(HTMLParserScriptingFlagPolicy::Enabled);
     page->settings().setAcceleratedCompositingEnabled(false);
     page->settings().setLinkPreloadEnabled(false);
+
+    if (fontGenericFamilies)
+        page->settings().fontGenericFamilies() = *fontGenericFamilies;
 
     RefPtr frame = page->localMainFrame();
     if (!frame)


### PR DESCRIPTION
#### b0139bf5a5423c8991e258815d264c076a6c1a13
<pre>
REGRESSION (292858@main): Pasting HTML renders sans-serif font as Times
<a href="https://bugs.webkit.org/show_bug.cgi?id=311688">https://bugs.webkit.org/show_bug.cgi?id=311688</a>
<a href="https://rdar.apple.com/173162166">rdar://173162166</a>

Reviewed by Ryosuke Niwa and Aditya Keerthi.

292858@main removed the default initialization of the standard font families
in Settings, in favor of the code that syncs them from WebKit. This is fine,
except for disconnected Pages, which don&apos;t have WebKit backing them.

It turns out that SVGImage and other disconnected Pages already propagate
these settings from the parent context, but the paste sanitization page
did not! This would *still* be fine, as the generic font family name
survives sanitization, but in the process, it pollutes the FontCascadeCache
with the incorrect family, and the cache keying is such that the invalid
entry persists and infects the parent context (if this is the first time
it&apos;s been encountered).

Fix this by propagating the generic font families into the paste sanitization
page just like we do for SVGImage.

Test: editing/pasteboard/paste-style-block-generic-font-family.html

* LayoutTests/editing/pasteboard/paste-style-block-generic-font-family-expected.html: Added.
* LayoutTests/editing/pasteboard/paste-style-block-generic-font-family.html: Added.
* Source/WebCore/editing/markup.cpp:
(WebCore::createPageForSanitizingWebContent):

Canonical link: <a href="https://commits.webkit.org/310757@main">https://commits.webkit.org/310757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73da81a9630f8245cc3ee36009dedd7a5545b433

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154809 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163569 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/96d8b763-082f-44d4-8dae-1b821547bb7f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156682 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27917 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119755 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c5a1182-6126-4750-a6e0-9f421dd39e74) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100448 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11395 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/130784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166043 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/9332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127858 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23186 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127998 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34741 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27537 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138667 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84242 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22886 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27229 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91331 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26807 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27038 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26880 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->