### PR TITLE
[css-anchor-position-1] Replace AnchorPositionedKey with WeakStyleable

### DIFF
--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -49,6 +49,7 @@
 #include "RenderView.h"
 #include "StyleBuilderState.h"
 #include "StyleScope.h"
+#include "StyleableInlines.h"
 #include "WritingMode.h"
 #include <ranges>
 
@@ -784,11 +785,11 @@ CheckedPtr<RenderBoxModelObject> AnchorPositionEvaluator::findAnchorForAnchorFun
     if (!isValid())
         return { };
 
-    Ref elementOrHost = *builderState.element();
+    Styleable styleable { *const_cast<Element*>(builderState.element()), style.pseudoElementIdentifier() };
 
-    // PseudoElement nodes are created on-demand by render tree builder so dont' work as keys here.
+    // PseudoElement nodes are created on-demand by render tree builder so don't work as keys here.
     auto& anchorPositionedStates = *builderState.anchorPositionedStates();
-    auto& anchorPositionedState = anchorPositionedStates.ensure({ elementOrHost.ptr(), style.pseudoElementIdentifier() }, [&] {
+    auto& anchorPositionedState = anchorPositionedStates.ensure(styleable, [&] {
         return makeUniqueRef<AnchorPositionedState>();
     }).iterator->value.get();
 
@@ -798,7 +799,7 @@ CheckedPtr<RenderBoxModelObject> AnchorPositionEvaluator::findAnchorForAnchorFun
         return defaultAnchorName(style);
     };
 
-    auto resolvedAnchorName = ResolvedScopedName::createFromScopedName(elementOrHost, scopedAnchorName());
+    auto resolvedAnchorName = ResolvedScopedName::createFromScopedName(styleable.element, scopedAnchorName());
 
     // Collect anchor names that this element refers to in anchor() or anchor-size()
     bool isNewAnchorName = anchorPositionedState.anchorNames.add(resolvedAnchorName).isNewEntry;
@@ -835,7 +836,8 @@ CheckedPtr<RenderBoxModelObject> AnchorPositionEvaluator::findAnchorForAnchorFun
         return { };
     }
 
-    if (auto* state = anchorPositionedStates.get(keyForElementOrPseudoElement(*anchorElement))) {
+    // FIXME: don't use Styleable::fromElement here.
+    if (auto* state = anchorPositionedStates.get(Styleable::fromElement(*anchorElement))) {
         // Check if the anchor is itself anchor-positioned but hasn't been positioned yet.
         if (state->stage < AnchorPositionResolutionStage::Positioned) {
             anchorPositionedState.stage = AnchorPositionResolutionStage::WaitingForAnchorToBePositioned;
@@ -1276,36 +1278,39 @@ void AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayou
     // FIXME: Make the code below oeprate on renderers (boxes) rather than elements.
     auto anchorsForAnchorName = collectAnchorsForAnchorName(document);
 
-    for (auto& elementAndState : anchorPositionedStates) {
-        auto& state = elementAndState.value.get();
+    for (auto& [weakStyleable, state] : anchorPositionedStates) {
+        auto styleable = weakStyleable.styleable();
+        if (!styleable)
+            continue;
 
-        switch (state.stage) {
+        CheckedPtr renderer = styleable->renderer();
+
+        switch (state->stage) {
         case AnchorPositionResolutionStage::FindAnchors: {
-            RefPtr element = elementAndState.key.first;
-            if (elementAndState.key.second)
-                element = element->pseudoElementIfExists(*elementAndState.key.second);
-
-            CheckedPtr renderer = element ? element->renderer() : nullptr;
             if (renderer) {
+                // FIXME: change the anchor finding pipeline to use Styleable instead.
+                RefPtr elementForFinding = &styleable->element;
+                if (styleable->pseudoElementIdentifier)
+                    elementForFinding = elementForFinding->pseudoElementIfExists(*styleable->pseudoElementIdentifier);
+
                 // FIXME: Remove the redundant anchorElements member. The mappings are available in anchorPositionedToAnchorMap.
-                state.anchorElements = findAnchorsForAnchorPositionedElement(*element, state.anchorNames, anchorsForAnchorName);
+                state->anchorElements = findAnchorsForAnchorPositionedElement(*elementForFinding, state->anchorNames, anchorsForAnchorName);
                 if (isLayoutTimeAnchorPositioned(renderer->style()))
                     renderer->setNeedsLayout();
 
                 Vector<ResolvedAnchor> anchors;
-                for (auto& anchorNameAndElement : state.anchorElements) {
+                for (auto& anchorNameAndElement : state->anchorElements) {
                     CheckedPtr anchorElement = anchorNameAndElement.value.get();
                     anchors.append(ResolvedAnchor {
                         .renderer = anchorElement ? dynamicDowncast<RenderBoxModelObject>(anchorElement->renderer()) : nullptr,
                         .name = anchorNameAndElement.key
                     });
                 }
-                document.styleScope().anchorPositionedToAnchorMap().set(*element, AnchorPositionedToAnchorEntry {
-                    .pseudoElementIdentifier = elementAndState.key.second,
+                document.styleScope().anchorPositionedToAnchorMap().set(*styleable, AnchorPositionedToAnchorEntry {
                     .anchors = WTF::move(anchors)
                 });
             }
-            state.stage = AnchorPositionResolutionStage::Resolved;
+            state->stage = AnchorPositionResolutionStage::Resolved;
             break;
         }
 
@@ -1313,11 +1318,10 @@ void AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayou
             break;
 
         case AnchorPositionResolutionStage::Resolved:
-            if (CheckedPtr anchored = elementAndState.key.first->renderer()) {
-                if (auto anchoredBox = dynamicDowncast<RenderBox>(anchored.get()))
-                    AnchorPositionEvaluator::captureScrollSnapshots(*anchoredBox, false);
-            }
-            state.stage = AnchorPositionResolutionStage::Positioned;
+            if (auto anchoredBox = dynamicDowncast<RenderBox>(renderer))
+                AnchorPositionEvaluator::captureScrollSnapshots(*anchoredBox, false);
+
+            state->stage = AnchorPositionResolutionStage::Positioned;
             break;
 
         case AnchorPositionResolutionStage::Positioned:
@@ -1339,7 +1343,9 @@ void AnchorPositionEvaluator::updateAnchorPositionedStateForDefaultAnchorAndPosi
     if (!shouldResolveDefaultAnchor && !hasPositionVisibilityNoOverflow)
         return;
 
-    auto& state = states.ensure({ &element, style.pseudoElementIdentifier() }, [&] {
+    Styleable styleable { element, style.pseudoElementIdentifier() };
+
+    auto& state = states.ensure(styleable, [&] {
         return makeUniqueRef<AnchorPositionedState>();
     }).iterator->value.get();
 
@@ -1358,14 +1364,23 @@ auto AnchorPositionEvaluator::makeAnchorPositionedForAnchorMap(AnchorPositionedT
 {
     AnchorToAnchorPositionedMap map;
 
-    for (auto elementAndAnchors : toAnchorMap) {
-        CheckedRef anchorPositionedElement = elementAndAnchors.key;
-        for (auto& anchor : elementAndAnchors.value.anchors) {
+    for (auto& [weakStyleable, anchors] : toAnchorMap) {
+        auto styleable = weakStyleable.styleable();
+        if (!styleable)
+            continue;
+
+        for (auto& anchor : anchors.anchors) {
             if (!anchor.renderer)
                 continue;
+
+            // FIXME: change AnchorToAnchorPositionedMap to use Styleable instead.
+            RefPtr element = &styleable->element;
+            if (styleable->pseudoElementIdentifier)
+                element = element->pseudoElementIfExists(*styleable->pseudoElementIdentifier);
+
             map.ensure(*anchor.renderer, [&] {
                 return Vector<Ref<Element>> { };
-            }).iterator->value.append(anchorPositionedElement);
+            }).iterator->value.append(*element);
         }
     }
     return map;
@@ -1645,13 +1660,6 @@ RefPtr<const Element> AnchorPositionEvaluator::anchorPositionedElementOrPseudoEl
     return element;
 }
 
-AnchorPositionedKey AnchorPositionEvaluator::keyForElementOrPseudoElement(const Element& element)
-{
-    if (auto* pseudoElement = dynamicDowncast<PseudoElement>(element))
-        return { pseudoElement->hostElement(), PseudoElementIdentifier { pseudoElement->pseudoElementType() } };
-    return { &element, { } };
-}
-
 bool AnchorPositionEvaluator::isAnchor(const RenderStyle& style)
 {
     if (!style.anchorNames().isNone())
@@ -1694,14 +1702,16 @@ CheckedPtr<RenderBoxModelObject> AnchorPositionEvaluator::defaultAnchorForBox(co
     if (!box.element())
         return nullptr;
 
-    CheckedRef element = *box.element();
+    auto styleable = Styleable::fromRenderer(box);
+    if (!styleable)
+        return nullptr;
 
     auto& anchorPositionedMap = box.document().styleScope().anchorPositionedToAnchorMap();
-    auto it = anchorPositionedMap.find(element);
+    auto it = anchorPositionedMap.find(*styleable);
     if (it == anchorPositionedMap.end())
         return nullptr;
 
-    auto anchorName = ResolvedScopedName::createFromScopedName(element, defaultAnchorName(box.style()));
+    auto anchorName = ResolvedScopedName::createFromScopedName(styleable->element, defaultAnchorName(box.style()));
 
     for (auto& anchor : it->value.anchors) {
         if (anchorName == anchor.name)
@@ -1710,16 +1720,17 @@ CheckedPtr<RenderBoxModelObject> AnchorPositionEvaluator::defaultAnchorForBox(co
     return nullptr;
 }
 
-HashMap<AnchorPositionedKey, size_t> AnchorPositionEvaluator::recordLastSuccessfulPositionOptions(const SingleThreadWeakHashSet<const RenderBox>& positionTryBoxes)
+HashMap<WeakStyleable, size_t> AnchorPositionEvaluator::recordLastSuccessfulPositionOptions(const SingleThreadWeakHashSet<const RenderBox>& positionTryBoxes)
 {
-    HashMap<Style::AnchorPositionedKey, size_t> lastSuccessfulPositionOptionMap;
+    HashMap<WeakStyleable, size_t> lastSuccessfulPositionOptionMap;
 
     for (const auto& positionTryBox : positionTryBoxes) {
         auto styleable = Styleable::fromRenderer(positionTryBox);
-        ASSERT(styleable);
+        if (!styleable)
+            continue;
 
         if (auto usedPositionOptionIndex = positionTryBox.style().usedPositionOptionIndex())
-            lastSuccessfulPositionOptionMap.add({ styleable->element, styleable->pseudoElementIdentifier }, *usedPositionOptionIndex);
+            lastSuccessfulPositionOptionMap.add(*styleable, *usedPositionOptionIndex);
     }
 
     return lastSuccessfulPositionOptionMap;

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -33,6 +33,7 @@
 #include <WebCore/PseudoElementIdentifier.h>
 #include <WebCore/ResolvedScopedName.h>
 #include <WebCore/ScopedName.h>
+#include <WebCore/Styleable.h>
 #include <WebCore/WritingMode.h>
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
@@ -155,8 +156,7 @@ struct AnchorPositionedState {
     WTF_MAKE_STRUCT_TZONE_ALLOCATED(AnchorPositionedState);
 };
 
-using AnchorPositionedKey = std::pair<RefPtr<const Element>, std::optional<PseudoElementIdentifier>>;
-using AnchorPositionedStates = HashMap<AnchorPositionedKey, UniqueRef<AnchorPositionedState>>;
+using AnchorPositionedStates = HashMap<WeakStyleable, UniqueRef<AnchorPositionedState>>;
 
 using AnchorsForAnchorName = HashMap<ResolvedScopedName, Vector<SingleThreadWeakRef<const RenderBoxModelObject>>>;
 
@@ -176,17 +176,12 @@ struct ResolvedAnchor {
 };
 
 struct AnchorPositionedToAnchorEntry {
-    // The pseudo-element identifier can be used to access the AnchorPositionedState struct
-    // of the current element in an AnchorPositionedStates map, in combination with the relevant
-    // Element object.
-    std::optional<PseudoElementIdentifier> pseudoElementIdentifier;
-
     Vector<ResolvedAnchor> anchors;
 
     WTF_MAKE_STRUCT_TZONE_ALLOCATED(AnchorPositionedToAnchorEntry);
 };
 
-using AnchorPositionedToAnchorMap = WeakHashMap<Element, AnchorPositionedToAnchorEntry, WeakPtrImplWithEventTargetData>;
+using AnchorPositionedToAnchorMap = HashMap<WeakStyleable, AnchorPositionedToAnchorEntry>;
 using AnchorToAnchorPositionedMap = SingleThreadWeakHashMap<const RenderBoxModelObject, Vector<Ref<Element>>>;
 
 class AnchorPositionEvaluator {
@@ -223,13 +218,12 @@ public:
 
     static CheckedPtr<RenderBoxModelObject> defaultAnchorForBox(const RenderBox&);
 
-    static HashMap<AnchorPositionedKey, size_t> recordLastSuccessfulPositionOptions(const SingleThreadWeakHashSet<const RenderBox>& positionTryBoxes);
+    static HashMap<WeakStyleable, size_t> recordLastSuccessfulPositionOptions(const SingleThreadWeakHashSet<const RenderBox>& positionTryBoxes);
 
 private:
     static CheckedPtr<RenderBoxModelObject> findAnchorForAnchorFunctionAndAttemptResolution(BuilderState&, std::optional<ScopedName> elementName);
     static AnchorElements findAnchorsForAnchorPositionedElement(const Element&, const HashSet<ResolvedScopedName>& anchorNames, const AnchorsForAnchorName&);
     static RefPtr<const Element> anchorPositionedElementOrPseudoElement(BuilderState&);
-    static AnchorPositionedKey NODELETE keyForElementOrPseudoElement(const Element&);
     static void addAnchorFunctionScrollCompensatedAxis(RenderStyle&, const RenderBox& anchored, const RenderBoxModelObject& anchor, BoxAxis);
     static LayoutSize scrollOffsetFromAnchor(const RenderBoxModelObject& anchor, const RenderBox& anchored);
 };

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -1148,19 +1148,17 @@ void Scope::updateAnchorPositioningStateAfterStyleResolution()
 
 std::optional<size_t> Scope::lastSuccessfulPositionOptionIndexFor(const Styleable& styleable)
 {
-    AnchorPositionedKey key { styleable.element, styleable.pseudoElementIdentifier };
-    return m_lastSuccessfulPositionOptionIndexes.getOptional(key);
+    return m_lastSuccessfulPositionOptionIndexes.getOptional(styleable);
 }
 
-void Scope::setLastSuccessfulPositionOptionIndexMap(HashMap<AnchorPositionedKey, size_t>&& map)
+void Scope::setLastSuccessfulPositionOptionIndexMap(HashMap<WeakStyleable, size_t>&& map)
 {
     m_lastSuccessfulPositionOptionIndexes = WTF::move(map);
 }
 
 void Scope::forgetLastSuccessfulPositionOptionIndex(const Styleable& styleable)
 {
-    AnchorPositionedKey key { styleable.element, styleable.pseudoElementIdentifier };
-    m_lastSuccessfulPositionOptionIndexes.remove(key);
+    m_lastSuccessfulPositionOptionIndexes.remove(styleable);
 }
 
 }

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -177,7 +177,7 @@ public:
     void updateAnchorPositioningStateAfterStyleResolution();
 
     std::optional<size_t> lastSuccessfulPositionOptionIndexFor(const Styleable&);
-    void setLastSuccessfulPositionOptionIndexMap(HashMap<AnchorPositionedKey, size_t>&&);
+    void setLastSuccessfulPositionOptionIndexMap(HashMap<WeakStyleable, size_t>&&);
     void forgetLastSuccessfulPositionOptionIndex(const Styleable&);
 
     bool invalidateForAnchorDependencies(LayoutDependencyUpdateContext&);
@@ -282,7 +282,7 @@ private:
     SingleThreadWeakHashMap<const RenderBoxModelObject, AnchorPosition> m_anchorPositionsOnLastUpdate;
     // Stores the last successful position option for each anchor-positioned element.
     // This is recorded when ResizeObserver events are delivered, at Document::updateResizeObservations
-    HashMap<AnchorPositionedKey, size_t> m_lastSuccessfulPositionOptionIndexes;
+    HashMap<WeakStyleable, size_t> m_lastSuccessfulPositionOptionIndexes;
 
     std::unique_ptr<MatchResultCache> m_matchResultCache;
 

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -261,7 +261,8 @@ void TreeResolver::resetStyleForNonRenderedDescendants(Element& subtreeRoot)
     }
 
     m_positionOptions.removeIf([&subtreeRoot] (const auto& kv) {
-        return kv.key.first->isComposedTreeDescendantOf(subtreeRoot);
+        auto styleable = kv.key.styleable();
+        return !styleable || styleable->element.isComposedTreeDescendantOf(subtreeRoot);
     });
 
     subtreeRoot.clearChildNeedsStyleRecalc();
@@ -1499,27 +1500,35 @@ std::unique_ptr<Update> TreeResolver::resolve()
         }
     }
 
-    for (auto& elementAndState : m_treeResolutionState.anchorPositionedStates) {
+    for (const auto& [weakAnchorPositioned, state] : m_treeResolutionState.anchorPositionedStates) {
+        auto anchorPositioned = weakAnchorPositioned.styleable();
+        if (!anchorPositioned)
+            continue;
+
         // Ensure that style resolution visits any unresolved anchor-positioned elements.
-        if (elementAndState.value->stage < AnchorPositionResolutionStage::Resolved) {
-            const_cast<Element&>(*elementAndState.key.first).invalidateForResumingAnchorPositionedElementResolution();
+        if (state->stage < AnchorPositionResolutionStage::Resolved) {
+            anchorPositioned->element.invalidateForResumingAnchorPositionedElementResolution();
             m_needsInterleavedLayout = true;
         }
     }
 
-    for (auto& [styleable, options] : m_positionOptions) {
+    for (auto& [weakStyleable, options] : m_positionOptions) {
+        auto styleable = weakStyleable.styleable();
+        if (!styleable)
+            continue;
+
         if (!options.chosen) {
-            ASSERT(styleable.first);
-            const_cast<Element&>(*styleable.first).invalidateForResumingAnchorPositionedElementResolution();
+            styleable->element.invalidateForResumingAnchorPositionedElementResolution();
             m_needsInterleavedLayout = true;
         }
     }
 
     if (!m_changedAnchorNames.isEmpty() || m_allAnchorNamesInvalid) {
         // If there are changes to the anchor names then loop through the existing anchors and see if any of them references those names.
-        for (auto entry : m_document->styleScope().anchorPositionedToAnchorMap()) {
-            CheckedRef anchorPositionedElement = entry.key;
-            auto& anchors = entry.value;
+        for (auto [weakAnchorPositioned, anchors] : m_document->styleScope().anchorPositionedToAnchorMap()) {
+            auto anchorPositioned = weakAnchorPositioned.styleable();
+            if (!anchorPositioned)
+                continue;
 
             bool anchorPositionedReferencesChangedAnchorNames = [&] {
                 if (m_allAnchorNamesInvalid)
@@ -1535,7 +1544,7 @@ std::unique_ptr<Update> TreeResolver::resolve()
 
             if (anchorPositionedReferencesChangedAnchorNames) {
                 // Invalidate the anchor-positioned element, so subsequent style resolution rounds would visit it.
-                anchorPositionedElement->invalidateForResumingAnchorPositionedElementResolution();
+                anchorPositioned->element.invalidateForResumingAnchorPositionedElementResolution();
 
                 // Mark that additional style resolution round is needed.
                 m_needsInterleavedLayout = true;
@@ -1543,8 +1552,7 @@ std::unique_ptr<Update> TreeResolver::resolve()
                 // If the anchor-positioned element is currently being tracked for resolution,
                 // reset the resolution stage to FindAnchor. This re-runs anchor resolution to
                 // pick up new anchor name changes.
-                AnchorPositionedKey anchorPositionedKey { anchorPositionedElement.ptr(), anchors.pseudoElementIdentifier };
-                if (auto* state = m_treeResolutionState.anchorPositionedStates.get(anchorPositionedKey))
+                if (auto* state = m_treeResolutionState.anchorPositionedStates.get(*anchorPositioned))
                     state->stage = AnchorPositionResolutionStage::FindAnchors;
             }
         }
@@ -1612,9 +1620,7 @@ void TreeResolver::generatePositionOptionsIfNeeded(const ResolvedStyle& resolved
     if (!resolvedStyle.style->hasOutOfFlowPosition())
         return;
 
-    AnchorPositionedKey positionOptionsKey { styleable.element, styleable.pseudoElementIdentifier };
-
-    if (m_positionOptions.contains(positionOptionsKey))
+    if (m_positionOptions.contains(styleable))
         return;
 
     auto generatePositionOptions = [&] {
@@ -1646,7 +1652,7 @@ void TreeResolver::generatePositionOptionsIfNeeded(const ResolvedStyle& resolved
     if (hasUnresolvedAnchorPosition(styleable))
         return;
 
-    m_positionOptions.add(positionOptionsKey, WTF::move(options));
+    m_positionOptions.add(styleable, WTF::move(options));
 }
 
 std::unique_ptr<RenderStyle> TreeResolver::generatePositionOption(const PositionTryFallback& fallback, const ResolvedStyle& resolvedStyle, const Styleable& styleable, const ResolutionContext& resolutionContext)
@@ -1757,9 +1763,7 @@ std::optional<ResolvedStyle> TreeResolver::tryChoosePositionOption(const Styleab
 {
     // https://drafts.csswg.org/css-anchor-position-1/#fallback-apply
 
-    AnchorPositionedKey anchorPositionedKey { styleable.element, styleable.pseudoElementIdentifier };
-
-    auto optionIt = m_positionOptions.find(anchorPositionedKey);
+    auto optionIt = m_positionOptions.find(styleable);
     if (optionIt == m_positionOptions.end())
         return { };
 
@@ -1815,7 +1819,7 @@ std::optional<ResolvedStyle> TreeResolver::tryChoosePositionOption(const Styleab
     }
 
     // We can't test for overflow before the box has been positioned.
-    auto* anchorPositionedState = m_treeResolutionState.anchorPositionedStates.get({ &styleable.element, styleable.pseudoElementIdentifier });
+    auto* anchorPositionedState = m_treeResolutionState.anchorPositionedStates.get(styleable);
     if (anchorPositionedState && anchorPositionedState->stage < AnchorPositionResolutionStage::Positioned)
         return ResolvedStyle { options.currentOption() };
 
@@ -1865,7 +1869,7 @@ void TreeResolver::updateForPositionVisibility(RenderStyle& style, const Styleab
                 return true;
         }
         if (style.positionVisibility().contains(PositionVisibilityValue::AnchorsValid)) {
-            auto* anchorPositionedState = m_treeResolutionState.anchorPositionedStates.get({ &styleable.element, styleable.pseudoElementIdentifier });
+            auto* anchorPositionedState = m_treeResolutionState.anchorPositionedStates.get(styleable);
             if (anchorPositionedState) {
                 for (auto& anchorElement : anchorPositionedState->anchorElements.values()) {
                     if (!anchorElement)
@@ -1905,7 +1909,7 @@ void TreeResolver::saveBeforeResolutionStyleForInterleaving(const Element& eleme
 
 bool TreeResolver::hasUnresolvedAnchorPosition(const Styleable& styleable) const
 {
-    auto* anchorPositionedState = m_treeResolutionState.anchorPositionedStates.get({ &styleable.element, styleable.pseudoElementIdentifier });
+    auto* anchorPositionedState = m_treeResolutionState.anchorPositionedStates.get(styleable);
     if (anchorPositionedState && anchorPositionedState->stage < AnchorPositionResolutionStage::Resolved)
         return true;
 
@@ -1914,7 +1918,7 @@ bool TreeResolver::hasUnresolvedAnchorPosition(const Styleable& styleable) const
 
 bool TreeResolver::hasResolvedAnchorPosition(const Styleable& styleable) const
 {
-    auto* anchorPositionedState = m_treeResolutionState.anchorPositionedStates.get({ &styleable.element, styleable.pseudoElementIdentifier });
+    auto* anchorPositionedState = m_treeResolutionState.anchorPositionedStates.get(styleable);
     if (anchorPositionedState && anchorPositionedState->stage >= AnchorPositionResolutionStage::Resolved)
         return true;
 
@@ -1923,7 +1927,7 @@ bool TreeResolver::hasResolvedAnchorPosition(const Styleable& styleable) const
 
 bool TreeResolver::isTryingPositionOption(const Styleable& styleable) const
 {
-    if (auto it = m_positionOptions.find({ styleable.element, styleable.pseudoElementIdentifier }); it != m_positionOptions.end())
+    if (auto it = m_positionOptions.find(styleable); it != m_positionOptions.end())
         return !it->value.chosen;
 
     return false;

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -187,11 +187,11 @@ private:
     const RenderStyle* beforeResolutionStyle(const Element&, std::optional<PseudoElementIdentifier>);
     void saveBeforeResolutionStyleForInterleaving(const Element&, const RenderStyle*);
 
-    bool NODELETE hasUnresolvedAnchorPosition(const Styleable&) const;
-    bool NODELETE hasResolvedAnchorPosition(const Styleable&) const;
+    bool hasUnresolvedAnchorPosition(const Styleable&) const;
+    bool hasResolvedAnchorPosition(const Styleable&) const;
     // Returns true if (1) the styleable specifies position fallbacks and
     // (2) we're in the middle of trying position options.
-    bool NODELETE isTryingPositionOption(const Styleable&) const;
+    bool isTryingPositionOption(const Styleable&) const;
 
     void collectChangedAnchorNames(const RenderStyle&, const RenderStyle* currentStyle);
 
@@ -247,7 +247,7 @@ private:
         const RenderStyle& NODELETE originalStyle() const;
         std::unique_ptr<RenderStyle> currentOption() const;
     };
-    HashMap<AnchorPositionedKey, PositionOptions> m_positionOptions;
+    HashMap<WeakStyleable, PositionOptions> m_positionOptions;
 
     HashSet<AtomString> m_changedAnchorNames;
     bool m_allAnchorNamesInvalid { false };


### PR DESCRIPTION
#### d2c22029e468944bffdf230921dab80d5c7bfb83
<pre>
[css-anchor-position-1] Replace AnchorPositionedKey with WeakStyleable
<a href="https://bugs.webkit.org/show_bug.cgi?id=311690">https://bugs.webkit.org/show_bug.cgi?id=311690</a>

Reviewed by Antti Koivisto.

Many HashMaps use AnchorPositionedKey as the hash key of anchor-positioned
elements. The key includes an Element pointer and an optional pseudo-element
identifier - identical to a Styleable, but it can be used as a hash key
(Styleable is not hash-key-able).

Now that 307912@main added hashing support for WeakStyleable (a variation of
Styleable that holds a weak pointer to the Element), this patch replaces
AnchorPositionedKey with Styleable.

There&apos;re some remaining places where anchor-positioned elements are represented
by their Element pointer, which will get in the way of supporting more
anchor-positioned pseudo elements beside ::before/::after. This will be fixed in
later patches.

Tested by the existing anchor positioning test suite.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::findAnchorForAnchorFunctionAndAttemptResolution):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositionedStateForDefaultAnchorAndPositionVisibility):
(WebCore::Style::AnchorPositionEvaluator::makeAnchorPositionedForAnchorMap):
(WebCore::Style::AnchorPositionEvaluator::defaultAnchorForBox):
(WebCore::Style::AnchorPositionEvaluator::recordLastSuccessfulPositionOptions):
(WebCore::Style::AnchorPositionEvaluator::keyForElementOrPseudoElement): Deleted.
* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::lastSuccessfulPositionOptionIndexFor):
(WebCore::Style::Scope::setLastSuccessfulPositionOptionIndexMap):
(WebCore::Style::Scope::forgetLastSuccessfulPositionOptionIndex):
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resetStyleForNonRenderedDescendants):
(WebCore::Style::TreeResolver::resolve):
(WebCore::Style::TreeResolver::generatePositionOptionsIfNeeded):
(WebCore::Style::TreeResolver::tryChoosePositionOption):
(WebCore::Style::TreeResolver::updateForPositionVisibility):
(WebCore::Style::TreeResolver::hasUnresolvedAnchorPosition const):
(WebCore::Style::TreeResolver::hasResolvedAnchorPosition const):
(WebCore::Style::TreeResolver::isTryingPositionOption const):
* Source/WebCore/style/StyleTreeResolver.h:

Canonical link: <a href="https://commits.webkit.org/311053@main">https://commits.webkit.org/311053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d65dc17e0518f77b996281e1ba1647a371561967

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164705 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157814 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29279 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120722 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158901 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22920 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101411 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22002 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20143 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12535 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131668 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17873 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167185 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11359 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19484 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128844 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28879 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24188 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128976 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34929 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28801 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139667 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86544 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23797 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16465 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28510 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92466 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28037 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28265 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28161 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->