### PR TITLE
`width: 0` does not collapse table cell to its minimum size

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-cell-width-0-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-cell-width-0-expected.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Reference for table cell with `width:0` case testing diferent table widths</title>
+<style>
+.row {
+  display: flex;
+  border: 2px solid black;
+  border-spacing: 2px;
+  text-indent: initial;
+  box-sizing: border-box;
+  width: fit-content;
+}
+
+.row.percent {
+  width: 100%;
+}
+
+.row.fixed {
+  width: 100px;
+}
+
+.cell {
+  padding: 1px;
+  line-height: normal;
+  font: initial;
+  box-sizing: content-box;
+}
+
+.zero {
+  width: fit-content;
+  background: lightblue;
+}
+
+.positive-width {
+  width: auto;
+  background: lightblue;
+}
+
+.big-positive-width {
+  width: 20px;
+  background: lightblue;
+}
+
+.normal {
+  background: lightgreen;
+  flex: 1;
+}
+</style>
+</head>
+<body>
+
+<!-- auto width -->
+<div class="row">
+  <div class="cell zero">1</div>
+  <div class="cell normal">2</div>
+</div>
+<br>
+
+<div class="row">
+  <div class="cell positive-width">1</div>
+  <div class="cell normal">2</div>
+</div>
+<br>
+
+<div class="row">
+  <div class="cell big-positive-width">1</div>
+  <div class="cell normal">2</div>
+</div>
+<br>
+
+<!-- width:100% -->
+<div class="row percent">
+  <div class="cell zero">1</div>
+  <div class="cell normal">2</div>
+</div>
+
+<div class="row percent">
+  <div class="cell positive-width">1</div>
+  <div class="cell normal">2</div>
+</div>
+
+<div class="row percent">
+  <div class="cell big-positive-width">1</div>
+  <div class="cell normal">2</div>
+</div>
+<br>
+
+<!-- width:100px -->
+<div class="row fixed">
+  <div class="cell zero">1</div>
+  <div class="cell normal">2</div>
+</div>
+
+<div class="row fixed">
+  <div class="cell positive-width">1</div>
+  <div class="cell normal">2</div>
+</div>
+
+<div class="row fixed">
+  <div class="cell big-positive-width">1</div>
+  <div class="cell normal">2</div>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-cell-width-0-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-cell-width-0-ref.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Reference for table cell with `width:0` case testing diferent table widths</title>
+<style>
+.row {
+  display: flex;
+  border: 2px solid black;
+  border-spacing: 2px;
+  text-indent: initial;
+  box-sizing: border-box;
+  width: fit-content;
+}
+
+.row.percent {
+  width: 100%;
+}
+
+.row.fixed {
+  width: 100px;
+}
+
+.cell {
+  padding: 1px;
+  line-height: normal;
+  font: initial;
+  box-sizing: content-box;
+}
+
+.zero {
+  width: fit-content;
+  background: lightblue;
+}
+
+.positive-width {
+  width: auto;
+  background: lightblue;
+}
+
+.big-positive-width {
+  width: 20px;
+  background: lightblue;
+}
+
+.normal {
+  background: lightgreen;
+  flex: 1;
+}
+</style>
+</head>
+<body>
+
+<!-- auto width -->
+<div class="row">
+  <div class="cell zero">1</div>
+  <div class="cell normal">2</div>
+</div>
+<br>
+
+<div class="row">
+  <div class="cell positive-width">1</div>
+  <div class="cell normal">2</div>
+</div>
+<br>
+
+<div class="row">
+  <div class="cell big-positive-width">1</div>
+  <div class="cell normal">2</div>
+</div>
+<br>
+
+<!-- width:100% -->
+<div class="row percent">
+  <div class="cell zero">1</div>
+  <div class="cell normal">2</div>
+</div>
+
+<div class="row percent">
+  <div class="cell positive-width">1</div>
+  <div class="cell normal">2</div>
+</div>
+
+<div class="row percent">
+  <div class="cell big-positive-width">1</div>
+  <div class="cell normal">2</div>
+</div>
+<br>
+
+<!-- width:100px -->
+<div class="row fixed">
+  <div class="cell zero">1</div>
+  <div class="cell normal">2</div>
+</div>
+
+<div class="row fixed">
+  <div class="cell positive-width">1</div>
+  <div class="cell normal">2</div>
+</div>
+
+<div class="row fixed">
+  <div class="cell big-positive-width">1</div>
+  <div class="cell normal">2</div>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-cell-width-0.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-cell-width-0.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Tests if cell with width:'0' uses intrinsic content size for width</title>
+<link rel="match" href="table-cell-width-0-ref.html">
+<style>
+table {
+  border-collapse: collapse;
+  border: 2px solid black;
+}
+.zero {
+  width: 0;
+  background: lightblue;
+}
+
+.positive-width 
+{
+  width: 2px;
+  background: lightblue; 
+}
+
+.big-positive-width 
+{
+  width: 20px;
+  background: lightblue; 
+}
+
+.normal {
+  background: lightgreen;
+}
+
+.percent-width
+{
+  width: 100%;
+}
+
+.fixed-width 
+{
+  width: 100px;
+}
+
+</style>
+</head>
+<body>
+<!-- auto width -->
+<table>
+  <tr>
+    <td class="zero">1</td>
+    <td class="normal">2</td>
+  </tr>
+</table>
+<br>
+<table>
+  <tr>
+    <td class="positive-width">1</td>
+    <td class="normal">2</td>
+  </tr>
+</table>
+<br>
+<table>
+  <tr>
+    <td class="big-positive-width">1</td>
+    <td class="normal">2</td>
+  </tr>
+</table>
+<br> 
+<!-- width:100% -->
+<table class="percent-width">
+  <tr>
+    <td class="zero">1</td>
+    <td class="normal">2</td>
+  </tr>
+</table>
+<table class="percent-width">
+  <tr>
+    <td class="positive-width">1</td>
+    <td class="normal">2</td>
+  </tr>
+</table>
+<table class="percent-width">
+  <tr>
+    <td class="big-positive-width">1</td>
+    <td class="normal">2</td>
+  </tr>
+</table>
+<br>
+<!-- width:100px -->
+<table class="fixed-width">
+  <tr>
+    <td class="zero">1</td>
+    <td class="normal">2</td>
+  </tr>
+</table>
+<table class="fixed-width">
+  <tr>
+    <td class="positive-width">1</td>
+    <td class="normal">2</td>
+  </tr>
+</table>
+<table class="fixed-width">
+  <tr>
+    <td class="big-positive-width">1</td>
+    <td class="normal">2</td>
+  </tr>
+</table>
+</body>
+</html>

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -112,8 +112,7 @@ void AutoTableLayout::recalcColumn(unsigned effCol)
                     }
                     WTF::switchOn(cellLogicalWidth,
                         [&](const Style::PreferredSize::Fixed& fixedCellLogicalWidth) {
-                            // ignore width=0
-                            if (fixedCellLogicalWidth.isPositive() && !columnLayout.logicalWidth.isPercentOrCalculated()) {
+                            if (fixedCellLogicalWidth.isPositiveOrZero() && !columnLayout.logicalWidth.isPercentOrCalculated()) {
                                 float logicalWidth = cell->adjustBorderBoxLogicalWidthForBoxSizing(fixedCellLogicalWidth);
                                 // Honor the cell's CSS max-width constraint.
                                 if (auto fixedMaxWidth = cell->style().logicalMaxWidth().tryFixed())


### PR DESCRIPTION
#### 35b8a8c39c7572f6d6d4c9d43ea18cfabd709e9d
<pre>
`width: 0` does not collapse table cell to its minimum size
<a href="https://bugs.webkit.org/show_bug.cgi?id=285849">https://bugs.webkit.org/show_bug.cgi?id=285849</a>

Reviewed by Elika Etemad and Darin Adler.

WebKit renders table cells with `width: 0` differently from other major engines
when using the auto table layout algorithm.The engine bug derives from the fact that,
in the `width: 0` case for table cells, the cell’s intrinsic width is not being calculated.

When calculating the column width,
the `AutoTableLayout::recalcColumn()` function does not execute the code path
responsible for computing the column size for cells with fixed width in case of cell with `width: 0`.
This happens because of the following statement is present before compute
cell width `fixedCellLogicalWidth.isPositive()`, where zero value is not include only positive
starting from 1.
the column width ends up being determined using the table’s width distribution algorithm instead.

This patch removes the condition that skips cells with `width: 0`,
making the code path for fixed width of the cell be executed for `width:0` case.

Tests:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-cell-width-0-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-cell-width-0-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/table-cell-width-0.html: Added.
* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::recalcColumn):

Canonical link: <a href="https://commits.webkit.org/311393@main">https://commits.webkit.org/311393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f269ebdc1b666719f0356181a1e2d450858094be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156195 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22712 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165016 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110273 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158066 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29663 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29533 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120946 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85117 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140263 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101620 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22232 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20392 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12788 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18094 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167495 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17029 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11611 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19707 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129077 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29131 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129184 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29053 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139888 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86820 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23875 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24003 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16687 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28762 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92719 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28289 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28517 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28413 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->