### PR TITLE
[WPE][cross-toolchain-helper] determineArchitecture() in webkitdirs.pm doesn't handle correctly the cross-toolchain-helper case.

### DIFF
--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -573,15 +573,25 @@ sub determineArchitecture
             $compiler = $ENV{'CC'} if (defined($ENV{'CC'}));
             my @compiler_machine = split('-', `$compiler -dumpmachine`);
             $architecture = $compiler_machine[0];
-        } elsif (open my $cmake_sysinfo, "cmake --system-information |") {
-            while (<$cmake_sysinfo>) {
-                next unless index($_, 'CMAKE_SYSTEM_PROCESSOR') == 0;
-                if (/^CMAKE_SYSTEM_PROCESSOR \"([^"]+)\"/) {
-                    $architecture = $1;
-                    last;
-                }
+        } else {
+            my $prefix = "";
+            # This gets called from argumentsForConfiguration() which needs to resolve the target architecture
+            # before entering into the cross-toolchain-env, so to achieve that we call the cross-target cmake.
+            if (shouldBuildForCrossTarget()) {
+                $prefix = sprintf("%s --cross-target=%s --cross-toolchain-run-cmd",
+                            File::Spec->catfile(sourceDir(), "Tools", "Scripts", "cross-toolchain-helper"),
+                            getCrossTargetName());
             }
-            close $cmake_sysinfo;
+            if (open my $cmake_sysinfo, "$prefix cmake --system-information |") {
+                while (<$cmake_sysinfo>) {
+                    next unless index($_, 'CMAKE_SYSTEM_PROCESSOR') == 0;
+                    if (/^CMAKE_SYSTEM_PROCESSOR \"([^"]+)\"/) {
+                        $architecture = $1;
+                        last;
+                    }
+                }
+                close $cmake_sysinfo;
+            }
         }
     }
 


### PR DESCRIPTION
#### 68c43f3fd9ecc6e734d0155a170c68b1649b0d67
<pre>
[WPE][cross-toolchain-helper] determineArchitecture() in webkitdirs.pm doesn&apos;t handle correctly the cross-toolchain-helper case.
<a href="https://bugs.webkit.org/show_bug.cgi?id=311694">https://bugs.webkit.org/show_bug.cgi?id=311694</a>

Reviewed by Philippe Normand.

When using cross-toolchain-helper determineArchitecture() in webkitdirs.pm fails
to correctly determine the target architecture.

The problem is that determineArchitecture() gets called before entering into the
cross-target environment because the value of architecuture is needed to resolve
the values of argumentsForConfiguration() which are passed when the build-webkit
gets re-execed into the cross-target environment.

So at that moment it can&apos;t reliable obtain the target architecture, and instead
it obtains the host one because the CC environment variable with the cross-compiler
is still not set.

To fix this problem this patch detects this edge case and then calls the cmake
binary from the cross-toolchain SDK which is configured to resolve the target
architecture.

* Tools/Scripts/webkitdirs.pm:
(determineArchitecture):

Canonical link: <a href="https://commits.webkit.org/311591@main">https://commits.webkit.org/311591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6b35d1ca86f0a34cd7a24e38c0947eb49846b8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163583 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108293 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28219 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119766 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84673 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139038 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100459 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21132 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19157 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11409 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146873 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130794 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16882 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166057 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15654 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18491 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127867 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27627 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23197 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128007 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27551 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138675 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84256 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23940 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22894 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15469 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186557 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27243 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47815 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26821 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27052 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26894 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->