### PR TITLE
Adopt Borrow<T> for Vector<T> in Source/WebKit and Source/WebCore (Debug ASSERT only)

### DIFF
--- a/Source/WTF/wtf/Borrow.h
+++ b/Source/WTF/wtf/Borrow.h
@@ -69,15 +69,8 @@ class Borrow {
     WTF_MAKE_NONCOPYABLE(Borrow);
     WTF_FORBID_HEAP_ALLOCATION;
 public:
-    explicit Borrow(T& ref)
+    Borrow(T& ref)
         : m_ref(ref)
-        , m_previous(m_ref.setIsBorrowed(true))
-    {
-        assertIsOnStack();
-    }
-
-    explicit Borrow(T* ptr)
-        : m_ref(*ptr)
         , m_previous(m_ref.setIsBorrowed(true))
     {
         assertIsOnStack();
@@ -86,6 +79,11 @@ public:
     ~Borrow()
     {
         m_ref.setIsBorrowed(m_previous);
+    }
+
+    operator T&() const LIFETIME_BOUND
+    {
+        return m_ref;
     }
 
     T& get() const LIFETIME_BOUND
@@ -116,15 +114,21 @@ private:
 };
 
 template<typename T>
+Borrow(T&) -> Borrow<T>;
+
+// -Wdangling reports false positives on temporaries in range-based for loops.
+// Suppress -Wdangling entirely when we're using borrow(x) so that we don't
+// have to suppress at every usage site.
+// FIXME: Remove this once all supported compilers have this fix.
+// Fixed in upstream Clang commit c86c815fc57c (July 2025).
+#if defined(__clang__) && defined(__clang_major__) && __clang_major__ < 21
+IGNORE_WARNINGS_BEGIN("dangling")
+#endif
+
+template<typename T>
 inline Borrow<T> borrow(T& ref)
 {
     return Borrow<T>(ref);
-}
-
-template<typename T>
-inline Borrow<T> borrow(T* ptr)
-{
-    return Borrow<T>(ptr);
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/CanBorrow.h
+++ b/Source/WTF/wtf/CanBorrow.h
@@ -58,23 +58,25 @@ class CanBorrow {
 public:
     ~CanBorrow()
     {
-        RELEASE_ASSERT(!m_isBorrowed);
+        // FIXME: Make this a RELEASE_ASSERT once we've proven it's stable.
+        ASSERT(!m_isBorrowed);
     }
 
     void crashIfBorrowed()
     {
-        RELEASE_ASSERT(!m_isBorrowed);
+        // FIXME: Make this a RELEASE_ASSERT once we've proven it's stable.
+        ASSERT(!m_isBorrowed);
     }
 
 private:
     template<typename T> friend class Borrow;
 
-    bool setIsBorrowed(bool isBorrowed)
+    bool setIsBorrowed(bool isBorrowed) const
     {
         return std::exchange(m_isBorrowed, isBorrowed);
     }
 
-    bool m_isBorrowed { false };
+    mutable bool m_isBorrowed { false };
 };
 
 } // namespace WTF

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -312,7 +312,7 @@ protected:
 
     T* m_buffer;
     unsigned m_capacity : 31;
-    unsigned m_isBorrowed : 1;
+    mutable unsigned m_isBorrowed : 1;
     unsigned m_size;
 
     unsigned exchangeCapacity(unsigned newCapacity)
@@ -331,7 +331,7 @@ protected:
 
     bool isBorrowed() const { return m_isBorrowed; }
 
-    bool setIsBorrowed(bool isBorrowed)
+    bool setIsBorrowed(bool isBorrowed) const
     {
         bool old = m_isBorrowed;
         m_isBorrowed = isBorrowed;
@@ -392,6 +392,8 @@ public:
     using Base::buffer;
     using Base::capacity;
     using Base::bufferMemoryOffset;
+    using Base::setIsBorrowed;
+    using Base::crashIfBorrowed;
 
     using Base::releaseBuffer;
     using Base::capacitySpan;
@@ -621,6 +623,7 @@ private:
     typedef VectorBuffer<T, inlineCapacity, Malloc> Base;
     typedef VectorTypeOperations<T> TypeOperations;
     friend class JSC::LLIntOffsetsExtractor;
+    template<typename> friend class Borrow;
 
 public:
     // FIXME: Remove uses of ValueType and standardize on value_type, which is required for std::span.

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -139,6 +139,7 @@
 #include "TextIterator.h"
 #include "TypedElementDescendantIteratorInlines.h"
 #include <utility>
+#include <wtf/Borrow.h>
 #include <wtf/DataLog.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/SetForScope.h>
@@ -5201,7 +5202,7 @@ void AXObjectCache::performDeferredCacheUpdate(ForceLayout forceLayout)
     m_deferredTextFormControlValue.clear();
 
     AXLOGDeferredCollection("AttributeChange"_s, m_deferredAttributeChange);
-    for (const auto& attributeChange : m_deferredAttributeChange) {
+    for (const auto& attributeChange : borrow(m_deferredAttributeChange).get()) {
         handleAttributeChange(attributeChange.element.get(), attributeChange.attrName, attributeChange.oldValue, attributeChange.newValue);
         if (attributeChange.attrName == idAttr)
             markRelationsDirty();

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -40,6 +40,7 @@
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StyleProperties.h"
 #include <ranges>
+#include <wtf/Borrow.h>
 
 namespace WebCore {
 
@@ -50,7 +51,7 @@ CSSFontFaceSet::CSSFontFaceSet(CSSFontSelector* owningFontSelector)
 
 CSSFontFaceSet::~CSSFontFaceSet()
 {
-    for (auto& face : m_faces)
+    for (Ref face : borrow(m_faces).get())
         face->removeClient(*this);
 
     for (auto& pair : m_locallyInstalledFacesLookupTable) {

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -373,6 +373,7 @@
 #include <ranges>
 #include <wtf/ASCIICType.h>
 #include <wtf/Assertions.h>
+#include <wtf/Borrow.h>
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/HexNumber.h>
 #include <wtf/Language.h>
@@ -10332,7 +10333,7 @@ size_t Document::gatherResizeObservations(size_t deeperThan)
 {
     LOG_WITH_STREAM(ResizeObserver, stream << *this << " gatherResizeObservations");
     size_t minDepth = ResizeObserver::maxElementDepth();
-    for (auto& weakObserver : m_resizeObservers) {
+    for (auto& weakObserver : borrow(m_resizeObservers).get()) {
         RefPtr observer = weakObserver.get();
         if (!observer || !observer->hasObservations())
             continue;

--- a/Source/WebCore/dom/DocumentFontLoader.cpp
+++ b/Source/WebCore/dom/DocumentFontLoader.cpp
@@ -36,6 +36,7 @@
 #include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "LocalFrame.h"
+#include <wtf/Borrow.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -133,7 +134,7 @@ void DocumentFontLoader::stopLoadingAndClearFonts()
     m_fontLoadingTimer.stop();
     Ref document = m_document.get();
     Ref cachedResourceLoader = document->cachedResourceLoader();
-    for (auto& fontHandle : m_fontsToBeginLoading) {
+    for (CachedResourceHandle fontHandle : borrow(m_fontsToBeginLoading).get()) {
         // Balances incrementRequestCount() in beginLoadingFontSoon().
         cachedResourceLoader->decrementRequestCount(*fontHandle);
     }

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -161,6 +161,7 @@
 #include <cmath>
 #include <memory>
 #include <wtf/Assertions.h>
+#include <wtf/Borrow.h>
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/Language.h>
 #include <wtf/MainThread.h>
@@ -2777,7 +2778,7 @@ void LocalDOMWindow::finalizeAndQueueEventTimingEntries()
         return;
 
     LOG_WITH_STREAM(PerformanceTimeline, stream << "Dispatching " << m_performanceEventTimingCandidates.size() << " event timing entries at t=" << renderingTime);
-    for (auto& candidateEntry : m_performanceEventTimingCandidates) {
+    for (auto& candidateEntry : borrow(m_performanceEventTimingCandidates).get()) {
         performance().countEvent(candidateEntry.type);
         if (!candidateEntry.duration)
             candidateEntry.duration = renderingTime - candidateEntry.startTime;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -217,6 +217,7 @@
 #include "WorkerOrWorkletScriptController.h"
 #include <JavaScriptCore/VM.h>
 #include <ranges>
+#include <wtf/Borrow.h>
 #include <wtf/FileSystem.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/SystemTracing.h>
@@ -4974,7 +4975,7 @@ void Page::mainFrameDidChangeToNonInitialEmptyDocument()
 {
     RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_mainFrame.get());
     ASSERT_UNUSED(localMainFrame, !localMainFrame || !localMainFrame->loader().stateMachine().isDisplayingInitialEmptyDocument());
-    for (auto& userStyleSheet : m_userStyleSheetsPendingInjection)
+    for (auto& userStyleSheet : borrow(m_userStyleSheetsPendingInjection).get())
         injectUserStyleSheet(userStyleSheet);
     m_userStyleSheetsPendingInjection.clear();
 }
@@ -6042,7 +6043,7 @@ void Page::addHardwareKeyboardAttachmentObserver(HardwareKeyboardAttachmentObser
 void Page::flushHardwareKeyboardAttachmentObservers()
 {
     bool attached = m_hardwareKeyboardAttached;
-    std::ranges::for_each(m_hardwareKeyboardAttachmentObservers, [attached](auto& observer) {
+    std::ranges::for_each(borrow(m_hardwareKeyboardAttachmentObservers).get(), [attached](auto& observer) {
         observer(attached);
     });
     m_hardwareKeyboardAttachmentObservers.clear();

--- a/Source/WebCore/page/PageOverlayController.cpp
+++ b/Source/WebCore/page/PageOverlayController.cpp
@@ -40,7 +40,9 @@
 #include "ScrollingCoordinator.h"
 #include "Settings.h"
 #include "TiledBacking.h"
+#include <wtf/Borrow.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <ranges>
 
 // FIXME: Someone needs to call didChangeSettings() if we want dynamic updates of layer border/repaint counter settings.
 
@@ -353,8 +355,8 @@ bool PageOverlayController::handleMouseEvent(const PlatformMouseEvent& mouseEven
     if (m_pageOverlays.isEmpty())
         return false;
 
-    for (auto it = m_pageOverlays.rbegin(), end = m_pageOverlays.rend(); it != end; ++it) {
-        if (Ref { *it }->mouseEvent(mouseEvent))
+    for (Ref overlay : borrow(m_pageOverlays).get() | std::views::reverse) {
+        if (overlay->mouseEvent(mouseEvent))
             return true;
     }
 
@@ -366,8 +368,8 @@ bool PageOverlayController::copyAccessibilityAttributeStringValueForPoint(String
     if (m_pageOverlays.isEmpty())
         return false;
 
-    for (auto it = m_pageOverlays.rbegin(), end = m_pageOverlays.rend(); it != end; ++it) {
-        if (Ref { *it }->copyAccessibilityAttributeStringValueForPoint(attribute, parameter, value))
+    for (Ref overlay : borrow(m_pageOverlays).get() | std::views::reverse) {
+        if (overlay->copyAccessibilityAttributeStringValueForPoint(attribute, parameter, value))
             return true;
     }
 
@@ -379,8 +381,8 @@ bool PageOverlayController::copyAccessibilityAttributeBoolValueForPoint(String a
     if (m_pageOverlays.isEmpty())
         return false;
 
-    for (auto it = m_pageOverlays.rbegin(), end = m_pageOverlays.rend(); it != end; ++it) {
-        if (Ref { *it }->copyAccessibilityAttributeBoolValueForPoint(attribute, parameter, value))
+    for (Ref overlay : borrow(m_pageOverlays).get() | std::views::reverse) {
+        if (overlay->copyAccessibilityAttributeBoolValueForPoint(attribute, parameter, value))
             return true;
     }
 

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -49,6 +49,7 @@
 #include "SVGUseElement.h"
 #include "SVGVisitedElementTracking.h"
 #include "XLinkNames.h"
+#include <wtf/Borrow.h>
 #include <wtf/MathExtras.h>
 #include <wtf/RobinHoodHashSet.h>
 #include <wtf/StdLibExtras.h>
@@ -582,7 +583,7 @@ void SVGSMILElement::connectConditions()
     if (m_conditionsConnected)
         disconnectConditions();
     m_conditionsConnected = true;
-    for (auto& condition : m_conditions) {
+    for (auto& condition : borrow(m_conditions).get()) {
         if (condition.m_type == Condition::EventBase) {
             ASSERT(!condition.m_syncbase);
             RefPtr eventBase = eventBaseFor(condition);
@@ -611,7 +612,7 @@ void SVGSMILElement::disconnectConditions()
     if (!m_conditionsConnected)
         return;
     m_conditionsConnected = false;
-    for (auto& condition : m_conditions) {
+    for (auto& condition : borrow(m_conditions).get()) {
         if (condition.m_type == Condition::EventBase) {
             ASSERT(!condition.m_syncbase);
             if (!condition.m_eventListener)

--- a/Source/WebCore/worklets/Worklet.cpp
+++ b/Source/WebCore/worklets/Worklet.cpp
@@ -38,6 +38,7 @@
 #include "WorkletGlobalScopeProxy.h"
 #include "WorkletPendingTasks.h"
 #include <JavaScriptCore/IdentifiersFactory.h>
+#include <wtf/Borrow.h>
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
@@ -85,7 +86,7 @@ void Worklet::addModule(const String& moduleURLString, WorkletOptions&& options,
     Ref pendingTasks = WorkletPendingTasks::create(*this, WTF::move(promise), m_proxies.size());
     m_pendingTasksSet.add(pendingTasks);
 
-    for (auto& proxy : m_proxies) {
+    for (Ref proxy : borrow(m_proxies).get()) {
         proxy->postTaskForModeToWorkletGlobalScope([pendingTasks = pendingTasks.copyRef(), moduleURL = moduleURL.isolatedCopy(), credentials = options.credentials, pendingActivity = makePendingActivity(*this)](ScriptExecutionContext& context) mutable {
             downcast<WorkletGlobalScope>(context).fetchAndInvokeScript(moduleURL, credentials, [pendingTasks = WTF::move(pendingTasks), pendingActivity = WTF::move(pendingActivity)](std::optional<Exception>&& exception) mutable {
                 callOnMainThread([pendingTasks = WTF::move(pendingTasks), exception = crossThreadCopy(WTF::move(exception)), pendingActivity = WTF::move(pendingActivity)]() mutable {

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -522,7 +522,7 @@ void Buffer::takeSlowIndexValidationPath(CommandBuffer& commandBuffer, uint32_t 
         verified = verifyIndexBufferData<uint32_t>(m_buffer, firstIndex, indexCount, vertexCount, primitiveOffset);
 
     if (!verified) {
-        SUPPRESS_UNCOUNTED_ARG Vector<uint8_t> priorData = borrow(this)->getBufferContents();
+        SUPPRESS_UNCOUNTED_ARG Vector<uint8_t> priorData = borrow(*this)->getBufferContents();
 
         queue->clearBuffer(m_buffer);
         queue->finalizeBlitCommandEncoder();
@@ -558,7 +558,7 @@ void Buffer::takeSlowIndirectIndexValidationPath(CommandBuffer& commandBuffer, B
         verified = verifyIndexBufferData<uint32_t>(apiIndexBuffer.buffer(), args.indexStart, args.indexCount, minVertexCount > static_cast<int64_t>(args.baseVertex) ? minVertexCount - args.baseVertex : 0, primitiveOffset);
 
     if (!verified) {
-        SUPPRESS_UNCOUNTED_ARG Vector<uint8_t> priorData = borrow(this)->getBufferContents();
+        SUPPRESS_UNCOUNTED_ARG Vector<uint8_t> priorData = borrow(*this)->getBufferContents();
 
         queue->clearBuffer(m_buffer, indirectOffset, sizeof(MTLDrawPrimitivesIndirectArguments));
         queue->finalizeBlitCommandEncoder();
@@ -595,7 +595,7 @@ void Buffer::takeSlowIndirectValidationPath(CommandBuffer& commandBuffer, uint64
     bool verified = verifyIndirectBufferData(args, minVertexCount, minInstanceCount);
 
     if (!verified) {
-        SUPPRESS_UNCOUNTED_ARG Vector<uint8_t> priorData = borrow(this)->getBufferContents();
+        SUPPRESS_UNCOUNTED_ARG Vector<uint8_t> priorData = borrow(*this)->getBufferContents();
 
         MTLDrawPrimitivesIndirectArguments data = {
             .vertexCount = std::min(args.vertexCount, minVertexCount),

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -56,6 +56,7 @@
 #include <WebCore/NotImplemented.h>
 #include <WebCore/ResourceError.h>
 #include <WebCore/SecurityOrigin.h>
+#include <wtf/Borrow.h>
 #include <wtf/MemoryFootprint.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/UniqueRef.h>
@@ -666,7 +667,7 @@ void RemoteMediaPlayerProxy::addRemoteAudioTrackProxy(WebCore::AudioTrackPrivate
     track.setLogger(protect(m_logger), mediaPlayerLogIdentifier());
 #endif
 
-    for (auto& audioTrack : m_audioTracks) {
+    for (auto& audioTrack : borrow(m_audioTracks).get()) {
         if (audioTrack.get() == track)
             return;
         if (audioTrack->id() == track.id()) {
@@ -680,7 +681,7 @@ void RemoteMediaPlayerProxy::addRemoteAudioTrackProxy(WebCore::AudioTrackPrivate
 
 void RemoteMediaPlayerProxy::audioTrackSetEnabled(TrackID trackId, bool enabled)
 {
-    for (auto& track : m_audioTracks) {
+    for (Ref track : borrow(m_audioTracks).get()) {
         if (track->id() == trackId) {
             track->setEnabled(enabled);
             return;
@@ -699,7 +700,7 @@ void RemoteMediaPlayerProxy::addRemoteVideoTrackProxy(WebCore::VideoTrackPrivate
     track.setLogger(protect(m_logger), mediaPlayerLogIdentifier());
 #endif
 
-    for (auto& videoTrack : m_videoTracks) {
+    for (auto& videoTrack : borrow(m_videoTracks).get()) {
         if (videoTrack.get() == track)
             return;
         if (videoTrack->id() == track.id()) {
@@ -713,7 +714,7 @@ void RemoteMediaPlayerProxy::addRemoteVideoTrackProxy(WebCore::VideoTrackPrivate
 
 void RemoteMediaPlayerProxy::videoTrackSetSelected(TrackID trackId, bool selected)
 {
-    for (auto& track : m_videoTracks) {
+    for (Ref track : borrow(m_videoTracks).get()) {
         if (track->id() == trackId) {
             track->setSelected(selected);
             return;
@@ -732,7 +733,7 @@ void RemoteMediaPlayerProxy::addRemoteTextTrackProxy(WebCore::InbandTextTrackPri
     track.setLogger(protect(m_logger), mediaPlayerLogIdentifier());
 #endif
 
-    for (auto& textTrack : m_textTracks) {
+    for (auto& textTrack : borrow(m_textTracks).get()) {
         if (textTrack.get() == track)
             return;
         if (textTrack->id() == track.id()) {
@@ -746,7 +747,7 @@ void RemoteMediaPlayerProxy::addRemoteTextTrackProxy(WebCore::InbandTextTrackPri
 
 void RemoteMediaPlayerProxy::textTrackSetMode(TrackID trackId, WebCore::InbandTextTrackPrivate::Mode mode)
 {
-    for (auto& track : m_textTracks) {
+    for (Ref track : borrow(m_textTracks).get()) {
         if (track->id() == trackId) {
             track->setMode(mode);
             return;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
@@ -37,6 +37,7 @@
 #include <WebCore/ContentType.h>
 #include <WebCore/NotImplemented.h>
 #include <WebCore/SourceBufferPrivate.h>
+#include <wtf/Borrow.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -65,7 +66,7 @@ RemoteMediaSourceProxy::~RemoteMediaSourceProxy()
 void RemoteMediaSourceProxy::setMediaPlayers(RemoteMediaPlayerProxy& remoteMediaPlayerProxy, WebCore::MediaPlayerPrivateInterface* mediaPlayerPrivate)
 {
     m_remoteMediaPlayerProxy = remoteMediaPlayerProxy;
-    for (auto& sourceBuffer : m_sourceBuffers)
+    for (RefPtr sourceBuffer : borrow(m_sourceBuffers).get())
         sourceBuffer->setMediaPlayer(remoteMediaPlayerProxy);
     if (RefPtr protectedPrivate = m_private)
         protectedPrivate->setPlayer(mediaPlayerPrivate);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -93,6 +93,7 @@
 #include <WebCore/SecurityOriginData.h>
 #include <WebCore/SecurityPolicy.h>
 #include <optional>
+#include <wtf/Borrow.h>
 #include <wtf/HashSet.h>
 #include <wtf/LogInitialization.h>
 
@@ -1488,7 +1489,7 @@ void NetworkConnectionToWebProcess::stopTrackingResourceLoad(WebCore::ResourceLo
 
 void NetworkConnectionToWebProcess::stopAllNetworkActivityTracking()
 {
-    for (auto& activityTracker : m_networkActivityTrackers)
+    for (auto& activityTracker : borrow(m_networkActivityTrackers).get())
         activityTracker.networkActivity.complete(NetworkActivityTracker::CompletionCode::Cancel);
 
     m_networkActivityTrackers.clear();
@@ -1497,7 +1498,7 @@ void NetworkConnectionToWebProcess::stopAllNetworkActivityTracking()
 
 void NetworkConnectionToWebProcess::stopAllNetworkActivityTrackingForPage(PageIdentifier pageID, NetworkActivityTracker::CompletionCode rootCompletionCode)
 {
-    for (auto& activityTracker : m_networkActivityTrackers) {
+    for (auto& activityTracker : borrow(m_networkActivityTrackers).get()) {
         if (activityTracker.pageID == pageID) {
             auto code = activityTracker.isRootActivity ? rootCompletionCode : NetworkActivityTracker::CompletionCode::Cancel;
             activityTracker.networkActivity.complete(code);

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -47,6 +47,7 @@
 #include <WebCore/ResourceError.h>
 #include <WebCore/ResourceResponse.h>
 #include <WebCore/SharedBuffer.h>
+#include <wtf/Borrow.h>
 #include <wtf/RunLoop.h>
 
 namespace WebKit {
@@ -80,7 +81,7 @@ NetworkDataTaskBlob::NetworkDataTaskBlob(NetworkSession& session, NetworkDataTas
     , m_fileReferences(fileReferences)
     , m_networkProcess(session.networkProcess())
 {
-    for (auto& fileReference : m_fileReferences)
+    for (Ref fileReference : borrow(m_fileReferences).get())
         fileReference->prepareForFileAccess();
 
     LOG(NetworkSession, "%p - Created NetworkDataTaskBlob for %s", this, request.url().string().utf8().data());
@@ -88,7 +89,7 @@ NetworkDataTaskBlob::NetworkDataTaskBlob(NetworkSession& session, NetworkDataTas
 
 NetworkDataTaskBlob::~NetworkDataTaskBlob()
 {
-    for (auto& fileReference : m_fileReferences)
+    for (Ref fileReference : borrow(m_fileReferences).get())
         fileReference->revokeFileAccess();
 
     clearStream();

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -80,6 +80,7 @@
 #include <WebCore/ShareableResource.h>
 #include <WebCore/SharedBuffer.h>
 #include <WebCore/ViolationReportType.h>
+#include <wtf/Borrow.h>
 #include <wtf/CallbackAggregator.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/Expected.h>
@@ -1834,7 +1835,7 @@ void NetworkResourceLoader::consumeSandboxExtensions()
         }
     }
 
-    for (auto& fileReference : m_fileReferences)
+    for (Ref fileReference : borrow(m_fileReferences).get())
         fileReference->prepareForFileAccess();
 
     m_didConsumeSandboxExtensions = true;
@@ -1846,7 +1847,7 @@ void NetworkResourceLoader::invalidateSandboxExtensions()
         for (auto extension : std::exchange(m_extensionsToRevoke, { }))
             extension->revoke();
 
-        for (auto& fileReference : m_fileReferences)
+        for (Ref fileReference : borrow(m_fileReferences).get())
             fileReference->revokeFileAccess();
 
         m_didConsumeSandboxExtensions = false;

--- a/Source/WebKit/NetworkProcess/PingLoad.cpp
+++ b/Source/WebKit/NetworkProcess/PingLoad.cpp
@@ -34,6 +34,7 @@
 #include "NetworkProcess.h"
 #include "NetworkSchemeRegistry.h"
 #include "WebErrors.h"
+#include <wtf/Borrow.h>
 
 #define PING_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - PingLoad::" fmt, this, ##__VA_ARGS__)
 
@@ -59,7 +60,7 @@ PingLoad::PingLoad(NetworkConnectionToWebProcess& connection, NetworkResourceLoa
     , m_networkLoadChecker(NetworkLoadChecker::create(connection.networkProcess(), nullptr,  &connection.schemeRegistry(), FetchOptions { m_parameters.options }, m_sessionID, m_parameters.webPageProxyID, WTF::move(m_parameters.originalRequestHeaders), URL { m_parameters.request.url() }, URL { m_parameters.documentURL }, m_parameters.sourceOrigin.copyRef(), m_parameters.topOrigin.copyRef(), m_parameters.parentOrigin(), m_parameters.preflightPolicy, m_parameters.request.httpReferrer(), m_parameters.allowPrivacyProxy, m_parameters.advancedPrivacyProtections))
     , m_blobFiles(connection.resolveBlobReferences(m_parameters))
 {
-    for (auto& file : m_blobFiles)
+    for (Ref file : borrow(m_blobFiles).get())
         file->prepareForFileAccess();
 
     initialize(Ref { connection.networkProcess() });
@@ -106,7 +107,7 @@ PingLoad::~PingLoad()
         task->clearClient();
         task->cancel();
     }
-    for (auto& file : m_blobFiles)
+    for (Ref file : borrow(m_blobFiles).get())
         file->revokeFileAccess();
 }
 

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
@@ -27,6 +27,7 @@
 #include "WebSocketTaskCurl.h"
 
 #include "NetworkProcess.h"
+#include <wtf/Borrow.h>
 #include "NetworkSessionCurl.h"
 #include "NetworkSocketChannel.h"
 #include <WebCore/AuthenticationChallenge.h>
@@ -358,7 +359,7 @@ std::optional<String> WebSocketTask::receiveFrames(Function<void(WebCore::WebSoc
             m_continuousFrameData.append(frame.payload);
 
             if (frame.final) {
-                callback(m_continuousFrameOpCode, m_continuousFrameData.span());
+                callback(m_continuousFrameOpCode, borrow(m_continuousFrameData)->span());
                 m_hasContinuousFrame = false;
                 m_continuousFrameData.clear();
             }

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -30,6 +30,7 @@
 #include "CacheStorageRegistry.h"
 #include <WebCore/ClientOrigin.h>
 #include <WebCore/StorageUtilities.h>
+#include <wtf/Borrow.h>
 #include <wtf/CallbackAggregator.h>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -266,7 +267,7 @@ void CacheStorageManager::reset()
         request.second(false);
     }
 
-    for (Ref cache : m_caches)
+    for (Ref cache : borrow(m_caches).get())
         m_registry->unregisterCache(cache->identifier());
     m_caches.clear();
 
@@ -352,7 +353,7 @@ void CacheStorageManager::allCaches(uint64_t updateCounter, WebCore::DOMCacheEng
     auto callbackAggregator = CallbackAggregator::create([callback = WTF::move(callback), cacheInfos = WTF::move(cacheInfos), updateCounter = m_updateCounter]() mutable {
         callback(WebCore::DOMCacheEngine::CacheInfos { WTF::move(cacheInfos), updateCounter });
     });
-    for (Ref cache : m_caches)
+    for (Ref cache : borrow(m_caches).get())
         cache->open([callbackAggregator](auto) { });
 }
 
@@ -393,13 +394,14 @@ void CacheStorageManager::requestSpaceAfterInitializingSize(uint64_t spaceReques
         return;
 
     m_pendingSize = { 0, { } };
-    for (auto& cache : m_caches)
+    auto caches = borrow(m_caches);
+    for (Ref cache : caches.get())
         m_pendingSize.second.add(cache->identifier());
 
     for (auto& identifier : m_removedCaches.keys())
         m_pendingSize.second.add(identifier);
 
-    for (Ref cache : m_caches)
+    for (Ref cache : caches.get())
         initializeCacheSize(cache);
 
     for (Ref cache : m_removedCaches.values())
@@ -496,7 +498,7 @@ void CacheStorageManager::removeUnusedCache(WebCore::DOMCacheIdentifier cacheIde
         return;
     }
 
-    for (Ref cache : m_caches) {
+    for (Ref cache : borrow(m_caches).get()) {
         if (cache->identifier() == cacheIdentifier) {
             cache->close();
             return;
@@ -524,7 +526,7 @@ String CacheStorageManager::representationString()
     builder.append("{ \"persistent\": ["_s);
 
     bool isFirst = true;
-    for (auto& cache : m_caches) {
+    for (Ref cache : borrow(m_caches).get()) {
         if (!isFirst)
             builder.append(", "_s);
         isFirst = false;

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -35,6 +35,7 @@
 #include "WorkQueueMessageReceiver.h"
 #include <memory>
 #include <wtf/ArgumentCoder.h>
+#include <wtf/Borrow.h>
 #include <wtf/HashCountedSet.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
@@ -595,7 +596,7 @@ Error Connection::sendMessageImpl(UniqueRef<Encoder>&& encoder, OptionSet<SendOp
 #if ENABLE(IPC_TESTING_API)
     if (isMainRunLoop()) {
         bool hasDeadObservers = false;
-        for (auto& observerWeakPtr : m_messageObservers) {
+        for (WeakPtr observerWeakPtr : borrow(m_messageObservers).get()) {
             if (RefPtr observer = observerWeakPtr.get())
                 observer->willSendMessage(encoder.get(), sendOptions);
             else
@@ -1406,7 +1407,7 @@ void Connection::dispatchMessage(Decoder& decoder)
 #if ENABLE(IPC_TESTING_API)
     if (isMainRunLoop()) {
         bool hasDeadObservers = false;
-        for (auto& observerWeakPtr : m_messageObservers) {
+        for (WeakPtr observerWeakPtr : borrow(m_messageObservers).get()) {
             if (RefPtr observer = observerWeakPtr.get())
                 observer->didReceiveMessage(decoder);
             else

--- a/Source/WebKit/Platform/IPC/glib/ConnectionGLib.cpp
+++ b/Source/WebKit/Platform/IPC/glib/ConnectionGLib.cpp
@@ -34,6 +34,7 @@
 #include <gio/gunixconnection.h>
 #include <gio/gunixfdmessage.h>
 #include <sys/socket.h>
+#include <wtf/Borrow.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/UniStdExtras.h>
@@ -134,7 +135,8 @@ std::unique_ptr<Decoder> Connection::createMessageDecoder()
         return nullptr;
     }
 
-    auto messageData = m_readBuffer.mutableSpan();
+    Borrow readBuffer = m_readBuffer;
+    auto messageData = readBuffer->mutableSpan();
     auto& messageInfo = consumeAndReinterpretCastTo<MessageInfo>(messageData);
     if (messageInfo.attachmentCount() > s_attachmentMaxAmount || (!messageInfo.isBodyOutOfLine() && messageInfo.bodySize() > s_messageMaxSize)) {
         ASSERT_NOT_REACHED();

--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
@@ -38,6 +38,7 @@
 #include <fcntl.h>
 #include <poll.h>
 #include <wtf/Assertions.h>
+#include <wtf/Borrow.h>
 #include <wtf/MallocSpan.h>
 #include <wtf/SafeStrerror.h>
 #include <wtf/StdLibExtras.h>
@@ -127,7 +128,8 @@ bool Connection::processMessage()
     if (m_readBuffer.size() < sizeof(MessageInfo))
         return false;
 
-    auto messageData = m_readBuffer.mutableSpan();
+    Borrow readBuffer = m_readBuffer;
+    auto messageData = readBuffer->mutableSpan();
     MessageInfo messageInfo;
     memcpySpan(asMutableByteSpan(messageInfo), consumeSpan(messageData, sizeof(messageInfo)));
 

--- a/Source/WebKit/Shared/SharedStringHashStore.cpp
+++ b/Source/WebKit/Shared/SharedStringHashStore.cpp
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <ranges>
+#include <wtf/Borrow.h>
 #include <wtf/MathExtras.h>
 #include <wtf/PageBlock.h>
 #include <wtf/StdLibExtras.h>
@@ -134,7 +135,7 @@ void SharedStringHashStore::resizeTable(unsigned newTableLength)
         }
     }
 
-    for (auto& operation : m_pendingOperations) {
+    for (auto& operation : borrow(m_pendingOperations).get()) {
         switch (operation.type) {
         case Operation::Add:
             if (m_table.add(operation.sharedStringHash))
@@ -169,7 +170,7 @@ void SharedStringHashStore::processPendingOperations()
     Vector<SharedStringHash> removedSharedStringHashes;
     addedSharedStringHashes.reserveInitialCapacity(approximateNewHashCount);
     removedSharedStringHashes.reserveInitialCapacity(m_pendingOperations.size() - approximateNewHashCount);
-    for (auto& operation : m_pendingOperations) {
+    for (auto& operation : borrow(m_pendingOperations).get()) {
         switch (operation.type) {
         case Operation::Add:
             if (m_table.add(operation.sharedStringHash)) {

--- a/Source/WebKit/UIProcess/API/C/WKContext.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKContext.cpp
@@ -48,6 +48,7 @@
 #include "WebPageProxy.h"
 #include "WebProcessPool.h"
 #include <WebCore/GamepadProvider.h>
+#include <wtf/Borrow.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
@@ -165,7 +166,7 @@ void WKContextSetHistoryClient(WKContextRef contextRef, const WKContextHistoryCl
 
     bool addsVisitedLinks = processPool->historyClient().addsVisitedLinks();
 
-    for (Ref process : processPool->processes()) {
+    for (Ref process : borrow(processPool->processes()).get()) {
         for (Ref page : process->pages())
             page->setAddsVisitedLinks(addsVisitedLinks);
     }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -59,6 +59,7 @@
 #import <WebCore/WebCoreObjCExtras.h>
 #import <pal/spi/cf/CFNetworkSPI.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/Borrow.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
@@ -430,7 +431,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (BOOL)_requestWebProcessTermination:(pid_t)pid
 {
-    for (Ref process : _processPool->processes()) {
+    for (Ref process : borrow(_processPool->processes()).get()) {
         if (process->processID() == pid)
             process->requestTermination(WebKit::ProcessTerminationReason::RequestedByClient);
         return YES;
@@ -440,7 +441,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (BOOL)_isWebProcessSuspended:(pid_t)pid
 {
-    for (Ref process : _processPool->processes()) {
+    for (Ref process : borrow(_processPool->processes()).get()) {
         if (process->processID() == pid)
             return process->throttler().isSuspended();
     }
@@ -454,7 +455,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (BOOL)_hasPrewarmedWebProcess
 {
-    for (Ref process : _processPool->processes()) {
+    for (Ref process : borrow(_processPool->processes()).get()) {
         if (process->isPrewarmed())
             return YES;
     }
@@ -464,7 +465,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 - (size_t)_webProcessCountIgnoringPrewarmed
 {
     size_t count = 0;
-    for (auto process : _processPool->processes()) {
+    for (auto process : borrow(_processPool->processes()).get()) {
         if (!process->isPrewarmed())
             ++count;
     }
@@ -474,7 +475,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 - (size_t)_webProcessCountIgnoringPrewarmedAndCached
 {
     size_t count = 0;
-    for (Ref process : _processPool->processes()) {
+    for (Ref process : borrow(_processPool->processes()).get()) {
         if (!process->isInProcessCache() && !process->isPrewarmed())
             ++count;
     }
@@ -719,7 +720,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     RetainPtr result = adoptNS([NSMutableArray new]);
 
     for (auto& webProcessPool : WebKit::WebProcessPool::allProcessPools()) {
-        for (auto& webProcess : webProcessPool->processes()) {
+        for (Ref webProcess : borrow(webProcessPool->processes()).get()) {
             if (auto taskInfo = webProcess->taskInfo())
                 [result addObject:adoptNS([[_WKWebContentProcessInfo alloc] initWithTaskInfo:*taskInfo process:webProcess.get()]).get()];
         }

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
@@ -62,6 +62,7 @@
 #include <libintl.h>
 #include <memory>
 #include <pal/HysteresisActivity.h>
+#include <wtf/Borrow.h>
 #include <wtf/DateMath.h>
 #include <wtf/FileSystem.h>
 #include <wtf/HashMap.h>
@@ -1938,7 +1939,7 @@ void webkit_web_context_send_message_to_all_extensions(WebKitWebContext* context
 
     // We sink the reference in case of being floating.
     GRefPtr<WebKitUserMessage> adoptedMessage = message;
-    for (Ref process : context->priv->processPool->processes())
+    for (Ref process : borrow(context->priv->processPool->processes()).get())
         process->send(Messages::WebProcess::SendMessageToWebProcessExtension(webkitUserMessageGetMessage(message)), 0);
 }
 

--- a/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
@@ -41,6 +41,7 @@
 #include "WebProcessPool.h"
 #include <JavaScriptCore/MathCommon.h>
 #include <limits>
+#include <wtf/Borrow.h>
 #include <wtf/Ref.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
@@ -233,7 +234,7 @@ void BidiBrowsingContextAgent::getTree(const BrowsingContext& optionalRoot, std:
     Vector<Ref<WebPageProxy>> pagesToProcess;
 
     RefPtr processPool = session->processPool();
-    for (Ref process : processPool->processes()) {
+    for (Ref process : borrow(processPool->processes()).get()) {
         for (Ref page : process->pages()) {
             if (!page->isControlledByAutomation())
                 continue;

--- a/Source/WebKit/UIProcess/Automation/BidiPermissionsAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiPermissionsAgent.cpp
@@ -37,6 +37,7 @@
 #include "WebPageProxy.h"
 #include "WebProcessPool.h"
 #include <WebCore/RegistrableDomain.h>
+#include <wtf/Borrow.h>
 #include <wtf/CallbackAggregator.h>
 
 namespace WebKit {
@@ -57,7 +58,7 @@ static Vector<Ref<WebPageProxy>> allPageProxiesFor(const WebAutomationSession& s
 {
     Vector<Ref<WebPageProxy>> pages;
     RefPtr processPool = session.processPool();
-    for (Ref process : processPool->processes()) {
+    for (Ref process : borrow(processPool->processes()).get()) {
         for (Ref page : process->pages()) {
             if (!page->isControlledByAutomation())
                 continue;

--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
@@ -45,6 +45,7 @@
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/SecurityOriginData.h>
 #include <algorithm>
+#include <wtf/Borrow.h>
 #include <wtf/CallbackAggregator.h>
 #include <wtf/ProcessID.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -566,7 +567,7 @@ void BidiScriptAgent::getRealms(const BrowsingContext& optionalBrowsingContext, 
     else {
         // Enumerate all controlled pages; filtering by context happens during collection.
         RefPtr processPool = session->processPool();
-        for (Ref process : processPool->processes()) {
+        for (Ref process : borrow(processPool->processes()).get()) {
             for (Ref page : process->pages()) {
                 if (page->isControlledByAutomation())
                     pagesToProcess.append(page);
@@ -864,7 +865,7 @@ std::optional<String> BidiScriptAgent::contextHandleForFrame(const FrameInfoData
 
     if (frameInfo.webPageProxyID) {
         RefPtr processPool = session->processPool();
-        for (Ref process : processPool->processes()) {
+        for (Ref process : borrow(processPool->processes()).get()) {
             for (Ref page : process->pages()) {
                 if (page->identifier() == *frameInfo.webPageProxyID)
                     return session->handleForWebPageProxy(page);

--- a/Source/WebKit/UIProcess/Automation/BidiUserContext.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiUserContext.cpp
@@ -31,6 +31,7 @@
 #include "WebPageProxy.h"
 #include "WebProcessPool.h"
 #include "WebsiteDataStore.h"
+#include <wtf/Borrow.h>
 #include <wtf/Vector.h>
 
 namespace WebKit {
@@ -55,7 +56,7 @@ BidiUserContext::~BidiUserContext() = default;
 Vector<Ref<WebPageProxy>> BidiUserContext::allPages() const
 {
     Vector<Ref<WebPageProxy>> pages;
-    for (Ref process : m_processPool->processes()) {
+    for (Ref process : borrow(m_processPool->processes()).get()) {
         for (Ref page : process->pages()) {
             if (page->websiteDataStore() == m_dataStore.get())
                 pages.append(WTF::move(page));

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -52,6 +52,7 @@
 #include <WebCore/MIMETypeRegistry.h>
 #include <WebCore/PointerEventTypeNames.h>
 #include <algorithm>
+#include <wtf/Borrow.h>
 #include <wtf/CallbackAggregator.h>
 #include <wtf/FileSystem.h>
 #include <wtf/HashMap.h>
@@ -436,7 +437,7 @@ void WebAutomationSession::getBrowsingContexts(CommandCallback<Ref<JSON::ArrayOf
 {
     Ref processPool = *m_processPool;
     Vector<Ref<WebPageProxy>> pages;
-    for (Ref process : processPool->processes()) {
+    for (Ref process : borrow(processPool->processes()).get()) {
         for (Ref page : process->pages()) {
             if (!page->isControlledByAutomation())
                 continue;

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -83,6 +83,7 @@
 #import <pal/system/ios/UserInterfaceIdiom.h>
 #import <sys/param.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/Borrow.h>
 #import <wtf/CallbackAggregator.h>
 #import <wtf/FileSystem.h>
 #import <wtf/ProcessPrivilege.h>
@@ -304,7 +305,7 @@ void WebProcessPool::setMediaAccessibilityPreferences(WebProcessProxy& process)
 
 static void logProcessPoolState(const WebProcessPool& pool)
 {
-    for (Ref process : pool.processes()) {
+    for (Ref process : borrow(pool.processes()).get()) {
         WTF::TextStream processDescription;
         processDescription << process;
 
@@ -719,7 +720,7 @@ void WebProcessPool::hardwareKeyboardAvailabilityChangedCallback(CFNotificationC
 
 void WebProcessPool::hardwareKeyboardAvailabilityChanged()
 {
-    for (Ref process : processes()) {
+    for (Ref process : borrow(this->processes()).get()) {
         auto pages = process->pages();
         for (auto& page : pages)
             page->hardwareKeyboardAvailabilityChanged(cachedHardwareKeyboardState());

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -49,6 +49,7 @@
 #import "WebUserContentControllerProxy.h"
 #import "_WKFrameHandle.h"
 #import "_WKFrameTreeNode.h"
+#import <wtf/Borrow.h>
 #import <wtf/CallbackAggregator.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/URL.h>
@@ -195,7 +196,7 @@ void removeStyleSheets(const SourcePairs& styleSheetPairs, WKWebView *webView,  
     auto& dynamicallyInjectedUserStyleSheets = context.dynamicallyInjectedUserStyleSheets();
 
     for (auto& styleSheetContent : styleSheetPairs) {
-        for (auto& userStyleSheet : dynamicallyInjectedUserStyleSheets) {
+        for (Ref userStyleSheet : borrow(dynamicallyInjectedUserStyleSheets).get()) {
             if (userStyleSheetMatchesContent(userStyleSheet, styleSheetContent, injectedFrames)) {
                 styleSheetsToRemove.append(userStyleSheet);
                 Ref controller = webView._page.get()->userContentController();

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -83,6 +83,7 @@
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/ResourceError.h>
 #include <WebCore/ShouldRelaxThirdPartyCookieBlocking.h>
+#include <wtf/Borrow.h>
 #include <wtf/CallbackAggregator.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/MainThread.h>

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm
@@ -35,6 +35,7 @@
 #import "WebProcessPool.h"
 #import "WebProcessProxy.h"
 #import "XPCEndpoint.h"
+#import <wtf/Borrow.h>
 #import <wtf/EnumTraits.h>
 #import <wtf/RuntimeApplicationChecks.h>
 #import <wtf/darwin/XPCExtras.h>
@@ -74,7 +75,7 @@ bool NetworkProcessProxy::XPCEventHandler::handleXPCEvent(xpc_object_t event)
     if (messageName == LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseXPCEndpointMessageName) {
         networkProcess->m_endpointMessage = event;
         for (auto& processPool : WebProcessPool::allProcessPools()) {
-            for (Ref process : processPool->processes())
+            for (Ref process : borrow(processPool->processes()).get())
                 networkProcess->sendXPCEndpointToProcess(process);
         }
 #if ENABLE(GPU_PROCESS)

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -40,6 +40,7 @@
 #include "WebPageProxy.h"
 #include <WebCore/DiagnosticLoggingClient.h>
 #include <WebCore/DiagnosticLoggingKeys.h>
+#include <wtf/Borrow.h>
 #include <wtf/DebugUtilities.h>
 #include <wtf/HexNumber.h>
 #include <wtf/text/StringBuilder.h>
@@ -438,8 +439,9 @@ BackForwardListState WebBackForwardList::backForwardListState(WTF::Function<bool
     if (m_currentIndex)
         backForwardListState.currentIndex = *m_currentIndex;
 
-    for (size_t i = 0; i < m_entries.size(); ++i) {
-        auto& entry = m_entries[i];
+    Borrow entries = m_entries;
+    for (size_t i = 0; i < entries->size(); ++i) {
+        auto& entry = entries.get()[i];
 
         if (filter && !filter(entry)) {
             auto& currentIndex = backForwardListState.currentIndex;

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -113,6 +113,7 @@
 #include <WebCore/Site.h>
 #include <algorithm>
 #include <pal/SessionID.h>
+#include <wtf/Borrow.h>
 #include <wtf/CallbackAggregator.h>
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/MainThread.h>
@@ -2505,7 +2506,7 @@ void WebProcessPool::setDomainsWithCrossPageStorageAccess(HashMap<TopFrameDomain
 {    
     Ref callbackAggregator = CallbackAggregator::create(WTF::move(completionHandler));
 
-    for (Ref process : processes())
+    for (Ref process : borrow(this->processes()).get())
         process->sendWithAsyncReply(Messages::WebProcess::SetDomainsWithCrossPageStorageAccess(domains), [callbackAggregator] { });
 
     for (auto& topDomain : domains.keys())
@@ -2516,7 +2517,7 @@ void WebProcessPool::seedResourceLoadStatisticsForTesting(const RegistrableDomai
 {
     Ref callbackAggregator = CallbackAggregator::create(WTF::move(completionHandler));
 
-    for (Ref process : processes())
+    for (Ref process : borrow(this->processes()).get())
         process->sendWithAsyncReply(Messages::WebProcess::SeedResourceLoadStatisticsForTesting(firstPartyDomain, thirdPartyDomain, shouldScheduleNotification), [callbackAggregator] { });
 }
 
@@ -2524,7 +2525,7 @@ void WebProcessPool::sendResourceLoadStatisticsDataImmediately(CompletionHandler
 {
     auto callbackAggregator = CallbackAggregator::create(WTF::move(completionHandler));
 
-    for (Ref process : processes()) {
+    for (Ref process : borrow(this->processes()).get()) {
         // WebProcess already flushes outstanding stats to NetworkProcess on suspend, so there's no
         // need to resume a suspended process to force another flush.
         if (!process->pageCount() || process->throttler().isSuspended())
@@ -2880,7 +2881,7 @@ void WebProcessPool::memoryPressureStatusChangedForProcess(WebProcessProxy& proc
 void WebProcessPool::updateWebProcessSuspensionDelay()
 {
     WeakHashSet<WebProcessProxy> remainingProcesses;
-    for (Ref process : processes()) {
+    for (Ref process : borrow(processes()).get()) {
         if (process->throttler().isSuspended()) {
             process->updateWebProcessSuspensionDelay();
             continue;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -74,6 +74,7 @@
 #include <WebCore/StorageUtilities.h>
 #include <WebCore/WebLockRegistry.h>
 #include <algorithm>
+#include <wtf/Borrow.h>
 #include <wtf/CallbackAggregator.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
@@ -880,7 +881,7 @@ HashSet<WebCore::ProcessIdentifier> WebsiteDataStore::activeWebProcesses() const
     HashSet<WebCore::ProcessIdentifier> identifiers;
     // m_processes does not include worker processes now, so we iterate all processes.
     for (Ref processPool : WebProcessPool::allProcessPools()) {
-        for (Ref process : processPool->processes()) {
+        for (Ref process : borrow(processPool->processes()).get()) {
             if (process->isPrewarmed() || process->websiteDataStore() != this)
                 continue;
 

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
@@ -38,6 +38,7 @@
 #endif
 #include "relative-pointer-unstable-v1-client-protocol.h"
 #include <gio/gio.h>
+#include <wtf/Borrow.h>
 #include <wtf/Deque.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/MonotonicTime.h>
@@ -443,7 +444,7 @@ PresentationFeedbackStatistics::PresentationFeedbackStatistics(unsigned historyS
 
 PresentationFeedbackStatistics::~PresentationFeedbackStatistics()
 {
-    for (auto [presentationFeedback, frameStartTime] : m_pendingFeedbacks)
+    for (auto [presentationFeedback, frameStartTime] : borrow(m_pendingFeedbacks).get())
         wp_presentation_feedback_destroy(presentationFeedback);
 }
 

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
@@ -47,6 +47,7 @@
 #include <WebCore/PageInspectorController.h>
 #include <WebCore/ScriptController.h>
 #include <WebCore/WindowFeatures.h>
+#include <wtf/Borrow.h>
 
 static const float minimumAttachedHeight = 250;
 static const float maximumAttachedHeightRatio = 0.75;
@@ -95,7 +96,7 @@ void WebInspectorBackend::setFrontendConnection(IPC::Connection::Handle&& connec
     m_frontendConnection = frontendConnection.copyRef();
     frontendConnection->open(*this);
 
-    for (auto& callback : m_frontendConnectionActions)
+    for (auto& callback : borrow(m_frontendConnectionActions).get())
         callback(frontendConnection.get());
     m_frontendConnectionActions.clear();
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -35,6 +35,7 @@
 #import <WebCore/NetscapePlugInStreamLoader.h>
 #import <WebCore/SharedBuffer.h>
 #import <pal/spi/cg/CoreGraphicsSPI.h>
+#import <wtf/Borrow.h>
 #import <wtf/CallbackAggregator.h>
 #import <wtf/Identified.h>
 #import <wtf/ObjectIdentifier.h>
@@ -112,7 +113,8 @@ void ByteRangeRequest::completeWithAccumulatedData(PDFIncrementalLoader& loader)
 {
     ASSERT(isMainRunLoop());
 
-    auto data = m_accumulatedData.span();
+    Borrow accumulatedData = m_accumulatedData;
+    auto data = accumulatedData->span();
     if (data.size() > m_count) {
         RELEASE_LOG_ERROR(IncrementalPDF, "PDF byte range request got more bytes back from the server than requested. This is likely due to a misconfigured server. Capping result at the requested number of bytes.");
         data = data.first(m_count);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -352,6 +352,7 @@
 #include <algorithm>
 #include <pal/SessionID.h>
 #include <ranges>
+#include <wtf/Borrow.h>
 #include <wtf/CoroutineUtilities.h>
 #include <wtf/ProcessID.h>
 #include <wtf/RunLoop.h>
@@ -7776,7 +7777,7 @@ void WebPage::didCommitLoad(WebFrame* frame)
     unfreezeLayerTree(LayerTreeFreezeReason::ProcessSwap);
 
 #if ENABLE(IMAGE_ANALYSIS)
-    for (auto& [element, completionHandlers] : m_elementsPendingTextRecognition) {
+    for (auto& [element, completionHandlers] : borrow(m_elementsPendingTextRecognition).get()) {
         for (auto& completionHandler : completionHandlers)
             completionHandler({ });
     }

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -66,6 +66,7 @@
 #import <WebCore/TiledBacking.h>
 #import <WebCore/WebActionDisablingCALayerDelegate.h>
 #import <WebCore/WindowEventLoop.h>
+#import <wtf/Borrow.h>
 #import <wtf/MachSendRight.h>
 #import <wtf/MainThread.h>
 #import <wtf/MonotonicTime.h>
@@ -107,7 +108,7 @@ TiledCoreAnimationDrawingArea::~TiledCoreAnimationDrawingArea()
 {
     invalidateRenderingUpdateRunLoopObserver();
     invalidatePostRenderingUpdateRunLoopObserver();
-    for (auto& callback : m_nextActivityStateChangeCallbacks)
+    for (auto& callback : borrow(m_nextActivityStateChangeCallbacks).get())
         callback();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
@@ -46,6 +46,7 @@
 #include <WebCore/LocalFrameView.h>
 #include <WebCore/Page.h>
 #include <WebCore/Settings.h>
+#include <wtf/Borrow.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebKit {
@@ -73,7 +74,7 @@ GraphicsLayerFactory* DrawingAreaWC::graphicsLayerFactory()
 
 void DrawingAreaWC::updateRootLayers()
 {
-    for (auto& rootLayer : m_rootLayers) {
+    for (auto& rootLayer : borrow(m_rootLayers).get()) {
         Vector<Ref<GraphicsLayer>> children;
         if (rootLayer.contentLayer) {
             children.append(*rootLayer.contentLayer);
@@ -256,14 +257,15 @@ void DrawingAreaWC::updateRendering()
 void DrawingAreaWC::sendUpdateAC()
 {
     bool didProcessMainFrame = false;
-    for (auto it = m_rootLayers.begin(); it != m_rootLayers.end(); it++) {
-        auto& rootLayer = *it;
+    Borrow rootLayers = m_rootLayers;
+    for (size_t i = 0; i < rootLayers->size(); i++) {
+        auto& rootLayer = rootLayers.get()[i];
         auto frame = WebProcess::singleton().webFrame(rootLayer.frameID);
         ASSERT(frame);
         m_updateInfo.remoteContextHostedIdentifier = frame->layerHostingContextIdentifier();
         m_updateInfo.rootLayer = rootLayer.layer->primaryLayerID();
 
-        bool isLastFrame = (it + 1) == m_rootLayers.end();
+        bool isLastFrame = (i + 1) == rootLayers->size();
         bool isMainFrame = frame->isMainFrame();
         didProcessMainFrame = didProcessMainFrame || isMainFrame;
         bool willCallDisplayDidRefresh = isMainFrame || (!didProcessMainFrame && isLastFrame);


### PR DESCRIPTION
#### c9d191414e48debce0079e0ac65c704d1e69e1f2
<pre>
Adopt Borrow&lt;T&gt; for Vector&lt;T&gt; in Source/WebKit and Source/WebCore (Debug ASSERT only)
<a href="https://bugs.webkit.org/show_bug.cgi?id=311697">https://bugs.webkit.org/show_bug.cgi?id=311697</a>
<a href="https://rdar.apple.com/174283122">rdar://174283122</a>

Reviewed by Ryosuke Niwa.

As dicated by a prototype SaferCPP checker for Vector&lt;T&gt; borrowing.

Documentation for Borrow&lt;T&gt;: <a href="https://github.com/WebKit/WebKit/wiki/SaferCPP">https://github.com/WebKit/WebKit/wiki/SaferCPP</a>:-Borrow-and-CanBorrow

* Source/WTF/wtf/Borrow.h:
(WTF::Borrow::Borrow): Removed the constructor that auto-converted pointer to
reference because the caller should decide if we have a non-null value or not.

Added an operator T&amp;() and a template deduction guide to assist adoption
without too much boilerplate code.

(WTF::Borrow::~Borrow):
(WTF::borrow): Added a #pragma to disable -Wdangling on clang &lt; 21 when a file
includes this header. This is pretty sad because -Wdangling is the whole point
of this work. But it&apos;s just broken and I can&apos;t think of any reasonable
workaround.

The good news is, the Apple Internal EWS bots already support clang 21, so we
do not lose EWS coverage. And the next bot upgrade cycle will upgrade all
Apple bots to clang 21.

* Source/WTF/wtf/CanBorrow.h:
(WTF::CanBorrow::~CanBorrow):
(WTF::CanBorrow::crashIfBorrowed): Downgraded to a debug assert to control
stability for now. We can upgrade after we have more experience.

(WTF::CanBorrow::setIsBorrowed const):
(WTF::CanBorrow::setIsBorrowed): Deleted. Make borrowing a const operation just
like reference counting -- the object itself isn&apos;t changing.

* Source/WTF/wtf/Vector.h:
(WTF::VectorBufferBase::setIsBorrowed const):
(WTF::VectorBufferBase::setIsBorrowed): Deleted. Same change for const.

The rest is a bunch of Borrow&lt;T&gt; where the tool though it was necessary:

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::performDeferredCacheUpdate):
* Source/WebCore/css/CSSFontFaceSet.cpp:
(WebCore::CSSFontFaceSet::~CSSFontFaceSet):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::gatherResizeObservations):
* Source/WebCore/dom/DocumentFontLoader.cpp:
(WebCore::DocumentFontLoader::stopLoadingAndClearFonts):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::finalizeAndQueueEventTimingEntries):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::mainFrameDidChangeToNonInitialEmptyDocument):
(WebCore::Page::flushHardwareKeyboardAttachmentObservers):
* Source/WebCore/page/PageOverlayController.cpp:
(WebCore::PageOverlayController::handleMouseEvent):
(WebCore::PageOverlayController::copyAccessibilityAttributeStringValueForPoint):
(WebCore::PageOverlayController::copyAccessibilityAttributeBoolValueForPoint):
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::connectConditions):
(WebCore::SVGSMILElement::disconnectConditions):
* Source/WebCore/worklets/Worklet.cpp:
(WebCore::Worklet::addModule):
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::takeSlowIndexValidationPath):
(WebGPU::Buffer::takeSlowIndirectIndexValidationPath):
(WebGPU::Buffer::takeSlowIndirectValidationPath):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::addRemoteAudioTrackProxy):
(WebKit::RemoteMediaPlayerProxy::audioTrackSetEnabled):
(WebKit::RemoteMediaPlayerProxy::addRemoteVideoTrackProxy):
(WebKit::RemoteMediaPlayerProxy::videoTrackSetSelected):
(WebKit::RemoteMediaPlayerProxy::addRemoteTextTrackProxy):
(WebKit::RemoteMediaPlayerProxy::textTrackSetMode):
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::setMediaPlayers):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::stopAllNetworkActivityTracking):
(WebKit::NetworkConnectionToWebProcess::stopAllNetworkActivityTrackingForPage):
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp:
(WebKit::NetworkDataTaskBlob::NetworkDataTaskBlob):
(WebKit::NetworkDataTaskBlob::~NetworkDataTaskBlob):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::consumeSandboxExtensions):
(WebKit::NetworkResourceLoader::invalidateSandboxExtensions):
* Source/WebKit/NetworkProcess/PingLoad.cpp:
(WebKit::m_blobFiles):
(WebKit::PingLoad::~PingLoad):
* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp:
(WebKit::WebSocketTask::receiveFrames):
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
(WebKit::CacheStorageManager::reset):
(WebKit::CacheStorageManager::allCaches):
(WebKit::CacheStorageManager::requestSpaceAfterInitializingSize):
(WebKit::CacheStorageManager::removeUnusedCache):
(WebKit::CacheStorageManager::representationString):
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::sendMessageImpl):
(IPC::Connection::dispatchMessage):
* Source/WebKit/Platform/IPC/glib/ConnectionGLib.cpp:
(IPC::Connection::createMessageDecoder):
* Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp:
(IPC::Connection::processMessage):
* Source/WebKit/Shared/SharedStringHashStore.cpp:
(WebKit::SharedStringHashStore::resizeTable):
(WebKit::SharedStringHashStore::processPendingOperations):
* Source/WebKit/UIProcess/API/C/WKContext.cpp:
(WKContextSetHistoryClient):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(-[WKProcessPool _requestWebProcessTermination:]):
(-[WKProcessPool _isWebProcessSuspended:]):
(-[WKProcessPool _hasPrewarmedWebProcess]):
(-[WKProcessPool _webProcessCountIgnoringPrewarmed]):
(-[WKProcessPool _webProcessCountIgnoringPrewarmedAndCached]):
(+[WKProcessPool _webContentProcessInfo]):
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:
* Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp:
(WebKit::BidiBrowsingContextAgent::getTree):
* Source/WebKit/UIProcess/Automation/BidiPermissionsAgent.cpp:
(WebKit::allPageProxiesFor):
* Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp:
(WebKit::BidiScriptAgent::getRealms):
(WebKit::BidiScriptAgent::contextHandleForFrame):
* Source/WebKit/UIProcess/Automation/BidiUserContext.cpp:
(WebKit::BidiUserContext::allPages const):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::getBrowsingContexts):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::logProcessPoolState):
(WebKit::WebProcessPool::hardwareKeyboardAvailabilityChanged):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::removeStyleSheets):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
* Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm:
(WebKit::NetworkProcessProxy::XPCEventHandler::handleXPCEvent):
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::backForwardListState const):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::setDomainsWithCrossPageStorageAccess):
(WebKit::WebProcessPool::seedResourceLoadStatisticsForTesting):
(WebKit::WebProcessPool::sendResourceLoadStatisticsDataImmediately):
(WebKit::WebProcessPool::updateWebProcessSuspensionDelay):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::activeWebProcesses const):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
(PresentationFeedbackStatistics::~PresentationFeedbackStatistics):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp:
(WebKit::WebInspectorBackend::setFrontendConnection):
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::ByteRangeRequest::completeWithAccumulatedData):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didCommitLoad):
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::~TiledCoreAnimationDrawingArea):
* Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp:
(WebKit::DrawingAreaWC::updateRootLayers):
(WebKit::DrawingAreaWC::sendUpdateAC):

Canonical link: <a href="https://commits.webkit.org/310949@main">https://commits.webkit.org/310949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdd56f68b8a54acf79fa5e54571cc46ffda648ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28810 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164312 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/59254ef1-5bb3-466a-9f6a-6dec2e365efa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157423 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/28954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28660 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/120387 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84973569-3607-40b0-b388-83cc0a77b99a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158509 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/28954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/139687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101077 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e1ef200a-7763-4573-bbd2-e3c105ba0f2a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/28954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12143 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/147600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/28954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/17519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166790 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16381 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/19130 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/128510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28354 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/23814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128643 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28278 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139312 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23693 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/23466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187435 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27972 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/92075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/48044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/27549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/27779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27622 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->