### PR TITLE
Defer pagehide/unload events to an asynchronous task when destroying a child navigable

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8280,4 +8280,7 @@ imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open_
 
 webkit.org/b/311207 imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared.html [ Pass Failure ]
 
+# This test has been flaky since its import.
+imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-default-style-meta-from-fragment.tentative.html [ Pass Failure ]
+
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/sizes-auto-dynamic-attributes.html [ Failure Pass ]

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-append-form-and-script-from-fragment.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-append-form-and-script-from-fragment.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS When adding a script+form in a fragment and the form matches an associated element, the script that checks whether the button is associated to the form should run after inserting the form
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-append-form-and-script-from-fragment.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-append-form-and-script-from-fragment.tentative.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Node.appendChild: inserting script and associated form</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<button id="someButton" form="someForm"></button>
+<script>
+test(() => {
+    const script = document.createElement("script");
+    const form = document.createElement("form");
+    form.id = "someForm";
+    const fragment = new DocumentFragment();
+    script.textContent = `
+        window.buttonAssociatedForm = document.querySelector("#someButton").form;
+    `;
+    fragment.append(script, form);
+    document.body.append(fragment);
+    assert_equals(window.buttonAssociatedForm, form);
+}, "When adding a script+form in a fragment and the form matches an associated element, " +
+    "the script that checks whether the button is associated to the form should run after " +
+    "inserting the form");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-append-meta-referrer-and-script-from-fragment.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-append-meta-referrer-and-script-from-fragment.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+PASS <meta name=referrer> gets processed and applied in the post-insertion steps
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-append-meta-referrer-and-script-from-fragment.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-append-meta-referrer-and-script-from-fragment.tentative.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Node.appendChild: inserting script and meta-referrer from a div</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+promise_test(async t => {
+  const preMetaScript = document.createElement("script");
+  preMetaScript.textContent = `
+    window.preMetaScriptPromise = fetch('/html/infrastructure/urls/terminology-0/resources/echo-referrer-text.py')
+      .then(response => response.text());
+  `;
+
+  const meta = document.createElement("meta");
+  meta.name = "referrer";
+  meta.content = "no-referrer";
+
+  const postMetaScript = document.createElement("script");
+  postMetaScript.textContent = `
+    window.postMetaScriptPromise = fetch('/html/infrastructure/urls/terminology-0/resources/echo-referrer-text.py')
+      .then(response => response.text());
+  `;
+
+  const fragment = new DocumentFragment();
+  fragment.append(preMetaScript, meta, postMetaScript);
+  document.head.append(fragment);
+
+  const preMetaReferrer = await window.preMetaScriptPromise;
+  assert_equals(preMetaReferrer, location.href,
+      "preMetaReferrer is the full URL; by the time the first script runs in " +
+      "its post-insertion steps, the later-inserted meta tag has not run its " +
+      "post-insertion steps, which is where meta tags are processed");
+
+  const postMetaReferrer = await window.postMetaScriptPromise;
+  assert_equals(postMetaReferrer, "",
+      "postMetaReferrer is empty; by the time the second script runs in " +
+      "its post-insertion steps, the later-inserted meta tag has run its " +
+      "post-insertion steps, and observes the meta tag's effect");
+}, "<meta name=referrer> gets processed and applied in the post-insertion " +
+   "steps");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-button-from-div.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-button-from-div.tentative-expected.txt
@@ -1,0 +1,5 @@
+
+
+FAIL Script inserted before a form-associated button can observe the button's form, because by the time the script executes, the DOM insertion that associates the button with the form is already done assert_equals: expected Element node <form id="form"><div><script>
+    buttonForm = button.for... but got null
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-button-from-div.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-button-from-div.tentative.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Node.appendChild: inserting script and button from a div</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<form id="form"></form>
+<script>
+let button = null;
+let buttonForm = null;
+test(() => {
+  const form = document.getElementById("form");
+  const script = document.createElement("script");
+  script.textContent = `
+    buttonForm = button.form;
+  `;
+  button = document.createElement("button");
+  const div = document.createElement("div");
+  div.appendChild(script);
+  div.appendChild(button);
+  assert_equals(buttonForm, null);
+  form.appendChild(div);
+  assert_equals(buttonForm, form);
+}, "Script inserted before a form-associated button can observe the button's " +
+   "form, because by the time the script executes, the DOM insertion that " +
+   "associates the button with the form is already done");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-custom-from-fragment.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-custom-from-fragment.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+PASS An earlier-inserted script can upgrade a later-inserted custom element, whose upgrading is synchronously observable to the script, since DOM insertion has been completed by the time it runs
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-custom-from-fragment.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-custom-from-fragment.tentative.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Node.appendChild: inserting script and custom element from a DocumentFragment</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script>
+let customConstructed = false;
+let customConstructedDuringEarlierScript = false;
+class CustomElement extends HTMLElement {
+    constructor() {
+        super();
+        customConstructed = true;
+    }
+}
+test(() => {
+  const script = document.createElement("script");
+  script.textContent = `
+    customElements.define("custom-element", CustomElement);
+    customConstructedDuringEarlierScript = customConstructed;
+  `;
+  const custom = document.createElement("custom-element");
+  const df = document.createDocumentFragment();
+  df.appendChild(script);
+  df.appendChild(custom);
+  assert_false(customConstructed);
+  assert_false(customConstructedDuringEarlierScript);
+  document.head.appendChild(df);
+  assert_true(customConstructed);
+  assert_true(customConstructedDuringEarlierScript);
+}, "An earlier-inserted script can upgrade a later-inserted custom element, " +
+   "whose upgrading is synchronously observable to the script, since DOM " +
+   "insertion has been completed by the time it runs");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-default-style-meta-from-fragment.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-default-style-meta-from-fragment.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Inserting <meta> that uses alternate stylesheets, applies the style during DOM post-insertion steps assert_equals: display: none; style WAS applied during DOM post-insertion steps, before later-inserted script runs expected "none" but got "block"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-default-style-meta-from-fragment.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-default-style-meta-from-fragment.tentative.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Node.appendChild: inserting script and default-style meta from a fragment</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<link rel="alternate stylesheet" title="alternative" href="data:text/css,%23div{display:none}">
+<div id="div">hello</div>
+<script>
+let scriptRan = false;
+let computedStyleInPreScript = null;
+let computedStyleInPostScript = null;
+test(() => {
+  const div = document.getElementById("div");
+
+  // 1. Gets inserted *before* the `<meta>` tag. Cannot observe the meta tag's
+  // effect, because this script runs before the meta tag's post-insertion steps
+  // run, and the meta tag's post-insertion steps is where the default style
+  // sheet actually changes.
+  const preScript = document.createElement("script");
+  preScript.textContent =  `
+    computedStyleInPreScript = getComputedStyle(div).display;
+    scriptRan = true;
+  `;
+
+  // 2. The `<meta>` tag itself.
+  const meta = document.createElement("meta");
+  meta.httpEquiv = "default-style";
+  meta.content = "alternative";
+
+  // 3. Gets inserted *after* the `<meta>` tag. Observes the meta tag's effect,
+  // because this script runs after the meta tag's post-insertion steps, which
+  // has the script-observable change to the default style sheet.
+  const postScript = document.createElement("script");
+  postScript.textContent = `
+    computedStyleInPostScript = getComputedStyle(div).display;
+    scriptRan = true;
+  `;
+
+  const df = document.createDocumentFragment();
+  df.append(preScript, meta, postScript);
+
+  assert_equals(getComputedStyle(div).display, "block",
+      "div still has block display before meta insertion");
+  assert_false(scriptRan, "script has not run before insertion");
+
+  document.head.appendChild(df);
+  assert_true(scriptRan, "script has run after insertion");
+  assert_equals(computedStyleInPreScript, "block",
+      "display: none; style was NOT applied during DOM insertion steps, " +
+      "before earlier-inserted script post-insertion steps run");
+  assert_equals(computedStyleInPostScript, "none",
+      "display: none; style WAS applied during DOM post-insertion steps, " +
+      "before later-inserted script runs");
+  assert_equals(getComputedStyle(div).display, "none",
+      "style remains display: none; after insertion");
+
+}, "Inserting <meta> that uses alternate stylesheets, applies the style " +
+   "during DOM post-insertion steps");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-div-from-fragment.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-div-from-fragment.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Earlier-inserted scripts can observe the parentNode of later-inserted nodes, because script runs after DOM insertion completes
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-div-from-fragment.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-div-from-fragment.tentative.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Node.appendChild: inserting script and div from a DocumentFragment</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script>
+let script = null;
+let scriptParent = null;
+let div = null;
+let divParent = null;
+test(() => {
+  script = document.createElement("script");
+  div = document.createElement("div");
+  script.textContent = `
+    divParent = div.parentNode;
+    scriptParent = script.parentNode;
+  `;
+  const df = document.createDocumentFragment();
+  df.appendChild(script);
+  df.appendChild(div);
+  assert_equals(divParent, null);
+  assert_equals(scriptParent, null);
+  document.head.appendChild(df);
+  assert_equals(divParent, scriptParent);
+  assert_equals(divParent, document.head);
+}, "Earlier-inserted scripts can observe the parentNode of later-inserted " +
+   "nodes, because script runs after DOM insertion completes");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-iframe.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-iframe.tentative-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Script inserted after an iframe in the same appendChild() call can observe the iframe's non-null contentWindow
+PASS A script inserted atomically before an iframe (using a div) does not observe the iframe's contentWindow, since the 'script running' and 'iframe setup' both happen in order, after DOM insertion completes
+PASS A script inserted atomically before an iframe (using a DocumentFragment) does not observe the iframe's contentWindow, since the 'script running' and 'iframe setup' both happen in order, after DOM insertion completes
+PASS A script inserted atomically before an iframe (using a append() with multiple arguments) does not observe the iframe's contentWindow, since the 'script running' and 'iframe setup' both happen in order, after DOM insertion completes
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-iframe.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-iframe.tentative.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Node.appendChild: inserting script and iframe</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script>
+
+const kScriptContent = `
+  state = iframe.contentWindow ? "iframe with content window" : "contentWindow is null";
+`;
+
+// This test ensures that a later-inserted script can observe an
+// earlier-inserted iframe's contentWindow.
+test(t => {
+  window.state = "script not run yet";
+  window.iframe = document.createElement("iframe");
+  t.add_cleanup(() => window.iframe.remove());
+
+  const script = document.createElement("script");
+  script.textContent = kScriptContent;
+
+  const div = document.createElement("div");
+  div.appendChild(iframe);
+  div.appendChild(script);
+
+  assert_equals(state, "script not run yet");
+  document.body.appendChild(div);
+  assert_equals(state, "iframe with content window");
+}, "Script inserted after an iframe in the same appendChild() call can " +
+   "observe the iframe's non-null contentWindow");
+
+// The below tests assert that an earlier-inserted script does not observe a
+// later-inserted iframe's contentWindow.
+test(t => {
+  window.state = "script not run yet";
+  window.iframe = document.createElement("iframe");
+  t.add_cleanup(() => window.iframe.remove());
+
+  const script = document.createElement("script");
+  script.textContent = kScriptContent;
+
+  const div = document.createElement("div");
+  div.appendChild(script);
+  div.appendChild(iframe);
+
+  assert_equals(state, "script not run yet");
+  document.body.appendChild(div);
+  assert_equals(state, "contentWindow is null");
+}, "A script inserted atomically before an iframe (using a div) does not " +
+   "observe the iframe's contentWindow, since the 'script running' and " +
+   "'iframe setup' both happen in order, after DOM insertion completes");
+
+test(t => {
+  window.state = "script not run yet";
+  window.iframe = document.createElement("iframe");
+  t.add_cleanup(() => window.iframe.remove());
+
+  const script = document.createElement("script");
+  script.textContent = kScriptContent;
+
+  const df = document.createDocumentFragment();
+  df.appendChild(script);
+  df.appendChild(iframe);
+
+  assert_equals(state, "script not run yet");
+  document.body.appendChild(df);
+  assert_equals(state, "contentWindow is null");
+}, "A script inserted atomically before an iframe (using a DocumentFragment) " +
+   "does not observe the iframe's contentWindow, since the 'script running' " +
+   "and 'iframe setup' both happen in order, after DOM insertion completes");
+
+test(t => {
+  window.state = "script not run yet";
+  window.iframe = document.createElement("iframe");
+  t.add_cleanup(() => window.iframe.remove());
+
+  const script = document.createElement("script");
+  script.textContent = kScriptContent;
+
+  assert_equals(state, "script not run yet");
+  document.body.append(script, iframe);
+
+  assert_equals(state, "contentWindow is null");
+}, "A script inserted atomically before an iframe (using a append() with " +
+   "multiple arguments) does not observe the iframe's contentWindow, since " +
+   "the 'script running' and 'iframe setup' both happen in order, after DOM " +
+   "insertion completes");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-source-from-fragment.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-source-from-fragment.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Empty <source> immediately sets media.networkState during DOM insertion, so that an earlier-running script can observe networkState
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-source-from-fragment.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-source-from-fragment.tentative.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Node.appendChild: inserting script and source from a fragment</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<video id="media"></video>
+<script>
+const happened = [];
+const media = document.getElementById("media");
+test(() => {
+  const source = document.createElement("source");
+  const script = document.createElement("script");
+  script.textContent = `
+    happened.push(media.networkState);
+  `;
+
+  const df = document.createDocumentFragment();
+  df.appendChild(script);
+  df.appendChild(source);
+
+  assert_array_equals(happened, []);
+  media.appendChild(df);
+  // This is because immediately during DOM insertion, before the
+  // post-insertion steps invoke script, `<source>` insertion invokes the
+  // resource selection algorithm [1] which does this assignment. This
+  // assignment takes place before earlier-inserted script elements run
+  // post-insertion.
+  //
+  // [1]: https://html.spec.whatwg.org/#concept-media-load-algorithm
+  assert_array_equals(happened, [HTMLMediaElement.NETWORK_NO_SOURCE]);
+}, "Empty <source> immediately sets media.networkState during DOM insertion, " +
+   "so that an earlier-running script can observe networkState");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-style.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-style.tentative-expected.txt
@@ -1,0 +1,7 @@
+
+PASS An earlier-inserted <script> synchronously observes a later-inserted <style> (via a div) being applied
+PASS An earlier-inserted <script> synchronously observes a later-inserted <style> (via a DocumentFragment) being applied
+FAIL Earlier-inserted <script> (via a DocumentFragment) synchronously observes a later-inserted <link rel=stylesheet>'s CSSStyleSheet creation assert_array_equals: expected property 0 to be "sheet" but got null (expected array ["sheet"] got [null])
+FAIL Earlier-inserted <script> (via a div) synchronously observes a later-inserted <link rel=stylesheet>'s CSSStyleSheet creation assert_array_equals: expected property 0 to be "sheet" but got null (expected array ["sheet"] got [null])
+FAIL Earlier-inserted <script> (via a append()) synchronously observes a later-inserted <link rel=stylesheet>'s CSSStyleSheet creation assert_array_equals: expected property 0 to be "sheet" but got null (expected array ["sheet"] got [null])
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-style.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-style.tentative.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Node.appendChild: inserting a script and a style where the script modifies the style</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script>
+// <script> & <style> element tests.
+test(() => {
+  window.happened = [];
+  window.style = document.createElement("style");
+  let styleSheet = null;
+
+  style.appendChild(new Text("body {}"));
+  const script = document.createElement("script");
+  script.textContent = `
+    styleSheet = style.sheet;
+    happened.push(style.sheet ? "sheet" : null);
+    style.appendChild(new Text("body {}"));
+    happened.push(style.sheet?.cssRules.length);
+  `;
+
+  const div = document.createElement("div");
+  div.appendChild(script);
+  div.appendChild(style);
+
+  assert_array_equals(happened, []);
+  document.body.appendChild(div);
+  assert_array_equals(happened, ["sheet", 2]);
+  assert_not_equals(style.sheet, styleSheet, "style sheet was created only once");
+}, "An earlier-inserted <script> synchronously observes a later-inserted " +
+   "<style> (via a div) being applied");
+
+test(() => {
+  window.happened = [];
+  window.style = document.createElement("style");
+  let styleSheet = null;
+
+  style.appendChild(new Text("body {}"));
+  const script = document.createElement("script");
+  script.textContent = `
+    styleSheet = style.sheet;
+    happened.push(style.sheet ? "sheet" : null);
+    style.appendChild(new Text("body {}"));
+    happened.push(style.sheet?.cssRules.length);
+`;
+
+  const df = document.createDocumentFragment();
+  df.appendChild(script);
+  df.appendChild(style);
+
+  assert_array_equals(happened, []);
+  document.body.appendChild(df);
+  assert_array_equals(happened, ["sheet", 2]);
+  assert_not_equals(style.sheet, styleSheet, "style sheet was created only once");
+}, "An earlier-inserted <script> synchronously observes a later-inserted " +
+   "<style> (via a DocumentFragment) being applied");
+
+// <script> & <link rel=stylesheet> element tests.
+test(() => {
+  window.happened = [];
+  window.link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "data:text/css,";
+
+  const script = document.createElement("script");
+  script.textContent = `
+    happened.push(link.sheet ? "sheet" : null);
+  `;
+
+  const df = document.createDocumentFragment();
+  df.appendChild(script);
+  df.appendChild(link);
+
+  assert_array_equals(happened, []);
+  document.body.appendChild(df);
+  assert_array_equals(happened, ["sheet"]);
+}, "Earlier-inserted <script> (via a DocumentFragment) synchronously " +
+   "observes a later-inserted <link rel=stylesheet>'s CSSStyleSheet creation");
+
+test(() => {
+  window.happened = [];
+  window.link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "data:text/css,";
+
+  const script = document.createElement("script");
+  script.textContent = `
+    happened.push(link.sheet ? "sheet" : null);
+`;
+
+  const div = document.createElement("div");
+  div.appendChild(script);
+  div.appendChild(link);
+
+  assert_array_equals(happened, []);
+  document.body.appendChild(div);
+  assert_array_equals(happened, ["sheet"]);
+}, "Earlier-inserted <script> (via a div) synchronously observes a " +
+   "later-inserted <link rel=stylesheet>'s CSSStyleSheet creation");
+
+test(() => {
+  window.happened = [];
+  window.link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "data:text/css,";
+
+  const script = document.createElement("script");
+  script.textContent = `
+    happened.push(link.sheet ? "sheet" : null);
+`;
+
+  assert_array_equals(happened, []);
+  document.body.append(script, link);
+  assert_array_equals(happened, ["sheet"]);
+}, "Earlier-inserted <script> (via a append()) synchronously observes a " +
+   "later-inserted <link rel=stylesheet>'s CSSStyleSheet creation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-in-script.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-in-script.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+PASS An outer script whose preparation/execution gets triggered by the insertion of a 'nested'/'inner' script, executes *before* the inner script executes
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-in-script.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-in-script.tentative.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Node.appendChild: inserting a script and some code in an empty script</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script id="s1"></script>
+<script>
+const happened = [];
+test(() => {
+  const s1 = document.getElementById("s1");
+  const s2 = document.createElement("script");
+
+  // This script, which is ultimately a *child* of the
+  // already-connected-but-empty `s1` script, runs second, after `s1` runs. See
+  // the example in
+  // http://html.spec.whatwg.org/C/#script-processing-model:children-changed-steps
+  // for more information.
+  //
+  // HISTORICAL CONTEXT: There used to be a condition in the HTML standard that
+  // said an "outer" script must be "prepared" when a node gets inserted into
+  // the script. BUT it also stipulated that if the insertion consists of any
+  // "inner" (nested, essentially) script elements, then this "outer" script
+  // must prepare/execute after any of those "inner" newly-inserted scripts
+  // themselves get prepared.
+  //
+  // This changed in https://github.com/whatwg/html/pull/10188.
+  s2.textContent = `
+    happened.push("s2");
+
+    // This text never executes in the outer script, because by the time this
+    // gets appended, the outer script has "already started" [1], so it does not
+    // get re-prepared/executed a second time.
+    //
+    // [1]: https://html.spec.whatwg.org/C#already-started
+    s1.appendChild(new Text("happened.push('s1ran');"));
+
+    happened.push("s2ran");
+`;
+
+  const df = document.createDocumentFragment();
+  df.appendChild(new Text(`happened.push("s1");`));
+  df.appendChild(s2);
+
+  assert_array_equals(happened, []);
+  s1.appendChild(df);
+  assert_array_equals(happened, ["s1", "s2", "s2ran"]);
+}, "An outer script whose preparation/execution gets triggered by the " +
+   "insertion of a 'nested'/'inner' script, executes *before* the inner " +
+   "script executes");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-with-mutation-observer-takeRecords-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-with-mutation-observer-takeRecords-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL An inserted script should be able to observe its own mutation record with takeRecords assert_equals: expected 1 but got 0
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-with-mutation-observer-takeRecords.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-with-mutation-observer-takeRecords.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Node.appendChild: inserted script should be able to take own mutation record</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<main></main>
+<script>
+
+test(() => {
+  window.mutationObserver = new MutationObserver(() => {});
+  window.mutationObserver.observe(document.querySelector("main"), {childList: true});
+  const script = document.createElement("script");
+  script.textContent = `
+    window.mutationRecords = window.mutationObserver.takeRecords();
+  `;
+  document.querySelector("main").appendChild(script);
+  assert_equals(window.mutationRecords.length, 1);
+  assert_array_equals(window.mutationRecords[0].addedNodes, [script]);
+}, "An inserted script should be able to observe its own mutation record with takeRecords");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-text-and-script-in-style.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-text-and-script-in-style.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL All style rules appended to a <style> element are inserted and script-observable to scripts inserted in the `<style>` element, by the time scripts execute after DOM insertions. assert_array_equals: expected property 0 to be 2 but got 1 (expected array [2] got [1])
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-text-and-script-in-style.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-text-and-script-in-style.tentative.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Node.appendChild: inserting text and script nodes in a style element</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<style id="style"></style>
+<body>
+<script>
+const happened = []
+const style = document.getElementById("style");
+test(() => {
+  const r1 = new Text("body {}");
+  const r2 = new Text("body {}");
+  const script = document.createElement("script");
+  script.textContent = `
+    happened.push(style.sheet.cssRules.length);
+  `;
+
+  const df = document.createDocumentFragment();
+  df.appendChild(r1);
+  df.appendChild(script);
+  df.appendChild(r2);
+
+  assert_array_equals(happened, []);
+  style.appendChild(df);
+  assert_array_equals(happened, [2]);
+}, "All style rules appended to a <style> element are inserted and " +
+   "script-observable to scripts inserted in the `<style>` element, by the " +
+   "time scripts execute after DOM insertions.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-text-in-script.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-text-in-script.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Node.appendChild: inserting two text nodes in an empty script
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-text-in-script.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-text-in-script.tentative.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Node.appendChild: inserting two text nodes in an empty script</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+  <script id="script"></script>
+<script>
+const happened = [];
+test(() => {
+  const script = document.getElementById("script");
+  const df = document.createDocumentFragment();
+  df.appendChild(new Text("happened.push('t1');"));
+  df.appendChild(new Text("happened.push('t2');"));
+  assert_array_equals(happened, []);
+  script.appendChild(df);
+  assert_array_equals(happened, ["t1", "t2"]);
+  // At this point it's already executed so further motifications are a no-op
+  script.appendChild(new Text("happened.push('t3');"));
+  script.textContent = "happened.push('t4');"
+  script.text = "happened.push('t5');"
+  assert_array_equals(happened, ["t1", "t2"]);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-three-scripts-from-fragment.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-three-scripts-from-fragment.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Node.appendChild: inserting three scripts from a document fragment
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-three-scripts-from-fragment.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-three-scripts-from-fragment.tentative.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Node.appendChild: inserting three scripts from a document fragment</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+  <script>
+const s1 = document.createElement("script");
+const s2 = document.createElement("script");
+const s3 = document.createElement("script");
+const happened = [];
+
+test(() => {
+  s1.textContent = `
+    s3.appendChild(new Text("happened.push('s3');"));
+    happened.push("s1");
+  `;
+  s2.textContent = `
+    happened.push("s2");
+  `;
+  const df = document.createDocumentFragment();
+  df.appendChild(s1);
+  df.appendChild(s2);
+  df.appendChild(s3);
+
+  assert_array_equals(happened, []);
+  document.body.appendChild(df);
+  assert_array_equals(happened, ["s3", "s1", "s2"]);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-three-scripts.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-three-scripts.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Node.appendChild: inserting three scripts from a div
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-three-scripts.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-three-scripts.tentative.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Node.appendChild: inserting three scripts from a div</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+  <script>
+const s1 = document.createElement("script");
+const s2 = document.createElement("script");
+const s3 = document.createElement("script");
+const happened = [];
+
+test(() => {
+  s1.textContent = `
+    s3.appendChild(new Text("happened.push('s3');"));
+    happened.push("s1");
+  `;
+  s2.textContent = `
+    happened.push("s2");
+  `;
+  const div = document.createElement("div");
+  div.appendChild(s1);
+  div.appendChild(s2);
+  div.appendChild(s3);
+
+  assert_array_equals(happened, []);
+  document.body.appendChild(div);
+  assert_array_equals(happened, ["s3", "s1", "s2"]);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: focus-events
+  files:
+  - blur-event.window.js

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/blur-event.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/blur-event.window-expected.txt
@@ -1,0 +1,4 @@
+
+PASS <input> element does not fire blur event upon DOM removal
+PASS <button> element does not fire blur/focusout events upon DOM removal
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/blur-event.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/blur-event.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/blur-event.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/blur-event.window.js
@@ -1,0 +1,28 @@
+test(() => {
+  const input = document.body.appendChild(document.createElement('input'));
+  input.focus();
+
+  let blurCalled = false;
+  input.onblur = e => blurCalled = true;
+  input.remove();
+  assert_false(blurCalled, "Blur event was not fired");
+}, "<input> element does not fire blur event upon DOM removal");
+
+test(() => {
+  const button = document.body.appendChild(document.createElement('button'));
+  button.focus();
+
+  let blur_called = false;
+  let focus_out_called = false;
+  let focus_called = false;
+
+  button.onblur = () => { blur_called = true; }
+  button.onfocusout = () => { focus_out_called = true; }
+  document.body.addEventListener("focus",
+    () => { focus_called = true; }, {capture: true});
+  button.remove();
+
+  assert_false(blur_called, "Blur event was not fired");
+  assert_false(focus_out_called, "FocusOut event was not fired");
+  assert_false(focus_called, "Focus was not fired");
+}, "<button> element does not fire blur/focusout events upon DOM removal");

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/insertion-removing-steps-iframe.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/insertion-removing-steps-iframe.window-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Insertion steps: load event fires synchronously *after* iframe DOM insertion, as part of the iframe element's insertion steps
+PASS Removing steps (innerHTML): script does not run synchronously during iframe destruction
+PASS Removing steps (replaceChildren): script does not run synchronously during iframe destruction
+PASS Removing steps (remove): script does not run synchronously during iframe destruction
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/insertion-removing-steps-iframe.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/insertion-removing-steps-iframe.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/insertion-removing-steps-iframe.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/insertion-removing-steps-iframe.window.js
@@ -1,0 +1,158 @@
+// These tests ensure that:
+//   1. The HTML element insertion steps for iframes [1] run *after* all DOM
+//      insertion mutations associated with any given call to
+//      #concept-node-insert [2] (which may insert many elements at once).
+//      Consequently, a preceding element's insertion steps can observe the
+//      side-effects of later elements being connected to the DOM, but cannot
+//      observe the side-effects of the later element's own insertion steps [1],
+//      since insertion steps are run in order after all DOM insertion mutations
+//      are complete.
+//   2. The HTML element removing steps for iframes [3] *do not* synchronously
+//      run script during child navigable destruction. Therefore, script cannot
+//      observe the state of the DOM in the middle of iframe removal, even when
+//      multiple iframes are being removed in the same task. Iframe removal,
+//      from the perspective of the parent's DOM tree, is atomic.
+//
+// [1]: https://html.spec.whatwg.org/C#the-iframe-element:html-element-insertion-steps
+// [2]: https://dom.spec.whatwg.org/#concept-node-insert
+// [3]: https://html.spec.whatwg.org/C#the-iframe-element:html-element-removing-steps
+
+promise_test(async t => {
+  const fragment = new DocumentFragment();
+
+  const iframe1 = fragment.appendChild(document.createElement('iframe'));
+  const iframe2 = fragment.appendChild(document.createElement('iframe'));
+
+  t.add_cleanup(() => {
+    iframe1.remove();
+    iframe2.remove();
+  });
+
+  let iframe1Loaded = false, iframe2Loaded = false;
+  iframe1.onload = t.step_func(e => {
+    // iframe1 assertions:
+    iframe1Loaded = true;
+    assert_equals(window.frames.length, 1,
+        "iframe1 load event can observe its own participation in the frame " +
+        "tree");
+    assert_equals(iframe1.contentWindow, window.frames[0]);
+
+    // iframe2 assertions:
+    assert_false(iframe2Loaded,
+        "iframe2's load event hasn't fired before iframe1's");
+    assert_true(iframe2.isConnected,
+        "iframe1 can observe that iframe2 is connected to the DOM...");
+    assert_equals(iframe2.contentWindow, null,
+        "... but iframe1 cannot observe iframe2's contentWindow because " +
+        "iframe2's insertion steps have not been run yet");
+  });
+
+  iframe2.onload = t.step_func(e => {
+    iframe2Loaded = true;
+    assert_equals(window.frames.length, 2,
+        "iframe2 load event can observe its own participation in the frame tree");
+    assert_equals(iframe1.contentWindow, window.frames[0]);
+    assert_equals(iframe2.contentWindow, window.frames[1]);
+  });
+
+  // Synchronously consecutively adds both `iframe1` and `iframe2` to the DOM,
+  // invoking their insertion steps (and thus firing each of their `load`
+  // events) in order. `iframe1` will be able to observe itself in the DOM but
+  // not `iframe2`, and `iframe2` will be able to observe both itself and
+  // `iframe1`.
+  document.body.append(fragment);
+  assert_true(iframe1Loaded, "iframe1 loaded");
+  assert_true(iframe2Loaded, "iframe2 loaded");
+}, "Insertion steps: load event fires synchronously *after* iframe DOM " +
+   "insertion, as part of the iframe element's insertion steps");
+
+// There are several versions of the removal variant, since there are several
+// ways to remove multiple elements "at once". For example:
+//   1. `node.innerHTML = ''` ultimately runs
+//      https://dom.spec.whatwg.org/#concept-node-replace-all which removes all
+//      of a node's children.
+//   2. `node.replaceChildren()` which follows roughly the same path above.
+//   3. `node.remove()` on a parent of many children will invoke not the DOM
+//      remove algorithm, but rather the "removing steps" hook [1], for each
+//      child.
+//
+// [1]: https://dom.spec.whatwg.org/#concept-node-remove-ext
+
+function runRemovalTest(removal_method) {
+  promise_test(async t => {
+    const div = document.createElement('div');
+
+    const iframe1 = div.appendChild(document.createElement('iframe'));
+    const iframe2 = div.appendChild(document.createElement('iframe'));
+    document.body.append(div);
+
+    // Now that both iframes have been inserted into the DOM, we'll set up a
+    // MutationObserver that we'll use to ensure that multiple synchronous
+    // mutations (removals) are only observed atomically at the end. Specifically,
+    // the observer's callback is not invoked synchronously for each removal.
+    let observerCallbackInvoked = false;
+    const removalObserver = new MutationObserver(t.step_func(mutations => {
+      assert_false(observerCallbackInvoked,
+          "MO callback is only invoked once, not multiple times, i.e., for " +
+          "each removal");
+      observerCallbackInvoked = true;
+      assert_equals(mutations.length, 1, "Exactly one MutationRecord is recorded");
+      assert_equals(mutations[0].removedNodes.length, 2);
+      assert_equals(window.frames.length, 0,
+          "No iframe Windows exist when the MO callback is run");
+      assert_equals(document.querySelector('iframe'), null,
+          "No iframe elements are connected to the DOM when the MO callback is " +
+          "run");
+    }));
+
+    removalObserver.observe(div, {childList: true});
+    t.add_cleanup(() => removalObserver.disconnect());
+
+    let iframe1UnloadFired = false, iframe2UnloadFired = false;
+    let iframe1PagehideFired = false, iframe2PagehideFired = false;
+    iframe1.contentWindow.addEventListener('pagehide', e => {
+      assert_false(iframe1UnloadFired, "iframe1 pagehide fires before unload");
+      iframe1PagehideFired = true;
+    });
+    iframe2.contentWindow.addEventListener('pagehide', e => {
+      assert_false(iframe2UnloadFired, "iframe2 pagehide fires before unload");
+      iframe2PagehideFired = true;
+    });
+    iframe1.contentWindow.addEventListener('unload', e => iframe1UnloadFired = true);
+    iframe2.contentWindow.addEventListener('unload', e => iframe2UnloadFired = true);
+
+    // Each `removal_method` will trigger the synchronous removal of each of
+    // `div`'s (iframe) children. This will synchronously, consecutively
+    // invoke HTML's "destroy a child navigable" (per [1]), for each iframe.
+    //
+    // [1]: https://html.spec.whatwg.org/C#the-iframe-element:destroy-a-child-navigable
+
+    if (removal_method === 'replaceChildren') {
+      div.replaceChildren();
+    } else if (removal_method === 'remove') {
+      div.remove();
+    } else if (removal_method === 'innerHTML') {
+      div.innerHTML = '';
+    }
+
+    assert_false(iframe1PagehideFired, "iframe1 pagehide did not fire");
+    assert_false(iframe2PagehideFired, "iframe2 pagehide did not fire");
+    assert_false(iframe1UnloadFired, "iframe1 unload did not fire");
+    assert_false(iframe2UnloadFired, "iframe2 unload did not fire");
+
+    assert_false(observerCallbackInvoked,
+        "MO callback is not invoked synchronously after removals");
+
+    // Wait one microtask.
+    await Promise.resolve();
+
+    if (removal_method !== 'remove') {
+      assert_true(observerCallbackInvoked,
+          "MO callback is invoked asynchronously after removals");
+    }
+  }, `Removing steps (${removal_method}): script does not run synchronously during iframe destruction`);
+}
+
+runRemovalTest('innerHTML');
+runRemovalTest('replaceChildren');
+runRemovalTest('remove');

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/insertion-removing-steps-script.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/insertion-removing-steps-script.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Script execution happens after all batched DOM insertions complete through post-connection steps
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/insertion-removing-steps-script.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/insertion-removing-steps-script.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/insertion-removing-steps-script.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/insertion-removing-steps-script.window.js
@@ -1,0 +1,47 @@
+promise_test(async t => {
+  const fragmentWithTwoScripts = new DocumentFragment();
+  const script0 = document.createElement('script');
+  const script1 = fragmentWithTwoScripts.appendChild(document.createElement('script'));
+  const script2 = fragmentWithTwoScripts.appendChild(document.createElement('script'));
+
+  window.kBaselineNumberOfScripts = document.scripts.length;
+  assert_equals(document.scripts.length, kBaselineNumberOfScripts,
+      "The WPT infra starts out with exactly 3 scripts");
+
+  window.script0Executed = false;
+  script0.innerText = `
+    script0Executed = true;
+    assert_equals(document.scripts.length, kBaselineNumberOfScripts + 1,
+        'script0 can observe itself and no other scripts');
+  `;
+
+  window.script1Executed = false;
+  script1.innerText = `
+    script1Executed = true;
+    assert_equals(document.scripts.length, kBaselineNumberOfScripts + 3,
+        "script1 executes after all DOM insertions complete, observing all " +
+        "scripts");
+  `;
+
+  window.script2Executed = false;
+  script2.innerText = `
+    script2Executed = true;
+    assert_equals(document.scripts.length, kBaselineNumberOfScripts + 3,
+        "script2 executes after all DOM insertions complete, observing all " +
+        "scripts");
+  `;
+
+  assert_false(script0Executed, "Script0 does not execute before append()");
+  document.body.append(script0);
+  assert_true(script0Executed,
+      "Script0 executes synchronously during append()");
+
+  assert_false(script1Executed, "Script1 does not execute before append()");
+  assert_false(script2Executed, "Script2 does not execute before append()");
+  document.body.append(fragmentWithTwoScripts);
+  assert_true(script1Executed,
+      "Script1 executes synchronously during fragment append()");
+  assert_true(script2Executed,
+      "Script2 executes synchronously during fragment append()");
+}, "Script execution happens after all batched DOM insertions complete " +
+   "through post-connection steps");

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/later-script-removed-by-earlier-script-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/later-script-removed-by-earlier-script-expected.txt
@@ -1,0 +1,4 @@
+
+PASS A later-inserted script removed by an earlier-inserted script in the same document fragment should not run
+PASS A later-inserted script removed by an earlier-inserted script in the same append() call should not run
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/later-script-removed-by-earlier-script.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/later-script-removed-by-earlier-script.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>A later-inserted script removed by an earlier-inserted script does not run</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script>
+
+test(t => {
+  const fragment = document.createDocumentFragment();
+  // Global so they can be more easily accessed by the inner script blocks.
+  window.script1 = fragment.appendChild(document.createElement("script"));
+  window.script2 = fragment.appendChild(document.createElement("script"));
+
+  window.script2Run = false;
+  t.add_cleanup(() => { window.script2Run = false; });
+  script1.textContent = `
+    assert_true(script2.isConnected, 'script2 is connected when script2 runs');
+    script2.remove();
+  `;
+  script2.textContent = "window.script2Run = true;";
+
+  document.body.append(fragment);
+  assert_false(window.script2Run, "script2 did not run");
+}, "A later-inserted script removed by an earlier-inserted script in the " +
+   "same document fragment should not run");
+
+test(t => {
+  window.script1 = document.createElement("script");
+  window.script2 = document.createElement("script");
+
+  window.script2Run = false;
+  t.add_cleanup(() => { window.script2Run = false; });
+  script1.textContent = `
+    assert_true(script2.isConnected, 'script2 is connected when script2 runs');
+    script2.remove();
+  `;
+  script2.textContent = "window.script2Run = true;";
+
+  document.body.append(script1, script2);
+  assert_false(window.script2Run, "script2 did not run");
+}, "A later-inserted script removed by an earlier-inserted script in the " +
+   "same append() call should not run");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/script-does-not-run-on-child-removal.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/script-does-not-run-on-child-removal.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Script execution is never triggered on child removals
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/script-does-not-run-on-child-removal.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/script-does-not-run-on-child-removal.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/script-does-not-run-on-child-removal.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/script-does-not-run-on-child-removal.window.js
@@ -1,0 +1,33 @@
+// See:
+//  - https://github.com/whatwg/dom/issues/808
+//  - https://github.com/whatwg/dom/pull/1261
+//  - https://github.com/whatwg/html/pull/10188
+//  - https://source.chromium.org/chromium/chromium/src/+/604e798ec6ee30f44d57a5c4a44ce3dab3a871ed
+//  - https://github.com/whatwg/dom/pull/732#pullrequestreview-328249015
+//  - https://github.com/whatwg/html/pull/4354#issuecomment-476038918
+test(() => {
+  window.script_did_run = false;
+
+  const script = document.createElement('script');
+  // This prevents execution on insertion.
+  script.type = '0';
+  script.textContent = `script_did_run = true;`;
+  document.body.append(script);
+  assert_false(script_did_run,
+      'Appending script with invalid type does not trigger execution');
+
+  const div = document.createElement('div');
+  script.append(div);
+  assert_false(script_did_run,
+      'Appending a child to an invalid-type script does not trigger execution');
+
+  // This enables, but does not trigger, execution.
+  script.type = '';
+  assert_false(script_did_run,
+      'Unsetting script type does not trigger execution');
+
+  div.remove();
+  assert_false(script_did_run,
+      'Removing child from valid script that has not already run, does not ' +
+      'trigger execution');
+}, "Script execution is never triggered on child removals");

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/w3c-import.log
@@ -1,0 +1,37 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-append-form-and-script-from-fragment.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-append-meta-referrer-and-script-from-fragment.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-button-from-div.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-custom-from-fragment.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-default-style-meta-from-fragment.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-div-from-fragment.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-iframe.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-source-from-fragment.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-style.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-in-script.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-with-mutation-observer-takeRecords.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-text-and-script-in-style.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-text-in-script.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-three-scripts-from-fragment.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-three-scripts.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/WEB_FEATURES.yml
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/blur-event.window.js
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/insertion-removing-steps-iframe.window.js
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/insertion-removing-steps-script.window.js
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/later-script-removed-by-earlier-script.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/script-does-not-run-on-child-removal.window.js

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4051,6 +4051,13 @@ ExceptionOr<void> Document::open(Document* entryDocument)
         setCookieURL(newCookieURL);
     }
 
+    // Fire pagehide/unload events on descendant navigables before replacing
+    // the document content. The subsequent implicitOpen() -> removeChildren()
+    // will destroy child navigables without firing unload events (per spec),
+    // so we need to do it here first.
+    if (RefPtr frame = this->frame())
+        frame->loader().detachChildren();
+
     implicitOpen();
     if (RefPtr parser = scriptableDocumentParser())
         parser->setWasCreatedByScript(true);

--- a/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -23,6 +23,7 @@
 #include "HTMLFrameOwnerElement.h"
 
 #include "ContainerNodeInlines.h"
+#include "EventLoop.h"
 #include "FrameInlines.h"
 #include "FrameLoader.h"
 #include "LocalDOMWindow.h"
@@ -83,10 +84,33 @@ void HTMLFrameOwnerElement::disconnectContentFrame()
     if (RefPtr frame = m_contentFrame.get()) {
         if (auto* innerDocument = contentDocument())
             innerDocument->willBeDisconnectedFromFrame(document());
-        frame->frameDetached();
-        if (frame == m_contentFrame.get())
+
+        // Per the HTML spec, "destroy a child navigable" synchronously sets
+        // the container's content navigable to null (step 3), then runs
+        // "destroy a document and its descendants" asynchronously (step 5).
+        // https://html.spec.whatwg.org/C#destroy-a-child-navigable
+        //
+        // Only clear the content frame pointer synchronously. Do not call
+        // disconnectOwnerElement() here as that triggers
+        // willBeRemovedFromFrame() which fully tears down the document.
+        // The full teardown (including pagehide/unload event dispatch) is
+        // deferred to the queued task below.
+        clearContentFrame();
+
+        if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame.get())) {
+            // Queue the actual frame destruction (which fires pagehide/unload
+            // events) as an asynchronous task. This ensures that script does
+            // not run synchronously during child navigable destruction.
+            document().eventLoop().queueTask(TaskSource::DOMManipulation, [localFrame = Ref { *localFrame }]() {
+                if (!localFrame->page())
+                    return;
+                localFrame->loader().frameDetached();
+                localFrame->disconnectOwnerElement();
+            });
+        } else {
+            frame->frameDetached();
             frame->disconnectOwnerElement();
-        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(frame != m_contentFrame.get());
+        }
     }
 }
 

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -264,6 +264,8 @@ public:
 
     void frameDetached();
 
+    WEBCORE_EXPORT void detachChildren();
+
     void setOutgoingReferrer(const URL&);
 
     void loadDone(LoadCompletionType);
@@ -448,7 +450,6 @@ private:
 
     ResourceLoaderIdentifier requestFromDelegate(ResourceRequest&, ResourceError&);
 
-    WEBCORE_EXPORT void detachChildren();
     void closeAndRemoveChild(LocalFrame&);
 
     void loadInSameDocument(URL, RefPtr<SerializedScriptValue> stateObject, const SecurityOrigin* requesterOrigin, bool isNewNavigation, NavigationHistoryBehavior historyHandling = NavigationHistoryBehavior::Auto);


### PR DESCRIPTION
#### 297a30e70336934593c3594b38d75bc232560551
<pre>
Defer pagehide/unload events to an asynchronous task when destroying a child navigable
<a href="https://bugs.webkit.org/show_bug.cgi?id=311698">https://bugs.webkit.org/show_bug.cgi?id=311698</a>

Reviewed by NOBODY (OOPS!).

Per the HTML spec, the iframe element&apos;s removing steps call &quot;destroy a
child navigable&quot;, which synchronously sets the container&apos;s content
navigable to null (step 3), then asynchronously runs &quot;destroy a document
and its descendants&quot; (step 5). WebKit was incorrectly firing pagehide
and unload events synchronously during iframe removal via the
frameDetached() -&gt; detachFromParent() -&gt; closeURL() -&gt;
dispatchUnloadEvents() code path. This meant script could observe DOM
state mid-removal when multiple iframes were being removed in the same
task.

To fix this, HTMLFrameOwnerElement::disconnectContentFrame() now only
clears the content frame pointer synchronously (matching spec step 3),
and queues the actual frame destruction — including pagehide/unload
event dispatch — as an asynchronous task on the document&apos;s event loop.
This ensures:
1. Script does not run synchronously during child navigable destruction,
   making iframe removal atomic from the parent DOM&apos;s perspective.
2. pagehide/unload events still fire (asynchronously), preserving
   keepalive fetch behavior and other functionality that depends on
   these events.

The full document teardown (willBeRemovedFromFrame) is deferred to after
frameDetached() completes in the queued task, so the frame/document/window
are still fully alive when event handlers execute.

<a href="https://html.spec.whatwg.org/C#destroy-a-child-navigable">https://html.spec.whatwg.org/C#destroy-a-child-navigable</a>

* LayoutTests/TestExpectations:

* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/insertion-removing-steps-iframe.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/insertion-removing-steps-iframe.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/insertion-removing-steps-iframe.window.js: Added.
Without the fix, this test was failing in Safari: <a href="https://wpt.fyi/results/dom/nodes/insertion-removing-steps/insertion-removing-steps-iframe.window.html?label=master&amp">https://wpt.fyi/results/dom/nodes/insertion-removing-steps/insertion-removing-steps-iframe.window.html?label=master&amp</a>;label=experimental&amp;aligned
It is now fully passing.

* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-append-form-and-script-from-fragment.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-append-form-and-script-from-fragment.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-append-meta-referrer-and-script-from-fragment.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-append-meta-referrer-and-script-from-fragment.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-button-from-div.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-button-from-div.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-custom-from-fragment.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-custom-from-fragment.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-default-style-meta-from-fragment.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-default-style-meta-from-fragment.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-div-from-fragment.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-div-from-fragment.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-iframe.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-iframe.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-source-from-fragment.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-source-from-fragment.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-style.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-and-style.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-in-script.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-in-script.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-with-mutation-observer-takeRecords-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-script-with-mutation-observer-takeRecords.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-text-and-script-in-style.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-text-and-script-in-style.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-text-in-script.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-text-in-script.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-three-scripts-from-fragment.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-three-scripts-from-fragment.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-three-scripts.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/Node-appendChild-three-scripts.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/blur-event.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/blur-event.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/blur-event.window.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/insertion-removing-steps-script.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/insertion-removing-steps-script.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/insertion-removing-steps-script.window.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/later-script-removed-by-earlier-script-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/later-script-removed-by-earlier-script.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/script-does-not-run-on-child-removal.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/script-does-not-run-on-child-removal.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/insertion-removing-steps/script-does-not-run-on-child-removal.window.js: Added.
Imported the whole folder from WPT to gain test coverage. The fix in this PR has no impact on the output of these tests.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::open):
* Source/WebCore/html/HTMLFrameOwnerElement.cpp:
(WebCore::HTMLFrameOwnerElement::disconnectContentFrame):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::detachChildren):
(WebCore::FrameLoader::frameDetached):
(WebCore::FrameLoader::detachFromParent):
* Source/WebCore/loader/FrameLoader.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/297a30e70336934593c3594b38d75bc232560551

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163668 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108378 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28016 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119845 "Found 140 new test failures: editing/deleting/merge-paragraphs-null-root-editable-element-crash.html editing/inserting/insert-html-crash-02.html fast/animation/request-animation-frame-throttling-detached-iframe.html fast/cookies/cookie-averse-document.html fast/dom/Range/range-created-during-remove-children.html fast/dom/Window/forbid-showModalDialog.html fast/dom/adopt-node-prevented.html fast/dom/exception-no-frame-inline-script-crash.html fast/dom/insert-new-child-to-remove-during-unload-crash.html fast/dom/microtask-detach.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84711 "1 flakes 33 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157867 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22117 "Found 58 new test failures: editing/deleting/merge-paragraphs-null-root-editable-element-crash.html editing/undo-manager/undo-manager-add-item-exceptions.html fast/animation/request-animation-frame-throttling-detached-iframe.html fast/cookies/cookie-averse-document.html fast/dom/Range/range-created-during-remove-children.html fast/dom/Window/forbid-showModalDialog.html fast/dom/adopt-node-prevented.html fast/dom/exception-no-frame-inline-script-crash.html fast/dom/insert-new-child-to-remove-during-unload-crash.html fast/dom/null-page-show-modal-dialog-crash.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139110 "Found 3 new API test failures: TestWebKitAPI.SiteIsolation.CoordinateTransformation, TestWebKitAPI.WebKitLegacy.DidRemoveFrameFromHierarchy, TestWebKitAPI.SiteIsolation.RemoveFrames (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100538 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21202 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/file/send-file-form-controls.html imported/w3c/web-platform-tests/FileAPI/file/send-file-form-iso-2022-jp.html imported/w3c/web-platform-tests/FileAPI/file/send-file-form-punctuation.html imported/w3c/web-platform-tests/FileAPI/file/send-file-form-utf-8.html imported/w3c/web-platform-tests/FileAPI/file/send-file-form-windows-1252.html imported/w3c/web-platform-tests/FileAPI/file/send-file-form-x-user-defined.html imported/w3c/web-platform-tests/badging/non-fully-active.https.html imported/w3c/web-platform-tests/close-watcher/frame-removal.html imported/w3c/web-platform-tests/credential-management/non-fully-active.https.html imported/w3c/web-platform-tests/css/cssom-view/screen-detached-frame.html ... (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19230 "Found 4 new API test failures: TestWebKitAPI.ElementFullscreen.RemoveFullscreenElementFromDOM, TestWebKitAPI.SiteIsolation.CoordinateTransformation, TestWebKitAPI.WebKitLegacy.DidRemoveFrameFromHierarchy, TestWebKitAPI.SiteIsolation.RemoveFrames (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11494 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130864 "Found 2 new API test failures: TestWebKitAPI.SiteIsolation.CoordinateTransformation, TestWebKitAPI.SiteIsolation.RemoveFrames (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16954 "Found 1 new test failure: http/tests/dom/same-origin-detached-window-properties.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166143 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9574 "Found 2 new failures in html/HTMLFrameOwnerElement.cpp") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18563 "Found 60 new test failures: accessibility/mac/stale-textmarker-crash.html editing/deleting/merge-paragraphs-null-root-editable-element-crash.html editing/execCommand/outdent-with-media-query-listener-in-iframe.html editing/pasteboard/drop-text-events-sideeffect-crash.html editing/undo-manager/undo-manager-add-item-exceptions.html fast/cookies/cookie-averse-document.html fast/dom/Range/range-created-during-remove-children.html fast/dom/Window/forbid-showModalDialog.html fast/dom/adopt-node-prevented.html fast/dom/exception-no-frame-inline-script-crash.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127946 "Found 140 new test failures: editing/deleting/merge-paragraphs-null-root-editable-element-crash.html editing/inserting/insert-html-crash-02.html fast/animation/request-animation-frame-throttling-detached-iframe.html fast/cookies/cookie-averse-document.html fast/dom/Range/range-created-during-remove-children.html fast/dom/Window/forbid-showModalDialog.html fast/dom/adopt-node-prevented.html fast/dom/exception-no-frame-inline-script-crash.html fast/dom/insert-new-child-to-remove-during-unload-crash.html fast/dom/microtask-detach.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27712 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23269 "Found 60 new test failures: accessibility/mac/stale-textmarker-crash.html editing/deleting/merge-paragraphs-null-root-editable-element-crash.html editing/execCommand/outdent-with-media-query-listener-in-iframe.html editing/inserting/insert-html-crash-02.html editing/pasteboard/drop-text-events-sideeffect-crash.html editing/undo-manager/undo-manager-add-item-exceptions.html fast/cookies/cookie-averse-document.html fast/dom/Range/range-created-during-remove-children.html fast/dom/Window/forbid-showModalDialog.html fast/dom/adopt-node-prevented.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128085 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27636 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138747 "Exiting early after 10 failures. 194 tests run. 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84341 "Built successfully") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22963 "Found 1 new test failure: resize-observer/modify-frametree-in-callback.html (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15542 "Found 60 new test failures: accessibility/mac/stale-textmarker-crash.html compositing/style-change/perspective-origin-change.html editing/deleting/merge-paragraphs-null-root-editable-element-crash.html editing/execCommand/outdent-with-media-query-listener-in-iframe.html editing/pasteboard/drop-text-events-sideeffect-crash.html editing/undo-manager/undo-manager-add-item-exceptions.html fast/cookies/cookie-averse-document.html fast/dom/Range/range-created-during-remove-children.html fast/dom/Window/forbid-showModalDialog.html fast/dom/adopt-node-prevented.html ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27328 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91432 "Found 2 new failures in html/HTMLFrameOwnerElement.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26906 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27137 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26979 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->