### PR TITLE
Range.extractContents should not extract out-of-bounds nodes if end container is removed during extraction

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/ranges/Range-extractContents-dynamic-end-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/ranges/Range-extractContents-dynamic-end-expected.txt
@@ -1,0 +1,5 @@
+Middle elements
+Should NOT be extracted
+
+PASS Range.extractContents should not extract out-of-bounds nodes if end container is removed during iframe unload
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/ranges/Range-extractContents-dynamic-end.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/ranges/Range-extractContents-dynamic-end.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel="help" href="https://crbug.com/486423704">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="root">
+    <div id="startContainer">
+        <span id="startNode">Start of Range</span>
+        <iframe id="triggerIframe" src="about:blank" style="display:none;"></iframe>
+    </div>
+    <div id="middle">Middle elements</div>
+    <div id="endContainer">
+        <span id="endNode">End of Range</span>
+    </div>
+    <div id="outOfBounds" style="color: red;">
+        Should NOT be extracted
+    </div>
+</div>
+
+<script>
+test(function() {
+    triggerIframe.contentWindow.addEventListener('unload', () => {
+        endContainer.remove();
+    });
+
+    const range = document.createRange();
+    range.setStart(startNode, 0);
+    range.setEnd(endNode, 1);
+
+    assert_true(!!document.getElementById('outOfBounds'), "Out of bounds element should exist initially");
+
+    const extractedFragment = range.extractContents();
+
+    assert_equals(extractedFragment.querySelector('.outOfBounds'), null, "Should not extract nodes outside of original range");
+
+    assert_true(!!document.getElementById('outOfBounds'), "Out of bounds element should remain in the document");
+}, "Range.extractContents should not extract out-of-bounds nodes if end container is removed during iframe unload");
+</script>

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -410,7 +410,10 @@ ExceptionOr<RefPtr<DocumentFragment>> Range::processContents(ActionType action)
                 return result.releaseException();
         }
 
-        if (processStart) {
+        // If the original end container was disconnected from the common root (e.g. by a mutation
+        // event during left contents processing), processEnd will be null and the loop below would
+        // extract all remaining siblings, including nodes beyond the original range.
+        if (processStart && (processEnd || commonRoot->contains(originalEnd.container()))) {
             Vector<Ref<Node>> nodes;
             for (RefPtr node = processStart.get(); node && node != processEnd; node = node->nextSibling())
                 nodes.append(*node);


### PR DESCRIPTION
#### 9dac73538145b8c77fa67608000f777e6e0ade99
<pre>
Range.extractContents should not extract out-of-bounds nodes if end container is removed during extraction
<a href="https://bugs.webkit.org/show_bug.cgi?id=311700">https://bugs.webkit.org/show_bug.cgi?id=311700</a>

Reviewed by Anne van Kesteren.

When Range::extractContents() processes nodes, removing an iframe can fire a synchronous
unload event. If that event handler removes the Range&apos;s end container from the DOM, the
extraction loop loses its end boundary (processEnd becomes null) and continues extracting
all remaining siblings of the common root, including nodes that were outside the original range.

Fix this by skipping the middle node processing when processEnd is null and the original
end container is no longer a descendant of the common root.

Test: imported/w3c/web-platform-tests/dom/ranges/Range-extractContents-dynamic-end.html
This test was contributed upstream by Blink. It fails in shipping Safari but passes with
this fix. This is thus aligning our behavior with Blink.

* LayoutTests/imported/w3c/web-platform-tests/dom/ranges/Range-extractContents-dynamic-end-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/ranges/Range-extractContents-dynamic-end.html: Added.
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::processContents):

Canonical link: <a href="https://commits.webkit.org/310770@main">https://commits.webkit.org/310770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a6f2b2c6d07aac99d0a9d8bf68e0985609fe159

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163601 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108311 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1357af8-5f72-46f1-a4b9-547577f1d2b0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156714 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28237 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119781 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84676 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff01f53d-5aa0-4c2e-94a2-a1f97e6f691e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157800 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139053 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100474 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e175bb89-bac8-47f5-be2d-bddd0e237b63) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21145 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19170 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11427 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130807 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166075 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9395 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18506 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127885 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27645 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23210 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128025 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34749 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27569 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138690 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84274 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22909 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15484 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27261 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91363 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26839 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27070 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26912 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->