### PR TITLE
AX: Keep element paths up-to-date as the viewport changes, and expand path support to border-radius and clip-path

### DIFF
--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -64,6 +64,9 @@ accessibility/textarea-insertion-point-line-number.html [ Failure ]
 
 accessibility/mac/html5-input-number.html [ Timeout ]
 
+# Fails because we don't get paint calls for SVG shapes and thus can't cache a path for them.
+accessibility/mac/bezier-path-curves.html [ Failure ]
+
 # Regressions from ENABLE(ACCESSIBILITY_LOCAL_FRAME).
 accessibility/mac/iframe-position-after-scroll.html [ Failure ]
 accessibility/scroll-to-global-point-main-window.html [ Failure ]

--- a/LayoutTests/accessibility/image-link-expected.txt
+++ b/LayoutTests/accessibility/image-link-expected.txt
@@ -35,6 +35,7 @@ AXElementBusy: 0
 AXURL: http://www.wowhead.com/?item=33924
 AXAccessKey: (null)
 AXLinkRelationshipType:
+AXPath: (null)
 
 
 Child 0:

--- a/LayoutTests/accessibility/image-map2-expected.txt
+++ b/LayoutTests/accessibility/image-map2-expected.txt
@@ -23,7 +23,7 @@ AXSelected: 0
 AXBlockQuoteLevel: 0
 AXTopLevelUIElement: <AXLink>
 AXLanguage:
-AXDOMIdentifier:
+AXDOMIdentifier: area1
 AXDOMClassList: <array of size 0>
 AXFocusableAncestor: <AXLink>
 AXEditableAncestor: (null)
@@ -58,7 +58,7 @@ AXSelected: 0
 AXBlockQuoteLevel: 0
 AXTopLevelUIElement: <AXLink>
 AXLanguage:
-AXDOMIdentifier:
+AXDOMIdentifier: area2
 AXDOMClassList: <array of size 0>
 AXFocusableAncestor: <AXLink>
 AXEditableAncestor: (null)

--- a/LayoutTests/accessibility/image-map2.html
+++ b/LayoutTests/accessibility/image-map2.html
@@ -7,8 +7,8 @@
 <body>
 
 <map id="apple" name="imagemap1">
-    <area shape="rect" coords="10,10,133,72" href="http://www.apple.com" alt="Link1" />
-    <area shape="rect" coords="12,74,134,88" href="http://www.apple.com" alt="Link2" />
+    <area id="area1" shape="rect" coords="10,10,133,72" href="http://www.apple.com" alt="Link1" />
+    <area id="area2" shape="rect" coords="12,74,134,88" href="http://www.apple.com" alt="Link2" />
 </map>
 
 <img src="resources/cake.png"  border="0" align="left" usemap="#imagemap1" vspace="1">
@@ -17,9 +17,21 @@
 var output = "This test ensures proper AX tree output for image map links with alt tags.\n\n";
 
 if (window.accessibilityController) {
-    var webArea = accessibilityController.rootElement.childAtIndex(0);
-    output += webArea.attributesOfChildren();
-    debugEscaped(output);
+    window.jsTestIsAsync = true;
+
+    var platform = accessibilityController.platformName;
+    (async () => {
+        if (platform === "mac" || platform === "ios") {
+            // Image map area paths are cached during paint. Wait for the
+            // path to become available on an area element before dumping attributes.
+            await waitUntilIDHasPathWith("area1", 1, "Line to");
+        }
+
+        var webArea = accessibilityController.rootElement.childAtIndex(0);
+        output += webArea.attributesOfChildren();
+        debugEscaped(output);
+        finishJSTest();
+    })();
 }
 </script>
 </body>

--- a/LayoutTests/accessibility/mac/document-links-expected.txt
+++ b/LayoutTests/accessibility/mac/document-links-expected.txt
@@ -26,7 +26,7 @@ AXSelected: 0
 AXBlockQuoteLevel: 0
 AXTopLevelUIElement: <AXLink: 'Link1'>
 AXLanguage:
-AXDOMIdentifier:
+AXDOMIdentifier: area1
 AXDOMClassList: <array of size 0>
 AXFocusableAncestor: <AXLink: 'Link1'>
 AXEditableAncestor: (null)
@@ -61,7 +61,7 @@ AXSelected: 0
 AXBlockQuoteLevel: 0
 AXTopLevelUIElement: <AXLink: 'Link2'>
 AXLanguage:
-AXDOMIdentifier:
+AXDOMIdentifier: area2
 AXDOMClassList: <array of size 0>
 AXFocusableAncestor: <AXLink: 'Link2'>
 AXEditableAncestor: (null)
@@ -105,6 +105,7 @@ AXElementBusy: 0
 AXURL: LayoutTests/accessibility/mac/document-links.html#Link3
 AXAccessKey: (null)
 AXLinkRelationshipType:
+AXPath: (null)
 
 ------------
 AXRole: AXLink
@@ -139,6 +140,7 @@ AXElementBusy: 0
 AXURL: LayoutTests/accessibility/mac/document-links.html#Link4
 AXAccessKey: (null)
 AXLinkRelationshipType:
+AXPath: (null)
 
 ------------
 

--- a/LayoutTests/accessibility/mac/document-links.html
+++ b/LayoutTests/accessibility/mac/document-links.html
@@ -7,8 +7,8 @@
 <body>
 
 <map id="apple" name="imagemap1">
-  <area shape="rect" coords="10,10,133,72" href="#Link1" title="Link1" />
-  <area shape="rect" coords="20,50,133,72" href="#Link2" title="Link2" />
+  <area id="area1" shape="rect" coords="10,10,133,72" href="#Link1" title="Link1" />
+  <area id="area2" shape="rect" coords="20,50,133,72" href="#Link2" title="Link2" />
 </map>
 
 <img src="resources/cake.png"  border="0" align="left" usemap="#imagemap1" vspace="1">
@@ -17,10 +17,21 @@
 <a href="#Link4">Link4</a>
 
 <script>
-    description("This test passes if all four links on the page are found.")
+description("This test passes if all four links on the page are found.");
 
-    let webarea = accessibilityController.rootElement.childAtIndex(0);
-    debugEscaped(webarea.attributesOfDocumentLinks());
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    (async () => {
+        // Image map area paths are cached during paint. Wait for the
+        // path to become available on an area element before dumping attributes.
+        await waitUntilIDHasPathWith("area1", 1, "Line to");
+
+        let webArea = accessibilityController.rootElement.childAtIndex(0);
+        debugEscaped(webArea.attributesOfDocumentLinks());
+        finishJSTest();
+    })();
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/accessibility/mac/element-paths-expected.txt
+++ b/LayoutTests/accessibility/mac/element-paths-expected.txt
@@ -1,41 +1,17 @@
+This tests that AXPath is correctly computed for SVG elements, image map areas, elements with border-radius, and elements with clip-path.
 
-This tests SVG group elements are accessible and that the svg:title element is returned properly.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
-PASS svg.isAttributeSupported('AXPath') is true
-SVG path description
-Start Path
-	Move to point
-	Line to
-	Line to
-	Close
-	Move to point
-
-PASS map1.isAttributeSupported('AXPath') is true
-Map1 path description
-Start Path
-	Move to point
-	Line to
-	Line to
-	Line to
-	Line to
-	Close
-	Move to point
-
-PASS map2.isAttributeSupported('AXPath') is true
-Map2 path description
-Start Path
-	Move to point
-	Curve to
-	Curve to
-	Curve to
-	Curve to
-	Close
-	Move to point
+PASS: svgSupportsPath === true
+PASS: noRadiusSupportsPath === false
+PASS: map1.isAttributeSupported('AXPath') === true
+PASS: map2.isAttributeSupported('AXPath') === true
+PASS: pathSegmentCountOfID('pill-button', 'Curve to') > 0 === true
+PASS: pathSegmentCountOfID('rounded-div', 'Curve to') > 0 === true
+PASS: pathSegmentCountOfID('clip-path-div', 'Line to') > 0 === true
 
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+   Pill
+Rounded
+Sharp
+Diamond

--- a/LayoutTests/accessibility/mac/element-paths.html
+++ b/LayoutTests/accessibility/mac/element-paths.html
@@ -1,7 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body id="body">
 
@@ -16,29 +17,51 @@
 
 <img src="resources/cake.png"  border="1" align="left" usemap="#imagemap1" vspace="1">
 
-<div id="console"></div>
+<!-- Border-radius test cases -->
+<button id="pill-button" style="border-radius: 50%; width: 100px; height: 50px;">Pill</button>
+<div id="rounded-div" role="button" style="border-radius: 10px; width: 100px; height: 50px;">Rounded</div>
+<div id="no-radius-div" role="button" style="width: 100px; height: 50px;">Sharp</div>
+
+<!-- Clip-path test case -->
+<div id="clip-path-div" role="button" style="clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%); width: 100px; height: 100px;">Diamond</div>
 
 <script>
+var output = "This tests that AXPath is correctly computed for SVG elements, image map areas, elements with border-radius, and elements with clip-path.\n\n";
 
-    description("This tests SVG group elements are accessible and that the svg:title element is returned properly.");
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
 
-    if (window.accessibilityController) {
+    var svgSupportsPath = accessibilityController.accessibleElementById("svg").isAttributeSupported("AXPath");
+    output += expect("svgSupportsPath", "true");
 
-          var svg = accessibilityController.accessibleElementById("svg");
-          shouldBeTrue("svg.isAttributeSupported('AXPath')");
-          debug("SVG path description" + svg.pathDescription);
+    // No border-radius: should not support AXPath.
+    var noRadiusSupportsPath = accessibilityController.accessibleElementById("no-radius-div").isAttributeSupported("AXPath");
+    output += expect("noRadiusSupportsPath", "false");
 
-          var map1 = accessibilityController.accessibleElementById("map1");
-          shouldBeTrue("map1.isAttributeSupported('AXPath')");
-          debug("Map1 path description" + map1.pathDescription);
+    var map1 = accessibilityController.accessibleElementById("map1");
+    var map2 = accessibilityController.accessibleElementById("map2");
+    (async () => {
+        // Image map areas and border-radius paths are cached during paint
+        // in the isolated tree. Wait for the paths to become available
+        // before querying.
+        await waitUntilIDHasPathWith("pill-button", 1, "Curve to");
 
-          var map2 = accessibilityController.accessibleElementById("map2");
-          shouldBeTrue("map2.isAttributeSupported('AXPath')");
-          debug("Map2 path description"  + map2.pathDescription);
-    }
+        output += expect("map1.isAttributeSupported('AXPath')", "true");
+        output += expect("map2.isAttributeSupported('AXPath')", "true");
 
+        // Border-radius: pill button (border-radius: 50%) should have curves.
+        output += expect("pathSegmentCountOfID('pill-button', 'Curve to') > 0", "true");
+
+        // Border-radius: rounded div (border-radius: 10px) should have curves.
+        output += expect("pathSegmentCountOfID('rounded-div', 'Curve to') > 0", "true");
+
+        // Clip-path: diamond polygon should have line segments.
+        output += expect("pathSegmentCountOfID('clip-path-div', 'Line to') > 0", "true");
+
+        debug(output);
+        finishJSTest();
+    })();
+}
 </script>
-
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -191,6 +191,8 @@ bool AXCoreObject::isGroup() const
     }
 }
 
+// FIXME: This should be moved to AccessibilityNodeObject, since AXCoreObjects
+// should not use element()s (those aren't available off the main-thread for AXIsolatedObject).
 bool AXCoreObject::isImageMapLink() const
 {
     RefPtr element = this->element();
@@ -1420,6 +1422,11 @@ bool AXCoreObject::containsOnlyStaticText() const
         return true;
     });
     return hasText && !nonTextDescendant;
+}
+
+bool AXCoreObject::supportsPath() const
+{
+    return isStaticTextLabel() || isLink();
 }
 
 String AXCoreObject::roleDescription()

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -786,6 +786,7 @@ public:
     virtual AccessibilityChildrenVector radioButtonGroup() const = 0;
 
     virtual bool containsOnlyStaticText() const;
+    bool isStaticTextLabel() const { return role() == AccessibilityRole::Label && containsOnlyStaticText(); }
 
     bool hasPopup() const;
     bool selfOrAncestorLinkHasPopup() const;
@@ -1010,7 +1011,7 @@ public:
     virtual IntSize size() const = 0;
     virtual IntPoint clickPoint() = 0;
     virtual Path elementPath() const = 0;
-    virtual bool supportsPath() const = 0;
+    virtual bool supportsPath() const;
 
     virtual CharacterRange selectedTextRange() const = 0;
     virtual int insertionPointLineNumber() const = 0;

--- a/Source/WebCore/accessibility/AXGeometryManager.cpp
+++ b/Source/WebCore/accessibility/AXGeometryManager.cpp
@@ -96,6 +96,28 @@ bool AXGeometryManager::cacheRectIfNeeded(AXID axID, IntRect&& rect)
     return true;
 }
 
+void AXGeometryManager::cachePathForID(AXID axID, std::unique_ptr<Path>&& path)
+{
+    Locker locker { m_cachedPathsLock };
+    m_cachedPaths.set(axID, WTF::move(path));
+}
+
+std::optional<Path> AXGeometryManager::cachedPathForID(AXID axID)
+{
+    Locker locker { m_cachedPathsLock };
+    auto iterator = m_cachedPaths.find(axID);
+    if (iterator != m_cachedPaths.end())
+        return *iterator->value;
+    return std::nullopt;
+}
+
+void AXGeometryManager::remove(AXID axID)
+{
+    m_cachedRects.remove(axID);
+    Locker locker { m_cachedPathsLock };
+    m_cachedPaths.remove(axID);
+}
+
 void AXGeometryManager::scheduleObjectRegionsUpdate(bool scheduleImmediately)
 {
     if (!scheduleImmediately) [[likely]] {

--- a/Source/WebCore/accessibility/AXGeometryManager.h
+++ b/Source/WebCore/accessibility/AXGeometryManager.h
@@ -28,6 +28,7 @@
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 #include <WebCore/AXCoreObject.h>
 #include <WebCore/IntRectHash.h>
+#include <WebCore/Path.h>
 #include <wtf/Lock.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/RefCounted.h>
@@ -64,7 +65,10 @@ public:
     // std::nullopt if there is no cached rect for the given ID (i.e. because it hasn't been cached yet via paint or otherwise, or cannot be painted / cached at all).
     std::optional<IntRect> NODELETE cachedRectForID(AXID);
 
-    void remove(AXID axID) { m_cachedRects.remove(axID); }
+    void cachePathForID(AXID, std::unique_ptr<Path>&&);
+    std::optional<Path> cachedPathForID(AXID);
+
+    void remove(AXID axID);
 
     std::optional<AXID> cachedHitTestResult(const IntPoint& screenPoint);
     void cacheHitTestResult(AXID resultID, const IntPoint& hitPoint);
@@ -85,6 +89,10 @@ private:
     const WeakPtr<AXObjectCache> m_cache;
     HashMap<AXID, IntRect> m_cachedRects;
     Timer m_updateObjectRegionsTimer;
+
+    Lock m_cachedPathsLock;
+    // Accessed by the main-thread for writing, and by the accessibility thread for reading.
+    HashMap<AXID, std::unique_ptr<Path>> m_cachedPaths WTF_GUARDED_BY_LOCK(m_cachedPathsLock);
 
     Lock m_hitTestCacheLock;
     static constexpr size_t HitTestCacheSize = 32;

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -1127,9 +1127,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::OuterHTML:
         stream << "OuterHTML";
         break;
-    case AXProperty::Path:
-        stream << "Path";
-        break;
     case AXProperty::PlaceholderValue:
         stream << "PlaceholderValue";
         break;

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -59,6 +59,7 @@
 #include "AccessibilityTableColumn.h"
 #include "AccessibilityTableHeaderContainer.h"
 #include "AriaNotifyOptions.h"
+#include "BorderShape.h"
 #include "CaretRectComputation.h"
 #include "Chrome.h"
 #include "ChromeClient.h"
@@ -107,6 +108,8 @@
 #include "RemoteFrame.h"
 #include "RemoteFrameView.h"
 #include "RenderAttachment.h"
+#include "RenderBox.h"
+#include "RenderElementStyleInlines.h"
 #include "RenderImage.h"
 #include "RenderInline.h"
 #include "RenderLayer.h"
@@ -5660,6 +5663,7 @@ void AXObjectCache::startUpdateTreeSnapshotTimer()
 void AXObjectCache::onPaint(const RenderObject& renderer, IntRect&& paintRect) const
 {
     if (std::optional axID = getAXID(const_cast<RenderObject&>(renderer))) {
+        auto paintRectOrigin = paintRect.location();
         bool cachedNewRect = m_geometryManager->cacheRectIfNeeded(*axID, WTF::move(paintRect));
 
         if (cachedNewRect) {
@@ -5667,10 +5671,51 @@ void AXObjectCache::onPaint(const RenderObject& renderer, IntRect&& paintRect) c
             if (RefPtr imageMap = renderImage ? renderImage->imageMap() : nullptr) {
                 // <area> elements have no renderers and thus will never be painted themselves.
                 // If the image was repainted in a new location, the associated area elements
-                // probably need new rects cached too.
+                // probably need new rects and paths cached too.
                 for (Ref area : descendantsOfType<HTMLAreaElement>(*imageMap)) {
-                    if (RefPtr areaObject = get(area.get()))
-                        std::ignore = m_geometryManager->cacheRectIfNeeded(areaObject->objectID(), snappedIntRect(LayoutRect(areaObject->relativeFrame())));
+                    if (RefPtr areaObject = get(area.get())) {
+                        bool areaCachedNewRect = m_geometryManager->cacheRectIfNeeded(areaObject->objectID(), snappedIntRect(LayoutRect(areaObject->relativeFrame())));
+                        if (areaCachedNewRect)
+                            m_geometryManager->cachePathForID(areaObject->objectID(), WTF::makeUnique<Path>(areaObject->elementPath()));
+                    }
+                }
+            }
+
+            // FIXME: SVG shapes (RenderSVGShape / LegacyRenderSVGShape) never trigger
+            // AccessibilityRegionContext::takeBounds, so this onPaint is never called for
+            // them and their paths aren't cached in the geometry manager. This means
+            // AXIsolatedObject::elementPath() returns empty for SVG in isolated tree mode.
+
+            // Some assistive technologies (e.g. VoiceOver) use the path to draw their cursor.
+            // Inflating the path a bit makes the cursor look better.
+            static constexpr unsigned shapePathInflationPx = 4;
+
+            // Recompute the element path when the rect changes for border-radius or
+            // clip-path boxes. Multi-line inlines compute their path on-demand from
+            // text runs (see AXIsolatedObject::elementPath).
+            if (auto* renderBox = dynamicDowncast<RenderBox>(renderer)) {
+                if (renderBox->hasClipPath()) {
+                    WTF::switchOn(renderBox->style().clipPath(),
+                        [&](const Style::BasicShapePath& clipPath) {
+                            auto borderRect = renderBox->borderBoxRect();
+                            borderRect.inflate(shapePathInflationPx);
+                            auto referenceBox = FloatRect(WTF::move(borderRect));
+                            auto path = Style::path(clipPath.shape(), referenceBox, renderBox->style().usedZoomForLength());
+                            path.transform(AffineTransform().translate(paintRectOrigin.x(), paintRectOrigin.y()));
+                            m_geometryManager->cachePathForID(*axID, WTF::makeUnique<Path>(WTF::move(path)));
+                        },
+                        [](const auto&) { }
+                    );
+                } else if (renderBox->style().border().hasBorderRadius()) {
+                    auto borderRect = renderBox->borderBoxRect();
+                    borderRect.inflate(shapePathInflationPx);
+                    auto borderShape = BorderShape::shapeForBorderRect(renderBox->style(), WTF::move(borderRect));
+                    auto path = borderShape.pathForOuterShape(renderer.document().deviceScaleFactor());
+                    // borderBoxRect() is in local coordinates starting at (0, 0). Use the paint
+                    // rect's origin to position the path, since it's already gone through
+                    // contentsToRootView and matches the relativeFrame coordinate system.
+                    path.transform(AffineTransform().translate(paintRectOrigin.x(), paintRectOrigin.y()));
+                    m_geometryManager->cachePathForID(*axID, WTF::makeUnique<Path>(WTF::move(path)));
                 }
             }
         }

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -335,6 +335,22 @@ Path AccessibilityNodeObject::elementPath() const
     return Path();
 }
 
+bool AccessibilityNodeObject::supportsPath() const
+{
+    if (auto* renderer = this->renderer()) {
+        if (is<RenderText>(renderer) || renderer->isRenderOrLegacyRenderSVGShape())
+            return true;
+        if (CheckedPtr renderBox = dynamicDowncast<RenderBox>(renderer)) {
+            if (renderBox->style().border().hasBorderRadius())
+                return true;
+        }
+        if (auto* renderElement = dynamicDowncast<RenderElement>(renderer); renderElement && renderElement->hasClipPath())
+            return true;
+    }
+
+    return isImageMapLink() || AXCoreObject::supportsPath();
+}
+
 LayoutRect AccessibilityNodeObject::boundingBoxRect() const
 {
     if (hasDisplayContents()) {

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -229,7 +229,7 @@ public:
 
     LayoutRect elementRect() const override;
     Path elementPath() const override;
-    bool supportsPath() const override { return isImageMapLink(); }
+    bool supportsPath() const override;
 
     bool isLabelContainingOnlyStaticText() const;
     bool isNativeLabel() const override;

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -41,6 +41,7 @@
 #include "AccessibilityObjectInlines.h"
 #include "AccessibilitySVGObject.h"
 #include "AccessibilitySpinButton.h"
+#include "BorderShape.h"
 #include "CachedImage.h"
 #include "Chrome.h"
 #include "ChromeClient.h"
@@ -103,8 +104,10 @@
 #include "ProgressTracker.h"
 #include "Range.h"
 #include "RenderBlockFlowInlines.h"
+#include "RenderBox.h"
 #include "RenderButton.h"
 #include "RenderElementInlines.h"
+#include "RenderElementStyleInlines.h"
 #include "RenderFileUploadControl.h"
 #include "RenderHTMLCanvas.h"
 #include "RenderImage.h"
@@ -705,9 +708,15 @@ bool AccessibilityRenderObject::isNonLayerSVGObject() const
     return renderer ? is<RenderSVGInlineText>(renderer) || is<LegacyRenderSVGModelObject>(renderer) : false;
 }
 
-bool AccessibilityRenderObject::supportsPath() const
+static Path computePathForRenderBox(const RenderBox& renderBox)
 {
-    return is<RenderText>(renderer()) || (renderer() && renderer()->isRenderOrLegacyRenderSVGShape());
+    auto borderShape = BorderShape::shapeForBorderRect(renderBox.style(), renderBox.borderBoxRect());
+    auto path = borderShape.pathForOuterShape(renderBox.document().deviceScaleFactor());
+    // borderBoxRect() is in local coordinates. Offset it to absolute document coordinates
+    // to match the coordinate system used by SVG, RenderText, and RenderInline paths.
+    auto absoluteOrigin = flooredLayoutPoint(renderBox.localToAbsolute());
+    path.transform(AffineTransform().translate(absoluteOrigin.x(), absoluteOrigin.y()));
+    return path;
 }
 
 Path AccessibilityRenderObject::elementPath() const
@@ -782,6 +791,26 @@ Path AccessibilityRenderObject::elementPath() const
             path.transform(AffineTransform().translate(parentOffset.x(), parentOffset.y()));
         }
         return path;
+    }
+
+    if (CheckedPtr renderBox = dynamicDowncast<RenderBox>(*m_renderer)) {
+        if (renderBox->hasClipPath()) {
+            std::optional<Path> clipPathResult;
+            WTF::switchOn(renderBox->style().clipPath(),
+                [&](const Style::BasicShapePath& clipPath) {
+                    auto referenceBox = FloatRect(renderBox->borderBoxRect());
+                    auto path = Style::path(clipPath.shape(), referenceBox, renderBox->style().usedZoomForLength());
+                    auto absoluteOrigin = flooredLayoutPoint(renderBox->localToAbsolute());
+                    path.transform(AffineTransform().translate(absoluteOrigin.x(), absoluteOrigin.y()));
+                    clipPathResult = WTF::move(path);
+                },
+                [](const auto&) { }
+            );
+            if (clipPathResult)
+                return *clipPathResult;
+        }
+        if (renderBox->style().border().hasBorderRadius())
+            return computePathForRenderBox(*renderBox);
     }
 
     return { };

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.h
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.h
@@ -209,7 +209,6 @@ private:
     AccessibilitySVGObject* remoteSVGRootElement(CreateIfNecessary) const;
     RefPtr<AccessibilityObject> remoteSVGElementHitTest(const IntPoint&) const;
     void offsetBoundingBoxForRemoteSVGElement(LayoutRect&) const;
-    bool supportsPath() const final;
 
 #if USE(ATSPI)
     void addNodeOnlyChildren();

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -441,10 +441,9 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
 
     auto role = this->role();
-    if (role == AccessibilityRole::Label) {
+    if (isStaticTextLabel()) {
         // Labels that only contain static text should just be mapped to static text.
-        if (containsOnlyStaticText())
-            role = AccessibilityRole::StaticText;
+        role = AccessibilityRole::StaticText;
     } else if (isAnonymousMathOperator()) {
         // The mfenced element creates anonymous RenderMathMLOperators with no RenderText
         // descendants. These anonymous renderers are the only accessible objects

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -162,7 +162,6 @@ bool isDefaultValue(AXProperty property, AXPropertyValueVariant& value)
         [](Vector<AXID>& typedValue) { return typedValue.isEmpty(); },
         [](Vector<std::pair<Markable<AXID>, Markable<AXID>>>& typedValue) { return typedValue.isEmpty(); },
         [](Vector<String>& typedValue) { return typedValue.isEmpty(); },
-        [](std::unique_ptr<Path>& typedValue) { return !typedValue || typedValue->isEmpty(); },
         [](OptionSet<AXAncestorFlag>& typedValue) { return typedValue.isEmpty(); },
 #if PLATFORM(COCOA)
         [](RetainPtr<NSAttributedString>& typedValue) { return !typedValue; },
@@ -871,19 +870,18 @@ URL AXIsolatedObject::urlAttributeValue(AXProperty property) const
     );
 }
 
-Path AXIsolatedObject::pathAttributeValue(AXProperty property) const
+bool AXIsolatedObject::supportsPath() const
 {
-    size_t index = indexOfProperty(property);
-    if (index == notFound)
-        return Path();
+    return boolAttributeValue(AXProperty::SupportsPath) || AXCoreObject::supportsPath();
+}
 
-    return WTF::switchOn(m_properties[index].second,
-        [] (const std::unique_ptr<Path>& typedValue) -> Path {
-            AX_ASSERT(typedValue.get());
-            return *typedValue.get();
-        },
-        [] (auto&) { return Path(); }
-    );
+Path AXIsolatedObject::elementPath() const
+{
+    if (RefPtr geometryManager = tree().geometryManager()) {
+        auto cachedPath = geometryManager->cachedPathForID(objectID());
+        return cachedPath.value_or(Path { });
+    }
+    return { };
 }
 
 static Color getColor(const AXPropertyValueVariant& value)

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -174,7 +174,6 @@ private:
     RetainPtr<CTFontRef> fontAttributeValue(AXProperty) const;
     URL urlAttributeValue(AXProperty) const;
     uint64_t uint64AttributeValue(AXProperty) const;
-    Path pathAttributeValue(AXProperty) const;
     Style::SpeakAs speakAsAttributeValue(AXProperty) const;
     std::pair<unsigned, unsigned> indexRangePairAttributeValue(AXProperty) const;
     template<typename T> T rectAttributeValue(AXProperty) const;
@@ -563,8 +562,8 @@ private:
 #endif
     AXObjectCache* NODELETE axObjectCache() const;
     Element* actionElement() const final;
-    Path elementPath() const final { return pathAttributeValue(AXProperty::Path); };
-    bool supportsPath() const final { return boolAttributeValue(AXProperty::SupportsPath); }
+    Path elementPath() const final;
+    bool supportsPath() const final;
 
     bool isWidget() const final
     {

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -2118,10 +2118,8 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
             setProperty(AXProperty::IsFocusedWebArea, object.isFocused());
         }
 
-        if (object.supportsPath()) {
+        if (object.supportsPath())
             setProperty(AXProperty::SupportsPath, true);
-            setProperty(AXProperty::Path, WTF::makeUnique<Path>(object.elementPath()));
-        }
 
         if (object.supportsKeyShortcuts()) {
             setProperty(AXProperty::SupportsKeyShortcuts, true);

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -264,7 +264,6 @@ enum class AXProperty : uint16_t {
     MinValueForRange,
     NameAttribute,
     OuterHTML,
-    Path,
     PlaceholderValue,
 #if PLATFORM(COCOA)
     PlatformWidget,
@@ -328,7 +327,7 @@ public:
 };
 
 // If this type is modified, the switchOn statment in AXIsolatedObject::setProperty must be updated as well.
-using AXPropertyValueVariant = Variant<std::nullptr_t, Markable<AXID>, String, bool, int, unsigned, double, float, uint64_t, WallTime, DateComponentsType, AccessibilityButtonState, Color, std::unique_ptr<URL>, LayoutRect, FloatPoint, FloatRect, InputType::Type, IntPoint, IntRect, std::pair<unsigned, unsigned>, Vector<AccessibilityText>, Vector<AXID>, Vector<std::pair<Markable<AXID>, Markable<AXID>>>, Vector<String>, std::unique_ptr<Path>, Vector<AXStitchGroup>, OptionSet<AXAncestorFlag>, Vector<Vector<Markable<AXID>>>, CharacterRange, std::unique_ptr<AXIDAndCharacterRange>, ElementName, AccessibilityOrientation
+using AXPropertyValueVariant = Variant<std::nullptr_t, Markable<AXID>, String, bool, int, unsigned, double, float, uint64_t, WallTime, DateComponentsType, AccessibilityButtonState, Color, std::unique_ptr<URL>, LayoutRect, FloatPoint, FloatRect, InputType::Type, IntPoint, IntRect, std::pair<unsigned, unsigned>, Vector<AccessibilityText>, Vector<AXID>, Vector<std::pair<Markable<AXID>, Markable<AXID>>>, Vector<String>, Vector<AXStitchGroup>, OptionSet<AXAncestorFlag>, Vector<Vector<Markable<AXID>>>, CharacterRange, std::unique_ptr<AXIDAndCharacterRange>, ElementName, AccessibilityOrientation
 #if PLATFORM(COCOA)
     , RetainPtr<NSAttributedString>
     , RetainPtr<NSView>


### PR DESCRIPTION
#### 8203ea8bcc856d8989dddfa20f968a54fdb9b953
<pre>
AX: Keep element paths up-to-date as the viewport changes, and expand path support to border-radius and clip-path
<a href="https://bugs.webkit.org/show_bug.cgi?id=311699">https://bugs.webkit.org/show_bug.cgi?id=311699</a>
<a href="https://rdar.apple.com/174283494">rdar://174283494</a>

Reviewed by Joshua Hoffman.

Previously, element paths were stored as an AXProperty::Path on each
AXIsolatedObject, snapshotted once at tree-build time. This made them
stale when elements or the viewport moved.

This patch removes AXProperty::Path from the isolated tree entirely and
instead caches paths in AXGeometryManager during paint, alongside the
existing rect cache. AXIsolatedObject::elementPath() now reads from
this cache on-demand. This lays groundwork for a follow-up that adds
on-demand path computation for multi-line text and links.

* LayoutTests/accessibility-isolated-tree/TestExpectations:
New test fails because we don&apos;t get paint callbacks for certain SVG types, meaning
we can&apos;t cache a path for them.
* LayoutTests/accessibility/image-link-expected.txt:
* LayoutTests/accessibility/image-map2-expected.txt:
* LayoutTests/accessibility/image-map2.html:
* LayoutTests/accessibility/mac/document-links-expected.txt:
* LayoutTests/accessibility/mac/document-links.html:
* LayoutTests/accessibility/mac/element-paths-expected.txt:
* LayoutTests/accessibility/mac/element-paths.html:
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::supportsPath const):
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::isStaticTextLabel const):
* Source/WebCore/accessibility/AXGeometryManager.cpp:
(WebCore::AXGeometryManager::cachePathForID):
(WebCore::AXGeometryManager::cachedPathForID):
(WebCore::AXGeometryManager::remove):
* Source/WebCore/accessibility/AXGeometryManager.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onPaint const):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::supportsPath const):
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::computePathForRenderBox):
(WebCore::AccessibilityRenderObject::elementPath const):
(WebCore::AccessibilityRenderObject::supportsPath const): Deleted.
* Source/WebCore/accessibility/AccessibilityRenderObject.h:
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::AXCoreObject::rolePlatformString):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::isDefaultValue):
(WebCore::AXIsolatedObject::supportsPath const):
(WebCore::AXIsolatedObject::elementPath const):
(WebCore::AXIsolatedObject::pathAttributeValue const): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::createIsolatedObjectData):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:

Canonical link: <a href="https://commits.webkit.org/310796@main">https://commits.webkit.org/310796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9737ea56cc015d5521c5217ce2fab2e00c1dc3c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163698 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108409 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e33c044-9cff-42cc-a3eb-9248bfba471e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156811 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28046 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119870 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84728 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22147 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139143 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100563 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2ffbe551-e207-49bb-824a-4b7538c1b14d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21232 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19260 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11524 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166173 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9693 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18596 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127971 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27742 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23299 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128110 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34770 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27666 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138780 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84375 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22994 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15575 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27358 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91462 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26936 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27167 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27009 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->