### PR TITLE
WebAuthn: AbortSignal reason is ignored when rejecting credentials.create() and credentials.get()

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-abort-reason.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-abort-reason.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS credentials.create() rejects with signal.reason when signal is pre-aborted with a string reason
+PASS credentials.create() rejects with signal.reason when signal is pre-aborted with a DOMException
+PASS credentials.get() rejects with signal.reason when signal is pre-aborted with a string reason
+PASS credentials.get() rejects with signal.reason when signal is pre-aborted with a DOMException
+

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-abort-reason.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-abort-reason.https.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<title>Web Authentication API: AbortSignal reason is propagated on credentials.create() and credentials.get()</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./resources/util.js"></script>
+<script>
+    // Use a HID mock that responds with an error so the callback fires and
+    // the abort-reason check in AuthenticatorCoordinator is exercised.
+    if (window.internals)
+        internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "malicious-payload" } });
+
+    // credentials.create() — signal aborted before call
+
+    promise_test(async t => {
+        const controller = new AbortController();
+        controller.abort("CustomReason");
+
+        const options = {
+            publicKey: {
+                rp: { name: "example.com" },
+                user: { name: "John Appleseed", id: asciiToUint8Array("123456"), displayName: "John" },
+                challenge: asciiToUint8Array("123456"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+            },
+            signal: controller.signal,
+        };
+
+        await navigator.credentials.create(options).then(
+            t.unreached_func("Should have rejected"),
+            reason => assert_equals(reason, "CustomReason", "Should reject with signal.reason, not a generic AbortError")
+        );
+    }, "credentials.create() rejects with signal.reason when signal is pre-aborted with a string reason");
+
+    promise_test(async t => {
+        const controller = new AbortController();
+        const error = new DOMException("Custom abort", "AbortError");
+        controller.abort(error);
+
+        const options = {
+            publicKey: {
+                rp: { name: "example.com" },
+                user: { name: "John Appleseed", id: asciiToUint8Array("123456"), displayName: "John" },
+                challenge: asciiToUint8Array("123456"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+            },
+            signal: controller.signal,
+        };
+
+        await navigator.credentials.create(options).then(
+            t.unreached_func("Should have rejected"),
+            reason => assert_equals(reason, error, "Should reject with the exact DOMException passed to abort()")
+        );
+    }, "credentials.create() rejects with signal.reason when signal is pre-aborted with a DOMException");
+
+    // credentials.get() — signal aborted before call
+
+    promise_test(async t => {
+        const controller = new AbortController();
+        controller.abort("CustomReason");
+
+        const options = {
+            publicKey: {
+                challenge: asciiToUint8Array("123456"),
+            },
+            signal: controller.signal,
+        };
+
+        await navigator.credentials.get(options).then(
+            t.unreached_func("Should have rejected"),
+            reason => assert_equals(reason, "CustomReason", "Should reject with signal.reason, not a generic AbortError")
+        );
+    }, "credentials.get() rejects with signal.reason when signal is pre-aborted with a string reason");
+
+    promise_test(async t => {
+        const controller = new AbortController();
+        const error = new DOMException("Custom abort", "AbortError");
+        controller.abort(error);
+
+        const options = {
+            publicKey: {
+                challenge: asciiToUint8Array("123456"),
+            },
+            signal: controller.signal,
+        };
+
+        await navigator.credentials.get(options).then(
+            t.unreached_func("Should have rejected"),
+            reason => assert_equals(reason, error, "Should reject with the exact DOMException passed to abort()")
+        );
+    }, "credentials.get() rejects with signal.reason when signal is pre-aborted with a DOMException");
+</script>

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -249,7 +249,7 @@ void AuthenticatorCoordinator::create(const Document& document, CredentialCreati
 
     auto callback = [promise = WTF::move(promise), abortSignal = WTF::move(abortSignal)](AuthenticatorResponseData&& data, AuthenticatorAttachment attachment, ExceptionData&& exception) mutable {
         if (abortSignal && abortSignal->aborted()) {
-            promise.reject(Exception { ExceptionCode::AbortError, "Aborted by AbortSignal."_s });
+            promise.rejectType<IDLAny>(abortSignal->reason().getValue());
             return;
         }
 
@@ -368,7 +368,7 @@ void AuthenticatorCoordinator::discoverFromExternalSource(const Document& docume
 
     auto callback = [weakThis = WeakPtr { *this }, promise = WTF::move(promise), abortSignal = WTF::move(requestOptions.signal), weakPage = WeakPtr { document.page() }] (AuthenticatorResponseData&& data, AuthenticatorAttachment attachment, ExceptionData&& exception) mutable {
         if (abortSignal && abortSignal->aborted()) {
-            promise.reject(Exception { ExceptionCode::AbortError, "Aborted by AbortSignal."_s });
+            promise.rejectType<IDLAny>(abortSignal->reason().getValue());
             return;
         }
 


### PR DESCRIPTION
#### 7a3f4c0ecbd3726a02b08c0870c6887583d1c8f9
<pre>
WebAuthn: AbortSignal reason is ignored when rejecting credentials.create() and credentials.get()
<a href="https://rdar.apple.com/174220589">rdar://174220589</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311625">https://bugs.webkit.org/show_bug.cgi?id=311625</a>

Reviewed by Pascoe and Anne van Kesteren.

When navigator.credentials.create() or navigator.credentials.get() is aborted
via controller.abort(reason), the promise should reject with signal.reason.
Instead, the reason was discarded and the promise always rejected with a
hard-coded AbortError DOMException.

Fix both callbacks in AuthenticatorCoordinator to use
promise.rejectType&lt;IDLAny&gt;(abortSignal-&gt;reason().getValue()), consistent
with the pattern used in CredentialsContainer.cpp.

Tests: http/wpt/webauthn/public-key-credential-abort-reason.https.html
       imported/w3c/web-platform-tests/webauthn/createcredential-abort.https.html
       imported/w3c/web-platform-tests/webauthn/getcredential-abort.https.html

* LayoutTests/http/wpt/webauthn/public-key-credential-abort-reason.https.html: Added.
* LayoutTests/http/wpt/webauthn/public-key-credential-abort-reason.https-expected.txt: Added.
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinator::create):
(WebCore::AuthenticatorCoordinator::discoverFromExternalSource):

Canonical link: <a href="https://commits.webkit.org/310782@main">https://commits.webkit.org/310782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/310266fe508ccddbe8ac84632dbaed62e3c8499e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154886 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28145 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163646 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108356 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1d2ecf3f-bc6a-489d-a17f-0393ede166b4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156759 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27994 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119824 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84696 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c9cd9899-5f64-4096-bd91-bc1d7296f8df) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22094 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139093 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100517 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e17d0e2-8695-4e54-b28d-8a96906ad998) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21179 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19209 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11472 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130841 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166120 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9502 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18546 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127925 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23249 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128064 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34759 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27614 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138730 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84319 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22942 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15525 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27306 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91408 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26884 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27115 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26957 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->