### PR TITLE
ParentNode.append() should de-duplicate nodes when the same node is passed multiple times

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/ParentNode-append-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/ParentNode-append-expected.txt
@@ -15,6 +15,7 @@ PASS Element.append() with only text as an argument, on a parent having no child
 PASS Element.append() with only one element as an argument, on a parent having no child.
 PASS Element.append() with null as an argument, on a parent having a child.
 PASS Element.append() with one element and text as argument, on a parent having a child.
+PASS Element.append() with the same element twice.
 PASS DocumentFragment.append() without any argument, on a parent having no child.
 PASS DocumentFragment.append() with null as an argument, on a parent having no child.
 PASS DocumentFragment.append() with undefined as an argument, on a parent having no child.
@@ -22,4 +23,5 @@ PASS DocumentFragment.append() with only text as an argument, on a parent having
 PASS DocumentFragment.append() with only one element as an argument, on a parent having no child.
 PASS DocumentFragment.append() with null as an argument, on a parent having a child.
 PASS DocumentFragment.append() with one element and text as argument, on a parent having a child.
+PASS DocumentFragment.append() with the same element twice.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/ParentNode-append.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/ParentNode-append.html
@@ -59,6 +59,16 @@ function test_append(node, nodeName) {
         assert_equals(parent.childNodes[1], x);
         assert_equals(parent.childNodes[2].textContent, 'text');
     }, nodeName + '.append() with one element and text as argument, on a parent having a child.');
+
+    test(function() {
+        const parent = node.cloneNode();
+        const x = document.createElement('x');
+        const y = document.createElement('y');
+        parent.append(x, y, x);
+        assert_equals(parent.childNodes.length, 2);
+        assert_equals(parent.childNodes[0], y);
+        assert_equals(parent.childNodes[1], x);
+    }, nodeName + '.append() with the same element twice.');
 }
 
 test_append(document.createElement('div'), 'Element');

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -640,6 +640,17 @@ ExceptionOr<NodeVector> Node::convertNodesOrStringsIntoNodeVector(FixedVector<No
     if (nodeVector.size() == 1)
         return nodeVector; // step 3, if nodes contains one node, then set node to nodes[0].
 
+    // If the same node appears multiple times, keep only the last occurrence
+    // to match the spec behavior (as if a temporary DocumentFragment was used).
+    // https://dom.spec.whatwg.org/#converting-nodes-into-a-node
+    {
+        HashSet<Ref<Node>> seen;
+        for (size_t i = nodeVector.size(); i > 0; --i) {
+            if (!seen.add(nodeVector[i - 1]).isNewEntry)
+                nodeVector.removeAt(i - 1);
+        }
+    }
+
     for (auto& node : nodeVector) {
         auto result = node->remove();
         if (result.hasException())


### PR DESCRIPTION
#### eda04d24c262500a374efe245de60fa7ed26da94
<pre>
ParentNode.append() should de-duplicate nodes when the same node is passed multiple times
<a href="https://bugs.webkit.org/show_bug.cgi?id=311708">https://bugs.webkit.org/show_bug.cgi?id=311708</a>

Reviewed by Ryosuke Niwa.

When the same node is passed multiple times to ParentNode.append() (e.g., append(x, y, x)),
convertNodesOrStringsIntoNodeVector() would produce a vector with duplicate entries. This
caused a crash in appendChildCommon() which asserts that the node has no parent, since the
first insertion already parented the node.

Fix by de-duplicating nodes in convertNodesOrStringsIntoNodeVector(), keeping only the last
occurrence of each duplicate node. This matches the spec behavior as if a temporary
DocumentFragment was used, and matches Blink and Gecko.

No new tests, covered by imported/w3c/web-platform-tests/dom/nodes/ParentNode-append.html
which was resync&apos;d from upstream to gain test coverage. This test is already passing in
Chrome and Firefox so this aligns our behavior with them.

* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/ParentNode-append-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/ParentNode-append.html:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::convertNodesOrStringsIntoNodeVector):

Canonical link: <a href="https://commits.webkit.org/310807@main">https://commits.webkit.org/310807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38491a6bcd56c704e09e982522a2a7df369dc607

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163642 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108352 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156755 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28279 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27990 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119821 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84694 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22092 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139092 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100514 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21177 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19206 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11468 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130839 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166116 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9481 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18545 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127923 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27686 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23246 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128062 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34780 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27610 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138729 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84315 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22940 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15524 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27302 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91404 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26880 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27111 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26953 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->