### PR TITLE
Fix flaky test http/tests/security/contentSecurityPolicy/script-src-strict-dynamic-and-script-src-elem.html

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7811,8 +7811,6 @@ imported/w3c/web-platform-tests/css/CSS2/floats/float-nowrap-hyphen-rewind-1.htm
 # This test is flaky. Resizing the window exposures the failure
 webkit.org/b/288689 svg/text/bidi-text-query.svg [ Skip ]
 
-webkit.org/b/289782 http/tests/security/contentSecurityPolicy/script-src-strict-dynamic-and-script-src-elem.html [ Pass Failure ]
-
 imported/w3c/web-platform-tests/css/css-align/abspos/align-items-static-position.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-align/abspos/align-self-static-position-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-align/abspos/align-self-static-position-002.html [ ImageOnlyFailure ]

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/script-src-strict-dynamic-and-script-src-elem-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/script-src-strict-dynamic-and-script-src-elem-expected.txt
@@ -1,2 +1,3 @@
 ALERT: importScripts allowed
+ALERT: importScripts allowed
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/script-src-strict-dynamic-and-script-src-elem.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/script-src-strict-dynamic-and-script-src-elem.html
@@ -11,11 +11,14 @@ if (window.testRunner) {
 <body>
 <script>
 try {
+    var messageCount = 0;
     var worker = new Worker('http://127.0.0.1:8000/security/contentSecurityPolicy/resources/worker.py?type=importscripts&csp=' +
                             encodeURIComponent("script-src 'strict-dynamic'; script-src-elem localhost:8000"));
     worker.onmessage = function (event) {
         alert(event.data);
-        if (window.testRunner)
+        // The worker sends two messages: one from the imported post-message.js
+        // and one from the worker script itself after importScripts() returns.
+        if (++messageCount === 2 && window.testRunner)
             testRunner.notifyDone();
     };
 } catch (e) {


### PR DESCRIPTION
#### 1829d31df6800bb3b44ad1d8d1bea60fa604b5d0
<pre>
Fix flaky test http/tests/security/contentSecurityPolicy/script-src-strict-dynamic-and-script-src-elem.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=311709">https://bugs.webkit.org/show_bug.cgi?id=311709</a>
<a href="https://rdar.apple.com/174297450">rdar://174297450</a>

Reviewed by Ryan Reno.

Layout test http/tests/security/contentSecurityPolicy/script-src-strict-dynamic-and-script-src-elem.html
creates a Worker whose script calls importScripts(&quot;post-message.js&quot;) followed by its own
postMessage(&quot;importScripts allowed&quot;). Since post-message.js also calls postMessage(&quot;importScripts allowed&quot;),
two identical messages are sent. The test only expected one, creating a race between notifyDone() and
the second message&apos;s delivery. This became flaky after 292030@main moved alert output from the injected
bundle (which had an isTestRunning() guard) to the UIProcess.

Fix by waiting for both messages before calling notifyDone() and expecting both alerts.

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/security/contentSecurityPolicy/script-src-strict-dynamic-and-script-src-elem-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/script-src-strict-dynamic-and-script-src-elem.html:

Canonical link: <a href="https://commits.webkit.org/310783@main">https://commits.webkit.org/310783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf6dfd7fc31689ccf7dcba1e6c22e14926be7cbe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163651 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108361 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8e244e17-431f-44b4-b910-f244b4105d83) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27999 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119828 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84698 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157850 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22097 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139096 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100521 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1bbede79-cfe6-4340-9efa-78136b1e20da) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21182 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19213 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11477 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130844 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16940 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166125 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18549 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127930 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27695 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23253 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128069 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34760 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27619 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138733 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84324 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22945 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15528 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27311 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26889 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27120 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26962 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->