### PR TITLE
CredentialsContainer: performCommonChecks() should take const Document& instead of acquiring it internally

### DIFF
--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
@@ -49,75 +49,15 @@ CredentialsContainer::CredentialsContainer(WeakPtr<Document, WeakPtrImplWithEven
 {
 }
 
-void CredentialsContainer::get(CredentialRequestOptions&& options, CredentialPromise&& promise)
-{
-    // The following implements https://www.w3.org/TR/credential-management-1/#algorithm-request as of 4 August 2017
-    // with enhancement from 14 November 2017 Editor's Draft.
-    if (!performCommonChecks(options, promise)) {
-        return;
-    }
-
-    Ref document = *this->document();
-    if (options.digital) {
-#if HAVE(DIGITAL_CREDENTIALS_UI)
-        DigitalCredential::discoverFromExternalSource(document, WTF::move(promise), WTF::move(options));
-#else
-        promise.resolve(nullptr);
-#endif
-        return;
-    }
-    document->page()->authenticatorCoordinator().discoverFromExternalSource(document, WTF::move(options), WTF::move(promise));
-}
-
-void CredentialsContainer::store(const BasicCredential&, CredentialPromise&& promise)
-{
-    promise.reject(Exception { ExceptionCode::NotSupportedError, "Not implemented."_s });
-}
-
-void CredentialsContainer::isCreate(CredentialCreationOptions&& options, CredentialPromise&& promise)
-{
-    if (!performCommonChecks(options, promise))
-        return;
-
-    // Extra.
-    Ref document = *this->document();
-    if (!document->hasFocus()) {
-        promise.reject(Exception { ExceptionCode::NotAllowedError, "The document is not focused."_s });
-        return;
-    }
-
-    if (options.publicKey) {
-        document->page()->authenticatorCoordinator().create(document, WTF::move(options), WTF::move(options.signal), WTF::move(promise));
-        return;
-    }
-
-    promise.resolve(nullptr);
-}
-
-void CredentialsContainer::preventSilentAccess(DOMPromiseDeferred<void>&& promise) const
-{
-    if (RefPtr document = this->document(); !document->isFullyActive()) {
-        promise.reject(Exception { ExceptionCode::InvalidStateError, "The document is not fully active."_s });
-        return;
-    }
-    promise.resolve();
-}
-
 template<typename Options>
-bool CredentialsContainer::performCommonChecks(const Options& options, CredentialPromise& promise)
+static bool performCommonChecks(const Document& document, const Options& options, CredentialPromise& promise)
 {
-    RefPtr document = this->document();
-    if (!document) {
-        promise.reject(Exception { ExceptionCode::NotSupportedError });
-        return false;
-    }
-
-    if (!document->isFullyActive()) {
+    if (!document.isFullyActive()) {
         promise.reject(Exception { ExceptionCode::InvalidStateError, "The document is not fully active."_s });
         return false;
     }
 
-    if (!document->page()) {
+    if (!document.page()) {
         promise.reject(Exception { ExceptionCode::InvalidStateError, "No browsing context"_s });
         return false;
     }
@@ -146,8 +86,71 @@ bool CredentialsContainer::performCommonChecks(const Options& options, Credentia
 #endif
     }
 
-    ASSERT(document->isSecureContext());
+    ASSERT(document.isSecureContext());
     return true;
+}
+
+void CredentialsContainer::get(CredentialRequestOptions&& options, CredentialPromise&& promise)
+{
+    // The following implements https://www.w3.org/TR/credential-management-1/#algorithm-request as of 4 August 2017
+    // with enhancement from 14 November 2017 Editor's Draft.
+    RefPtr document = this->document();
+    if (!document) {
+        promise.reject(Exception { ExceptionCode::NotSupportedError });
+        return;
+    }
+
+    if (!performCommonChecks(*document, options, promise))
+        return;
+
+    if (options.digital) {
+#if HAVE(DIGITAL_CREDENTIALS_UI)
+        DigitalCredential::discoverFromExternalSource(*document, WTF::move(promise), WTF::move(options));
+#else
+        promise.resolve(nullptr);
+#endif
+        return;
+    }
+    document->page()->authenticatorCoordinator().discoverFromExternalSource(*document, WTF::move(options), WTF::move(promise));
+}
+
+void CredentialsContainer::store(const BasicCredential&, CredentialPromise&& promise)
+{
+    promise.reject(Exception { ExceptionCode::NotSupportedError, "Not implemented."_s });
+}
+
+void CredentialsContainer::isCreate(CredentialCreationOptions&& options, CredentialPromise&& promise)
+{
+    RefPtr document = this->document();
+    if (!document) {
+        promise.reject(Exception { ExceptionCode::NotSupportedError });
+        return;
+    }
+
+    if (!performCommonChecks(*document, options, promise))
+        return;
+
+    // Extra.
+    if (!document->hasFocus()) {
+        promise.reject(Exception { ExceptionCode::NotAllowedError, "The document is not focused."_s });
+        return;
+    }
+
+    if (options.publicKey) {
+        document->page()->authenticatorCoordinator().create(*document, WTF::move(options), WTF::move(options.signal), WTF::move(promise));
+        return;
+    }
+
+    promise.resolve(nullptr);
+}
+
+void CredentialsContainer::preventSilentAccess(DOMPromiseDeferred<void>&& promise) const
+{
+    if (RefPtr document = this->document(); !document->isFullyActive()) {
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "The document is not fully active."_s });
+        return;
+    }
+    promise.resolve();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h
@@ -64,8 +64,6 @@ private:
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 
 protected:
-    template<typename Options>
-    bool performCommonChecks(const Options&, CredentialPromise&);
     const Document* document() const { return m_document.get(); }
 };
 


### PR DESCRIPTION
#### acecc70c238299e5724c7ea79eaafc475fdacfab
<pre>
CredentialsContainer: performCommonChecks() should take const Document&amp; instead of acquiring it internally
<a href="https://bugs.webkit.org/show_bug.cgi?id=311707">https://bugs.webkit.org/show_bug.cgi?id=311707</a>
<a href="https://rdar.apple.com/174293959">rdar://174293959</a>

Reviewed by Chris Dumez.

Change performCommonChecks() to a static free function that takes
const Document&amp; and returns bool. Callers acquire and null-check the
document themselves before calling it. This keeps the function name
semantically consistent, avoids ref churn, and removes the function
from the header entirely.

* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h:

Canonical link: <a href="https://commits.webkit.org/310779@main">https://commits.webkit.org/310779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ced3033813c384026ed9620467e57d285a3467e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163660 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108370 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156773 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28298 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28008 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119837 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/84707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22104 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139105 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100530 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/060f15fe-5522-4d0a-a3e0-528b869d80f6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21189 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19224 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11486 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130851 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16949 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166134 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9541 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18558 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127939 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23263 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128078 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34756 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27628 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138742 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84333 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22953 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15537 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27320 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91424 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26898 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27129 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26971 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->