### PR TITLE
Remove obsolete OS version checks in process-entitlements.sh

### DIFF
--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -16,11 +16,8 @@ function mac_process_webcontent_entitlements()
 
     if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
     then
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 ))
-        then
-            plistbuddy Add :com.apple.private.verified-jit bool YES
-            plistbuddy Add :com.apple.security.cs.single-jit bool YES
-        fi
+        plistbuddy Add :com.apple.private.verified-jit bool YES
+        plistbuddy Add :com.apple.security.cs.single-jit bool YES
     fi
 
     mac_process_webcontent_shared_entitlements
@@ -55,46 +52,28 @@ function mac_process_gpu_entitlements()
 
     if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
     then
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 101400 ))
-        then
-            plistbuddy Add :com.apple.tcc.delegated-services array
-            plistbuddy Add :com.apple.tcc.delegated-services:1 string kTCCServiceMicrophone
-            plistbuddy Add :com.apple.tcc.delegated-services:0 string kTCCServiceCamera
-        fi
+        plistbuddy Add :com.apple.tcc.delegated-services array
+        plistbuddy Add :com.apple.tcc.delegated-services:1 string kTCCServiceMicrophone
+        plistbuddy Add :com.apple.tcc.delegated-services:0 string kTCCServiceCamera
 
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
-        then
-            plistbuddy Add :com.apple.developer.videotoolbox.client-sandboxed-decoder bool YES
-            plistbuddy Add :com.apple.avfoundation.allow-system-wide-context bool YES
-            plistbuddy add :com.apple.QuartzCore.webkit-limited-types bool YES
-        fi
+        plistbuddy Add :com.apple.developer.videotoolbox.client-sandboxed-decoder bool YES
+        plistbuddy Add :com.apple.avfoundation.allow-system-wide-context bool YES
+        plistbuddy add :com.apple.QuartzCore.webkit-limited-types bool YES
 
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
-        then
-            plistbuddy Add :com.apple.private.security.message-filter bool YES
-            plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
-        fi
+        plistbuddy Add :com.apple.private.security.message-filter bool YES
+        plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
 
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 ))
-        then
-            plistbuddy add :com.apple.coreaudio.allow-vorbis-decode bool YES
-        fi
+        plistbuddy add :com.apple.coreaudio.allow-vorbis-decode bool YES
 
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 130000 ))
-        then
-            plistbuddy Add :com.apple.private.gpu-restricted bool YES
-            plistbuddy Add :com.apple.private.screencapturekit.sharingsession bool YES
-            plistbuddy Add :com.apple.private.tcc.allow array
-            plistbuddy Add :com.apple.private.tcc.allow:0 string kTCCServiceScreenCapture
-            plistbuddy Add :com.apple.runningboard.assertions.webkit bool YES
-            plistbuddy Add :com.apple.mediaremote.external-artwork-validation bool YES
-        fi
+        plistbuddy Add :com.apple.private.gpu-restricted bool YES
+        plistbuddy Add :com.apple.private.screencapturekit.sharingsession bool YES
+        plistbuddy Add :com.apple.private.tcc.allow array
+        plistbuddy Add :com.apple.private.tcc.allow:0 string kTCCServiceScreenCapture
+        plistbuddy Add :com.apple.runningboard.assertions.webkit bool YES
+        plistbuddy Add :com.apple.mediaremote.external-artwork-validation bool YES
 
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 140000 ))
-        then
-            plistbuddy add :com.apple.private.disable.screencapturekit.alert bool YES
-            plistbuddy add :com.apple.aneuserd.private.allow bool YES
-        fi
+        plistbuddy add :com.apple.private.disable.screencapturekit.alert bool YES
+        plistbuddy add :com.apple.aneuserd.private.allow bool YES
 
         plistbuddy Add :com.apple.private.memory.ownership_transfer bool YES
         plistbuddy Add :com.apple.private.webkit.use-xpc-endpoint bool YES
@@ -125,36 +104,21 @@ function mac_process_network_entitlements()
 
     if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
     then
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 101500 ))
-        then
-            plistbuddy Add :com.apple.private.network.socket-delegate bool YES
-        fi
+        plistbuddy Add :com.apple.private.network.socket-delegate bool YES
 
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
-        then
-            plistbuddy Add :com.apple.private.security.message-filter bool YES
-            plistbuddy Add :com.apple.private.tcc.manager.check-by-audit-token array
-            plistbuddy Add :com.apple.private.tcc.manager.check-by-audit-token:0 string kTCCServiceWebKitIntelligentTrackingPrevention
-            plistbuddy Add :com.apple.private.tcc.manager.check-by-audit-token:1 string kTCCServiceUserTracking
-        fi
+        plistbuddy Add :com.apple.private.security.message-filter bool YES
+        plistbuddy Add :com.apple.private.tcc.manager.check-by-audit-token array
+        plistbuddy Add :com.apple.private.tcc.manager.check-by-audit-token:0 string kTCCServiceWebKitIntelligentTrackingPrevention
+        plistbuddy Add :com.apple.private.tcc.manager.check-by-audit-token:1 string kTCCServiceUserTracking
 
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
-        then
-            plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
-        fi
+        plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
 
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 130000 ))
-        then
-            plistbuddy Add :com.apple.runningboard.assertions.webkit bool YES
-            plistbuddy Add :com.apple.private.assets.bypass-asset-types-check bool YES
-            plistbuddy Add :com.apple.private.assets.accessible-asset-types array
-            plistbuddy Add :com.apple.private.assets.accessible-asset-types:0 string com.apple.MobileAsset.WebContentRestrictions
-        fi
+        plistbuddy Add :com.apple.runningboard.assertions.webkit bool YES
+        plistbuddy Add :com.apple.private.assets.bypass-asset-types-check bool YES
+        plistbuddy Add :com.apple.private.assets.accessible-asset-types array
+        plistbuddy Add :com.apple.private.assets.accessible-asset-types:0 string com.apple.MobileAsset.WebContentRestrictions
 
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 140000 ))
-        then
-            plistbuddy Add :com.apple.private.ciphermld.allow bool YES
-        fi
+        plistbuddy Add :com.apple.private.ciphermld.allow bool YES
 
         plistbuddy Add :com.apple.private.launchservices.allowedtochangethesekeysinotherapplications array
         plistbuddy Add :com.apple.private.launchservices.allowedtochangethesekeysinotherapplications:0 string LSActivePageUserVisibleOriginsKey
@@ -251,21 +215,12 @@ function mac_process_webcontent_shared_entitlements()
 {
     if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
     then
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
-        then
-            plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
-        fi
+        plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
 
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 ))
-        then
-            plistbuddy add :com.apple.coreaudio.allow-vorbis-decode bool YES
-        fi
+        plistbuddy add :com.apple.coreaudio.allow-vorbis-decode bool YES
 
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 130000 ))
-        then
-            webcontent_sandbox_entitlements
-            plistbuddy Add :com.apple.runningboard.assertions.webkit bool YES
-        fi
+        webcontent_sandbox_entitlements
+        plistbuddy Add :com.apple.runningboard.assertions.webkit bool YES
 
         if [[ "${WK_WEBCONTENT_SERVICE_NEEDS_XPC_DOMAIN_EXTENSION_ENTITLEMENT}" == YES ]]
         then
@@ -282,24 +237,20 @@ function mac_process_webcontent_shared_entitlements()
         plistbuddy Add :com.apple.private.webkit.use-xpc-endpoint bool YES
         plistbuddy Add :com.apple.rootless.storage.WebKitWebContentSandbox bool YES
         plistbuddy Add :com.apple.QuartzCore.webkit-end-points bool YES
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
-        then
-            plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
-            plistbuddy Add :com.apple.developer.videotoolbox.client-sandboxed-decoder bool YES
-            plistbuddy Add :com.apple.pac.shared_region_id string WebContent
-            plistbuddy Add :com.apple.private.security.message-filter bool YES
-            plistbuddy Add :com.apple.avfoundation.allow-system-wide-context bool YES
-            plistbuddy add :com.apple.QuartzCore.webkit-limited-types bool YES
 
-            if [[ "${WK_USE_FATAL_EXCEPTIONS}" == YES ]]
-            then
-                plistbuddy Add :com.apple.private.pac.exception bool YES
-            fi
-        fi
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 130000 ))
+        plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
+        plistbuddy Add :com.apple.developer.videotoolbox.client-sandboxed-decoder bool YES
+        plistbuddy Add :com.apple.pac.shared_region_id string WebContent
+        plistbuddy Add :com.apple.private.security.message-filter bool YES
+        plistbuddy Add :com.apple.avfoundation.allow-system-wide-context bool YES
+        plistbuddy add :com.apple.QuartzCore.webkit-limited-types bool YES
+
+        if [[ "${WK_USE_FATAL_EXCEPTIONS}" == YES ]]
         then
-            plistbuddy Add :com.apple.private.gpu-restricted bool YES
+            plistbuddy Add :com.apple.private.pac.exception bool YES
         fi
+
+        plistbuddy Add :com.apple.private.gpu-restricted bool YES
     fi
 
     if [[ "${WK_XPC_SERVICE_VARIANT}" == Development ]]
@@ -355,26 +306,20 @@ function maccatalyst_process_webcontent_shared_entitlements()
         plistbuddy Add :com.apple.security.fatal-exceptions:0 string jit
     fi
 
-    if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
-    then
-        plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
-        plistbuddy Add :com.apple.pac.shared_region_id string WebContent
-        plistbuddy Add :com.apple.private.security.message-filter bool YES
-        plistbuddy Add :com.apple.UIKit.view-service-wants-custom-idiom-and-scale bool YES
-        plistbuddy Add :com.apple.QuartzCore.webkit-limited-types bool YES
+    plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
+    plistbuddy Add :com.apple.pac.shared_region_id string WebContent
+    plistbuddy Add :com.apple.private.security.message-filter bool YES
+    plistbuddy Add :com.apple.UIKit.view-service-wants-custom-idiom-and-scale bool YES
+    plistbuddy Add :com.apple.QuartzCore.webkit-limited-types bool YES
 
-        if [[ "${WK_USE_FATAL_EXCEPTIONS}" == YES ]]
-        then
-            plistbuddy Add :com.apple.private.pac.exception bool YES
-        fi
+    if [[ "${WK_USE_FATAL_EXCEPTIONS}" == YES ]]
+    then
+        plistbuddy Add :com.apple.private.pac.exception bool YES
     fi
 
     if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
     then
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
-        then
-            plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
-        fi
+        plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
 
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 260000 ))
         then
@@ -392,11 +337,8 @@ function maccatalyst_process_webcontent_entitlements()
 {
     plistbuddy Add :com.apple.security.cs.allow-jit bool YES
 
-    if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 120000 ))
-    then
-        plistbuddy Add :com.apple.private.verified-jit bool YES
-        plistbuddy Add :com.apple.security.cs.single-jit bool YES
-    fi
+    plistbuddy Add :com.apple.private.verified-jit bool YES
+    plistbuddy Add :com.apple.security.cs.single-jit bool YES
 
     maccatalyst_process_webcontent_shared_entitlements
 }
@@ -438,10 +380,7 @@ function maccatalyst_process_gpu_entitlements()
 
     if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
     then
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
-        then
-            plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
-        fi
+        plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 260000 ))
         then
             plistbuddy Add :com.apple.security.hardened-process.checked-allocations.no-tagged-receive bool YES
@@ -471,10 +410,7 @@ function maccatalyst_process_network_entitlements()
 
     if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
     then
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
-        then
-            plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
-        fi
+        plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 260000 ))
         then
             plistbuddy Add :com.apple.security.hardened-process.checked-allocations.no-tagged-receive bool YES


### PR DESCRIPTION
#### 1e054343a3ef797a1385fffb04a177969a072245
<pre>
Remove obsolete OS version checks in process-entitlements.sh
<a href="https://bugs.webkit.org/show_bug.cgi?id=311710">https://bugs.webkit.org/show_bug.cgi?id=311710</a>
<a href="https://rdar.apple.com/174298667">rdar://174298667</a>

Reviewed by Brandon Stewart, Sihui Liu, and Ben Nham.

* Source/WebKit/Scripts/process-entitlements.sh:

Canonical link: <a href="https://commits.webkit.org/310822@main">https://commits.webkit.org/310822@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16e398f6a5ec913b857eb7ff9cbfdfae3b93d4ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154894 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21313 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163654 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108364 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4b8f4edf-f119-4d27-a4f8-961e4bb7f3c6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28002 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119833 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84699 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9eea9e40-fc4b-4e28-bffc-d79cad84ea9e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22105 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139102 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100526 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba330d6a-bc10-40ac-b8a7-25e03d333b57) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/154214 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21190 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19217 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11480 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130852 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166128 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9538 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18555 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127932 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27698 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23257 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128071 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27622 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138739 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84327 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23638 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22951 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15534 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27314 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91418 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26892 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27123 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26965 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->