### PR TITLE
Remove CPU checks in WebContent process sandbox for arm64 on macOS

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -32,11 +32,12 @@
 (define (lockdown-mode)
     (signing-identifier "com.apple.WebKit.WebContent.CaptivePortal"))
 
+#define TRUE #t
 #define FALSE #f
 
 (define webcontent_gpu_sandbox_extensions_blocking?
 #if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 140400 && defined(RC_XBS) && RC_XBS == 1
-    (equal? (param "CPU") "arm64")
+    TRUE
 #else
     FALSE
 #endif
@@ -574,54 +575,46 @@
     (deny iokit-get-properties (with no-report)
         (iokit-property "APTDevice")))
 
-(if (equal? (param "CPU") "arm64")
-    (with-filter (iokit-registry-entry-class "AppleARMIODevice")
-        (deny iokit-get-properties (with no-report)
-            (iokit-property "supports-apt"))))
+(with-filter (iokit-registry-entry-class "AppleARMIODevice")
+    (deny iokit-get-properties (with no-report)
+        (iokit-property "supports-apt")))
 
-(if (equal? (param "CPU") "arm64")
-    (with-filter (iokit-registry-entry-class "AppleJPEGDriver")
-        (deny iokit-get-properties (with no-report)
-            (iokit-property "AppleJPEGNumCores"))))
+(with-filter (iokit-registry-entry-class "AppleJPEGDriver")
+    (deny iokit-get-properties (with no-report)
+        (iokit-property "AppleJPEGNumCores")))
 
 ;; <rdar://problem/60088861>
-(if (equal? (param "CPU") "arm64")
+(allow iokit-get-properties
+    (iokit-property "ADSSupported")
+    (iokit-property "IOAVDHEVCDecodeCapabilities")
+    (iokit-property "IOGLESBundleName") ;; <rdar://problem/67473780>
+    (iokit-property "MetalPluginClassName") ;; <rdar://problem/67473780>
+    (iokit-property "MetalPluginName") ;; <rdar://problem/67473780>
+    (iokit-property "IOSurfaceAcceleratorCapabilitiesDict") ;; <rdar://problem/63696732>
+    (iokit-property "acoustic-id")) ;; <rdar://problem/65290967>
+
+(with-filter (iokit-registry-entry-class "IOService")
     (allow iokit-get-properties
-        (iokit-property "ADSSupported")
-        (iokit-property "IOAVDHEVCDecodeCapabilities")
-        (iokit-property "IOGLESBundleName") ;; <rdar://problem/67473780>
-        (iokit-property "MetalPluginClassName") ;; <rdar://problem/67473780>
-        (iokit-property "MetalPluginName") ;; <rdar://problem/67473780>
-        (iokit-property "IOSurfaceAcceleratorCapabilitiesDict") ;; <rdar://problem/63696732>
-        (iokit-property "acoustic-id") ;; <rdar://problem/65290967>
-    ))
+        (iokit-property "IORegistryEntryPropertyKeys")))
 
-(if (equal? (param "CPU") "arm64")
-    (with-filter (iokit-registry-entry-class "IOService")
-        (allow iokit-get-properties
-            (iokit-property "IORegistryEntryPropertyKeys"))))
+(with-filter (iokit-registry-entry-class "IOMobileFramebuffer")
+    (allow iokit-get-properties
+        (iokit-property "AppleTV"
+                        "DisplayPipePlaneBaseAlignment"
+                        "DisplayPipeStrideRequirements"
+                        "dfr"
+                        "external"
+                        "hdcp-hoover-protocol")))
 
-(if (equal? (param "CPU") "arm64")
-    (with-filter (iokit-registry-entry-class "IOMobileFramebuffer")
-        (allow iokit-get-properties
-            (iokit-property "AppleTV"
-                            "DisplayPipePlaneBaseAlignment"
-                            "DisplayPipeStrideRequirements"
-                            "dfr"
-                            "external"
-                            "hdcp-hoover-protocol"))))
+(with-filter (iokit-registry-entry-class "IOPlatformDevice")
+    (allow iokit-get-properties
+        (iokit-property "soc-generation")))
 
-(if (equal? (param "CPU") "arm64")
-    (with-filter (iokit-registry-entry-class "IOPlatformDevice")
-        (allow iokit-get-properties
-            (iokit-property "soc-generation"))))
-
-(if (equal? (param "CPU") "arm64")
-    (with-filter (iokit-registry-entry-class "IOService")
-        (allow iokit-get-properties
-            (iokit-property "chip-id"
-                            "display-rotation"
-                            "display-scale"))))
+(with-filter (iokit-registry-entry-class "IOService")
+    (allow iokit-get-properties
+        (iokit-property "chip-id"
+                        "display-rotation"
+                        "display-scale")))
 
 (deny mach-lookup (xpc-service-name-prefix ""))
 
@@ -1350,8 +1343,7 @@
 
 (with-filter (require-not (lockdown-mode))
     (allow syscall-unix (syscall-unix-blocked-in-lockdown-mode))
-    (when (equal? (param "CPU") "arm64")
-        (allow syscall-unix (syscall-unix-apple-silicon)))
+    (allow syscall-unix (syscall-unix-apple-silicon))
     (allow syscall-unix (with report) (with telemetry) (syscalls-rarely-used-blocked-in-lockdown-mode)))
 
 (when (defined? 'SYS_objc_bp_assist_cfg_np)
@@ -1370,8 +1362,7 @@
 (with-filter (lockdown-mode)
     (deny syscall-unix (with telemetry) (syscall-unix-blocked-in-lockdown-mode))
     (deny syscall-unix (with telemetry) (syscalls-rarely-used-blocked-in-lockdown-mode))
-    (when (equal? (param "CPU") "arm64")
-        (deny syscall-unix (with telemetry) (syscall-unix-apple-silicon))))
+    (deny syscall-unix (with telemetry) (syscall-unix-apple-silicon)))
 
 #if HAVE(SANDBOX_MESSAGE_FILTERING)
 (define (mach-bootstrap-message-numbers)
@@ -1482,12 +1473,9 @@
 
 (define (allow-mach-exceptions operation)
 #if HAVE(HARDENED_MACH_EXCEPTIONS)
-    (when (equal? (param "CPU") "arm64")
-        (with-filter (require-not (webcontent-process-launched))
-            (allow operation (kernel-mig-routine task_register_hardened_exception_handler)))
-        (allow operation (kernel-mig-routine thread_adopt_exception_handler)))
-    (when (not (equal? (param "CPU") "arm64"))
-        (allow operation (kernel-mig-routine thread_set_exception_ports))))
+    (with-filter (require-not (webcontent-process-launched))
+        (allow operation (kernel-mig-routine task_register_hardened_exception_handler)))
+    (allow operation (kernel-mig-routine thread_adopt_exception_handler)))
 #else
     (allow operation (kernel-mig-routine thread_set_exception_ports)))
 #endif


### PR DESCRIPTION
#### 67c60225f7c804700d6f89d293822551bda4b55d
<pre>
Remove CPU checks in WebContent process sandbox for arm64 on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=311711">https://bugs.webkit.org/show_bug.cgi?id=311711</a>
<a href="https://rdar.apple.com/174299099">rdar://174299099</a>

Reviewed by Sihui Liu.

After &lt;<a href="https://commits.webkit.org/310762@main">https://commits.webkit.org/310762@main</a>&gt;, which added an Intel specific sandbox,
we can remove CPU checks in the sandbox for arm64.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/310823@main">https://commits.webkit.org/310823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5105d8f013e5520d4eca5fc347417a50b7c6c931

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21316 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163657 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108367 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dae1b015-c5ca-4866-b108-40715655ce27) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28005 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119835 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84701 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de7c2adb-ac5b-4a0c-852a-33edd37d63bb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157856 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22111 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139104 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100528 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21196 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19218 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11483 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130858 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166131 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9529 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18557 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127937 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27701 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23258 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128076 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138741 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84330 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23639 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22955 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15536 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27317 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91421 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26895 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27126 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26968 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->