### PR TITLE
[Navigation API] replaceState() on traversed entry changes NavigationHistoryEntry.key

### DIFF
--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -61,7 +61,6 @@ HistoryItem::HistoryItem(Client& client, const String& urlString, const String& 
     , m_displayTitle(alternateTitle)
     , m_itemID(itemID ? *itemID : BackForwardItemIdentifier::generate())
     , m_frameItemID(frameItemID ? *frameItemID : BackForwardFrameItemIdentifier::generate())
-    , m_uuidIdentifier(WTF::UUID::createVersion4Weak())
     , m_client(client)
 {
 }
@@ -83,6 +82,7 @@ HistoryItem::HistoryItem(const HistoryItem& item)
     , m_isTargetItem(item.m_isTargetItem)
     , m_itemSequenceNumber(item.m_itemSequenceNumber)
     , m_documentSequenceNumber(item.m_documentSequenceNumber)
+    , m_navigationAPIKey(item.m_navigationAPIKey)
     , m_formData(item.m_formData ? RefPtr<FormData> { RefPtr { item.m_formData }->copy() } : nullptr)
     , m_formContentType(item.m_formContentType)
 #if PLATFORM(IOS_FAMILY)
@@ -92,7 +92,6 @@ HistoryItem::HistoryItem(const HistoryItem& item)
 #endif
     , m_itemID(item.m_itemID)
     , m_frameItemID(item.m_frameItemID)
-    , m_uuidIdentifier(WTF::UUID::createVersion4Weak())
     , m_client(item.m_client)
 {
 }
@@ -116,17 +115,17 @@ void HistoryItem::reset()
     m_isTargetItem = false;
 
     m_itemSequenceNumber = generateSequenceNumber();
+    m_documentSequenceNumber = generateSequenceNumber();
 
     m_stateObject = nullptr;
+
     m_navigationAPIStateObject = nullptr;
-    m_documentSequenceNumber = generateSequenceNumber();
+    m_navigationAPIKey = WTF::UUID::createVersion4();
 
     m_formData = nullptr;
     m_formContentType = String();
 
     clearChildren();
-
-    m_uuidIdentifier = WTF::UUID::createVersion4Weak();
 }
 
 const String& HistoryItem::urlString() const

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -84,8 +84,6 @@ public:
 
     BackForwardItemIdentifier itemID() const { return m_itemID; }
     BackForwardFrameItemIdentifier frameItemID() const { return m_frameItemID; }
-    const WTF::UUID& uuidIdentifier() const LIFETIME_BOUND { return m_uuidIdentifier; }
-    void setUUIDIdentifier(const WTF::UUID& uuidIdentifier) { m_uuidIdentifier = uuidIdentifier; }
 
     // Resets the HistoryItem to its initial state, as returned by create().
     void reset();
@@ -146,6 +144,9 @@ public:
 
     void setNavigationAPIStateObject(RefPtr<SerializedScriptValue>&&);
     SerializedScriptValue* navigationAPIStateObject() const { return m_navigationAPIStateObject.get(); }
+
+    const WTF::UUID& navigationAPIKey() const LIFETIME_BOUND { return m_navigationAPIKey; }
+    void setNavigationAPIKey(const WTF::UUID& navigationAPIKey) { m_navigationAPIKey = navigationAPIKey; }
 
     void setItemSequenceNumber(long long number) { m_itemSequenceNumber = number; }
     long long itemSequenceNumber() const { return m_itemSequenceNumber; }
@@ -267,9 +268,10 @@ private:
 
     // Support for HTML5 History
     RefPtr<SerializedScriptValue> m_stateObject;
-    
+
     // Navigation API
     RefPtr<SerializedScriptValue> m_navigationAPIStateObject;
+    WTF::UUID m_navigationAPIKey { WTF::UUID::createVersion4() };
 
     // info used to repost form data
     RefPtr<FormData> m_formData;
@@ -292,7 +294,6 @@ private:
 
     BackForwardItemIdentifier m_itemID;
     BackForwardFrameItemIdentifier m_frameItemID;
-    WTF::UUID m_uuidIdentifier;
     std::optional<PolicyContainer> m_policyContainer;
     const Ref<Client> m_client;
 };

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -1029,12 +1029,12 @@ void HistoryController::updateCurrentItem()
         // property of how this HistoryItem was originally created and is not
         // dependent on the document.
         bool isTargetItem = currentItem->isTargetItem();
-        auto uuidIdentifier = currentItem->uuidIdentifier();
+        auto navigationAPIKey = currentItem->navigationAPIKey();
         bool sameOrigin = SecurityOrigin::create(currentItem->url())->isSameOriginAs(SecurityOrigin::create(documentLoader->url()));
         currentItem->reset();
         initializeItem(*currentItem, documentLoader);
         if (sameOrigin)
-            currentItem->setUUIDIdentifier(uuidIdentifier);
+            currentItem->setNavigationAPIKey(navigationAPIKey);
         currentItem->setIsTargetItem(isTargetItem);
     } else {
         // Even if the final URL didn't change, the form data may have changed.

--- a/Source/WebCore/page/NavigationHistoryEntry.cpp
+++ b/Source/WebCore/page/NavigationHistoryEntry.cpp
@@ -49,11 +49,10 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NavigationHistoryEntry);
 
-NavigationHistoryEntry::NavigationHistoryEntry(Navigation& navigation, const DocumentState& originalDocumentState, Ref<HistoryItem>&& historyItem, String urlString, WTF::UUID key, RefPtr<SerializedScriptValue>&& state, WTF::UUID id)
+NavigationHistoryEntry::NavigationHistoryEntry(Navigation& navigation, const DocumentState& originalDocumentState, Ref<HistoryItem>&& historyItem, String urlString, RefPtr<SerializedScriptValue>&& state, WTF::UUID id)
     : ActiveDOMObject(protect(navigation.scriptExecutionContext()).get())
     , m_navigation(navigation)
     , m_urlString(urlString)
-    , m_key(key)
     , m_id(id)
     , m_state(state)
     , m_associatedHistoryItem(WTF::move(historyItem))
@@ -63,7 +62,7 @@ NavigationHistoryEntry::NavigationHistoryEntry(Navigation& navigation, const Doc
 
 Ref<NavigationHistoryEntry> NavigationHistoryEntry::create(Navigation& navigation, Ref<HistoryItem>&& historyItem)
 {
-    Ref entry = adoptRef(*new NavigationHistoryEntry(navigation, DocumentState::fromContext(protect(navigation.scriptExecutionContext()).get()), WTF::move(historyItem), historyItem->urlString(), historyItem->uuidIdentifier()));
+    Ref entry = adoptRef(*new NavigationHistoryEntry(navigation, DocumentState::fromContext(protect(navigation.scriptExecutionContext()).get()), WTF::move(historyItem), historyItem->urlString()));
     entry->suspendIfNeeded();
     return entry;
 }
@@ -74,7 +73,7 @@ Ref<NavigationHistoryEntry> NavigationHistoryEntry::create(Navigation& navigatio
     RefPtr state = historyItem->navigationAPIStateObject();
     if (!state)
         state = other.m_state;
-    Ref entry = adoptRef(*new NavigationHistoryEntry(navigation, DocumentState::fromContext(protect(other.scriptExecutionContext()).get()), WTF::move(historyItem), other.m_urlString, other.m_key, WTF::move(state), other.m_id));
+    Ref entry = adoptRef(*new NavigationHistoryEntry(navigation, DocumentState::fromContext(protect(other.scriptExecutionContext()).get()), WTF::move(historyItem), other.m_urlString, WTF::move(state), other.m_id));
     entry->suspendIfNeeded();
     return entry;
 }
@@ -112,7 +111,7 @@ String NavigationHistoryEntry::key() const
     RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
     if (!document || !document->isFullyActive())
         return nullString();
-    return m_key.toString();
+    return m_associatedHistoryItem->navigationAPIKey().toString();
 }
 
 String NavigationHistoryEntry::id() const

--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -78,7 +78,7 @@ private:
         ReferrerPolicy referrerPolicy { ReferrerPolicy::Default };
     };
 
-    NavigationHistoryEntry(Navigation&, const DocumentState&, Ref<HistoryItem>&&, String urlString, WTF::UUID key, RefPtr<SerializedScriptValue>&& state = { }, WTF::UUID = WTF::UUID::createVersion4());
+    NavigationHistoryEntry(Navigation&, const DocumentState&, Ref<HistoryItem>&&, String urlString, RefPtr<SerializedScriptValue>&& state = { }, WTF::UUID = WTF::UUID::createVersion4());
 
     // ActiveDOMObject.
     bool NODELETE virtualHasPendingActivity() const final;
@@ -92,7 +92,6 @@ private:
 
     WeakPtr<Navigation, WeakPtrImplWithEventTargetData> m_navigation;
     const String m_urlString;
-    const WTF::UUID m_key;
     const WTF::UUID m_id;
     RefPtr<SerializedScriptValue> m_state;
     const Ref<HistoryItem> m_associatedHistoryItem;

--- a/Source/WebKit/Shared/SessionState.cpp
+++ b/Source/WebKit/Shared/SessionState.cpp
@@ -32,7 +32,7 @@
 
 namespace WebKit {
 
-FrameState::FrameState(String&& urlString, String&& originalURLString, String&& referrer, AtomString&& target, std::optional<WebCore::FrameIdentifier> frameID, std::optional<Vector<uint8_t>>&& stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, std::optional<HTTPBody>&& httpBody, std::optional<WebCore::BackForwardItemIdentifier> itemID, std::optional<WebCore::BackForwardFrameItemIdentifier> frameItemID, bool hasCachedPage, String&& title, WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction, bool wasRestoredFromSession,  std::optional<WebCore::PolicyContainer>&& policyContainer,
+FrameState::FrameState(String&& urlString, String&& originalURLString, String&& referrer, AtomString&& target, std::optional<WebCore::FrameIdentifier> frameID, std::optional<Vector<uint8_t>>&& stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, std::optional<WTF::UUID> navigationAPIKey, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, std::optional<HTTPBody>&& httpBody, std::optional<WebCore::BackForwardItemIdentifier> itemID, std::optional<WebCore::BackForwardFrameItemIdentifier> frameItemID, bool hasCachedPage, String&& title, WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction, bool wasRestoredFromSession,  std::optional<WebCore::PolicyContainer>&& policyContainer,
 #if PLATFORM(IOS_FAMILY)
     WebCore::FloatRect exposedContentRect, WebCore::IntRect unobscuredContentRect, WebCore::FloatSize minimumLayoutSizeInScrollViewCoordinates, WebCore::IntSize contentSize, bool scaleIsInitial, WebCore::FloatBoxExtent obscuredInsets,
 #endif
@@ -46,6 +46,7 @@ FrameState::FrameState(String&& urlString, String&& originalURLString, String&& 
     , stateObjectData(WTF::move(stateObjectData))
     , documentSequenceNumber(documentSequenceNumber)
     , itemSequenceNumber(itemSequenceNumber)
+    , navigationAPIKey(navigationAPIKey)
     , scrollPosition(scrollPosition)
     , shouldRestoreScrollPosition(shouldRestoreScrollPosition)
     , pageScaleFactor(pageScaleFactor)
@@ -72,7 +73,7 @@ FrameState::FrameState(String&& urlString, String&& originalURLString, String&& 
 {
 }
 
-FrameState::FrameState(const String& urlString, const String& originalURLString, const String& referrer, const AtomString& target, std::optional<WebCore::FrameIdentifier> frameID, std::optional<Vector<uint8_t>> stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, const std::optional<HTTPBody>& httpBody, std::optional<WebCore::BackForwardItemIdentifier> itemID, std::optional<WebCore::BackForwardFrameItemIdentifier> frameItemID, bool hasCachedPage, const String& title, WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction, bool wasRestoredFromSession, const std::optional<WebCore::PolicyContainer>& policyContainer,
+FrameState::FrameState(const String& urlString, const String& originalURLString, const String& referrer, const AtomString& target, std::optional<WebCore::FrameIdentifier> frameID, std::optional<Vector<uint8_t>> stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, std::optional<WTF::UUID> navigationAPIKey, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, const std::optional<HTTPBody>& httpBody, std::optional<WebCore::BackForwardItemIdentifier> itemID, std::optional<WebCore::BackForwardFrameItemIdentifier> frameItemID, bool hasCachedPage, const String& title, WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction, bool wasRestoredFromSession, const std::optional<WebCore::PolicyContainer>& policyContainer,
 #if PLATFORM(IOS_FAMILY)
     WebCore::FloatRect exposedContentRect, WebCore::IntRect unobscuredContentRect, WebCore::FloatSize minimumLayoutSizeInScrollViewCoordinates, WebCore::IntSize contentSize, bool scaleIsInitial, WebCore::FloatBoxExtent obscuredInsets,
 #endif
@@ -86,6 +87,7 @@ FrameState::FrameState(const String& urlString, const String& originalURLString,
     , stateObjectData(stateObjectData)
     , documentSequenceNumber(documentSequenceNumber)
     , itemSequenceNumber(itemSequenceNumber)
+    , navigationAPIKey(navigationAPIKey)
     , scrollPosition(scrollPosition)
     , shouldRestoreScrollPosition(shouldRestoreScrollPosition)
     , pageScaleFactor(pageScaleFactor)
@@ -123,6 +125,7 @@ Ref<FrameState> FrameState::copy()
         stateObjectData,
         documentSequenceNumber,
         itemSequenceNumber,
+        navigationAPIKey,
         scrollPosition,
         shouldRestoreScrollPosition,
         pageScaleFactor,

--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -39,6 +39,7 @@
 #include <wtf/RunLoop.h>
 #include <wtf/SwiftBridging.h>
 #include <wtf/URL.h>
+#include <wtf/UUID.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -96,6 +97,8 @@ public:
     int64_t documentSequenceNumber { 0 };
     int64_t itemSequenceNumber { 0 };
 
+    std::optional<WTF::UUID> navigationAPIKey;
+
     WebCore::IntPoint scrollPosition;
     bool shouldRestoreScrollPosition { true };
     float pageScaleFactor { 0 };
@@ -130,14 +133,14 @@ private:
     // This is used to help debug <rdar://problem/48634553>.
     FrameState() { RELEASE_ASSERT(RunLoop::isMain()); }
 
-    FrameState(String&& urlString, String&& originalURLString, String&& referrer, AtomString&& target, std::optional<WebCore::FrameIdentifier>, std::optional<Vector<uint8_t>>&& stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, std::optional<HTTPBody>&&, std::optional<WebCore::BackForwardItemIdentifier>, std::optional<WebCore::BackForwardFrameItemIdentifier>, bool hasCachedPage, String&& title, WebCore::ShouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction, bool wasRestoredFromSession,  std::optional<WebCore::PolicyContainer>&&,
+    FrameState(String&& urlString, String&& originalURLString, String&& referrer, AtomString&& target, std::optional<WebCore::FrameIdentifier>, std::optional<Vector<uint8_t>>&& stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, std::optional<WTF::UUID> navigationAPIKey, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, std::optional<HTTPBody>&&, std::optional<WebCore::BackForwardItemIdentifier>, std::optional<WebCore::BackForwardFrameItemIdentifier>, bool hasCachedPage, String&& title, WebCore::ShouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction, bool wasRestoredFromSession,  std::optional<WebCore::PolicyContainer>&&,
 #if PLATFORM(IOS_FAMILY)
         WebCore::FloatRect exposedContentRect, WebCore::IntRect unobscuredContentRect, WebCore::FloatSize minimumLayoutSizeInScrollViewCoordinates, WebCore::IntSize contentSize, bool scaleIsInitial, WebCore::FloatBoxExtent obscuredInsets,
 #endif
         Vector<Ref<FrameState>>&& children, Vector<AtomString>&& documentState
     );
 
-    FrameState(const String& urlString, const String& originalURLString, const String& referrer, const AtomString& target, std::optional<WebCore::FrameIdentifier>, std::optional<Vector<uint8_t>> stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, const std::optional<HTTPBody>&, std::optional<WebCore::BackForwardItemIdentifier>, std::optional<WebCore::BackForwardFrameItemIdentifier>, bool hasCachedPage, const String& title, WebCore::ShouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction, bool wasRestoredFromSession, const std::optional<WebCore::PolicyContainer>&,
+    FrameState(const String& urlString, const String& originalURLString, const String& referrer, const AtomString& target, std::optional<WebCore::FrameIdentifier>, std::optional<Vector<uint8_t>> stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, std::optional<WTF::UUID> navigationAPIKey, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, const std::optional<HTTPBody>&, std::optional<WebCore::BackForwardItemIdentifier>, std::optional<WebCore::BackForwardFrameItemIdentifier>, bool hasCachedPage, const String& title, WebCore::ShouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction, bool wasRestoredFromSession, const std::optional<WebCore::PolicyContainer>&,
 #if PLATFORM(IOS_FAMILY)
         WebCore::FloatRect exposedContentRect, WebCore::IntRect unobscuredContentRect, WebCore::FloatSize minimumLayoutSizeInScrollViewCoordinates, WebCore::IntSize contentSize, bool scaleIsInitial, WebCore::FloatBoxExtent obscuredInsets,
 #endif

--- a/Source/WebKit/Shared/SessionState.serialization.in
+++ b/Source/WebKit/Shared/SessionState.serialization.in
@@ -49,6 +49,8 @@ header: "SessionState.h"
     int64_t documentSequenceNumber;
     int64_t itemSequenceNumber;
 
+    std::optional<WTF::UUID> navigationAPIKey;
+
     WebCore::IntPoint scrollPosition;
     bool shouldRestoreScrollPosition;
     float pageScaleFactor;

--- a/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
@@ -81,6 +81,8 @@ Ref<FrameState> toFrameState(const HistoryItem& historyItem)
     frameState->documentSequenceNumber = historyItem.documentSequenceNumber();
     frameState->itemSequenceNumber = historyItem.itemSequenceNumber();
 
+    frameState->navigationAPIKey = historyItem.navigationAPIKey();
+
     frameState->scrollPosition = historyItem.scrollPosition();
     frameState->shouldRestoreScrollPosition = historyItem.shouldRestoreScrollPosition();
     frameState->pageScaleFactor = historyItem.pageScaleFactor();
@@ -153,6 +155,9 @@ static void applyFrameState(HistoryItemClient& client, HistoryItem& historyItem,
 
     historyItem.setDocumentSequenceNumber(frameState.documentSequenceNumber);
     historyItem.setItemSequenceNumber(frameState.itemSequenceNumber);
+
+    if (frameState.navigationAPIKey)
+        historyItem.setNavigationAPIKey(*frameState.navigationAPIKey);
 
     historyItem.setScrollPosition(frameState.scrollPosition);
     historyItem.setShouldRestoreScrollPosition(frameState.shouldRestoreScrollPosition);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NavigationAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NavigationAPI.mm
@@ -87,4 +87,38 @@ TEST(NavigationAPI, ReplaceStateUpdatesCurrentEntryIDWithoutAllowPrivacySensitiv
     EXPECT_FALSE([idBefore isEqualToString:idAfter]);
 }
 
+TEST(NavigationAPI, ReplaceStateAfterBackPreservesKey)
+{
+    HTTPServer server({
+        { "/example"_s, { "example"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 300) configuration:configuration.get()]);
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView stringByEvaluatingJavaScript:@"history.pushState({}, '', '/page-a')"];
+    NSString *keyPageA = [webView stringByEvaluatingJavaScript:@"navigation.currentEntry.key"];
+
+    [webView stringByEvaluatingJavaScript:@"history.pushState({}, '', '/page-b')"];
+    NSString *keyPageB = [webView stringByEvaluatingJavaScript:@"navigation.currentEntry.key"];
+    EXPECT_FALSE([keyPageA isEqualToString:keyPageB]);
+
+    [webView _evaluateJavaScriptWithoutUserGesture:@"history.back()" completionHandler:nil];
+    [navigationDelegate waitForDidSameDocumentNavigation];
+
+    NSString *keyAfterBack = [webView stringByEvaluatingJavaScript:@"navigation.currentEntry.key"];
+    EXPECT_TRUE([keyPageA isEqualToString:keyAfterBack]);
+
+    [webView stringByEvaluatingJavaScript:@"history.replaceState({ updated: true }, '')"];
+    NSString *keyAfterReplace = [webView stringByEvaluatingJavaScript:@"navigation.currentEntry.key"];
+    EXPECT_TRUE([keyPageA isEqualToString:keyAfterReplace]);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### f3c8181805f802a59ab78b431fa252144a5d8a68
<pre>
[Navigation API] replaceState() on traversed entry changes NavigationHistoryEntry.key
<a href="https://bugs.webkit.org/show_bug.cgi?id=310321">https://bugs.webkit.org/show_bug.cgi?id=310321</a>
<a href="https://rdar.apple.com/173388766">rdar://173388766</a>

Reviewed by Basuke Suzuki.

The description of NavigationHistoryEntry&apos;s key in the web-developers section
says that the key should not change for &quot;replace&quot; operations since the key
represents the entry&apos;s slot in the back forward list, which replace operations
do not change:
(<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-navigationhistoryentry-interface)">https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-navigationhistoryentry-interface)</a>

The bug is that calling history.replaceState() on a history entry that was
reached via history.back() changes navigation.currentEntry.key to a new UUID.

Note: currently the key is represented by HistoryItem::m_uuidIdentifier which
is copied into NavigationHistoryEntry::m_key.

The process:

1. history.pushState({}, &apos;&apos;, &apos;/page-a&apos;)
   --&gt; New HistoryItem (UUID-A, itemSequenceNumber=ISN-A)
   --&gt; WebBackForwardListProxy::addItem()
   --&gt; HistoryItem is sent to UIProcess as a FrameState
       (the FrameState does not contain the UUID)

2. history.pushState({}, &apos;&apos;, &apos;/page-b&apos;)
   --&gt; New HistoryItem (UUID-B, itemSequenceNumber=ISN-B)
   --&gt; WebBackForwardListProxy::addItem()
   --&gt; HistoryItem is sent to UIProcess as a FrameState
       (the FrameState does not contain the UUID)

3. history.back()
   --&gt; ScheduledHistoryNavigation::fire() with steps = -1
   --&gt; targetHistoryItem() (to get the item to navigate to)
   --&gt; WebBackForwardListProxy::itemAtIndex()
       (gets the FrameState of item for page-a from the UI Process)
   --&gt; toHistoryItem(frameState)
       (creates a new HistoryItem out of this FrameState. The item sequence
        number ISN-A is preserved. The UUID was not preserved, so a new UUID
        is created: UUID-A&apos;)
   --&gt; HistoryController::m_currentItem gets set to this new HistoryItem with
       UUID-A&apos;

4. history.replaceState({ updated: true }, &apos;&apos;)
   --&gt; HistoryController::replaceState takes m_currentItem
       (The HistoryItem with UUID-A&apos;)
   --&gt; updateBackForwardListForReplaceState modifies it in place
       (UUID-A&apos; is unchanged)
   --&gt; Navigation::updateForNavigation(*currentItem, Replace).
       (Disposes of the oldCurrentEntry, which is the entry with key UUID-A)
   --&gt; Navigation::updateNavigationEntry(WTF::move(item), ...)
       (Creates a new NavigationHistoryEntry with this HistoryItem. This create
        function reads historyItem-&gt;uuidIdentifier() -&gt; UUID-A&apos;. The new entry
        gets m_key = UUID-A&apos;)

So our issue is that the UUID was not saved in the FrameState.

The spec says the navigationAPIKey should be stored on the session history entry
(which is HistoryItem in WebKit):
<a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#session-history-entry">https://html.spec.whatwg.org/multipage/browsing-the-web.html#session-history-entry</a>

Also, getting the key from the NavigationHistoryEntry is done by getting it from
the session history entry:
<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-navigationhistoryentry-key">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-navigationhistoryentry-key</a>

So we make 3 changes:
1. Rename HistoryItem::m_uuidIdentifier to m_navigationAPIKey
   (Make it clear what this is and where its stored)
2. Save this in FrameState
   (When toHistoryItem() is called, applyFrameState() will set this saved key on
    the newly created HistoryItem)
3. Remove NavigationHistoryEntry::m_key and have key() get
   HistoryItem::m_navigationAPIKey

This is tested by a new API test: NavigationAPI.ReplaceStateAfterBackPreservesKey

* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::HistoryItem):
(WebCore::HistoryItem::reset):
* Source/WebCore/history/HistoryItem.h:
(WebCore::HistoryItem::frameItemID const):
(WebCore::HistoryItem::setNavigationAPIKey):
(WebCore::HistoryItem::setUUIDIdentifier): Deleted.
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::updateCurrentItem):
* Source/WebCore/page/NavigationHistoryEntry.cpp:
(WebCore::NavigationHistoryEntry::NavigationHistoryEntry):
(WebCore::NavigationHistoryEntry::create):
(WebCore::NavigationHistoryEntry::key const):
* Source/WebCore/page/NavigationHistoryEntry.h:
* Source/WebKit/Shared/SessionState.cpp:
(WebKit::FrameState::FrameState):
(WebKit::FrameState::copy):
* Source/WebKit/Shared/SessionState.h:
* Source/WebKit/Shared/SessionState.serialization.in:
* Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp:
(WebKit::toFrameState):
(WebKit::applyFrameState):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAPI.mm:
(TestWebKitAPI::TEST(NavigationAPI, ReplaceStateAfterBackPreservesKey)):

Canonical link: <a href="https://commits.webkit.org/310849@main">https://commits.webkit.org/310849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eefb4904da00175ea9780df6ce2476b2b8794cfb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163711 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108422 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e4d3a6a-ff1d-45b6-8747-1bf7eef25ba6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156824 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28059 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119882 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84734 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6dbdc1b1-05e8-49e8-863f-775e295562ab) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157910 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139154 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100575 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21238 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19270 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11537 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130900 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16998 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166186 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9728 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18607 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127986 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27755 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128125 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27679 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138791 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84388 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23651 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23010 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15586 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27371 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91475 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26949 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27180 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27022 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->