### PR TITLE
Remove CPU checks in sandbox definition file on macOS

### DIFF
--- a/Source/WebKit/Shared/Sandbox/macOS/webcontent-defines.sb
+++ b/Source/WebKit/Shared/Sandbox/macOS/webcontent-defines.sb
@@ -278,44 +278,43 @@
                 (iokit-user-client-class "IOAudioEngineUserClient")))))
 
 (define (allow-iokit-with-extension-arm64)
-    (when (equal? (param "CPU") "arm64")
-        (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-            (allow IOKIT_OPEN_USER_CLIENT
-                (require-all
-                    (extension "com.apple.webkit.extension.iokit")
-                    (iokit-user-client-class
-                        "AppleAVDUserClient")) ;; <rdar://problem/60088861>
-                (AppleAVDUserClientMessageFilter))
-            ; else
-            (allow IOKIT_OPEN_USER_CLIENT
-                (require-all
-                    (extension "com.apple.webkit.extension.iokit")
-                    (iokit-user-client-class "AppleAVDUserClient"))))
+    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-user-client-class
+                    "AppleAVDUserClient")) ;; <rdar://problem/60088861>
+            (AppleAVDUserClientMessageFilter))
+        ; else
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-user-client-class "AppleAVDUserClient"))))
 
-        (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-            (allow IOKIT_OPEN_USER_CLIENT
-                (require-all
-                    (extension "com.apple.webkit.extension.iokit")
-                    (iokit-user-client-class "IOMobileFramebufferUserClient"))
-                (IOMobileFramebufferUserClientMessageFilter))
-            ; else
-            (allow IOKIT_OPEN_USER_CLIENT
-                (require-all
-                    (extension "com.apple.webkit.extension.iokit")
-                    (iokit-user-client-class "IOMobileFramebufferUserClient"))))
+    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-user-client-class "IOMobileFramebufferUserClient"))
+            (IOMobileFramebufferUserClientMessageFilter))
+        ; else
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-user-client-class "IOMobileFramebufferUserClient"))))
 
-        (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-            (allow IOKIT_OPEN_USER_CLIENT
-                (require-all
-                    (extension "com.apple.webkit.extension.iokit")
-                    (iokit-user-client-class "IOSurfaceAcceleratorClient")) ;; <rdar://problem/63696732>
-                (IOSurfaceAcceleratorClientMessageFilter))
-            ; else
-            (allow IOKIT_OPEN_USER_CLIENT
-                (require-all
-                    (extension "com.apple.webkit.extension.iokit")
-                    (iokit-user-client-class
-                        "IOSurfaceAcceleratorClient")))))) ;; <rdar://problem/63696732>
+    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-user-client-class "IOSurfaceAcceleratorClient")) ;; <rdar://problem/63696732>
+            (IOSurfaceAcceleratorClientMessageFilter))
+        ; else
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-user-client-class
+                    "IOSurfaceAcceleratorClient"))))) ;; <rdar://problem/63696732>
 
 (define (allow-iokit-without-extension)
     (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
@@ -330,31 +329,6 @@
                 (require-not (extension "com.apple.webkit.extension.iokit"))
                 (iokit-registry-entry-class "IOSurfaceRootUserClient"))))
 
-    (when (equal? (param "CPU") "arm64")
-        (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-            (allow IOKIT_OPEN_USER_CLIENT
-                (require-all
-                    (require-not (extension "com.apple.webkit.extension.iokit"))
-                    (iokit-user-client-class "AppleAVDUserClient"))
-                (AppleAVDUserClientMessageFilter))
-            ; else
-            (allow IOKIT_OPEN_USER_CLIENT
-                (require-all
-                    (require-not (extension "com.apple.webkit.extension.iokit"))
-                    (iokit-user-client-class "AppleAVDUserClient"))))
-
-        (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-            (allow IOKIT_OPEN_USER_CLIENT
-                (require-all
-                    (require-not (extension "com.apple.webkit.extension.iokit"))
-                    (iokit-user-client-class "IOSurfaceAcceleratorClient"))
-                (IOSurfaceAcceleratorClientMessageFilter))
-            ; else
-            (allow IOKIT_OPEN_USER_CLIENT
-                (require-all
-                    (require-not (extension "com.apple.webkit.extension.iokit"))
-                    (iokit-user-client-class "IOSurfaceAcceleratorClient")))))
-
     (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
         (allow IOKIT_OPEN_USER_CLIENT
             (require-all
@@ -366,6 +340,31 @@
             (require-all
                 (require-not (extension "com.apple.webkit.extension.iokit"))
                 (iokit-connection "IOAccelerator")))))
+
+(define (allow-iokit-without-extension-arm64)
+    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (require-not (extension "com.apple.webkit.extension.iokit"))
+                (iokit-user-client-class "AppleAVDUserClient"))
+            (AppleAVDUserClientMessageFilter))
+        ; else
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (require-not (extension "com.apple.webkit.extension.iokit"))
+                (iokit-user-client-class "AppleAVDUserClient"))))
+
+    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (require-not (extension "com.apple.webkit.extension.iokit"))
+                (iokit-user-client-class "IOSurfaceAcceleratorClient"))
+            (IOSurfaceAcceleratorClientMessageFilter))
+        ; else
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (require-not (extension "com.apple.webkit.extension.iokit"))
+                (iokit-user-client-class "IOSurfaceAcceleratorClient")))))
 
 (define (allow-metal-compiler-service)
     (allow mach-lookup

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1619,7 +1619,8 @@
 #endif // HAVE(SANDBOX_MESSAGE_FILTERING)
 
 (when (not webcontent_gpu_sandbox_extensions_blocking?)
-    (allow-iokit-without-extension))
+    (allow-iokit-without-extension)
+    (allow-iokit-without-extension-arm64))
 
 (deny IOKIT_OPEN_USER_CLIENT
     (require-all

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.x86.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.x86.sb.in
@@ -783,8 +783,7 @@
     (iokit-user-client-class "AppleJPEGDriverUserClient"))
 
 (when (not webcontent_gpu_sandbox_extensions_blocking?)
-    (allow-iokit-with-extension)
-    (allow-iokit-with-extension-arm64))
+    (allow-iokit-with-extension))
 
 ;; Audio
 (allow ipc-posix-shm-read* ipc-posix-shm-write-data


### PR DESCRIPTION
#### 366e9abb88729764dd9b13fec89e990bd83e2f82
<pre>
Remove CPU checks in sandbox definition file on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=311713">https://bugs.webkit.org/show_bug.cgi?id=311713</a>
<a href="https://rdar.apple.com/174299988">rdar://174299988</a>

Reviewed by Sihui Liu.

After &lt;<a href="https://commits.webkit.org/310762@main">https://commits.webkit.org/310762@main</a>&gt;, which added an Intel specific sandbox,
we can remove CPU checks in the sandbox definition file on macOS.

* Source/WebKit/Shared/Sandbox/macOS/webcontent-defines.sb:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:
* Source/WebKit/WebProcess/com.apple.WebProcess.x86.sb.in:

Canonical link: <a href="https://commits.webkit.org/310824@main">https://commits.webkit.org/310824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47aa2c5dc5f17084aee7fc312e1d9b0e25771b7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21320 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163661 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108371 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5fe6a2de-4149-4b6f-83ed-6d47786396de) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28009 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119838 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84705 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157860 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22103 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139108 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100531 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b18c7488-bf0b-4bb2-8e2d-fdd918433eb4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21188 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19225 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11487 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130850 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166135 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9545 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18561 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127941 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23264 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128080 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27629 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138745 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84334 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23640 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22954 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15540 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27321 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91425 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26899 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27130 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26972 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->