### PR TITLE
Fix a regression and turn on correct composition event ordering by default

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3930,17 +3930,17 @@ InlineMediaPlaybackRequiresPlaysInlineAttribute:
 
 InputMethodUsesCorrectKeyEventOrder:
   type: bool
-  status: testable
+  status: stable
   category: dom
   humanReadableName: "Correct key event ordering with composition events"
   condition: PLATFORM(MAC)
   defaultValue:
     WebKitLegacy:
-      default: false
+      default: true
     WebKit:
-      default: false
+      default: true
     WebCore:
-      default: false
+      default: true
   sharedPreferenceForWebProcess: true
 
 InputTypeColorEnabled:

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -1119,7 +1119,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     std::optional<Vector<WebCore::KeypressCommand>> m_collectedKeypressCommands;
     std::optional<NSRange> m_stagedMarkedRange;
-    Vector<CompletionHandler<void()>> m_interpretKeyEventHoldingTank;
+    Vector<Function<void()>> m_interpretKeyEventHoldingTank;
 
     String m_lastStringForCandidateRequest;
     NSInteger m_lastCandidateRequestSequenceNumber;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -5565,7 +5565,8 @@ void WebViewImpl::interpretKeyEvent(NSEvent *event, void(^completionHandler)(BOO
         }
 
         auto additionalCommands = checkedThis->collectKeyboardLayoutCommandsForEvent(capturedEvent.get());
-        commands.appendVector(additionalCommands);
+        if (!hasInsertText)
+            commands.appendVector(additionalCommands);
         capturedBlock(NO, commands);
 #if PLATFORM(MAC)
         ASSERT(checkedThis->m_page->editorState().inputMethodUsesCorrectKeyEventOrder || checkedThis->m_interpretKeyEventHoldingTank.isEmpty());

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WKWebViewMacEditingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WKWebViewMacEditingTests.mm
@@ -97,9 +97,11 @@
 @interface MockTextInputContextAction : NSObject
 
 - (instancetype)initWithMarkedText:(NSString *)markedText selectedRange:(NSRange)selectedRange replacementRange:(NSRange)replacementRange;
+- (instancetype)initWithInsertText:(NSString *)insertedText replacementRange:(NSRange)replacementRange;
 
 @property (nonatomic) double delay;
 @property (nonatomic, assign) NSString *markedText;
+@property (nonatomic, assign) NSString *insertedText;
 @property (nonatomic) NSRange selectedRange;
 @property (nonatomic) NSRange replacementRange;
 @end
@@ -116,6 +118,15 @@
     return self;
 }
 
+- (instancetype)initWithInsertText:(NSString *)insertedText replacementRange:(NSRange)replacementRange
+{
+    if (self = [super init]) {
+        _insertedText = insertedText;
+        _replacementRange = replacementRange;
+    }
+    return self;
+}
+
 @end
 
 @interface MockTextInputContext : NSTextInputContext
@@ -127,16 +138,18 @@
 - (void)handleEventByInputMethod:(NSEvent *)event completionHandler:(void(^)(BOOL handled))completionHandler
 {
     [super handleEventByInputMethod:event completionHandler:^(BOOL handled) {
-        if (!_actions.count) {
+        if (!_actions.count || event.type != NSEventTypeKeyDown) {
             completionHandler(NO);
             return;
         }
-        MockTextInputContextAction *lastItem = _actions.lastObject;
-        [_actions removeLastObject];
+        MockTextInputContextAction *lastItem = _actions.firstObject;
+        [_actions removeObjectAtIndex:0];
         double delay = lastItem ? lastItem.delay : 10;
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), mainDispatchQueueSingleton(), ^{
-            if (lastItem)
+            if (lastItem.markedText)
                 [self.client setMarkedText:lastItem.markedText selectedRange:lastItem.selectedRange replacementRange:lastItem.replacementRange];
+            else
+                [self.client insertText:lastItem.insertedText replacementRange:lastItem.replacementRange];
             completionHandler(!!lastItem);
         });
     }];
@@ -270,6 +283,7 @@ TEST(WKWebViewMacEditingTests, KeyDownFiresBeforeCompositionEvent)
         [[[MockTextInputContextAction alloc] initWithMarkedText:@"n" selectedRange:NSMakeRange(0, 1) replacementRange:NSMakeRange(NSNotFound, 0)] autorelease],
         [[[MockTextInputContextAction alloc] initWithMarkedText:@"ni" selectedRange:NSMakeRange(0, 2) replacementRange:NSMakeRange(NSNotFound, 0)] autorelease],
         [[[MockTextInputContextAction alloc] initWithMarkedText:@"\u4F60" selectedRange:NSMakeRange(0, 1) replacementRange:NSMakeRange(NSNotFound, 0)] autorelease],
+        [[[MockTextInputContextAction alloc] initWithInsertText:@"\u4F60" replacementRange:NSMakeRange(NSNotFound, 0)] autorelease],
     ].mutableCopy autorelease];
     [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<body contenteditable>Hello world</body>"]];
     [webView stringByEvaluatingJavaScript:@"const target = document.body; const logs = [];"
@@ -283,8 +297,41 @@ TEST(WKWebViewMacEditingTests, KeyDownFiresBeforeCompositionEvent)
     Util::runFor(1_s);
     [webView typeCharacter:' '];
     Util::runFor(1_s);
+    [webView typeCharacter:'\r'];
+    Util::runFor(1_s);
 
-    EXPECT_STREQ("keydown,compositionstart,compositionupdate,input,keyup,keydown,compositionupdate,input,keyup,keydown,input,input,compositionend,keyup",
+    EXPECT_STREQ("keydown,compositionstart,compositionupdate,input,keyup,keydown,compositionupdate,input,keyup,keydown,compositionupdate,input,keyup,keydown,input,input,compositionend,keyup",
+        [webView stringByEvaluatingJavaScript:@"logs.map((event) => event.type).join(',')"].UTF8String);
+}
+
+TEST(WKWebViewMacEditingTests, KeyDownInsertAccentedCharacterOnce)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    for (_WKFeature *feature in WKPreferences._features) {
+        NSString *key = feature.key;
+        if ([key isEqualToString:@"InputMethodUsesCorrectKeyEventOrder"])
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+    }
+
+    RetainPtr webView = adoptNS([[TestWebViewWithMockTextInputContext alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    [webView _web_superInputContext].actions = [@[
+        [[[MockTextInputContextAction alloc] initWithMarkedText:@"\u00B4" selectedRange:NSMakeRange(0, 1) replacementRange:NSMakeRange(NSNotFound, 0)] autorelease],
+        [[[MockTextInputContextAction alloc] initWithInsertText:@"\u00E9" replacementRange:NSMakeRange(NSNotFound, 0)] autorelease],
+    ].mutableCopy autorelease];
+    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<body contenteditable></body>"]];
+    [webView stringByEvaluatingJavaScript:@"const target = document.body; const logs = [];"
+        "['keydown', 'keyup', 'compositionstart', 'compositionend', 'compositionupdate']"
+        ".forEach((type) => { target.addEventListener(type, (event) => logs.push(event)); }); document.body.focus()"];
+    [webView waitForNextPresentationUpdate];
+    [webView removeFromSuperview];
+    [webView typeCharacter:'e' modifiers:NSEventModifierFlagOption];
+    Util::runFor(1_s);
+    [webView typeCharacter:'e'];
+    Util::runFor(1_s);
+
+    EXPECT_STREQ(@"\u00E9".UTF8String, [webView stringByEvaluatingJavaScript:@"document.body.textContent"].UTF8String);
+
+    EXPECT_STREQ("keydown,compositionstart,compositionupdate,keyup,keydown,compositionend,keyup",
         [webView stringByEvaluatingJavaScript:@"logs.map((event) => event.type).join(',')"].UTF8String);
 }
 


### PR DESCRIPTION
#### 6031db379af6aec30c03b076077c57e1c4b3c93d
<pre>
Fix a regression and turn on correct composition event ordering by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=311717">https://bugs.webkit.org/show_bug.cgi?id=311717</a>

Reviewed by Wenson Hsieh.

When InputMethodUsesCorrectKeyEventOrder is enabled, dead key input (e.g., Option+E
followed by &apos;e&apos; to produce &quot;é&quot;) results in the accented character being inserted
twice through two independent mechanisms:

  1. The input method&apos;s insertText: call with &quot;é&quot; is collected as a keypress command
     and replayed during keypress event processing, inserting &quot;é&quot; into the document.
  2. WebViewImpl::collectKeyboardLayoutCommandsForEvent independently interprets the
     same key event and produces its own insertText: command for the input, which is
     appended to the command list and also executed during keypress processing.

Redundant insertions happen because WebViewImpl::interpretKeyEvent unconditionally
merges the commands from collectKeyboardLayoutCommandsForEvent with the commands
from the input method, even if the input method has already provided the final text.

This PR addresses this regression by ignoring the commands collected from
collectKeyboardLayoutCommandsForEvent when the input method had already included
the final insertText:, and enables the correct event ordering by default as we&apos;ve
identified other web apps such as Claude was also affected by this bug.

In addition, this PR fixes a bug in MockTextInputContext that we were processing
MockTextInputContextAction in the reverse order. This was not caught with
KeyDownFiresBeforeCompositionEvent because it doesn&apos;t check the inserted text
but the new test does.

Finally, change the type of function we queue up in m_interpretKeyEventHoldingTank
from a CompletionHandler to a Function since handleEventByInputMethod may never call
us when the view is destructed prematurely.

Test: WKWebViewMacEditingTests.KeyDownInsertAccentedCharacterOnce

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::interpretKeyEvent):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WKWebViewMacEditingTests.mm:
(-[MockTextInputContextAction initWithInsertText:replacementRange:]):
(-[MockTextInputContext handleEventByInputMethod:completionHandler:]):
(TestWebKitAPI::TEST(WKWebViewMacEditingTests, KeyDownFiresBeforeCompositionEvent)):
(TestWebKitAPI::TEST(WKWebViewMacEditingTests, KeyDownInsertAccentedCharacterOnce)):

Canonical link: <a href="https://commits.webkit.org/310826@main">https://commits.webkit.org/310826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbcb727727a121923035430ef59bdb37a66c0308

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163809 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a06e22b1-7005-4021-8a2f-906f6d1aeeb9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28157 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119956 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 9 flakes 4 failures; Uploaded test results; 1 flakes; Running analyze-layout-tests-results") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22220 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139236 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100649 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21305 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19344 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11635 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147099 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130967 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166285 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15880 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18688 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128059 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27853 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128197 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27777 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138872 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84486 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23641 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23073 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15667 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186836 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27469 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91573 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47877 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27048 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27278 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27120 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->