### PR TITLE
ANGLE: Metal: Run unit tests with validation layers by default

### DIFF
--- a/Source/ThirdParty/ANGLE/src/tests/perf_tests/ANGLEPerfTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/perf_tests/ANGLEPerfTest.cpp
@@ -762,9 +762,9 @@ void ANGLEPerfTest::atraceCounter(const char *counterName, int64_t counterValue)
 RenderTestParams::RenderTestParams()
 {
 #if defined(ANGLE_DEBUG_LAYERS_ENABLED)
-    eglParameters.debugLayersEnabled = true;
+    eglParameters.debugLayersEnabled = EGL_TRUE;
 #else
-    eglParameters.debugLayersEnabled = false;
+    eglParameters.debugLayersEnabled = EGL_FALSE;
 #endif
 }
 

--- a/Source/ThirdParty/ANGLE/src/tests/test_utils/ANGLETest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/test_utils/ANGLETest.cpp
@@ -444,6 +444,7 @@ constexpr char kBatchId[]                        = "--batch-id=";
 constexpr char kDelayTestStart[]                 = "--delay-test-start=";
 constexpr char kRenderDoc[]                      = "--renderdoc";
 constexpr char kNoRenderDoc[]                    = "--no-renderdoc";
+constexpr char kDisableDebugLayers[]             = "--disable-debug-layers";
 
 void SetupEnvironmentVarsForCaptureReplay()
 {
@@ -542,10 +543,18 @@ ANGLETestBase::ANGLETestBase(const PlatformParameters &params)
     if (withMethods.getRenderer() == EGL_PLATFORM_ANGLE_TYPE_VULKAN_ANGLE)
     {
 #if defined(ANGLE_ENABLE_VULKAN_VALIDATION_LAYERS)
-        withMethods.eglParameters.debugLayersEnabled = true;
+        withMethods.eglParameters.debugLayersEnabled = EGL_TRUE;
 #else
-        withMethods.eglParameters.debugLayersEnabled = false;
+        withMethods.eglParameters.debugLayersEnabled = EGL_FALSE;
 #endif
+    }
+    else
+    {
+        if (withMethods.eglParameters.debugLayersEnabled == EGL_DONT_CARE)
+        {
+            withMethods.eglParameters.debugLayersEnabled =
+                gDisableDebugLayers ? EGL_FALSE : EGL_TRUE;
+        }
     }
 
     if (gEnableRenderDocCapture)
@@ -1903,6 +1912,10 @@ void ANGLEProcessTestArgs(int *argc, char *argv[])
         else if (strncmp(argv[argIndex], kNoRenderDoc, strlen(kNoRenderDoc)) == 0)
         {
             gEnableRenderDocCapture = false;
+        }
+        else if (strncmp(argv[argIndex], kDisableDebugLayers, strlen(kDisableDebugLayers)) == 0)
+        {
+            gDisableDebugLayers = true;
         }
     }
 }

--- a/Source/ThirdParty/ANGLE/src/tests/test_utils/ANGLETestCL.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/test_utils/ANGLETestCL.cpp
@@ -41,9 +41,9 @@ ANGLETestCL<PlatformParameters>::ANGLETestCL(const PlatformParameters &params)
     if (mCurrentParams.getRenderer() == EGL_PLATFORM_ANGLE_TYPE_VULKAN_ANGLE)
     {
 #if defined(ANGLE_ENABLE_VULKAN_VALIDATION_LAYERS)
-        mCurrentParams.eglParameters.debugLayersEnabled = true;
+        mCurrentParams.eglParameters.debugLayersEnabled = EGL_TRUE;
 #else
-        mCurrentParams.eglParameters.debugLayersEnabled = false;
+        mCurrentParams.eglParameters.debugLayersEnabled = EGL_FALSE;
 #endif
     }
 

--- a/Source/ThirdParty/ANGLE/src/tests/test_utils/angle_test_instantiate.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/test_utils/angle_test_instantiate.cpp
@@ -197,6 +197,8 @@ bool gEnableRenderDocCapture = true;
 bool gEnableRenderDocCapture = false;
 #endif
 
+bool gDisableDebugLayers = false;
+
 bool IsConfigSelected()
 {
     return gSelectedConfig[0] != 0;

--- a/Source/ThirdParty/ANGLE/src/tests/test_utils/angle_test_instantiate.h
+++ b/Source/ThirdParty/ANGLE/src/tests/test_utils/angle_test_instantiate.h
@@ -359,6 +359,8 @@ extern bool gEnableANGLEPerTestCaptureLabel;
 
 extern bool gEnableRenderDocCapture;
 
+extern bool gDisableDebugLayers;
+
 // For use with ANGLE_INSTANTIATE_TEST_ARRAY
 template <typename ParamsT>
 using ModifierFunc = std::function<ParamsT(const ParamsT &)>;

--- a/Source/ThirdParty/ANGLE/src/tests/test_utils/runner/README.md
+++ b/Source/ThirdParty/ANGLE/src/tests/test_utils/runner/README.md
@@ -28,6 +28,7 @@ following additional command-line arguments:
  * `--disable-crash-handler` forces off OS-level crash handling
  * `--isolated-outdir` specifies a test artifacts directory
  * `--max-failures` specifies a count of failures after which the harness early exits.
+ * `--disable-debug-layers` disables debug layers for GPU drivers, if they were used by default.
 
 `--isolated-script-test-output` and `--isolated-script-perf-test-output` mirror `--results-file`
 and `--histogram-json-file` respectively.

--- a/Source/ThirdParty/ANGLE/src/tests/test_utils/runner/TestSuite.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/test_utils/runner/TestSuite.cpp
@@ -48,6 +48,7 @@ constexpr char kFilterFileArg[]       = "--filter-file";
 constexpr char kResultFileArg[]       = "--results-file";
 constexpr char kTestTimeoutArg[]      = "--test-timeout";
 constexpr char kDisableCrashHandler[] = "--disable-crash-handler";
+constexpr char kDisableDebugLayers[]  = "--disable-debug-layers";
 constexpr char kIsolatedOutDir[]      = "--isolated-outdir";
 
 constexpr char kStartedTestString[] = "[ RUN      ] ";
@@ -1116,6 +1117,16 @@ TestSuite::TestSuite(int *argc, char **argv, std::function<void()> registerTests
         mCrashCallback = [this]() { onCrashOrTimeout(TestResultType::Crash); };
         InitCrashHandler(&mCrashCallback);
     }
+    if (!mDisableDebugLayers)
+    {
+#if defined(ANGLE_ENABLE_METAL)
+        // Metal does not support toggling per-context debug layers for tests.
+        SetEnvironmentVar("MTL_DEBUG_LAYER", "1");
+        SetEnvironmentVar("MTL_SHADER_VALIDATION", "1");
+        SetEnvironmentVar("MTL_SHADER_VALIDATION_ABORT_ON_FAULT", "1");
+        SetEnvironmentVar("MTL_SHADER_VALIDATION_REPORT_TO_STDERR", "1");
+#endif
+    }
 
 #if defined(ANGLE_PLATFORM_WINDOWS) || defined(ANGLE_PLATFORM_LINUX)
     if (IsASan())
@@ -1380,7 +1391,8 @@ bool TestSuite::parseSingleArg(int *argc, char **argv, int argIndex)
            ParseFlag("--gtest_list_tests", argc, argv, argIndex, &mGTestListTests) ||
            ParseFlag("--list-tests", argc, argv, argIndex, &mListTests) ||
            ParseFlag("--print-test-stdout", argc, argv, argIndex, &mPrintTestStdout) ||
-           ParseFlag(kDisableCrashHandler, argc, argv, argIndex, &mDisableCrashHandler);
+           ParseFlag(kDisableCrashHandler, argc, argv, argIndex, &mDisableCrashHandler) ||
+           ParseFlag(kDisableDebugLayers, argc, argv, argIndex, &mDisableDebugLayers);
 }
 
 void TestSuite::onCrashOrTimeout(TestResultType crashOrTimeout)

--- a/Source/ThirdParty/ANGLE/src/tests/test_utils/runner/TestSuite.h
+++ b/Source/ThirdParty/ANGLE/src/tests/test_utils/runner/TestSuite.h
@@ -215,6 +215,7 @@ class TestSuite
     bool mListTests;
     bool mPrintTestStdout;
     bool mDisableCrashHandler;
+    bool mDisableDebugLayers{false};
     int mBatchSize;
     int mCurrentResultCount;
     int mTotalResultCount;


### PR DESCRIPTION
#### 0480ede811e031853bb8b7f5e759ff014bebc564
<pre>
ANGLE: Metal: Run unit tests with validation layers by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=311724">https://bugs.webkit.org/show_bug.cgi?id=311724</a>
<a href="https://rdar.apple.com/174311180">rdar://174311180</a>

Reviewed by Mike Wyrzykowski.

Add test runner flag --disable-debug-layers to disable the layers,
since the layers change the output in some cases.

Metal debug layers are global and the environment variable must be
set before Metal framework is used. IsMetalRendererAvailable()
and EGLContextCompatibilityTest create Metal devices before command
line is parsed, so force debug layers on at the runner level
instead of the test level.

For consistency, handle --disable-debug-layers for other platforms too.

* Source/ThirdParty/ANGLE/src/tests/perf_tests/ANGLEPerfTest.cpp:
(RenderTestParams::RenderTestParams):
* Source/ThirdParty/ANGLE/src/tests/test_utils/ANGLETest.cpp:
(ANGLETestBase::ANGLETestBase):
* Source/ThirdParty/ANGLE/src/tests/test_utils/ANGLETestCL.cpp:
(ANGLETestCL&lt;PlatformParameters&gt;::ANGLETestCL):
* Source/ThirdParty/ANGLE/src/tests/test_utils/angle_test_instantiate.cpp:
* Source/ThirdParty/ANGLE/src/tests/test_utils/angle_test_instantiate.h:
* Source/ThirdParty/ANGLE/src/tests/test_utils/runner/README.md:
* Source/ThirdParty/ANGLE/src/tests/test_utils/runner/TestSuite.cpp:
(angle::TestSuite::TestSuite):
(angle::TestSuite::parseSingleArg):
* Source/ThirdParty/ANGLE/src/tests/test_utils/runner/TestSuite.h:

Canonical link: <a href="https://commits.webkit.org/310832@main">https://commits.webkit.org/310832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df0d0fa800d84e91feb8054f2a5331d199fe68ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163680 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108390 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119856 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84719 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a407d9cc-2cfd-4f1f-a063-119a84c8e91c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22127 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139128 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100549 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/179ee413-74c8-4b2c-9170-abc2fee8b816) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21212 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19242 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11506 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130874 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166155 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18581 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127957 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23281 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128096 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34793 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27648 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138765 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84353 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22979 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15560 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27340 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26918 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27149 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26991 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->