### PR TITLE
[web-animations] setting effect to null in `CustomEffect` callback leads to a crash

### DIFF
--- a/LayoutTests/webanimations/custom-effect/custom-effect-set-to-null-in-callback-expected.txt
+++ b/LayoutTests/webanimations/custom-effect/custom-effect-set-to-null-in-callback-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Setting an animation's effect to null in a CustomEffect callback.
+

--- a/LayoutTests/webanimations/custom-effect/custom-effect-set-to-null-in-callback.html
+++ b/LayoutTests/webanimations/custom-effect/custom-effect-set-to-null-in-callback.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Setting an animation's effect to null in a CustomEffect callback</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+<body>
+<script>
+'use strict';
+
+promise_test(async t => {
+    const animation = document.timeline.animate(progress => animation.effect = null, 1000);
+    await waitForAnimationFrames(1);
+}, "Setting an animation's effect to null in a CustomEffect callback.");
+
+</script>
+</body>

--- a/Source/WebCore/animation/AnimationEffect.h
+++ b/Source/WebCore/animation/AnimationEffect.h
@@ -64,7 +64,6 @@ public:
     ExceptionOr<void> updateTiming(Document&, const OptionalEffectTiming&);
 
     virtual void animationDidTick() { };
-    virtual void animationBecameReady() { };
     virtual void animationDidChangeTimingProperties() { };
     virtual void animationWasCanceled() { };
     virtual void animationSuspensionStateDidChange(bool) { };

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -136,6 +136,7 @@ public:
     OptionSet<AnimationImpact> apply(RenderStyle& targetStyle, const Style::ResolutionContext&, EndpointInclusiveActiveInterval = EndpointInclusiveActiveInterval::No);
     void invalidate();
 
+    void animationBecameReady();
     void animationRelevancyDidChange();
     void transformRelatedPropertyDidChange();
     enum class RecomputationReason : uint8_t { LogicalPropertyChange, Other };
@@ -274,7 +275,6 @@ private:
     // AnimationEffect
     bool isKeyframeEffect() const final { return true; }
     void animationDidTick() final;
-    void animationBecameReady() final;
     void animationDidChangeTimingProperties() final;
     void animationWasCanceled() final;
     void animationSuspensionStateDidChange(bool) final;

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1571,8 +1571,10 @@ void WebAnimation::tick()
 
     if (!isEffectInvalidationSuspended() && m_effect) {
         m_effect->animationDidTick();
-        if (wasPending && !pending())
-            m_effect->animationBecameReady();
+        if (RefPtr keyframeEffect = this->keyframeEffect()) {
+            if (wasPending && !pending())
+                keyframeEffect->animationBecameReady();
+        }
     }
 }
 


### PR DESCRIPTION
#### 106edd02a3cc67449bfd4024396c45d124aeb7ab
<pre>
[web-animations] setting effect to null in `CustomEffect` callback leads to a crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=311072">https://bugs.webkit.org/show_bug.cgi?id=311072</a>
<a href="https://rdar.apple.com/173671661">rdar://173671661</a>

Reviewed by Anne van Kesteren.

The callback for a `CustomEffect`, which is called under `CustomEffect::animationDidTick()`,
can reset the associated animation&apos;s effect to null. We must make sure that the subsequent
call to `AnimationEffect::animationBecameReady()` is performed on a valid effect.

Since the only concrete implementation of `AnimationEffect::animationBecameReady()` was for
`KeyframeEffect`, we move this function to `KeyframeEffect` instead of being a virtual function
on the superclass.

Test: webanimations/custom-effect/custom-effect-set-to-null-in-callback.html

* LayoutTests/webanimations/custom-effect/custom-effect-set-to-null-in-callback-expected.txt: Added.
* LayoutTests/webanimations/custom-effect/custom-effect-set-to-null-in-callback.html: Added.
* Source/WebCore/animation/AnimationEffect.h:
(WebCore::AnimationEffect::animationDidTick):
(WebCore::AnimationEffect::animationBecameReady): Deleted.
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::tick):

Canonical link: <a href="https://commits.webkit.org/310785@main">https://commits.webkit.org/310785@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/843ac2ebd2f3be04bea1274266d4d2dbe2efd49b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154931 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21350 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163691 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156804 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28039 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119868 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f183dc46-1229-48bf-b22f-fc0fd11fd35f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157890 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139139 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100561 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/43f3ed23-ab47-4619-ac5a-2f6b1477e1c2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21224 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19256 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11517 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130886 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16983 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166166 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/9651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18592 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127969 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27735 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23295 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128108 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27659 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138776 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84367 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23624 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22989 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15571 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27351 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91455 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26929 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27160 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27002 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->