### PR TITLE
[EME][GStreamer][OCDM] Persistent licenses on CDMThunder

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -132,6 +132,14 @@ const String& MediaKeySession::sessionId() const
     return m_sessionId;
 }
 
+bool MediaKeySession::hasSecurityOrigin(const String& origin) const
+{
+    String sessionOrigin;
+    if (RefPtr document = downcast<Document>(scriptExecutionContext()))
+        sessionOrigin = protect(document->securityOrigin())->toString();
+    return origin == sessionOrigin;
+}
+
 double MediaKeySession::expiration() const
 {
     return m_expiration;
@@ -323,19 +331,27 @@ void MediaKeySession::load(const String& sessionId, Ref<DeferredPromise>&& promi
             return;
         }
 
-        // 8.3. If there is a MediaKeySession object that is not closed in this object's Document whose sessionId attribute is sanitized session ID, reject promise with a QuotaExceededError.
-        // FIXME: This needs a global MediaKeySession tracker.
-
         String origin;
         if (RefPtr document = downcast<Document>(session.scriptExecutionContext()))
-            origin = document->securityOrigin().toString();
+            origin = protect(document->securityOrigin())->toString();
+
+        // 8.3. If there is a MediaKeySession object that is not closed in this object's Document whose sessionId attribute is sanitized session ID, reject promise with a QuotaExceededError.
+        if (session.m_keys && session.m_keys->hasOpenSessionWithIdForOrigin(sanitizedSessionId.value(), WTF::move(origin))) {
+            ERROR_LOG_WITH_THIS(&session, identifier, "Rejected: Another open MediaKeySession with the same session ID already exists for this security origin");
+            promise->reject(ExceptionCode::QuotaExceededError);
+            return;
+        }
 
         // 8.4. Let expiration time be NaN.
         // 8.5. Let message be null.
         // 8.6. Let message type be null.
         // 8.7. Let cdm be the CDM instance represented by this object's cdm instance value.
         // 8.8. Use the cdm to execute the following steps:
-        session.m_instanceSession->loadSession(session.m_sessionType, *sanitizedSessionId, origin, [weakThis = WeakPtr { session }, promise = WTF::move(promise), sanitizedSessionId = *sanitizedSessionId, identifier = WTF::move(identifier)] (std::optional<CDMInstanceSession::KeyStatusVector>&& knownKeys, std::optional<double>&& expiration, std::optional<CDMInstanceSession::Message>&& message, CDMInstanceSession::SuccessValue succeeded, CDMInstanceSession::SessionLoadFailure failure) mutable {
+        session.m_instanceSession->loadSession(session.m_sessionType, *sanitizedSessionId, origin,
+            [weakThis = WeakPtr { session }, promise = WTF::move(promise), sanitizedSessionId = *sanitizedSessionId, identifier = WTF::move(identifier), origin]
+            (std::optional<CDMInstanceSession::KeyStatusVector>&& knownKeys, std::optional<double>&& expiration,
+            std::optional<CDMInstanceSession::Message>&& message, CDMInstanceSession::SuccessValue succeeded,
+            CDMInstanceSession::SessionLoadFailure failure) mutable {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis) {
                 promise->reject(ExceptionCode::InvalidStateError);
@@ -375,7 +391,17 @@ void MediaKeySession::load(const String& sessionId, Ref<DeferredPromise>&& promi
             }
 
             // 8.9. Queue a task to run the following steps:
-            queueTaskKeepingObjectAlive(*protectedThis, TaskSource::Networking, [knownKeys = WTF::move(knownKeys), expiration = WTF::move(expiration), message = WTF::move(message), sanitizedSessionId, succeeded, promise = WTF::move(promise), identifier = WTF::move(identifier)](auto& session) mutable {
+            queueTaskKeepingObjectAlive(*protectedThis, TaskSource::Networking, [knownKeys = WTF::move(knownKeys), expiration = WTF::move(expiration), message = WTF::move(message), sanitizedSessionId, succeeded, promise = WTF::move(promise), identifier = WTF::move(identifier), origin = WTF::move(origin)](auto& session) mutable {
+                // We must reevaluate condition 8.3 to avoid a race condition in case the id of the sessions
+                // compared before were empty at the moment of comparison because they were in the middle of a
+                // session loading that completed asynchronously. Their ids should have settled now, so let's
+                // check again.
+                if (session.m_keys && session.m_keys->hasOpenSessionWithIdForOrigin(sanitizedSessionId, origin)) {
+                    ERROR_LOG_WITH_THIS(&session, identifier, "Rejected (later): Another open MediaKeySession with the same session ID already exists for this security origin");
+                    promise->reject(ExceptionCode::QuotaExceededError);
+                    return;
+                }
+
                 // 8.9.1. If any of the preceding steps failed, reject promise with a the appropriate error name.
                 if (succeeded == CDMInstanceSession::SuccessValue::Failed) {
                     ERROR_LOG_WITH_THIS(&session, identifier, "::task() Rejected: Other failure");

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.h
@@ -94,6 +94,8 @@ public:
 
     unsigned internalInstanceSessionObjectRefCount() const { return m_instanceSession->refCount(); }
 
+    bool hasSecurityOrigin(const String&) const;
+
 private:
     MediaKeySession(Document&, WeakPtr<MediaKeys>&&, MediaKeySessionType, bool useDistinctiveIdentifier, Ref<CDM>&&, Ref<CDMInstanceSession>&&);
     void enqueueMessage(MediaKeyMessageType, const SharedBuffer&);

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
@@ -182,6 +182,15 @@ bool MediaKeys::hasOpenSessions() const
         });
 }
 
+bool MediaKeys::hasOpenSessionWithIdForOrigin(const String& sessionId, const String& origin) const
+{
+    return std::any_of(m_sessions.begin(), m_sessions.end(),
+        [&sessionId, &origin](auto& session) {
+            return session->sessionId() == sessionId && !session->isClosed()
+                && session->hasSecurityOrigin(origin);
+        });
+}
+
 void MediaKeys::unrequestedInitializationDataReceived(const String& initDataType, Ref<SharedBuffer>&& initData)
 {
     for (Ref cdmClient : m_cdmClients)

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeys.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeys.h
@@ -76,6 +76,7 @@ public:
     void attemptToResumePlaybackOnClients();
 
     bool hasOpenSessions() const;
+    bool hasOpenSessionWithIdForOrigin(const String& sessionId, const String& origin) const;
     CDMInstance& cdmInstance() { return m_instance; }
     const CDMInstance& cdmInstance() const { return m_instance; }
 

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -277,7 +277,8 @@ CDMInstanceSessionThunder::CDMInstanceSessionThunder(CDMInstanceThunder& instanc
     m_thunderSessionCallbacks.process_challenge_callback = [](OpenCDMSession*, void* userData, const char[], const uint8_t challenge[],
         const uint16_t challengeLength) {
         GST_DEBUG("Got 'challenge' OCDM notification with length %hu", challengeLength);
-        ASSERT(challengeLength > 0);
+
+        // Persistent license loading can generate a challenge with length 0.
         callOnMainThread([session = WeakPtr { static_cast<CDMInstanceSessionThunder*>(userData) }, buffer = WebCore::SharedBuffer::create(unsafeMakeSpan(challenge, challengeLength))]() mutable {
             if (!session)
                 return;
@@ -360,6 +361,10 @@ private:
 
 void CDMInstanceSessionThunder::challengeGeneratedCallback(RefPtr<SharedBuffer>&& buffer)
 {
+    if (!buffer->size()) {
+        GST_DEBUG("Ignoring empty challenge response (maybe persistent license load)");
+        return;
+    }
     ParsedResponseMessage parsedResponseMessage(buffer);
     if (!parsedResponseMessage) {
         GST_ERROR("response message parsing failed");
@@ -598,17 +603,69 @@ void CDMInstanceSessionThunder::updateLicense(const String& sessionID, LicenseTy
         sessionChanged(SessionChangedResult::Failure);
 }
 
-void CDMInstanceSessionThunder::loadSession(LicenseType, const String& sessionID, const String&, LoadSessionCallback&& callback)
+void CDMInstanceSessionThunder::loadSession(LicenseType licenseType, const String& sessionID, const String& /* origin */, LoadSessionCallback&& callback)
 {
-    ASSERT_UNUSED(sessionID, sessionID == m_sessionID);
+    ASSERT(isMainThread());
 
+    // MediaKeySession::load() is guaranteeing this (so we don't have to double-check):
+    // - MediaKeySession is not uninitialized (is initialized) and is not closed.
+    // - sessionID is sanitized.
+    // - LicenseType sessionType is not temporary (it's either PersistentUsageRecord or PersistentLicense).
+
+    auto instance = cdmInstanceThunder();
+    ASSERT(instance);
+
+    GST_TRACE("Going to load session for session id %s", sessionID.utf8().data());
+
+    OpenCDMSession* session = nullptr;
+    auto sessionIDUtf8 = sessionID.utf8();
+
+    // The convention agreed with the OpenCDM team is that, when constructing a (persistent) session that is
+    // going to be loaded, we will (ab)use the CDMData parameter (an CDMDataLength) to supply the sessionID.
+    OpenCDMError result = opencdm_construct_session(&instance->thunderSystem(), thunderLicenseType(licenseType), "",
+        nullptr, 0, reinterpret_cast<const uint8_t*>(sessionIDUtf8.span().data()), sessionIDUtf8.length(), &m_thunderSessionCallbacks, this, &session);
+
+    if (!session) {
+        SessionLoadFailure failureReason { SessionLoadFailure::Other };
+        switch (result) {
+        case ERROR_NONE:
+            failureReason = SessionLoadFailure::None;
+            break;
+        case ERROR_KEYSYSTEM_NOT_SUPPORTED:
+        case ERROR_OUT_OF_MEMORY:
+        // FIXME: Other cases not yet included in the current version of open_cdm.h
+        // case ERROR_BUSY_CANNOT_INITIALIZE:
+        // case ERROR_BUFFER_TOO_SMALL:
+            failureReason = SessionLoadFailure::QuotaExceeded;
+            break;
+        case ERROR_INVALID_SESSION:
+            failureReason = SessionLoadFailure::NoSessionData;
+            break;
+        default:
+            break;
+        }
+
+        GST_ERROR("Could not create session. OpenCDMError: %" PRIu32, static_cast<uint32_t>(result));
+
+        callback(std::nullopt, std::nullopt, std::nullopt, SuccessValue::Failed, failureReason);
+        return;
+    }
+
+    m_session = adoptInBoxPtr(session);
+    m_sessionID = String::fromUTF8(opencdm_session_id(m_session->get()));
+
+    GST_TRACE("Session created with id %s", m_sessionID.utf8().data());
+
+    ASSERT(sessionID == m_sessionID);
+
+    // FIXME: Is this callback for the response actually needed, since we're not doing generateRequest()?
     m_sessionChangedCallbacks.append([this, callback = WTF::move(callback)](bool success, RefPtr<SharedBuffer>&& responseMessage) mutable {
         ASSERT(isMainThread());
         if (success) {
             if (!responseMessage)
                 callback(m_keyStore.convertToJSKeyStatusVector(), std::nullopt, std::nullopt, SuccessValue::Succeeded, SessionLoadFailure::None);
             else {
-                // FIXME: Using JSON reponse messages is much cleaner than using string prefixes, I believe there
+                // FIXME: Using JSON response messages is much cleaner than using string prefixes, I believe there
                 // will even be other parts of the spec where not having structured data will be bad.
                 ParsedResponseMessage parsedResponseMessage(responseMessage);
                 ASSERT(parsedResponseMessage);
@@ -638,10 +695,16 @@ void CDMInstanceSessionThunder::loadSession(LicenseType, const String& sessionID
             }
         }
     });
-    if (!m_session || m_sessionID.isEmpty() || opencdm_session_load(m_session->get())) {
-        GST_DEBUG("loading failed");
+
+    result = OpenCDMError::ERROR_NONE;
+    if (!m_session || m_sessionID.isEmpty() || (result = opencdm_session_load(m_session->get()))) {
+        GST_DEBUG("loading failed for session %s (%p). OpenCDMError: %" PRIu32,
+            m_sessionID.utf8().data(), m_session.get(), static_cast<uint32_t>(result));
         sessionChanged(SessionChangedResult::Failure);
+        return;
     }
+
+    GST_TRACE("session %s loaded. OpenCDMError: %" PRIu32, m_sessionID.utf8().data(), static_cast<uint32_t>(result));
 }
 
 void CDMInstanceSessionThunder::closeSession(const String& sessionID, CloseSessionCallback&& callback)


### PR DESCRIPTION
#### e3c739f5d15c05a8c7635b28d7c2bd0ac46d188f
<pre>
[EME][GStreamer][OCDM] Persistent licenses on CDMThunder
<a href="https://bugs.webkit.org/show_bug.cgi?id=311719">https://bugs.webkit.org/show_bug.cgi?id=311719</a>

Reviewed by Xabier Rodriguez-Calvar.

The mechanism to store/retrieve persistent EME licenses has been defined
on opencdm_construct_session() and opencdm_session_load() in a backwards
compatible way (no API changes, just using the current API in a specific
way). A way to use that feature should be added to CDMThunder.

The way in which this has been defined is that
opencdm_construct_session() would get the previously stored sessionID at
construction time in its CDMData parameter and specifying
PersistentLicense as licenseType. If that session exists, a valid
session will be returned. The actual data load will happen in
opencdm_session_load().

See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/1546">https://github.com/WebPlatformForEmbedded/WPEWebKit/issues/1546</a>

This change adds a mechanism to MediaKeySession to check that no other
active session with the same id for the same security origin exists (a
FIXME pending in the preexisting code). The spec[1] mandates that this
check must be done synchronously at load time, but that&apos;s not enough in
practice. Sessions are created by MediaKeys.createSession() in an
uninitialized state and with an empty session id. In the case of
persistent sessions, that id is populated by load() in a queued task, so
there&apos;s some time after the synchronous check is done and after the
session id is set in MediaKeySession when the set id is still empty.
That can create a race condition when two sessions are trying to load
with the same id. That&apos;s why the check is done again when the queued
task is processed, to give another session loading in parallel time to
set its id, so we can check that no other session is using the same
value we&apos;re trying to set.

The proper code to load the session using OpenCDM API has been added to
CDMInstanceSessionThunder.

[1] <a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysession-load">https://www.w3.org/TR/encrypted-media/#dom-mediakeysession-load</a> (step 8.3)
&quot;do not create a session if a non-closed session, regardless of type,
already exists for this sanitized session ID in this browsing context&quot;

* Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
(WebCore::MediaKeySession::hasSecurityOrigin const): Added API to check if a session has a specific security origin, without revealing what the session security origin is.
(WebCore::MediaKeySession::load): Immediately reject loading if there&apos;s already another open session with the same id for the same security origin. Capture &quot;origin&quot; (security origin) and pass it to the lambda of the enqueued task that processes the promise and repeat the check later, right before resolving the promise, to avoid the race condition explained before.
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.h: Added hasSecurityOrigin().
* Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp:
(WebCore::MediaKeys::hasOpenSessionWithIdForOrigin const): Check if there&apos;s another open session with the supplied id. It&apos;s a way to check that without revealing the session id to the caller.
* Source/WebCore/Modules/encryptedmedia/MediaKeys.h: Added hasOpenSessionWithIdForOrigin().
* Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp:
(WebCore::CDMInstanceSessionThunder::CDMInstanceSessionThunder): Removed the assert for zero challengeLength, since persistent license loading can generate a challenge with length 0.
(WebCore::CDMInstanceSessionThunder::challengeGeneratedCallback): Empty challenges (generated by license loading) aren&apos;t processed, since there&apos;s no data to process. Exit early.
(WebCore::CDMInstanceSessionThunder::loadSession): Implement loading by constructing the session passing the session id as CDMData (and its length). Check for error conditions and finally set the session id if loading succeeds. Finally, load the data. Some safety assumptions (initialized and open MediaKeySession, sanitized session id, license type being one of the persistent ones) are guaranteed by the upper WebCore layer and aren&apos;t checked again here. The changed callbacks are kept, since they might be useful if the session changes (renewal is required, etc.). I can&apos;t check this in practice until the real integration is done. I&apos;ve been working with a mockup to check the code until now.

Canonical link: <a href="https://commits.webkit.org/310914@main">https://commits.webkit.org/310914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a22d9c5d4478c84ed55d926c87a5989fab93c9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164059 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157171 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28408 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120176 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139469 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100871 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21491 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19567 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11885 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131159 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166537 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18912 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128289 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28102 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23601 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128420 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34850 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28026 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139095 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85532 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23276 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15892 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27720 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91823 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27297 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27527 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->