### PR TITLE
Add sandbox parameter for simulator runtime root

### DIFF
--- a/Source/WebKit/Scripts/compile-sandbox.sh
+++ b/Source/WebKit/Scripts/compile-sandbox.sh
@@ -12,6 +12,7 @@ if [ -z "$(xcrun --sdk $SDK_NAME -f sbutil 2> /dev/null)" ]; then
 fi;
 
 SIMULATOR_SANDBOX_PATH="$SANDBOX_NAME.simulator"
+SIMULATOR_RUNTIME_ROOT="${SIMULATOR_RUNTIME_BUNDLE_INSTALL_DIR_iphonesimulator}/Contents/Resources/RuntimeRoot"
 
 if [[ $SDK_NAME =~ "iphone" || $SDK_NAME =~ "watch" || $SDK_NAME =~ "appletv" || $SDK_NAME =~ "xr" ]]; then
     if [[ $SANDBOX_NAME == "com.apple.WebKit.adattributiond" || $SANDBOX_NAME == "com.apple.WebKit.webpushd" ]]; then
@@ -25,7 +26,7 @@ if [[ $SDK_NAME =~ "iphone" || $SDK_NAME =~ "watch" || $SDK_NAME =~ "appletv" ||
     fi;
     if [[ $SANDBOX_NAME == "com.apple.WebKit.GPU" || $SANDBOX_NAME == "com.apple.WebKit.GPU.Development" || $SANDBOX_NAME == "com.apple.WebKit.Networking"* || $SANDBOX_NAME == "com.apple.WebKit.WebContent"* ]]; then
 
-        xcrun --sdk $SDK_NAME sbutil compile $SANDBOX_PATH > $SIMULATOR_SANDBOX_PATH;
+        xcrun --sdk $SDK_NAME sbutil compile -D SIMULATOR_RUNTIME_ROOT="$SIMULATOR_RUNTIME_ROOT" $SANDBOX_PATH > $SIMULATOR_SANDBOX_PATH;
         if [[ $? != 0 ]]; then
             exit 1;
         fi


### PR DESCRIPTION
#### 3baa7ee40b21f71db925dcf8437130835ccaf7f4
<pre>
Add sandbox parameter for simulator runtime root
<a href="https://bugs.webkit.org/show_bug.cgi?id=311730">https://bugs.webkit.org/show_bug.cgi?id=311730</a>
<a href="https://rdar.apple.com/174319725">rdar://174319725</a>

Reviewed by Sihui Liu.

This is a requirement before enabling sandboxing in the simulator, since some sandbox rules
will have to take the runtime root into account. These rules will be added in follow-up
patches.

* Source/WebKit/Scripts/compile-sandbox.sh:

Canonical link: <a href="https://commits.webkit.org/310910@main">https://commits.webkit.org/310910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca1855313ed3c1a4077e88f41f0b75ce4f81fb65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163695 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108406 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d46b0431-895c-40db-b361-2a647bd2d5f3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28333 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119869 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84724 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/25715ebb-1e48-4ab3-85c3-7cddce03f90b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157894 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22142 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139142 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100562 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5ced6805-c1e2-4cd0-a83b-9ec98041bb9a) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/154255 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21227 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19259 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11521 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130889 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166170 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9658 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18595 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127970 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23298 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128109 "Found 1 new API test failure: WebKitGTK/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/ephemeral (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27663 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138779 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84372 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23676 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22992 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15574 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27355 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91459 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26933 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27164 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27006 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->