### PR TITLE
[JSC] Add LLInt IC for `op_in_by_id`

### DIFF
--- a/JSTests/microbenchmarks/in-by-id-own-hit-llint.js
+++ b/JSTests/microbenchmarks/in-by-id-own-hit-llint.js
@@ -1,0 +1,10 @@
+function test(o)
+{
+    return ("a" in o) + ("b" in o) + ("c" in o) + ("d" in o);
+}
+noInline(test);
+
+var o = { a: 1, b: 2, c: 3, d: 4 };
+var result = 0;
+for (var i = 0; i < 1e4; ++i)
+    result += test(o);

--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -759,6 +759,16 @@ op :try_get_by_id,
         offset: unsigned,
     }
 
+op :in_by_id,
+    args: {
+        dst: VirtualRegister,
+        base: VirtualRegister,
+        property: unsigned,
+    },
+    metadata: {
+        structureID: StructureID,
+    }
+
 # Alignment: 1
 op :jneq_ptr,
     args: {
@@ -816,13 +826,6 @@ op :to_object,
         operand: VirtualRegister,
         message: unsigned,
         valueProfile: unsigned,
-    }
-
-op :in_by_id,
-    args: {
-        dst: VirtualRegister,
-        base: VirtualRegister,
-        property: unsigned,
     }
 
 op :has_private_name,

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -502,6 +502,7 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
 
         LINK(OpTryGetById)
         LINK(OpGetByIdDirect)
+        LINK(OpInById)
         LINK(OpGetByValWithThis)
         LINK(OpToThis)
 
@@ -1537,6 +1538,14 @@ void CodeBlock::finalizeLLIntInlineCaches()
             dataLogLnIf(Options::verboseOSR(), "Clearing get_by_id_direct LLInt property access.");
             metadata.m_structureID = StructureID();
             metadata.m_offset = 0;
+        });
+
+        m_metadata->forEach<OpInById>([&] (auto& metadata) {
+            StructureID oldStructureID = metadata.m_structureID;
+            if (!oldStructureID || vm.heap.isMarked(oldStructureID.decode()))
+                return;
+            dataLogLnIf(Options::verboseOSR(), "Clearing in_by_id LLInt property access.");
+            metadata.m_structureID = StructureID();
         });
 
         m_metadata->forEach<OpGetPrivateName>([&] (auto& metadata) {

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -1619,7 +1619,38 @@ LLINT_SLOW_PATH_DECL(slow_path_in_by_id)
     if (!baseValue.isObject())
         LLINT_THROW(createInvalidInParameterError(globalObject, baseValue));
 
-    LLINT_RETURN(jsBoolean(asObject(baseValue)->hasProperty(globalObject, codeBlock->identifier(bytecode.m_property))));
+    const Identifier& ident = codeBlock->identifier(bytecode.m_property);
+    JSObject* baseObject = asObject(baseValue);
+    PropertySlot slot(baseObject, PropertySlot::InternalMethodType::HasProperty);
+    bool found = baseObject->getPropertySlot(globalObject, ident, slot);
+    LLINT_CHECK_EXCEPTION();
+
+    if (Options::useLLIntICs() && found && slot.isCacheable()) {
+        auto& metadata = bytecode.metadata(codeBlock);
+        {
+            StructureID oldStructureID = metadata.m_structureID;
+            if (oldStructureID) {
+                Structure* a = oldStructureID.decode();
+                Structure* b = baseObject->structure();
+
+                if (Structure::shouldConvertToPolyProto(a, b)) {
+                    ASSERT(a->rareData()->sharedPolyProtoWatchpoint().get() == b->rareData()->sharedPolyProtoWatchpoint().get());
+                    a->rareData()->sharedPolyProtoWatchpoint()->invalidate(vm, StringFireDetail("Detected poly proto opportunity."));
+                }
+            }
+        }
+
+        Structure* structure = baseObject->structure();
+        if (slot.slotBase() == baseValue && structure->propertyAccessesAreCacheable() && !structure->needImpurePropertyWatchpoint()) {
+            {
+                ConcurrentJSLocker locker(codeBlock->m_lock);
+                metadata.m_structureID = structure->id();
+            }
+            vm.writeBarrier(codeBlock);
+        }
+    }
+
+    LLINT_RETURN(jsBoolean(found));
 }
 
 LLINT_SLOW_PATH_DECL(slow_path_in_by_val)

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -3610,7 +3610,17 @@ llintOpWithMetadata(op_enumerator_has_own_property, OpEnumeratorHasOwnProperty, 
     hasPropertyImpl(OpEnumeratorHasOwnProperty, size, get, dispatch, metadata, return, _slow_path_enumerator_has_own_property)
 end)
 
-llintOpWithReturn(op_in_by_id, OpInById, macro (size, get, dispatch, return)
+llintOpWithMetadata(op_in_by_id, OpInById, macro (size, get, dispatch, metadata, return)
+    metadata(t2, t0)
+    get(m_base, t0)
+    loadConstantOrVariableCell(size, t0, t3, .opInByIdSlow)
+    loadi JSCell::m_structureID[t3], t1
+    loadi OpInById::Metadata::m_structureID[t2], t0
+    bineq t0, t1, .opInByIdSlow
+    move ValueTrue, t0
+    return(t0)
+
+.opInByIdSlow:
     callSlowPath(_llint_slow_path_in_by_id)
     dispatch()
 .osrReturnPoint:


### PR DESCRIPTION
#### ddf0c6b74008a2ca9db6d656c13022c72b44e5d7
<pre>
[JSC] Add LLInt IC for `op_in_by_id`
<a href="https://bugs.webkit.org/show_bug.cgi?id=311729">https://bugs.webkit.org/show_bug.cgi?id=311729</a>

Reviewed by NOBODY (OOPS!).

Add a simple LLInt inline cache for op_in_by_id, mirroring the existing
op_try_get_by_id / op_get_by_id_direct LLInt ICs. The fast path caches
the base structureID on an own cacheable hit and returns ValueTrue when
it matches; no offset is stored since `in` only tests presence.

                                TipOfTree                  Patched

in-by-id-own-hit-llint        1.2645+-0.0595     ^      0.7153+-0.0334        ^ definitely 1.7677x faster

Test: JSTests/microbenchmarks/in-by-id-own-hit-llint.js

* JSTests/microbenchmarks/in-by-id-own-hit-llint.js: Added.
(test):
* Source/JavaScriptCore/bytecode/BytecodeList.rb:
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::finishCreation):
(JSC::CodeBlock::finalizeLLIntInlineCaches):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::LLINT_SLOW_PATH_DECL):
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddf0c6b74008a2ca9db6d656c13022c72b44e5d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163697 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108408 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28045 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119872 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84727 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22146 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139144 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100565 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21231 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19261 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11523 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146987 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166172 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15768 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9665 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18597 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127977 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27741 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23300 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128116 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27665 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138781 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84374 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22993 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15576 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186724 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27357 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91461 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47845 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26935 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27166 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27008 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->