### PR TITLE
Parse 'systemLanguage' as a comma separated list

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/systemLanguage-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/systemLanguage-parsing-expected.txt
@@ -1,0 +1,15 @@
+
+PASS Comma-separated tokens are split into individual items
+PASS Whitespace after comma is stripped
+PASS Whitespace before comma is stripped
+PASS Whitespace around commas is stripped
+PASS Leading and trailing whitespace on the value is stripped
+PASS Tabs and newlines as leading/trailing whitespace are stripped
+PASS Single token without commas
+PASS BCP 47 subtags are preserved within tokens
+PASS Double comma produces an empty token between the two commas
+PASS Empty string results in a single empty token
+PASS A single comma separates two empty tokens
+PASS Numeric tokens are parsed without validation
+PASS Invalid language tags are stored as tokens without validation
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/systemLanguage-parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/systemLanguage-parsing.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<title>systemLanguage attribute is parsed as comma-separated tokens</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#ConditionalProcessingSystemLanguageAttribute">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#set-of-comma-separated-tokens">
+<meta name="assert" content="The systemLanguage attribute value is a set of comma-separated tokens per SVG2. Each token is trimmed of surrounding ASCII whitespace.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+function parsesAs(input, expected, description) {
+    test(() => {
+        const el = document.createElementNS("http://www.w3.org/2000/svg", "text");
+        el.setAttribute("systemLanguage", input);
+        const list = el.systemLanguage;
+        assert_equals(list.length, expected.length, "token count");
+        for (let i = 0; i < expected.length; i++)
+            assert_equals(list.getItem(i), expected[i], `token ${i}`);
+    }, description);
+}
+
+// SVG2: "The value is a set of comma-separated tokens, each of which must be
+// a Language-Tag value, as defined in BCP 47."
+//
+// HTML: "A set of comma-separated tokens is a string containing zero or more
+// tokens each separated from the next by a single U+002C COMMA character (,),
+// where tokens consist of any string of zero or more characters, neither
+// beginning nor ending with ASCII whitespace, nor containing any U+002C COMMA
+// characters (,), and optionally surrounded by ASCII whitespace."
+
+parsesAs("en,fr,de", ["en", "fr", "de"],
+    "Comma-separated tokens are split into individual items");
+
+parsesAs("en, fr, de", ["en", "fr", "de"],
+    "Whitespace after comma is stripped");
+
+parsesAs("en ,fr ,de", ["en", "fr", "de"],
+    "Whitespace before comma is stripped");
+
+parsesAs("en , fr , de", ["en", "fr", "de"],
+    "Whitespace around commas is stripped");
+
+parsesAs("  en, fr  ", ["en", "fr"],
+    "Leading and trailing whitespace on the value is stripped");
+
+parsesAs(" \t\nen, fr\t\n ", ["en", "fr"],
+    "Tabs and newlines as leading/trailing whitespace are stripped");
+
+parsesAs("en", ["en"],
+    "Single token without commas");
+
+// "each of which must be a Language-Tag value, as defined in BCP 47"
+// BCP 47 tags use hyphens for subtags (e.g. "en-US", "zh-Hans").
+// Hyphens are not separators — only commas are.
+parsesAs("en-US, zh-Hans, pt-BR", ["en-US", "zh-Hans", "pt-BR"],
+    "BCP 47 subtags are preserved within tokens");
+
+// Edge cases: the parser does not validate token content.
+// Invalid BCP 47 tags are stored as-is. They simply won't match
+// any user language, so the element won't render.
+
+// Double comma — per the HTML comma-separated token spec, the empty
+// string between consecutive commas is a valid token.
+// https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#set-of-comma-separated-tokens
+// Example from spec: " a ,b,,d d " → ["a", "b", "", "d d"]
+parsesAs("en,,fr", ["en", "", "fr"],
+    "Double comma produces an empty token between the two commas");
+
+// "zero or more tokens" — an empty string yields an empty list.
+// SVG2: "If a null string or empty string value is given to attribute
+// 'systemLanguage', the attribute evaluates to 'false'."
+parsesAs("", [""],
+    "Empty string results in a single empty token");
+
+// A lone comma separates two empty tokens per the HTML spec.
+parsesAs(",", ["", ""],
+    "A single comma separates two empty tokens");
+
+// Numeric strings are not valid BCP 47 tags but are stored as tokens.
+parsesAs("123, 456", ["123", "456"],
+    "Numeric tokens are parsed without validation");
+
+// Arbitrary invalid strings are stored as tokens without validation.
+parsesAs("not-a-lang, ???, @#$", ["not-a-lang", "???", "@#$"],
+    "Invalid language tags are stored as tokens without validation");
+</script>

--- a/LayoutTests/svg/dom/svg-list-properties-parser-leading-trailing-spaces-expected.txt
+++ b/LayoutTests/svg/dom/svg-list-properties-parser-leading-trailing-spaces-expected.txt
@@ -17,7 +17,7 @@ PASS polylineElement.points.length is 4
 PASS SVGListToString(polylineElement.points) is "[0,0 100,0 100,100 0,100]"
 
 Check SVStringList parsing
-PASS textElement.systemLanguage.length is 10
+PASS textElement.systemLanguage.length is 1
 PASS SVGListToString(textElement.systemLanguage) is "[1 2 3 4 5 6 7 8 9 10]"
 
 Check SVTransformList parsing

--- a/LayoutTests/svg/dom/svg-list-properties-parser-leading-trailing-spaces.html
+++ b/LayoutTests/svg/dom/svg-list-properties-parser-leading-trailing-spaces.html
@@ -71,7 +71,7 @@ textElement.setAttribute("systemLanguage", " \t\n1 2 3 4 5 6 7 8 9 10\t\n ");
 
 debug("");
 debug("Check SVStringList parsing");
-shouldBe("textElement.systemLanguage.length", "10");
+shouldBe("textElement.systemLanguage.length", "1");
 shouldBeEqualToString("SVGListToString(textElement.systemLanguage)", "[1 2 3 4 5 6 7 8 9 10]");
 
 textElement.setAttribute('transform', ' \t\nscale(2, 2) translate(10 10)\t\n ');

--- a/Source/WebCore/svg/SVGStringList.cpp
+++ b/Source/WebCore/svg/SVGStringList.cpp
@@ -27,35 +27,57 @@
 #include "SVGStringList.h"
 
 #include "SVGParserUtilities.h"
-#include <wtf/text/StringBuilder.h>
+#include <wtf/text/MakeString.h>
 #include <wtf/text/StringParsingBuffer.h>
 
 namespace WebCore {
 
-bool SVGStringList::parse(StringView data, char16_t delimiter)
+void SVGStringList::setFromCommaSeparatedTokens(StringView string)
 {
+    m_delimiter = ',';
     clearItems();
+    parseCommaSeparatedTokens(string);
 
-    auto isSVGSpaceOrDelimiter = [delimiter](auto c) {
-        return isASCIIWhitespace(c) || c == delimiter;
-    };
+    if (m_items.isEmpty())
+        m_items.append(emptyString());
+}
 
-    return readCharactersForParsing(data, [&](auto buffer) {
+void SVGStringList::setFromSpaceSeparatedTokens(StringView string)
+{
+    m_delimiter = ' ';
+    clearItems();
+    parseSpaceSeparatedTokens(string);
+
+    if (m_items.isEmpty())
+        m_items.append(emptyString());
+}
+
+// FIXME: This should use a general-purpose WTF space-separated token parser. https://webkit.org/b/312153
+// https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#set-of-comma-separated-tokens
+void SVGStringList::parseCommaSeparatedTokens(StringView data)
+{
+    for (auto token : data.splitAllowingEmptyEntries(','))
+        m_items.append(token.trim(isASCIIWhitespace).toString());
+}
+
+// FIXME: This should use a general-purpose WTF space-separated token parser. https://webkit.org/b/312153
+// https://bugs.webkit.org/show_bug.cgi?id=312153
+// https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#set-of-space-separated-tokens
+void SVGStringList::parseSpaceSeparatedTokens(StringView data)
+{
+    readCharactersForParsing(data, [&](auto buffer) {
         skipOptionalSVGSpaces(buffer);
 
         while (buffer.hasCharactersRemaining()) {
             auto start = buffer.position();
-            
-            // FIXME: It would be a nice improvement to add a variant of skipUntil which worked
-            // with lambda predicates.
-            while (buffer.hasCharactersRemaining() && !isSVGSpaceOrDelimiter(*buffer))
-                ++buffer;
+
+            skipUntil<isASCIIWhitespace>(buffer);
 
             if (buffer.position() == start)
                 break;
 
             m_items.append(String({ start, buffer.position() }));
-            skipOptionalSVGSpacesOrDelimiter(buffer, delimiter);
+            skipOptionalSVGSpaces(buffer);
         }
 
         return buffer.atEnd();
@@ -64,16 +86,8 @@ bool SVGStringList::parse(StringView data, char16_t delimiter)
 
 String SVGStringList::valueAsString() const
 {
-    StringBuilder builder;
-
-    for (const auto& string : m_items) {
-        if (builder.length())
-            builder.append(' ');
-
-        builder.append(string);
-    }
-
-    return builder.toString();
+    auto delimiter = m_delimiter == ',' ? ", "_s : " "_s;
+    return makeString(interleave(m_items, delimiter));
 }
 
 }

--- a/Source/WebCore/svg/SVGStringList.h
+++ b/Source/WebCore/svg/SVGStringList.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "SVGPrimitiveList.h"
-#include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
@@ -41,17 +40,15 @@ public:
         return adoptRef(*new SVGStringList(owner));
     }
 
-    void reset(const String& string)
-    {
-        parse(string, ' ');
+    void setFromCommaSeparatedTokens(StringView);
+    void setFromSpaceSeparatedTokens(StringView);
 
-        // Add empty string, if list is empty.
-        if (m_items.isEmpty())
-            m_items.append(emptyString());
-    }
-
-    bool parse(StringView, char16_t delimiter);
     String valueAsString() const override;
+
+private:
+    void parseCommaSeparatedTokens(StringView);
+    void parseSpaceSeparatedTokens(StringView);
+    char16_t m_delimiter { ' ' };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGTests.cpp
+++ b/Source/WebCore/svg/SVGTests.cpp
@@ -91,10 +91,10 @@ void SVGTests::parseAttribute(const QualifiedName& attributeName, const AtomStri
 {
     switch (attributeName.nodeName()) {
     case AttributeNames::requiredExtensionsAttr:
-        protect(requiredExtensions())->reset(value);
+        protect(requiredExtensions())->setFromSpaceSeparatedTokens(value);
         break;
     case AttributeNames::systemLanguageAttr:
-        protect(systemLanguage())->reset(value);
+        protect(systemLanguage())->setFromCommaSeparatedTokens(value);
         break;
     default:
         break;


### PR DESCRIPTION
#### 94ce6308f5028935574e1f569f55df46de8a0473
<pre>
Parse &apos;systemLanguage&apos; as a comma separated list
<a href="https://bugs.webkit.org/show_bug.cgi?id=262146">https://bugs.webkit.org/show_bug.cgi?id=262146</a>
<a href="https://rdar.apple.com/116427520">rdar://116427520</a>

Reviewed by Darin Adler and Nikolas Zimmermann.

The SVG2 specification defines systemLanguage as
&quot;a set of comma-separated tokens&quot; (per the HTML definition),
where each token is a BCP 47 language tag. WebKit was parsing
it as space-separated, which meant &quot;en,fr,de&quot; was treated as
a single token.

SVGStringList now exposes two public methods:
* setFromCommaSeparatedTokens()
* setFromSpaceSeparatedTokens()
and as two private methods:
* parseCommaSeparatedTokens()
* parseSpaceSeparatedTokens()
systemLanguage uses the comma path;
requiredExtensions continues to use the space path.

Note: This PR is about parsing only. The validation logic
(matching user preferences against the parsed tags) is tracked
separately in <a href="https://webkit.org/b/262140.">https://webkit.org/b/262140.</a>

Note: This also invites to create a more general parseCommaSeparatedTokens
and parseSpaceSeparatedTokens, because there are other parts of WebCore
using similar needs. See <a href="https://webkit.org/b/312153.">https://webkit.org/b/312153.</a>

Spec: <a href="https://w3c.github.io/svgwg/svg2-draft/struct.html#ConditionalProcessingSystemLanguageAttribute">https://w3c.github.io/svgwg/svg2-draft/struct.html#ConditionalProcessingSystemLanguageAttribute</a>
An issue has been opened on the spec to clarify it too.
<a href="https://github.com/w3c/svgwg/issues/1089">https://github.com/w3c/svgwg/issues/1089</a>

Test: imported/w3c/web-platform-tests/svg/struct/systemLanguage-parsing.html

* LayoutTests/imported/w3c/web-platform-tests/svg/struct/systemLanguage-parsing-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/struct/systemLanguage-parsing.html: Added.
* LayoutTests/svg/dom/svg-list-properties-parser-leading-trailing-spaces-expected.txt:
* LayoutTests/svg/dom/svg-list-properties-parser-leading-trailing-spaces.html:
* Source/WebCore/svg/SVGStringList.cpp:
(WebCore::SVGStringList::setFromCommaSeparatedTokens):
(WebCore::SVGStringList::setFromSpaceSeparatedTokens):
(WebCore::SVGStringList::parseCommaSeparatedTokens):
(WebCore::SVGStringList::parseSpaceSeparatedTokens):
(WebCore::SVGStringList::valueAsString const):
(WebCore::SVGStringList::parse): Deleted.
* Source/WebCore/svg/SVGStringList.h:
* Source/WebCore/svg/SVGTests.cpp:
(WebCore::SVGTests::parseAttribute):

Canonical link: <a href="https://commits.webkit.org/311439@main">https://commits.webkit.org/311439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7ae23f3ee3770278eefb70d6bb5601475bc3d9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165790 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111049 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158838 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121558 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/76b20e07-7749-4b68-b23c-8511be627381) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23796 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140955 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102226 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22850 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21084 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13562 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132531 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168275 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12434 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20403 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129684 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29905 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25162 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129792 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35158 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140577 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87632 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24615 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17381 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29539 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93553 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29061 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29291 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29187 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->