### PR TITLE
[JSC] Add C++ concept which is a derived JSInternalFieldObject class and initial value creatable

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -44,6 +44,7 @@
 #include "JSAsyncFromSyncIterator.h"
 #include "JSAsyncGenerator.h"
 #include "JSGenerator.h"
+#include "JSInternalFieldObjectImpl.h"
 #include "JSInternalPromise.h"
 #include "JSIteratorHelper.h"
 #include "JSMapIterator.h"
@@ -917,7 +918,7 @@ private:
         m_rootInsertionSet.execute(m_graph.block(0));
     }
 
-    template<typename InternalFieldClass>
+    template<JSInternalFieldObjectInitialValueCreatable InternalFieldClass>
     Allocation* handleInternalFieldClass(Node* node, UncheckedKeyHashMap<PromotedLocationDescriptor, LazyNode>& writes)
     {
         Allocation* result = &m_heap.newAllocation(node, Allocation::Kind::InternalFieldObject);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -63,6 +63,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "JSCInlines.h"
 #include "JSCellButterfly.h"
 #include "JSGeneratorFunction.h"
+#include "JSInternalFieldObjectImpl.h"
 #include "JSIteratorHelper.h"
 #include "JSLexicalEnvironment.h"
 #include "JSMapIterator.h"
@@ -15837,7 +15838,7 @@ void SpeculativeJIT::compileCreatePromise(Node* node)
 }
 
 
-template<typename JSClass, typename Operation>
+template<JSInternalFieldObjectInitialValueCreatable JSClass, typename Operation>
 void SpeculativeJIT::compileCreateInternalFieldObject(Node* node, Operation operation)
 {
     SpeculateCellOperand callee(this, node->child1());
@@ -15920,7 +15921,7 @@ void SpeculativeJIT::compileNewObject(Node* node)
     cellResult(resultGPR, node);
 }
 
-template<typename JSClass, typename Operation>
+template<JSInternalFieldObjectInitialValueCreatable JSClass, typename Operation>
 void SpeculativeJIT::compileNewInternalFieldObjectImpl(Node* node, Operation operation)
 {
     GPRTemporary result(this);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -38,6 +38,7 @@
 #include "DFGSilentRegisterSavePlan.h"
 #include "JITMathIC.h"
 #include "JITOperations.h"
+#include "JSInternalFieldObjectImpl.h"
 #include "PropertyInlineCache.h"
 #include "SpillRegistersMode.h"
 #include "ValueRecovery.h"
@@ -1810,9 +1811,9 @@ public:
     void compilePromiseThen(Node*);
     void compilePerformPromiseThen(Node*);
 
-    template<typename JSClass, typename Operation>
+    template<JSInternalFieldObjectInitialValueCreatable JSClass, typename Operation>
     void compileCreateInternalFieldObject(Node*, Operation);
-    template<typename JSClass, typename Operation>
+    template<JSInternalFieldObjectInitialValueCreatable JSClass, typename Operation>
     void compileNewInternalFieldObjectImpl(Node*, Operation);
 
     void moveTrueTo(GPRReg);

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
@@ -215,5 +215,6 @@ private:
     typedef UncheckedKeyHashMap<RefPtr<UniquedStringImpl>, Resolution, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>> Resolutions;
     Resolutions m_resolutionCache;
 };
+static_assert(JSInternalFieldObjectInitialValueCreatable<AbstractModuleRecord>);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSArrayIterator.h
+++ b/Source/JavaScriptCore/runtime/JSArrayIterator.h
@@ -84,5 +84,6 @@ private:
     JSArrayIterator(VM&, Structure*);
     void finishCreation(VM&);
 };
+static_assert(JSInternalFieldObjectInitialValueCreatable<JSArrayIterator>);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSAsyncDisposableStack.h
+++ b/Source/JavaScriptCore/runtime/JSAsyncDisposableStack.h
@@ -83,6 +83,8 @@ private:
     void finishCreation(VM&);
 };
 
+static_assert(JSInternalFieldObjectInitialValueCreatable<JSAsyncDisposableStack>);
+
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSAsyncDisposableStack);
 
 }

--- a/Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.h
+++ b/Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.h
@@ -77,6 +77,7 @@ private:
 
     void finishCreation(VM&, JSValue syncIterator, JSValue nextMethod);
 };
+static_assert(JSInternalFieldObjectInitialValueCreatable<JSAsyncFromSyncIterator>);
 
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSAsyncFromSyncIterator);
 

--- a/Source/JavaScriptCore/runtime/JSAsyncGenerator.h
+++ b/Source/JavaScriptCore/runtime/JSAsyncGenerator.h
@@ -195,4 +195,6 @@ private:
     void finishCreation(VM&);
 };
 
+static_assert(JSInternalFieldObjectInitialValueCreatable<JSAsyncGenerator>);
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSDisposableStack.h
+++ b/Source/JavaScriptCore/runtime/JSDisposableStack.h
@@ -83,6 +83,7 @@ private:
 
     void finishCreation(VM&);
 };
+static_assert(JSInternalFieldObjectInitialValueCreatable<JSDisposableStack>);
 
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSDisposableStack);
 

--- a/Source/JavaScriptCore/runtime/JSFinalizationRegistry.h
+++ b/Source/JavaScriptCore/runtime/JSFinalizationRegistry.h
@@ -120,6 +120,7 @@ private:
     DeadRegistrations m_noUnregistrationDead;
     bool m_hasAlreadyScheduledWork { false };
 };
+static_assert(JSInternalFieldObjectInitialValueCreatable<JSFinalizationRegistry>);
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/runtime/JSGenerator.h
+++ b/Source/JavaScriptCore/runtime/JSGenerator.h
@@ -128,6 +128,8 @@ private:
     void finishCreation(VM&);
 };
 
+static_assert(JSInternalFieldObjectInitialValueCreatable<JSGenerator>);
+
 OVERLOAD_RELATIONAL_OPERATORS_FOR_ENUM_CLASS_WITH_INTEGRALS(JSGenerator::Argument);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSInternalFieldObjectImpl.h
+++ b/Source/JavaScriptCore/runtime/JSInternalFieldObjectImpl.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/JSObject.h>
+#include <concepts>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -76,6 +77,13 @@ protected:
     }
 
     WriteBarrier<Unknown> m_internalFields[numberOfInternalFields] { };
+};
+
+template<typename T>
+concept JSInternalFieldObjectInitialValueCreatable = std::derived_from<T, ::JSC::JSInternalFieldObjectImpl<T::numberOfInternalFields>> && requires(T a)
+{
+    { T::initialValues() } -> std::same_as<std::array<::JSC::JSValue, T::numberOfInternalFields>>;
+    { T::info() } -> std::same_as<const ::JSC::ClassInfo*>;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSInternalPromise.h
+++ b/Source/JavaScriptCore/runtime/JSInternalPromise.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSInternalFieldObjectImpl.h>
 #include <JavaScriptCore/JSPromise.h>
 
 namespace JSC {
@@ -56,5 +57,6 @@ public:
 private:
     JSInternalPromise(VM&, Structure*);
 };
+static_assert(JSInternalFieldObjectInitialValueCreatable<JSInternalPromise>);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSIteratorHelper.h
+++ b/Source/JavaScriptCore/runtime/JSIteratorHelper.h
@@ -70,6 +70,8 @@ private:
     void finishCreation(VM&, JSValue generator, JSValue underlyingIterator);
 };
 
+static_assert(JSInternalFieldObjectInitialValueCreatable<JSIteratorHelper>);
+
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSIteratorHelper);
 
 JSC_DECLARE_HOST_FUNCTION(iteratorHelperPrivateFuncCreate);

--- a/Source/JavaScriptCore/runtime/JSMapIterator.h
+++ b/Source/JavaScriptCore/runtime/JSMapIterator.h
@@ -200,6 +200,7 @@ private:
     JS_EXPORT_PRIVATE void finishCreation(VM&, JSMap*, IterationKind);
     void finishCreation(VM&);
 };
+static_assert(JSInternalFieldObjectInitialValueCreatable<JSMapIterator>);
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSMapIterator);
 
 JSC_DECLARE_HOST_FUNCTION(mapIteratorPrivateFuncMapIteratorNext);

--- a/Source/JavaScriptCore/runtime/JSPromise.h
+++ b/Source/JavaScriptCore/runtime/JSPromise.h
@@ -165,6 +165,8 @@ private:
     static void triggerPromiseReactions(VM&, JSGlobalObject*, JSPromise::Status, JSPromiseReaction* head, JSValue argument);
 };
 
+static_assert(JSInternalFieldObjectInitialValueCreatable<JSPromise>);
+
 static constexpr PropertyOffset promiseCapabilityResolvePropertyOffset = 0;
 static constexpr PropertyOffset promiseCapabilityRejectPropertyOffset = 1;
 static constexpr PropertyOffset promiseCapabilityPromisePropertyOffset = 2;

--- a/Source/JavaScriptCore/runtime/JSRegExpStringIterator.h
+++ b/Source/JavaScriptCore/runtime/JSRegExpStringIterator.h
@@ -114,6 +114,7 @@ private:
 
     void finishCreation(VM&);
 };
+static_assert(JSInternalFieldObjectInitialValueCreatable<JSRegExpStringIterator>);
 
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSRegExpStringIterator);
 

--- a/Source/JavaScriptCore/runtime/JSSetIterator.h
+++ b/Source/JavaScriptCore/runtime/JSSetIterator.h
@@ -175,6 +175,7 @@ private:
     JS_EXPORT_PRIVATE void finishCreation(VM&, JSSet*, IterationKind);
     void finishCreation(VM&);
 };
+static_assert(JSInternalFieldObjectInitialValueCreatable<JSSetIterator>);
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSSetIterator);
 
 JSC_DECLARE_HOST_FUNCTION(setIteratorPrivateFuncSetIteratorNext);

--- a/Source/JavaScriptCore/runtime/JSStringIterator.h
+++ b/Source/JavaScriptCore/runtime/JSStringIterator.h
@@ -90,5 +90,6 @@ private:
     void finishCreation(VM&);
     void finishCreation(VM&, JSString* iteratedString);
 };
+static_assert(JSInternalFieldObjectInitialValueCreatable<JSStringIterator>);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSWrapForValidIterator.h
+++ b/Source/JavaScriptCore/runtime/JSWrapForValidIterator.h
@@ -82,6 +82,7 @@ private:
 
     void finishCreation(VM&, JSValue iterator, JSValue nextMethod);
 };
+static_assert(JSInternalFieldObjectInitialValueCreatable<JSWrapForValidIterator>);
 
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSWrapForValidIterator);
 

--- a/Source/JavaScriptCore/runtime/ProxyObject.h
+++ b/Source/JavaScriptCore/runtime/ProxyObject.h
@@ -141,6 +141,7 @@ private:
     WriteBarrierStructureID m_handlerStructureID;
     WriteBarrierStructureID m_handlerPrototypeStructureID;
 };
+static_assert(JSInternalFieldObjectInitialValueCreatable<ProxyObject>);
 
 ALWAYS_INLINE bool ProxyObject::isHandlerTrapsCacheValid(JSObject* handler)
 {


### PR DESCRIPTION
#### ecde3c7cbbff56efd41b97206db0c36786fc21f2
<pre>
[JSC] Add C++ concept which is a derived JSInternalFieldObject class and initial value creatable
<a href="https://bugs.webkit.org/show_bug.cgi?id=311733">https://bugs.webkit.org/show_bug.cgi?id=311733</a>

Reviewed by NOBODY (OOPS!).

This is just for making a code relationship explicit.

* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/runtime/AbstractModuleRecord.h:
* Source/JavaScriptCore/runtime/JSArrayIterator.h:
* Source/JavaScriptCore/runtime/JSAsyncDisposableStack.h:
* Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.h:
* Source/JavaScriptCore/runtime/JSAsyncGenerator.h:
* Source/JavaScriptCore/runtime/JSDisposableStack.h:
* Source/JavaScriptCore/runtime/JSFinalizationRegistry.h:
* Source/JavaScriptCore/runtime/JSGenerator.h:
* Source/JavaScriptCore/runtime/JSInternalFieldObjectImpl.h:
(JSC::requires):
* Source/JavaScriptCore/runtime/JSInternalPromise.h:
* Source/JavaScriptCore/runtime/JSIteratorHelper.h:
* Source/JavaScriptCore/runtime/JSMapIterator.h:
* Source/JavaScriptCore/runtime/JSPromise.h:
* Source/JavaScriptCore/runtime/JSRegExpStringIterator.h:
* Source/JavaScriptCore/runtime/JSSetIterator.h:
* Source/JavaScriptCore/runtime/JSStringIterator.h:
* Source/JavaScriptCore/runtime/JSWrapForValidIterator.h:
* Source/JavaScriptCore/runtime/ProxyObject.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecde3c7cbbff56efd41b97206db0c36786fc21f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28206 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163707 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108418 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28055 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119881 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84735 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157906 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22154 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139153 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100574 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21239 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19268 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11533 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146997 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130901 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166182 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15778 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9704 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18606 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127982 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27751 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23307 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128121 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27675 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138790 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/84384 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23002 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15585 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186734 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27367 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91471 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47847 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26945 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27176 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27018 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->