### PR TITLE
[JSC] Short-circuit assignment should not overwrite read-only locals

### DIFF
--- a/JSTests/stress/short-circuit-assignment-readonly-local.js
+++ b/JSTests/stress/short-circuit-assignment-readonly-local.js
@@ -1,0 +1,49 @@
+function shouldBe(a, e, m) { if (a !== e) throw new Error(m + ": " + a + " !== " + e); }
+function shouldThrow(f, m) { let threw = false; try { f(); } catch (e) { threw = e instanceof TypeError; } if (!threw) throw new Error(m + ": did not throw TypeError"); }
+
+function testConstAnd() {
+    const a = true;
+    shouldThrow(() => { a &&= 99; }, "const &&=");
+    shouldBe(a, true, "const a unchanged after &&=");
+    const b = false;
+    b &&= (() => { throw new Error("should not evaluate"); })();
+    shouldBe(b, false, "const b short-circuit &&=");
+}
+
+function testConstOr() {
+    const a = false;
+    shouldThrow(() => { a ||= 99; }, "const ||=");
+    shouldBe(a, false, "const a unchanged after ||=");
+    const b = true;
+    b ||= (() => { throw new Error("should not evaluate"); })();
+    shouldBe(b, true, "const b short-circuit ||=");
+}
+
+function testConstCoalesce() {
+    const a = null;
+    shouldThrow(() => { a ??= 99; }, "const ??=");
+    shouldBe(a, null, "const a unchanged after ??=");
+    const b = 1;
+    b ??= (() => { throw new Error("should not evaluate"); })();
+    shouldBe(b, 1, "const b short-circuit ??=");
+}
+
+let f = function fn() {
+    let r = (fn &&= 42);
+    shouldBe(fn, f, "sloppy fn name binding unchanged after &&=");
+    shouldBe(r, 42, "expression value is rhs");
+};
+
+let g = function fn() {
+    "use strict";
+    shouldThrow(() => { fn &&= 42; }, "strict fn name binding &&=");
+    shouldBe(fn, g, "strict fn name binding unchanged after &&=");
+};
+
+for (let i = 0; i < testLoopCount; ++i) {
+    testConstAnd();
+    testConstOr();
+    testConstCoalesce();
+    f();
+    g();
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -920,8 +920,6 @@ test/staging/sm/expressions/object-literal-computed-property-evaluation.js:
 test/staging/sm/expressions/short-circuit-compound-assignment-anon-fns.js:
   default: 'Test262Error: Expected SameValue(«"a"», «""») to be true'
   strict mode: 'Test262Error: Expected SameValue(«"a"», «""») to be true'
-test/staging/sm/expressions/short-circuit-compound-assignment-const.js:
-  default: 'Test262Error: Expected SameValue(«true», «function fn() {'
 test/staging/sm/extensions/DataView-construct-arguments-detaching.js:
   default: 'Test262Error: byteOffset weirdness should have thrown Expected a TypeError but got a RangeError'
   strict mode: 'Test262Error: byteOffset weirdness should have thrown Expected a TypeError but got a RangeError'

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -4045,7 +4045,8 @@ RegisterID* ShortCircuitReadModifyResolveNode::emitBytecode(BytecodeGenerator& g
         generator.emitTDZCheckIfNecessary(var, local.get(), nullptr);
 
         if (isReadOnly) {
-            RefPtr<RegisterID> result = local;
+            RefPtr<RegisterID> result = generator.tempDestination(dst);
+            generator.move(result.get(), local.get());
 
             Ref<Label> afterAssignment = generator.newLabel();
             emitShortCircuitAssignment(generator, result.get(), m_operator, afterAssignment.get());


### PR DESCRIPTION
#### d55d921dd45a79ee02ed349c9b17c57d32fa74e1
<pre>
[JSC] Short-circuit assignment should not overwrite read-only locals
<a href="https://bugs.webkit.org/show_bug.cgi?id=311734">https://bugs.webkit.org/show_bug.cgi?id=311734</a>

Reviewed by Yusuke Suzuki.

For `a &amp;&amp;= b` (and `||=`, `??=`) where `a` is a read-only local binding
(a const, or a function expression&apos;s own name), the bytecode generator
evaluated the right-hand side directly into `a`&apos;s register before
emitting the read-only error. The overwritten value became observable
when the TypeError was caught, or in sloppy mode for function-name
bindings where assignment is silently ignored and no error is thrown.

Test: JSTests/stress/short-circuit-assignment-readonly-local.js

* JSTests/stress/short-circuit-assignment-readonly-local.js: Added.
(shouldBe):
(shouldThrow):
(testConstAnd):
(testConstOr):
(testConstCoalesce):
(let.f):
(let.g):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::ShortCircuitReadModifyResolveNode::emitBytecode):

Canonical link: <a href="https://commits.webkit.org/311025@main">https://commits.webkit.org/311025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6b73d8fa025cc19e2d11a775640d576ecaa4680

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163710 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108421 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28058 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119880 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84733 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157909 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139150 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100573 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21235 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19269 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11536 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147000 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130897 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16994 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166185 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15781 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9712 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18603 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127981 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27754 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23308 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128120 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34911 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27678 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138787 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84387 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22998 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15582 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186737 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27370 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91474 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47849 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26948 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27179 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27021 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->