### PR TITLE
AX: `contextmenu` event is not fired for either keyboard event or AT event (e.g. VoiceOver's VO+Shift+M) in iframes

### DIFF
--- a/LayoutTests/accessibility/show-menu-fires-contextmenu-event-expected.txt
+++ b/LayoutTests/accessibility/show-menu-fires-contextmenu-event-expected.txt
@@ -1,0 +1,13 @@
+This test ensures that the ShowMenu accessibility action fires a contextmenu DOM event on elements in the main frame and inside iframes.
+
+PASS: contextMenuEvent !== null === true
+PASS: contextMenuEvent.type === 'contextmenu'
+PASS: contextMenuEvent.target.id === 'target'
+PASS: iframeContextMenuEvent !== null === true
+PASS: iframeContextMenuEvent.type === 'contextmenu'
+PASS: iframeContextMenuEvent.target.id === 'iframe-target'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Show my context menu

--- a/LayoutTests/accessibility/show-menu-fires-contextmenu-event.html
+++ b/LayoutTests/accessibility/show-menu-fires-contextmenu-event.html
@@ -1,0 +1,53 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<button id="target">Show my context menu</button>
+<iframe id="iframe" srcdoc="<button id='iframe-target'>Iframe button</button>"></iframe>
+
+<script>
+var output = "This test ensures that the ShowMenu accessibility action fires a contextmenu DOM event on elements in the main frame and inside iframes.\n\n";
+
+var contextMenuEvent = null;
+var iframeContextMenuEvent = null;
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    document.getElementById("target").addEventListener("contextmenu", function(event) {
+        event.preventDefault();
+        contextMenuEvent = event;
+    });
+
+    // Show the context menu via the accessibility API (simulating an AT performing the action).
+    accessibilityController.accessibleElementById("target").showMenu();
+    setTimeout(async function() {
+        output += await expectAsync("contextMenuEvent !== null", "true");
+        output += await expectAsync("contextMenuEvent.type", "'contextmenu'");
+        output += await expectAsync("contextMenuEvent.target.id", "'target'");
+
+        // Now test with an element inside an iframe.
+        var iframeDoc = document.getElementById("iframe").contentDocument;
+        iframeDoc.getElementById("iframe-target").addEventListener("contextmenu", function(event) {
+            event.preventDefault();
+            iframeContextMenuEvent = event;
+        });
+
+        var axIframeButton = await waitForElementById("iframe-target");
+        axIframeButton.showMenu();
+
+        output += await expectAsync("iframeContextMenuEvent !== null", "true");
+        output += await expectAsync("iframeContextMenuEvent.type", "'contextmenu'");
+        output += await expectAsync("iframeContextMenuEvent.target.id", "'iframe-target'");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/accessibility/show-menu-fires-contextmenu-event-in-remote-frame-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/accessibility/show-menu-fires-contextmenu-event-in-remote-frame-expected.txt
@@ -1,0 +1,8 @@
+Ensures that the ShowMenu accessibility action fires a contextmenu DOM event on elements inside a remote iframe.
+PASS: contextMenuFired === true
+PASS: contextMenuTargetId === 'contextmenu-target'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/accessibility/show-menu-fires-contextmenu-event-in-remote-frame.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/show-menu-fires-contextmenu-event-in-remote-frame.html
@@ -1,0 +1,47 @@
+<html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<iframe src="http://localhost:8000/site-isolation/resources/iframe-with-contextmenu-target.html" onload="runTest();"></iframe>
+
+<script>
+var output = "Ensures that the ShowMenu accessibility action fires a contextmenu DOM event on elements inside a remote iframe.\n";
+
+window.jsTestIsAsync = true;
+
+if (window.accessibilityController)
+    accessibilityController.setClientAccessibilityMode(true);
+
+var contextMenuFired = false;
+var contextMenuTargetId = null;
+
+window.addEventListener("message", function(event) {
+    if (event.data && event.data.type === "contextmenu") {
+        contextMenuFired = true;
+        contextMenuTargetId = event.data.targetId;
+    }
+});
+
+async function runTest() {
+    if (!window.accessibilityController)
+        return;
+
+    // Find the element inside the remote iframe via client accessibility mode,
+    // which traverses the AX tree through the UI process. Then trigger the menu
+    // via the AX API.
+    var target = await waitForElementById("contextmenu-target");
+    target.showMenu();
+
+    await waitFor(() => contextMenuFired);
+    output += expect("contextMenuFired", "true");
+    output += expect("contextMenuTargetId", "'contextmenu-target'");
+
+    debug(output);
+    finishJSTest();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/iframe-with-contextmenu-target.html
+++ b/LayoutTests/http/tests/site-isolation/resources/iframe-with-contextmenu-target.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Site isolation iframe with contextmenu target</title>
+</head>
+<body>
+<input id="contextmenu-target" type="text" value="Context menu target">
+<script>
+document.getElementById("contextmenu-target").addEventListener("contextmenu", function(event) {
+    event.preventDefault();
+    window.parent.postMessage({
+        type: "contextmenu",
+        targetId: event.target.id
+    }, "*");
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -924,6 +924,9 @@ accessibility/dynamic-speak-as.html [ Failure ]
 # Missing AccessibilityUIElement::{ariaActionsElementAtIndex, invokeCustomActionAtIndex} implementations.
 accessibility/aria-actions.html [ Skip ]
 
+# Missing AccessibilityUIElement::showMenu implementation.
+accessibility/show-menu-fires-contextmenu-event.html [ Skip ]
+
 # Failing since introduced, Atspi::State::Visited may not be set / updated properly?
 accessibility/link-becomes-visited.html [ Failure ]
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -48,6 +48,7 @@
 #include "Chrome.h"
 #include "ChromeClient.h"
 #include "ContainerNodeInlines.h"
+#include "ContextMenuController.h"
 #include "CustomElementDefaultARIA.h"
 #include "DOMTokenList.h"
 #include "DocumentPage.h"
@@ -1555,6 +1556,34 @@ bool AccessibilityObject::press()
     }
 
     return pressElement->accessKeyAction(true) || pressElement->dispatchSimulatedClick(nullptr, SendMouseUpDownEvents);
+}
+
+bool AccessibilityObject::performShowMenuAction()
+{
+#if ENABLE(CONTEXT_MENUS) && USE(ACCESSIBILITY_CONTEXT_MENUS)
+    RefPtr page = this->page();
+    if (!page)
+        return false;
+
+    RefPtr frameView = documentFrameView();
+    if (!frameView)
+        return false;
+
+    RefPtr document = this->document();
+    RefPtr frame = document ? document->frame() : nullptr;
+    if (!frame)
+        return false;
+
+    UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, document.get());
+    // Use the element's own frame rather than the main frame so that
+    // sendContextMenuEvent (which does not dispatch to subframes) hit-tests
+    // in the correct frame. This is necessary for elements inside iframes.
+    auto point = frameView->contentsToWindow(roundedIntPoint(elementRect().center()));
+    page->contextMenuController().showContextMenuAt(*frame, point);
+    return true;
+#else
+    return false;
+#endif // ENABLE(CONTEXT_MENUS) && USE(ACCESSIBILITY_CONTEXT_MENUS)
 }
 
 bool AccessibilityObject::dispatchTouchEvent()

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -555,6 +555,7 @@ public:
 
     void performDismissActionIgnoringResult() final { performDismissAction(); }
     bool press() override;
+    bool performShowMenuAction();
 
     std::optional<AccessibilityOrientation> explicitOrientation() const override { return std::nullopt; }
     void increment() override { }

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -3046,45 +3046,16 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     Accessibility::performFunctionOnMainThread([protectedSelf = retainPtr(self)] {
         // This needs to be performed in an iteration of the run loop that did not start from an AX call.
         // If it's the same run loop iteration, the menu open notification won't be sent.
-        [protectedSelf performSelector:@selector(_accessibilityShowContextMenu) withObject:nil afterDelay:0.0];
+        [protectedSelf performSelector:@selector(_accessibilityPerformShowMenuAction) withObject:nil afterDelay:0.0];
     });
 }
 
-- (void)_accessibilityShowContextMenu
+- (void)_accessibilityPerformShowMenuAction
 {
-    AXTRACE("WebAccessibilityObjectWrapper _accessibilityShowContextMenu"_s);
     AX_ASSERT(isMainThread());
 
-    RefPtr<AccessibilityObject> backingObject = dynamicDowncast<AccessibilityObject>(self.axBackingObject);
-    if (!backingObject) {
-        AXLOG(makeString("No backingObject for wrapper "_s, hex(reinterpret_cast<uintptr_t>(self))));
-        return;
-    }
-
-    RefPtr page = backingObject->page();
-    if (!page)
-        return;
-
-    IntRect rect = snappedIntRect(backingObject->elementRect());
-    // On WK2, we need to account for the scroll position with regards to root view.
-    // On WK1, we need to convert rect to window space to match mouse clicking.
-    RefPtr frameView = backingObject->documentFrameView();
-    if (frameView) {
-        // Find the appropriate scroll view to convert the coordinates to window space.
-        RefPtr axScrollView = Accessibility::findAncestor(*backingObject, false, [] (const auto& ancestor) {
-            return ancestor.isScrollArea() && ancestor.scrollView();
-        });
-
-        if (RefPtr scrollView = axScrollView ? axScrollView->scrollView() : nullptr) {
-            if (!frameView->platformWidget())
-                rect = scrollView->contentsToRootView(rect);
-            else
-                rect = scrollView->contentsToWindow(rect);
-        }
-    }
-
-    if (RefPtr localMainFrame = page->localMainFrame())
-        page->contextMenuController().showContextMenuAt(*localMainFrame, rect.center());
+    if (RefPtr backingObject = dynamicDowncast<AccessibilityObject>(self.updateObjectBackingStore))
+        backingObject->performShowMenuAction();
 }
 
 - (void)accessibilityScrollToVisible

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.h
@@ -67,6 +67,9 @@ public:
     double width() override;
     double height() override;
 
+    // Actions.
+    void showMenu() override;
+
     // Helpers.
     JSRetainPtr<JSStringRef> getStringAttribute(const char* attributeName) const;
     double getNumberAttribute(const char* attributeName) const;

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.mm
@@ -189,6 +189,18 @@ static std::pair<double, double> axCopyAttributeValueAsSize(uint64_t elementToke
     return { width, height };
 }
 
+static void axPerformAction(uint64_t elementToken, const char* actionName)
+{
+    WKRetainPtr dictionary = adoptWK(WKMutableDictionaryCreate());
+    setValue(dictionary, "elementToken", elementToken);
+    setValue(dictionary, "actionName", actionName);
+
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    WKTypeRef returnData = nullptr;
+    WKBundlePostSynchronousMessage(InjectedBundle::singleton().bundle(), toWK("AXPerformAction").get(), dictionary.get(), &returnData);
+    ALLOW_DEPRECATED_DECLARATIONS_END
+}
+
 Ref<AccessibilityUIElementClientMac> AccessibilityUIElementClientMac::create(uint64_t elementToken)
 {
     return adoptRef(*new AccessibilityUIElementClientMac(elementToken));
@@ -401,6 +413,14 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElementClientMac::childAtIndex(uns
 {
     Vector children = getChildrenInRange(index, 1);
     return children.size() == 1 ? children[0] : nullptr;
+}
+
+void AccessibilityUIElementClientMac::showMenu()
+{
+    if (!isValid())
+        return;
+
+    axPerformAction(m_elementToken, "AXShowMenu");
 }
 
 JSValueRef AccessibilityUIElementClientMac::uiElementsForSearchPredicate(JSContextRef context, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly, unsigned resultsLimit)

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -3458,6 +3458,11 @@ void TestController::didReceiveSynchronousMessageFromInjectedBundle(WKStringRef 
 
     if (WKStringIsEqualToUTF8CString(messageName, "AXSearchPredicate"))
         return completionHandler(handleAXSearchPredicate(dictionaryValue(messageBody)).get());
+
+    if (WKStringIsEqualToUTF8CString(messageName, "AXPerformAction")) {
+        handleAXPerformAction(dictionaryValue(messageBody));
+        return completionHandler(nullptr);
+    }
 #endif
 
     completionHandler(protectedCurrentInvocation()->didReceiveSynchronousMessageFromInjectedBundle(messageName, messageBody).get());
@@ -5725,6 +5730,19 @@ WKRetainPtr<WKTypeRef> TestController::handleAXSearchPredicate(WKDictionaryRef m
     }
 
     return tokenArray;
+}
+
+void TestController::handleAXPerformAction(WKDictionaryRef messageBody)
+{
+    uint64_t elementToken = uint64Value(messageBody, "elementToken");
+    WKStringRef actionName = stringValue(messageBody, "actionName");
+
+    AXUIElementRef element = static_cast<AXUIElementRef>(getAXElement(elementToken));
+    if (!element)
+        return;
+
+    RetainPtr actionNameCF = adoptCF(CFStringCreateWithCString(kCFAllocatorDefault, toSTD(actionName).c_str(), kCFStringEncodingUTF8));
+    AXUIElementPerformAction(element, actionNameCF.get());
 }
 
 #endif // PLATFORM(MAC)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -593,6 +593,7 @@ private:
     WKRetainPtr<WKTypeRef> handleAXCopyAttributeValueAsPoint(WKDictionaryRef);
     WKRetainPtr<WKTypeRef> handleAXCopyAttributeValueAsSize(WKDictionaryRef);
     WKRetainPtr<WKTypeRef> handleAXSearchPredicate(WKDictionaryRef);
+    void handleAXPerformAction(WKDictionaryRef);
 #endif
 
     // WKContextClient


### PR DESCRIPTION
#### 38d9120295b679bfe0fea60b075e041fc3efd1d6
<pre>
AX: `contextmenu` event is not fired for either keyboard event or AT event (e.g. VoiceOver&apos;s VO+Shift+M) in iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=302049">https://bugs.webkit.org/show_bug.cgi?id=302049</a>
<a href="https://rdar.apple.com/164128676">rdar://164128676</a>

Reviewed by Joshua Hoffman.

performShowMenuAction() was calling showContextMenuAt() with the local
main frame. Since sendContextMenuEvent does not dispatch to subframes, it
would hit-test in the main frame and find the &lt;iframe&gt; element itself,
so the contextmenu event never reached the actual target element inside
the iframe.

Fix by using the element&apos;s own document frame and contentsToWindow()
for coordinate conversion, so the hit-test runs in the correct local frame.

No special remote frame handling is needed (e.g. IPC), as if the AT is initiating
the show-menu action for an element, it does so by directly talking
directly to that element from within the remote frame.

* LayoutTests/accessibility/show-menu-fires-contextmenu-event-expected.txt: Added.
* LayoutTests/accessibility/show-menu-fires-contextmenu-event.html: Added.
* LayoutTests/http/tests/site-isolation/accessibility/show-menu-fires-contextmenu-event-in-remote-frame-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/accessibility/show-menu-fires-contextmenu-event-in-remote-frame.html: Added.
* LayoutTests/http/tests/site-isolation/resources/iframe-with-contextmenu-target.html: Added.
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::performShowMenuAction):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityPerformShowMenuAction]):
(-[WebAccessibilityObjectWrapper _accessibilityPerformShowMenuAction]):
(-[WebAccessibilityObjectWrapper _accessibilityShowContextMenu]): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.h:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.mm:
(WTR::axPerformAction):
(WTR::AccessibilityUIElementClientMac::showMenu):
* Tools/WebKitTestRunner/TestController.cpp:
* Tools/WebKitTestRunner/TestController.h:

Canonical link: <a href="https://commits.webkit.org/310897@main">https://commits.webkit.org/310897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3fcdcf94fb01f4f0d0ad4502a4e5a186d1eab15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155243 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21662 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164003 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aae1bcd7-e41d-4d79-b8ed-7bd0dcc16fda) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157116 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28643 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28351 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120128 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/22b8b05a-1db4-4925-b8bd-141fae1af17f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139418 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100823 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab342a0e-8cca-4bd7-a935-2c89b80a2c6e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21464 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19520 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11829 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131130 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166481 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18862 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128231 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28047 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23554 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128368 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34838 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27971 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139046 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84680 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23230 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15843 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27664 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91768 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27242 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27472 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27315 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->