### PR TITLE
Scroll container with composited child paints background twice

### DIFF
--- a/LayoutTests/compositing/overflow/scroll-container-background-with-composited-child-expected.html
+++ b/LayoutTests/compositing/overflow/scroll-container-background-with-composited-child-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            margin: 0;
+        }
+        .scroller {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 300px;
+            height: 200px;
+            overflow: auto;
+            background: rgba(0, 0, 0, 0.5);
+        }
+        .child {
+            width: 200px;
+            height: 400px;
+            margin: 20px auto;
+            background: green;
+        }
+    </style>
+</head>
+<body>
+    <div class="scroller">
+        <div class="child"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/overflow/scroll-container-background-with-composited-child.html
+++ b/LayoutTests/compositing/overflow/scroll-container-background-with-composited-child.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            margin: 0;
+        }
+        .scroller {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 300px;
+            height: 200px;
+            overflow: auto;
+            background: rgba(0, 0, 0, 0.5);
+        }
+        .child {
+            width: 200px;
+            height: 400px;
+            margin: 20px auto;
+            background: green;
+        }
+
+        .force-layer {
+            transform: perspective(1px);
+        }
+    </style>
+</head>
+<body>
+    <div class="scroller">
+        <div class="child force-layer"></div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3235,6 +3235,11 @@ bool RenderLayerBacking::isSimpleContainerCompositingLayer(PaintedContentsInfo& 
     if (m_owningLayer.isRenderViewLayer())
         return false;
 
+    // Scroll containers intentionally use the bitmap path for their background
+    // in updateDrawsContent(), so they are not simple containers.
+    if (m_scrollContainerLayer)
+        return false;
+
     if (hasBackingSharingLayers())
         return false;
 


### PR DESCRIPTION
#### b46c0917d14d731f9e1792e262acd4ea47d34562
<pre>
Scroll container with composited child paints background twice
<a href="https://bugs.webkit.org/show_bug.cgi?id=311738">https://bugs.webkit.org/show_bug.cgi?id=311738</a>
<a href="https://rdar.apple.com/171024685">rdar://171024685</a>

Reviewed by Simon Fraser.

When a scroll container has a background and a composited child, the
background color is painted twice. Once in the layer&apos;s bitmap and
once in a contents color sublayer.

The fix skips creating the contents color sublayer for scroll containers,
since their bitmap already paints the background.

User impact: This was visible on sites like etsy.com where checkout and
edit modal dialogs use a semi-transparent scrollable overlay with composited
children. The overlay background would appear noticeably darker than
intended, then flash to the correct shade when children de-composite.

Test: compositing/overflow/scroll-container-background-with-composited-child.html

* LayoutTests/compositing/overflow/scroll-container-background-with-composited-child-expected.html: Added.
* LayoutTests/compositing/overflow/scroll-container-background-with-composited-child.html: Added.
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::isSimpleContainerCompositingLayer const):

Canonical link: <a href="https://commits.webkit.org/311198@main">https://commits.webkit.org/311198@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f7615f50a86488264844d0093f3973e52f2dc89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22620 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164924 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157974 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120869 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23105 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140190 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101551 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22185 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20307 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12696 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131845 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18022 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167403 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11519 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19634 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128983 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29039 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24375 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129111 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35021 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28961 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139816 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86728 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23939 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16615 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28670 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92627 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28197 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28425 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28321 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->