### PR TITLE
Retry whenever we see "Busy" starting an NFC session

### DIFF
--- a/Source/WebCore/testing/MockWebAuthenticationConfiguration.h
+++ b/Source/WebCore/testing/MockWebAuthenticationConfiguration.h
@@ -58,7 +58,8 @@ struct MockWebAuthenticationConfiguration {
         NoTags,
         WrongTagType,
         NoConnections,
-        MaliciousPayload
+        MaliciousPayload,
+        HardwareBusy
     };
 
     enum class UserVerification : uint8_t {

--- a/Source/WebCore/testing/MockWebAuthenticationConfiguration.idl
+++ b/Source/WebCore/testing/MockWebAuthenticationConfiguration.idl
@@ -56,7 +56,8 @@
     "no-tags",
     "wrong-tag-type",
     "no-connections",
-    "malicious-payload"
+    "malicious-payload",
+    "hardware-busy"
 };
 
 [

--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -333,3 +333,9 @@ selectors = [
     { name = "setAllowsTypeSelect:", class = "UIContextMenuConfiguration" },
 ]
 requires = ["HAVE_UICONTEXTMENUCONFIGURATION_ALLOWTYPESELECT_SUPPORT"]
+
+[[not-web-essential]]
+request = "rdar://171940190"
+selectors = [
+    { name = "endSessionWithCompletion:", class = "NFSession" },
+]

--- a/Source/WebKit/Platform/spi/Cocoa/NearFieldSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/NearFieldSPI.h
@@ -90,6 +90,7 @@ typedef NS_ENUM(uint32_t, NFNdefAvailability) {
 @end
 
 @interface NFSession : NSObject <NFSession>
+- (void)endSessionWithCompletion:(void(^)(void))theCallback;
 @end
 
 @protocol NFReaderSessionDelegate;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6017,7 +6017,8 @@ header: <WebCore/ISOVTTCue.h>
     NoTags,
     WrongTagType,
     NoConnections,
-    MaliciousPayload
+    MaliciousPayload,
+    HardwareBusy
 };
 
 [Nested] struct WebCore::MockWebAuthenticationConfiguration::NfcConfiguration {

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.h
@@ -46,6 +46,7 @@ public:
 
     Vector<uint8_t> transact(Vector<uint8_t>&& data) const;
     void stop() const;
+    void stopWithCompletionHandler(Function<void()>&&);
 
     // For WKNFReaderSessionDelegate
     void didDetectTags(NSArray *);

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.mm
@@ -31,6 +31,7 @@
 #import "NfcService.h"
 #import "WKNFReaderSessionDelegate.h"
 #import <WebCore/FidoConstants.h>
+#import <wtf/BlockPtr.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/Base64.h>
@@ -98,6 +99,15 @@ void NfcConnection::stop() const
     [m_session disconnectTag];
     [m_session stopPolling];
     [m_session endSession];
+}
+
+void NfcConnection::stopWithCompletionHandler(Function<void()>&& completionHandler)
+{
+    [m_session disconnectTag];
+    [m_session stopPolling];
+    [m_session endSessionWithCompletion:makeBlockPtr([completionHandler = WTF::move(completionHandler)]() mutable {
+        completionHandler();
+    }).get()];
 }
 
 void NfcConnection::didDetectTags(NSArray *tags)

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.h
@@ -54,17 +54,18 @@ protected:
     void setConnection(Ref<NfcConnection>&&); // For MockNfcConnection
 #endif
 
+    // Overrided by MockNfcService.
+    virtual void platformStartDiscovery();
+
 private:
     void startDiscoveryInternal() final;
     void restartDiscoveryInternal() final;
-
-    // Overrided by MockNfcService.
-    virtual void platformStartDiscovery();
 
 #if HAVE(NEAR_FIELD)
     // Only one reader session is allowed per time.
     // Keep the reader session alive here when it tries to connect to a tag.
     RefPtr<NfcConnection> m_connection;
+    bool m_startingSession { false };
 #endif
     RunLoop::Timer m_restartTimer;
 };

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.mm
@@ -29,6 +29,7 @@
 #if ENABLE(WEB_AUTHN)
 
 #import "CtapNfcDriver.h"
+#import "Logging.h"
 #import "NearFieldSPI.h"
 #import "NfcConnection.h"
 #import <wtf/BlockPtr.h>
@@ -91,8 +92,17 @@ void NfcService::startDiscoveryInternal()
 void NfcService::restartDiscoveryInternal()
 {
 #if HAVE(NEAR_FIELD)
-    if (RefPtr connection = m_connection)
-        connection->stop();
+    if (RefPtr connection = m_connection) {
+        m_connection = nullptr;
+        RELEASE_LOG(WebAuthn, "NfcService::restartDiscoveryInternal: ending session before starting new one");
+        connection->stopWithCompletionHandler([weakThis = WeakPtr { *this }] {
+            RunLoop::mainSingleton().dispatch([weakThis] {
+                if (RefPtr protectedThis = weakThis.get())
+                    protectedThis->platformStartDiscovery();
+            });
+        });
+        return;
+    }
 #endif
     m_restartTimer.startOneShot(1_s); // Magic number to give users enough time for reactions.
 }
@@ -103,11 +113,22 @@ void NfcService::platformStartDiscovery()
     if (!isAvailable())
         return;
 
+    if (m_startingSession)
+        return;
+    m_startingSession = true;
+
+    RELEASE_LOG(WebAuthn, "NfcService::platformStartDiscovery: starting new NFC reader session");
     // Will be executed in a different thread.
     auto callback = makeBlockPtr([weakThis = WeakPtr { *this }] (NFReaderSession *session, NSError *error) mutable {
         ASSERT(!RunLoop::isMain());
         if (error) {
-            LOG_ERROR("Couldn't start a NFC reader session: %@", error);
+            RELEASE_LOG(WebAuthn, "NfcService::platformStartDiscovery: failed to start NFC reader session, scheduling retry");
+            RunLoop::mainSingleton().dispatch([weakThis = WTF::move(weakThis)] {
+                if (RefPtr protectedThis = weakThis.get()) {
+                    protectedThis->m_startingSession = false;
+                    protectedThis->m_restartTimer.startOneShot(1_s);
+                }
+            });
             return;
         }
 
@@ -118,6 +139,7 @@ void NfcService::platformStartDiscovery()
                 return;
             }
 
+            protectedThis->m_startingSession = false;
             // NfcConnection will take care of polling tags and connecting to them.
             protectedThis->m_connection = NfcConnection::create(WTF::move(session), *protectedThis);
         });

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
@@ -31,6 +31,7 @@
 #import "NearFieldSPI.h"
 #import "NfcConnection.h"
 #import <WebCore/FidoConstants.h>
+#import <objc/runtime.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/RetainPtr.h>
@@ -182,6 +183,33 @@ static NSData* NFReaderSessionTransceive(id, SEL, NSData *)
     return globalNfcService ? globalNfcService->transceive() : nil;
 }
 
+static void NFSessionEndSessionWithCompletion(id, SEL, void (^completion)(void)) {
+    if (completion)
+        completion();
+}
+
+static id NFHardwareManagerSharedManager(id, SEL)
+{
+    static NeverDestroyed<RetainPtr<id>> manager = adoptNS([[getNFHardwareManagerClassSingleton() alloc] init]);
+    return manager.get().get();
+}
+
+static BOOL NFHardwareManagerAreFeaturesSupported(id, SEL, NFFeature, NSError**)
+{
+    return YES;
+}
+
+static void NFHardwareManagerStartReaderSessionWithBusyError(id, SEL, void (^callback)(NFReaderSession*, NSError*)) {
+    dispatch_async(globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        NSError *error = [NSError errorWithDomain:@"com.apple.nfcd" code:2 userInfo:@{ NSLocalizedDescriptionKey: @"Busy" }];
+        callback(nil, error);
+    });
+}
+
+static IMP originalSharedHardwareManager;
+static IMP originalAreFeaturesSupported;
+static IMP originalStartReaderSession;
+
 } // namespace
 
 #endif // HAVE(NEAR_FIELD)
@@ -225,7 +253,51 @@ void MockNfcService::receiveStartPolling()
 void MockNfcService::platformStartDiscovery()
 {
 #if HAVE(NEAR_FIELD)
+    if (m_configuration.nfc && m_configuration.nfc->error == Mock::NfcError::HardwareBusy) {
+        // Clear error so retry (via m_restartTimer) will succeed through normal mock path.
+        m_configuration.nfc->error = Mock::NfcError::Success;
+
+        // Ensure NFHardwareManager class exists. On platforms where the NearField
+        // framework is not available (e.g., macOS), the soft-link returns nil. Register
+        // a fake class so the soft-link accessor finds it on first call and the
+        // subsequent method swizzles have a real class to operate on.
+        if (!objc_getClass("NFHardwareManager")) {
+            SUPPRESS_UNRETAINED_LOCAL Class cls = objc_allocateClassPair([NSObject class], "NFHardwareManager", 0);
+            ASSERT(cls);
+            SUPPRESS_UNRETAINED_LOCAL Class metaCls = object_getClass(cls);
+            class_addMethod(metaCls, @selector(sharedHardwareManager), (IMP)NFHardwareManagerSharedManager, "@@:");
+            class_addMethod(cls, @selector(areFeaturesSupported:outError:), (IMP)NFHardwareManagerAreFeaturesSupported, "B@:I^@");
+            class_addMethod(cls, @selector(startReaderSession:), (IMP)NFHardwareManagerStartReaderSessionWithBusyError, "@@:@?");
+            objc_registerClassPair(cls);
+        }
+
+        Method hmMethod0 = class_getClassMethod(getNFHardwareManagerClassSingleton(), @selector(sharedHardwareManager));
+        originalSharedHardwareManager = method_setImplementation(hmMethod0, (IMP)NFHardwareManagerSharedManager);
+
+        Method hmMethod1 = class_getInstanceMethod(getNFHardwareManagerClassSingleton(), @selector(areFeaturesSupported:outError:));
+        originalAreFeaturesSupported = method_setImplementation(hmMethod1, (IMP)NFHardwareManagerAreFeaturesSupported);
+
+        Method hmMethod2 = class_getInstanceMethod(getNFHardwareManagerClassSingleton(), @selector(startReaderSession:));
+        originalStartReaderSession = method_setImplementation(hmMethod2, (IMP)NFHardwareManagerStartReaderSessionWithBusyError);
+
+        NfcService::platformStartDiscovery();
+        return;
+    }
     if (!!m_configuration.nfc) {
+        // Restore any swizzled NFHardwareManager methods from the HardwareBusy path.
+        if (originalSharedHardwareManager) {
+            method_setImplementation(class_getClassMethod(getNFHardwareManagerClassSingleton(), @selector(sharedHardwareManager)), originalSharedHardwareManager);
+            originalSharedHardwareManager = nil;
+        }
+        if (originalAreFeaturesSupported) {
+            method_setImplementation(class_getInstanceMethod(getNFHardwareManagerClassSingleton(), @selector(areFeaturesSupported:outError:)), originalAreFeaturesSupported);
+            originalAreFeaturesSupported = nil;
+        }
+        if (originalStartReaderSession) {
+            method_setImplementation(class_getInstanceMethod(getNFHardwareManagerClassSingleton(), @selector(startReaderSession:)), originalStartReaderSession);
+            originalStartReaderSession = nil;
+        }
+
         weakGlobalNfcService() = *this;
 
         Method methodToSwizzle1 = class_getInstanceMethod(getNFReaderSessionClassSingleton(), @selector(setDelegate:));
@@ -245,6 +317,11 @@ void MockNfcService::platformStartDiscovery()
 
         Method methodToSwizzle5 = class_getInstanceMethod(getNFReaderSessionClassSingleton(), @selector(startPollingWithError:));
         method_setImplementation(methodToSwizzle5, (IMP)NFReaderSessionStartPollingWithError);
+
+        // endSessionWithCompletion: is declared on NFSession (superclass), not NFReaderSession.
+        // Use class_replaceMethod to add it directly to NFReaderSession so the mock completion
+        // handler fires during restartDiscoveryInternal without modifying the superclass.
+        class_replaceMethod(getNFReaderSessionClassSingleton(), @selector(endSessionWithCompletion:), (IMP)NFSessionEndSessionWithCompletion, "v@:@?");
 
         auto readerSession = adoptNS([allocNFReaderSessionInstance() initWithUIType:NFReaderSessionUINone]);
         setConnection(NfcConnection::create(readerSession.get(), *this));

--- a/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-nfc-busy.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-nfc-busy.html
@@ -1,0 +1,34 @@
+<input type="text" id="input">
+<script>
+    const testNfcCtapVersionBase64 = "RklET18yXzCQAA==";
+    const testGetInfoResponseApduBase64 =
+        "AKYBgmZVMkZfVjJoRklET18yXzACgWtobWFjLXNlY3JldANQbUS6m/bsLkm5MAyP" +
+        "6SDLcwSkYnJr9WJ1cPVkcGxhdPRpY2xpZW50UGlu9AUZBLAGgQGQAA==";
+    const testAssertionMessageApduBase64 =
+        "AKMBomJpZFhAKAitzuj+Tslzelf3/vZwIGtDQNgoKeFd5oEieYzhyzA65saf0tK2" +
+        "w/mooa7tQtGgDdwZIjOhjcuZ0pQ1ajoE4GR0eXBlanB1YmxpYy1rZXkCWCVGzH+5" +
+        "Z51VstuQkuHI2eXh0Ct1gPC0gSx3CWLh5I9a2AEAAABQA1hHMEUCIQCSFTuuBWgB" +
+        "4/F0VB7DlUVM09IHPmxe1MzHUwRoCRZbCAIgGKov6xoAx2MEf6/6qNs8OutzhP2C" +
+        "QoJ1L7Fe64G9uBeQAA==";
+    if (window.internals) {
+        internals.setMockWebAuthenticationConfiguration({ silentFailure: true, nfc: { error: "hardware-busy", payloadBase64: [testNfcCtapVersionBase64, testGetInfoResponseApduBase64, "Lg==", testAssertionMessageApduBase64] } });
+        internals.withUserGesture(() => { input.focus(); });
+    }
+
+    const options = {
+        publicKey: {
+            challenge: new Uint8Array(16),
+            allowCredentials: [
+                { type: "public-key", id: new Uint8Array(16), transports: ["nfc"] }
+            ],
+        }
+    };
+
+    navigator.credentials.get(options).then(credential => {
+        // console.log("Succeeded!");
+        window.webkit.messageHandlers.testHandler.postMessage("Succeeded!");
+    }, error => {
+        // console.log(error.message);
+        window.webkit.messageHandlers.testHandler.postMessage(error.message);
+    });
+</script>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm
@@ -441,6 +441,17 @@ TEST(WebAuthenticationPanel, NoPanelNfcSucceed)
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     [webView waitForMessage:@"Succeeded!"];
 }
+
+TEST(WebAuthenticationPanel, NfcHardwareBusyRetry)
+{
+    RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-nfc-busy" withExtension:@"html"];
+
+    auto webView = setUpTestWebViewForTestAuthenticationPanel();
+    [webView focus];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
+    [webView waitForMessage:@"Succeeded!"];
+}
 #endif
 
 // FIXME rdar://145102423


### PR DESCRIPTION
#### 349a4f20ed1c4a0586ecd4ccb009514d50c2fa42
<pre>
Retry whenever we see &quot;Busy&quot; starting an NFC session
<a href="https://rdar.apple.com/171940190">rdar://171940190</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311731">https://bugs.webkit.org/show_bug.cgi?id=311731</a>

Reviewed by Brent Fulgham.

In some cases, things like (but not limited to) NDEF tags on a security key can
cause an error that prevents us from opening a NFC session for CTAP purposes.

Currently, we don&apos;t recover from this error and the NFC transport silently doesn&apos;t
work for the ceremony. We do have a restart polling timer, but it never restarts
the entire session if it failed. To fix this, we schedule a retry whenever we
encounter an error starting a NFC session.

Tests: Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-nfc-busy.html
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm

* Source/WebCore/testing/MockWebAuthenticationConfiguration.h:
* Source/WebCore/testing/MockWebAuthenticationConfiguration.idl:
* Source/WebKit/Configurations/AllowedSPI.toml:
* Source/WebKit/Platform/spi/Cocoa/NearFieldSPI.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.mm:
(WebKit::NfcConnection::stopWithCompletionHandler):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.mm:
(WebKit::NfcService::restartDiscoveryInternal):
(WebKit::NfcService::platformStartDiscovery):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm:
(WebKit::MockNfcService::platformStartDiscovery):
* Tools/TestWebKitAPI/Resources/cocoa/web-authentication-get-assertion-nfc-busy.html: Added.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::TEST(WebAuthenticationPanel, NfcHardwareBusyRetry)):

Canonical link: <a href="https://commits.webkit.org/311613@main">https://commits.webkit.org/311613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8812c4bb48513e05181ca7572d62a18d5c71fc3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166304 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b3e4f7f-259d-49a7-b416-b7576b1f6bb9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159351 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30819 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b525705d-a4d6-4797-8d0b-10af09c7ecbb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141406 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/102620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/977babe6-b1c7-46e7-b6ce-011676fd147e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23281 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21537 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14075 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132960 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168790 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13092 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20854 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130100 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30418 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25615 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130209 "Found 3 new API test failures: TestWebKit:WebKit.RestoreSessionStateContainingFormData, TestWebKit:WebKit.UserMediaBasic, TestWebKit:WebKit.OnDeviceChangeCrash (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35270 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30341 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141028 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88282 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25044 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17833 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30052 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94251 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29574 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29804 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29701 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->