### PR TITLE
NEW-TEST: [macOS] media/encrypted-media/mock-navigator-requestMediaKeySystemAccess.html is a constant text failure

### DIFF
--- a/LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess-in-background.html
+++ b/LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess-in-background.html
@@ -26,6 +26,7 @@
         run('promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", [capabilities])');
         await shouldResolve(promise);
         internals.settings.setCanStartMedia(true);
+        mock.unregister();
     }
 
     window.addEventListener('load', event => {

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2444,8 +2444,6 @@ http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target
 
 webkit.org/b/308165 [ Debug ] scrollingcoordinator/mac/latching/simple-page-rubberbands.html [ Pass Failure ]
 
-webkit.org/b/311743 media/encrypted-media/mock-navigator-requestMediaKeySystemAccess.html [ Failure ]
-
 webkit.org/b/308325 [ Debug ] http/wpt/cache-storage/cache-in-stopped-context.html [ Pass Failure ]
 
 webkit.org/b/309173 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/modulepreload-referrerpolicy.html [ Pass Failure ]

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -729,6 +729,10 @@ void Internals::resetToConsistentState(Page& page)
 
     PlatformMediaEngineConfigurationFactory::disableMock();
 
+#if ENABLE(ENCRYPTED_MEDIA)
+    MockCDMFactory::unregisterAllMockFactories();
+#endif
+
 #if ENABLE(MEDIA_STREAM)
     page.settings().setInterruptAudioOnPageVisibilityChangeEnabled(false);
 #endif

--- a/Source/WebCore/testing/MockCDMFactory.cpp
+++ b/Source/WebCore/testing/MockCDMFactory.cpp
@@ -42,16 +42,30 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MockCDM);
 
+static HashSet<MockCDMFactory*>& allMockFactories()
+{
+    static NeverDestroyed<HashSet<MockCDMFactory*>> factories;
+    return factories;
+}
+
+void MockCDMFactory::unregisterAllMockFactories()
+{
+    for (auto* factory : copyToVector(allMockFactories()))
+        factory->unregister();
+}
+
 MockCDMFactory::MockCDMFactory()
     : m_supportedSessionTypes({ MediaKeySessionType::Temporary, MediaKeySessionType::PersistentUsageRecord, MediaKeySessionType::PersistentLicense })
     , m_supportedEncryptionSchemes({ MediaKeyEncryptionScheme::cenc })
 {
     CDMFactory::registerFactory(*this);
+    allMockFactories().add(this);
 }
 
 MockCDMFactory::~MockCDMFactory()
 {
     unregister();
+    allMockFactories().remove(this);
 }
 
 void MockCDMFactory::unregister()

--- a/Source/WebCore/testing/MockCDMFactory.h
+++ b/Source/WebCore/testing/MockCDMFactory.h
@@ -45,6 +45,7 @@ namespace WebCore {
 class MockCDMFactory : public RefCounted<MockCDMFactory>, public CDMFactory {
 public:
     static Ref<MockCDMFactory> create() { return adoptRef(*new MockCDMFactory); }
+    static void unregisterAllMockFactories();
     ~MockCDMFactory();
 
     void ref() const final { RefCounted::ref(); }


### PR DESCRIPTION
#### f08f053d1260cbc0365cb887c0904376441ec1ab
<pre>
NEW-TEST: [macOS] media/encrypted-media/mock-navigator-requestMediaKeySystemAccess.html is a constant text failure
<a href="https://rdar.apple.com/174337907">rdar://174337907</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311743">https://bugs.webkit.org/show_bug.cgi?id=311743</a>

EWS run-through draft.

* LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess-in-background.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):
* Source/WebCore/testing/MockCDMFactory.cpp:
(WebCore::MockCDMFactory::unregisterAllMockFactories):
(WebCore::MockCDMFactory::~MockCDMFactory):
* Source/WebCore/testing/MockCDMFactory.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f08f053d1260cbc0365cb887c0904376441ec1ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163764 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108475 "Failed to checkout and rebase branch from PR 62286") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156877 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28112 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119918 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/108475 "Failed to checkout and rebase branch from PR 62286") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139189 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100611 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21276 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19306 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11590 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130938 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166240 "Built successfully") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9829 "Failed to checkout and rebase branch from PR 62286") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18642 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128021 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27808 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128159 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27732 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138826 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84441 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23035 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15621 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27424 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91528 "Found 1 new failure in testing/MockCDMFactory.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27002 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27233 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27075 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->