### PR TITLE
Defer InlineContent destruction to opportunistic task scheduler

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3538,8 +3538,10 @@ void Document::destroyRenderTree()
         while (m_renderView->firstChild())
             builder.destroy(*m_renderView->firstChild());
 
-        if (RefPtr view = this->view())
+        if (RefPtr view = this->view()) {
             view->layoutContext().deleteDetachedRenderersNow();
+            view->layoutContext().deleteDetachedInlineContentNow();
+        }
 
         m_renderView->destroy();
     }

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h
@@ -155,7 +155,7 @@ struct Box {
     void setExpansion(Expansion);
     Expansion expansion() const { return { m_expansionBehavior, m_horizontalExpansion }; }
 
-    const Layout::Box& layoutBox() const { return m_layoutBox; }
+    const Layout::Box& layoutBox() const { return *m_layoutBox; }
     const RenderStyle& style() const LIFETIME_BOUND { return isFirstFormattedLine() ? layoutBox().firstLineStyle() : layoutBox().style(); }
     WritingMode writingMode() const { return style().writingMode(); }
 
@@ -173,9 +173,10 @@ struct Box {
     bool isInGlyphDisplayListCache() const { return m_isInGlyphDisplayListCache; }
     void setIsInGlyphDisplayListCache() { m_isInGlyphDisplayListCache = true; }
     void removeFromGlyphDisplayListCache();
+    void detachLayoutBox() { m_layoutBox = nullptr; }
 
 private:
-    CheckedRef<const Layout::Box> m_layoutBox;
+    CheckedPtr<const Layout::Box> m_layoutBox;
     FloatRect m_unflippedVisualRect;
     FloatRect m_inkOverflow;
 
@@ -198,7 +199,7 @@ private:
 };
 
 inline Box::Box(size_t lineIndex, Type type, const Layout::Box& layoutBox, UBiDiLevel bidiLevel, const FloatRect& physicalRect, const FloatRect& inkOverflow, bool isFirstFormattedLine, Expansion expansion, std::optional<Text> text, bool hasContent, bool isFullyTruncated, EnumSet<PositionWithinInlineLevelBox> positionWithinInlineLevelBox)
-    : m_layoutBox(layoutBox)
+    : m_layoutBox(&layoutBox)
     , m_unflippedVisualRect(physicalRect)
     , m_inkOverflow(inkOverflow)
     , m_lineIndex(lineIndex)

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 namespace LayoutIntegration {
 
 InlineContent::InlineContent(const RenderBlockFlow& formattingContextRoot)
-    : m_formattingContextRoot(formattingContextRoot)
+    : m_formattingContextRoot(&formattingContextRoot)
 {
 }
 
@@ -107,7 +107,7 @@ IteratorRange<const InlineDisplay::Box*> InlineContent::boxesForRect(const Layou
 
 const RenderBlockFlow& InlineContent::formattingContextRoot() const
 {
-    return m_formattingContextRoot;
+    return *m_formattingContextRoot;
 }
 
 size_t InlineContent::indexForBox(const InlineDisplay::Box& box) const
@@ -209,6 +209,11 @@ void InlineContent::releaseCaches()
 {
     m_firstBoxIndexCache = { };
     m_inlineBoxIndexCache = { };
+}
+
+void InlineContent::clearFormattingContextRoot()
+{
+    m_formattingContextRoot = nullptr;
 }
 
 void InlineContent::shrinkToFit()

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
@@ -104,6 +104,8 @@ public:
     void shrinkToFit();
     void releaseCaches();
 
+    void clearFormattingContextRoot();
+
 private:
     friend class InlineContentBuilder;
     friend class LineLayout;
@@ -119,7 +121,7 @@ private:
 
     const Vector<size_t>& nonRootInlineBoxIndexesForLayoutBox(const Layout::Box&) const LIFETIME_BOUND;
 
-    CheckedRef<const RenderBlockFlow> m_formattingContextRoot;
+    CheckedPtr<const RenderBlockFlow> m_formattingContextRoot;
 
     InlineDisplay::Content m_displayContent;
     using FirstBoxIndexCache = HashMap<CheckedRef<const Layout::Box>, size_t>;

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -48,6 +48,8 @@
 #include "LayoutIntegrationPagination.h"
 #include "LayoutIntegrationUtils.h"
 #include "LayoutTreeBuilder.h"
+#include "LocalFrameView.h"
+#include "LocalFrameViewLayoutContext.h"
 #include "PaintInfo.h"
 #include "PlacedFloats.h"
 #include "RenderBlockFlow.h"
@@ -216,7 +218,17 @@ LineLayout::~LineLayout()
     };
     if (shouldPopulateBreakingPositionCache())
         Layout::InlineItemsBuilder::populateBreakingPositionCache(m_inlineContentCache.inlineItems().content(), rootRenderer->document());
-    clearInlineContent();
+
+    auto prepareAndDetachInlineContent = [&] {
+        if (!m_inlineContent)
+            return;
+        for (auto& box : m_inlineContent->displayContent().boxes)
+            box.detachLayoutBox();
+        m_inlineContent->releaseCaches();
+        m_inlineContent->clearFormattingContextRoot();
+        rootRenderer->view().frameView().layoutContext().detachInlineContent(WTF::move(m_inlineContent));
+    };
+    prepareAndDetachInlineContent();
     layoutState().destroyInlineContentCache(rootLayoutBox());
     layoutState().destroyBlockFormattingState(rootLayoutBox());
     m_boxGeometryUpdater.clear();

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -33,6 +33,7 @@
 #include "LayoutBoxGeometry.h"
 #include "LayoutContext.h"
 #include "LayoutDisallowedScope.h"
+#include "LayoutIntegrationInlineContent.h"
 #include "LayoutIntegrationLineLayout.h"
 #include "LayoutState.h"
 #include "LayoutTreeBuilder.h"
@@ -50,6 +51,7 @@
 #include "RenderStyle.h"
 #include "RenderStyle+GettersInlines.h"
 #include "RenderView.h"
+#include "SVGTextFragment.h"
 #include "ScriptDisallowedScope.h"
 #include "Settings.h"
 #include "StyleScope.h"
@@ -805,12 +807,38 @@ bool LocalFrameViewLayoutContext::DetachedRendererList::append(RenderPtr<RenderO
         return false;
     }
 
-    static constexpr int maximumNumberOfDetachedRenderers = 5000;
+    static constexpr unsigned maximumNumberOfDetachedRenderers = 5000;
     if (m_renderers.size() == maximumNumberOfDetachedRenderers)
         clear();
 
     m_renderers.append(detachedRenderer.release());
     return true;
+}
+
+LocalFrameViewLayoutContext::DetachedInlineContentList::~DetachedInlineContentList() = default;
+
+void LocalFrameViewLayoutContext::DetachedInlineContentList::append(std::unique_ptr<LayoutIntegration::InlineContent>&& content)
+{
+    static constexpr unsigned maximumNumberOfDeferredInlineContent = 5000;
+    if (m_inlineContent.size() == maximumNumberOfDeferredInlineContent)
+        clear();
+
+    m_inlineContent.append(WTF::move(content));
+}
+
+void LocalFrameViewLayoutContext::DetachedInlineContentList::clear()
+{
+    m_inlineContent.clear();
+}
+
+void LocalFrameViewLayoutContext::detachInlineContent(std::unique_ptr<LayoutIntegration::InlineContent>&& content) const
+{
+    m_detachedInlineContent.append(WTF::move(content));
+}
+
+void LocalFrameViewLayoutContext::deleteDetachedInlineContentNow() const
+{
+    m_detachedInlineContent.clear();
 }
 
 void LocalFrameViewLayoutContext::setBoxNeedsTransformUpdateAfterContainerLayout(RenderBox& box, RenderBlock& container)

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -53,6 +53,10 @@ class LayoutState;
 class LayoutTree;
 }
 
+namespace LayoutIntegration {
+class InlineContent;
+}
+
 enum class LayoutOptions : uint8_t;
 
 struct UpdateScrollInfoAfterLayoutTransaction {
@@ -166,6 +170,9 @@ public:
 
     bool addToDetachedRendererList(RenderPtr<RenderObject>&& renderer) const { return m_detachedRendererList.append(WTF::move(renderer)); }
     void deleteDetachedRenderersNow() const { m_detachedRendererList.clear(); }
+
+    void detachInlineContent(std::unique_ptr<LayoutIntegration::InlineContent>&&) const;
+    void deleteDetachedInlineContentNow() const;
 
     Vector<AnchorScrollAdjuster>& anchorScrollAdjusters() LIFETIME_BOUND { return m_anchorScrollAdjusters; }
     const AnchorScrollAdjuster* anchorScrollAdjusterFor(const RenderBox& anchored) const LIFETIME_BOUND;
@@ -296,6 +303,17 @@ private:
         SegmentedVector<std::unique_ptr<RenderObject>, 50> m_renderers;
     };
     mutable DetachedRendererList m_detachedRendererList;
+
+    class DetachedInlineContentList {
+    public:
+        ~DetachedInlineContentList();
+        void append(std::unique_ptr<LayoutIntegration::InlineContent>&&);
+        void clear();
+
+    private:
+        Vector<std::unique_ptr<LayoutIntegration::InlineContent>> m_inlineContent;
+    };
+    mutable DetachedInlineContentList m_detachedInlineContent;
 };
 
 class RepaintBlocker {

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -100,6 +100,7 @@ static void releaseNoncriticalMemory(MaintainMemoryCache maintainMemoryCache)
             LayoutIntegration::LineLayout::releaseCaches(*renderView);
             Layout::TextBreakingPositionCache::singleton().clear();
             renderView->layoutContext().deleteDetachedRenderersNow();
+            renderView->layoutContext().deleteDetachedInlineContentNow();
         }
     }
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5358,6 +5358,7 @@ void Page::deleteRemovedNodesAndDetachedRenderers()
         if (!frameView)
             return;
         protect(frameView->layoutContext())->deleteDetachedRenderersNow();
+        protect(frameView->layoutContext())->deleteDetachedInlineContentNow();
     });
 }
 


### PR DESCRIPTION
#### 0c9f895d724ddd4bad87fcb10cc596c1b83e2ec8
<pre>
Defer InlineContent destruction to opportunistic task scheduler
<a href="https://bugs.webkit.org/show_bug.cgi?id=311748">https://bugs.webkit.org/show_bug.cgi?id=311748</a>
<a href="https://rdar.apple.com/173186053">rdar://173186053</a>

Reviewed by Alan Baradlay.

When LineLayout is destroyed, it synchronously destroys InlineContent,
which is shown on profiles to be one of the largest contributors of work to the render tree
teardown time.

Defer InlineContent destruction to the opportunistic task scheduler.
In the LineLayout destructor, instead of destroying InlineContent
synchronously, sever its references to objects with shorter
lifetimes and move InlineContent to a deferred list on LocalFrameViewLayoutContext.
This list is then managed by opportunistic task scheduler to opportunistically delete
the InlineContents.

A/B testing shows this is a small performance gain.

No new tests because there should be no change in behavior. This PR
just changes when InlineContent deletion occurs.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::destroyRenderTree):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h:
(WebCore::InlineDisplay::Box::layoutBox const):
(WebCore::InlineDisplay::Box::detachLayoutBox):
(WebCore::InlineDisplay::Box::Box):
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp:
(WebCore::LayoutIntegration::InlineContent::InlineContent):
(WebCore::LayoutIntegration::InlineContent::formattingContextRoot const):
(WebCore::LayoutIntegration::InlineContent::clearFormattingContextRoot):
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::~LineLayout):
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::DetachedRendererList::append):
(WebCore::LocalFrameViewLayoutContext::DetachedInlineContentList::append):
(WebCore::LocalFrameViewLayoutContext::DetachedInlineContentList::clear):
(WebCore::LocalFrameViewLayoutContext::detachInlineContent const):
(WebCore::LocalFrameViewLayoutContext::deleteDetachedInlineContentNow const):
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/page/MemoryRelease.cpp:
(WebCore::releaseNoncriticalMemory):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::deleteRemovedNodesAndDetachedRenderers):

Canonical link: <a href="https://commits.webkit.org/311134@main">https://commits.webkit.org/311134@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd6ec87aad247ac26e589e722e1a171bed79b627

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28836 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164339 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109373 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157449 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28686 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120405 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85066 "1 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22595 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139707 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101095 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/88c9604d-5a33-4957-b81c-31f569ca26cf) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21681 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19800 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12169 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131350 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17539 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166816 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10994 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19150 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128522 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128655 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34977 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28304 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139332 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85747 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23482 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16129 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27998 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92101 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27575 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27805 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27648 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->