### PR TITLE
Local JSC builds should use local JavaScriptCore.framework by default

### DIFF
--- a/Tools/Scripts/build-jsc
+++ b/Tools/Scripts/build-jsc
@@ -32,7 +32,23 @@ use lib $FindBin::Bin;
 use webkitperl::FeatureList qw(getFeatureOptionList);
 use webkitperl::BuildSubproject;
 
+sub makeJSCStandalone
+{
+    my $jsc = File::Spec->catfile(productDir(), "jsc");
+    die "Can't find jsc at $jsc\n" unless -f $jsc;
+
+    my $oldPath = "/System/Library/Frameworks/JavaScriptCore.framework/Versions/A/JavaScriptCore";
+    my $newPath = "\@executable_path/JavaScriptCore.framework/Versions/A/JavaScriptCore";
+
+    system("xcrun", "install_name_tool", "-change", $oldPath, $newPath, $jsc);
+    die "install_name_tool failed on $jsc\n" if $?;
+
+    system("codesign", "--force", "--sign", "-", $jsc);
+    die "codesign failed on $jsc\n" if $?;
+}
+
 buildUpToProject("Source/JavaScriptCore", "JavaScriptCore");
 if (isAppleCocoaWebKit()) {
+    makeJSCStandalone();
     writeCongrats("JavaScriptCore");
 }

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -1171,16 +1171,23 @@ sub determineConfigurationProductDir
     return if defined $configurationProductDir;
     determineBaseProductDir();
     determineConfiguration();
+
+    # Release+Assert and Testing are meta-configurations that map to Release
+    # and Debug respectively in Xcodebuild (see Makefile.shared).
+    my $buildConfiguration = $configuration;
+    $buildConfiguration = "Release" if $configuration eq "Release+Assert";
+    $buildConfiguration = "Debug" if $configuration eq "Testing";
+
     if (isWin() || isPlayStation() || (isJSCOnly() && isWindows())) {
-        $configurationProductDir = File::Spec->catdir($baseProductDir, $configuration);
+        $configurationProductDir = File::Spec->catdir($baseProductDir, $buildConfiguration);
     } else {
         if (usesPerConfigurationBuildDirectory()) {
             $configurationProductDir = "$baseProductDir";
         } else {
             if (isGtk() or isWPE() or isJSCOnly() or shouldUseFlatpak() or shouldBuildForCrossTarget() or inCrossTargetEnvironment()) {
-                $configurationProductDir = "$baseProductDir/$portName/$configuration";
+                $configurationProductDir = "$baseProductDir/$portName/$buildConfiguration";
             } else {
-                $configurationProductDir = "$baseProductDir/$configuration";
+                $configurationProductDir = "$baseProductDir/$buildConfiguration";
             }
             $configurationProductDir .= "-" . xcodeSDKPlatformName() if isEmbeddedWebKit() || isMacCatalystWebKit();
         }


### PR DESCRIPTION
#### 58bd711105b0879c8f135d41916356e7e3be5245
<pre>
Local JSC builds should use local JavaScriptCore.framework by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=311749">https://bugs.webkit.org/show_bug.cgi?id=311749</a>
<a href="https://rdar.apple.com/174343361">rdar://174343361</a>

Reviewed by NOBODY (OOPS!).

* Tools/Scripts/build-jsc:
(makeJSCStandalone):
    Use install-name-tool to load JavaScriptCore.framework relative to
    the binary rather than from the system. I put this in the build-jsc
    script so it has no chance of breaking production builds. build-jsc
    is only used for at desk builds.
* Tools/Scripts/webkitdirs.pm:
(determineConfigurationProductDir):
    productDir reports the wrong path for Testing/Release+Assert builds
    this should fix that.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58bd711105b0879c8f135d41916356e7e3be5245

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21431 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163772 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108483 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ad4016d7-63f5-4f12-ae0e-1cb030144650) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156885 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28120 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119927 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84755 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139204 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100620 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21279 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19315 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11598 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147062 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130941 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17048 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166248 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15843 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18657 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128029 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27816 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23354 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128167 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27740 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138841 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84449 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23042 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15636 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186799 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27432 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47864 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27010 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27241 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27083 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->