### PR TITLE
Move Client Website Environment SPI to API

### DIFF
--- a/Source/WebCore/dom/DocumentImmersive.cpp
+++ b/Source/WebCore/dom/DocumentImmersive.cpp
@@ -179,16 +179,16 @@ void DocumentImmersive::exitImmersive(CompletionHandler<void(ExceptionOr<void>)>
     });
 }
 
-void DocumentImmersive::exitImmersiveIfNeeded()
+void DocumentImmersive::exitImmersiveIfNeeded(CompletionHandler<void()>&& completionHandler)
 {
     if (immersiveElement()) {
-        exitImmersive([weakThis = WeakPtr { *this }](auto result) {
+        exitImmersive([weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)](auto result) mutable {
             RefPtr protectedThis = weakThis.get();
-            if (!protectedThis)
-                return;
-
-            if (result.hasException())
+            if (protectedThis && result.hasException())
                 RELEASE_LOG_ERROR(Immersive, "%p - DocumentImmersive: %s", protectedThis.get(), result.releaseException().message().utf8().data());
+
+            if (completionHandler)
+                completionHandler();
         });
         return;
     }
@@ -196,6 +196,9 @@ void DocumentImmersive::exitImmersiveIfNeeded()
     m_pendingImmersiveElement = nullptr;
     m_activeRequest.stage = ActiveRequest::Stage::None;
     m_activeRequest.element = nullptr;
+
+    if (completionHandler)
+        completionHandler();
 }
 
 void DocumentImmersive::exitRemovedImmersiveElementIfNeeded(HTMLModelElement* element, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebCore/dom/DocumentImmersive.h
+++ b/Source/WebCore/dom/DocumentImmersive.h
@@ -59,7 +59,7 @@ public:
 
     void requestImmersive(HTMLModelElement*, CompletionHandler<void(ExceptionOr<void>)>&&);
     void exitImmersive(CompletionHandler<void(ExceptionOr<void>)>&&);
-    WEBCORE_EXPORT void exitImmersiveIfNeeded();
+    WEBCORE_EXPORT void exitImmersiveIfNeeded(CompletionHandler<void()>&& = nullptr);
     void exitRemovedImmersiveElementIfNeeded(HTMLModelElement*, CompletionHandler<void()>&&);
 
     enum class EventType : bool { Change, Error };

--- a/Source/WebKit/Shared/API/Cocoa/WebKit.h
+++ b/Source/WebKit/Shared/API/Cocoa/WebKit.h
@@ -40,6 +40,8 @@
 #import <WebKit/WKFoundation.h>
 #import <WebKit/WKFrameInfo.h>
 #import <WebKit/WKHTTPCookieStore.h>
+#import <WebKit/WKImmersiveEnvironment.h>
+#import <WebKit/WKImmersiveEnvironmentDelegate.h>
 #import <WebKit/WKJSHandle.h>
 #import <WebKit/WKJSScriptingBuffer.h>
 #import <WebKit/WKJSSerializedNode.h>

--- a/Source/WebKit/Shared/API/Cocoa/WebKitPrivate.h
+++ b/Source/WebKit/Shared/API/Cocoa/WebKitPrivate.h
@@ -26,6 +26,7 @@
 #import <WebKit/WKDownloadDelegatePrivate.h>
 #import <WebKit/WKFoundation.h>
 #import <WebKit/WKHistoryDelegatePrivate.h>
+#import <WebKit/WKImmersiveEnvironmentPrivate.h>
 #import <WebKit/WKNavigationPrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKUIDelegatePrivate.h>
@@ -49,7 +50,6 @@
 #import <WebKit/_WKElementAction.h>
 #import <WebKit/_WKFocusedElementInfo.h>
 #import <WebKit/_WKFormInputSession.h>
-#import <WebKit/_WKImmersiveEnvironmentDelegate.h>
 #import <WebKit/_WKInputDelegate.h>
 #import <WebKit/_WKPageLoadTiming.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -364,6 +364,7 @@ UIProcess/API/Cocoa/WKFindResult.mm @nonARC
 UIProcess/API/Cocoa/WKFormInfo.mm @nonARC
 UIProcess/API/Cocoa/WKFrameInfo.mm @nonARC
 UIProcess/API/Cocoa/WKHTTPCookieStore.mm @nonARC
+UIProcess/API/Cocoa/WKImmersiveEnvironment.mm @nonARC
 UIProcess/API/Cocoa/WKJSHandle.mm @nonARC
 UIProcess/API/Cocoa/WKJSScriptingBuffer.mm @nonARC
 UIProcess/API/Cocoa/WKJSSerializedNode.mm @nonARC

--- a/Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironment.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironment.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Foundation/Foundation.h>
+#import <WebKit/WKFoundation.h>
+
+@class WKFrameInfo;
+
+NS_HEADER_AUDIT_BEGIN(nullability, sendability)
+
+/*! @abstract An object representing a website-provided immersive environment that is ready for presentation.
+ */
+NS_SWIFT_UI_ACTOR
+NS_SWIFT_SENDABLE
+WK_CLASS_AVAILABLE(visionos(WK_XROS_TBA))
+WK_API_UNAVAILABLE(macos, ios)
+@interface WKImmersiveEnvironment : NSObject
+
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
+
+/*! @abstract The frame information of the website that provided this immersive environment.
+ */
+@property (nonatomic, readonly) WKFrameInfo *sourceFrame WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+
+@end
+
+NS_HEADER_AUDIT_END(nullability, sendability)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironment.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironment.mm
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WKImmersiveEnvironmentInternal.h"
+
+#import <wtf/RetainPtr.h>
+
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+#import "UIKitSPI.h"
+#endif
+
+@implementation WKImmersiveEnvironment {
+    RetainPtr<WKFrameInfo> _sourceFrame;
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    RetainPtr<UIView> _environmentView;
+    uint64_t _contextID;
+    pid_t _processIdentifier;
+#endif
+}
+
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+
+- (instancetype)_initWithContextID:(WebCore::LayerHostingContextIdentifier)contextID processIdentifier:(pid_t)processIdentifier frameInfo:(WKFrameInfo *)frameInfo
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _sourceFrame = frameInfo;
+    _contextID = contextID.toUInt64();
+    _processIdentifier = processIdentifier;
+
+    return self;
+}
+
+- (UIView *)_environmentView
+{
+    if (!_environmentView) {
+        RetainPtr environmentView = adoptNS([[UIView alloc] initWithFrame:CGRectZero]);
+        RetainPtr remoteModelView = adoptNS([[_UIRemoteView alloc] initWithFrame:CGRectZero pid:_processIdentifier contextID:_contextID]);
+        [environmentView addSubview:remoteModelView.get()];
+        // To match the assumptions made in ModelProcessModelPlayerProxy.mm, the frame of the model view must stay zero, and be centered inside its container.
+        // This ensures that the model is correctly placed at the world's origin when the client puts the view inside their Immersive Space.
+        [remoteModelView setFrame:CGRectZero];
+        [remoteModelView setAutoresizingMask:(UIViewAutoresizingNone | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleBottomMargin)];
+        _environmentView = WTF::move(environmentView);
+    }
+    return _environmentView.get();
+}
+
+#endif
+
+- (WKFrameInfo *)sourceFrame
+{
+    return _sourceFrame.get();
+}
+
+@end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironmentDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironmentDelegate.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Foundation/Foundation.h>
+#import <WebKit/WKFoundation.h>
+
+@class WKFrameInfo;
+@class WKImmersiveEnvironment;
+@class WKWebView;
+
+NS_HEADER_AUDIT_BEGIN(nullability, sendability)
+
+/*! @abstract A protocol for managing immersive environment presentation in a web view.
+ @discussion Implement the methods of this protocol to control authorization, presentation,
+ and dismissal of immersive environments requested by websites.
+ */
+NS_SWIFT_UI_ACTOR
+WK_API_AVAILABLE(visionos(WK_XROS_TBA))
+WK_API_UNAVAILABLE(macos, ios)
+@protocol WKImmersiveEnvironmentDelegate <NSObject>
+
+/*! @abstract Asks the delegate whether to allow an immersive environment from the specified frame.
+ @param webView The web view that received the immersive environment request.
+ @param frame The frame information from the website requesting the immersive environment.
+ @param completionHandler The completion handler you must invoke with the request's answer. `YES` to allow
+ the environment presentation, or `NO` to deny it.
+ */
+- (void)webView:(WKWebView *)webView shouldAllowImmersiveEnvironmentFromFrame:(WKFrameInfo *)frame completionHandler:(void (^)(BOOL allow))completionHandler NS_SWIFT_ASYNC_NAME(webView(_:shouldAllowImmersiveEnvironmentFrom:)) WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+
+/*! @abstract Asks the delegate to present an immersive environment.
+ @param webView The web view requesting presentation.
+ @param environment The immersive environment to present.
+ @param completionHandler The completion handler you must invoke once the presentation transition has completed.
+ The error argument should be used in case the presentation failed and the environment couldn't be presented.
+ */
+- (void)webView:(WKWebView *)webView presentImmersiveEnvironment:(WKImmersiveEnvironment *)environment completionHandler:(void (^)(NSError * _Nullable error))completionHandler NS_SWIFT_ASYNC_NAME(webView(_:presentImmersiveEnvironment:)) WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+
+/*! @abstract Asks the delegate to dismiss an immersive environment.
+ @param webView The web view requesting dismissal.
+ @param environment The immersive environment to dismiss.
+ @param completionHandler The completion handler you must invoke once the dismissal transition has completed.
+ */
+- (void)webView:(WKWebView *)webView dismissImmersiveEnvironment:(WKImmersiveEnvironment *)environment completionHandler:(void (^)(void))completionHandler NS_SWIFT_ASYNC_NAME(webView(_:dismissImmersiveEnvironment:)) WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+
+@end
+
+NS_HEADER_AUDIT_END(nullability, sendability)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironmentInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironmentInternal.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/WKImmersiveEnvironment.h>
+
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+
+#import "APIFrameInfo.h"
+#import "WKImmersiveEnvironmentPrivate.h"
+#import <WebCore/LayerHostingContextIdentifier.h>
+#import <wtf/RetainPtr.h>
+
+@class WKFrameInfo;
+
+@interface WKImmersiveEnvironment ()
+
+- (instancetype)_initWithContextID:(WebCore::LayerHostingContextIdentifier)contextID processIdentifier:(pid_t)processIdentifier frameInfo:(WKFrameInfo *)frameInfo;
+
+@end
+
+#endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironmentPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironmentPrivate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,23 +23,16 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <Foundation/Foundation.h>
-#import <WebKit/WKFoundation.h>
+#import <WebKit/WKImmersiveEnvironment.h>
 
-NS_ASSUME_NONNULL_BEGIN
+#if defined(TARGET_OS_VISION) && TARGET_OS_VISION
 
-// FIXME: This SPI should become an API - rdar://problem/164244457
+#import <UIKit/UIKit.h>
 
-WK_SWIFT_UI_ACTOR
-WK_API_AVAILABLE(visionos(26.4))
-@protocol _WKImmersiveEnvironmentDelegate <NSObject>
+@interface WKImmersiveEnvironment ()
 
-#if (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
-- (void)webView:(WKWebView *)webView allowImmersiveEnvironmentFromURL:(NSURL *)url completion:(void (^)(bool allow))completion NS_SWIFT_ASYNC_NAME(webView(_:allowImmersiveEnvironmentFromURL:)) WK_API_AVAILABLE(visionos(26.4));
-- (void)webView:(WKWebView *)webView presentImmersiveEnvironment:(UIView *)environmentView completion:(void (^)(NSError * _Nullable error))completion NS_SWIFT_ASYNC_NAME(webView(_:presentImmersiveEnvironment:)) WK_API_AVAILABLE(visionos(26.4));
-- (void)webView:(WKWebView *)webView dismissImmersiveEnvironment:(void (^)(void))completion NS_SWIFT_ASYNC_NAME(webViewDismissImmersiveEnvironment(_:)) WK_API_AVAILABLE(visionos(26.4));
-#endif
+@property (nonatomic, readonly) UIView *_environmentView;
 
 @end
 
-NS_ASSUME_NONNULL_END
+#endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
@@ -49,11 +49,13 @@ NS_ASSUME_NONNULL_BEGIN
 @class WKFindConfiguration;
 @class WKFindResult;
 @class WKFrameInfo;
+@class WKImmersiveEnvironment;
 @class WKNavigation;
 @class WKPDFConfiguration;
 @class WKSnapshotConfiguration;
 @class WKWebViewConfiguration;
 
+@protocol WKImmersiveEnvironmentDelegate;
 @protocol WKNavigationDelegate;
 @protocol WKUIDelegate;
 
@@ -724,6 +726,16 @@ typedef NS_OPTIONS(NSUInteger, WKWebViewDataType) {
 @property (nonatomic) NSEdgeInsets obscuredContentInsets WK_API_AVAILABLE(macos(26.0));
 #else
 @property (nonatomic) UIEdgeInsets obscuredContentInsets WK_API_AVAILABLE(ios(26.0), visionos(26.0));
+#endif
+
+#if defined(TARGET_OS_VISION) && TARGET_OS_VISION
+/*! @abstract The delegate that manages immersive environment presentation.
+ */
+@property (nullable, nonatomic, weak) id <WKImmersiveEnvironmentDelegate> immersiveEnvironmentDelegate WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+
+/*! @abstract Dismisses the currently presented immersive environment.
+ */
+- (void)dismissImmersiveEnvironmentWithCompletionHandler:(NS_SWIFT_UI_ACTOR void (^)(void))completionHandler NS_SWIFT_ASYNC_NAME(dismissImmersiveEnvironment()) WK_API_AVAILABLE(visionos(WK_XROS_TBA));
 #endif
 
 #if 0 // API_WEBKIT_ADDITIONS_REPLACEMENT

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -89,6 +89,8 @@
 #import "WKFormInfoInternal.h"
 #import "WKFrameInfoInternal.h"
 #import "WKHistoryDelegatePrivate.h"
+#import "WKImmersiveEnvironmentDelegate.h"
+#import "WKImmersiveEnvironmentInternal.h"
 #import "WKIntelligenceReplacementTextEffectCoordinator.h"
 #import "WKIntelligenceSmartReplyTextEffectCoordinator.h"
 #import "WKIntelligenceTextEffectCoordinator.h"
@@ -144,7 +146,6 @@
 #import "_WKFrameTreeNodeInternal.h"
 #import "_WKFullscreenDelegate.h"
 #import "_WKHitTestResultInternal.h"
-#import "_WKImmersiveEnvironmentDelegate.h"
 #import "_WKInputDelegate.h"
 #import "_WKInspectorInternal.h"
 #import "_WKPageLoadTimingInternal.h"
@@ -2144,50 +2145,54 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
 #endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-- (void)_allowImmersiveElementFromURL:(const URL&)url completion:(CompletionHandler<void(bool)>&&)completion
+- (void)_allowImmersiveElement:(WKFrameInfo *)frameInfo completion:(CompletionHandler<void(bool)>&&)completion
 {
-    id<_WKImmersiveEnvironmentDelegate> immersiveEnvironmentDelegate = self._immersiveEnvironmentDelegate;
+    id<WKImmersiveEnvironmentDelegate> immersiveEnvironmentDelegate = self.immersiveEnvironmentDelegate;
     if (!immersiveEnvironmentDelegate) {
         completion(false);
         return;
     }
 
-    auto nsURL = url.createNSURL();
-    [immersiveEnvironmentDelegate webView:self allowImmersiveEnvironmentFromURL:nsURL.get() completion:makeBlockPtr([completion = WTF::move(completion)](bool allow) mutable {
+    [immersiveEnvironmentDelegate webView:self shouldAllowImmersiveEnvironmentFromFrame:frameInfo completionHandler:makeBlockPtr([completion = WTF::move(completion)](BOOL allow) mutable {
         completion(allow);
     }).get()];
 }
 
-- (void)_presentImmersiveElement:(const WebCore::LayerHostingContextIdentifier)contextID completion:(CompletionHandler<void(bool)>&&)completion
+- (void)_presentImmersiveElement:(const WebCore::LayerHostingContextIdentifier)contextID frameInfo:(WKFrameInfo *)frameInfo completion:(CompletionHandler<void(bool)>&&)completion
 {
-    id<_WKImmersiveEnvironmentDelegate> immersiveEnvironmentDelegate = self._immersiveEnvironmentDelegate;
+    id<WKImmersiveEnvironmentDelegate> immersiveEnvironmentDelegate = self.immersiveEnvironmentDelegate;
     if (!immersiveEnvironmentDelegate) {
         completion(false);
         return;
     }
 
-    RetainPtr environmentView = adoptNS([[UIView alloc] initWithFrame:CGRectZero]);
-    RetainPtr remoteModelView = adoptNS([[_UIRemoteView alloc] initWithFrame:CGRectZero pid:[self _webProcessIdentifier] contextID:contextID.toUInt64()]);
-    [environmentView addSubview:remoteModelView.get()];
-    // To match the assumptions made in ModelProcessModelPlayerProxy.mm, the frame of the model view must stay zero, and be centered inside its container.
-    // This ensures that the model is correctly placed at the world's origin when the client puts the view inside their Immersive Space.
-    [remoteModelView setFrame:CGRectZero];
-    [remoteModelView setAutoresizingMask:(UIViewAutoresizingNone | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleBottomMargin)];
+    RetainPtr environment = adoptNS([[WKImmersiveEnvironment alloc] _initWithContextID:contextID processIdentifier:[self _webProcessIdentifier] frameInfo:frameInfo]);
+    _currentImmersiveEnvironment = environment;
 
-    [immersiveEnvironmentDelegate webView:self presentImmersiveEnvironment:environmentView.autorelease() completion:makeBlockPtr([completion = WTF::move(completion)](NSError *error) mutable {
+    [immersiveEnvironmentDelegate webView:self presentImmersiveEnvironment:environment.get() completionHandler:makeBlockPtr([weakSelf = WeakObjCPtr<WKWebView>(self), completion = WTF::move(completion)](NSError *error) mutable {
+        if (error) {
+            if (RetainPtr retainedSelf = weakSelf.get())
+                retainedSelf->_currentImmersiveEnvironment = nil;
+        }
         completion(!error);
     }).get()];
 }
 
 - (void)_dismissImmersiveElement:(CompletionHandler<void()>&&)completion
 {
-    id<_WKImmersiveEnvironmentDelegate> immersiveEnvironmentDelegate = self._immersiveEnvironmentDelegate;
+    id<WKImmersiveEnvironmentDelegate> immersiveEnvironmentDelegate = self.immersiveEnvironmentDelegate;
     if (!immersiveEnvironmentDelegate) {
         completion();
         return;
     }
 
-    [immersiveEnvironmentDelegate webView:self dismissImmersiveEnvironment:makeBlockPtr([completion = WTF::move(completion)]() mutable {
+    RetainPtr environment = std::exchange(_currentImmersiveEnvironment, nil);
+    if (!environment) {
+        completion();
+        return;
+    }
+
+    [immersiveEnvironmentDelegate webView:self dismissImmersiveEnvironment:environment.get() completionHandler:makeBlockPtr([completion = WTF::move(completion)]() mutable {
         completion();
     }).get()];
 }
@@ -3892,6 +3897,35 @@ struct WKWebViewData {
 
 #endif
 
+- (id<WKImmersiveEnvironmentDelegate>)immersiveEnvironmentDelegate
+{
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    return _immersiveEnvironmentDelegate.getAutoreleased();
+#else
+    return nil;
+#endif
+}
+
+- (void)setImmersiveEnvironmentDelegate:(id<WKImmersiveEnvironmentDelegate>)delegate
+{
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    _immersiveEnvironmentDelegate = delegate;
+#else
+    UNUSED_PARAM(delegate);
+#endif
+}
+
+- (void)dismissImmersiveEnvironmentWithCompletionHandler:(void (^)(void))completionHandler
+{
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    _page->exitImmersive([completionHandler = makeBlockPtr(completionHandler)] {
+        completionHandler();
+    });
+#else
+    completionHandler();
+#endif
+}
+
 @end
 
 #pragma mark -
@@ -4760,29 +4794,6 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
     _page->restoreAppHighlightsAndScrollToIndex(buffers, 0);
 #else
     UNUSED_PARAM(highlight);
-#endif
-}
-
-- (id<_WKImmersiveEnvironmentDelegate>)_immersiveEnvironmentDelegate
-{
-#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    return _immersiveEnvironmentDelegate.getAutoreleased();
-#else
-    return nil;
-#endif
-}
-
-- (void)_setImmersiveEnvironmentDelegate:(id<_WKImmersiveEnvironmentDelegate>)delegate
-{
-#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    _immersiveEnvironmentDelegate = delegate;
-#endif
-}
-
-- (void)_exitImmersive
-{
-#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    _page->exitImmersive();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration+Extras.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration+Extras.swift
@@ -65,6 +65,10 @@ extension WKWebViewConfiguration {
             let handlerAdapter = WKURLSchemeHandlerAdapter(handler)
             self.setURLSchemeHandler(handlerAdapter, forURLScheme: scheme.rawValue)
         }
+
+        #if ENABLE_MODEL_ELEMENT_IMMERSIVE
+        self.allowsImmersiveEnvironments = wrapped.allowsImmersiveEnvironments
+        #endif
     }
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.h
@@ -249,6 +249,15 @@ on the system setting.
 @property (nonatomic) NSWritingToolsBehavior writingToolsBehavior WK_API_AVAILABLE(macos(15.0));
 #endif
 
+#if defined(TARGET_OS_VISION) && TARGET_OS_VISION
+/*! @abstract A Boolean value that determines whether the web view allows immersive environments.
+ @discussion Set this property to YES to enable support for website-provided immersive environments.
+ If NO, requests to present immersive environments are ignored. If YES, requests are routed to your `WKImmersiveEnvironmentDelegate`.
+ The default value is NO.
+ */
+@property (nonatomic) BOOL allowsImmersiveEnvironments WK_API_AVAILABLE(visionos(WK_XROS_TBA));
+#endif
+
 @end
 
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -1635,14 +1635,14 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 #endif
 }
 
-- (void)_setAllowsImmersiveEnvironments:(BOOL)allows
+- (void)setAllowsImmersiveEnvironments:(BOOL)allows
 {
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     _pageConfiguration->setAllowsImmersiveEnvironments(allows);
 #endif
 }
 
-- (BOOL)_allowsImmersiveEnvironments
+- (BOOL)allowsImmersiveEnvironments
 {
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     return _pageConfiguration->allowsImmersiveEnvironments();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
@@ -179,7 +179,6 @@ typedef NS_ENUM(NSUInteger, _WKContentSecurityPolicyModeForExtension) {
 #if defined(TARGET_OS_VISION) && TARGET_OS_VISION
 @property (nonatomic, setter=_setGamepadAccessRequiresExplicitConsent:) BOOL _gamepadAccessRequiresExplicitConsent WK_API_AVAILABLE(visionos(2.0));
 @property (nonatomic, setter=_setCSSTransformStyleSeparatedEnabled:) BOOL _cssTransformStyleSeparatedEnabled WK_API_AVAILABLE(visionos(2.4));
-@property (nonatomic, setter=_setAllowsImmersiveEnvironments:) BOOL _allowsImmersiveEnvironments WK_API_AVAILABLE(visionos(WK_XROS_TBA));
 #endif
 
 @property (nonatomic, setter=_setSystemTextExtractionEnabled:) BOOL _systemTextExtractionEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -225,7 +225,8 @@ enum class PreferSolidColorHardPocketReason : uint8_t {
 @protocol _WKAppHighlightDelegate;
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-@protocol _WKImmersiveEnvironmentDelegate;
+@protocol WKImmersiveEnvironmentDelegate;
+@class WKImmersiveEnvironment;
 #endif
 
 enum class SimilarToOriginalTextTag : uint8_t { Value };
@@ -325,7 +326,8 @@ struct PerWebProcessState {
     WeakObjCPtr<id <_WKAppHighlightDelegate>> _appHighlightDelegate;
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    WeakObjCPtr<id <_WKImmersiveEnvironmentDelegate>> _immersiveEnvironmentDelegate;
+    WeakObjCPtr<id <WKImmersiveEnvironmentDelegate>> _immersiveEnvironmentDelegate;
+    RetainPtr<WKImmersiveEnvironment> _currentImmersiveEnvironment;
 #endif
 
     RetainPtr<_WKWarningView> _warningView;
@@ -572,8 +574,8 @@ struct PerWebProcessState {
 #endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-- (void)_allowImmersiveElementFromURL:(const URL&)url completion:(CompletionHandler<void(bool)>&&)completion;
-- (void)_presentImmersiveElement:(const WebCore::LayerHostingContextIdentifier)contextID completion:(CompletionHandler<void(bool)>&&)completion;
+- (void)_allowImmersiveElement:(WKFrameInfo *)frameInfo completion:(CompletionHandler<void(bool)>&&)completion;
+- (void)_presentImmersiveElement:(const WebCore::LayerHostingContextIdentifier)contextID frameInfo:(WKFrameInfo *)frameInfo completion:(CompletionHandler<void(bool)>&&)completion;
 - (void)_dismissImmersiveElement:(CompletionHandler<void()>&&)completion;
 #endif
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -168,7 +168,6 @@ typedef NS_ENUM(NSInteger, _WKImmediateActionType) {
 @protocol _WKFindDelegate;
 @protocol _WKFullscreenDelegate;
 @protocol _WKIconLoadingDelegate;
-@protocol _WKImmersiveEnvironmentDelegate;
 @protocol _WKInputDelegate;
 @protocol _WKResourceLoadDelegate;
 @protocol _WKTextManipulationDelegate;
@@ -493,9 +492,6 @@ for this property.
 #endif
 
 @property (nonatomic, readonly) _WKSpatialBackdropSource *_spatialBackdropSource WK_API_AVAILABLE(visionos(26.0));
-
-@property (nonatomic, weak, setter=_setImmersiveEnvironmentDelegate:) id <_WKImmersiveEnvironmentDelegate> _immersiveEnvironmentDelegate WK_API_AVAILABLE(visionos(26.4));
-- (void)_exitImmersive WK_API_AVAILABLE(visionos(26.4));
 
 - (void)_grantAccessToAssetServices WK_API_AVAILABLE(macos(12.0), ios(14.0));
 - (void)_revokeAccessToAssetServices WK_API_AVAILABLE(macos(12.0), ios(14.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
@@ -29,6 +29,7 @@
 #import "_WKWebsiteDataSizeInternal.h"
 #import <WebCore/SecurityOriginData.h>
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/cocoa/VectorCocoa.h>
 
 NSString * const WKWebsiteDataTypeFetchCache = @"WKWebsiteDataTypeFetchCache";
 NSString * const WKWebsiteDataTypeDiskCache = @"WKWebsiteDataTypeDiskCache";

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
@@ -98,6 +98,25 @@ extension WebPage {
         /// If true, they are enabled based on the system setting.
         public var allowsInlinePredictions: Bool = false
 
+        private var backingAllowsImmersiveEnvironments = false
+
+        /// Indicates whether website immersive environments are allowed.
+        ///
+        /// Set this property to `true` to enable support for website immersive environments.
+        /// If `false`, requests to present immersive environments are ignored.
+        /// If `true`, requests are routed through the `onWebViewImmersiveEnvironmentRequest` view modifier callbacks.
+        ///
+        /// The default value is `false`.
+        @available(WK_XROS_TBA, *)
+        @available(iOS, unavailable)
+        @available(macOS, unavailable)
+        @available(watchOS, unavailable)
+        @available(tvOS, unavailable)
+        public var allowsImmersiveEnvironments: Bool {
+            get { backingAllowsImmersiveEnvironments }
+            set { backingAllowsImmersiveEnvironments = newValue }
+        }
+
         /// Indicates whether insertion of adaptive image glyphs is allowed.
         ///
         /// The default value is `false`. If `false`, adaptive image glyphs are inserted as regular images.

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+FrameInfo.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+FrameInfo.swift
@@ -32,7 +32,9 @@ extension WebPage {
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public struct FrameInfo {
-        init(_ wrapped: WKFrameInfo) {
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+        @_spi(CrossImportOverlay)
+        public init(_ wrapped: WKFrameInfo) {
             self.wrapped = wrapped
         }
 

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+ImmersiveEnvironment.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+ImmersiveEnvironment.swift
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Apple Inc. All rights reserved.
+// Copyright (C) 2026 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -23,40 +23,32 @@
 
 #if ENABLE_SWIFTUI
 
-import SwiftUI
-@_spi(Private) import WebKit
+public import Foundation
 
-struct ContextMenuContext {
-    #if os(macOS)
-    let menu: @MainActor (WebView.ActivatedElementInfo) -> NSMenu
-    #endif
-}
+extension WebPage {
+    /// An object representing a website-provided immersive environment that is ready for presentation.
+    @MainActor
+    @available(WK_XROS_TBA, *)
+    @available(iOS, unavailable)
+    @available(macOS, unavailable)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    public struct ImmersiveEnvironment: Sendable {
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+        @_spi(CrossImportOverlay)
+        public init(_ wrapped: WKImmersiveEnvironment) {
+            self.wrapped = wrapped
+        }
 
-struct OnScrollGeometryChangeContext {
-    let transform: (ScrollGeometry) -> AnyHashable
-    let action: (AnyHashable, AnyHashable) -> Void
-}
+        /// The frame information of the website that provided this immersive environment.
+        public var sourceFrame: WebPage.FrameInfo {
+            WebPage.FrameInfo(wrapped.sourceFrame)
+        }
 
-struct ScrollPositionContext {
-    var position: Binding<ScrollPosition>?
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+        @_spi(CrossImportOverlay)
+        public let wrapped: WKImmersiveEnvironment
+    }
 }
-
-struct ScrollInputBehaviorContext {
-    let behavior: ScrollInputBehavior
-    let input: ScrollInputKind
-}
-
-struct ScrollEdgeEffectStyleContext {
-    let style: ScrollEdgeEffectStyle?
-    let edges: Edge.Set
-}
-
-#if ENABLE_MODEL_ELEMENT_IMMERSIVE
-struct ImmersiveEnvironmentRequestContext {
-    let shouldAllow: @MainActor (_ sourceFrame: WebPage.FrameInfo) async -> Bool
-    let present: @MainActor (_ environment: WebPage.ImmersiveEnvironment) async throws -> Void
-    let dismiss: @MainActor (_ environment: WebPage.ImmersiveEnvironment) async -> Void
-}
-#endif
 
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -85,8 +85,8 @@ public:
 #endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    void allowImmersiveElementFromURL(const URL&, CompletionHandler<void(bool)>&&) const final;
-    void presentImmersiveElement(const WebCore::LayerHostingContextIdentifier, CompletionHandler<void(bool)>&&) const final;
+    void allowImmersiveElement(Ref<API::FrameInfo>&&, CompletionHandler<void(bool)>&&) const final;
+    void presentImmersiveElement(const WebCore::LayerHostingContextIdentifier, Ref<API::FrameInfo>&&, CompletionHandler<void(bool)>&&) const final;
     void dismissImmersiveElement(CompletionHandler<void()>&&) const final;
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -26,9 +26,11 @@
 #import "config.h"
 #import "PageClientImplCocoa.h"
 
+#import "APIFrameInfo.h"
 #import "APIUIClient.h"
 #import "RemoteLayerTreeCommitBundle.h"
 #import "RemoteLayerTreeTransaction.h"
+#import "WKFrameInfoInternal.h"
 #import "WKWebViewInternal.h"
 #import "WebFullScreenManagerProxy.h"
 #import "WebPageProxy.h"
@@ -124,14 +126,14 @@ void PageClientImplCocoa::spatialBackdropSourceDidChange()
 #endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-void PageClientImplCocoa::allowImmersiveElementFromURL(const URL& url, CompletionHandler<void(bool)>&& completion) const
+void PageClientImplCocoa::allowImmersiveElement(Ref<API::FrameInfo>&& frameInfo, CompletionHandler<void(bool)>&& completion) const
 {
-    [webView() _allowImmersiveElementFromURL:url completion:WTF::move(completion)];
+    [webView() _allowImmersiveElement:wrapper(WTF::move(frameInfo)).get() completion:WTF::move(completion)];
 }
 
-void PageClientImplCocoa::presentImmersiveElement(const WebCore::LayerHostingContextIdentifier contextID, CompletionHandler<void(bool)>&& completion) const
+void PageClientImplCocoa::presentImmersiveElement(const WebCore::LayerHostingContextIdentifier contextID, Ref<API::FrameInfo>&& frameInfo, CompletionHandler<void(bool)>&& completion) const
 {
-    [webView() _presentImmersiveElement:contextID completion:WTF::move(completion)];
+    [webView() _presentImmersiveElement:contextID frameInfo:wrapper(WTF::move(frameInfo)).get() completion:WTF::move(completion)];
 }
 
 void PageClientImplCocoa::dismissImmersiveElement(CompletionHandler<void()>&& completion) const

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "DownloadID.h"
+#include "NetworkProcessProxy.h"
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RetainPtr.h>
@@ -47,7 +48,6 @@ class ResourceRequest;
 namespace WebKit {
 
 class DownloadProxy;
-class NetworkProcessProxy;
 class ProcessAssertion;
 class WebPageProxy;
 class WebsiteDataStore;

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -102,6 +102,7 @@ OBJC_CLASS WKView;
 
 namespace API {
 class Attachment;
+class FrameInfo;
 class HitTestResult;
 class Navigation;
 class Object;
@@ -879,8 +880,8 @@ public:
 #endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    virtual void allowImmersiveElementFromURL(const URL&, CompletionHandler<void(bool)>&& completion) const { completion(false); }
-    virtual void presentImmersiveElement(const WebCore::LayerHostingContextIdentifier, CompletionHandler<void(bool)>&& completion) const { completion(false); }
+    virtual void allowImmersiveElement(Ref<API::FrameInfo>&&, CompletionHandler<void(bool)>&& completion) const { completion(false); }
+    virtual void presentImmersiveElement(const WebCore::LayerHostingContextIdentifier, Ref<API::FrameInfo>&&, CompletionHandler<void(bool)>&& completion) const { completion(false); }
     virtual void dismissImmersiveElement(CompletionHandler<void()>&& completion) const { completion(); }
 #endif
 };

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
@@ -38,6 +38,7 @@
 #import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
+#import "AuthenticationServicesCoreSoftLink.h"
 #import "LocalAuthenticationSoftLink.h"
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12553,7 +12553,7 @@ void WebPageProxy::resetState(ResetStateReason resetStateReason)
     m_lastSuspendedPage = nullptr;
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    m_allowedImmersiveElementFrameURL = std::nullopt;
+    m_allowedImmersiveElementFrameInfo = nullptr;
     if (m_immersive)
         dismissImmersiveElement([] { });
 #endif
@@ -14254,39 +14254,56 @@ void WebPageProxy::allowImmersiveElement(CompletionHandler<void(bool)>&& complet
 {
     if (!m_mainFrame)
         return completion(false);
-    auto url = m_mainFrame->url();
 
-    if (RefPtr pageClient = this->pageClient()) {
-        pageClient->allowImmersiveElementFromURL(url, [weakThis = WeakPtr { *this }, url, completion = WTF::move(completion)](bool allow) mutable {
-            if (weakThis && allow)
-                weakThis.get()->m_allowedImmersiveElementFrameURL = url;
-            completion(allow);
-        });
-    } else
-        completion(false);
+    m_mainFrame->getFrameInfo([weakThis = WeakPtr { *this }, completion = WTF::move(completion)](std::optional<FrameInfoData>&& frameInfoData) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !frameInfoData)
+            return completion(false);
+
+        auto frameInfo = API::FrameInfo::create(WTF::move(*frameInfoData));
+
+        if (RefPtr pageClient = protectedThis->pageClient()) {
+            pageClient->allowImmersiveElement(frameInfo.copyRef(), [weakThis, frameInfo = WTF::move(frameInfo), completion = WTF::move(completion)](bool allow) mutable {
+                RefPtr protectedThis = weakThis.get();
+                if (protectedThis && allow)
+                    protectedThis->m_allowedImmersiveElementFrameInfo = WTF::move(frameInfo);
+                completion(allow);
+            });
+        } else
+            completion(false);
+    });
 }
 
 void WebPageProxy::presentImmersiveElement(const WebCore::LayerHostingContextIdentifier contextID, CompletionHandler<void(bool)>&& completion)
 {
-    if (!m_mainFrame)
+    if (!m_mainFrame || !m_allowedImmersiveElementFrameInfo)
         return completion(false);
-    auto currentURL = m_mainFrame->url();
 
-    if (!m_allowedImmersiveElementFrameURL || m_allowedImmersiveElementFrameURL.value() != currentURL) {
-        WEBPAGEPROXY_RELEASE_LOG_ERROR(ModelElement, "presentImmersiveElement: Rejecting request - URL mismatch or no prior permission.");
-        completion(false);
-        return;
-    }
-    m_allowedImmersiveElementFrameURL = std::nullopt;
+    m_mainFrame->getFrameInfo([weakThis = WeakPtr { *this }, contextID, completion = WTF::move(completion)](std::optional<FrameInfoData>&& frameInfoData) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !frameInfoData)
+            return completion(false);
 
-    if (RefPtr pageClient = this->pageClient()) {
-        pageClient->presentImmersiveElement(contextID, [weakThis = WeakPtr { *this }, completion = WTF::move(completion)](bool success) mutable {
-            if (success && weakThis)
-                weakThis.get()->m_immersive = true;
-            completion(success);
-        });
-    } else
-        completion(false);
+        RefPtr allowedFrameInfo = std::exchange(protectedThis->m_allowedImmersiveElementFrameInfo, nullptr);
+        if (!allowedFrameInfo
+            || allowedFrameInfo->request().url() != frameInfoData->request.url()
+            || allowedFrameInfo->securityOrigin() != frameInfoData->securityOrigin) {
+            RELEASE_LOG_ERROR(ModelElement, "%p - WebPageProxy::presentImmersiveElement: Rejecting request - frame info mismatch with previously allowed frame.", protectedThis.get());
+            return completion(false);
+        }
+
+        auto frameInfo = API::FrameInfo::create(WTF::move(*frameInfoData));
+
+        if (RefPtr pageClient = protectedThis->pageClient()) {
+            pageClient->presentImmersiveElement(contextID, WTF::move(frameInfo), [weakThis, completion = WTF::move(completion)](bool success) mutable {
+                RefPtr protectedThis = weakThis.get();
+                if (protectedThis && success)
+                    protectedThis->m_immersive = true;
+                completion(success);
+            });
+        } else
+            completion(false);
+    });
 }
 
 void WebPageProxy::dismissImmersiveElement(CompletionHandler<void()>&& completion)
@@ -14299,9 +14316,9 @@ void WebPageProxy::dismissImmersiveElement(CompletionHandler<void()>&& completio
         completion();
 }
 
-void WebPageProxy::exitImmersive()
+void WebPageProxy::exitImmersive(CompletionHandler<void()>&& completion)
 {
-    send(Messages::WebPage::ExitImmersive());
+    sendWithAsyncReply(Messages::WebPage::ExitImmersive(), WTF::move(completion));
 }
 #endif
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2956,10 +2956,6 @@ public:
     RefPtr<WebDeviceOrientationUpdateProviderProxy> NODELETE webDeviceOrientationUpdateProviderProxy();
 #endif
 
-#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    void exitImmersive();
-#endif
-
     friend class TextExtractionAssertionScope;
     UniqueRef<TextExtractionAssertionScope> NODELETE createTextExtractionAssertionScope();
 
@@ -2971,6 +2967,10 @@ public:
 #endif
 
     bool shouldUseBackForwardCache() const;
+
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    void exitImmersive(CompletionHandler<void()>&&);
+#endif
 
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
@@ -4220,7 +4220,7 @@ private:
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     bool m_immersive { false };
-    std::optional<URL> m_allowedImmersiveElementFrameURL;
+    RefPtr<API::FrameInfo> m_allowedImmersiveElementFrameInfo;
 #endif
 
 #if HAVE(AUDIT_TOKEN)

--- a/Source/WebKit/UIProcess/ios/WKVisibilityPropagationView.mm
+++ b/Source/WebKit/UIProcess/ios/WKVisibilityPropagationView.mm
@@ -31,6 +31,7 @@
 #import "AuxiliaryProcessProxy.h"
 #import "ExtensionKitSPI.h"
 #import "Logging.h"
+#import "UIKitSPI.h"
 #import <wtf/RetainPtr.h>
 #import <wtf/WeakPtr.h>
 

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
@@ -42,6 +42,7 @@
 #import "WKStringCF.h"
 #import "WKURLCF.h"
 #import "WKWebViewInternal.h"
+#import "WKWebViewPrivateForTesting.h"
 #import "WebIconUtilities.h"
 #import "WebOpenPanelResultListenerProxy.h"
 #import "WebPageProxy.h"

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -46,6 +46,7 @@
 #include <WebCore/PlatformPlaybackSessionInterface.h>
 #include <WebCore/ScrollTypes.h>
 #include <WebCore/ShareableBitmap.h>
+#include <WebCore/TextAnimationTypes.h>
 #include <WebCore/TextIndicator.h>
 #include <WebCore/UserInterfaceLayoutDirection.h>
 #include <WebKit/WKDragDestinationAction.h>

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		0765D1C52DEBFF840029CDD0 /* WKGroupSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF1B90D266F395E0007EC10 /* WKGroupSession.swift */; };
 		076867FF2D4C283E004DA801 /* WebViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076867F72D4C26A8004DA801 /* WebViewRepresentable.swift */; };
 		076868022D4C285B004DA801 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076867F62D4C26A8004DA801 /* WebView.swift */; };
+		B6B64F30272BA2A17EF9AD14 /* WebViewImmersiveEnvironmentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD28341B551FAD199FFF404 /* WebViewImmersiveEnvironmentView.swift */; };
 		076868032D4C2867004DA801 /* View+WebViewModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04B52CF2B4D300B453A6 /* View+WebViewModifiers.swift */; };
 		076897EE2D07B0BE006F9FA7 /* WebPage+DialogPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076897ED2D07B0BE006F9FA7 /* WebPage+DialogPresenting.swift */; };
 		076897F02D07B330006F9FA7 /* WKUIDelegateAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076897EF2D07B330006F9FA7 /* WKUIDelegateAdapter.swift */; };
@@ -192,6 +193,7 @@
 		078B04462CF1154B00B453A6 /* WebPage+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04452CF1154B00B453A6 /* WebPage+Configuration.swift */; };
 		078B04A02CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B049F2CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift */; };
 		078B04B42CF1A27F00B453A6 /* WebPage+FrameInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04B32CF1A27F00B453A6 /* WebPage+FrameInfo.swift */; };
+		EC0D6F5F1ED1A1526CFC635B /* WebPage+ImmersiveEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3B2400719F4A5C968D0E31 /* WebPage+ImmersiveEnvironment.swift */; };
 		0792314C239CBCB8009598E2 /* RemoteMediaPlayerManagerProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 07923146239CBCB7009598E2 /* RemoteMediaPlayerManagerProxyMessages.h */; };
 		079A4DA12D72CC0D00CA387F /* WebPageWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079A4DA02D72CC0D00CA387F /* WebPageWebView.swift */; };
 		079A4DA32D72CDB400CA387F /* WKWebViewConfiguration+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079A4DA22D72CDB400CA387F /* WKWebViewConfiguration+Extras.swift */; };
@@ -2301,7 +2303,11 @@
 		C6A4CA0B2252899800169289 /* WKBundlePageMac.h in Headers */ = {isa = PBXBuildFile; fileRef = C6A4CA092252899800169289 /* WKBundlePageMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		C6A4CA0C2252899800169289 /* WKBundlePageMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = C6A4CA0A2252899800169289 /* WKBundlePageMac.mm */; };
 		CA05397923EE324400A553DC /* ContentAsStringIncludesChildFrames.h in Headers */ = {isa = PBXBuildFile; fileRef = CA05397823EE324400A553DC /* ContentAsStringIncludesChildFrames.h */; };
-		CA272BF72ED5BB24003AABF9 /* _WKImmersiveEnvironmentDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = CA272BF62ED5BB1B003AABF9 /* _WKImmersiveEnvironmentDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		C19A9963A5CCC9430AE3A51D /* WKImmersiveEnvironment.h in Headers */ = {isa = PBXBuildFile; fileRef = BE33BD7F218389F1713A5EE5 /* WKImmersiveEnvironment.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0273F4BA82E4AC37A79BDD33 /* WKImmersiveEnvironment.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9A8C42AE535B28E40886C56B /* WKImmersiveEnvironment.mm */; };
+		6BC94707C9319F43B957AF30 /* WKImmersiveEnvironmentDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 860A5EA0FD5FBC32B5398AC3 /* WKImmersiveEnvironmentDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BAD09C7B35BFC09CD70F3EB4 /* WKImmersiveEnvironmentInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 816C18758ACB9F66D87FBE39 /* WKImmersiveEnvironmentInternal.h */; };
+		A1F7E3D2C4B8D9E1F0A23456 /* WKImmersiveEnvironmentPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = D3E8A4F1B7C2E5D9A0163478 /* WKImmersiveEnvironmentPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CA33440C2D1673FC007473A1 /* _WKSpatialBackdropSource.h in Headers */ = {isa = PBXBuildFile; fileRef = CA33440B2D1673FB007473A1 /* _WKSpatialBackdropSource.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CA33440F2D1680F9007473A1 /* _WKSpatialBackdropSourceInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = CA33440E2D1680F9007473A1 /* _WKSpatialBackdropSourceInternal.h */; };
 		CD003A5319D49B5D005ABCE0 /* WebMediaKeyStorageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = CD003A5119D49B5D005ABCE0 /* WebMediaKeyStorageManager.h */; };
@@ -3447,6 +3453,7 @@
 		076867F42D4C26A8004DA801 /* CocoaWebViewAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CocoaWebViewAdapter.swift; sourceTree = "<group>"; };
 		076867F52D4C26A8004DA801 /* PlatformTextSearching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformTextSearching.swift; sourceTree = "<group>"; };
 		076867F62D4C26A8004DA801 /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
+		BFD28341B551FAD199FFF404 /* WebViewImmersiveEnvironmentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewImmersiveEnvironmentView.swift; sourceTree = "<group>"; };
 		076867F72D4C26A8004DA801 /* WebViewRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewRepresentable.swift; sourceTree = "<group>"; };
 		076897ED2D07B0BE006F9FA7 /* WebPage+DialogPresenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+DialogPresenting.swift"; sourceTree = "<group>"; };
 		076897EF2D07B330006F9FA7 /* WKUIDelegateAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKUIDelegateAdapter.swift; sourceTree = "<group>"; };
@@ -3461,6 +3468,7 @@
 		078B04452CF1154B00B453A6 /* WebPage+Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+Configuration.swift"; sourceTree = "<group>"; };
 		078B049F2CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+NavigationPreferences.swift"; sourceTree = "<group>"; };
 		078B04B32CF1A27F00B453A6 /* WebPage+FrameInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+FrameInfo.swift"; sourceTree = "<group>"; };
+		7A3B2400719F4A5C968D0E31 /* WebPage+ImmersiveEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+ImmersiveEnvironment.swift"; sourceTree = "<group>"; };
 		078B04B52CF2B4D300B453A6 /* View+WebViewModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+WebViewModifiers.swift"; sourceTree = "<group>"; };
 		07923130239B3B0C009598E2 /* RemoteMediaPlayerManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaPlayerManager.cpp; sourceTree = "<group>"; };
 		07923131239B3B0C009598E2 /* MediaPlayerPrivateRemote.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MediaPlayerPrivateRemote.cpp; sourceTree = "<group>"; };
@@ -8267,7 +8275,11 @@
 		C6A4CA092252899800169289 /* WKBundlePageMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKBundlePageMac.h; sourceTree = "<group>"; };
 		C6A4CA0A2252899800169289 /* WKBundlePageMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKBundlePageMac.mm; sourceTree = "<group>"; };
 		CA05397823EE324400A553DC /* ContentAsStringIncludesChildFrames.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ContentAsStringIncludesChildFrames.h; sourceTree = "<group>"; };
-		CA272BF62ED5BB1B003AABF9 /* _WKImmersiveEnvironmentDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKImmersiveEnvironmentDelegate.h; sourceTree = "<group>"; };
+		BE33BD7F218389F1713A5EE5 /* WKImmersiveEnvironment.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKImmersiveEnvironment.h; sourceTree = "<group>"; };
+		9A8C42AE535B28E40886C56B /* WKImmersiveEnvironment.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKImmersiveEnvironment.mm; sourceTree = "<group>"; };
+		860A5EA0FD5FBC32B5398AC3 /* WKImmersiveEnvironmentDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKImmersiveEnvironmentDelegate.h; sourceTree = "<group>"; };
+		816C18758ACB9F66D87FBE39 /* WKImmersiveEnvironmentInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKImmersiveEnvironmentInternal.h; sourceTree = "<group>"; };
+		D3E8A4F1B7C2E5D9A0163478 /* WKImmersiveEnvironmentPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKImmersiveEnvironmentPrivate.h; sourceTree = "<group>"; };
 		CA33440B2D1673FB007473A1 /* _WKSpatialBackdropSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKSpatialBackdropSource.h; sourceTree = "<group>"; };
 		CA33440D2D16748F007473A1 /* _WKSpatialBackdropSource.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKSpatialBackdropSource.mm; sourceTree = "<group>"; };
 		CA33440E2D1680F9007473A1 /* _WKSpatialBackdropSourceInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKSpatialBackdropSourceInternal.h; sourceTree = "<group>"; };
@@ -9606,6 +9618,7 @@
 				07275C622D00D32D002315A5 /* WebPage+SwiftUI.swift */,
 				07A4CEC62D0933E700764F5E /* WebPageNavigationAction+SwiftUI.swift */,
 				076867F62D4C26A8004DA801 /* WebView.swift */,
+				BFD28341B551FAD199FFF404 /* WebViewImmersiveEnvironmentView.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -9739,6 +9752,7 @@
 				076897ED2D07B0BE006F9FA7 /* WebPage+DialogPresenting.swift */,
 				510C98972F3C50B5002455B3 /* WebPage+FormInfo.swift */,
 				078B04B32CF1A27F00B453A6 /* WebPage+FrameInfo.swift */,
+				7A3B2400719F4A5C968D0E31 /* WebPage+ImmersiveEnvironment.swift */,
 				07FAA74A2CE947AA00128360 /* WebPage+Navigation.swift */,
 				074E87E02CF8EA3D0059E469 /* WebPage+NavigationDeciding.swift */,
 				078B049F2CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift */,
@@ -12735,7 +12749,6 @@
 				63C32C231E9810D900699BD0 /* _WKGeolocationPosition.mm */,
 				63C32C271E98119000699BD0 /* _WKGeolocationPositionInternal.h */,
 				5143B25E1DDCDFD10014FAC6 /* _WKIconLoadingDelegate.h */,
-				CA272BF62ED5BB1B003AABF9 /* _WKImmersiveEnvironmentDelegate.h */,
 				37A64E5418F38E3C00EB30F1 /* _WKInputDelegate.h */,
 				5CAFDE422130843500B1F7E1 /* _WKInspector.h */,
 				5CAFDE432130843600B1F7E1 /* _WKInspector.mm */,
@@ -12973,6 +12986,11 @@
 				51D124851E734AE3002B2820 /* WKHTTPCookieStore.mm */,
 				51D124861E734AE3002B2820 /* WKHTTPCookieStoreInternal.h */,
 				DF462E0E23F22F5300EFF35F /* WKHTTPCookieStorePrivate.h */,
+				BE33BD7F218389F1713A5EE5 /* WKImmersiveEnvironment.h */,
+				9A8C42AE535B28E40886C56B /* WKImmersiveEnvironment.mm */,
+				860A5EA0FD5FBC32B5398AC3 /* WKImmersiveEnvironmentDelegate.h */,
+				816C18758ACB9F66D87FBE39 /* WKImmersiveEnvironmentInternal.h */,
+				D3E8A4F1B7C2E5D9A0163478 /* WKImmersiveEnvironmentPrivate.h */,
 				51DB22E72F3EB13300BDCDCE /* WKJSHandle.h */,
 				51DB22E82F3EB13300BDCDCE /* WKJSHandle.mm */,
 				51DB22E92F3EB13300BDCDCE /* WKJSHandleInternal.h */,
@@ -17752,7 +17770,6 @@
 				93E6A4EE1BC5DD3900F8A0E7 /* _WKHitTestResult.h in Headers */,
 				93A88B3B1BC710D900ABA5C2 /* _WKHitTestResultInternal.h in Headers */,
 				510F59101DDE296900412FF5 /* _WKIconLoadingDelegate.h in Headers */,
-				CA272BF72ED5BB24003AABF9 /* _WKImmersiveEnvironmentDelegate.h in Headers */,
 				37A64E5518F38E3C00EB30F1 /* _WKInputDelegate.h in Headers */,
 				5CAFDE452130846300B1F7E1 /* _WKInspector.h in Headers */,
 				994C6042253CA54400BDF060 /* _WKInspectorConfiguration.h in Headers */,
@@ -19290,6 +19307,10 @@
 				933DF82E1B3BC09000AEA9E3 /* WKImagePreviewViewController.h in Headers */,
 				9321D5861A38EE3C008052BE /* WKImmediateActionController.h in Headers */,
 				9321D58A1A38F196008052BE /* WKImmediateActionTypes.h in Headers */,
+				C19A9963A5CCC9430AE3A51D /* WKImmersiveEnvironment.h in Headers */,
+				6BC94707C9319F43B957AF30 /* WKImmersiveEnvironmentDelegate.h in Headers */,
+				BAD09C7B35BFC09CD70F3EB4 /* WKImmersiveEnvironmentInternal.h in Headers */,
+				A1F7E3D2C4B8D9E1F0A23456 /* WKImmersiveEnvironmentPrivate.h in Headers */,
 				1C8E293912761E5B00BC7BD0 /* WKInspector.h in Headers */,
 				0F3C725B196F604E00AEDD0C /* WKInspectorHighlightView.h in Headers */,
 				A54293A4195A43DA002782C7 /* WKInspectorNodeSearchGestureRecognizer.h in Headers */,
@@ -21589,6 +21610,7 @@
 				07275C632D00D32D002315A5 /* WebPage+SwiftUI.swift in Sources */,
 				07A4CEC72D0933E700764F5E /* WebPageNavigationAction+SwiftUI.swift in Sources */,
 				076868022D4C285B004DA801 /* WebView.swift in Sources */,
+				B6B64F30272BA2A17EF9AD14 /* WebViewImmersiveEnvironmentView.swift in Sources */,
 				2AE6D2B72F501404002BE327 /* WebViewRepresentable+Extras.swift in Sources */,
 				076867FF2D4C283E004DA801 /* WebViewRepresentable.swift in Sources */,
 			);
@@ -22199,6 +22221,7 @@
 				076897EE2D07B0BE006F9FA7 /* WebPage+DialogPresenting.swift in Sources */,
 				510C98982F3C50B5002455B3 /* WebPage+FormInfo.swift in Sources */,
 				078B04B42CF1A27F00B453A6 /* WebPage+FrameInfo.swift in Sources */,
+				EC0D6F5F1ED1A1526CFC635B /* WebPage+ImmersiveEnvironment.swift in Sources */,
 				07FAA74B2CE947AA00128360 /* WebPage+Navigation.swift in Sources */,
 				074E87E12CF8EA3D0059E469 /* WebPage+NavigationDeciding.swift in Sources */,
 				078B04A02CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift in Sources */,

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7922,7 +7922,7 @@ void WebPage::didCommitLoad(WebFrame* frame)
     flushDeferredDidReceiveMouseEvent();
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    exitImmersive();
+    exitImmersive([] { });
 #endif
 
     if (frame && frame->isMainFrame())
@@ -8135,10 +8135,12 @@ void WebPage::dismissImmersiveElement(CompletionHandler<void()>&& completion)
     sendWithAsyncReply(Messages::WebPageProxy::DismissImmersiveElement(), WTF::move(completion));
 }
 
-void WebPage::exitImmersive() const
+void WebPage::exitImmersive(CompletionHandler<void()>&& completion)
 {
     if (RefPtr localTopDocument = this->localTopDocument(); RefPtr protectedImmersive = localTopDocument->immersiveIfExists())
-        protectedImmersive->exitImmersiveIfNeeded();
+        protectedImmersive->exitImmersiveIfNeeded(WTF::move(completion));
+    else
+        completion();
 }
 
 bool WebPage::allowsImmersiveEnvironments() const

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1751,7 +1751,7 @@ public:
     void allowImmersiveElement(CompletionHandler<void(bool)>&&);
     void presentImmersiveElement(const WebCore::LayerHostingContextIdentifier, CompletionHandler<void(bool)>&&);
     void dismissImmersiveElement(CompletionHandler<void()>&&);
-    void exitImmersive() const;
+    void exitImmersive(CompletionHandler<void()>&&);
     bool allowsImmersiveEnvironments() const;
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -967,7 +967,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 #endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    ExitImmersive()
+    ExitImmersive() -> ()
 #endif
 
     UpdateRemoteIntersectionObservers();

--- a/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
@@ -166,6 +166,47 @@ extension View {
             .ignoresSafeArea(edges: edges)
             .environment(\.webViewScrollEdgeEffectStyleContext, .init(style: style, edges: edges))
     }
+
+    /// Manages the lifecycle of immersive environments requested by websites.
+    ///
+    /// Use this modifier to control authorization, presentation, and dismissal of
+    /// immersive environments from websites.
+    ///
+    /// - Parameters:
+    ///   - shouldAllow: An async closure called when a website requests an immersive environment.
+    ///     This can be used to request user consent or apply custom authorization logic.
+    ///     It receives the source `WebPage.FrameInfo` and should return `true` to allow
+    ///     the environment presentation, or `false` to deny it.
+    ///   - present: An async throwing closure called after the environment has loaded and is ready
+    ///     for presentation. It receives the `WebPage.ImmersiveEnvironment`. Use this to
+    ///     open an Immersive Space containing a `WebViewImmersiveEnvironmentView` initialized
+    ///     with this environment. If another immersive space is already being presented,
+    ///     dismiss it first. This closure should return after the presentation transition completes.
+    ///   - dismiss: An async closure called when the website or the application asks to dismiss
+    ///     the immersive environment. It receives the `WebPage.ImmersiveEnvironment` to dismiss.
+    ///     This closure should return after the dismissal transition completes.
+    /// - Returns: A modified view that manages immersive environment lifecycle.
+    @available(WK_XROS_TBA, *)
+    @available(iOS, unavailable)
+    @available(macOS, unavailable)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    public nonisolated func onWebViewImmersiveEnvironmentRequest(
+        shouldAllow: @escaping @MainActor (_ sourceFrame: WebPage.FrameInfo) async -> Bool,
+        present: @escaping @MainActor (_ environment: WebPage.ImmersiveEnvironment) async throws -> Void,
+        dismiss: @escaping @MainActor (_ environment: WebPage.ImmersiveEnvironment) async -> Void
+    ) -> some View {
+        #if ENABLE_MODEL_ELEMENT_IMMERSIVE
+        let context = ImmersiveEnvironmentRequestContext(
+            shouldAllow: shouldAllow,
+            present: present,
+            dismiss: dismiss
+        )
+        return environment(\.webViewImmersiveEnvironmentRequestContext, context)
+        #else
+        return self
+        #endif
+    }
 }
 
 #endif

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebViewImmersiveEnvironmentView.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebViewImmersiveEnvironmentView.swift
@@ -1,0 +1,75 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI
+
+public import SwiftUI
+@_spi(CrossImportOverlay) import WebKit
+import WebKit_Private
+
+/// A SwiftUI view that renders a specific website-provided immersive environment.
+///
+/// Place this view in your app's Immersive Space hierarchy. Initialize it with the
+/// `WebPage.ImmersiveEnvironment` received from the presentation callback to render
+/// that specific environment.
+@MainActor
+@available(WK_XROS_TBA, *)
+@available(iOS, unavailable)
+@available(macOS, unavailable)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+public struct WebViewImmersiveEnvironmentView: View {
+    private let environment: WKImmersiveEnvironment
+
+    /// Creates an immersive environment view from a ``WebPage/ImmersiveEnvironment``.
+    public init(_ environment: WebPage.ImmersiveEnvironment) {
+        self.init(environment.wrapped)
+    }
+
+    /// Creates an immersive environment view from a `WKImmersiveEnvironment`.
+    public init(_ environment: WKImmersiveEnvironment) {
+        self.environment = environment
+    }
+
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    public var body: some View {
+        #if os(visionOS)
+        Representable(environment: environment)
+        #endif
+    }
+
+    #if os(visionOS)
+    @MainActor
+    private struct Representable: UIViewRepresentable {
+        let environment: WKImmersiveEnvironment
+
+        func makeUIView(context: Context) -> UIView {
+            environment._environmentView
+        }
+
+        func updateUIView(_ uiView: UIView, context: Context) {}
+    }
+    #endif
+}
+
+#endif

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift
@@ -59,6 +59,11 @@ extension EnvironmentValues {
 
     @Entry
     var webViewScrollEdgeEffectStyleContext: ScrollEdgeEffectStyleContext? = nil
+
+    #if ENABLE_MODEL_ELEMENT_IMMERSIVE
+    @Entry
+    var webViewImmersiveEnvironmentRequestContext: ImmersiveEnvironmentRequestContext? = nil
+    #endif
 }
 
 #endif

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
@@ -126,6 +126,10 @@ struct WebViewRepresentable {
 
         platformView.onScrollGeometryChange = environment.webViewOnScrollGeometryChange
 
+        #if ENABLE_MODEL_ELEMENT_IMMERSIVE
+        context.coordinator.updateImmersiveEnvironmentContext(environment.webViewImmersiveEnvironmentRequestContext, webView: webView)
+        #endif
+
         context.coordinator.update(platformView, configuration: self, context: context)
 
         #if os(macOS) && !targetEnvironment(macCatalyst)
@@ -175,6 +179,23 @@ final class WebViewCoordinator {
     var configuration: WebViewRepresentable
     #if ENABLE_WEBVIEW_ADDITIONAL_SETUP
     var additionalInformation: Information?
+    #endif
+
+    #if ENABLE_MODEL_ELEMENT_IMMERSIVE
+    var immersiveEnvironmentDelegateAdapter: ImmersiveEnvironmentDelegateAdapter?
+
+    func updateImmersiveEnvironmentContext(_ context: ImmersiveEnvironmentRequestContext?, webView: WebPageWebView) {
+        if let context {
+            if immersiveEnvironmentDelegateAdapter == nil {
+                immersiveEnvironmentDelegateAdapter = ImmersiveEnvironmentDelegateAdapter()
+            }
+            immersiveEnvironmentDelegateAdapter?.context = context
+            webView.immersiveEnvironmentDelegate = immersiveEnvironmentDelegateAdapter
+        } else {
+            immersiveEnvironmentDelegateAdapter = nil
+            webView.immersiveEnvironmentDelegate = nil
+        }
+    }
     #endif
 
     func update(_ view: CocoaWebViewAdapter, configuration: WebViewRepresentable, context: WebViewRepresentable.Context) {
@@ -288,6 +309,32 @@ extension WebViewRepresentable: NSViewRepresentable {
 
     static func dismantleNSView(_ nsView: CocoaWebViewAdapter, coordinator: WebViewCoordinator) {
         dismantlePlatformView(nsView, coordinator: coordinator)
+    }
+}
+#endif
+
+#if ENABLE_MODEL_ELEMENT_IMMERSIVE
+@MainActor
+final class ImmersiveEnvironmentDelegateAdapter: NSObject, WKImmersiveEnvironmentDelegate {
+    var context: ImmersiveEnvironmentRequestContext?
+
+    func webView(_ webView: WKWebView, shouldAllowImmersiveEnvironmentFrom frame: WKFrameInfo) async -> Bool {
+        guard let context else { return false }
+        return await context.shouldAllow(WebPage.FrameInfo(frame))
+    }
+
+    func webView(_ webView: WKWebView, presentImmersiveEnvironment environment: WKImmersiveEnvironment) async throws {
+        guard let context else { throw ImmersiveEnvironmentPresentationError.noContext }
+        try await context.present(WebPage.ImmersiveEnvironment(environment))
+    }
+
+    func webView(_ webView: WKWebView, dismissImmersiveEnvironment environment: WKImmersiveEnvironment) async {
+        guard let context else { return }
+        await context.dismiss(WebPage.ImmersiveEnvironment(environment))
+    }
+
+    enum ImmersiveEnvironmentPresentationError: Error {
+        case noContext
     }
 }
 #endif

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -318,7 +318,7 @@ void TestController::platformCreateWebView(WKPageConfigurationRef configuration,
 #endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    [cocoaConfiguration _setAllowsImmersiveEnvironments:YES];
+    [cocoaConfiguration setAllowsImmersiveEnvironments:YES];
 #endif
 
     if (options.enableAttachmentElement())

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
@@ -41,7 +41,8 @@
 #import <wtf/darwin/DispatchExtras.h>
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-#import <WebKit/_WKImmersiveEnvironmentDelegate.h>
+#import <WebKit/WKImmersiveEnvironment.h>
+#import <WebKit/WKImmersiveEnvironmentDelegate.h>
 #endif
 
 #if PLATFORM(MAC)
@@ -79,7 +80,7 @@ struct CustomMenuActionInfo {
     , UIGestureRecognizerDelegate
 #endif
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    , _WKImmersiveEnvironmentDelegate
+    , WKImmersiveEnvironmentDelegate
 #endif
 > {
     RetainPtr<NSNumber> _stableStateOverride;
@@ -231,7 +232,7 @@ IGNORE_WARNINGS_END
         self.traitOverrides.displayScale = 2.0f;
 #endif
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-        self._immersiveEnvironmentDelegate = self;
+        self.immersiveEnvironmentDelegate = self;
 #endif
     }
     return self;
@@ -807,21 +808,21 @@ static bool isQuickboardViewController(UIViewController *viewController)
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
 
-#pragma mark - _WKImmersiveEnvironmentDelegate
+#pragma mark - WKImmersiveEnvironmentDelegate
 
-- (void)webView:(WKWebView *)webView allowImmersiveEnvironmentFromURL:(NSURL *)url completion:(void (^)(bool))completion
+- (void)webView:(WKWebView *)webView shouldAllowImmersiveEnvironmentFromFrame:(WKFrameInfo *)frame completionHandler:(void (^)(BOOL))completionHandler
 {
-    completion(self.shouldAcceptImmersiveEnvironmentRequests);
+    completionHandler(self.shouldAcceptImmersiveEnvironmentRequests);
 }
 
-- (void)webView:(WKWebView *)webView presentImmersiveEnvironment:(UIView *)environmentView completion:(void (^)(NSError * _Nullable))completion
+- (void)webView:(WKWebView *)webView presentImmersiveEnvironment:(WKImmersiveEnvironment *)environment completionHandler:(void (^)(NSError * _Nullable))completionHandler
 {
-    completion(nil);
+    completionHandler(nil);
 }
 
-- (void)webView:(WKWebView *)webView dismissImmersiveEnvironment:(void (^)())completion
+- (void)webView:(WKWebView *)webView dismissImmersiveEnvironment:(WKImmersiveEnvironment *)environment completionHandler:(void (^)(void))completionHandler
 {
-    completion();
+    completionHandler();
 }
 
 #endif

--- a/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
@@ -651,7 +651,7 @@ void TestController::setHasMouseDeviceForTesting(bool hasMouseDevice)
 void TestController::exitImmersive()
 {
     TestRunnerWKWebView *webView = mainWebView()->platformView();
-    [webView _exitImmersive];
+    [webView dismissImmersiveEnvironmentWithCompletionHandler:^{ }];
 }
 #endif
 


### PR DESCRIPTION
#### 794f0ec1309b56e62c53019b8906a24942cd8c50
<pre>
Move Client Website Environment SPI to API
<a href="https://bugs.webkit.org/show_bug.cgi?id=311751">https://bugs.webkit.org/show_bug.cgi?id=311751</a>
<a href="https://rdar.apple.com/164244457">rdar://164244457</a>

Reviewed by Etienne Segonzac and Abrar Rahman Protyasha.

Promote immersive environment SPI to public API

* Source/WebCore/dom/DocumentImmersive.cpp:
* Source/WebCore/dom/DocumentImmersive.h:
Add CompletionHandler parameter so callers can await dismissal.

* Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironment.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironment.mm: Added.
* Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironmentInternal.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironmentPrivate.h: Added.
New public class wrapping a website-provided immersive environment.

* Source/WebKit/UIProcess/API/Cocoa/WKImmersiveEnvironmentDelegate.h: Added.
New public delegate protocol for authorization, presentation, and dismissal.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
Add public immersive environment delegate and dismiss API.
Adopt new delegate protocol and WKImmersiveEnvironment object.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
Rename from underscore-prefixed SPI selectors.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration+Extras.swift:
Forward allowsImmersiveEnvironments from Swift Configuration wrapper.

* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm:
*Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:
* Source/WebKit/UIProcess/ios/WKVisibilityPropagationView.mm:
Unified source build fix.

* Source/WebKit/UIProcess/API/Swift/WebPage+FrameInfo.swift:
Make init @_spi(CrossImportOverlay) public for _WebKit_SwiftUI access.

* Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+ImmersiveEnvironment.swift: Added.
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
Switch from URL tracking to FrameInfo tracking with security origin
comparison. Make exitImmersive async with sendWithAsyncReply.

* Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift:
New SwiftUI modifier for immersive environment lifecycle management.

* Source/WebKit/_WebKit_SwiftUI/API/WebViewImmersiveEnvironmentView.swift: Added.
* Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift:
* Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift:
* Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift:
Add ImmersiveEnvironmentDelegateAdapter bridging SwiftUI callbacks to
WKImmersiveEnvironmentDelegate. Wire up in coordinator update.

* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm:
* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
Adopt WKImmersiveEnvironmentDelegate public protocol and updated selectors.

Canonical link: <a href="https://commits.webkit.org/311194@main">https://commits.webkit.org/311194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46ee330e42891e0de9c4424b0200cfa79142bcc4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164231 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109266 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157342 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28872 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28579 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120322 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84877 "2 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22514 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139615 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101012 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21600 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19709 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12061 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17447 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166709 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10886 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19057 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128432 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28273 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128569 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35020 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139240 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85634 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23407 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16037 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27891 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91994 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27468 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27698 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27541 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->