### PR TITLE
Web Inspector: Layers 3D view Three.js resource issues

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/Layers3DContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/Layers3DContentView.js
@@ -252,7 +252,13 @@ WI.Layers3DContentView = class Layers3DContentView extends WI.ContentView
         if (documentNode === this._documentNode)
             return false;
 
-        this._scene.children.length = 0;
+        this._pendingTextureLoads.clear();
+
+        for (let layerGroup of this._layerGroupsById.values()) {
+            this._disposeLayerGroupChildren(layerGroup);
+            this._scene.remove(layerGroup);
+        }
+
         this._layerGroupsById.clear();
         this._layers.length = 0;
 
@@ -269,8 +275,10 @@ WI.Layers3DContentView = class Layers3DContentView extends WI.ContentView
 
         for (let layer of removals) {
             let layerGroup = this._layerGroupsById.get(layer.layerId);
+            this._disposeLayerGroupChildren(layerGroup);
             this._scene.remove(layerGroup);
             this._layerGroupsById.delete(layer.layerId);
+            this._pendingTextureLoads.delete(layer.layerId);
         }
 
         if (this._selectedLayerGroup && !this._layerGroupsById.get(this._selectedLayerGroup.userData.layer.layerId))
@@ -375,6 +383,15 @@ WI.Layers3DContentView = class Layers3DContentView extends WI.ContentView
             };
             textureLoader.load(content, onLoad, onProgress, onError);
         });
+    }
+
+    _disposeLayerGroupChildren(layerGroup)
+    {
+        for (let child of layerGroup.children) {
+            child.geometry?.dispose();
+            child.material?.map?.dispose();
+            child.material?.dispose();
+        }
     }
 
     _createLayerMesh({x, y, width, height}, {isOutline, texture} = {})


### PR DESCRIPTION
#### 4bab01728a05a59e34e2b5517e0226439078d2e4
<pre>
Web Inspector: Layers 3D view Three.js resource issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=311684">https://bugs.webkit.org/show_bug.cgi?id=311684</a>
<a href="https://rdar.apple.com/174273220">rdar://174273220</a>

Reviewed by Devin Rousso.

Three.js geometries, materials, and textures require explicit dispose()
calls to free GPU resources. The previous code used
`this._scene.children.length = 0` to clear the scene on navigation,
which truncates the internal array without releasing any GPU memory and
without calling scene.remove() (leaving stale parent references on
orphaned groups). Similarly, when individual layers were removed during
layer tree mutations, scene.remove() was called but children&apos;s resources
were never disposed.

Additionally, _pendingTextureLoads was not cleared on navigation, so
in-flight backend snapshot requests from the previous page would still
complete and attempt to apply textures to removed layer groups.

* Source/WebInspectorUI/UserInterface/Views/Layers3DContentView.js:
(WI.Layers3DContentView.prototype._updateDocument):
(WI.Layers3DContentView.prototype._updateLayers):
(WI.Layers3DContentView.prototype._disposeLayerGroupChildren):

Canonical link: <a href="https://commits.webkit.org/310889@main">https://commits.webkit.org/310889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f081ff2184cee11da76715c782c0b3d5bc776f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164047 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28396 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120166 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158245 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139456 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100861 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21486 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11872 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147336 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131154 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17289 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166525 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18899 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128270 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28090 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23590 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128483 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34833 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28014 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139082 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23268 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15879 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27708 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91811 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27285 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27515 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27358 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->