### PR TITLE
Wasm OMG bounds check should use AboveEqual

### DIFF
--- a/JSTests/wasm/stress/omg-multimem-oob.js
+++ b/JSTests/wasm/stress/omg-multimem-oob.js
@@ -1,0 +1,140 @@
+//@ skip if !$isWasmPlatform
+//@ runDefault("--useDollarVM=1", "--useWasmMultiMemory=1", "--useWasmFastMemory=0", "--useConcurrentJIT=0")
+
+// Build minimal Wasm module with 2 memories and a function that loads from memory 1
+function buildModule() {
+    const bytes = [];
+    function emit(...bs) { bs.forEach(b => bytes.push(b & 0xFF)); }
+    function emitLEB(v) {
+        do {
+            let byte = v & 0x7F;
+            v >>>= 7;
+            if (v) byte |= 0x80;
+            bytes.push(byte);
+        } while (v);
+    }
+    function section(id, content) {
+        emit(id);
+        emitLEB(content.length);
+        content.forEach(b => bytes.push(b & 0xFF));
+    }
+
+    // Wasm header
+    emit(0x00, 0x61, 0x73, 0x6D); // magic
+    emit(0x01, 0x00, 0x00, 0x00); // version 1
+
+    // Type section: two types
+    // Type 0: (i32) -> (i32)  - for load function
+    // Type 1: (i32, i32) -> () - for store function
+    section(0x01, [
+        0x02,                    // 2 types
+        0x60, 0x01, 0x7F, 0x01, 0x7F,  // (i32) -> (i32)
+        0x60, 0x02, 0x7F, 0x7F, 0x00,  // (i32, i32) -> ()
+    ]);
+
+    // Function section: 2 functions
+    section(0x03, [
+        0x02,       // 2 functions
+        0x00,       // func 0 uses type 0
+        0x01,       // func 1 uses type 1
+    ]);
+
+    // Memory section: 2 memories, each 1 page
+    section(0x05, [
+        0x02,       // 2 memories
+        0x00, 0x01, // memory 0: no max, initial 1 page
+        0x00, 0x01, // memory 1: no max, initial 1 page
+    ]);
+
+    // Export section: export both functions and memory 1
+    section(0x07, [
+        0x03,       // 3 exports
+        // "load" -> func 0
+        0x04, 0x6C, 0x6F, 0x61, 0x64, 0x00, 0x00,
+        // "store" -> func 1
+        0x05, 0x73, 0x74, 0x6F, 0x72, 0x65, 0x00, 0x01,
+        // "mem1" -> memory 1
+        0x04, 0x6D, 0x65, 0x6D, 0x31, 0x02, 0x01,
+    ]);
+
+    // Code section
+    // func 0: (i32 addr) -> i32  { return i32.load8_u mem1[addr] }
+    const func0Body = [
+        0x00,             // 0 locals
+        0x20, 0x00,       // local.get 0 (addr)
+        0x2D,             // i32.load8_u
+        0x40,             // align=0 with multi-memory flag (bit 6)
+        0x01,             // memory index = 1
+        0x00,             // offset = 0
+        0x0B,             // end
+    ];
+    // func 1: (i32 addr, i32 val) -> void  { i32.store8 mem1[addr] = val }
+    const func1Body = [
+        0x00,             // 0 locals
+        0x20, 0x00,       // local.get 0 (addr)
+        0x20, 0x01,       // local.get 1 (val)
+        0x3A,             // i32.store8
+        0x40,             // align=0 with multi-memory flag (bit 6)
+        0x01,             // memory index = 1
+        0x00,             // offset = 0
+        0x0B,             // end
+    ];
+
+    const codeBodies = [];
+    codeBodies.push(func0Body.length);
+    func0Body.forEach(b => codeBodies.push(b));
+    codeBodies.push(func1Body.length);
+    func1Body.forEach(b => codeBodies.push(b));
+
+    const codeContent = [0x02]; // 2 function bodies
+    codeBodies.forEach(b => codeContent.push(b));
+
+    section(0x0A, codeContent);
+
+    return new Uint8Array(bytes);
+}
+
+const PAGE_SIZE = 65536;
+
+(function() {
+    const wasmBytes = buildModule();
+    const module = new WebAssembly.Module(wasmBytes);
+    const instance = new WebAssembly.Instance(module);
+
+    // Fill memory 1 with a known pattern near the boundary
+    const mem1 = new Uint8Array(instance.exports.mem1.buffer);
+    for (let i = PAGE_SIZE - 16; i < PAGE_SIZE; i++)
+        mem1[i] = 0xAA;
+
+    // Warm up both functions so OMG compiles them
+    for (let i = 0; i < 200000; i++) {
+        instance.exports.load(i & 0xFF);
+        instance.exports.store(i & 0xFF, 0x42);
+    }
+
+    // Sanity: load last valid byte (offset PAGE_SIZE - 1)
+    mem1[PAGE_SIZE - 1] = 0xBB;
+    let val = instance.exports.load(PAGE_SIZE - 1);
+    if (val != 0xBB) throw new Error("sanity check failed");
+
+    // BUG: load at exactly PAGE_SIZE (first invalid byte)
+    // For i32.load8_u, sizeOfOp=1, lastLoadedOffset = 0 + 1 - 1 = 0
+    // OMG check: pointer + 0 > memorySize  =>  65536 > 65536  =>  false  => NO TRAP
+    // Correct:   pointer + 0 >= memorySize  =>  65536 >= 65536 =>  true   => TRAP
+    let oob = false;
+    try {
+        let oobVal = instance.exports.load(PAGE_SIZE);
+        oob = true;
+    } catch (e) {
+    }
+    if (oob) throw new Error("out of bounds 1");
+
+    // BUG: store at exactly PAGE_SIZE (1-byte OOB write)
+    oob = false;
+    try {
+        instance.exports.store(PAGE_SIZE, 0xDE);
+        oob = true;
+    } catch (e) {
+    }
+    if (oob) throw new Error("out of bounds 2");
+})();

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -2392,7 +2392,7 @@ inline Value* OMGIRGenerator::emitCheckAndPreparePointer(Value* pointer, uint32_
     lastLoadedOffset += static_cast<uint64_t>(sizeOfOperation - 1);
     auto boundsCheckOffset = constant(Int64, lastLoadedOffset);
     pointer = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), pointer);
-    Value* outOfBounds = m_currentBlock->appendNew<Value>(m_proc, Above, origin(), m_currentBlock->appendNew<Value>(m_proc, Add, origin(), pointer, boundsCheckOffset), memorySize);
+    Value* outOfBounds = m_currentBlock->appendNew<Value>(m_proc, AboveEqual, origin(), m_currentBlock->appendNew<Value>(m_proc, Add, origin(), pointer, boundsCheckOffset), memorySize);
     // FIXME: this should probably use a CheckAdd once memory64 is supported
     CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(), outOfBounds);
     check->setGenerator([=, this, origin = this->origin()](CCallHelpers& jit, const B3::StackmapGenerationParams&) {


### PR DESCRIPTION
#### 7900f4775411a2bee6cd91de6b919ff383cec437
<pre>
Wasm OMG bounds check should use AboveEqual
<a href="https://bugs.webkit.org/show_bug.cgi?id=311756">https://bugs.webkit.org/show_bug.cgi?id=311756</a>
<a href="https://rdar.apple.com/174287745">rdar://174287745</a>

Reviewed by Yusuke Suzuki.

In bounds checking mode the OMG IR generator checks for overflow using
Above instead of AboveEqual, causing an off by one error if address is
the same as memory size. This patch fixes the check by emitting
AboveEqual.

Test: JSTests/wasm/stress/omg-multimem-oob.js

* JSTests/wasm/stress/omg-multimem-oob.js: Added.
(buildModule):
(buildModule.section):
(catch):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitCheckAndPreparePointer):

Canonical link: <a href="https://commits.webkit.org/310942@main">https://commits.webkit.org/310942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ace786a746d727b65afa4df7b908d73b16069a0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155256 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164016 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109044 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2807b326-e027-4eff-a1d1-77f4e2bc2ae9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28364 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120136 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84843 "2 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fae60fe4-56b8-44bb-a3d5-f43fb5719c97) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22391 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139427 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100831 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3bf99e1f-6974-48ab-a120-07d82efd7b11) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21477 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19527 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11842 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147306 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131144 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166495 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16087 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10653 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18871 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128240 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28060 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23561 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128377 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34869 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27984 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139055 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/84693 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23238 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15852 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187141 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27677 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91781 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47991 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27255 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27485 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27328 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->