### PR TITLE
[css-anchor-position-1] position-area can't anchor to an element positioned using anchor function

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/mixed-dependency-chain-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/mixed-dependency-chain-expected.txt
@@ -1,0 +1,15 @@
+You should see a row of boxes in order.
+
+12345678910
+
+PASS .target 1
+PASS .target 2
+PASS .target 3
+PASS .target 4
+PASS .target 5
+PASS .target 6
+PASS .target 7
+PASS .target 8
+PASS .target 9
+PASS .target 10
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/mixed-dependency-chain.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/mixed-dependency-chain.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+
+<title>Tests that chain of elements that anchor to each other using anchor() and position-area works.</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#determining">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<script src="support/test-common.js"></script>
+
+<style>
+  .containing-block {
+    border: 1px solid black;
+
+    position: relative;
+    width: 700px;
+    height: 500px;
+  }
+
+  .box {
+    width: 50px;
+    height: 50px;
+    position: absolute;
+    anchor-name: --box;
+
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  #box1 {
+    top: 0;
+    left: 0;
+    background: green;
+  }
+
+  .uses-anchor-function {
+    background: blue;
+    position-anchor: --box;
+    left: calc(anchor(right) + 10px);
+  }
+
+  .uses-position-area {
+    background: magenta;
+    position-anchor: --box;
+    position-area: right center;
+    margin-left: 10px;
+  }
+</style>
+
+<body onload="checkLayoutForAnchorPos('.target')">
+  <p>You should see a row of boxes in order.</p>
+
+  <div class="containing-block">
+    <div class="target box" id="box1" data-offset-x="0">1</div>
+
+    <div class="target box uses-position-area" data-offset-x="60">2</div>
+    <div class="target box uses-position-area" data-offset-x="120">3</div>
+
+    <div class="target box uses-anchor-function" data-offset-x="180">4</div>
+    <div class="target box uses-anchor-function" data-offset-x="240">5</div>
+
+    <div class="target box uses-position-area" data-offset-x="300">6</div>
+    <div class="target box uses-anchor-function" data-offset-x="360">7</div>
+    <div class="target box uses-position-area" data-offset-x="420">8</div>
+    <div class="target box uses-anchor-function" data-offset-x="480">9</div>
+    <div class="target box uses-position-area" data-offset-x="540">10</div>
+  </div>
+</body>

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -814,7 +814,7 @@ CheckedPtr<RenderBoxModelObject> AnchorPositionEvaluator::findAnchorForAnchorFun
     // should also have layout information for the anchor-positioned element alongside
     // the anchors referenced by the anchor-positioned element. Until then, we cannot
     // resolve this anchor() instance.
-    if (anchorPositionedState.stage <= AnchorPositionResolutionStage::FindAnchors)
+    if (anchorPositionedState.stage < AnchorPositionResolutionStage::Resolved)
         return { };
 
     auto anchorPositionedElement = anchorPositionedElementOrPseudoElement(builderState);
@@ -822,7 +822,6 @@ CheckedPtr<RenderBoxModelObject> AnchorPositionEvaluator::findAnchorForAnchorFun
     CheckedPtr anchorPositionedRenderer = anchorPositionedElement ? anchorPositionedElement->renderer() : nullptr;
     if (!anchorPositionedRenderer) {
         // If no render tree information is present, the procedure is finished.
-        anchorPositionedState.stage = AnchorPositionResolutionStage::Resolved;
         return { };
     }
 
@@ -831,21 +830,8 @@ CheckedPtr<RenderBoxModelObject> AnchorPositionEvaluator::findAnchorForAnchorFun
     RefPtr anchorElement = anchorPositionedState.anchorElements.get(resolvedAnchorName);
     if (!anchorElement) {
         // See: https://drafts.csswg.org/css-anchor-position-1/#valid-anchor-function
-        anchorPositionedState.stage = AnchorPositionResolutionStage::Resolved;
-
         return { };
     }
-
-    // FIXME: don't use Styleable::fromElement here.
-    if (auto* state = anchorPositionedStates.get(Styleable::fromElement(*anchorElement))) {
-        // Check if the anchor is itself anchor-positioned but hasn't been positioned yet.
-        if (state->stage < AnchorPositionResolutionStage::Positioned) {
-            anchorPositionedState.stage = AnchorPositionResolutionStage::WaitingForAnchorToBePositioned;
-            return { };
-        }
-    }
-
-    anchorPositionedState.stage = AnchorPositionResolutionStage::Resolved;
 
     return dynamicDowncast<RenderBoxModelObject>(anchorElement->renderer());
 }
@@ -1278,6 +1264,8 @@ void AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayou
     // FIXME: Make the code below oeprate on renderers (boxes) rather than elements.
     auto anchorsForAnchorName = collectAnchorsForAnchorName(document);
 
+    auto& anchorPositionedToAnchorMap = document.styleScope().anchorPositionedToAnchorMap();
+
     for (auto& [weakAnchorPositioned, state] : anchorPositionedStates) {
         auto anchorPositioned = weakAnchorPositioned.styleable();
         if (!anchorPositioned)
@@ -1301,10 +1289,13 @@ void AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayou
                         .name = anchorNameAndElement.key
                     });
                 }
-                document.styleScope().anchorPositionedToAnchorMap().set(*anchorPositioned, AnchorPositionedToAnchorEntry {
+
+                anchorPositionedToAnchorMap.set(*anchorPositioned, AnchorPositionedToAnchorEntry {
                     .anchors = WTF::move(anchors)
                 });
             }
+
+            // Temporary stage, the loop below could adjust it to WaitingForAnchorToBePositioned.
             state->stage = AnchorPositionResolutionStage::Resolved;
             break;
         }
@@ -1322,6 +1313,59 @@ void AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayou
         case AnchorPositionResolutionStage::Positioned:
             break;
         }
+    }
+
+    // This loop checks whether an anchor-positioned element anchors on another
+    // anchor-positioned element. If so, and the anchor isn't positioned yet,
+    // the anchor-positioned element has to wait until its anchor is positioned.
+    // This loop is done _after_ the above loop to give anchors the change to
+    // transition to Positioned.
+    for (auto& [weakAnchorPositioned, state] : anchorPositionedStates) {
+        auto anchorPositioned = weakAnchorPositioned.styleable();
+        if (!anchorPositioned)
+            continue;
+
+        // This loop should run all the time, even when an anchor-positioned is already
+        // Resolved/Positioned. It's possible an anchor it anchored to has regressed
+        // back to FindAnchors (e.g because it adds a new anchor reference after
+        // being Resolved/Positioned)
+
+        CheckedPtr anchorPositionedRenderer = anchorPositioned->renderer();
+        if (!anchorPositionedRenderer)
+            continue;
+
+        auto it = anchorPositionedToAnchorMap.find(*anchorPositioned);
+        if (it == anchorPositionedToAnchorMap.end())
+            continue;
+        auto& anchorPositionedToAnchorEntry = it->value;
+
+        bool allAnchorsPositioned = [&] () {
+            for (auto& anchor : anchorPositionedToAnchorEntry.anchors) {
+                CheckedPtr anchorRenderer = anchor.renderer;
+                if (!anchorRenderer)
+                    continue;
+
+                auto anchorElement = Styleable::fromRenderer(*anchorRenderer);
+                if (!anchorElement)
+                    continue;
+
+                if (auto anchorState = anchorPositionedStates.get(*anchorElement)) {
+                    if (anchorState->stage < AnchorPositionResolutionStage::Positioned)
+                        return false;
+                }
+            }
+
+            return true;
+        }();
+
+        if (allAnchorsPositioned) {
+            state->stage = std::max(state->stage, AnchorPositionResolutionStage::Resolved);
+            if (isLayoutTimeAnchorPositioned(anchorPositionedRenderer->style()))
+                anchorPositionedRenderer->setNeedsLayout();
+        } else
+            state->stage = AnchorPositionResolutionStage::WaitingForAnchorToBePositioned;
+
+        anchorPositionedToAnchorEntry.allAnchorsPositioned = allAnchorsPositioned;
     }
 }
 
@@ -1705,10 +1749,14 @@ CheckedPtr<RenderBoxModelObject> AnchorPositionEvaluator::defaultAnchorForBox(co
     auto it = anchorPositionedMap.find(*styleable);
     if (it == anchorPositionedMap.end())
         return nullptr;
+    auto& anchors = it->value;
+
+    if (!anchors.allAnchorsPositioned)
+        return nullptr;
 
     auto anchorName = ResolvedScopedName::createFromScopedName(styleable->element, defaultAnchorName(box.style()));
 
-    for (auto& anchor : it->value.anchors) {
+    for (auto& anchor : anchors.anchors) {
         if (anchorName == anchor.name)
             return anchor.renderer.get();
     }

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -136,9 +136,8 @@ enum class AnchorPositionResolutionStage : uint8_t {
     // transition to Resolved.
     WaitingForAnchorToBePositioned,
 
-    // The anchor-positioned element has resolved the anchors it refers to.
-    // If we determine any anchor(s) in itself is/are anchor-positioned,
-    // we kick it back to WaitingForAnchorToBePositioned.
+    // The anchor-positioned element has resolved the anchors it refers to, and
+    // the anchors are also at Positioned stage, if they themselves are anchor-positioned.
     Resolved,
 
     // The anchor-positioned element has been laid out and its position determined.
@@ -177,6 +176,10 @@ struct ResolvedAnchor {
 
 struct AnchorPositionedToAnchorEntry {
     Vector<ResolvedAnchor> anchors;
+
+    // True if all anchors above have been laid out and positioned.
+    // Only then can this anchor-positioned element be positioned.
+    bool allAnchorsPositioned { false };
 
     WTF_MAKE_STRUCT_TZONE_ALLOCATED(AnchorPositionedToAnchorEntry);
 };


### PR DESCRIPTION
#### 8ce3ea26b295d49e6b52b2a0473195ed3c4fef4b
<pre>
[css-anchor-position-1] position-area can&apos;t anchor to an element positioned using anchor function
<a href="https://rdar.apple.com/173964030">rdar://173964030</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311365">https://bugs.webkit.org/show_bug.cgi?id=311365</a>

Reviewed by Antti Koivisto.

309845@main explicitly serializes the resolution of elements in a chain of anchors
(chain of elements where one anchors to another and is also an anchor for other
elements to anchor to). But that only works when all elements uses anchor functions.
This patch brings this to elements using layout-time anchor positioning
(position-area and anchor-center)

1) In updateAnchorPositioningStatesAfterInterleavedLayout, add a loop that computes whether
   all anchor dependencies of an anchor-positioned element have been positioned or not, and
   store this result in AnchorPositionedToAnchorEntry (used by defaultAnchorForBox)
2) In defaultAnchorForBox, only resolves the default anchor box if all anchor dependencies
   have been positioned.

This patch also centralizes state machine transition logic to be under
updateAnchorPositioningStatesAfterInterleavedLayout. Previously this logic is scattered
around the anchor function resolution code.

Test: imported/w3c/web-platform-tests/css/css-anchor-position/mixed-dependency-chain.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/mixed-dependency-chain-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/mixed-dependency-chain.html: Added.
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::findAnchorForAnchorFunctionAndAttemptResolution):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout):
(WebCore::Style::AnchorPositionEvaluator::defaultAnchorForBox):
* Source/WebCore/style/AnchorPositionEvaluator.h:

Canonical link: <a href="https://commits.webkit.org/311601@main">https://commits.webkit.org/311601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f2be34f0b41f68a99344d1e999b0f0cda488614

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166008 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111267 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1bd4e557-9958-4592-93ee-699288698b62) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30657 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30524 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121727 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85470 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/950406b0-b4ee-4fb6-abb1-e88a4e081ee4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23976 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141140 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102395 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/367ca8bc-0f49-4bf3-a951-a41a8f8b774e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23031 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21269 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13780 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132711 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168493 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12652 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20588 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129863 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30123 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25347 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129971 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35265 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30046 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140762 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87867 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24789 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17566 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29757 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93771 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29279 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29509 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29406 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->