### PR TITLE
Web Inspector: InspectorLayerTreeAgent suppresses layer change events permanently after error

### DIFF
--- a/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp
@@ -122,6 +122,8 @@ void InspectorLayerTreeAgent::pseudoElementDestroyed(PseudoElement& pseudoElemen
 
 Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::LayerTree::Layer>>> InspectorLayerTreeAgent::layersForNode(Inspector::Protocol::DOM::NodeId nodeId)
 {
+    m_suppressLayerChangeEvents = false;
+
     Ref agents = m_instrumentingAgents.get();
     RefPtr node = CheckedPtr { agents->persistentDOMAgent() }->nodeForId(nodeId);
     if (!node)
@@ -137,8 +139,6 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::LayerT
     auto layers = JSON::ArrayOf<Inspector::Protocol::LayerTree::Layer>::create();
 
     gatherLayersUsingRenderObjectHierarchy(downcast<RenderElement>(*renderer), layers);
-
-    m_suppressLayerChangeEvents = false;
 
     return layers;
 }
@@ -363,14 +363,20 @@ Inspector::CommandResult<String> InspectorLayerTreeAgent::requestContent(const I
     if (layerSize.isEmpty())
         return makeUnexpected("Layer has zero size"_s);
 
-    constexpr float scaleFactor = 2.0;
-    IntSize integralSize = IntSize(layerSize);
+    // Limit scale factor for large layers to prevent excessive memory usage.
+    constexpr float maxScaleFactor = 2;
+    constexpr float maxSnapshotDimension = 4096;
+    float scaleFactor = std::min({
+        maxSnapshotDimension / layerSize.width(),
+        maxSnapshotDimension / layerSize.height(),
+        maxScaleFactor,
+    });
 
-    auto imageBuffer = ImageBuffer::create(integralSize, RenderingMode::Unaccelerated, RenderingPurpose::Snapshot, scaleFactor, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
+    auto imageBuffer = ImageBuffer::create(layerSize, RenderingMode::Unaccelerated, RenderingPurpose::Snapshot, scaleFactor, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
     if (!imageBuffer)
         return makeUnexpected("Failed to create image buffer"_s);
 
-    graphicsLayer->paintGraphicsLayerContents(imageBuffer->context(), { { }, integralSize });
+    graphicsLayer->paintGraphicsLayerContents(imageBuffer->context(), { { }, layerSize });
 
     return encodeDataURL(WTF::move(imageBuffer), "image/png"_s);
 }


### PR DESCRIPTION
#### 53f169c93ad3645e1386e4f46e3210728e6e5237
<pre>
Web Inspector: InspectorLayerTreeAgent suppresses layer change events permanently after error
<a href="https://bugs.webkit.org/show_bug.cgi?id=311755">https://bugs.webkit.org/show_bug.cgi?id=311755</a>
<a href="https://rdar.apple.com/174348493">rdar://174348493</a>

Reviewed by Devin Rousso and Qianlang Chen.

m_suppressLayerChangeEvents is set to true in layerTreeDidChange() but
only reset at the end of layersForNode() after the success path. Any
early error return (missing node, missing renderer) leaves the flag
permanently true, silently suppressing all future layerTreeDidChange
events and breaking the Layers tab. Move the reset to the top of
layersForNode so it fires unconditionally.

Also in requestContent-a FloatSize with sub-pixel dimensions (e.g.
0.5x100) passes isEmpty() but truncates to 0 in IntSize, causing a
division by zero in the scale factor calculation. Add an IntSize
emptiness guard. Cap the scale factor so snapshot pixel dimensions
never exceed 4096 in either axis, preventing excessive memory usage
on large composited layers.

* Source/WebCore/inspector/agents/InspectorLayerTreeAgent.cpp:
(WebCore::InspectorLayerTreeAgent::layersForNode):
(WebCore::InspectorLayerTreeAgent::requestContent):

Canonical link: <a href="https://commits.webkit.org/310890@main">https://commits.webkit.org/310890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fa776678c6062478689d958ccf60a32815a178b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28547 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164048 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e0cb4863-6989-4a62-8f4c-211cc67c59bf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28397 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120167 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d23175bb-9c9c-4412-a2b2-b25a132e63b9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158246 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22401 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139458 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100862 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21487 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11874 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131155 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17291 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166526 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18901 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128271 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28091 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128408 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34834 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28015 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139084 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85400 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23267 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15881 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27709 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91812 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27286 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27516 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27359 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->