### PR TITLE
REGRESSION(309943@main): Crashing under WebViewImpl::startDrag() on sub-pixel drag images

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4691,7 +4691,7 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Hand
     RetainPtr dragCGImage = dragImageAsBitmap->createPlatformImage(DontCopyBackingStore);
     auto dragNSImage = adoptNS([[NSImage alloc] initWithCGImage:dragCGImage.get() size:dragImageAsBitmap->size()]);
 
-    WebCore::IntSize size([dragNSImage size]);
+    WebCore::FloatSize size { [dragNSImage size] };
     size.scale(1.0 / m_page->deviceScaleFactor());
     [dragNSImage setSize:size];
 

--- a/Tools/TestWebKitAPI/Resources/cocoa/draggable-with-tiny-drag-image.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/draggable-with-tiny-drag-image.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body, html { width: 100%; height: 100%; margin: 0; }
+    #draggable {
+        width: 300px;
+        height: 100px;
+        background-color: salmon;
+    }
+    #tiny { position: absolute; width: 1px; height: 1px; }
+</style>
+</head>
+<body>
+<div id="draggable" draggable="true">Drag me</div>
+<img id="tiny" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">
+<script>
+window.dragStartFired = false;
+
+draggable.addEventListener("dragstart", event => {
+    var img = document.getElementById("tiny");
+    img.remove();
+    event.dataTransfer.setDragImage(img, 0, 0);
+    event.dataTransfer.setData("text/plain", "test");
+    window.dragStartFired = true;
+});
+
+document.body.addEventListener("dragover", event => event.preventDefault());
+</script>
+</body>
+</html>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm
@@ -169,6 +169,17 @@ TEST(DragAndDropTests, DragEndEventCoordinatesWithNestedIframes)
     }
 }
 
+TEST(DragAndDropTests, DraggableElementWithTinyDragImageDoesNotCrash)
+{
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = [simulator webView];
+    [webView synchronouslyLoadTestPageNamed:@"draggable-with-tiny-drag-image"];
+    [simulator runFrom:NSMakePoint(150, 50) to:NSMakePoint(150, 200)];
+    TestWebKitAPI::Util::waitForConditionWithLogging([&] -> bool {
+        return [webView stringByEvaluatingJavaScript:@"window.dragStartFired"].boolValue;
+    }, 2, @"Expected dragstart to fire for the tiny drag image case.");
+}
+
 TEST(DragAndDropTests, DropUserSelectAllUserDragElementDiv)
 {
     auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 320, 500)]);


### PR DESCRIPTION
#### 1ebe546b649dafed99e73e2da5f3cfc417422abb
<pre>
REGRESSION(309943@main): Crashing under WebViewImpl::startDrag() on sub-pixel drag images
<a href="https://bugs.webkit.org/show_bug.cgi?id=311757">https://bugs.webkit.org/show_bug.cgi?id=311757</a>
<a href="https://rdar.apple.com/174306324">rdar://174306324</a>

Reviewed by Richard Robinson and Aditya Keerthi.

NSDraggingItem.setDraggingFrame: throws NSRangeException for zero-size
frame rects. This was silently allowed prior to 309943@main by the older
dragImage: API. The frame is represented as an IntSize, so on a 2x
display, a 1×1 pixel bitmap scales to { 0, 0 }, leading to the problem.

In practice, this happens when sites call DataTransfer.setDragImage()
with a disconnected 1x1 &lt;img&gt; element (Slack does this). Since the image
elmeent is not connected, we store the cached image in m_dragImage
rather than the element in m_dragImageElement, following which we
snapshot this cached image, returning the raw pixel data - 1x1 sized.

This is not a problem for connected image elments since snapshotting
would render at CSS layout size in device pixels (i.e. producing a 2x2
bitmap in this case).

We fix this by simply using FloatSize instead of IntSize to preserve
sub-pixel frame sizes.

Tests: TestWebKitAPI.DragAndDropTests.DraggableElementWithTinyDragImageDoesNotCrash

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::startDrag):
* Tools/TestWebKitAPI/Resources/cocoa/draggable-with-tiny-drag-image.html: Added.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm:
(TEST(DragAndDropTests, DraggableElementWithTinyDragImageDoesNotCrash)):

Canonical link: <a href="https://commits.webkit.org/310831@main">https://commits.webkit.org/310831@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12bb377f0e5029e5cd8efc14da65c60ba8f24639

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163803 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/53524662-d72d-4d23-b447-0dc885b932ee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119951 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22216 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139227 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100644 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e6cc8fb6-5c0d-4e14-9878-17e5da8db5ad) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21301 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19338 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11629 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130963 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17070 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166279 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/9981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18679 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128053 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27847 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23377 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128191 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27771 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138863 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84480 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23644 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23067 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15658 "Found 1 new test failure: imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getSynchronizationSources.https.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27463 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91567 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27042 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27272 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27114 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->