### PR TITLE
Web Inspector: Layers 3D view maps textures to wrong bounds and tints them on selection

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/Layers3DContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/Layers3DContentView.js
@@ -282,7 +282,7 @@ WI.Layers3DContentView = class Layers3DContentView extends WI.ContentView
         }
 
         if (this._selectedLayerGroup && !this._layerGroupsById.get(this._selectedLayerGroup.userData.layer.layerId))
-            this.selectedLayerGroup = null;
+            this._selectedLayerGroup = null;
 
         for (let layer of additions) {
             let layerGroup = this._createLayerGroup(layer);
@@ -319,6 +319,9 @@ WI.Layers3DContentView = class Layers3DContentView extends WI.ContentView
         let outlineMesh = this._createLayerMesh(layer.compositedBounds, {isOutline: true});
         layerGroup.add(fillMesh, outlineMesh);
 
+        if (layerGroup === this._selectedLayerGroup)
+            this._applyLayerGroupStyle(layerGroup, WI.Layers3DContentView._selectedLayerColor);
+
         if (WI.settings.experimentalLayers3DShowLayerContents.value) {
             this._loadLayerTexture(layer, (texture) => {
                 if (!texture)
@@ -336,9 +339,12 @@ WI.Layers3DContentView = class Layers3DContentView extends WI.ContentView
                 fillMesh.material?.map?.dispose();
                 fillMesh.material?.dispose();
 
-                let texturedMesh = this._createLayerMesh(layer.bounds, {texture});
+                let texturedMesh = this._createLayerMesh(layer.compositedBounds, {texture});
                 layerGroup.add(texturedMesh);
                 layerGroup.add(outlineMesh);
+
+                if (layerGroup === this._selectedLayerGroup)
+                    this._applyLayerGroupStyle(layerGroup, WI.Layers3DContentView._selectedLayerColor);
             });
         }
     }
@@ -480,19 +486,30 @@ WI.Layers3DContentView = class Layers3DContentView extends WI.ContentView
 
     _updateLayerGroupSelection(layerGroup)
     {
-        let setColor = ({fill, stroke}) => {
-            let [plane, outline] = this._selectedLayerGroup.children;
-            plane.material.color.set(fill);
-            outline.material.color.set(stroke);
-        };
-
         if (this._selectedLayerGroup)
-            setColor(WI.Layers3DContentView._layerColor);
+            this._applyLayerGroupStyle(this._selectedLayerGroup, WI.Layers3DContentView._layerColor);
 
         this._selectedLayerGroup = layerGroup;
 
         if (this._selectedLayerGroup)
-            setColor(WI.Layers3DContentView._selectedLayerColor);
+            this._applyLayerGroupStyle(this._selectedLayerGroup, WI.Layers3DContentView._selectedLayerColor);
+    }
+
+    _applyLayerGroupStyle(layerGroup, color)
+    {
+        let [plane, outline] = layerGroup.children;
+        if (!plane)
+            return;
+
+        let isTextured = !!plane.material.map;
+
+        if (isTextured) {
+            let isSelected = color === WI.Layers3DContentView._selectedLayerColor;
+            plane.material.opacity = isSelected ? 0.85 : 1.0;
+        } else
+            plane.material.color.set(color.fill);
+
+        outline.material.color.set(color.stroke);
     }
 
     _centerOnSelection()


### PR DESCRIPTION
#### cea4509f7c052a29c84856dce0882f0c6124e382
<pre>
Web Inspector: Layers 3D view maps textures to wrong bounds and tints them on selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=311760">https://bugs.webkit.org/show_bug.cgi?id=311760</a>
<a href="https://rdar.apple.com/174355052">rdar://174355052</a>

Reviewed by Devin Rousso.

The layer content snapshot feature added textured meshes but the
selection styling was never updated to handle them. color.set() on a
textured material tints the snapshot image instead of highlighting it.
Extract _applyLayerGroupStyle that uses opacity for textured layers and
color for non-textured. Re-apply selection after texture load and
refresh.

Also fix textured meshes using layer.bounds instead of
layer.compositedBounds (causing distortion), and a missing underscore
on this.selectedLayerGroup that prevented clearing stale selection.

* Source/WebInspectorUI/UserInterface/Views/Layers3DContentView.js:
(WI.Layers3DContentView.prototype._updateLayers):
(WI.Layers3DContentView.prototype._populateLayerGroup):
(WI.Layers3DContentView.prototype._updateLayerGroupSelection):
(WI.Layers3DContentView.prototype._applyLayerGroupStyle):

Canonical link: <a href="https://commits.webkit.org/310891@main">https://commits.webkit.org/310891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1f67b62c85c6deba78f873b05b42cb9773d65d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155337 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164098 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4abcfece-4bb3-4a45-a257-3e24e09bc7a4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120212 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/15ea155a-dad9-4601-b076-b6e7f73988e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158296 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22415 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139501 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100902 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21501 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11928 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131169 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17333 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166576 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18943 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128322 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28141 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128454 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34835 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28065 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139126 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23307 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15923 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27759 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91862 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27336 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27566 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27409 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->