### PR TITLE
REGRESSION(309943@main): No drag event fired when pasteboard has only custom data type

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4793,6 +4793,7 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Hand
                     if (page->sessionID().isEphemeral())
                         [pasteboard _setExpirationDate:[NSDate dateWithTimeIntervalSinceNow:pasteboardExpirationDelay.seconds()]];
                 }
+                [pasteboard setString:@"" forType:PasteboardTypes::WebDummyPboardType];
                 page->didStartDrag(frameID);
             }
         });

--- a/Tools/TestWebKitAPI/Resources/cocoa/draggable-only-custom-data.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/draggable-only-custom-data.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body, html { width: 100%; height: 100%; margin: 0; }
+    #draggable {
+        width: 300px;
+        height: 100px;
+        background-color: cornflowerblue;
+    }
+</style>
+</head>
+<body>
+<div id="draggable" draggable="true">Drag me</div>
+<script>
+window.dragEventCount = 0;
+window.dragOverEventCount = 0;
+
+draggable.addEventListener("dragstart", event => {
+    event.dataTransfer.setData("application/x-custom", "test-data");
+});
+
+draggable.addEventListener("drag", () => {
+    window.dragEventCount++;
+});
+
+document.body.addEventListener("dragover", event => {
+    window.dragOverEventCount++;
+    event.preventDefault();
+});
+</script>
+</body>
+</html>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm
@@ -180,6 +180,26 @@ TEST(DragAndDropTests, DraggableElementWithTinyDragImageDoesNotCrash)
     }, 2, @"Expected dragstart to fire for the tiny drag image case.");
 }
 
+TEST(DragAndDropTests, DraggableElementWithOnlyCustomPasteboardDataFiresDragEvents)
+{
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = [simulator webView];
+    [webView synchronouslyLoadTestPageNamed:@"draggable-only-custom-data"];
+    [simulator runFrom:NSMakePoint(150, 50) to:NSMakePoint(150, 200)];
+
+    TestWebKitAPI::Util::waitForConditionWithLogging([&] -> bool {
+        return [webView stringByEvaluatingJavaScript:@"window.dragEventCount"].intValue > 0;
+    }, 2, @"Expected drag events to fire on the source element.");
+
+    TestWebKitAPI::Util::waitForConditionWithLogging([&] -> bool {
+        return [webView stringByEvaluatingJavaScript:@"window.dragOverEventCount"].intValue > 0;
+    }, 2, @"Expected dragover events to fire on the drop target.");
+
+    // WebDummyPboardType should be on the drag pasteboard so
+    // AppKit recognizes the view as a valid drag destination.
+    EXPECT_TRUE([simulator containsDraggedType:@"Apple WebKit dummy pasteboard type"]);
+}
+
 TEST(DragAndDropTests, DropUserSelectAllUserDragElementDiv)
 {
     auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 320, 500)]);


### PR DESCRIPTION
#### 9df7894d2af3a88365856881afcb60eaa691e9e1
<pre>
REGRESSION(309943@main): No drag event fired when pasteboard has only custom data type
<a href="https://bugs.webkit.org/show_bug.cgi?id=311762">https://bugs.webkit.org/show_bug.cgi?id=311762</a>
<a href="https://rdar.apple.com/174354602">rdar://174354602</a>

Reviewed by Wenson Hsieh.

The migration to beginDraggingSessionWithItems: in the regressing commit
removed the line that wrote WebDummyPboardType to the pasteboard before
starting the drag. WebDummyPboardType (&quot;Apple WebKit dummy pasteboard
type&quot;) is one of the types the web view registers for via
registerForDraggedTypes:. When the pasteboard contains only types the
view isn&apos;t registered for (e.g. com.apple.WebKit.custom-pasteboard-data),
AppKit does not recognize the view as a valid drag destination and never
calls draggingEntered: or draggingUpdated:. As a result, drag events
never fire, breaking sites like Slack which hide the default drag
preview with a 1x1 drag image and place a custom overlay via drag
events.

To fix this, we restore WebDummyPboardType on the drag pasteboard after
restoring legacy data in the DHTML/legacy drag path.

Tests: TestWebKitAPI.DragAndDropTests.DraggableElementWithOnlyCustomPasteboardDataFiresDragEvents

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::startDrag):
* Tools/TestWebKitAPI/Resources/cocoa/draggable-only-custom-data.html: Added.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm:
(TEST(DragAndDropTests, DraggableElementWithOnlyCustomPasteboardDataFiresDragEvents)):

Canonical link: <a href="https://commits.webkit.org/310833@main">https://commits.webkit.org/310833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78e5f6e643f74838bbfca1276fcd07a6466a195e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28421 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/21580 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163921 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f25742e-6233-4867-be0e-4e4c87c1fd12) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157034 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28269 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/120050 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158120 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/22304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/139335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/100745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d22a167-1576-40ff-9410-14098ceb463b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11747 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/17175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166399 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/18784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128155 "Failed to checkout and rebase branch from PR 62302") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/27965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/23478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128292 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27889 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/138968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/84598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23645 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/23156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27582 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/91686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/27160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/27390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27233 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->