### PR TITLE
Add uncaught script error and unhandled promise rejection reporting for Web Extensions.

### DIFF
--- a/Source/JavaScriptCore/runtime/StackFrame.cpp
+++ b/Source/JavaScriptCore/runtime/StackFrame.cpp
@@ -141,9 +141,9 @@ SourceID StackFrame::sourceID() const
     return noSourceID;
 }
 
-static String processSourceURL(VM& vm, const JSC::StackFrame& frame, const String& sourceURL)
+static String processSourceURL(VM& vm, const JSC::StackFrame& frame, const String& sourceURL, AllowURLOverride allowOverride = AllowURLOverride::Yes)
 {
-    if (vm.clientData && (!protocolIsInHTTPFamily(sourceURL) && !protocolIs(sourceURL, "blob"_s))) {
+    if (allowOverride == AllowURLOverride::Yes && vm.clientData && (!protocolIsInHTTPFamily(sourceURL) && !protocolIs(sourceURL, "blob"_s))) {
         String overrideURL = vm.clientData->overrideSourceURL(frame, sourceURL);
         if (!overrideURL.isNull())
             return overrideURL;
@@ -154,20 +154,20 @@ static String processSourceURL(VM& vm, const JSC::StackFrame& frame, const Strin
     return emptyString();
 }
 
-String StackFrame::sourceURL(VM& vm) const
+String StackFrame::sourceURL(VM& vm, AllowURLOverride allowOverride) const
 {
     return WTF::switchOn(m_frameData,
-        [&vm, this](const JSFrameData& jsFrame) -> String {
+        [&vm, allowOverride, this](const JSFrameData& jsFrame) -> String {
             if (isAsyncFrameWithoutCodeBlock()) {
                 ASSERT(jsFrame.callee);
                 ASSERT(!jsFrame.codeBlock);
                 JSFunction* calleeFn = jsDynamicCast<JSFunction*>(jsFrame.callee.get());
-                return processSourceURL(vm, *this, calleeFn->jsExecutable()->sourceURL());
+                return processSourceURL(vm, *this, calleeFn->jsExecutable()->sourceURL(), allowOverride);
             }
 
             if (!jsFrame.codeBlock)
                 return "[native code]"_s;
-            return processSourceURL(vm, *this, jsFrame.codeBlock->ownerExecutable()->sourceURL());
+            return processSourceURL(vm, *this, jsFrame.codeBlock->ownerExecutable()->sourceURL(), allowOverride);
         },
         [](const WasmFrameData& wasmFrame) -> String {
             auto moduleName = wasmFrame.functionIndexOrName.moduleName();

--- a/Source/JavaScriptCore/runtime/StackFrame.h
+++ b/Source/JavaScriptCore/runtime/StackFrame.h
@@ -52,6 +52,8 @@ struct WasmFrameData {
     size_t functionIndex { 0 };
 };
 
+enum class AllowURLOverride : bool { No, Yes };
+
 class StackFrame {
 public:
     using FrameData = Variant<JSFrameData, WasmFrameData>;
@@ -96,7 +98,7 @@ public:
     LineColumn computeLineAndColumn() const;
     String functionName(VM&) const;
     SourceID sourceID() const;
-    String sourceURL(VM&) const;
+    JS_EXPORT_PRIVATE String sourceURL(VM&, AllowURLOverride = AllowURLOverride::Yes) const;
     String sourceURLStripped(VM&) const;
     String toString(VM&) const;
 

--- a/Source/WebCore/bindings/js/JSDOMExceptionHandling.cpp
+++ b/Source/WebCore/bindings/js/JSDOMExceptionHandling.cpp
@@ -29,6 +29,7 @@
 #include "JSDOMWindow.h"
 #include "LocalDOMWindow.h"
 #include "ScriptExecutionContext.h"
+#include "WebCoreJSClientData.h"
 #include <JavaScriptCore/ErrorHandlingScope.h>
 #include <JavaScriptCore/Exception.h>
 #include <JavaScriptCore/ExceptionHelpers.h>
@@ -133,6 +134,18 @@ void reportException(JSGlobalObject* lexicalGlobalObject, JSC::Exception* except
     }
 
     auto errorMessage = retrieveErrorMessage(*lexicalGlobalObject, vm, exception->value(), scope);
+
+    if (globalObject->hasScriptErrorCallbacks()) {
+        // The call stack may contain masked URLs (e.g. webkit-masked-url://hidden/) for scripts
+        // whose origin is hidden from the page (e.g. extension content scripts in the main world).
+        // Use the unmasked URL from the exception's code blocks for internal reporting.
+        auto unmaskedSourceURL = exceptionSourceURL;
+        if (auto url = unmaskedSourceURLFromException(*exception, vm); !url.isEmpty())
+            unmaskedSourceURL = url;
+
+        globalObject->invokeScriptErrorCallbacks(errorMessage, unmaskedSourceURL, lineNumber, columnNumber);
+    }
+
     protect(globalObject->scriptExecutionContext())->reportException(errorMessage, lineNumber, columnNumber, exceptionSourceURL, exception, callStack->size() ? callStack.ptr() : nullptr, cachedScript, fromModule);
 
     if (exceptionDetails) {

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -807,6 +807,22 @@ JSC::JSObject* JSDOMGlobalObject::readableStreamByteStrategySize()
     return m_readableStreamByteStrategySize.get();
 }
 
+void JSDOMGlobalObject::addScriptErrorCallback(ScriptErrorCallback&& callback)
+{
+    m_scriptErrorCallbacks.append(WTF::move(callback));
+}
+
+bool JSDOMGlobalObject::hasScriptErrorCallbacks() const
+{
+    return !m_scriptErrorCallbacks.isEmpty();
+}
+
+void JSDOMGlobalObject::invokeScriptErrorCallbacks(const String& message, const String& sourceURL, unsigned lineNumber, unsigned columnNumber) const
+{
+    for (auto& callback : m_scriptErrorCallbacks)
+        callback(message, sourceURL, lineNumber, columnNumber);
+}
+
 JSDOMGlobalObject* toJSDOMGlobalObject(ScriptExecutionContext& context, DOMWrapperWorld& world)
 {
     if (auto* document = dynamicDowncast<Document>(context))

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.h
@@ -119,6 +119,12 @@ public:
 
     JSC::JSObject* readableStreamByteStrategySize();
 
+    using ScriptErrorCallback = Function<void(const String& message, const String& sourceURL, unsigned lineNumber, unsigned columnNumber)>;
+
+    void addScriptErrorCallback(ScriptErrorCallback&&);
+    bool hasScriptErrorCallbacks() const;
+    void invokeScriptErrorCallbacks(const String& message, const String& sourceURL, unsigned lineNumber, unsigned columnNumber) const;
+
 protected:
     JSDOMGlobalObject(JSC::VM&, JSC::Structure*, Ref<DOMWrapperWorld>&&, const JSC::GlobalObjectMethodTable* = nullptr);
     void finishCreation(JSC::VM&);
@@ -156,6 +162,7 @@ private:
     JSC::WeakGCMap<CrossOriginMapKey, JSC::JSFunction> m_crossOriginFunctionMap;
     JSC::WeakGCMap<CrossOriginMapKey, JSC::GetterSetter> m_crossOriginGetterSetterMap;
     JSC::Weak<JSC::JSObject> m_readableStreamByteStrategySize;
+    Vector<ScriptErrorCallback> m_scriptErrorCallbacks;
 };
 
 JSDOMGlobalObject* toJSDOMGlobalObject(ScriptExecutionContext&, DOMWrapperWorld&);

--- a/Source/WebCore/bindings/js/WebCoreJSClientData.cpp
+++ b/Source/WebCore/bindings/js/WebCoreJSClientData.cpp
@@ -199,6 +199,17 @@ void JSVMClientData::initNormalWorld(VM* vm, WorkerThreadType type)
     vm->m_typedArrayController = adoptRef(new WebCoreTypedArrayController(type == WorkerThreadType::DedicatedWorker || type == WorkerThreadType::Worklet));
 }
 
+String unmaskedSourceURLFromException(const JSC::Exception& exception, JSC::VM& vm)
+{
+    for (auto& frame : exception.stack()) {
+        String url = frame.sourceURL(vm, JSC::AllowURLOverride::No);
+        if (!url.isEmpty() && url != "[native code]"_s)
+            return url;
+    }
+
+    return emptyString();
+}
+
 String JSVMClientData::overrideSourceURL(const JSC::StackFrame& frame, const String& originalSourceURL) const
 {
     if (originalSourceURL.isEmpty())

--- a/Source/WebCore/bindings/js/WebCoreJSClientData.h
+++ b/Source/WebCore/bindings/js/WebCoreJSClientData.h
@@ -33,6 +33,10 @@
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 
+namespace JSC {
+class Exception;
+}
+
 namespace WebCore {
 
 class ExtendedDOMClientIsoSubspaces;
@@ -193,6 +197,10 @@ private:
 
     WeakHashSet<JSVMClientDataClient> m_clients;
 };
+
+// Returns the first non-native source URL from the exception's stack frames without applying
+// URL masking, unlike StackFrame::sourceURL(VM&) which goes through overrideSourceURL.
+String unmaskedSourceURLFromException(const JSC::Exception&, JSC::VM&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/dom/RejectedPromiseTracker.cpp
+++ b/Source/WebCore/dom/RejectedPromiseTracker.cpp
@@ -35,6 +35,7 @@
 #include "Node.h"
 #include "PromiseRejectionEvent.h"
 #include "ScriptExecutionContext.h"
+#include "WebCoreJSClientData.h"
 #include <JavaScriptCore/Exception.h>
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/JSCJSValueInlines.h>
@@ -58,9 +59,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RejectedPromiseTracker);
 class UnhandledPromise {
     WTF_MAKE_NONCOPYABLE(UnhandledPromise);
 public:
-    UnhandledPromise(JSDOMGlobalObject& globalObject, JSPromise& promise, RefPtr<ScriptCallStack>&& stack)
+    UnhandledPromise(JSDOMGlobalObject& globalObject, JSPromise& promise, RefPtr<ScriptCallStack>&& stack, String&& unmaskedSourceURL)
         : m_promise(DOMPromise::create(globalObject, promise))
         , m_stack(WTF::move(stack))
+        , m_unmaskedSourceURL(WTF::move(unmaskedSourceURL))
     {
     }
 
@@ -76,9 +78,12 @@ public:
         return m_promise.get();
     }
 
+    const String& unmaskedSourceURL() const { return m_unmaskedSourceURL; }
+
 private:
     const Ref<DOMPromise> m_promise;
     const RefPtr<ScriptCallStack> m_stack;
+    String m_unmaskedSourceURL;
 };
 
 
@@ -110,7 +115,17 @@ void RejectedPromiseTracker::promiseRejected(JSDOMGlobalObject& globalObject, JS
     // https://html.spec.whatwg.org/multipage/webappapis.html#the-hostpromiserejectiontracker-implementation
 
     JSValue reason = promise.result();
-    m_aboutToBeNotifiedRejectedPromises.append(UnhandledPromise { globalObject, promise, createScriptCallStackFromReason(globalObject, reason) });
+
+    String unmaskedURL;
+    if (globalObject.hasScriptErrorCallbacks()) {
+        // Capture the unmasked source URL now while vm.lastException() is still set.
+        // The JSC::Exception is not kept alive past this point, so it won't be available
+        // when reportUnhandledRejections runs asynchronously via a posted task.
+        if (auto* exception = globalObject.vm().lastException(); exception && exception->value() == reason)
+            unmaskedURL = unmaskedSourceURLFromException(*exception, globalObject.vm());
+    }
+
+    m_aboutToBeNotifiedRejectedPromises.append(UnhandledPromise { globalObject, promise, createScriptCallStackFromReason(globalObject, reason), WTF::move(unmaskedURL) });
 }
 
 void RejectedPromiseTracker::promiseHandled(JSDOMGlobalObject& globalObject, JSPromise& promise)
@@ -174,7 +189,7 @@ void RejectedPromiseTracker::reportUnhandledRejections(Vector<UnhandledPromise>&
         target->dispatchEvent(event);
 
         if (!event->defaultPrevented())
-            m_context->reportUnhandledPromiseRejection(lexicalGlobalObject, promise, unhandledPromise.callStack());
+            m_context->reportUnhandledPromiseRejection(lexicalGlobalObject, promise, unhandledPromise.callStack(), unhandledPromise.unmaskedSourceURL());
 
         if (!promise.isHandled())
             m_outstandingRejectedPromises.set(&promise, &promise);

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -45,6 +45,7 @@
 #include "FontLoadRequest.h"
 #include "FrameDestructionObserverInlines.h"
 #include "JSDOMExceptionHandling.h"
+#include "JSDOMGlobalObject.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSWorkerGlobalScope.h"
 #include "JSWorkletGlobalScope.h"
@@ -554,7 +555,7 @@ void ScriptExecutionContext::reportException(const String& errorMessage, int lin
         logExceptionToConsole(exception->m_errorMessage, exception->m_sourceURL, exception->m_lineNumber, exception->m_columnNumber, WTF::move(exception->m_callStack));
 }
 
-void ScriptExecutionContext::reportUnhandledPromiseRejection(JSC::JSGlobalObject& state, JSC::JSPromise& promise, RefPtr<Inspector::ScriptCallStack>&& callStack)
+void ScriptExecutionContext::reportUnhandledPromiseRejection(JSC::JSGlobalObject& state, JSC::JSPromise& promise, RefPtr<Inspector::ScriptCallStack>&& callStack, const String& unmaskedSourceURL)
 {
     Page* page = nullptr;
     if (auto* document = dynamicDowncast<Document>(*this))
@@ -585,6 +586,25 @@ void ScriptExecutionContext::reportUnhandledPromiseRejection(JSC::JSGlobalObject
 
     if (!errorMessage)
         errorMessage = "Unhandled Promise Rejection"_s;
+
+    if (auto* domGlobalObject = jsDynamicCast<JSDOMGlobalObject*>(&state); domGlobalObject && domGlobalObject->hasScriptErrorCallbacks()) {
+        // Use the unmasked source URL captured at rejection time when available; fall back
+        // to the call stack URL which may be masked for extension content scripts.
+        String rejectionSourceURL = unmaskedSourceURL;
+        unsigned rejectionLine = 0;
+        unsigned rejectionColumn = 0;
+
+        if (callStack) {
+            if (auto* frame = callStack->firstNonNativeCallFrame()) {
+                if (rejectionSourceURL.isEmpty())
+                    rejectionSourceURL = frame->sourceURL();
+                rejectionLine = frame->lineNumber();
+                rejectionColumn = frame->columnNumber();
+            }
+        }
+
+        domGlobalObject->invokeScriptErrorCallbacks(resultMessage, rejectionSourceURL, rejectionLine, rejectionColumn);
+    }
 
     std::unique_ptr<Inspector::ConsoleMessage> message;
     if (callStack)

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -186,7 +186,7 @@ public:
 
     bool canIncludeErrorDetails(CachedScript*, const String& sourceURL, bool = false);
     void reportException(const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL, JSC::Exception*, RefPtr<Inspector::ScriptCallStack>&&, CachedScript* = nullptr, bool = false);
-    void reportUnhandledPromiseRejection(JSC::JSGlobalObject&, JSC::JSPromise&, RefPtr<Inspector::ScriptCallStack>&&);
+    void reportUnhandledPromiseRejection(JSC::JSGlobalObject&, JSC::JSPromise&, RefPtr<Inspector::ScriptCallStack>&&, const String& unmaskedSourceURL = { });
 
     virtual void addConsoleMessage(std::unique_ptr<Inspector::ConsoleMessage>&&) = 0;
 

--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -7,6 +7,9 @@
 /* accessibility help text for media controller time value >= 60 seconds */
 "%1$d minutes %2$d seconds" = "%1$d minutes %2$d seconds";
 
+/* Label for PDF page number indicator. */
+"%1$d of %2$d" = "%1$d of %2$d";
+
 /* accessibility help text for media controller time value < 60 seconds */
 "%1$d seconds" = "%1$d seconds";
 
@@ -64,9 +67,6 @@
 /* Visible name of the web process. The argument is the application name. */
 "%@ Web Content (Prewarmed)" = "%@ Web Content (Prewarmed)";
 
-/* Extension's process name that appears in Activity Monitor where the parameter is the name of the extension */
-"%s Web Extension" = "%s Web Extension";
-
 /* Visible name of Web Inspector's web process. The argument is the application name. */
 "%@ Web Inspector" = "%@ Web Inspector";
 
@@ -76,20 +76,11 @@
 /* The domain and application using the camera and/or microphone. The first argument is domain, the second is the application name (iOS only). */
 "%@ in %%@" = "%@ in %%@";
 
-/* Label for an inspectable Web Extension background page */
-"%s — Extension Background Page" = "%s— Extension Background Page";
-
 /* Label for an inspectable Web Extension popup page */
 "%@ — Extension Popup Page" = "%@ — Extension Popup Page";
 
-/* Label for an inspectable Web Extension service worker */
-"%s — Extension Service Worker" = "%s — Extension Service Worker";
-
 /* Label to describe the number of files selected in a file upload control that allows multiple files */
 "%d files" = "%d files";
-
-/* Label for PDF page number indicator. */
-"%1$d of %2$d" = "%1$d of %2$d";
 
 /* Codec Level (Codec Strings) */
 "%d.%d" = "%d.%d";
@@ -99,6 +90,15 @@
 
 /* window title for a standalone image (uses multiplication symbol, not x) */
 "%s %d×%d pixels" = "%s %d×%d pixels";
+
+/* Extension's process name that appears in Activity Monitor where the parameter is the name of the extension */
+"%s Web Extension" = "%s Web Extension";
+
+/* Label for an inspectable Web Extension background page */
+"%s — Extension Background Page" = "%s — Extension Background Page";
+
+/* Label for an inspectable Web Extension service worker */
+"%s — Extension Service Worker" = "%s — Extension Service Worker";
 
 /* Present the number of selected <option> items in a <select multiple> element (iOS only) */
 "%zu Items" = "%zu Items";
@@ -132,6 +132,9 @@
 
 /* WKErrorJavaScriptExceptionOccurred description */
 "A JavaScript exception occurred" = "A JavaScript exception occurred";
+
+/* WKWebExtensionContextErrorScriptExecutionError description */
+"A script error has occurred." = "A script error has occurred.";
 
 /* Codec Strings */
 "AAC-LC Codec String" = "AAC-LC";
@@ -286,14 +289,14 @@
 /* Cancel */
 "Cancel" = "Cancel";
 
+/* Cancel displaying QuickLook Preview of 3D object */
+"Cancel (QuickLook Preview)" = "Cancel";
+
 /* Button title in Device Orientation Permission API prompt */
 "Cancel (device motion and orientation access)" = "Cancel";
 
 /* Cancel displaying QuickLook Preview of 3D model */
 "Cancel (usdz QuickLook Preview)" = "Cancel";
-
-/* Cancel displaying QuickLook Preview of 3D object */
-"Cancel (QuickLook Preview)" = "Cancel";
 
 /* Title for Cancel button label in button bar */
 "Cancel button label in button bar" = "Cancel";
@@ -428,7 +431,7 @@
 "DAY (Date picker for extra zoom mode)" = "DAY";
 
 /* Base accessibility text for the window containing the date picker of <input type='date'> */
-"Date Picker Window Accessibility Title" = "date picker";
+"Date Picker Window Accessibility Title" = "Date Picker Window Accessibility Title";
 
 /* Phishing warning title */
 "Deceptive Website Warning" = "Deceptive Website Warning";
@@ -599,10 +602,7 @@
 "Exceeded maximum number of `declarative_net_request` rulesets. Ignoring extra rulesets." = "Exceeded maximum number of `declarative_net_request` rulesets. Ignoring extra rulesets.";
 
 /* WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for too many enabled static rulesets */
-"Exceeded maximum number of enabled `declarative_net_request` static rulesets. The first %lu will be applied, the remaining will be ignored." = "Exceeded maximum number of enabled `declarative_net_request` static rulesets. The first %lu will be applied, the remaining will be ignored.";
-
-/* WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for a duplicated rule id */
-"`declarative_net_request` ruleset with id `%@` duplicates the rule id `%@`." = "`declarative_net_request` ruleset with id `%@` duplicates the rule id `%@`.";
+"Exceeded maximum number of enabled `declarative_net_request` static rulesets. The first %zu will be applied, the remaining will be ignored." = "Exceeded maximum number of enabled `declarative_net_request` static rulesets. The first %zu will be applied, the remaining will be ignored.";
 
 /* Button for exiting full screen when in full screen media playback */
 "Exit Full Screen" = "Exit Full Screen";
@@ -661,12 +661,6 @@
 /* Default application name for Open With context menu */
 "Finder" = "Finder";
 
-/* Inspector element selection tooltip text for Flexbox containers. */
-"flex (Inspector Element Selection)" = "flex";
-
-/* Inspector element selection tooltip text for items inside a Flexbox Container. */
-"flex item (Inspector Element Selection)" = "flex item";
-
 /* Font context sub-menu item */
 "Font" = "Font";
 
@@ -690,21 +684,6 @@
 
 /* Action from safe browsing warning */
 "Go Back" = "Go Back";
-
-/* Google Safe Browsing */
-"Google Safe Browsing" = "Google Safe Browsing";
-
-/* Inspector element selection tooltip text for Grid containers. */
-"grid (Inspector Element Selection)" = "grid";
-
-/* Inspector element selection tooltip text for Grid Lanes containers. */
-"grid lanes (Inspector Element Selection)" = "grid lanes";
-
-/* Inspector element selection tooltip text for items inside a Grid Container. */
-"grid item (Inspector Element Selection)" = "grid item";
-
-/* Inspector element selection tooltip text for Subgrid containers. */
-"subgrid (Inspector Element Selection)" = "subgrid";
 
 /* Codec Strings */
 "HEVC (Codec String)" = "HEVC";
@@ -750,9 +729,6 @@
 
 /* WKWebExtensionMatchPatternErrorInvalidHost description for invalid or missing host */
 "Host \"%s\" is invalid." = "Host \"%s\" is invalid.";
-
-/* Phishing warning description */
-"This website was reported as deceptive by %provider-display-name%. If you believe this website is safe, you can %report-an-error% to %provider%. Or, if you understand the risks involved, you can %bypass-link%." = "This website was reported as deceptive by %provider-display-name%. If you believe this website is safe, you can %report-an-error% to %provider%. Or, if you understand the risks involved, you can %bypass-link%.";
 
 /* Action from safe browsing warning */
 "If you understand the risks involved, you can %visit-this-unsafe-site-link%." = "If you understand the risks involved, you can %visit-this-unsafe-site-link%.";
@@ -817,7 +793,7 @@
 /* Undo action name */
 "Italics (Undo action name)" = "Italics";
 
-/* Inspector Grid/Flex Item DOM order label */
+/* Inspector Grid Item DOM order label */
 "Item %lu" = "Item %lu";
 
 /* WebKitErrorJavaUnavailable description */
@@ -931,6 +907,9 @@
 /* Codec Strings */
 "Level 7.3 (AV1 Codec Level)" = "Level 7.3";
 
+/* Codec Strings */
+"Level Maximum (AV1 Codec Level)" = "Level Maximum";
+
 /* Media controller status message when watching a live broadcast */
 "Live Broadcast" = "Live Broadcast";
 
@@ -1006,11 +985,11 @@
 /* Malware warning title */
 "Malware Website Warning" = "Malware Website Warning";
 
-/* Media Element Source Type */
-"ManagedMediaSource (Media Element Source Type)" = "Managed Media Source";
-
 /* Subtitle Styles Submenu Link to System Preferences */
 "Manage Styles (Caption Style Menu Title)" = "Manage Styles";
+
+/* Media Element Source Type */
+"ManagedMediaSource (Media Element Source Type)" = "Managed Media Source";
 
 /* WKWebExtensionErrorInvalidBackgroundContent description for empty or invalid preferred environment key */
 "Manifest `background` entry has an empty or invalid `preferred_environment` key." = "Manifest `background` entry has an empty or invalid `preferred_environment` key.";
@@ -1162,17 +1141,11 @@
 /* Title for Open in External Application Link action button */
 "Open in “%@”" = "Open in “%@”";
 
-/* context menu item for PDF */
+/* Open with default PDF viewer context menu item */
 "Open with %@" = "Open with %@";
-
-/* Open with Preview context menu item */
-"Open with Preview" = "Open with Preview";
 
 /* Codec Strings */
 "Opus Codec String" = "Opus";
-
-/* Inspector Grid/Flex Item CSS order property label */
-"order: %d" = "order: %d";
 
 /* Label for the order with Apple Pay button. */
 "Order with Apple Pay" = "Order with Apple Pay";
@@ -1324,6 +1297,9 @@
 /* Display name for SDH (i.e. deaf and/or hard of hearing) text tracks. */
 "SDH (text track)" = "SDH";
 
+/* Label for Spatial Photos with image controls next to spatial glyph */
+"SPATIAL" = "SPATIAL";
+
 /* Title for Save to Photos action button */
 "Save to Photos" = "Save to Photos";
 
@@ -1423,14 +1399,11 @@
 /* Smart Links context menu item */
 "Smart Links" = "Smart Links";
 
-/* Smart Quotes context menu item */
-"Smart Quotes" = "Smart Quotes";
-
 /* Smart Lists context menu item */
 "Smart Lists" = "Smart Lists";
 
-/* Label for Spatial Photos with image controls next to spatial glyph */
-"SPATIAL" = "SPATIAL";
+/* Smart Quotes context menu item */
+"Smart Quotes" = "Smart Quotes";
 
 /* Speech context sub-menu item */
 "Speech" = "Speech";
@@ -1471,11 +1444,11 @@
 /* Label for strong password. */
 "Strong Password" = "Strong Password";
 
-/* Styles context menu item */
-"Styles…" = "Styles…";
-
 /* Subtitles media controls menu title */
 "Styles (Media Controls Menu)" = "Styles";
+
+/* Styles context menu item */
+"Styles…" = "Styles…";
 
 /* default label for Submit buttons in forms on web pages */
 "Submit" = "Submit";
@@ -1521,9 +1494,6 @@
 
 /* Validation message for required switches that are not on */
 "Tap this switch" = "Tap this switch";
-
-/* Tencent Safe Browsing */
-"Tencent Safe Browsing" = "Tencent Safe Browsing";
 
 /* Text Replacement context menu item */
 "Text Replacement" = "Text Replacement";
@@ -1582,14 +1552,17 @@
 /* Title when a PDF needs a password to be unlocked */
 "This document is password protected." = "This document is password protected.";
 
+/* Description HTML for frame unloaded by ResourceMonitor */
+"This frame is hidden for using too many system resources." = "This frame is hidden for using too many system resources.";
+
+/* Caption Style Preview String */
+"This is a preview style (Caption User Preferences)" = "This is a preview style";
+
 /* text that appears at the start of nearly-obsolete web pages in the form of a 'searchable index' */
 "This is a searchable index. Enter search keywords: " = "This is a searchable index. Enter search keywords: ";
 
 /* This is the %s subtitle style (Caption User Preferences) */
 "This is the %s subtitle style" = "This is the %s subtitle style";
-
-/* Caption Style Preview String */
-"This is a preview style" = "This is a preview style";
 
 /* Not Secure Connection warning text */
 "This website does not support connecting securely over HTTPS. The information you see and enter on this website, including credit cards, phone numbers, and passwords, can be read and altered by other people." = "This website does not support connecting securely over HTTPS. The information you see and enter on this website, including credit cards, phone numbers, and passwords, can be read and altered by other people.";
@@ -1602,6 +1575,9 @@
 
 /* Unwanted software warning */
 "This website may try to trick you into installing software that harms your browsing experience, like changing your settings without your permission or showing you unwanted ads. Once installed, it may be difficult to remove." = "This website may try to trick you into installing software that harms your browsing experience, like changing your settings without your permission or showing you unwanted ads. Once installed, it may be difficult to remove.";
+
+/* Phishing warning description */
+"This website was reported as deceptive by %provider-display-name%. If you believe this website is safe, you can %report-an-error% to %provider%. Or, if you understand the risks involved, you can %bypass-link%." = "This website was reported as deceptive by %provider-display-name%. If you believe this website is safe, you can %report-an-error% to %provider%. Or, if you understand the risks involved, you can %bypass-link%.";
 
 /* Message informing the user that the website will have approximate location data */
 "This website will use your approximate location because “%@” currently has access to your approximate location." = "This website will use your approximate location because “%@” currently has access to your approximate location.";
@@ -1674,6 +1650,12 @@
 
 /* WKWebExtensionErrorResourceNotFound description with invalid file path */
 "Unable to find \"%@\" in the extension’s resources. It is an invalid path." = "Unable to find \"%@\" in the extension’s resources. It is an invalid path.";
+
+/* WKWebExtensionErrorResourceNotFound description with file name */
+"Unable to find \"%s\" in the extension’s resources." = "Unable to find \"%s\" in the extension’s resources.";
+
+/* WKWebExtensionErrorResourceNotFound description with invalid file path */
+"Unable to find \"%s\" in the extension’s resources. It is an invalid path." = "Unable to find \"%s\" in the extension’s resources. It is an invalid path.";
 
 /* Error description for missing default_locale */
 "Unable to find `default_locale` in “_locales” folder." = "Unable to find `default_locale` in “_locales” folder.";
@@ -1765,32 +1747,26 @@
 /* Validation message for input form controls with value higher than allowed maximum */
 "Value must be less than or equal to %s" = "Value must be less than or equal to %s";
 
-/* Title for View Spatial action button while in fullscreen */
-"View Spatial" = "View Spatial";
-
-/* Title for View Immersive action button while in fullscreen */
-"View Immersive" = "View Immersive";
-
-/* Allow displaying QuickLook Preview of 3D model */
-"View in AR (usdz QuickLook Preview)" = "View in AR";
-
-/* View in AR? */
-"View in AR?" = "View in AR?";
-
-/* View in AR? description */
-"You can view this object in 3D and place it in your surroundings using augmented reality." = "You can view this object in 3D and place it in your surroundings using augmented reality.";
-
 /* Allow displaying QuickLook Preview of 3D object */
 "View 3D Object (QuickLook Preview)" = "View 3D Object";
 
 /* View 3D Object? */
 "View 3D Object?" = "View 3D Object?";
 
-/* View 3D Object description */
-"You can see a preview of this object before viewing in 3D." = "You can see a preview of this object before viewing in 3D.";
+/* Title for View Immersive action button while in fullscreen */
+"View Immersive" = "View Immersive";
+
+/* Title for View Spatial action button while in fullscreen */
+"View Spatial" = "View Spatial";
 
 /* Title for View Spatial Photo action button */
 "View Spatial Photo" = "View Spatial Photo";
+
+/* Allow displaying QuickLook Preview of 3D model */
+"View in AR (usdz QuickLook Preview)" = "View in AR";
+
+/* View in AR? */
+"View in AR?" = "View in AR?";
 
 /* Codec Strings */
 "Vorbis Codec String" = "Vorbis";
@@ -1825,6 +1801,12 @@
 /* Year label in date picker */
 "YEAR (Date picker for extra zoom mode)" = "YEAR";
 
+/* You can see a preview of this object before viewing in 3D. */
+"You can see a preview of this object before viewing in 3D." = "You can see a preview of this object before viewing in 3D.";
+
+/* You can view this object in 3D and place it in your surroundings using augmented reality. */
+"You can view this object in 3D and place it in your surroundings using augmented reality." = "You can view this object in 3D and place it in your surroundings using augmented reality.";
+
 /* message in authentication panel */
 "Your login information will be sent securely." = "Your login information will be sent securely.";
 
@@ -1854,6 +1836,9 @@
 
 /* WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for duplicate ruleset id */
 "`declarative_net_request` ruleset with id \"%s\" is invalid. Ruleset id must be unique." = "`declarative_net_request` ruleset with id \"%s\" is invalid. Ruleset id must be unique.";
+
+/* WKWebExtensionErrorInvalidDeclarativeNetRequestEntry description for a duplicated rule id */
+"`declarative_net_request` ruleset with id `%@` duplicates the rule id `%@`." = "`declarative_net_request` ruleset with id `%@` duplicates the rule id `%@`.";
 
 /* Verb stating the action that will occur when a text field is selected, as used by accessibility */
 "activate" = "activate";
@@ -1966,14 +1951,26 @@
 /* accessibility role description for a file upload button */
 "file upload button" = "file upload button";
 
-/* accessibility role description for a footer */
-"footer" = "footer";
+/* Inspector element selection tooltip text for Flexbox containers. */
+"flex (Inspector Element Selection)" = "flex";
 
-/* accessibility role description for a form */
- "form" = "form";
+/* Inspector element selection tooltip text for items inside a Flexbox Container. */
+"flex item (Inspector Element Selection)" = "flex item";
+
+/* An ARIA accessibility group that acts as a form region. */
+"form" = "form";
 
 /* Web Push Notification string to indicate the name of the Web App/Web Site a notification was sent from, such as 'from Wikipedia' */
 "from %@" = "from %@";
+
+/* Inspector element selection tooltip text for Grid containers. */
+"grid (Inspector Element Selection)" = "grid";
+
+/* Inspector element selection tooltip text for items inside a Grid Container. */
+"grid item (Inspector Element Selection)" = "grid item";
+
+/* Inspector element selection tooltip text for Grid Lanes containers. */
+"grid lanes (Inspector Element Selection)" = "grid lanes";
 
 /* accessibility role description for headings */
 "heading" = "heading";
@@ -2071,6 +2068,9 @@
 /* The optimum value description for a meter element. */
 "optimal value" = "optimal value";
 
+/* Inspector Grid Item CSS order property label */
+"order: %d" = "order: %d";
+
 /* accessibility role description for an output element */
 "output" = "output";
 
@@ -2101,9 +2101,6 @@
 /* accessibility label for time remaining display */
 "remaining time" = "remaining time";
 
-/* prefix for announcing removed content in ARIA live regions */
-"removed" = "removed";
-
 /* Action from safe browsing warning */
 "report an error" = "report an error";
 
@@ -2118,6 +2115,12 @@
 
 /* accessibility label for seconds fields. */
 "seconds" = "seconds";
+
+/* accessibility role description for a footer */
+"section footer" = "section footer";
+
+/* accessibility role description for a header */
+"section header" = "section header";
 
 /* accessibility help text for jump back 30 seconds button */
 "seek movie back 30 seconds" = "seek movie back 30 seconds";
@@ -2134,12 +2137,6 @@
 /* accessibility role description for a horizontal rule [<hr>] */
 "separator" = "separator";
 
-/* accessibility role description for a footer region [<footer>] */
-"section footer" = "section footer";
-
-/* accessibility role description for a header region [<header>] */
-"section header" = "section header";
-
 /* accessibility label for show closed captions button */
 "show closed captions" = "show closed captions";
 
@@ -2154,6 +2151,9 @@
 
 /* Label for the strong password AutoFill button inside a text field. */
 "strong password AutoFill" = "strong password AutoFill";
+
+/* Inspector element selection tooltip text for Subgrid containers. */
+"subgrid (Inspector Element Selection)" = "subgrid";
 
 /* The suboptimal value description for a meter element. */
 "suboptimal value" = "suboptimal value";
@@ -2242,5 +2242,3 @@
 /* Option in segmented control for choosing list type in text editing */
 "•" = "•";
 
-/* Description HTML for frame unloaded by ResourceMonitor */
-"This frame is hidden for using too many system resources." = "This frame is hidden for using too many system resources.";

--- a/Source/WebCore/page/FrameConsoleClient.cpp
+++ b/Source/WebCore/page/FrameConsoleClient.cpp
@@ -53,6 +53,7 @@
 #include "InspectorInstrumentation.h"
 #include "IntRect.h"
 #include "JSCanvasRenderingContext2D.h"
+#include "JSDOMGlobalObject.h"
 #include "JSDOMRectReadOnly.h"
 #include "JSExecState.h"
 #include "JSHTMLCanvasElement.h"
@@ -210,22 +211,24 @@ void FrameConsoleClient::addMessage(MessageSource source, MessageLevel level, co
 void FrameConsoleClient::messageWithTypeAndLevel(MessageType type, MessageLevel level, JSC::JSGlobalObject* lexicalGlobalObject, Ref<Inspector::ScriptArguments>&& arguments)
 {
     String messageText;
-    std::span<const String> additionalArguments;
-    Vector<String> messageArgumentsVector = arguments->getArgumentsAsStrings();
-    if (!messageArgumentsVector.isEmpty()) {
-        messageText = messageArgumentsVector.first();
-        additionalArguments = messageArgumentsVector.subspan(1);
-    }
+    arguments->getFirstArgumentAsString(messageText);
 
     auto message = makeUnique<Inspector::ConsoleMessage>(MessageSource::ConsoleAPI, type, level, messageText, arguments.copyRef(), lexicalGlobalObject);
 
-    String url = message->url();
-    unsigned lineNumber = message->line();
-    unsigned columnNumber = message->column();
+    auto url = message->url();
+    auto lineNumber = message->line();
+    auto columnNumber = message->column();
+
+    auto* domGlobalObject = jsDynamicCast<JSDOMGlobalObject*>(lexicalGlobalObject);
+    if (level == MessageLevel::Error && domGlobalObject && domGlobalObject->hasScriptErrorCallbacks()) {
+        auto fullMessageText = makeStringByJoining(arguments->getArgumentsAsStrings(), " "_s);
+        domGlobalObject->invokeScriptErrorCallbacks(fullMessageText, url, lineNumber, columnNumber);
+    }
 
 #if ENABLE(WEBDRIVER_BIDI)
     AutomationInstrumentation::addMessageToConsole(message);
 #endif
+
     Ref frame = m_frame.get();
     InspectorInstrumentation::addMessageToConsole(frame.get(), WTF::move(message));
 
@@ -236,7 +239,7 @@ void FrameConsoleClient::messageWithTypeAndLevel(MessageType type, MessageLevel 
     if (page->usesEphemeralSession())
         return;
 
-    if (!messageArgumentsVector.isEmpty()) {
+    if (arguments->argumentCount()) {
         page->chrome().client().addMessageToConsole(MessageSource::ConsoleAPI, level, messageText, lineNumber, columnNumber, url);
 
         if (RefPtr consoleMessageListener = page->consoleMessageListenerForTesting())

--- a/Source/WebCore/workers/WorkerConsoleClient.cpp
+++ b/Source/WebCore/workers/WorkerConsoleClient.cpp
@@ -34,6 +34,7 @@
 #include "InspectorCanvas.h"
 #include "InspectorInstrumentation.h"
 #include "IntRect.h"
+#include "JSDOMGlobalObject.h"
 #include "JSImageBitmap.h"
 #include "JSImageBitmapRenderingContext.h"
 #include "JSImageData.h"
@@ -77,8 +78,15 @@ void WorkerConsoleClient::messageWithTypeAndLevel(MessageType type, MessageLevel
 {
     String messageText;
     arguments->getFirstArgumentAsString(messageText);
-    auto message = makeUnique<Inspector::ConsoleMessage>(MessageSource::ConsoleAPI, type, level, messageText, WTF::move(arguments), exec);
-    Ref { m_globalScope.get() }->addConsoleMessage(WTF::move(message));
+
+    auto message = makeUnique<Inspector::ConsoleMessage>(MessageSource::ConsoleAPI, type, level, messageText, arguments.copyRef(), exec);
+    protect(m_globalScope.get())->addConsoleMessage(WTF::move(message));
+
+    auto* domGlobalObject = jsDynamicCast<JSDOMGlobalObject*>(exec);
+    if (level == MessageLevel::Error && domGlobalObject && domGlobalObject->hasScriptErrorCallbacks()) {
+        auto fullMessageText = makeStringByJoining(arguments->getArgumentsAsStrings(), " "_s);
+        domGlobalObject->invokeScriptErrorCallbacks(fullMessageText, message->url(), message->line(), message->column());
+    }
 }
 
 void WorkerConsoleClient::count(JSC::JSGlobalObject* exec, const String& label)

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -836,12 +836,11 @@ localizedStrings["Fragment Shader"] = "Fragment Shader";
 localizedStrings["Frame"] = "Frame";
 localizedStrings["Frame %d"] = "Frame %d";
 localizedStrings["Frame %d \u2014 %s"] = "Frame %d \u2014 %s";
+localizedStrings["Frame Targets"] = "Frame Targets";
 localizedStrings["Frames"] = "Frames";
 localizedStrings["Frames %d \u2013 %d"] = "Frames %d \u2013 %d";
 /* Title for list of HTML subframe JavaScript execution contexts */
 localizedStrings["Frames @ Execution Context Picker"] = "Frames";
-/* Title for list of site-isolated frame JavaScript execution contexts */
-localizedStrings["Frame Targets"] = "Frame Targets";
 /* Title for Frames row in Media Sidebar */
 localizedStrings["Frames @ Media Sidebar Frame Count"] = "Frames";
 localizedStrings["Full Garbage Collection"] = "Full Garbage Collection";
@@ -1325,6 +1324,7 @@ localizedStrings["Power Efficient Playback"] = "Power Efficient Playback";
 localizedStrings["Prefer Shorthands"] = "Prefer Shorthands";
 localizedStrings["Prefer indent using:"] = "Prefer indent using:";
 localizedStrings["Preserve Log"] = "Preserve Log";
+/* Label for option that controls whether captured network requests are cleared when the page navigates. */
 localizedStrings["Preserve Requests @ Network Tab"] = "Preserve Requests";
 localizedStrings["Press %s to create a new audit."] = "Press %s to create a new audit.";
 localizedStrings["Press %s to enable audits."] = "Press %s to enable audits.";
@@ -1742,7 +1742,7 @@ localizedStrings["Subscript @ Font Details Sidebar Property Value"] = "Subscript
 localizedStrings["Subtree Modified @ DOM Breakpoint"] = "Subtree Modified";
 localizedStrings["Suggest property names based on usage"] = "Suggest property names based on usage";
 localizedStrings["Summary"] = "Summary";
-/* Section header for network redirect details. */
+/* Section header for network redirect details */
 localizedStrings["Summary @ Network Redirect Headers"] = "Summary";
 /* Property value for `font-variant-position: super`. */
 localizedStrings["Superscript @ Font Details Sidebar Property Value"] = "Superscript";
@@ -1943,15 +1943,23 @@ localizedStrings["Video Details @ Media Sidebar"] = "Video Details";
 localizedStrings["Video Format @ Media Sidebar"] = "Video Format";
 /* Value string for Video Range color in the Media Sidebar */
 localizedStrings["Video range @ Media Sidebar"] = "Video range";
-localizedStrings["View Redirect"] = "View Redirect";
-localizedStrings["View Response"] = "View Response";
 localizedStrings["View Image"] = "View Image";
 localizedStrings["View Recording"] = "View Recording";
+localizedStrings["View Redirect"] = "View Redirect";
+localizedStrings["View Response"] = "View Response";
 localizedStrings["View Shader"] = "View Shader";
 localizedStrings["Viewport"] = "Viewport";
 /* Title for Viewport row in Media Sidebar */
 localizedStrings["Viewport @ Media Sidebar"] = "Viewport";
 localizedStrings["Visible"] = "Visible";
+/* Tooltip for AA contrast line in color picker */
+localizedStrings["WCAG AA minimum contrast (4.5:1) @ Tooltip for AA contrast line in color picker"] = "WCAG AA minimum contrast (4.5:1)";
+/* Tooltip for AA contrast line in color picker for large text */
+localizedStrings["WCAG AA minimum contrast for large text (3:1) @ Tooltip for AA contrast line in color picker"] = "WCAG AA minimum contrast for large text (3:1)";
+/* Tooltip for AAA contrast line in color picker */
+localizedStrings["WCAG AAA enhanced contrast (7:1) @ Tooltip for AAA contrast line in color picker"] = "WCAG AAA enhanced contrast (7:1)";
+/* Tooltip for AAA contrast line in color picker for large text */
+localizedStrings["WCAG AAA enhanced contrast for large text (4.5:1) @ Tooltip for AAA contrast line in color picker"] = "WCAG AAA enhanced contrast for large text (4.5:1)";
 localizedStrings["Waiting"] = "Waiting";
 localizedStrings["Waiting for animations created by CSS."] = "Waiting for animations created by CSS.";
 localizedStrings["Waiting for animations created by JavaScript."] = "Waiting for animations created by JavaScript.";
@@ -1964,14 +1972,6 @@ localizedStrings["Warning: "] = "Warning: ";
 localizedStrings["Warnings"] = "Warnings";
 localizedStrings["Watch Expressions"] = "Watch Expressions";
 localizedStrings["Waterfall"] = "Waterfall";
-/* Tooltip for AA contrast line in color picker */
-localizedStrings["WCAG AA minimum contrast (4.5:1) @ Tooltip for AA contrast line in color picker"] = "WCAG AA minimum contrast (4.5:1)";
-/* Tooltip for AA contrast line in color picker for large text */
-localizedStrings["WCAG AA minimum contrast for large text (3:1) @ Tooltip for AA contrast line in color picker"] = "WCAG AA minimum contrast for large text (3:1)";
-/* Tooltip for AAA contrast line in color picker */
-localizedStrings["WCAG AAA enhanced contrast (7:1) @ Tooltip for AAA contrast line in color picker"] = "WCAG AAA enhanced contrast (7:1)";
-/* Tooltip for AAA contrast line in color picker for large text */
-localizedStrings["WCAG AAA enhanced contrast for large text (4.5:1) @ Tooltip for AAA contrast line in color picker"] = "WCAG AAA enhanced contrast for large text (4.5:1)";
 localizedStrings["Web Animation"] = "Web Animation";
 /* Section title for the JavaScript backtrace of the creation of a web animation */
 localizedStrings["Web Animation Backtrace Title"] = "Backtrace";

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContextPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContextPrivate.h
@@ -27,6 +27,9 @@
 
 @class _WKWebExtensionSidebar;
 
+/*! @abstract Indicates a script error occurred in the extension, such as an uncaught exception, unhandled promise rejection, or a call to console.error(). */
+static const WKWebExtensionContextError WKWebExtensionContextErrorScriptExecutionError = (WKWebExtensionContextError)7;
+
 WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface WKWebExtensionContext ()

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -246,6 +246,20 @@ void WebExtensionContext::clearError(Error error)
     }).get());
 }
 
+void WebExtensionContext::didEncounterScriptError(const String& message, const String& sourceURL, uint32_t lineNumber, uint32_t columnNumber, WebExtensionContentWorldType)
+{
+    auto path = sourceURL.isEmpty() ? String() : URL(sourceURL).path().toString();
+    if (path.startsWith('/'))
+        path = path.substring(1);
+    auto location = !path.isEmpty() ? (columnNumber ? makeString(path, ':', lineNumber, ':', columnNumber) : makeString(path, ':', lineNumber)) : String();
+    String description;
+    if (message.isEmpty())
+        description = !location.isEmpty() ? makeString('(', location, ')') : String();
+    else
+        description = !location.isEmpty() ? makeString(message, " ("_s, location, ')') : message;
+    recordError(createError(Error::ScriptExecutionError, description));
+}
+
 Expected<bool, RefPtr<API::Error>> WebExtensionContext::load(WebExtensionController& controller, String storageDirectory)
 {
     if (isLoaded()) {

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -66,6 +66,8 @@ int WebExtensionContext::toAPIError(WebExtensionContext::Error error)
         return static_cast<int>(WebExtensionContext::APIError::NoBackgroundContent);
     case WebExtensionContext::Error::BackgroundContentFailedToLoad:
         return static_cast<int>(WebExtensionContext::APIError::BackgroundContentFailedToLoad);
+    case WebExtensionContext::Error::ScriptExecutionError:
+        return static_cast<int>(WebExtensionContext::APIError::ScriptExecutionError);
     }
 
     ASSERT_NOT_REACHED();
@@ -100,6 +102,10 @@ Ref<API::Error> WebExtensionContext::createError(Error error, const String& cust
 
     case Error::BackgroundContentFailedToLoad:
         localizedDescription = WEB_UI_STRING("The background content failed to load due to an error.", "WKWebExtensionContextErrorBackgroundContentFailedToLoad description");
+        break;
+
+    case Error::ScriptExecutionError:
+        localizedDescription = WEB_UI_STRING("A script error has occurred.", "WKWebExtensionContextErrorScriptExecutionError description");
         break;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -262,6 +262,7 @@ public:
         BaseURLAlreadyInUse,
         NoBackgroundContent,
         BackgroundContentFailedToLoad,
+        ScriptExecutionError,
     };
 
     // Keep in sync with WKWebExtensionContextError values
@@ -271,7 +272,8 @@ public:
         NotLoaded,
         BaseURLAlreadyInUse,
         NoBackgroundContent,
-        BackgroundContentFailedToLoad
+        BackgroundContentFailedToLoad,
+        ScriptExecutionError,
     };
 
     enum class PermissionNotification : uint8_t {
@@ -875,6 +877,9 @@ private:
 
     // Extension APIs
     void extensionIsAllowedIncognitoAccess(CompletionHandler<void(bool)>&&);
+
+    // Runtime Error Reporting
+    void didEncounterScriptError(const String& message, const String& sourceURL, uint32_t lineNumber, uint32_t columnNumber, WebExtensionContentWorldType);
 
     // Menus APIs
     bool isMenusMessageAllowed(IPC::Decoder&);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -31,6 +31,9 @@
     DispatchedTo=UI
 ]
 messages -> WebExtensionContext {
+    // Runtime Error Reporting
+    [Validator=isLoaded] DidEncounterScriptError(String message, String sourceURL, uint32_t lineNumber, uint32_t columnNumber, WebKit::WebExtensionContentWorldType worldType)
+
     // Action APIs
     [Validator=isActionMessageAllowed] ActionGetTitle(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (Expected<String, WebKit::WebExtensionError> result)
     [Validator=isActionMessageAllowed] ActionSetTitle(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, String title) -> (Expected<void, WebKit::WebExtensionError> result)

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
@@ -34,8 +34,10 @@
 #include "WebPage.h"
 #include <JavaScriptCore/APICast.h>
 #include <JavaScriptCore/JSClassRef.h>
+#include <JavaScriptCore/JSLock.h>
 #include <JavaScriptCore/JSObjectRef.h>
 #include <JavaScriptCore/JSWeakObjectMapRefPrivate.h>
+#include <WebCore/JSDOMExceptionHandling.h>
 #include <WebCore/JSDOMGlobalObject.h>
 
 namespace WebKit {
@@ -114,7 +116,16 @@ JSValueRef callWithArguments(JSObjectRef callbackFunction, JSRetainPtr<JSGlobalC
     if (!context || context->activeDOMObjectsAreStopped())
         return nil;
 
-    return JSObjectCallAsFunction(globalContext.get(), callbackFunction, nullptr, ArgumentCount, arguments.data(), nullptr);
+    JSValueRef exception = nullptr;
+    JSValueRef result = JSObjectCallAsFunction(globalContext.get(), callbackFunction, nullptr, ArgumentCount, arguments.data(), &exception);
+    if (exception) {
+        JSC::JSLockHolder lock(globalObject->vm());
+        auto exceptionValue = toJS(globalObject, exception);
+        RELEASE_LOG_ERROR(Extensions, "Uncaught exception in extension callback: %" PUBLIC_LOG_STRING, exceptionValue.toWTFString(globalObject).utf8().data());
+        WebCore::reportException(globalObject, exceptionValue);
+    }
+
+    return result;
 }
 
 void WebExtensionCallbackHandler::reportError(const String& message)

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
@@ -202,6 +202,11 @@ Ref<WebCore::DOMWrapperWorld> WebExtensionContextProxy::toDOMWrapperWorld(WebExt
     }
 }
 
+void WebExtensionContextProxy::didEncounterScriptError(const String& message, const String& sourceURL, unsigned lineNumber, unsigned columnNumber, WebExtensionContentWorldType worldType)
+{
+    WebProcess::singleton().send(Messages::WebExtensionContext::DidEncounterScriptError(message, sourceURL, lineNumber, columnNumber, worldType), identifier());
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
@@ -44,6 +44,8 @@
 #include "WebFrame.h"
 #include "WebPage.h"
 #include "WebProcess.h"
+#include <JavaScriptCore/APICast.h>
+#include <WebCore/JSDOMGlobalObject.h>
 
 namespace WebKit {
 
@@ -97,6 +99,12 @@ void WebExtensionControllerProxy::globalObjectIsAvailableForFrame(WebPage& page,
         // This is a safer cpp false positive (rdar://163760990).
         SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, globalObject, chromeString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
     }
+
+    if (auto* domGlobalObject = JSC::jsDynamicCast<JSDOMGlobalObject*>(toJS(context))) {
+        domGlobalObject->addScriptErrorCallback([extension = Ref { *extension }, contentWorldType](const String& message, const String& sourceURL, unsigned lineNumber, unsigned columnNumber) {
+            extension->didEncounterScriptError(message, sourceURL, lineNumber, columnNumber, contentWorldType);
+        });
+    }
 }
 
 void WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame(WebPage& page, WebFrame& frame, DOMWrapperWorld& world)
@@ -129,6 +137,12 @@ void WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame(W
         // This is a safer cpp false positive (rdar://163760990).
         SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, globalObject, chromeString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
     }
+
+    if (auto* domGlobalObject = JSC::jsDynamicCast<JSDOMGlobalObject*>(toJS(context))) {
+        domGlobalObject->addScriptErrorCallback([extension = Ref { *extension }](const String& message, const String& sourceURL, unsigned lineNumber, unsigned columnNumber) {
+            extension->didEncounterScriptError(message, sourceURL, lineNumber, columnNumber, WebExtensionContentWorldType::Main);
+        });
+    }
 }
 
 void WebExtensionControllerProxy::addBindingsToWebPageFrameIfNecessary(WebFrame& frame, DOMWrapperWorld& world)
@@ -142,13 +156,36 @@ void WebExtensionControllerProxy::addBindingsToWebPageFrameIfNecessary(WebFrame&
 
     // This is a safer cpp false positive (rdar://163760990).
     SUPPRESS_UNCOUNTED_ARG auto namespaceObject = JSObjectGetProperty(context, globalObject, browserString.get(), nullptr);
-    if (namespaceObject && JSValueIsObject(context, namespaceObject))
+    bool browserAlreadySet = namespaceObject && JSValueIsObject(context, namespaceObject);
+
+    auto* domGlobalObject = JSC::jsDynamicCast<JSDOMGlobalObject*>(toJS(context));
+    bool callbacksAlreadyRegistered = !domGlobalObject || domGlobalObject->hasScriptErrorCallbacks();
+
+    // If both browser and callbacks are already set up, nothing to do.
+    if (browserAlreadySet && callbacksAlreadyRegistered)
         return;
 
-    namespaceObject = toJS(context, WebExtensionAPIWebPageNamespace::create(WebExtensionContentWorldType::WebPage).ptr());
+    if (!browserAlreadySet) {
+        namespaceObject = toJS(context, WebExtensionAPIWebPageNamespace::create(WebExtensionContentWorldType::WebPage).ptr());
 
-    // This is a safer cpp false positive (rdar://163760990).
-    SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, globalObject, browserString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
+        // This is a safer cpp false positive (rdar://163760990).
+        SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, globalObject, browserString.get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
+    }
+
+    // For each loaded extension, install a callback that fires only when an error's sourceURL
+    // originates from that extension (main-world content script case). Guard against registering
+    // duplicate callbacks: if no callbacks are registered yet (e.g. extension contexts were not
+    // yet loaded when the global object was first created), register them now.
+    if (domGlobalObject && !domGlobalObject->hasScriptErrorCallbacks()) {
+        for (Ref extensionContext : m_extensionContexts) {
+            domGlobalObject->addScriptErrorCallback([extensionContext = extensionContext.copyRef()](const String& message, const String& sourceURL, unsigned lineNumber, unsigned columnNumber) {
+                if (!extensionContext->isURLForThisExtension(URL(URL(), sourceURL)))
+                    return;
+
+                extensionContext->didEncounterScriptError(message, sourceURL, lineNumber, columnNumber, WebExtensionContentWorldType::Main);
+            });
+        }
+    }
 }
 
 static WebExtensionFrameParameters toFrameParameters(WebFrame& frame, const URL& url, bool includeDocumentIdentifier = true)

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
@@ -56,6 +56,11 @@ void WebExtensionContextProxy::addFrameWithExtensionContent(WebFrame& frame)
     m_extensionContentFrames.add(frame);
 }
 
+bool WebExtensionContextProxy::isURLForThisExtension(const URL& url) const
+{
+    return url.isValid() && url.string().startsWith(m_baseURL.string());
+}
+
 std::optional<WebExtensionTabIdentifier> WebExtensionContextProxy::tabIdentifier(WebPage& page) const
 {
     if (m_popupPageMap.contains(page))

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -84,6 +84,8 @@ public:
     const URL& baseURL() const LIFETIME_BOUND { return m_baseURL; }
     const String& uniqueIdentifier() const LIFETIME_BOUND { return m_uniqueIdentifier; }
 
+    bool isURLForThisExtension(const URL&) const;
+
 #if PLATFORM(COCOA)
     NSDictionary *manifest() const { return m_manifest.get(); }
 
@@ -106,6 +108,8 @@ public:
     void setContentScriptWorld(WebCore::DOMWrapperWorld&);
 
     void addFrameWithExtensionContent(WebFrame&);
+
+    void didEncounterScriptError(const String& message, const String& sourceURL, unsigned lineNumber, unsigned columnNumber, WebExtensionContentWorldType);
 
     std::optional<WebExtensionTabIdentifier> NODELETE tabIdentifier(WebPage&) const;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionContext.mm
@@ -27,6 +27,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/cocoa/TestCocoa.h"
 #import "Helpers/cocoa/WebExtensionUtilities.h"
 #import <WebKit/WKFoundation.h>
@@ -970,6 +971,527 @@ TEST(WKWebExtensionContext, LoadNonExistentImage)
 
         [manager done];
     }];
+}
+
+TEST(WKWebExtensionContext, TopLevelThrowInModuleBackground)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"name": @"Test Extension",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+    };
+
+    auto *backgroundScript = @"throw new Error('Top level module error')";
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    [manager runForTimeInterval:2];
+
+    EXPECT_EQ(manager.get().context.errors.count, 1ul);
+
+    auto *error = manager.get().context.errors.firstObject;
+    EXPECT_EQ(error.code, WKWebExtensionContextErrorScriptExecutionError);
+    EXPECT_NS_EQUAL(error.localizedDescription, @"Error: Top level module error (background.js:1:42)");
+}
+
+TEST(WKWebExtensionContext, ReferenceErrorInBackground)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"name": @"Test Extension",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+    };
+
+    auto *backgroundScript = @"undeclaredVariable.foo";
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    [manager runForTimeInterval:2];
+
+    EXPECT_EQ(manager.get().context.errors.count, 1ul);
+
+    auto *error = manager.get().context.errors.firstObject;
+    EXPECT_EQ(error.code, WKWebExtensionContextErrorScriptExecutionError);
+    EXPECT_NS_EQUAL(error.localizedDescription, @"ReferenceError: Can't find variable: undeclaredVariable (background.js:1:19)");
+}
+
+TEST(WKWebExtensionContext, CallingMissingBrowserAPIInBackground)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"name": @"Test Extension",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+    };
+
+    auto *backgroundScript = @"browser.runtime.nonExistentMethod()";
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    [manager runForTimeInterval:2];
+
+    EXPECT_EQ(manager.get().context.errors.count, 1ul);
+
+    auto *error = manager.get().context.errors.firstObject;
+    EXPECT_EQ(error.code, WKWebExtensionContextErrorScriptExecutionError);
+    EXPECT_NS_EQUAL(error.localizedDescription, @"TypeError: browser.runtime.nonExistentMethod is not a function. (In 'browser.runtime.nonExistentMethod()', 'browser.runtime.nonExistentMethod' is undefined) (background.js:1:34)");
+}
+
+TEST(WKWebExtensionContext, UncaughtScriptErrorInBackground)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"name": @"Test Extension",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+    };
+
+    // Use setTimeout so the throw happens as a runtime uncaught exception, not a module evaluation rejection.
+    auto *backgroundScript = @"setTimeout(() => { throw new Error('Test uncaught error') }, 0)";
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    [manager runForTimeInterval:2];
+
+    EXPECT_EQ(manager.get().context.errors.count, 1ul);
+
+    auto *error = manager.get().context.errors.firstObject;
+    EXPECT_EQ(error.code, WKWebExtensionContextErrorScriptExecutionError);
+    EXPECT_NS_EQUAL(error.localizedDescription, @"Error: Test uncaught error (background.js:1:58)");
+}
+
+TEST(WKWebExtensionContext, UnhandledPromiseRejectionInBackground)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"name": @"Test Extension",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+    };
+
+    auto *backgroundScript = @"Promise.reject(new Error('Test rejection'))";
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    [manager runForTimeInterval:2];
+
+    EXPECT_EQ(manager.get().context.errors.count, 1ul);
+
+    auto *error = manager.get().context.errors.firstObject;
+    EXPECT_EQ(error.code, WKWebExtensionContextErrorScriptExecutionError);
+    EXPECT_NS_EQUAL(error.localizedDescription, @"Error: Test rejection");
+}
+
+TEST(WKWebExtensionContext, UncaughtScriptErrorInServiceWorkerBackground)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"name": @"Test Extension",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"background": @{
+            @"service_worker": @"background.js",
+        },
+    };
+
+    auto *backgroundScript = @"setTimeout(() => { throw new Error('Service worker uncaught error') }, 0)";
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    [manager runForTimeInterval:2];
+
+    EXPECT_EQ(manager.get().context.errors.count, 1ul);
+
+    auto *error = manager.get().context.errors.firstObject;
+    EXPECT_EQ(error.code, WKWebExtensionContextErrorScriptExecutionError);
+    EXPECT_NS_EQUAL(error.localizedDescription, @"Error: Service worker uncaught error (background.js:1:68)");
+}
+
+TEST(WKWebExtensionContext, UnhandledPromiseRejectionInServiceWorkerBackground)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"name": @"Test Extension",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"background": @{
+            @"service_worker": @"background.js",
+        },
+    };
+
+    auto *backgroundScript = @"Promise.reject(new Error('Service worker rejection'))";
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    [manager runForTimeInterval:2];
+
+    EXPECT_EQ(manager.get().context.errors.count, 1ul);
+
+    auto *error = manager.get().context.errors.firstObject;
+    EXPECT_EQ(error.code, WKWebExtensionContextErrorScriptExecutionError);
+    EXPECT_NS_EQUAL(error.localizedDescription, @"Error: Service worker rejection");
+}
+
+TEST(WKWebExtensionContext, SyntaxErrorInBackground)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"name": @"Test Extension",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"persistent": @NO,
+        },
+    };
+
+    // A bare syntax error: fails at parse time, so exception->stack() will be empty.
+    // Validates that the source URL fallback via error.sourceURL is correctly reported.
+    auto *backgroundScript = @")(";
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    [manager runForTimeInterval:2];
+
+    EXPECT_EQ(manager.get().context.errors.count, 1ul);
+
+    auto *error = manager.get().context.errors.firstObject;
+    EXPECT_EQ(error.code, WKWebExtensionContextErrorScriptExecutionError);
+    EXPECT_NS_EQUAL(error.localizedDescription, @"SyntaxError: Unexpected token ')' (background.js:1)");
+}
+
+TEST(WKWebExtensionContext, NoErrorForCaughtExceptionsInBackground)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"name": @"Test Extension",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        // Caught synchronous exception — should not populate errors.
+        @"try { throw new Error('Caught error') } catch (e) {}",
+
+        // Handled promise rejection — should not populate errors.
+        @"Promise.reject(new Error('Handled rejection')).catch(() => {})",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    [manager run];
+
+    EXPECT_EQ(manager.get().context.errors.count, 0ul);
+}
+
+TEST(WKWebExtensionContext, UncaughtScriptErrorInContentScript)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"name": @"Test Extension",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"content_scripts": @[ @{
+            @"matches": @[ @"*://localhost/*" ],
+            @"js": @[ @"content.js" ],
+        } ],
+    };
+
+    auto *contentScript = @"throw new Error('Content script error')";
+
+    auto manager = Util::loadExtension(manifest, @{ @"content.js": contentScript });
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+
+    [manager runForTimeInterval:2];
+
+    EXPECT_EQ(manager.get().context.errors.count, 1ul);
+
+    auto *error = manager.get().context.errors.firstObject;
+    EXPECT_EQ(error.code, WKWebExtensionContextErrorScriptExecutionError);
+    EXPECT_NS_EQUAL(error.localizedDescription, @"Error: Content script error (content.js:1:40)");
+}
+
+TEST(WKWebExtensionContext, UncaughtScriptErrorInMainWorldContentScript)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"name": @"Test Extension",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"content_scripts": @[ @{
+            @"matches": @[ @"*://localhost/*" ],
+            @"js": @[ @"content.js" ],
+            @"world": @"MAIN",
+        } ],
+    };
+
+    auto *contentScript = @"throw new Error('Main world error')";
+
+    auto manager = Util::loadExtension(manifest, @{ @"content.js": contentScript });
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+
+    [manager runForTimeInterval:2];
+
+    EXPECT_EQ(manager.get().context.errors.count, 1ul);
+
+    auto *error = manager.get().context.errors.firstObject;
+    EXPECT_EQ(error.code, WKWebExtensionContextErrorScriptExecutionError);
+    EXPECT_NS_EQUAL(error.localizedDescription, @"Error: Main world error (content.js:1:36)");
+}
+
+TEST(WKWebExtensionContext, PageScriptErrorNotReportedToExtension)
+{
+    // Verify that errors thrown by page scripts (not extension scripts) are not reported to the extension,
+    // even when a main-world content script is active on the same page.
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<script>throw new Error('Page error')</script>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"name": @"Test Extension",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"content_scripts": @[ @{
+            @"matches": @[ @"*://localhost/*" ],
+            @"js": @[ @"content.js" ],
+            @"world": @"MAIN",
+        } ],
+    };
+
+    // The content script itself does not throw; only the page script does.
+    auto *contentScript = @"let result = 2 + 2;";
+
+    auto manager = Util::loadExtension(manifest, @{ @"content.js": contentScript });
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+
+    [manager runForTimeInterval:2];
+
+    EXPECT_NS_EQUAL(manager.get().context.errors, @[ ]);
+}
+
+TEST(WKWebExtensionContext, UncaughtScriptErrorInEventListener)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"name": @"Test Extension",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+        @"action": @{ },
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.action.onClicked.addListener((tab) => {",
+        @"  throw new Error('Error in event listener')",
+        @"})",
+
+        @"browser.test.sendMessage('Ready')",
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    [manager runUntilTestMessage:@"Ready"];
+
+    [manager.get().context performActionForTab:manager.get().defaultTab];
+
+    [manager runForTimeInterval:2];
+
+    EXPECT_EQ(manager.get().context.errors.count, 1ul);
+
+    auto *error = manager.get().context.errors.firstObject;
+    EXPECT_EQ(error.code, WKWebExtensionContextErrorScriptExecutionError);
+    EXPECT_NS_EQUAL(error.localizedDescription, @"Error: Error in event listener (background.js:2:18)");
+}
+
+TEST(WKWebExtensionContext, TopLevelThrowInPopup)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"name": @"Test Extension",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"action": @{
+            @"default_popup": @"popup.html",
+        },
+    };
+
+    auto *popupScript = Util::constructScript(@[
+        @"browser.test.sendMessage('Ready')",
+        @"throw new Error('Popup error')",
+    ]);
+
+    auto *resources = @{
+        @"popup.html": @"<script type='module' src='popup.js'></script>",
+        @"popup.js": popupScript,
+    };
+
+    auto manager = Util::loadExtension(manifest, resources);
+
+    manager.get().internalDelegate.presentPopupForAction = ^(WKWebExtensionAction *action) {
+        EXPECT_NOT_NULL(action.popupWebView);
+    };
+
+    [manager.get().context performActionForTab:manager.get().defaultTab];
+
+    [manager runUntilTestMessage:@"Ready"];
+
+    [manager runForTimeInterval:2];
+
+    EXPECT_EQ(manager.get().context.errors.count, 1ul);
+
+    auto *error = manager.get().context.errors.firstObject;
+    EXPECT_EQ(error.code, WKWebExtensionContextErrorScriptExecutionError);
+    EXPECT_NS_EQUAL(error.localizedDescription, @"Error: Popup error (popup.js:2:31)");
+}
+
+TEST(WKWebExtensionContext, ConsoleErrorReportedNotLogOrWarn)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"name": @"Test Extension",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"console.log('This is a log message')",
+        @"console.warn('This is a warning message')",
+        @"console.error('Failed to inject script:', new Error('Missing permission'))",
+
+        @"browser.test.sendMessage('Ready')",
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    [manager runUntilTestMessage:@"Ready"];
+
+    [manager runForTimeInterval:2];
+
+    EXPECT_EQ(manager.get().context.errors.count, 1ul);
+
+    auto *error = manager.get().context.errors.firstObject;
+    EXPECT_EQ(error.code, WKWebExtensionContextErrorScriptExecutionError);
+    EXPECT_NS_EQUAL(error.localizedDescription, @"Failed to inject script: Error: Missing permission (background.js:3:14)");
+}
+
+TEST(WKWebExtensionContext, ConsoleAssertWithMessage)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"name": @"Test Extension",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"console.assert(true, 'This should not appear')",
+        @"console.assert(false, 'Something went wrong')",
+
+        @"browser.test.sendMessage('Ready')",
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    [manager runUntilTestMessage:@"Ready"];
+
+    [manager runForTimeInterval:2];
+
+    EXPECT_EQ(manager.get().context.errors.count, 1ul);
+
+    auto *error = manager.get().context.errors.firstObject;
+    EXPECT_EQ(error.code, WKWebExtensionContextErrorScriptExecutionError);
+    EXPECT_NS_EQUAL(error.localizedDescription, @"Something went wrong (background.js:2:15)");
+}
+
+TEST(WKWebExtensionContext, ConsoleAssertWithoutMessage)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"name": @"Test Extension",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"console.assert(true)",
+        @"console.assert(false)",
+
+        @"browser.test.sendMessage('Ready')",
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    [manager runUntilTestMessage:@"Ready"];
+
+    [manager runForTimeInterval:2];
+
+    EXPECT_EQ(manager.get().context.errors.count, 1ul);
+
+    auto *error = manager.get().context.errors.firstObject;
+    EXPECT_EQ(error.code, WKWebExtensionContextErrorScriptExecutionError);
+    EXPECT_NS_EQUAL(error.localizedDescription, @"(background.js:2:15)");
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### dde2f8447714d9b0d6a627f759b5bc201b390126
<pre>
Add uncaught script error and unhandled promise rejection reporting for Web Extensions.
<a href="https://webkit.org/b/311758">https://webkit.org/b/311758</a>
<a href="https://rdar.apple.com/problem/174354070">rdar://problem/174354070</a>

Reviewed by Yusuke Suzuki and Brian Weinstein.

Errors occurring in any extension script — background pages, service workers, popups, full tab pages,
and content scripts in both extension and main worlds — are now forwarded to the extension context
so the browser and test harness can observe and display them. Service worker background scripts had
a particularly acute gap: unlike other extension contexts whose errors appear in Web Inspector,
exceptions thrown during a service worker&apos;s startup were completely invisible.

A subtlety arises with content scripts injected into the main world, whose URLs are masked as
webkit-masked-url://hidden/ in call stacks to prevent the page from fingerprinting extensions. An
option was added to the existing source URL lookup to bypass this masking when reporting errors
internally. For promise rejections, the unmasked URL must be captured eagerly at rejection time,
since the underlying exception is not retained by the time unhandled rejections are processed.

Exceptions thrown inside extension event listener callbacks are also now propagated, where they were
previously silently captured by the JSC C API (JSObjectCallAsFunction) and discarded. In addition
to being captured for the errors array, they will now also appear in Web Inspector.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm

* Source/JavaScriptCore/runtime/StackFrame.cpp:
(JSC::processSourceURL):
(JSC::StackFrame::sourceURL const):
* Source/JavaScriptCore/runtime/StackFrame.h:
* Source/WebCore/bindings/js/JSDOMExceptionHandling.cpp:
(WebCore::reportException):
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSDOMGlobalObject::addScriptErrorCallback):
(WebCore::JSDOMGlobalObject::hasScriptErrorCallbacks const):
(WebCore::JSDOMGlobalObject::invokeScriptErrorCallbacks const):
* Source/WebCore/bindings/js/JSDOMGlobalObject.h:
* Source/WebCore/bindings/js/WebCoreJSClientData.cpp:
(WebCore::unmaskedSourceURLFromException):
* Source/WebCore/bindings/js/WebCoreJSClientData.h:
* Source/WebCore/dom/RejectedPromiseTracker.cpp:
(WebCore::UnhandledPromise::UnhandledPromise):
(WebCore::UnhandledPromise::unmaskedSourceURL const):
(WebCore::RejectedPromiseTracker::promiseRejected):
(WebCore::RejectedPromiseTracker::reportUnhandledRejections):
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::reportUnhandledPromiseRejection):
* Source/WebCore/dom/ScriptExecutionContext.h:
(WebCore::ScriptExecutionContext::reportUnhandledPromiseRejection):
* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContextPrivate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::didEncounterScriptError):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::toAPIError):
(WebKit::WebExtensionContext::createError):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp:
(WebKit::callWithArguments):
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
(WebKit::WebExtensionContextProxy::didEncounterScriptError):
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm:
(WebKit::WebExtensionControllerProxy::globalObjectIsAvailableForFrame):
(WebKit::WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame):
(WebKit::WebExtensionControllerProxy::addBindingsToWebPageFrameIfNecessary):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp:
(WebKit::WebExtensionContextProxy::isURLForThisExtension const):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionContext.mm:
(TestWebKitAPI::TEST(WKWebExtensionContext, TopLevelThrowInModuleBackground)): Added.
(TestWebKitAPI::TEST(WKWebExtensionContext, ReferenceErrorInBackground)): Added.
(TestWebKitAPI::TEST(WKWebExtensionContext, CallingMissingBrowserAPIInBackground)): Added.
(TestWebKitAPI::TEST(WKWebExtensionContext, UncaughtScriptErrorInBackground)): Added.
(TestWebKitAPI::TEST(WKWebExtensionContext, UnhandledPromiseRejectionInBackground)): Added.
(TestWebKitAPI::TEST(WKWebExtensionContext, UncaughtScriptErrorInServiceWorkerBackground)): Added.
(TestWebKitAPI::TEST(WKWebExtensionContext, UnhandledPromiseRejectionInServiceWorkerBackground)): Added.
(TestWebKitAPI::TEST(WKWebExtensionContext, SyntaxErrorInBackground)): Added.
(TestWebKitAPI::TEST(WKWebExtensionContext, NoErrorForCaughtExceptionsInBackground)): Added.
(TestWebKitAPI::TEST(WKWebExtensionContext, UncaughtScriptErrorInContentScript)): Added.
(TestWebKitAPI::TEST(WKWebExtensionContext, UncaughtScriptErrorInMainWorldContentScript)): Added.
(TestWebKitAPI::TEST(WKWebExtensionContext, PageScriptErrorNotReportedToExtension)): Added.
(TestWebKitAPI::TEST(WKWebExtensionContext, UncaughtScriptErrorInEventListener)): Added.
(TestWebKitAPI::TEST(WKWebExtensionContext, TopLevelThrowInPopup)): Added.

Canonical link: <a href="https://commits.webkit.org/311150@main">https://commits.webkit.org/311150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fc0ea58b6dd35324be86a7e0d6abc67bb4e4d1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164898 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157948 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120860 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23058 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140169 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101542 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22139 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20285 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12670 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148127 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131799 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167377 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16911 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11493 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19613 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128986 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24350 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129114 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28935 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139795 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86702 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23773 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23923 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16593 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187960 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28644 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92601 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48327 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28171 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28399 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28295 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->