### PR TITLE
Work in progress: Web Inspector: Layers 3D view does not re-snapshot preserved layers after repaint

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/Layers3DContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/Layers3DContentView.js
@@ -271,7 +271,7 @@ WI.Layers3DContentView = class Layers3DContentView extends WI.ContentView
     {
         // FIXME: This should be made into the basic usage of the manager, if not the agent itself.
         //        At that point, we can remove this duplication from the visualization and sidebar.
-        let {removals, additions} = WI.layerTreeManager.layerTreeMutations(this._layers, newLayers);
+        let {preserved, removals, additions} = WI.layerTreeManager.layerTreeMutations(this._layers, newLayers);
 
         for (let layer of removals) {
             let layerGroup = this._layerGroupsById.get(layer.layerId);
@@ -288,6 +288,20 @@ WI.Layers3DContentView = class Layers3DContentView extends WI.ContentView
             let layerGroup = this._createLayerGroup(layer);
             this._layerGroupsById.set(layer.layerId, layerGroup);
             this._scene.add(layerGroup);
+        }
+
+        for (let layer of preserved) {
+            let layerGroup = this._layerGroupsById.get(layer.layerId);
+            let previousLayer = layerGroup.userData.layer;
+            layerGroup.userData.layer = layer;
+
+            if (WI.settings.experimentalLayers3DShowLayerContents.value && layer.paintCount !== previousLayer.paintCount) {
+                this._disposeLayerGroupChildren(layerGroup);
+                while (layerGroup.children.length > 0)
+                    layerGroup.remove(layerGroup.children[0]);
+
+                this._populateLayerGroup(layerGroup, layer);
+            }
         }
 
         // FIXME: Update the backend to provide a literal "layer tree" so we can decide z-indices less naively.
@@ -564,6 +578,17 @@ WI.Layers3DContentView = class Layers3DContentView extends WI.ContentView
         this._pendingTextureLoads.clear();
 
         this._refreshAllLayers();
+
+        // z-interval changes between textured (10) and non-textured (25) modes,
+        // so reposition layers and update camera constraints to match.
+        let zInterval = this._zInterval();
+        this._layers.forEach((layer, index) => {
+            let layerGroup = this._layerGroupsById.get(layer.layerId);
+            layerGroup?.position.set(0, 0, index * zInterval);
+        });
+
+        this._boundingBox.setFromObject(this._scene);
+        this._controls.maxDistance = this._boundingBox.max.z + WI.Layers3DContentView._zPadding;
     }
 
     _handleRefreshLayersButtonClicked(event)


### PR DESCRIPTION
#### 787ecfcaf6c0f0bfbf05d1d9b3b80b5adcc09ab1
<pre>
Work in progress: Web Inspector: Layers 3D view does not re-snapshot preserved layers after repaint
<a href="https://bugs.webkit.org/show_bug.cgi?id=311767">https://bugs.webkit.org/show_bug.cgi?id=311767</a>
<a href="https://rdar.apple.com/174358757">rdar://174358757</a>

Reviewed by Devin Rousso.

When layerTreeDidChange fires and layers have the same IDs as before,
they are classified as &quot;preserved&quot; and keep their existing textures
indefinitely — even if their content has been repainted. Compare each
preserved layer&apos;s paintCount to detect repaints and re-snapshot when
it changes.

Toggling the layer contents setting rebuilds meshes but does not
reposition layer groups at the new z-interval (10 for textured, 25
for non-textured). Add z-position update and bounding box
recalculation after refresh.

* Source/WebInspectorUI/UserInterface/Views/Layers3DContentView.js:
(WI.Layers3DContentView.prototype._updateLayers):
(WI.Layers3DContentView.prototype._disposeLayerGroupChildren):
(WI.Layers3DContentView.prototype._handleLayerContentsSettingChanged):

Canonical link: <a href="https://commits.webkit.org/310892@main">https://commits.webkit.org/310892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/650714f34b68a731be662d91609e88153545377d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21766 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164109 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d53ca0dc-795d-46b6-9d50-3aa78d524820) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120224 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc1e300e-981f-4c79-adb2-76ce40b6e378) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22417 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139510 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100914 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8815d0f6-53fc-4f29-8221-4b9114a43edc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21503 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11938 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131172 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17342 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166587 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18952 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128332 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28151 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128466 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34836 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28075 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139135 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85460 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23315 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27769 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91872 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27346 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/27576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27419 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->