### PR TITLE
IPInt nonzero memory bounds check should check the last accessed byte

### DIFF
--- a/JSTests/wasm/stress/ipint-multimem-oob.js
+++ b/JSTests/wasm/stress/ipint-multimem-oob.js
@@ -1,0 +1,44 @@
+//@ skip if !$isWasmPlatform
+//@ runDefault("--useWasmMultiMemory=1", "--useWasmFastMemory=0")
+
+function leb128(v) {
+    const r = [];
+    do { let b = v & 0x7F; v >>>= 7; if (v) b |= 0x80; r.push(b); } while (v);
+    return r;
+}
+
+function buildModule() {
+    const b = [];
+    const push = (...x) => b.push(...x);
+    const pushSec = (id, content) => {
+        push(id); push(...leb128(content.length)); push(...content);
+    };
+
+    push(0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00);
+    pushSec(1, [1, 0x60, 1, 0x7F, 1, 0x7F]);
+    pushSec(3, [1, 0]);
+    pushSec(5, [2, 0x00, 10, 0x00, 1]);
+    pushSec(7, [1, 5, 0x6C, 0x6F, 0x61, 0x64, 0x31, 0x00, 0x00]);
+    const f0 = [0x00, 0x20, 0x00, 0x28, 0x42, 0x01, 0x00, 0x0B];
+    pushSec(10, [1, ...leb128(f0.length), ...f0]);
+    return new Uint8Array(b);
+}
+
+const mod = new WebAssembly.Module(buildModule());
+const inst = new WebAssembly.Instance(mod);
+
+// Memory 1 = 65536 bytes. i32.load = 4 bytes.
+// Max valid address = 65532 (65532 + 4 = 65536).
+inst.exports.load1(65532);
+
+// Address 65533: bounds check should fail because 65533 + 3 >= 65536.
+// Bug: IPInt checks 65533 >= 65536 (passes) instead of 65536 >= 65536 (fails).
+let trapped = false;
+try {
+    inst.exports.load1(65533);
+} catch(e) {
+    trapped = true;
+}
+
+if (!trapped)
+    throw new Error("expected trap");

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -928,6 +928,7 @@ macro metadataMemoryMakePointer(offsetField, memoryIndexField, wasmAddrReg, size
     mulp constexpr (sizeof(JSWebAssemblyInstance::WasmMemoryBaseAndSize)), scratch
     # FIXME: it's probably worth trying to use a loadpair here, but that requires a separate x86 codepath
     loadp (constexpr (JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0) + sizeof(void*))) [wasmInstance, scratch], scratch2 # bounds checking size
+    subp size - 1, scratch2 # wasmAddrReg + (size-1) >= scratch2 is equivalent to wasmAddrReg >= scratch2 - (size-1)
     bpaeq wasmAddrReg, scratch2, .outOfBounds
     loadp (constexpr (JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0))) [wasmInstance, scratch], scratch2 # memory base
     addp scratch2, wasmAddrReg


### PR DESCRIPTION
#### 39def582d5c1bde29f8af34c20071a25faa5a6bb
<pre>
IPInt nonzero memory bounds check should check the last accessed byte
<a href="https://bugs.webkit.org/show_bug.cgi?id=311764">https://bugs.webkit.org/show_bug.cgi?id=311764</a>
<a href="https://rdar.apple.com/174338638">rdar://174338638</a>

Reviewed by Yijia Huang.

IPInt bounds checking checks that the last byte of the access is within
bounds in the default case of memory 0, but for other memories only
checks the first byte of the access. This patch updates it to check that
the last byte is within bounds.

Test: JSTests/wasm/stress/ipint-multimem-oob.js

* JSTests/wasm/stress/ipint-multimem-oob.js: Added.
(leb128):
(buildModule):
(catch):
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:

Canonical link: <a href="https://commits.webkit.org/311123@main">https://commits.webkit.org/311123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c7f46300c4512468897694b5e36437e6da2a866

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155563 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28823 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21982 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164326 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109360 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a8ed3242-8d42-4123-ba65-4d6187242561) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28673 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120395 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84897 "2 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22581 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139696 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101085 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21667 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19790 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12156 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147613 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131336 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17528 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166803 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16394 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10981 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19139 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128516 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28367 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128649 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34973 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28291 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139321 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85734 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23475 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16118 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187448 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27985 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92088 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48045 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27562 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27792 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27635 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->