### PR TITLE
NEW-TEST: [macOS] media/encrypted-media/mock-navigator-requestMediaKeySystemAccess.html is a constant text failure

### DIFF
--- a/LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess-in-background.html
+++ b/LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess-in-background.html
@@ -26,6 +26,7 @@
         run('promise = navigator.requestMediaKeySystemAccess("org.webkit.mock", [capabilities])');
         await shouldResolve(promise);
         internals.settings.setCanStartMedia(true);
+        mock.unregister();
     }
 
     window.addEventListener('load', event => {

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2447,8 +2447,6 @@ webkit.org/b/308165 [ Debug ] scrollingcoordinator/mac/latching/simple-page-rubb
 
 webkit.org/b/311759 [ Release arm64 ] imported/w3c/web-platform-tests/event-timing/keydown.html [ Pass Failure ]
 
-webkit.org/b/311743 media/encrypted-media/mock-navigator-requestMediaKeySystemAccess.html [ Failure ]
-
 webkit.org/b/308325 [ Debug ] http/wpt/cache-storage/cache-in-stopped-context.html [ Pass Failure ]
 
 webkit.org/b/309173 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/modulepreload-referrerpolicy.html [ Pass Failure ]

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -733,6 +733,10 @@ void Internals::resetToConsistentState(Page& page)
 
     PlatformMediaEngineConfigurationFactory::disableMock();
 
+#if ENABLE(ENCRYPTED_MEDIA)
+    MockCDMFactory::unregisterAllMockFactories();
+#endif
+
 #if ENABLE(MEDIA_STREAM)
     page.settings().setInterruptAudioOnPageVisibilityChangeEnabled(false);
 #endif

--- a/Source/WebCore/testing/MockCDMFactory.cpp
+++ b/Source/WebCore/testing/MockCDMFactory.cpp
@@ -35,6 +35,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/UUID.h>
+#include <wtf/WeakHashSet.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/StringView.h>
 
@@ -42,16 +43,32 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MockCDM);
 
+static WeakHashSet<MockCDMFactory>& allMockFactories()
+{
+    static NeverDestroyed<WeakHashSet<MockCDMFactory>> factories;
+    return factories;
+}
+
+void MockCDMFactory::unregisterAllMockFactories()
+{
+    for (auto& weakFactory : copyToVector(allMockFactories())) {
+        if (RefPtr factory = weakFactory.get())
+            factory->unregister();
+    }
+}
+
 MockCDMFactory::MockCDMFactory()
     : m_supportedSessionTypes({ MediaKeySessionType::Temporary, MediaKeySessionType::PersistentUsageRecord, MediaKeySessionType::PersistentLicense })
     , m_supportedEncryptionSchemes({ MediaKeyEncryptionScheme::cenc })
 {
     CDMFactory::registerFactory(*this);
+    allMockFactories().add(*this);
 }
 
 MockCDMFactory::~MockCDMFactory()
 {
     unregister();
+    allMockFactories().remove(*this);
 }
 
 void MockCDMFactory::unregister()

--- a/Source/WebCore/testing/MockCDMFactory.h
+++ b/Source/WebCore/testing/MockCDMFactory.h
@@ -45,6 +45,7 @@ namespace WebCore {
 class MockCDMFactory : public RefCounted<MockCDMFactory>, public CDMFactory {
 public:
     static Ref<MockCDMFactory> create() { return adoptRef(*new MockCDMFactory); }
+    static void unregisterAllMockFactories();
     ~MockCDMFactory();
 
     void ref() const final { RefCounted::ref(); }


### PR DESCRIPTION
#### ec0c999ff89cdce5b1eff2e5c4c7678e62592085
<pre>
NEW-TEST: [macOS] media/encrypted-media/mock-navigator-requestMediaKeySystemAccess.html is a constant text failure
<a href="https://rdar.apple.com/174337907">rdar://174337907</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311743">https://bugs.webkit.org/show_bug.cgi?id=311743</a>

Reviewed by Philippe Normand.

mock-navigator-requestMediaKeySystemAccess.html is flakily failing due to preceding tests (in test list)
not doing proper cleanup. The -in-background test is missing mock.unregister() at the end of runTest().
So its MockCDMFactory stays registered in the global CDM factory list after the test completed. When the
main test ran next in the same WebProcess, there were now two mock factories registered - the stale one from
the background test plus the one the main test just created. This caused requestMediaKeySystemAccess to behave
differently than expected, producing wrong text output.

Changes made:
Test fix (-in-background.html): Added the missing mock.unregister() call so the test
properly cleans up after itself, matching what the main test already does at line 26.

Harness-level fix (Internals.cpp + MockCDMFactory.cpp/.h):
Added MockCDMFactory::unregisterAllMockFactories() and hooked it into Internals::resetToConsistentState().
This is the function the test harness calls between every test to reset global state. Now, even if a test
forgets to call mock.unregister(), all mock factories are automatically cleaned up before the next test
begins. This is a static WeakHashSet&lt;MockCDMFactory&gt; that tracks all live factory instances and unregisters
them all during reset.

* LayoutTests/media/encrypted-media/mock-navigator-requestMediaKeySystemAccess-in-background.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):
* Source/WebCore/testing/MockCDMFactory.cpp:
(WebCore::allMockFactories):
(WebCore::MockCDMFactory::unregisterAllMockFactories):
(WebCore::MockCDMFactory::~MockCDMFactory):
* Source/WebCore/testing/MockCDMFactory.h:

Canonical link: <a href="https://commits.webkit.org/311144@main">https://commits.webkit.org/311144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbdd1ef8cc69e3cf2d530e410ae7c7487f1de323

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29492 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164978 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158028 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29625 "Failed to checkout and rebase branch from PR 62309") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29493 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/120914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159115 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/29625 "Failed to checkout and rebase branch from PR 62309") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101591 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/29625 "Failed to checkout and rebase branch from PR 62309") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12750 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/29625 "Failed to checkout and rebase branch from PR 62309") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/18057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167457 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/11573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19669 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129155 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34983 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29015 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139851 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23974 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28724 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/92681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/28479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28375 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->