### PR TITLE
Add hit test support for HTMLModelElement

### DIFF
--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -38,6 +38,7 @@
 #include "HTMLEmbedElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLInputElement.h"
+#include "HTMLModelElement.h"
 #include "HTMLObjectElement.h"
 #include "HTMLTextAreaElement.h"
 #include "HTMLVideoElement.h"
@@ -515,6 +516,19 @@ URL HitTestResult::absoluteMediaURL() const
 {
 #if ENABLE(VIDEO)
     if (RefPtr element = mediaElement()) {
+        auto sourceURL = element->currentSrc();
+        if (RefPtr page = element->document().page())
+            return page->applyLinkDecorationFiltering(sourceURL, LinkDecorationFilteringTrigger::Unspecified);
+        return sourceURL;
+    }
+#endif
+    return { };
+}
+
+URL HitTestResult::absoluteModelURL() const
+{
+#if ENABLE(MODEL_ELEMENT)
+    if (RefPtr element = dynamicDowncast<HTMLModelElement>(m_innerNonSharedNode.get())) {
         auto sourceURL = element->currentSrc();
         if (RefPtr page = element->document().page())
             return page->applyLinkDecorationFiltering(sourceURL, LinkDecorationFilteringTrigger::Unspecified);

--- a/Source/WebCore/rendering/HitTestResult.h
+++ b/Source/WebCore/rendering/HitTestResult.h
@@ -121,6 +121,7 @@ public:
     WEBCORE_EXPORT URL absoluteImageURL() const;
     WEBCORE_EXPORT URL absolutePDFURL() const;
     WEBCORE_EXPORT URL absoluteMediaURL() const;
+    WEBCORE_EXPORT URL absoluteModelURL() const;
     WEBCORE_EXPORT URL absoluteLinkURL() const;
     WEBCORE_EXPORT bool hasLocalDataForLinkURL() const;
     WEBCORE_EXPORT String textContent() const;

--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h
@@ -48,6 +48,7 @@ WK_CLASS_AVAILABLE(macos(10.12), ios(16.0))
 @property (nonatomic, readonly) BOOL hasLocalDataForLinkURL WK_API_DEPRECATED_WITH_REPLACEMENT("linkLocalResourceResponse", macos(15.0, 26.0), ios(18.0, 26.0), visionos(2.0, 26.0));
 @property (nonatomic, readonly, copy) NSString *linkLocalDataMIMEType WK_API_DEPRECATED_WITH_REPLACEMENT("linkLocalResourceResponse.MIMEType", macos(15.0, 26.0), ios(18.0, 26.0), visionos(2.0, 26.0));
 @property (nonatomic, readonly, copy) NSURL *absoluteMediaURL;
+@property (nonatomic, readonly, copy) NSURL *absoluteModelURL WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 @property (nonatomic, readonly, copy) NSURLResponse *linkLocalResourceResponse WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
 
 @property (nonatomic, readonly, copy) NSString *linkLabel;

--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
@@ -81,6 +81,11 @@ static NSURL *URLFromString(const WTF::String& urlString)
     return URLFromString(_hitTestResult->absoluteMediaURL());
 }
 
+- (NSURL *)absoluteModelURL
+{
+    return URLFromString(_hitTestResult->absoluteModelURL());
+}
+
 - (NSString *)linkLabel
 {
     return _hitTestResult->linkLabel().createNSString().autorelease();

--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h
@@ -100,6 +100,7 @@ struct InteractionInformationAtPosition {
         WebCore::FloatPoint&& adjustedPointForNodeRespondingToClickEvents,
         URL&&,
         URL&& imageURL,
+        URL&& modelURL,
         String&& imageMIMEType,
         String&& title,
         String&& idAttribute,
@@ -165,6 +166,7 @@ struct InteractionInformationAtPosition {
     WebCore::FloatPoint adjustedPointForNodeRespondingToClickEvents;
     URL url;
     URL imageURL;
+    URL modelURL;
     String imageMIMEType;
     String title;
     String idAttribute;

--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.mm
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.mm
@@ -73,6 +73,7 @@ InteractionInformationAtPosition::InteractionInformationAtPosition(
     WebCore::FloatPoint&& adjustedPointForNodeRespondingToClickEvents,
     URL&& url,
     URL&& imageURL,
+    URL&& modelURL,
     String&& imageMIMEType,
     String&& title,
     String&& idAttribute,
@@ -134,6 +135,7 @@ InteractionInformationAtPosition::InteractionInformationAtPosition(
     , adjustedPointForNodeRespondingToClickEvents(WTF::move(adjustedPointForNodeRespondingToClickEvents))
     , url(WTF::move(url))
     , imageURL(WTF::move(imageURL))
+    , modelURL(WTF::move(modelURL))
     , imageMIMEType(WTF::move(imageMIMEType))
     , title(WTF::move(title))
     , idAttribute(WTF::move(idAttribute))

--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.serialization.in
@@ -71,6 +71,7 @@ struct WebKit::InteractionInformationAtPosition {
     WebCore::FloatPoint adjustedPointForNodeRespondingToClickEvents;
     URL url;
     URL imageURL;
+    URL modelURL;
     String imageMIMEType;
     String title;
     String idAttribute;

--- a/Source/WebKit/Shared/WebHitTestResultData.cpp
+++ b/Source/WebKit/Shared/WebHitTestResultData.cpp
@@ -93,6 +93,7 @@ WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, c
     , absolutePDFURL(hitTestResult.absolutePDFURL().string())
     , absoluteLinkURL(hitTestResult.absoluteLinkURL().string())
     , absoluteMediaURL(hitTestResult.absoluteMediaURL().string())
+    , absoluteModelURL(hitTestResult.absoluteModelURL().string())
     , linkLabel(hitTestResult.textContent())
     , linkTitle(hitTestResult.titleDisplayString())
     , linkSuggestedFilename(hitTestResult.linkSuggestedFilename())
@@ -153,7 +154,7 @@ WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, c
 WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, bool includeImage)
     : WebHitTestResultData(hitTestResult, String(), includeImage) { }
 
-WebHitTestResultData::WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, const String& imageSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar& isScrollbar, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, bool isActivePDFAnnotation, const WebHitTestResultData::ElementType& elementType, std::optional<FrameInfoData>&& frameInfo, std::optional<WebCore::FrameIdentifier> targetFrame, std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData, const String& lookupText, const String& tooltipText, const String& imageText, std::optional<WebCore::SharedMemory::Handle>&& imageHandle, const RefPtr<WebCore::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType, bool hasEntireImage, bool allowsFollowingLink, bool allowsFollowingImageURL, std::optional<WebCore::ResourceResponse>&& linkLocalResourceResponse,
+WebHitTestResultData::WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& absoluteModelURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, const String& imageSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar& isScrollbar, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, bool isActivePDFAnnotation, const WebHitTestResultData::ElementType& elementType, std::optional<FrameInfoData>&& frameInfo, std::optional<WebCore::FrameIdentifier> targetFrame, std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData, const String& lookupText, const String& tooltipText, const String& imageText, std::optional<WebCore::SharedMemory::Handle>&& imageHandle, const RefPtr<WebCore::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType, bool hasEntireImage, bool allowsFollowingLink, bool allowsFollowingImageURL, std::optional<WebCore::ResourceResponse>&& linkLocalResourceResponse,
 #if PLATFORM(MAC)
     const WebHitTestResultPlatformData& platformData,
 #endif
@@ -162,6 +163,7 @@ WebHitTestResultData::WebHitTestResultData(const String& absoluteImageURL, const
         , absolutePDFURL(absolutePDFURL)
         , absoluteLinkURL(absoluteLinkURL)
         , absoluteMediaURL(absoluteMediaURL)
+        , absoluteModelURL(absoluteModelURL)
         , linkLabel(linkLabel)
         , linkTitle(linkTitle)
         , linkSuggestedFilename(linkSuggestedFilename)

--- a/Source/WebKit/Shared/WebHitTestResultData.h
+++ b/Source/WebKit/Shared/WebHitTestResultData.h
@@ -71,6 +71,7 @@ struct WebHitTestResultData {
     String absolutePDFURL;
     String absoluteLinkURL;
     String absoluteMediaURL;
+    String absoluteModelURL;
     String linkLabel;
     String linkTitle;
     String linkSuggestedFilename;
@@ -118,7 +119,7 @@ struct WebHitTestResultData {
     WebHitTestResultData& operator=(const WebHitTestResultData&) = default;
     WebHitTestResultData(const WebCore::HitTestResult&, const String& tooltipText);
     WebHitTestResultData(const WebCore::HitTestResult&, bool includeImage);
-    WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, const String& imageSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar&, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, bool isActivePDFAnnotation, const WebKit::WebHitTestResultData::ElementType&, std::optional<FrameInfoData>&&, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::RemoteUserInputEventData>, const String& lookupText, const String& tooltipText, const String& imageText, std::optional<WebCore::SharedMemory::Handle>&& imageHandle, const RefPtr<WebCore::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType, bool hasEntireImage, bool allowsFollowingLink, bool allowsFollowingImageURL, std::optional<WebCore::ResourceResponse>&&,
+    WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& absoluteModelURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, const String& imageSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar&, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, bool isActivePDFAnnotation, const WebKit::WebHitTestResultData::ElementType&, std::optional<FrameInfoData>&&, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::RemoteUserInputEventData>, const String& lookupText, const String& tooltipText, const String& imageText, std::optional<WebCore::SharedMemory::Handle>&& imageHandle, const RefPtr<WebCore::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType, bool hasEntireImage, bool allowsFollowingLink, bool allowsFollowingImageURL, std::optional<WebCore::ResourceResponse>&&,
 #if PLATFORM(MAC)
         const WebHitTestResultPlatformData&,
 #endif

--- a/Source/WebKit/Shared/WebHitTestResultData.serialization.in
+++ b/Source/WebKit/Shared/WebHitTestResultData.serialization.in
@@ -39,6 +39,7 @@ struct WebKit::WebHitTestResultData {
     String absolutePDFURL;
     String absoluteLinkURL;
     String absoluteMediaURL;
+    String absoluteModelURL;
     String linkLabel;
     String linkTitle;
     String linkSuggestedFilename;

--- a/Source/WebKit/UIProcess/API/APIHitTestResult.h
+++ b/Source/WebKit/UIProcess/API/APIHitTestResult.h
@@ -48,6 +48,7 @@ public:
     WTF::String absolutePDFURL() const { return m_data.absolutePDFURL; }
     WTF::String absoluteLinkURL() const { return m_data.absoluteLinkURL; }
     WTF::String absoluteMediaURL() const { return m_data.absoluteMediaURL; }
+    WTF::String absoluteModelURL() const { return m_data.absoluteModelURL; }
 
     WTF::String linkLabel() const { return m_data.linkLabel; }
     WTF::String linkTitle() const { return m_data.linkTitle; }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfo.h
@@ -43,6 +43,7 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 
 @property (nonatomic, readonly) NSURL *URL;
 @property (nonatomic, readonly) NSURL *imageURL;
+@property (nonatomic, readonly) NSURL *modelURL WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 @property (nonatomic, readonly) NSString *title;
 @property (nonatomic, readonly) _WKActivatedElementType type;
 @property (nonatomic, readonly) CGRect boundingRect;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfo.mm
@@ -39,6 +39,7 @@
 @implementation _WKActivatedElementInfo  {
     RetainPtr<NSURL> _URL;
     RetainPtr<NSURL> _imageURL;
+    RetainPtr<NSURL> _modelURL;
     RetainPtr<NSString> _title;
     WebCore::IntPoint _interactionLocation;
     RetainPtr<NSString> _ID;
@@ -71,6 +72,7 @@
     
     _URL = information.url.createNSURL();
     _imageURL = information.imageURL.createNSURL();
+    _modelURL = information.modelURL.createNSURL();
     _imageMIMEType = information.imageMIMEType.createNSString().get();
     _interactionLocation = information.request.point;
     _title = information.title.createNSString().get();
@@ -171,6 +173,11 @@
 - (NSURL *)imageURL
 {
     return _imageURL.get();
+}
+
+- (NSURL *)modelURL
+{
+    return _modelURL.get();
 }
 
 - (NSString *)title

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
@@ -671,6 +671,11 @@ InteractionInformationAtPosition positionInformationForWebPage(WebPage& page, co
         info.isInteractiveModel = modelElement->model() && modelElement->supportsStageModeInteraction();
 #endif
 
+#if ENABLE(MODEL_ELEMENT)
+    if (RefPtr modelElement = dynamicDowncast<WebCore::HTMLModelElement>(hitTestNode); modelElement && !modelElement->currentSrc().isEmpty())
+        info.modelURL = modelElement->currentSrc();
+#endif
+
 #if ENABLE(PDF_PLUGIN) && PLATFORM(IOS_FAMILY)
     if (pluginView) {
         if (auto&& [url, bounds, textIndicator] = pluginView->linkDataAtPoint(request.point); !url.isEmpty()) {


### PR DESCRIPTION
#### b481551117e55256f35b55096783401dff5ba7b6
<pre>
Add hit test support for HTMLModelElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=311768">https://bugs.webkit.org/show_bug.cgi?id=311768</a>
<a href="https://rdar.apple.com/173910796">rdar://173910796</a>

Reviewed by Etienne Segonzac.

Add hit test support for HTMLModelElement so browsers can
download the usdz files.

* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::absoluteMediaURL const):
(WebCore::HitTestResult::absoluteModelURL const):
* Source/WebCore/rendering/HitTestResult.h:
* Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h:
* Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm:
(-[_WKHitTestResult absoluteModelURL]):
* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h:
* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.mm:
(WebKit::InteractionInformationAtPosition::InteractionInformationAtPosition):
* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.serialization.in:
* Source/WebKit/Shared/WebHitTestResultData.cpp:
(WebKit::WebHitTestResultData::WebHitTestResultData):
* Source/WebKit/Shared/WebHitTestResultData.h:
* Source/WebKit/Shared/WebHitTestResultData.serialization.in:
* Source/WebKit/UIProcess/API/APIHitTestResult.h:
(API::HitTestResult::absoluteModelURL const):
* Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfo.mm:
(-[_WKActivatedElementInfo _initWithInteractionInformationAtPosition:isUsingAlternateURLForImage:userInfo:]):
(-[_WKActivatedElementInfo modelURL]):
* Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm:
(WebKit::positionInformationForWebPage):

Canonical link: <a href="https://commits.webkit.org/311320@main">https://commits.webkit.org/311320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef0a3349c776f401980d287cd12a73e3d788bbe5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156592 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165415 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110673 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158463 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121285 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159550 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101952 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20757 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13187 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132252 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18452 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167898 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12018 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20069 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129401 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29530 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24835 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129511 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35088 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29453 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140246 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87254 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24338 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17048 "Too many flaky failures: http/tests/media/clearkey/collect-webkit-media-session.html, http/tests/misc/percent-sign-in-form-field-name.html, http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/resourceLoadStatistics/operating-dates-all-website-data-removed.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/register-bypassing-scheme.html, http/tests/security/mixedContent/redirect-https-to-http-iframe-in-main-frame.html, http/tests/site-isolation/frame-index.html, http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss-ephemeral.html, http/tests/websocket/tests/hybi/close-code-and-reason.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29160 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93125 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28686 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28916 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28811 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->