### PR TITLE
[WTF] Make UTF-8 StringImpl::create defensive against concurrent content modification

### DIFF
--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -295,29 +295,18 @@ RefPtr<StringImpl> StringImpl::create(std::span<const char8_t> codeUnits)
         return create(byteCast<Latin1Character>(codeUnits));
 
     auto inputLength = codeUnits.size();
-#if CPU(ARM64)
     auto input = reinterpret_cast<const char*>(codeUnits.data());
-    if (!simdutf::validate_utf8(input, inputLength))
-        return nullptr;
 
-    size_t utf16Length = simdutf::utf16_length_from_utf8(input, inputLength);
-
-    std::span<char16_t> data;
-    auto string = createUninitializedInternalNonEmpty(utf16Length, data);
-
-    size_t written = simdutf::convert_valid_utf8_to_utf16le(input, inputLength, data.data());
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(written == utf16Length);
-
-    return string;
-#else
+    // We are observing some clients changing the string content while converting!
+    // This makes it impossible to use utf16_length_from_utf8 & convert_valid_utf8_to_utf16le
+    // because of TOCTOU issue. For now, we use pre-allocated Vector (with maximally possible length)
+    // and use convert_utf8_to_utf16 instead.
     Vector<char16_t, 1024> buffer(inputLength);
-    auto result = Unicode::convert(codeUnits, buffer.mutableSpan());
-    if (result.code != Unicode::ConversionResultCode::Success)
+    size_t written = simdutf::convert_utf8_to_utf16(input, inputLength, buffer.mutableSpan().data());
+    if (!written)
         return nullptr;
-
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(result.buffer.size() <= inputLength);
-    return create(result.buffer);
-#endif
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(written <= inputLength);
+    return create(buffer.span().first(written));
 }
 
 Ref<StringImpl> StringImpl::createStaticStringImpl(std::span<const Latin1Character> characters)


### PR DESCRIPTION
#### 83b6ec32bc2507fda83b3675e918a05c3b91f39a
<pre>
[WTF] Make UTF-8 StringImpl::create defensive against concurrent content modification
<a href="https://bugs.webkit.org/show_bug.cgi?id=311771">https://bugs.webkit.org/show_bug.cgi?id=311771</a>
<a href="https://rdar.apple.com/173601233">rdar://173601233</a>

Reviewed by Mark Lam and Sosuke Suzuki.

It seems that some of JSC clients are using StringImpl::create wrongly,
and modifying the passed content concurrently. Previously, it was a bit
gracefully handled without SIMDUTF, but new code requires this invariant
more strictly and getting release-assert when this is broken. Modifying
concurrently is not allowed and that&apos;s a client bug, but anyway, let&apos;s
make it a bit defensive against such a behavior. This patch uses
pre-allocated maximally-possible sized Vector and using
simdutf::convert_utf8_to_utf16 instead.

* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::create):

Canonical link: <a href="https://commits.webkit.org/310857@main">https://commits.webkit.org/310857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a683847d4ba554f192cb2bfd2494952eb6e0041

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163840 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108551 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3ba0049f-97a4-4411-ab44-c3823bc330c6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119980 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84781 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7ded0c92-588e-445f-a4ff-0ef8515f4e85) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22240 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139254 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100673 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9601a856-7405-42d1-97d3-0f7bae97bd0f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21325 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19364 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11666 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147130 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130987 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17097 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166316 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15911 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10092 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18706 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128083 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27884 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23403 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128221 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27808 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138890 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84517 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23656 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23093 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15685 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186867 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27500 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91604 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47881 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27079 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27309 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27151 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->