### PR TITLE
REGRESSION (310465@main): prefers-color-scheme in an iframe ignores system preference when the main page does not set an explicit color-scheme.

### DIFF
--- a/LayoutTests/css-dark-mode/prefers-color-scheme-in-iframe-follows-system-preference-without-parent-color-scheme-expected.html
+++ b/LayoutTests/css-dark-mode/prefers-color-scheme-in-iframe-follows-system-preference-without-parent-color-scheme-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+
+<style>
+  .box {
+    width: 100px;
+    height: 100px;
+    background-color: red;
+  }
+</style>
+
+<p>Test passes if the box is red.</p>
+<div class="box"></div>

--- a/LayoutTests/css-dark-mode/prefers-color-scheme-in-iframe-follows-system-preference-without-parent-color-scheme.html
+++ b/LayoutTests/css-dark-mode/prefers-color-scheme-in-iframe-follows-system-preference-without-parent-color-scheme.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+
+<title>prefers-color-scheme in an iframe follows the system preference when the parent page has no explicit color-scheme</title>
+
+<style>
+  #ifr {
+    width: 500px;
+    height: 500px;
+    margin: 0;
+    border: 0;
+    padding: 0;
+    display: block;
+  }
+</style>
+
+<p>Test passes if the box is red.</p>
+<iframe id="ifr"></iframe>
+
+<script>
+  if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.setUseDarkAppearanceForTesting(true);
+
+    ifr.addEventListener("load", () => {
+      testRunner.notifyDone();
+    })
+  }
+
+  ifr.src = "resources/prefers-color-scheme-iframe.html";
+</script>

--- a/LayoutTests/http/tests/css/prefers-color-scheme-in-cross-origin-iframe-follows-system-preference-without-parent-color-scheme-expected.html
+++ b/LayoutTests/http/tests/css/prefers-color-scheme-in-cross-origin-iframe-follows-system-preference-without-parent-color-scheme-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+
+<style>
+  .box {
+    width: 100px;
+    height: 100px;
+    background-color: red;
+  }
+</style>
+
+<p>Test passes if the box is red.</p>
+<div class="box"></div>

--- a/LayoutTests/http/tests/css/prefers-color-scheme-in-cross-origin-iframe-follows-system-preference-without-parent-color-scheme.html
+++ b/LayoutTests/http/tests/css/prefers-color-scheme-in-cross-origin-iframe-follows-system-preference-without-parent-color-scheme.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+
+<title>prefers-color-scheme in a cross-origin iframe follows the system preference when the parent page has no explicit color-scheme</title>
+
+<style>
+  #ifr {
+    width: 500px;
+    height: 500px;
+    margin: 0;
+    border: 0;
+    padding: 0;
+    display: block;
+  }
+</style>
+
+<p>Test passes if the box is red.</p>
+<iframe id="ifr"></iframe>
+
+<script>
+  if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.setUseDarkAppearanceForTesting(true);
+
+    ifr.addEventListener("load", () => {
+      testRunner.notifyDone();
+    })
+  }
+
+  ifr.src = "http://localhost:8000/css/resources/prefers-color-scheme-iframe.html";
+</script>

--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -423,6 +423,9 @@ imported/w3c/web-platform-tests/intersection-observer/cross-origin-tall-iframe-r
 media/media-vp8-hiddenframes.html [ ImageOnlyFailure ]
 svg/animations/mozilla/animateMotion-mpath-pathLength-1.svg [ ImageOnlyFailure ]
 svg/custom/svg-image-dark-mode-initial.html [ ImageOnlyFailure ]
+webkit.org/b/311812 http/tests/css/prefers-color-scheme-in-cross-origin-iframe-follows-system-preference-without-parent-color-scheme.html [ ImageOnlyFailure ]
+webkit.org/b/311812 imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-cross-origin.sub.html [ ImageOnlyFailure ]
+webkit.org/b/311812 imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-dark-cross-origin.sub.html [ ImageOnlyFailure ]
 
 ####################################
 # Tests with missing expectations #

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -495,6 +495,9 @@ imported/w3c/web-platform-tests/svg/shapes/rect-01.svg [ ImageOnlyFailure ]
 svg/compositing/hidpi-legacy-svg-compositing-sibling-no-shift.html [ ImageOnlyFailure ]
 svg/compositing/transform-change-repainting-no-viewBox.html [ ImageOnlyFailure ]
 svg/custom/svg-image-dark-mode-initial.html [ ImageOnlyFailure ]
+webkit.org/b/311812 http/tests/css/prefers-color-scheme-in-cross-origin-iframe-follows-system-preference-without-parent-color-scheme.html [ ImageOnlyFailure ]
+webkit.org/b/311812 imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-cross-origin.sub.html [ ImageOnlyFailure ]
+webkit.org/b/311812 imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-dark-cross-origin.sub.html [ ImageOnlyFailure ]
 
 ####################################
 # Tests with missing expectations #

--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -806,7 +806,10 @@ static bool frameUsesDarkAppearanceForPrefersColorScheme(const Frame& frame)
         // > the preferred color scheme must reflect the value of the used color scheme on the
         // > embedding node in the embedding document.
         // FIXME (webkit.org/b/309611): this should recurse up to the main frame.
-        return protect(parent->virtualView())->ownerElementOfChildFrameUsesDarkAppearance(frame);
+        if (RefPtr ownerRenderer = frame.ownerRenderer()) {
+            if (ownerRenderer->style().hasExplicitlySetColorScheme())
+                return protect(parent->virtualView())->ownerElementOfChildFrameUsesDarkAppearance(frame);
+        }
     }
 
     return protect(frame.page())->useDarkAppearance();


### PR DESCRIPTION
#### f89a7480911d44491ef56f235efba4f50e0b090b
<pre>
REGRESSION (310465@main): prefers-color-scheme in an iframe ignores system preference when the main page does not set an explicit color-scheme.
<a href="https://bugs.webkit.org/show_bug.cgi?id=311766">https://bugs.webkit.org/show_bug.cgi?id=311766</a>

Reviewed by Simon Fraser.

310465@main changed how subframes resolve prefers-color-scheme: instead of reading the
system preference, they now inherit it from the color-scheme property of their parent page.

This accidentally broke the case where the parent page has no explicit color-scheme set,
so the iframe has nothing to inherit and then the code defaults to light instead of falling
back to the system preference.

The patch changes the code to look if the parent has an explicit color-scheme set before
inheriting from it. If it doesn&apos;t then defaults to the system preference like before 310465@main.

This behaviour is consistent with how Chrome (147) and Firefox (149) handle this.

Tests: prefers-color-scheme-in-iframe-follows-system-preference-without-parent-color-scheme.html
       http/tests/css/prefers-color-scheme-in-cross-origin-iframe-follows-system-preference-without-parent-color-scheme.html

* LayoutTests/css-dark-mode/prefers-color-scheme-in-iframe-follows-system-preference-without-parent-color-scheme-expected.html: Added.
* LayoutTests/css-dark-mode/prefers-color-scheme-in-iframe-follows-system-preference-without-parent-color-scheme.html: Added.
* LayoutTests/http/tests/css/prefers-color-scheme-in-cross-origin-iframe-follows-system-preference-without-parent-color-scheme-expected.html: Added.
* LayoutTests/http/tests/css/prefers-color-scheme-in-cross-origin-iframe-follows-system-preference-without-parent-color-scheme.html: Added.
* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::frameUsesDarkAppearanceForPrefersColorScheme):

Canonical link: <a href="https://commits.webkit.org/310874@main">https://commits.webkit.org/310874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d725e88fbc4747b9489d1b04c6dc61474486cbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163956 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157069 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28304 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120084 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22340 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139371 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100779 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21426 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19476 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11782 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131090 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17209 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166434 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18818 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128187 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23511 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128324 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34818 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27924 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139002 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84633 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23191 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15798 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27617 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91721 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27195 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27425 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27268 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->