### PR TITLE
Fix the replacement logic of i18n named placeholders

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionLocalization.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionLocalization.cpp
@@ -304,10 +304,10 @@ String WebExtensionLocalization::stringByReplacingNamedPlaceholdersInString(Stri
 
         auto originalKey = localizedString.substring(index, matchLength);
 
-        if (originalKey.startsWith(' '))
+        if (!originalKey.startsWith('$'))
             originalKey = localizedString.substring(index + 1, matchLength - 1);
 
-        auto key = originalKey.trim(isASCIIWhitespace).substring(1, originalKey.length() - 2).convertToASCIILowercase();
+        auto key = originalKey.substring(1, originalKey.length() - 2).convertToASCIILowercase();
 
         auto localizedReplacement = placeholders->getObject(key) ? placeholders->getObject(key)->getString(placeholderDictionaryContentKey) : emptyString();
 
@@ -332,9 +332,12 @@ String WebExtensionLocalization::stringByReplacingPositionalPlaceholdersInString
         if (index < 0)
             break;
 
-        auto originalKey = localizedString.substring(index, matchLength).trim(isASCIIWhitespace<char16_t>);
-        auto key = originalKey.substring(1, originalKey.length());
-        auto keyInteger = parseInteger<size_t>(key);
+        auto originalKey = localizedString.substring(index, matchLength);
+
+        if (!originalKey.startsWith('$'))
+            originalKey = localizedString.substring(index + 1, matchLength - 1);
+
+        auto keyInteger = parseInteger<size_t>(originalKey.substring(1, originalKey.length() - 1));
 
         String replacement;
         if (keyInteger && placeholders.size() && *keyInteger <= placeholders.size() && keyInteger > 0)
@@ -347,7 +350,7 @@ String WebExtensionLocalization::stringByReplacingPositionalPlaceholdersInString
         if (!matchLength)
             break;
 
-        index += replacement.length() + 2;
+        index += replacement.length();
     }
 
     return localizedString;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPILocalization.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPILocalization.mm
@@ -443,6 +443,36 @@ TEST(WKWebExtensionAPILocalization, Placeholders)
                 },
             },
         },
+        @"key9": @{
+            messageKey: @"v$version$",
+            placeholdersKey: @{
+                @"version": @{
+                    placeholderDictionaryContentKey: @"$1",
+                },
+            },
+        },
+        @"key10": @{
+            messageKey: @"v$major$.$minor$版",
+            placeholdersKey: @{
+                @"major": @{
+                    placeholderDictionaryContentKey: @"$1",
+                },
+                @"minor": @{
+                    placeholderDictionaryContentKey: @"$2",
+                },
+            },
+        },
+        @"key11": @{
+            messageKey: @"$index$ $volume$",
+            placeholdersKey: @{
+                @"index": @{
+                    placeholderDictionaryContentKey: @"$1",
+                },
+                @"volume": @{
+                    placeholderDictionaryContentKey: @"$2",
+                },
+            },
+        },
     };
 
     auto *backgroundScript = Util::constructScript(@[
@@ -456,6 +486,11 @@ TEST(WKWebExtensionAPILocalization, Placeholders)
         @"browser.test.assertEq(browser.i18n.getMessage('key4', placeholders), ' with $5')",
         @"browser.test.assertEq(browser.i18n.getMessage('key7', placeholders), '$dontreplaceme or me$ or th$is or $th$at$')",
         @"browser.test.assertEq(browser.i18n.getMessage('key8', placeholders), '1234명, 총 42명')",
+
+        [NSString stringWithFormat:@"var placeholders = %@", Util::constructJSArrayOfStrings(@[ @"3", @"4" ])],
+        @"browser.test.assertEq(browser.i18n.getMessage('key9', placeholders), 'v3')",
+        @"browser.test.assertEq(browser.i18n.getMessage('key10', placeholders), 'v3.4版')",
+        @"browser.test.assertEq(browser.i18n.getMessage('key11', placeholders), '3 4')",
 
         [NSString stringWithFormat:@"placeholders = %@", Util::constructJSArrayOfStrings(@[ @"irrelevant", @"argument value" ])],
         @"browser.test.assertEq(browser.i18n.getMessage('key5', placeholders), ' and argument value')",


### PR DESCRIPTION
#### bf4fcdebe4815c2e87795773aa5ce8c80a2626a0
<pre>
Fix the replacement logic of i18n named placeholders
<a href="https://bugs.webkit.org/show_bug.cgi?id=306492">https://bugs.webkit.org/show_bug.cgi?id=306492</a>

Reviewed by Timothy Hatcher.

This fixes placeholder substitution when a named or positional placeholder is immediately preceded by a normal character. The fix now trims the prefix character and only substitutes the actual placeholder token. It also removes the extra + 2 cursor advance in positional replacement so iteration proceeds correctly over the rewritten string.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPILocalization.mm

* Source/WebKit/Shared/Extensions/WebExtensionLocalization.cpp:
(WebKit::WebExtensionLocalization::stringByReplacingNamedPlaceholdersInString):
(WebKit::WebExtensionLocalization::stringByReplacingPositionalPlaceholdersInString):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPILocalization.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, Placeholders)):

Canonical link: <a href="https://commits.webkit.org/311685@main">https://commits.webkit.org/311685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f880f1cfb7a2914988f79fa3e4c227c725eff6a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155114 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163874 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108628 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156987 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28222 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120010 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84794 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139292 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100703 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21347 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19399 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11700 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131009 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166352 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10572 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18743 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128111 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27918 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23438 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128249 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27842 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138927 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/84551 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23983 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23115 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15722 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27535 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91638 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27113 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27343 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27186 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->