### PR TITLE
[libpas] atomic-load gets CSE-ed while it can be changed concurrently

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_directory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_directory.c
@@ -133,6 +133,14 @@ pas_bitfit_directory_get_first_free_view(pas_bitfit_directory* directory,
             found_empty_index = pas_bitfit_directory_find_first_empty(directory,
                                                                       (unsigned)first_empty.value);
             if (found_empty_index.did_succeed) {
+                /* find_first_empty iterates max_frees via _iterate, which reads
+                   max_frees.size independently and may observe a newer size than
+                   max_frees_size loaded at the top of the loop. The returned index
+                   is derived from data loaded by _iterate. Re-establish the dependency
+                   through directory using the returned index so that subsequent views
+                   accesses (which go through directory) are ordered relative to what
+                   _iterate observed, not relative to the stale max_frees_size. */
+                directory += pas_depend(found_empty_index.index);
                 pas_versioned_field_maximize_watched(
                     &directory->first_empty, first_empty, found_empty_index.index);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_compact_atomic_ptr.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_compact_atomic_ptr.h
@@ -41,37 +41,40 @@ typedef uint64_t pas_compact_atomic_ptr_impl;
 #error "Cannot use PAS_COMPACT_PTR_SIZE > 8"
 #endif
 
-#define PAS_COMPACT_ATOMIC_PTR_INITIALIZER { .payload = 0 }
+#define PAS_COMPACT_ATOMIC_PTR_INITIALIZER { .payload = 0u }
 
 #define PAS_DEFINE_COMPACT_ATOMIC_PTR(type, name) \
     struct name; \
     typedef struct name name; \
     \
     struct name { \
-        pas_compact_atomic_ptr_impl payload; \
+        PAS_ATOMIC_TYPE(pas_compact_atomic_ptr_impl) payload; \
     }; \
     \
     PAS_DEFINE_COMPACT_PTR_HELPERS(type, name); \
     \
     static inline void name ## _store(name* ptr, type* value) \
     { \
-        ptr->payload = (pas_compact_atomic_ptr_impl)name ## _index_for_ptr(value); \
+        PAS_ATOMIC_STORE_RELAXED(&ptr->payload, \
+            (pas_compact_atomic_ptr_impl)name ## _index_for_ptr(value)); \
     } \
     \
     static inline type* name ## _load(name* ptr) \
     { \
-        return name ## _ptr_for_index(ptr->payload); \
+        return name ## _ptr_for_index( \
+            PAS_ATOMIC_LOAD_RELAXED(&ptr->payload)); \
     } \
     \
     static inline type* name ## _load_non_null(name* ptr) \
     { \
-        return name ## _ptr_for_index_non_null(ptr->payload); \
+        return name ## _ptr_for_index_non_null( \
+            PAS_ATOMIC_LOAD_RELAXED(&ptr->payload)); \
     } \
     \
     static inline bool name ## _weak_cas(name* ptr, type* old_value, type* new_value) \
     { \
         return pas_compare_and_swap_uint32_weak( \
-            &ptr->payload, \
+            (unsigned*)&ptr->payload, \
             (pas_compact_atomic_ptr_impl)name ## _index_for_ptr(old_value), \
             (pas_compact_atomic_ptr_impl)name ## _index_for_ptr(new_value)); \
     } \
@@ -80,19 +83,20 @@ typedef uint64_t pas_compact_atomic_ptr_impl;
     { \
         return name ## _ptr_for_index( \
             pas_compare_and_swap_uint32_strong( \
-                &ptr->payload, \
+                (unsigned*)&ptr->payload, \
                 (pas_compact_atomic_ptr_impl)name ## _index_for_ptr(old_value), \
                 (pas_compact_atomic_ptr_impl)name ## _index_for_ptr(new_value))); \
     } \
     \
     static inline bool name ## _is_null(name* ptr) \
     { \
-        return !ptr->payload; \
+        return !PAS_ATOMIC_LOAD_RELAXED(&ptr->payload); \
     } \
     \
     static inline type* name ## _load_remote(pas_enumerator* enumerator, name* ptr) \
     { \
-        return name ## _ptr_for_remote_index(enumerator, ptr->payload); \
+        return name ## _ptr_for_remote_index(enumerator, \
+            PAS_ATOMIC_LOAD_RELAXED(&ptr->payload)); \
     } \
     \
     struct pas_dummy

--- a/Source/bmalloc/libpas/src/libpas/pas_compact_tagged_atomic_ptr.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_compact_tagged_atomic_ptr.h
@@ -39,41 +39,45 @@ typedef uint64_t pas_compact_tagged_atomic_ptr_impl;
 #error "Cannot use PAS_COMPACT_TAGGED_PTR_SIZE > 8"
 #endif
 
-#define PAS_COMPACT_TAGGED_ATOMIC_PTR_INITIALIZER { .payload = 0 }
+#define PAS_COMPACT_TAGGED_ATOMIC_PTR_INITIALIZER { .payload = 0u }
 
 #define PAS_DEFINE_COMPACT_TAGGED_ATOMIC_PTR(type, name) \
     struct name; \
     typedef struct name name; \
     \
     struct name { \
-        pas_compact_tagged_atomic_ptr_impl payload; \
+        PAS_ATOMIC_TYPE(pas_compact_tagged_atomic_ptr_impl) payload; \
     }; \
     \
     PAS_DEFINE_COMPACT_TAGGED_PTR_HELPERS(type, name); \
     \
     static inline void name ## _store(name* ptr, type value) \
     { \
-        ptr->payload = (pas_compact_tagged_atomic_ptr_impl)name ## _offset_for_ptr(value); \
+        PAS_ATOMIC_STORE_RELAXED(&ptr->payload, \
+            (pas_compact_tagged_atomic_ptr_impl)name ## _offset_for_ptr(value)); \
     } \
     \
     static inline type name ## _load(name* ptr) \
     { \
-        return name ## _ptr_for_offset(ptr->payload); \
+        return name ## _ptr_for_offset( \
+            PAS_ATOMIC_LOAD_RELAXED(&ptr->payload)); \
     } \
     \
     static inline type name ## _load_non_null(name* ptr) \
     { \
-        return name ## _ptr_for_offset_non_null(ptr->payload); \
+        return name ## _ptr_for_offset_non_null( \
+            PAS_ATOMIC_LOAD_RELAXED(&ptr->payload)); \
     } \
     \
     static inline bool name ## _is_null(name* ptr) \
     { \
-        return !ptr->payload; \
+        return !PAS_ATOMIC_LOAD_RELAXED(&ptr->payload); \
     } \
     \
     static inline type name ## _load_remote(pas_enumerator* enumerator, name* ptr) \
     { \
-        return name ## _ptr_for_remote_offset(enumerator, ptr->payload); \
+        return name ## _ptr_for_remote_offset(enumerator, \
+            PAS_ATOMIC_LOAD_RELAXED(&ptr->payload)); \
     } \
     \
     struct pas_dummy

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.h
@@ -1073,6 +1073,16 @@ PAS_IGNORE_WARNINGS_END
 #endif
 }
 
+#if PAS_COMPILER(CLANG)
+#define PAS_ATOMIC_TYPE(T) _Atomic T
+#define PAS_ATOMIC_LOAD_RELAXED(ptr) __c11_atomic_load((ptr), __ATOMIC_RELAXED)
+#define PAS_ATOMIC_STORE_RELAXED(ptr, val) __c11_atomic_store((ptr), (val), __ATOMIC_RELAXED)
+#else
+#define PAS_ATOMIC_TYPE(T) T
+#define PAS_ATOMIC_LOAD_RELAXED(ptr) __atomic_load_n((ptr), __ATOMIC_RELAXED)
+#define PAS_ATOMIC_STORE_RELAXED(ptr, val) __atomic_store_n((ptr), (val), __ATOMIC_RELAXED)
+#endif
+
 static inline pas_pair pas_atomic_load_pair_relaxed(void* raw_ptr)
 {
 #if PAS_COMPILER(CLANG)


### PR DESCRIPTION
#### 75529ed6e070fa9b97f4e3830819f118c3b40e20
<pre>
[libpas] atomic-load gets CSE-ed while it can be changed concurrently
<a href="https://bugs.webkit.org/show_bug.cgi?id=311776">https://bugs.webkit.org/show_bug.cgi?id=311776</a>
<a href="https://rdar.apple.com/174363026">rdar://174363026</a>

Reviewed by Marcus Plutowski.

This patch fixes two issues.

1. pas_compact_atomic_ptr&apos;s null check gets eliminated.

Since it is just a normal load and store, compiler can do CSE if no
current-thread&apos;s modification possibility is found. Given that this
atomic load / store is almost always for concurrent access, we should
just use atomic relaxed load and store.

2. Debug assertion failure via `pas_bitfit_directory_get_view`&apos;s bound
   check in `pas_bitfit_directory_get_first_free_view` call.

When we call `pas_bitfit_directory_find_first_empty`, which reloads the
new max_size. so `found_empty_index.index` can be larger than the
previously loaded max_size. This leads to hitting a debug assertion
failure in pas_bitfit_directory_get_view since we get a size from a
old `directory`, and this obtained index and loading directory does not
have any dependencies. We put a dependency between then to get the fresh
up-to-date max_size for assertion.

* Source/bmalloc/libpas/src/libpas/pas_bitfit_directory.c:
(pas_bitfit_directory_get_first_free_view):
* Source/bmalloc/libpas/src/libpas/pas_compact_atomic_ptr.h:
* Source/bmalloc/libpas/src/libpas/pas_compact_tagged_atomic_ptr.h:
* Source/bmalloc/libpas/src/libpas/pas_utils.h:

Canonical link: <a href="https://commits.webkit.org/310860@main">https://commits.webkit.org/310860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3b16acdbfc55e8e4d7e01f6a6afed2b57a1460c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155121 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163881 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28229 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120015 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22269 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139299 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100708 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21354 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19405 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11707 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147171 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131016 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17141 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166359 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15952 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18750 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128118 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23444 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128256 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27849 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138934 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84558 "Hash d3b16acd for PR 62315 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23659 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23124 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15729 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186908 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27542 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47894 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27120 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27350 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27193 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->