### PR TITLE
[JSC][WASM][Debugger] Capture source bytes for streaming-compiled WebAssembly modules

### DIFF
--- a/JSTests/wasm/debugger/resources/wasm/streaming-module-load.js
+++ b/JSTests/wasm/debugger/resources/wasm/streaming-module-load.js
@@ -1,0 +1,59 @@
+// A module compiled via the streaming path (instantiateStreaming), fed in two chunks.
+// func_a's 'end' instruction is at binary offset 0x23 -> virtual address 0x4000000000000023.
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic: \0asm
+    0x01, 0x00, 0x00, 0x00, // version: 1
+
+    // [0x08] Type section: 1 type
+    0x01, 0x04,             // section id=1, size=4
+    0x01,                   // 1 type
+    0x60, 0x00, 0x00,       // Type 0: (func [] -> [])
+
+    // [0x0e] Function section: 1 function
+    0x03, 0x02,             // section id=3, size=2
+    0x01,                   // 1 function
+    0x00,                   // function 0: type 0
+
+    // [0x12] Export section: export function 0 as "func_a"
+    0x07, 0x0a,             // section id=7, size=10
+    0x01,                   // 1 export
+    0x06, 0x66, 0x75, 0x6e, 0x63, 0x5f, 0x61, // name "func_a" (length=6)
+    0x00,                   // export kind: function
+    0x00,                   // function index 0
+
+    // [0x1e] Code section: 1 function body
+    0x0a, 0x04,             // section id=10, size=4
+    0x01,                   // 1 function body
+
+    // [0x21] func_a body
+    0x02,                   // body size=2
+    0x00,                   // 0 local declarations
+    0x0b,                   // [0x23] end
+]);
+
+async function main() {
+    var result = await $vm.createWasmStreamingCompilerForInstantiate(function(compiler) {
+        compiler.addBytes(wasm.slice(0, 16)); // chunk 1
+        compiler.addBytes(wasm.slice(16));    // chunk 2
+    });
+
+    print("Streaming module loaded");
+    print("Waiting for debugger — attach LLDB and type 'c' to continue.");
+    while (!$vm.hasDebuggerContinued()) { }
+    print("Debugger continued");
+
+    let iteration = 0;
+    for (;;) {
+        result.instance.exports.func_a();
+        iteration += 1;
+        if (iteration % 1e6 == 0)
+            print("iteration=", iteration);
+    }
+}
+
+main().catch(function(error) {
+    print(String(error));
+    print(String(error.stack));
+    $vm.abort();
+});

--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -2081,3 +2081,28 @@ class SwiftWasmDynamicModuleLoadTestCase(BaseTestCase):
 
         # Resume: stops at the func_b breakpoint (module B) on the first call, confirming that the pending breakpoint was resolved via debug info.
         self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped", "func_b"])
+
+
+class StreamingModuleLoadTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/streaming-module-load.js", extra_jsc_options=["--useDollarVM=1"])
+
+        try:
+            self.test()
+
+        except Exception as e:
+            raise Exception(f"Test failed: {e}")
+
+    def test(self):
+        # The streaming module is already loaded, so the breakpoint resolves immediately.
+        self.send_lldb_command_or_raise("b 0x4000000000000023", patterns=["Breakpoint 1"])
+
+        # Resume: stops at the func_a breakpoint in the streaming-compiled module.
+        # Disassembly confirms the stopped instruction is 'end' at the expected address.
+        self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped", "->  0x4000000000000023: end"])
+
+        self.send_lldb_command_or_raise("br del -f", patterns=["All breakpoints removed. (1 breakpoint)"])

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.h
@@ -63,8 +63,11 @@ public:
     {
         RELEASE_ASSERT(!failed() && !hasWork());
 #if ENABLE(WEBASSEMBLY_DEBUGGER)
-        if (Options::enableWasmDebugger()) [[unlikely]]
-            m_moduleInformation->debugInfo->takeSource(WTF::move(m_source));
+        if (Options::enableWasmDebugger()) [[unlikely]] {
+            // Skip if already populated by the streaming path (StreamingCompiler::addBytes).
+            if (m_moduleInformation->debugInfo->source.isEmpty())
+                m_moduleInformation->debugInfo->takeSource(WTF::move(m_source));
+        }
 #endif
         return WTF::move(m_moduleInformation);
     }

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.h
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.h
@@ -53,7 +53,15 @@ public:
 
     JS_EXPORT_PRIVATE ~StreamingCompiler();
 
-    void addBytes(std::span<const uint8_t> bytes) { m_parser.addBytes(bytes); }
+    void addBytes(std::span<const uint8_t> bytes)
+    {
+#if ENABLE(WEBASSEMBLY_DEBUGGER)
+        // Accumulate source bytes for the debugger — the streaming path has no single source vector and discards bytes as it's done with them.
+        if (Options::enableWasmDebugger()) [[unlikely]]
+            m_info->debugInfo->source.append(bytes);
+#endif
+        m_parser.addBytes(bytes);
+    }
     JS_EXPORT_PRIVATE void finalize(JSGlobalObject*);
     JS_EXPORT_PRIVATE void fail(JSGlobalObject*, JSValue);
     JS_EXPORT_PRIVATE void cancel();


### PR DESCRIPTION
#### e435f7f730a959591b0dbd1056ba7aa8f96ba02a
<pre>
[JSC][WASM][Debugger] Capture source bytes for streaming-compiled WebAssembly modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=311773">https://bugs.webkit.org/show_bug.cgi?id=311773</a>
<a href="https://rdar.apple.com/174362152">rdar://174362152</a>

Reviewed by Keith Miller.

WebAssembly.instantiateStreaming (and its compile variant) feed module bytes
incrementally through StreamingCompiler::addBytes. Unlike the synchronous path,
there is no single source vector that gets moved into ModuleInformation at the
end — so debugInfo-&gt;source remained empty for every streaming-compiled module.

Fix by accumulating bytes into debugInfo-&gt;source inside StreamingCompiler::addBytes
(guarded by ENABLE(WEBASSEMBLY_DEBUGGER)).  Guard the existing takeSource call in
EntryPlan::takeModuleInformation so it no longer overwrites bytes that the streaming
path already populated.

Tests:
* JSTests/wasm/debugger/tests/tests.py: (StreamingModuleLoadTestCase)

Canonical link: <a href="https://commits.webkit.org/310852@main">https://commits.webkit.org/310852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e8e6352b29dea28d27e6e04b1d11f1f091c3ff7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155258 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/28518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/21677 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/164018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/28658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/28366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/164018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158217 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/28658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/139431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/164018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/28658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/28366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/11844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/147308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/28658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/17266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166497 "Failed to checkout and rebase branch from PR 62317") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/16089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/18875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/166497 "Failed to checkout and rebase branch from PR 62317") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/28062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/28366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/166497 "Failed to checkout and rebase branch from PR 62317") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/27986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/139059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/84695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23652 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/27986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187143 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/27679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/91783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/47992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/27257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/27487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/27330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->