### PR TITLE
Use Variant instead of raw pointer union in IndexValueEntry

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/IndexValueEntry.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IndexValueEntry.cpp
@@ -34,80 +34,72 @@ namespace IDBServer {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IndexValueEntry);
 
-IndexValueEntry::IndexValueEntry(bool unique)
-    : m_unique(unique)
+static Variant<std::optional<IDBKeyData>, IDBKeyDataSet> constructEmptyKeys(bool isUnique)
 {
-    if (m_unique)
-        m_key = nullptr;
-    else
-        m_orderedKeys = new IDBKeyDataSet;
+    if (isUnique)
+        return std::nullopt;
+
+    return IDBKeyDataSet { };
 }
 
-IndexValueEntry::~IndexValueEntry()
+IndexValueEntry::IndexValueEntry(bool isUnique)
+    : m_keys(constructEmptyKeys(isUnique))
 {
-    if (m_unique)
-        delete m_key;
-    else
-        delete m_orderedKeys;
 }
 
 void IndexValueEntry::addKey(const IDBKeyData& key)
 {
-    if (m_unique) {
-        delete m_key;
-        m_key = new IDBKeyData(key);
-        return;
-    }
-
-    m_orderedKeys->insert(key);
+    WTF::switchOn(m_keys, [&key](std::optional<IDBKeyData>& singleKey) {
+        singleKey = key;
+    }, [&key](IDBKeyDataSet& orderedKeys) {
+        orderedKeys.insert(key);
+    });
 }
 
 bool IndexValueEntry::removeKey(const IDBKeyData& key)
 {
-    if (m_unique) {
-        if (m_key && *m_key == key) {
-            delete m_key;
-            m_key = nullptr;
+    return WTF::switchOn(m_keys, [&key](std::optional<IDBKeyData>& singleKey) {
+        if (singleKey == key) {
+            singleKey = std::nullopt;
             return true;
         }
-
         return false;
-    }
-
-    return m_orderedKeys->erase(key);
+    }, [&key](IDBKeyDataSet& orderedKeys) {
+        return !!orderedKeys.erase(key);
+    });
 }
 
 bool IndexValueEntry::contains(const IDBKeyData& key)
 {
-    if (m_unique)
-        return m_key && *m_key == key;
-
-    return m_orderedKeys && m_orderedKeys->count(key);
+    return WTF::switchOn(m_keys, [&key](const std::optional<IDBKeyData>& singleKey) {
+        return singleKey && *singleKey == key;
+    }, [&key](const IDBKeyDataSet& orderedKeys) {
+        return orderedKeys.contains(key);
+    });
 }
 
 const IDBKeyData* IndexValueEntry::getLowest() const LIFETIME_BOUND
 {
-    if (m_unique)
-        return m_key;
-
-    if (m_orderedKeys->empty())
-        return nullptr;
-
-    return &(*m_orderedKeys->begin());
+    return WTF::switchOn(m_keys, [](const std::optional<IDBKeyData>& singleKey) -> const IDBKeyData* {
+        return singleKey ? &*singleKey : nullptr;
+    }, [](const IDBKeyDataSet& orderedKeys) -> const IDBKeyData* {
+        return orderedKeys.empty() ? nullptr : &(*orderedKeys.begin());
+    });
 }
 
 uint64_t IndexValueEntry::getCount() const
 {
-    if (m_unique)
-        return m_key ? 1 : 0;
-
-    return m_orderedKeys->size();
+    return WTF::switchOn(m_keys, [](const std::optional<IDBKeyData>& singleKey) -> uint64_t {
+        return singleKey ? 1 : 0;
+    }, [](const IDBKeyDataSet& orderedKeys) -> uint64_t {
+        return orderedKeys.size();
+    });
 }
 
 IndexValueEntry::Iterator::Iterator(IndexValueEntry& entry)
     : m_entry(&entry)
 {
-    ASSERT(m_entry->m_key);
+    ASSERT(entry.isUnique());
 }
 
 IndexValueEntry::Iterator::Iterator(IndexValueEntry& entry, IDBKeyDataSet::iterator iterator)
@@ -126,25 +118,16 @@ IndexValueEntry::Iterator::Iterator(IndexValueEntry& entry, IDBKeyDataSet::rever
 const IDBKeyData& IndexValueEntry::Iterator::key() const
 {
     ASSERT(isValid());
-    if (m_entry->unique()) {
-        ASSERT(m_entry->m_key);
-        return *m_entry->m_key;
-    }
-
-    return m_forward ? *m_forwardIterator : *m_reverseIterator;
+    return WTF::switchOn(m_entry->m_keys, [](const std::optional<IDBKeyData>& singleKey) -> const IDBKeyData& {
+        ASSERT(singleKey);
+        return *singleKey;
+    }, [this](const IDBKeyDataSet&) -> const IDBKeyData& {
+        return m_forward ? *m_forwardIterator : *m_reverseIterator;
+    });
 }
 
 bool IndexValueEntry::Iterator::isValid() const
 {
-#if !LOG_DISABLED
-    if (m_entry) {
-        if (m_entry->m_unique)
-            ASSERT(m_entry->m_key);
-        else
-            ASSERT(m_entry->m_orderedKeys);
-    }
-#endif
-
     return m_entry;
 }
 
@@ -158,93 +141,87 @@ IndexValueEntry::Iterator& IndexValueEntry::Iterator::operator++()
     if (!isValid())
         return *this;
 
-    if (m_entry->m_unique) {
+    WTF::switchOn(m_entry->m_keys, [this](const std::optional<IDBKeyData>&) {
         invalidate();
-        return *this;
-    }
-
-    if (m_forward) {
-        ++m_forwardIterator;
-        if (m_forwardIterator == m_entry->m_orderedKeys->end())
-            invalidate();
-    } else {
-        ++m_reverseIterator;
-        if (m_reverseIterator == m_entry->m_orderedKeys->rend())
-            invalidate();
-    }
+    }, [this](const IDBKeyDataSet& orderedKeys) {
+        if (m_forward) {
+            ++m_forwardIterator;
+            if (m_forwardIterator == orderedKeys.end())
+                invalidate();
+        } else {
+            ++m_reverseIterator;
+            if (m_reverseIterator == orderedKeys.rend())
+                invalidate();
+        }
+    });
 
     return *this;
 }
 
 IndexValueEntry::Iterator IndexValueEntry::begin() LIFETIME_BOUND
 {
-    if (m_unique) {
-        ASSERT(m_key);
+    return WTF::switchOn(m_keys, [this](const std::optional<IDBKeyData>& singleKey) -> Iterator {
+        ASSERT_UNUSED(singleKey, singleKey);
         return { *this };
-    }
-
-    ASSERT(m_orderedKeys);
-    return { *this, m_orderedKeys->begin() };
+    }, [this](IDBKeyDataSet& orderedKeys) -> Iterator {
+        ASSERT(!orderedKeys.empty());
+        return { *this, orderedKeys.begin() };
+    });
 }
 
 IndexValueEntry::Iterator IndexValueEntry::reverseBegin(CursorDuplicity duplicity) LIFETIME_BOUND
 {
-    if (m_unique) {
-        ASSERT(m_key);
+    return WTF::switchOn(m_keys, [this](const std::optional<IDBKeyData>& singleKey) -> Iterator {
+        ASSERT_UNUSED(singleKey, singleKey);
         return { *this };
-    }
-
-    ASSERT(m_orderedKeys);
-
-    if (duplicity == CursorDuplicity::Duplicates)
-        return { *this, m_orderedKeys->rbegin() };
-
-    auto iterator = m_orderedKeys->rend();
-    --iterator;
-    return { *this, iterator };
+    }, [this, duplicity](IDBKeyDataSet& orderedKeys) -> Iterator {
+        ASSERT(!orderedKeys.empty());
+        if (duplicity == CursorDuplicity::Duplicates)
+            return { *this, orderedKeys.rbegin() };
+        auto iterator = orderedKeys.rend();
+        --iterator;
+        return { *this, iterator };
+    });
 }
 
 IndexValueEntry::Iterator IndexValueEntry::find(const IDBKeyData& key) LIFETIME_BOUND
 {
-    if (m_unique) {
-        ASSERT(m_key);
-        return *m_key == key ? IndexValueEntry::Iterator(*this) : IndexValueEntry::Iterator();
-    }
-
-    ASSERT(m_orderedKeys);
-    auto iterator = m_orderedKeys->lower_bound(key);
-    if (iterator == m_orderedKeys->end())
-        return { };
-
-    return { *this, iterator };
+    return WTF::switchOn(m_keys, [this, &key](const std::optional<IDBKeyData>& singleKey) -> Iterator {
+        ASSERT(singleKey);
+        return *singleKey == key ? Iterator(*this) : Iterator();
+    }, [this, &key](IDBKeyDataSet& orderedKeys) -> Iterator {
+        ASSERT(!orderedKeys.empty());
+        auto iterator = orderedKeys.lower_bound(key);
+        if (iterator == orderedKeys.end())
+            return { };
+        return { *this, iterator };
+    });
 }
 
 IndexValueEntry::Iterator IndexValueEntry::reverseFind(const IDBKeyData& key, CursorDuplicity) LIFETIME_BOUND
 {
-    if (m_unique) {
-        ASSERT(m_key);
-        return *m_key == key ? IndexValueEntry::Iterator(*this) : IndexValueEntry::Iterator();
-    }
-
-    ASSERT(m_orderedKeys);
-    auto iterator = IDBKeyDataSet::reverse_iterator(m_orderedKeys->upper_bound(key));
-    if (iterator == m_orderedKeys->rend())
-        return { };
-
-    return { *this, iterator };
+    return WTF::switchOn(m_keys, [this, &key](const std::optional<IDBKeyData>& singleKey) -> Iterator {
+        ASSERT(singleKey);
+        return *singleKey == key ? Iterator(*this) : Iterator();
+    }, [this, &key](IDBKeyDataSet& orderedKeys) -> Iterator {
+        ASSERT(!orderedKeys.empty());
+        auto iterator = IDBKeyDataSet::reverse_iterator(orderedKeys.upper_bound(key));
+        if (iterator == orderedKeys.rend())
+            return { };
+        return { *this, iterator };
+    });
 }
 
 Vector<IDBKeyData> IndexValueEntry::keys() const
 {
     Vector<IDBKeyData> result;
-    if (m_unique) {
-        if (m_key)
-            result.append(*m_key);
-    } else if (m_orderedKeys) {
-        for (auto& key : *m_orderedKeys)
+    WTF::switchOn(m_keys, [&result](const std::optional<IDBKeyData>& singleKey) {
+        if (singleKey)
+            result.append(*singleKey);
+    }, [&result](const IDBKeyDataSet& orderedKeys) {
+        for (auto& key : orderedKeys)
             result.append(key);
-    }
-
+    });
     return result;
 }
 

--- a/Source/WebCore/Modules/indexeddb/server/IndexValueEntry.h
+++ b/Source/WebCore/Modules/indexeddb/server/IndexValueEntry.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/IDBKeyData.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/Variant.h>
 
 namespace WebCore {
 
@@ -40,7 +41,6 @@ class IndexValueEntry {
     WTF_MAKE_TZONE_ALLOCATED(IndexValueEntry);
 public:
     explicit IndexValueEntry(bool unique);
-    ~IndexValueEntry();
 
     void addKey(const IDBKeyData&);
 
@@ -48,9 +48,9 @@ public:
     bool removeKey(const IDBKeyData&);
     bool contains(const IDBKeyData&);
 
-    const IDBKeyData* NODELETE getLowest() const LIFETIME_BOUND;
+    const IDBKeyData* getLowest() const LIFETIME_BOUND;
 
-    uint64_t NODELETE getCount() const;
+    uint64_t getCount() const;
 
     class Iterator {
     public:
@@ -65,10 +65,10 @@ public:
         bool NODELETE isValid() const;
         void NODELETE invalidate();
 
-        const IDBKeyData& NODELETE key() const;
+        const IDBKeyData& key() const;
         const ThreadSafeDataBuffer& value() const;
 
-        Iterator& NODELETE operator++();
+        Iterator& operator++();
 
     private:
         IndexValueEntry* m_entry { nullptr };
@@ -77,24 +77,19 @@ public:
         IDBKeyDataSet::reverse_iterator m_reverseIterator;
     };
 
-    Iterator NODELETE begin() LIFETIME_BOUND;
-    Iterator NODELETE reverseBegin(CursorDuplicity) LIFETIME_BOUND;
+    Iterator begin() LIFETIME_BOUND;
+    Iterator reverseBegin(CursorDuplicity) LIFETIME_BOUND;
 
     // Finds the key, or the next higher record after the key.
     Iterator find(const IDBKeyData&) LIFETIME_BOUND;
     // Finds the key, or the next lowest record before the key.
     Iterator reverseFind(const IDBKeyData&, CursorDuplicity) LIFETIME_BOUND;
 
-    bool unique() const { return m_unique; }
+    bool isUnique() const { return std::holds_alternative<std::optional<IDBKeyData>>(m_keys); }
     Vector<IDBKeyData> keys() const;
 
 private:
-    union {
-        IDBKeyDataSet* m_orderedKeys;
-        IDBKeyData* m_key;
-    };
-
-    bool m_unique;
+    Variant<std::optional<IDBKeyData>, IDBKeyDataSet> m_keys;
 };
 
 } // namespace IDBServer

--- a/Source/WebCore/Modules/indexeddb/server/IndexValueStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/IndexValueStore.h
@@ -79,7 +79,7 @@ public:
         bool NODELETE isValid();
 
         const IDBKeyData& NODELETE key();
-        const IDBKeyData& NODELETE primaryKey();
+        const IDBKeyData& primaryKey();
         const ThreadSafeDataBuffer& value();
 
         Iterator& operator++();


### PR DESCRIPTION
#### 86df89933752ae06accd35c8fa2702268da1824c
<pre>
Use Variant instead of raw pointer union in IndexValueEntry
<a href="https://bugs.webkit.org/show_bug.cgi?id=311777">https://bugs.webkit.org/show_bug.cgi?id=311777</a>
<a href="https://rdar.apple.com/174363490">rdar://174363490</a>

Reviewed by Ryosuke Niwa.

Replace the union of raw IDBKeyData*/IDBKeyDataSet* with Variant&lt;std::optional&lt;IDBKeyData&gt;, IDBKeyDataSet&gt;, which
manages lifetime automatically and provides type safety via WTF::switchOn. This eliminates the manual destructor, the
m_unique bool, and all heap allocations for the unique-index case.

Remove some NODELETE annotations since new implementation gets &quot;it contains code that could destruct an object&quot; SaferCPP
error because of them.

* Source/WebCore/Modules/indexeddb/server/IndexValueEntry.cpp:
(WebCore::IDBServer::constructEmptyKeys):
(WebCore::IDBServer::IndexValueEntry::IndexValueEntry):
(WebCore::IDBServer::IndexValueEntry::addKey):
(WebCore::IDBServer::IndexValueEntry::removeKey):
(WebCore::IDBServer::IndexValueEntry::contains):
(WebCore::IDBServer::IndexValueEntry::getCount const):
(WebCore::IDBServer::IndexValueEntry::Iterator::Iterator):
(WebCore::IDBServer::IndexValueEntry::Iterator::key const):
(WebCore::IDBServer::IndexValueEntry::Iterator::isValid const):
(WebCore::IDBServer::IndexValueEntry::Iterator::operator++):
(WebCore::IDBServer::IndexValueEntry::keys const):
(WebCore::IDBServer::IndexValueEntry::~IndexValueEntry): Deleted.
* Source/WebCore/Modules/indexeddb/server/IndexValueEntry.h:
(WebCore::IDBServer::IndexValueEntry::isUnique const):
(WebCore::IDBServer::IndexValueEntry::unique const): Deleted.
* Source/WebCore/Modules/indexeddb/server/IndexValueStore.h:

Canonical link: <a href="https://commits.webkit.org/311131@main">https://commits.webkit.org/311131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/288ba81ba60debf3b6da0b1b83ef31682b06893d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164900 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157950 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29415 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/120848 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23059 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140171 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101532 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12672 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131800 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/18003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167379 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11495 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19615 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/128967 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24351 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129096 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34974 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28937 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139797 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/23924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28646 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92603 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/28401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28297 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->