### PR TITLE
[JSC] DFG constant folding doesn't handle top correctly in CheckIsConstant

### DIFF
--- a/JSTests/stress/dfg-check-is-constant-generic-iterator.js
+++ b/JSTests/stress/dfg-check-is-constant-generic-iterator.js
@@ -1,0 +1,23 @@
+let fastArr   = [1.1, 2.2, 3.3];
+fastArr.foo   = 1;
+let innerArr  = [100.0, 200.0];
+let throwMode = false;
+function symIter() { if (throwMode) throw 42; return innerArr[Symbol.iterator](); }
+noInline(symIter);
+let genericArr = [5.5, 6.6, 7.7];
+genericArr[Symbol.iterator] = symIter;
+function opt(it){ let r=0; for (let v of it) r+=v; return r; }
+noInline(opt);
+
+opt(fastArr);
+opt(genericArr);
+opt(fastArr);
+opt(genericArr);
+
+throwMode = true;
+for (let i=0;i<10000;i++){ opt(fastArr); try{ opt(genericArr); }catch(e){} }
+
+throwMode = false;
+let r = opt(genericArr);
+if (Math.abs(r - (100.0+200.0)) >= 1e-9)
+    throw new Error("CheckIsConstant incorrectly elided");

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -5196,7 +5196,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
 
     case CheckIsConstant: {
         AbstractValue& value = forNode(node->child1());
-        if (value.value() == node->constant()->value() && (value.value() || value.m_type == SpecEmpty))
+        if (value.value() == node->constant()->value() && !value.valueIsTop())
             break;
         filterByValue(node->child1(), *node->constant());
         break;

--- a/Source/JavaScriptCore/dfg/DFGAbstractValue.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractValue.h
@@ -200,7 +200,7 @@ struct AbstractValue {
     
     bool valueIsTop() const
     {
-        return !m_value && m_type;
+        return !m_value && m_type != SpecEmpty;
     }
 
     bool isInt52Any() const

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -413,7 +413,8 @@ private:
             }
                 
             case CheckIsConstant: {
-                if (m_state.forNode(node->child1()).value() != node->constant()->value())
+                AbstractValue& value = m_state.forNode(node->child1());
+                if (value.value() != node->constant()->value() || value.valueIsTop())
                     break;
                 node->remove(m_graph);
                 eliminated = true;


### PR DESCRIPTION
#### 291f0457787d09848b9d55d64f1508c6e7f335f0
<pre>
[JSC] DFG constant folding doesn&apos;t handle top correctly in CheckIsConstant
<a href="https://bugs.webkit.org/show_bug.cgi?id=311779">https://bugs.webkit.org/show_bug.cgi?id=311779</a>
<a href="https://rdar.apple.com/174288568">rdar://174288568</a>

Reviewed by Keith Miller.

CheckIsConstant incorrectly treats all JSEmpty values as an actual empty
constant, whereas it may be a top value (i.e. indeterminate) when the
speculated type isn&apos;t SpecEmpty. This PR fixes it by not eliminating top
values.

Sidebar: AbstractValue::valueIsTop() exists, but isn&apos;t used at all right now
and hasn&apos;t been updated to consider SpecEmpty. This PR also fixes that and uses
it.

Test: JSTests/stress/dfg-check-is-constant-generic-iterator.js

* JSTests/stress/dfg-check-is-constant-generic-iterator.js: Added.
(symIter):
(opt):
(i.catch):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGAbstractValue.h:
(JSC::DFG::AbstractValue::valueIsTop const):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):

Canonical link: <a href="https://commits.webkit.org/310818@main">https://commits.webkit.org/310818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e8ec058a9fd8e473b61e94d4bf2d83a173ad912

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163860 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28208 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119997 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158059 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22257 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139277 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100690 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11686 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147150 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/17120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166337 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15931 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18729 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128098 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27904 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23423 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128236 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34789 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138913 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/84537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23104 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186887 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27520 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/91624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47889 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27099 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/27329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27171 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->