### PR TITLE
Instagram.com: story circle borders are black instead of colorful.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.gradient.arc-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.gradient.arc-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>Canvas test: 2d.strokeStyle.gradient.arc (reference)</title>
+<body>
+  <canvas id="canvas" width="200" height="200"></canvas>
+</body>
+<script>
+  var canvas = document.getElementById('canvas');
+  var ctx = canvas.getContext('2d');
+  var g = ctx.createLinearGradient(0, 0, 200, 0);
+  g.addColorStop(0, 'red');
+  g.addColorStop(1, 'blue');
+  ctx.fillStyle = g;
+  // Fill an annulus matching a 20px-wide stroke on a radius-60 arc.
+  ctx.beginPath();
+  ctx.arc(100, 100, 70, 0, 2 * Math.PI);
+  ctx.arc(100, 100, 50, 0, 2 * Math.PI, true);
+  ctx.fill();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.gradient.arc-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.gradient.arc-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>Canvas test: 2d.strokeStyle.gradient.arc (reference)</title>
+<body>
+  <canvas id="canvas" width="200" height="200"></canvas>
+</body>
+<script>
+  var canvas = document.getElementById('canvas');
+  var ctx = canvas.getContext('2d');
+  var g = ctx.createLinearGradient(0, 0, 200, 0);
+  g.addColorStop(0, 'red');
+  g.addColorStop(1, 'blue');
+  ctx.fillStyle = g;
+  // Fill an annulus matching a 20px-wide stroke on a radius-60 arc.
+  ctx.beginPath();
+  ctx.arc(100, 100, 70, 0, 2 * Math.PI);
+  ctx.arc(100, 100, 50, 0, 2 * Math.PI, true);
+  ctx.fill();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.gradient.arc.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.gradient.arc.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<link rel="match" href="2d.strokeStyle.gradient.arc-ref.html">
+<meta name="fuzzy" content="maxDifference=0-72; totalPixels=0-752">
+<title>Canvas test: 2d.strokeStyle.gradient.arc</title>
+<body>
+  <canvas id="canvas" width="200" height="200"></canvas>
+</body>
+<script>
+  var canvas = document.getElementById('canvas');
+  var ctx = canvas.getContext('2d');
+  ctx.lineWidth = 20;
+  var g = ctx.createLinearGradient(0, 0, 200, 0);
+  g.addColorStop(0, 'red');
+  g.addColorStop(1, 'blue');
+  ctx.strokeStyle = g;
+  ctx.beginPath();
+  ctx.arc(100, 100, 60, 0, 2 * Math.PI);
+  ctx.stroke();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.pattern.arc-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.pattern.arc-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>Canvas test: 2d.strokeStyle.pattern.arc (reference)</title>
+<body>
+  <canvas id="canvas" width="200" height="200"></canvas>
+</body>
+<script>
+  var canvas = document.getElementById('canvas');
+  var ctx = canvas.getContext('2d');
+  // Create the same checkerboard pattern.
+  var patternCanvas = document.createElement('canvas');
+  patternCanvas.width = 20;
+  patternCanvas.height = 20;
+  var pctx = patternCanvas.getContext('2d');
+  pctx.fillStyle = 'red';
+  pctx.fillRect(0, 0, 10, 10);
+  pctx.fillStyle = 'blue';
+  pctx.fillRect(10, 0, 10, 10);
+  pctx.fillStyle = 'blue';
+  pctx.fillRect(0, 10, 10, 10);
+  pctx.fillStyle = 'red';
+  pctx.fillRect(10, 10, 10, 10);
+  var pattern = ctx.createPattern(patternCanvas, 'repeat');
+  ctx.fillStyle = pattern;
+  // Fill an annulus matching a 20px-wide stroke on a radius-60 arc.
+  ctx.beginPath();
+  ctx.arc(100, 100, 70, 0, 2 * Math.PI);
+  ctx.arc(100, 100, 50, 0, 2 * Math.PI, true);
+  ctx.fill();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.pattern.arc-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.pattern.arc-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>Canvas test: 2d.strokeStyle.pattern.arc (reference)</title>
+<body>
+  <canvas id="canvas" width="200" height="200"></canvas>
+</body>
+<script>
+  var canvas = document.getElementById('canvas');
+  var ctx = canvas.getContext('2d');
+  // Create the same checkerboard pattern.
+  var patternCanvas = document.createElement('canvas');
+  patternCanvas.width = 20;
+  patternCanvas.height = 20;
+  var pctx = patternCanvas.getContext('2d');
+  pctx.fillStyle = 'red';
+  pctx.fillRect(0, 0, 10, 10);
+  pctx.fillStyle = 'blue';
+  pctx.fillRect(10, 0, 10, 10);
+  pctx.fillStyle = 'blue';
+  pctx.fillRect(0, 10, 10, 10);
+  pctx.fillStyle = 'red';
+  pctx.fillRect(10, 10, 10, 10);
+  var pattern = ctx.createPattern(patternCanvas, 'repeat');
+  ctx.fillStyle = pattern;
+  // Fill an annulus matching a 20px-wide stroke on a radius-60 arc.
+  ctx.beginPath();
+  ctx.arc(100, 100, 70, 0, 2 * Math.PI);
+  ctx.arc(100, 100, 50, 0, 2 * Math.PI, true);
+  ctx.fill();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.pattern.arc.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.pattern.arc.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<link rel="match" href="2d.strokeStyle.pattern.arc-ref.html">
+<meta name="fuzzy" content="maxDifference=0-72; totalPixels=0-1802">
+<title>Canvas test: 2d.strokeStyle.pattern.arc</title>
+<body>
+  <canvas id="canvas" width="200" height="200"></canvas>
+</body>
+<script>
+  var canvas = document.getElementById('canvas');
+  var ctx = canvas.getContext('2d');
+  // Create a simple checkerboard pattern.
+  var patternCanvas = document.createElement('canvas');
+  patternCanvas.width = 20;
+  patternCanvas.height = 20;
+  var pctx = patternCanvas.getContext('2d');
+  pctx.fillStyle = 'red';
+  pctx.fillRect(0, 0, 10, 10);
+  pctx.fillStyle = 'blue';
+  pctx.fillRect(10, 0, 10, 10);
+  pctx.fillStyle = 'blue';
+  pctx.fillRect(0, 10, 10, 10);
+  pctx.fillStyle = 'red';
+  pctx.fillRect(10, 10, 10, 10);
+  var pattern = ctx.createPattern(patternCanvas, 'repeat');
+  ctx.lineWidth = 20;
+  ctx.strokeStyle = pattern;
+  ctx.beginPath();
+  ctx.arc(100, 100, 60, 0, 2 * Math.PI);
+  ctx.stroke();
+</script>

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1333,11 +1333,16 @@ void GraphicsContextCG::strokeRect(const FloatRect& rect, float lineWidth)
 void GraphicsContextCG::strokeArc(const PathArc& arc)
 {
 #if HAVE(CGCONTEXT_STROKE_ARC)
-    CGContextRef context = platformContext();
-    CGContextStrokeArc(context, arc.center.x(), arc.center.y(), arc.radius, arc.startAngle, arc.endAngle, arc.direction == RotationDirection::Counterclockwise);
-#else
-    GraphicsContext::strokeArc(arc);
+    if (!strokeGradient()) {
+        if (strokePattern())
+            applyStrokePattern();
+
+        CGContextRef context = platformContext();
+        CGContextStrokeArc(context, arc.center.x(), arc.center.y(), arc.radius, arc.startAngle, arc.endAngle, arc.direction == RotationDirection::Counterclockwise);
+        return;
+    }
 #endif
+    GraphicsContext::strokeArc(arc);
 }
 
 void GraphicsContextCG::setLineCap(LineCap cap)


### PR DESCRIPTION
#### 425ee6b761800ebfcce152ecea2073c254a0cc47
<pre>
Instagram.com: story circle borders are black instead of colorful.
<a href="https://bugs.webkit.org/show_bug.cgi?id=311780">https://bugs.webkit.org/show_bug.cgi?id=311780</a>
&lt;<a href="https://rdar.apple.com/173536875">rdar://173536875</a>&gt;

Reviewed by Simon Fraser.

Stroked arcs with a gradient fill aren&apos;t being rendered correctly.

Fall back to strokePath if there&apos;s a gradient fill, since that requires special
handling outside of CG.  Match strokePath&apos;s behaviour for pattern fills, and
explicitly apply it.

Tests: imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.gradient.arc-ref.html
       imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.gradient.arc.html
       imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.pattern.arc-ref.html
       imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.pattern.arc.html

* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.gradient.arc-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.gradient.arc-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.gradient.arc.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.pattern.arc-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.pattern.arc-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.strokeStyle.pattern.arc.html: Added.
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::strokeArc):

Canonical link: <a href="https://commits.webkit.org/310865@main">https://commits.webkit.org/310865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60bbef05b1a0682e5fd1b63c0ab67fcfe9213222

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21550 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163891 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108679 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a46f6827-bf04-40fb-a5b9-57fb75b6ecc5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157004 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28239 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120021 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84799 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158090 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139306 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100714 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea9d9fc4-b404-4477-ad82-cee84578cc62) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21361 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19413 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11717 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131023 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17148 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166369 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10342 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18757 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128126 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27935 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23451 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128264 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34812 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27859 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138941 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84568 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23135 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15736 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27552 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91655 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27130 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27360 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27203 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->