### PR TITLE
Reduce unnecessary usage of ternary operator in WebCore

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -4649,7 +4649,7 @@ bool AccessibilityNodeObject::canSetValueAttribute() const
 
     String readOnly = readOnlyValue();
     if (!readOnly.isEmpty())
-        return readOnly == "true"_s ? false : true;
+        return readOnly != "true"_s;
 
     if (isNonNativeTextControl())
         return true;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9382,7 +9382,7 @@ void Document::updateLastHandledUserGestureTimestamp(MonotonicTime time)
 bool Document::mainFrameDocumentHasHadUserInteraction() const
 {
     RefPtr mainFrameDocument = this->mainFrameDocument();
-    return mainFrameDocument ? mainFrameDocument->hasHadUserInteraction() : false;
+    return mainFrameDocument && mainFrameDocument->hasHadUserInteraction();
 }
 
 bool Document::processingUserGestureForMedia() const

--- a/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -272,7 +272,7 @@ bool UserGestureIndicator::processingUserGestureForMedia()
         return false;
 
     RefPtr token = currentToken(commonVM());
-    return token ? token->processingUserGestureForMedia() : false;
+    return token && token->processingUserGestureForMedia();
 }
 
 std::optional<WTF::UUID> UserGestureIndicator::authorizationToken() const

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -153,7 +153,7 @@ static FragmentAndResources createFragmentInternal(LocalFrame& frame, NSAttribut
 
 #if PLATFORM(MAC)
     RefPtr view = frame.view();
-    LocalDefaultSystemAppearance localAppearance(view ? view->useDarkAppearance() : false);
+    LocalDefaultSystemAppearance localAppearance(view && view->useDarkAppearance());
 #endif
 
     NSArray *subresources = nil;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3819,7 +3819,7 @@ void HTMLMediaElement::addPlayedRange(const MediaTime& start, const MediaTime& e
 bool HTMLMediaElement::supportsScanning() const
 {
     RefPtr player = m_player;
-    return player ? player->supportsScanning() : false;
+    return player && player->supportsScanning();
 }
 
 void HTMLMediaElement::prepareToPlay()
@@ -4144,7 +4144,7 @@ std::optional<MediaSessionGroupIdentifier> HTMLMediaElement::mediaSessionGroupId
 bool HTMLMediaElement::hasAudio() const
 {
     RefPtr player = m_player;
-    return player ? player->hasAudio() : false;
+    return player && player->hasAudio();
 }
 
 bool HTMLMediaElement::seeking() const

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -141,7 +141,7 @@
 
 #define PAGE_ID (m_frame && m_frame->pageID() ? m_frame->pageID()->toUInt64() : 0)
 #define FRAME_ID (m_frame ? m_frame->frameID().toUInt64() : 0)
-#define IS_MAIN_FRAME (m_frame ? m_frame->isMainFrame() : false)
+#define IS_MAIN_FRAME (m_frame && m_frame->isMainFrame())
 #define DOCUMENTLOADER_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFrame=%d] DocumentLoader::" fmt, this, PAGE_ID, FRAME_ID, IS_MAIN_FRAME, ##__VA_ARGS__)
 #define DOCUMENTLOADER_RELEASE_LOG_FORWARDABLE(fmt, ...) RELEASE_LOG_FORWARDABLE(Network, fmt, PAGE_ID, FRAME_ID, IS_MAIN_FRAME, ##__VA_ARGS__)
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3972,7 +3972,7 @@ static bool NODELETE shouldAskForNavigationConfirmation(Document& document, cons
         return false;
 
     auto* page = document.page();
-    bool userDidInteractWithPage = page ? page->userDidInteractWithPage() : false;
+    bool userDidInteractWithPage = page && page->userDidInteractWithPage();
 
     // Web pages can request we ask for confirmation before navigating by:
     // - Cancelling the BeforeUnloadEvent (modern way)

--- a/Source/WebCore/loader/NavigationAction.h
+++ b/Source/WebCore/loader/NavigationAction.h
@@ -106,7 +106,7 @@ public:
 
     NavigationType type() const { return m_type; }
 
-    bool processingUserGesture() const { return m_userGestureToken ? m_userGestureToken->processingUserGesture() : false; }
+    bool processingUserGesture() const { return m_userGestureToken && m_userGestureToken->processingUserGesture(); }
     RefPtr<UserGestureToken> userGestureToken() const { return m_userGestureToken; }
 
     bool treatAsSameOriginNavigation() const { return m_treatAsSameOriginNavigation; }

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -940,7 +940,7 @@ bool ResourceLoader::isPDFJSResourceLoad() const
 
     RefPtr frame = m_frame.get();
     RefPtr document = frame && frame->ownerElement() ? &frame->ownerElement()->document() : nullptr;
-    return document ? document->isPDFDocument() : false;
+    return document && document->isPDFDocument();
 #else
     return false;
 #endif

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4160,7 +4160,7 @@ bool EventHandler::keyEvent(const PlatformKeyboardEvent& keyEvent)
     RefPtr page = frame->page();
     RefPtr mainFrameDocument = frame->document() ? frame->document()->mainFrameDocument() : nullptr;
     MonotonicTime savedLastHandledUserGestureTimestamp;
-    bool savedUserDidInteractWithPage = page ? page->userDidInteractWithPage() : false;
+    bool savedUserDidInteractWithPage = page && page->userDidInteractWithPage();
 
     if (auto* document = frame->document())
         savedLastHandledUserGestureTimestamp = document->lastHandledUserGestureTimestamp();

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -645,7 +645,7 @@ static void printFrames(const WebCore::Frame& frame, const WebCore::Frame* targe
         printIndent(indent);
         printf("  ownerElement=%p\n", localFrame->ownerElement());
         printIndent(indent);
-        printf("  frameView=%p (needs layout %d)\n", view, view ? view->needsLayout() : false);
+        printf("  frameView=%p (needs layout %d)\n", view, view && view->needsLayout());
         printIndent(indent);
         printf("  renderView=%p\n", view ? view->renderView() : nullptr);
         printIndent(indent);

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -171,7 +171,7 @@ ExceptionOr<void> History::forward(Document& document)
 ExceptionOr<void> History::go(int distance)
 {
     RefPtr frame = this->frame();
-    LOG(History, "History %p go(%d) frame %p (main frame %d)", this, distance, frame.get(), frame ? frame->isMainFrame() : false);
+    LOG(History, "History %p go(%d) frame %p (main frame %d)", this, distance, frame.get(), frame && frame->isMainFrame());
 
     if (!isDocumentFullyActive(frame.get()))
         return documentNotFullyActive();
@@ -183,7 +183,7 @@ ExceptionOr<void> History::go(int distance)
 ExceptionOr<void> History::go(Document& document, int distance)
 {
     RefPtr frame = this->frame();
-    LOG(History, "History %p go(%d) in document %p frame %p (main frame %d)", this, distance, &document, frame.get(), frame ? frame->isMainFrame() : false);
+    LOG(History, "History %p go(%d) in document %p frame %p (main frame %d)", this, distance, &document, frame.get(), frame && frame->isMainFrame());
 
     if (!isDocumentFullyActive(frame.get()))
         return documentNotFullyActive();

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -764,7 +764,7 @@ public:
     struct AutoPreventLayerAccess {
         AutoPreventLayerAccess(LocalFrameView* view)
             : frameView(view)
-            , oldPreventLayerAccess(view ? view->layerAccessPrevented() : false)
+            , oldPreventLayerAccess(view && view->layerAccessPrevented())
         {
             if (view)
                 view->setLayerAcessPrevented(true);

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -1210,7 +1210,7 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
         return DispatchResult::Completed;
     }
 
-    bool wasBeingDispatched = m_ongoingNavigateEvent ? m_ongoingNavigateEvent->isBeingDispatched() : false;
+    bool wasBeingDispatched = m_ongoingNavigateEvent && m_ongoingNavigateEvent->isBeingDispatched();
 
     abortOngoingNavigationIfNeeded();
 

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
@@ -76,7 +76,7 @@ public:
 
     bool hasAudio() const { return m_hasAudio; }
     bool hasVideo() const { return m_hasVideo; }
-    bool shouldApplyVideoRotation() const { return m_writer ? m_writer->shouldApplyVideoRotation() : false; }
+    bool shouldApplyVideoRotation() const { return m_writer && m_writer->shouldApplyVideoRotation(); }
 
 private:
     MediaRecorderPrivateEncoder(bool hasAudio, bool hasVideo);

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -1501,9 +1501,9 @@ std::optional<LayoutUnit> RenderBlockFlow::selfCollapsingMarginBeforeWithClear(R
 
 LayoutUnit RenderBlockFlow::collapseMarginsWithChildInfo(RenderBox* child, MarginInfo& marginInfo)
 {
-    bool childIsSelfCollapsing = child ? child->isSelfCollapsingBlock() : false;
-    bool beforeQuirk = child ? hasMarginBeforeQuirk(*child) : false;
-    bool afterQuirk = child ? hasMarginAfterQuirk(*child) : false;
+    bool childIsSelfCollapsing = child && child->isSelfCollapsingBlock();
+    bool beforeQuirk = child && hasMarginBeforeQuirk(*child);
+    bool afterQuirk = child && hasMarginAfterQuirk(*child);
     auto trimChildBlockMargins = [&]() {
         auto childBlockFlow = dynamicDowncast<RenderBlockFlow>(child);
         if (childBlockFlow)

--- a/Source/WebCore/rendering/RenderImageResource.h
+++ b/Source/WebCore/rendering/RenderImageResource.h
@@ -57,12 +57,12 @@ public:
 
     Ref<Image> image(const IntSize& size = { }) const;
     bool currentFrameIsComplete() const;
-    bool errorOccurred() const { return m_styleImage ? m_styleImage->errorOccurred() : false; }
+    bool errorOccurred() const { return m_styleImage && m_styleImage->errorOccurred(); }
 
     void setContainerContext(const IntSize&, const URL&);
 
-    bool imageHasRelativeWidth() const { return m_styleImage ? m_styleImage->imageHasRelativeWidth() : false; }
-    bool imageHasRelativeHeight() const { return m_styleImage ? m_styleImage->imageHasRelativeHeight() : false; }
+    bool imageHasRelativeWidth() const { return m_styleImage && m_styleImage->imageHasRelativeWidth(); }
+    bool imageHasRelativeHeight() const { return m_styleImage && m_styleImage->imageHasRelativeHeight(); }
 
     inline LayoutSize imageSize(float multiplier) const { return imageSize(multiplier, CachedImage::UsedSize); }
     inline LayoutSize intrinsicSize(float multiplier) const { return imageSize(multiplier, CachedImage::IntrinsicSize); }

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3876,7 +3876,7 @@ bool RenderLayerCompositor::requiresCompositingForTransform(RenderLayerModelObje
         // Continue to allow pages to avoid the very slow software filter path.
         if (styleHas3DTransformOperation(renderer.style()) && renderer.hasFilter())
             return true;
-        return styleTransformOperationsAreRepresentableIn2D(renderer.style()) ? false : true;
+        return !styleTransformOperationsAreRepresentableIn2D(renderer.style());
     }
     return false;
 }

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -155,7 +155,7 @@ void RenderTable::styleDidChange(Style::Difference diff, const RenderStyle* oldS
     RenderBlock::styleDidChange(diff, oldStyle);
     propagateStyleToAnonymousChildren(StylePropagationType::AllChildren);
 
-    bool oldFixedTableLayout = oldStyle ? oldStyle->isFixedTableLayout() : false;
+    bool oldFixedTableLayout = oldStyle && oldStyle->isFixedTableLayout();
 
     // In the collapsed border model, there is no cell spacing.
     m_hSpacing = collapseBorders() ? 0 : style().borderHorizontalSpacing().resolveZoom(style().usedZoomForLength());

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -282,7 +282,7 @@ void RenderSVGPath::updateMarkerPositions()
     ASSERT(hasPath());
     auto* markerStart = svgMarkerStartResourceFromStyle();
 
-    SVGMarkerData markerData(m_markerPositions, markerStart ? markerStart->hasReverseStart() : false);
+    SVGMarkerData markerData(m_markerPositions, markerStart && markerStart->hasReverseStart());
     path().applyElements([&markerData](const PathElement& pathElement) {
         SVGMarkerData::updateFromPathElement(markerData, pathElement);
     });

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -8040,7 +8040,7 @@ RefPtr<PushSubscription> Internals::createPushSubscription(const String& endpoin
 bool Internals::hasSleepDisabler() const
 {
     auto* document = contextDocument();
-    return document ? document->hasSleepDisabler() : false;
+    return document && document->hasSleepDisabler();
 }
 
 void Internals::acceptTypedArrays(Int32Array&)


### PR DESCRIPTION
#### 586a96e75ccf13e024033723ed68b2dd226d75d7
<pre>
Reduce unnecessary usage of ternary operator in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=311781">https://bugs.webkit.org/show_bug.cgi?id=311781</a>
<a href="https://rdar.apple.com/174365617">rdar://174365617</a>

Reviewed by Ryosuke Niwa.

This improves readability and enforces more idiomatic C++ by resorting to
equivalent binary boolean operations.

* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::canSetValueAttribute const):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::mainFrameDocumentHasHadUserInteraction const):
* Source/WebCore/dom/UserGestureIndicator.cpp:
(WebCore::UserGestureIndicator::processingUserGestureForMedia):
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::createFragmentInternal):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::supportsScanning const):
(WebCore::HTMLMediaElement::hasAudio const):
* Source/WebCore/loader/DocumentLoader.cpp:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::shouldAskForNavigationConfirmation):
* Source/WebCore/loader/NavigationAction.h:
(WebCore::NavigationAction::processingUserGesture const):
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::isPDFJSResourceLoad const):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::keyEvent):
* Source/WebCore/page/FrameTree.cpp:
(printFrames):
* Source/WebCore/page/History.cpp:
(WebCore::History::go):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::innerDispatchNavigateEvent):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::collapseMarginsWithChildInfo):
* Source/WebCore/rendering/RenderImageResource.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::requiresCompositingForTransform const):
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::styleDidChange):
* Source/WebCore/rendering/svg/RenderSVGPath.cpp:
(WebCore::RenderSVGPath::updateMarkerPositions):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::hasSleepDisabler const):

Canonical link: <a href="https://commits.webkit.org/310851@main">https://commits.webkit.org/310851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8c3d9115ac7ec5afcf772ab64d575a75d57a5c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155105 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163865 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156978 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120005 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158064 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100698 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21339 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19389 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11691 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131001 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17125 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166342 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10167 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18734 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128106 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27909 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23428 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128244 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34805 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27833 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138918 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84542 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23112 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15713 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27526 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91629 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27104 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27334 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27177 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->