### PR TITLE
[macOS release] imported/w3c/web-platform-tests/event-timing/keydown is a flaky text failure.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/event-timing/resources/event-timing-test-utils.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/event-timing/resources/event-timing-test-utils.js
@@ -277,7 +277,7 @@ async function testEventType(t, eventType, looseCount=false) {
   const durationThreshold = 16;
   // Now add an event handler to cause a slow event.
   target.addEventListener(eventType, () => {
-    mainThreadBusy(durationThreshold + 4);
+    mainThreadBusy(durationThreshold + 5);
   });
   const observerPromise = new Promise(async resolve => {
     new PerformanceObserver(t.step_func(entryList => {

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2444,8 +2444,6 @@ http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target
 
 webkit.org/b/308165 [ Debug ] scrollingcoordinator/mac/latching/simple-page-rubberbands.html [ Pass Failure ]
 
-webkit.org/b/311759 [ Release arm64 ] imported/w3c/web-platform-tests/event-timing/keydown.html [ Pass Failure ]
-
 webkit.org/b/311743 media/encrypted-media/mock-navigator-requestMediaKeySystemAccess.html [ Failure ]
 
 webkit.org/b/308325 [ Debug ] http/wpt/cache-storage/cache-in-stopped-context.html [ Pass Failure ]


### PR DESCRIPTION
#### 76a95d0f671282df9664afcd3556e092a7cdb42b
<pre>
[macOS release] imported/w3c/web-platform-tests/event-timing/keydown is a flaky text failure.
<a href="https://rdar.apple.com/174354241">rdar://174354241</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311759">https://bugs.webkit.org/show_bug.cgi?id=311759</a>

Reviewed by NOBODY (OOPS!).

The test uses event-timing-test-utils.js to create intentionally &quot;slow&quot; events and verify they are reported.
A PerformanceObserver is set up with durationThreshold: 16 — meaning events with duration ≥ 16ms should be reported.
The test then blocks the main thread for durationThreshold + 4 = 20ms to create a slow event.

The problem is that 20ms sits exactly on an 8ms rounding boundary. The Event Timing spec requires
durations to be rounded to the nearest 8ms for security (&quot;The duration has an 8 millisecond granularity&quot;). The
boundary between rounding to 16ms vs 24ms is at exactly 20.0ms. Additionally, WebKit spec states performance.now()
precision is 1ms. Since mainThreadBusy(20) uses performance.now() in its busy-wait loop, the 1ms floor quantization
means it can block for as little as ~19ms depending on where the initial timestamp falls relative to a 1ms tick. A
raw duration of 19ms rounds to 16ms instead of 24ms.

When the duration rounds to 16ms, the entry is still delivered to the observer (16 ≥ 16 satisfies the threshold),
but the verification assertion entry.duration + 4 &gt;= entry.processingEnd - entry.startTime fails — because 16 + 4 = 20
is not greater than or equal to the actual processing time of ~20+ms (processingEnd - startTime includes more than just
the busy-wait — it also includes the dispatch delay (time from event creation to handler invocation))

The fix is to change the blocking duration from durationThreshold + 4 (20ms) to durationThreshold + 5 (21ms), which
provides enough margin that even with worst-case clock quantization, the raw duration stays above the 20ms rounding
boundary and always rounds to 24ms.

* LayoutTests/imported/w3c/web-platform-tests/event-timing/resources/event-timing-test-utils.js:
* LayoutTests/platform/mac-wk2/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76a95d0f671282df9664afcd3556e092a7cdb42b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163871 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108695 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28219 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120007 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84801 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139289 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100700 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21353 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19394 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11697 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131015 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17132 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166349 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128109 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27915 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128247 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27839 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138925 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84548 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23113 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15720 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27532 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27110 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27340 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27183 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->