### PR TITLE
[Site Isolation] Use Page::mainFrame() instead of Frame::mainFrame() in LocalFrameView::axObjectCache()

### DIFF
--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -3,16 +3,6 @@
 ####################
 # Tests that crash #
 ####################
-http/tests/security/referrer-policy-header-empty.html [ Crash ]
-http/tests/security/referrer-policy-header-invalid.html [ Crash ]
-http/tests/security/referrer-policy-header-no-referrer-when-downgrade.html [ Crash ]
-http/tests/security/referrer-policy-header-no-referrer.html [ Crash ]
-http/tests/security/referrer-policy-header-origin-when-cross-origin.html [ Crash ]
-http/tests/security/referrer-policy-header-origin.html [ Crash ]
-http/tests/security/referrer-policy-header-same-origin.html [ Crash ]
-http/tests/security/referrer-policy-header-strict-origin-when-cross-origin.html [ Crash ]
-http/tests/security/referrer-policy-header-strict-origin.html [ Crash ]
-http/tests/security/referrer-policy-header-unsafe-url.html [ Crash ]
 imported/w3c/web-platform-tests/content-security-policy/inheritance/history.sub.html [ Crash ]
 imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https.html?origin=cross-site-redirect [ Crash ]
 imported/w3c/web-platform-tests/speculation-rules/speculation-tags/same-site-to-cross-site-redirection-prefetch.https.html [ Crash ]

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -6553,10 +6553,12 @@ AXObjectCache* LocalFrameView::axObjectCache() const
     // FIXME: We should generally always be using the main-frame cache rather than
     // using it as a fallback as we do here.
     if (!cache && !m_frame->isMainFrame()) {
-        RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_frame->mainFrame());
-        if (localMainFrame) {
-            if (RefPtr mainFrameDocument = localMainFrame->document())
-                cache = mainFrameDocument->existingAXObjectCache();
+        if (RefPtr page = m_frame->page()) {
+            RefPtr localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
+            if (localMainFrame) {
+                if (RefPtr mainFrameDocument = localMainFrame->document())
+                    cache = mainFrameDocument->existingAXObjectCache();
+            }
         }
     }
     return cache;


### PR DESCRIPTION
#### 3ff849dcd224fe599f4601ba703689280d38ce00
<pre>
[Site Isolation] Use Page::mainFrame() instead of Frame::mainFrame() in LocalFrameView::axObjectCache()
<a href="https://bugs.webkit.org/show_bug.cgi?id=311782">https://bugs.webkit.org/show_bug.cgi?id=311782</a>
<a href="https://rdar.apple.com/174366042">rdar://174366042</a>

Reviewed by NOBODY (OOPS!).

Frame::m_mainFrame is a WeakPtr&lt;Frame&gt; that can become null with site isolation enabled.
LocalFrameView::axObjectCache() calls isMainFrame() which returns false when
the WeakPtr is null, then unconditionally dereferences it via mainFrame(),
crashing in WeakPtr::operator*.

Go through Page::mainFrame() instead, which holds a Ref&lt;Frame&gt; that is
always valid and reflects the current main frame after a swap.

This patch fixes:
http/tests/security/referrer-policy-header-invalid.html
http/tests/security/referrer-policy-header-no-referrer-when-downgrade.html
http/tests/security/referrer-policy-header-no-referrer.html
http/tests/security/referrer-policy-header-origin-when-cross-origin.html
http/tests/security/referrer-policy-header-origin.html
http/tests/security/referrer-policy-header-same-origin.html
http/tests/security/referrer-policy-header-strict-origin-when-cross-origin.html
http/tests/security/referrer-policy-header-strict-origin.html
http/tests/security/referrer-policy-header-unsafe-url.html

* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::axObjectCache const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ff849dcd224fe599f4601ba703689280d38ce00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28477 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163977 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108923 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/da7589be-1dce-4e0e-985c-48b051caf368) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157090 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28325 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120104 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84830 "1 flakes 1 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a09cc4fc-373f-47aa-b33f-ad1d13ab397c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22354 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100799 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13e582af-1fab-414b-b5aa-a1702c9cb714) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21440 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19493 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11803 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131105 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166455 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10611 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18834 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128207 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23528 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128344 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27945 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139018 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84654 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23206 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15814 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27638 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91742 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27216 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27446 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27289 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->