### PR TITLE
AX: AXFrameGeometry should work for scrolling inside iframes

### DIFF
--- a/LayoutTests/accessibility/mac/iframe-content-position-after-inner-scroll-expected.txt
+++ b/LayoutTests/accessibility/mac/iframe-content-position-after-inner-scroll-expected.txt
@@ -1,0 +1,8 @@
+This test verifies that scrolling inside an iframe correctly updates the screen position of elements within it.
+
+PASS: delta was equal or approximately equal to 200.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/iframe-content-position-after-inner-scroll.html
+++ b/LayoutTests/accessibility/mac/iframe-content-position-after-inner-scroll.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+body {
+    margin: 0;
+}
+#container {
+    position: absolute;
+    top: 50px;
+    left: 10px;
+}
+iframe {
+    width: 300px;
+    height: 200px;
+    border: none;
+}
+</style>
+</head>
+<body>
+
+<div id="container">
+    <iframe id="iframe" onload="runTest()" src="data:text/html,<body style='margin:0'><div style='height:500px'><button id='target' style='width:80px;height:30px;position:absolute;top:300px'>Click me</button></div></body>"></iframe>
+</div>
+
+<script>
+window.jsTestIsAsync = true;
+
+var output = "This test verifies that scrolling inside an iframe correctly updates the screen position of elements within it.\n\n";
+
+var target, initialY, scrolledY, delta;
+function runTest() {
+    if (!window.accessibilityController)
+        return;
+
+    setTimeout(async function() {
+        target = await waitForIframeAccessibilityReady("container", "target");
+        initialY = target.y;
+
+        // Scroll the iframe content down by 200px.
+        document.getElementById("iframe").contentWindow.scrollTo(0, 200);
+
+        // Wait for the element's screen position to reflect the scroll.
+        // On macOS (bottom-left origin), scrolling content up makes the
+        // element's y value increase (it moves closer to the top of the
+        // iframe, which is higher on screen).
+        await waitFor(() => {
+            target = accessibilityController.accessibleElementById("target");
+            return target && target.y !== initialY;
+        });
+
+        scrolledY = target.y;
+        delta = scrolledY - initialY;
+        output += expectNumber("delta", 200, /* Allowed variance */ 5);
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/iframe-nested-scroll-position-expected.txt
+++ b/LayoutTests/accessibility/mac/iframe-nested-scroll-position-expected.txt
@@ -1,0 +1,8 @@
+This test verifies that scrolling a nested iframe correctly updates the screen position of elements within it.
+
+PASS: delta was equal or approximately equal to 200.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/iframe-nested-scroll-position.html
+++ b/LayoutTests/accessibility/mac/iframe-nested-scroll-position.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+body {
+    margin: 0;
+}
+#container {
+    position: absolute;
+    top: 50px;
+    left: 10px;
+}
+iframe {
+    width: 300px;
+    height: 200px;
+    border: none;
+}
+</style>
+</head>
+<body>
+
+<div id="container">
+    <iframe id="outer-iframe" onload="runTest()" src="data:text/html,
+        <body style='margin:0; height:600px'>
+            <div id='inner-container' style='position:absolute; top:50px'>
+                <iframe id='inner-iframe' style='width:280px; height:150px; border:none'
+                    src='data:text/html,<body style=&quot;margin:0; height:500px&quot;><button id=&quot;target&quot; style=&quot;width:80px; height:30px; position:absolute; top:300px&quot;>Click me</button></body>'>
+                </iframe>
+            </div>
+        </body>
+    "></iframe>
+</div>
+
+<script>
+window.jsTestIsAsync = true;
+
+var output = "This test verifies that scrolling a nested iframe correctly updates the screen position of elements within it.\n\n";
+
+var target, initialY, scrolledY, delta;
+function runTest() {
+    if (!window.accessibilityController)
+        return;
+
+    setTimeout(async function() {
+        await waitForIframeAccessibilityReady("container", "target");
+        target = await waitForIframeAccessibilityReady("inner-container", "target");
+        initialY = target.y;
+
+        // Scroll the inner iframe's content down by 200px.
+        document.getElementById("outer-iframe").contentWindow
+            .document.getElementById("inner-iframe").contentWindow
+            .scrollTo(0, 200);
+
+        // Wait for the element's screen position to reflect the scroll.
+        await waitFor(() => {
+            target = accessibilityController.accessibleElementById("target");
+            return target && target.y !== initialY;
+        });
+
+        scrolledY = target.y;
+        delta = scrolledY - initialY;
+        output += expectNumber("delta", 200, /* Allowed variance */ 5);
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/iframe-position-after-div-move.html
+++ b/LayoutTests/accessibility/mac/iframe-position-after-div-move.html
@@ -34,23 +34,12 @@ function runTest() {
         return;
 
     setTimeout(async function() {
-        // Wait for the iframe's frame geometry to be initialized and the
-        // target element inside the iframe to be accessible.
-        await waitFor(() => {
-            var iframeContainer = accessibilityController.accessibleElementById("container");
-            if (!iframeContainer)
-                return false;
-            var iframeScrollView = iframeContainer.childAtIndex(0);
-            if (!iframeScrollView || !iframeScrollView.isFrameGeometryInitialized)
-                return false;
-            target = accessibilityController.accessibleElementById("target");
-            return target;
-        });
-
+        target = await waitForIframeAccessibilityReady("container", "target");
         initialY = target.y;
 
         // Move the container div down by 200px.
         document.getElementById("container").style.top = "300px";
+
         // Wait for the element's absolute screen y to change after the move.
         await waitFor(() => {
             target = accessibilityController.accessibleElementById("target");

--- a/LayoutTests/accessibility/mac/iframe-position-after-scroll.html
+++ b/LayoutTests/accessibility/mac/iframe-position-after-scroll.html
@@ -37,24 +37,7 @@ function runTest() {
         return;
 
     setTimeout(async function() {
-        // Wait for the iframe's frame geometry to be initialized and the
-        // target element's position to stabilize.
-        var lastY;
-        await waitFor(() => {
-            var iframeContainer = accessibilityController.accessibleElementById("container");
-            if (!iframeContainer)
-                return false;
-            var iframeScrollView = iframeContainer.childAtIndex(0);
-            if (!iframeScrollView || !iframeScrollView.isFrameGeometryInitialized)
-                return false;
-            target = accessibilityController.accessibleElementById("target");
-            if (!target)
-                return false;
-            var stable = lastY === target.y;
-            lastY = target.y;
-            return stable;
-        });
-
+        target = await waitForIframeAccessibilityReady("container", "target");
         initialY = target.y;
 
         // Scroll the main page down by 300px.

--- a/LayoutTests/resources/accessibility-helper.js
+++ b/LayoutTests/resources/accessibility-helper.js
@@ -281,6 +281,23 @@ async function waitForFrameGeometryReady() {
     });
 }
 
+// Waits for an iframe's frame geometry to be initialized and for the target
+// element to be accessible. Returns the target element.
+async function waitForIframeAccessibilityReady(iframeContainerID, targetID) {
+    let target;
+    await waitFor(() => {
+        let container = accessibilityController.accessibleElementById(iframeContainerID);
+        if (!container)
+            return false;
+        let scrollView = container.childAtIndex(0);
+        if (!scrollView || !scrollView.isFrameGeometryInitialized)
+            return false;
+        target = accessibilityController.accessibleElementById(targetID);
+        return target;
+    });
+    return target;
+}
+
 async function waitForElementById(id) {
     let element;
     await waitFor(() => {

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1186,18 +1186,18 @@ void AXObjectCache::setFrameInheritedState(LocalFrame& frame, const InheritedFra
     scrollView->setInheritedFrameState(state);
 }
 
-void AXObjectCache::setFrameGeometry(LocalFrame& frame, const FrameGeometry& geometry)
+void AXObjectCache::setFrameGeometry(LocalFrame& frame, const AXFrameGeometry& geometry)
 {
     UNUSED_PARAM(frame);
     m_frameGeometry = geometry;
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     if (RefPtr tree = AXIsolatedTree::treeForFrameID(m_frameID))
-        tree->setFrameGeometry(FrameGeometry { geometry });
+        tree->setFrameGeometry(AXFrameGeometry { geometry });
 #endif
 }
 
-const std::optional<FrameGeometry>& AXObjectCache::getAndUpdateFrameGeometry()
+const std::optional<AXFrameGeometry>& AXObjectCache::getAndUpdateFrameGeometry()
 {
     if (RefPtr page = document()->page())
         page->chrome().client().requestFrameScreenPosition(frameID());

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -261,9 +261,21 @@ struct InheritedFrameState {
     bool isRenderHidden { false };
 };
 
+// Describes a frame's position and scale on screen for accessibility coordinate conversion.
+// Sent from the UIProcess to the WebProcess via IPC whenever the frame scrolls, moves, or resizes.
 // When this is updated, WebCoreArgumentCoders.serialization.in must be updated as well.
-struct FrameGeometry {
+struct AXFrameGeometry {
+    // The frame's content origin in screen coordinates.
+    //   - Coordinate space: bottom-left on macOS, top-left on other platforms.
+    //   - Points to: the top-left of the frame's document.
+    //   - Units: display pixels.
+    //   - Scroll: document-origin-based, so accounts for the frame's scroll position
+    //     (e.g. scrolling down moves the document origin up on screen).
+    // Element rects in content space compose with this directly to produce screen coordinates.
     IntPoint screenPosition;
+
+    // Scale accounts for page zoom and device scale factor, among other things.
+    // Applied to the element rect before adding screenPosition.
     AffineTransform screenTransform;
 };
 #endif
@@ -352,9 +364,9 @@ public:
     AccessibilityObject* rootWebArea();
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     WEBCORE_EXPORT void setFrameInheritedState(LocalFrame&, const InheritedFrameState&);
-    WEBCORE_EXPORT void setFrameGeometry(LocalFrame&, const FrameGeometry&);
-    const std::optional<FrameGeometry>& frameGeometry() const LIFETIME_BOUND { return m_frameGeometry; }
-    const std::optional<FrameGeometry>& getAndUpdateFrameGeometry() LIFETIME_BOUND;
+    WEBCORE_EXPORT void setFrameGeometry(LocalFrame&, const AXFrameGeometry&);
+    const std::optional<AXFrameGeometry>& frameGeometry() const LIFETIME_BOUND { return m_frameGeometry; }
+    const std::optional<AXFrameGeometry>& getAndUpdateFrameGeometry() LIFETIME_BOUND;
 #endif
 
     // Creation/retrieval of AX objects associated with a DOM or RenderTree object.
@@ -984,7 +996,7 @@ private:
     const WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     const FrameIdentifier m_frameID; // constant for object's lifetime.
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-    std::optional<FrameGeometry> m_frameGeometry;
+    std::optional<AXFrameGeometry> m_frameGeometry;
 #endif
     OptionSet<ActivityState> m_pageActivityState;
     HashMap<AXID, Ref<AccessibilityObject>> m_objects;

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -571,10 +571,8 @@ FloatRect AccessibilityObject::convertFrameToSpace(const FloatRect& frameRect, A
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     if (conversionSpace == AccessibilityConversionSpace::Screen) {
-        // For screen space, use contentsToView() to adjust for scroll *within* this frame,
-        // then apply the frame's screen transform and position (which account for iframe offsets and viewport scale).
-        if (parentScrollView)
-            snappedFrameRect = parentScrollView->contentsToView(snappedFrameRect);
+        // screenPosition is content-origin-based (shifts with scroll). Element rects are in content
+        // space (no scroll applied). These compose directly to give correct screen coordinates.
 
         RefPtr rootScrollView = dynamicDowncast<AccessibilityScrollView>(ancestorAccessibilityScrollView(true /* includeSelf */));
         if (!rootScrollView)
@@ -596,9 +594,8 @@ FloatRect AccessibilityObject::convertFrameToSpace(const FloatRect& frameRect, A
         return { position, scaledRect.size() };
     }
 
-    // FIXME: ENABLE(ACCESSIBILITY_LOCAL_FRAME) doesn't support page-relative frame, but this is used for old tests. Remove this once all tests are updated.
-    if (parentScrollView)
-        snappedFrameRect = parentScrollView->contentsToRootView(snappedFrameRect);
+    // For page space geometry (somewhat deprecated with ENABLE_ACCESSIBILITY_LOCAL_FRAME), return element rects in content space (no scroll applied).
+    return snappedFrameRect;
 #else
     // Legacy behavior: contentsToRootView walks up through all frames for local frames.
     // For remote frames, the caller (e.g., relativeFrame()) adds remoteFrameOffset().

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -594,7 +594,7 @@ bool AccessibilityScrollView::isFrameGeometryInitialized() const
     return true;
 }
 
-FrameGeometry AccessibilityScrollView::frameGeometry() const
+AXFrameGeometry AccessibilityScrollView::frameGeometry() const
 {
     if (CheckedPtr cache = axObjectCache()) {
         if (std::optional geometry = cache->frameGeometry())

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -62,7 +62,7 @@ public:
     // Returns the screen position and transform for this frame.
     // Reads from the AXObjectCache's cached value, populated asynchronously via IPC.
     // On first access when cache is empty, fires an async requestFrameScreenPosition.
-    FrameGeometry frameGeometry() const;
+    AXFrameGeometry frameGeometry() const;
     IntPoint frameScreenPosition() const final { return frameGeometry().screenPosition; }
     AffineTransform frameScreenTransform() const final { return frameGeometry().screenTransform; }
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -1400,6 +1400,9 @@ FloatRect AXIsolatedObject::convertFrameToSpace(const FloatRect& rect, Accessibi
         auto screenTransform = frameScreenTransform();
         auto scaledRect = screenTransform.mapRect(rect);
 
+        // scaledRect is in content space (no scroll applied at paint time).
+        // screenPosition is content-origin-based (shifts with scroll).
+        // Composing them directly gives the correct screen position.
         // Screen coordinates use bottom-left origin (on macOS).
         FloatPoint position = {
             screenPosition.x() + scaledRect.x(),

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -199,7 +199,7 @@ RefPtr<AXIsolatedTree> AXIsolatedTree::create(AXObjectCache& axObjectCache)
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     if (std::optional geometry = axObjectCache.getAndUpdateFrameGeometry())
-        tree->setFrameGeometry(FrameGeometry { *geometry });
+        tree->setFrameGeometry(AXFrameGeometry { *geometry });
 #endif
 
     auto relations = axObjectCache.relations();
@@ -1269,7 +1269,7 @@ void AXIsolatedTree::setSelectedTextMarkerRange(AXTextMarkerRange&& range)
 }
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-void AXIsolatedTree::setFrameGeometry(FrameGeometry&& geometry)
+void AXIsolatedTree::setFrameGeometry(AXFrameGeometry&& geometry)
 {
     Locker locker { m_changeLogLock };
     m_pendingFrameGeometry = WTF::move(geometry);
@@ -1313,7 +1313,7 @@ void AXIsolatedTree::updateRootScreenRelativePosition()
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
         // Sync current cache value to isolated tree and fire async request to keep it up-to-date.
         if (std::optional geometry = cache->getAndUpdateFrameGeometry())
-            setFrameGeometry(FrameGeometry { *geometry });
+            setFrameGeometry(AXFrameGeometry { *geometry });
 #endif
     }
 }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -446,9 +446,9 @@ public:
     constexpr AXGeometryManager* geometryManager() const { return m_geometryManager.get(); }
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-    FrameGeometry frameGeometry() const { return m_frameGeometry; }
+    AXFrameGeometry frameGeometry() const { return m_frameGeometry; }
     bool isFrameGeometryInitialized() const { return m_hasReceivedFrameGeometry; }
-    void setFrameGeometry(FrameGeometry&&);
+    void setFrameGeometry(AXFrameGeometry&&);
 #endif
 
     AXIsolatedObject* rootNode() { AX_ASSERT(!isMainThread()); return m_rootNode.get(); }
@@ -688,7 +688,7 @@ private:
     std::optional<HashMap<AXID, AXRelations>> m_pendingRelations WTF_GUARDED_BY_LOCK(m_changeLogLock);
     std::optional<AXTextMarkerRange> m_pendingSelectedTextMarkerRange WTF_GUARDED_BY_LOCK(m_changeLogLock);
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-    std::optional<FrameGeometry> m_pendingFrameGeometry WTF_GUARDED_BY_LOCK(m_changeLogLock);
+    std::optional<AXFrameGeometry> m_pendingFrameGeometry WTF_GUARDED_BY_LOCK(m_changeLogLock);
 #endif
     Markable<AXID> m_focusedNodeID;
     std::atomic<double> m_loadingProgress { 0 };
@@ -700,7 +700,7 @@ private:
     HashMap<AXID, LineRange> m_mostRecentlyPaintedText;
     HashMap<AXID, AXRelations> m_relations;
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-    FrameGeometry m_frameGeometry;
+    AXFrameGeometry m_frameGeometry;
     bool m_hasReceivedFrameGeometry { false };
 #endif
 

--- a/Source/WebCore/rendering/AccessibilityRegionContext.cpp
+++ b/Source/WebCore/rendering/AccessibilityRegionContext.cpp
@@ -116,9 +116,8 @@ void AccessibilityRegionContext::takeBounds(const RenderInline* renderInline, La
 void AccessibilityRegionContext::takeBoundsInternal(const RenderBoxModelObject& renderObject, IntRect&& paintRect)
 {
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-    // contentsToView() just applies *this* frame's scroll position. Scroll from other frames will be accounted for in  frameScreenPosition.
-    if (RefPtr view = renderObject.document().view())
-        paintRect = view->contentsToView(paintRect);
+    // We want to cache element rects without scroll applied (that's handled by AXFrameGeometry), so don't apply contentsToView.
+    UNUSED_PARAM(renderObject);
 #else
     if (RefPtr view = renderObject.document().view())
         paintRect = view->contentsToRootView(paintRect);
@@ -135,9 +134,8 @@ void AccessibilityRegionContext::takeBounds(const RenderText& renderText, FloatR
 {
     auto mappedPaintRect = enclosingIntRect(mapRect(WTF::move(paintRect)));
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-    // contentsToView() just applies *this* frame's scroll position. Scroll from other frames will be accounted for in  frameScreenPosition.
-    if (RefPtr view = renderText.document().view())
-        mappedPaintRect = view->contentsToView(mappedPaintRect);
+    // Same as takeBoundsInternal: keep rects in content space for ACCESSIBILITY_LOCAL_FRAME.
+    UNUSED_PARAM(renderText);
 #else
     if (RefPtr view = renderText.document().view())
         mappedPaintRect = view->contentsToRootView(mappedPaintRect);
@@ -172,11 +170,7 @@ void AccessibilityRegionContext::onPaint(const ScrollView& scrollView)
     if (RefPtr frameOwnerElement = frameView->frame().ownerElement()) {
         if (RefPtr ownerDocumentFrameView = frameOwnerElement->document().view()) {
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-            // contentsToView() just applies *this* frame's scroll position. Scroll from other frames will be accounted for in frameScreenPosition.
-            relativeFrame = ownerDocumentFrameView->contentsToView(relativeFrame);
             // Zero out the iframe position since frameScreenPosition accounts for it.
-            // This matches AccessibilityScrollView::elementRect() which also zeros the
-            // location for subframe root scroll views.
             relativeFrame.setLocation(IntPoint());
 #else
             relativeFrame = ownerDocumentFrameView->contentsToRootView(relativeFrame);

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1232,7 +1232,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WebCore::FontSmoothingMode': ['<WebCore/GraphicsTypes.h>'],
         'WebCore::FoundElementInRemoteFrame': ['<WebCore/FocusControllerTypes.h>'],
         'WebCore::FragmentedSharedBuffer': ['<WebCore/SharedBuffer.h>'],
-        'WebCore::FrameGeometry': ['<WebCore/AXObjectCache.h>'],
+        'WebCore::AXFrameGeometry': ['<WebCore/AXObjectCache.h>'],
         'WebCore::FrameIdentifierID': ['"GeneratedSerializers.h"'],
         'WebCore::FrameLoadType': ['<WebCore/FrameLoaderTypes.h>'],
         'WebCore::FrameTreeSyncSerializationData': ['<WebCore/FrameTreeSyncData.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9117,7 +9117,7 @@ header: <WebCore/AXObjectCache.h>
 };
 
 header: <WebCore/AXObjectCache.h>
-[CustomHeader] struct WebCore::FrameGeometry {
+[CustomHeader] struct WebCore::AXFrameGeometry {
     WebCore::IntPoint screenPosition;
     WebCore::AffineTransform screenTransform;
 };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10088,29 +10088,56 @@ void WebPageProxy::requestFrameScreenPosition(FrameIdentifier frameID)
         return;
 
     static constexpr float unitRectSize = 1000;
-    convertRectToMainFrameCoordinates(FloatRect(0, 0, unitRectSize, unitRectSize), frameID, [weakThis = WeakPtr { *this }, frameID](std::optional<FloatRect> finalRect) mutable {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !finalRect)
-            return;
 
-        RefPtr pageClient = protectedThis->pageClient();
-        if (!pageClient)
-            return;
+    RefPtr frame = WebFrameProxy::webFrame(frameID);
+    if (!frame)
+        return;
 
-        auto screenRect = pageClient->rootViewToAccessibilityScreen(enclosingIntRect(*finalRect));
+    RefPtr parent = frame->parentFrame();
 
-        FrameGeometry geometry;
+    if (parent) {
+        // For non-main frames, use convertRectToMainFrameCoordinates to chain ContentsToRootViewRect
+        // calls up through the frame hierarchy.
+        convertRectToMainFrameCoordinates(FloatRect(0, 0, unitRectSize, unitRectSize), frameID, [weakThis = WeakPtr { *this }, frameID](std::optional<FloatRect> finalRect) mutable {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis || !finalRect)
+                return;
+            protectedThis->applyAccessibilityFrameScreenPosition(frameID, *finalRect);
+        });
+    } else {
+        // Main frame: apply ContentsToRootViewRect directly to account for main frame scroll.
+        sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::ContentsToRootViewRect(frameID, FloatRect(0, 0, unitRectSize, unitRectSize)), [weakThis = WeakPtr { *this }, frameID](FloatRect convertedRect) mutable {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return;
+            protectedThis->applyAccessibilityFrameScreenPosition(frameID, convertedRect);
+        });
+    }
+}
+
+void WebPageProxy::applyAccessibilityFrameScreenPosition(FrameIdentifier frameID, const FloatRect& rootViewRect)
+{
+    static constexpr float unitRectSize = 1000;
+
+    RefPtr client = pageClient();
+    if (!client)
+        return;
+
+    // This screen rect will be offset based on the scroll of the frame, so when combined with element rects,
+    // will properly account for iframe's scroll.
+    auto screenRect = client->rootViewToAccessibilityScreen(enclosingIntRect(rootViewRect));
+
+    AXFrameGeometry geometry;
 #if PLATFORM(MAC)
-        // On macOS, NSRect origin is the bottom-left corner, so screenRect.location()
-        // is offset downward by the rect's height. Add it back to get the content origin.
-        geometry.screenPosition = { screenRect.x(), screenRect.y() + screenRect.height() };
+    // On macOS, NSRect origin is the bottom-left corner, so screenRect.location()
+    // is offset downward by the rect's height. Add it back to get the viewport origin.
+    geometry.screenPosition = { screenRect.x(), screenRect.y() + screenRect.height() };
 #else
-        geometry.screenPosition = screenRect.location();
+    geometry.screenPosition = screenRect.location();
 #endif
-        geometry.screenTransform = AffineTransform::makeScale({ screenRect.width() / unitRectSize, screenRect.height() / unitRectSize });
+    geometry.screenTransform = AffineTransform::makeScale({ screenRect.width() / unitRectSize, screenRect.height() / unitRectSize });
 
-        protectedThis->sendToProcessContainingFrame(frameID, Messages::WebPage::UpdateRemotePageAccessibilityScreenPosition(frameID, geometry));
-    });
+    sendToProcessContainingFrame(frameID, Messages::WebPage::UpdateRemotePageAccessibilityScreenPosition(frameID, geometry));
 }
 
 void WebPageProxy::updateAccessibilityFrameGeometry()

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3117,6 +3117,7 @@ private:
     void rootViewToAccessibilityScreen(const WebCore::IntRect& viewRect, CompletionHandler<void(WebCore::IntRect)>&&);
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     void requestFrameScreenPosition(WebCore::FrameIdentifier);
+    void applyAccessibilityFrameScreenPosition(WebCore::FrameIdentifier, const WebCore::FloatRect& rootViewRect);
 #endif
 #if PLATFORM(IOS_FAMILY)
     void relayAccessibilityNotification(String&&, std::span<const uint8_t>);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1813,7 +1813,7 @@ void WebPage::updateRemotePageAccessibilityInheritedState(WebCore::FrameIdentifi
     cache->setFrameInheritedState(*coreFrame, state);
 }
 
-void WebPage::updateRemotePageAccessibilityScreenPosition(WebCore::FrameIdentifier frameID, const WebCore::FrameGeometry& geometry)
+void WebPage::updateRemotePageAccessibilityScreenPosition(WebCore::FrameIdentifier frameID, const WebCore::AXFrameGeometry& geometry)
 {
     RefPtr frame = WebProcess::singleton().webFrame(frameID);
     RefPtr coreFrame = frame ? frame->coreLocalFrame() : nullptr;
@@ -8287,12 +8287,18 @@ void WebPage::getSamplingProfilerOutput(CompletionHandler<void(const String&)>&&
 
 void WebPage::didChangeScrollOffsetForFrame(LocalFrame& frame)
 {
-    if (!frame.isMainFrame())
-        return;
-
     // If this is called when tearing down a FrameView, the WebCore::Frame's
     // current FrameView will be null.
     if (!frame.view())
+        return;
+
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    // When any frame scrolls, the frame's screenPosition (content-origin-based)
+    // changes and needs to be recomputed for correct accessibility geometry.
+    scheduleAccessibilityFrameGeometryUpdate();
+#endif
+
+    if (!frame.isMainFrame())
         return;
 
     updateMainFrameScrollOffsetPinning();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -323,7 +323,7 @@ class HTMLAttachmentElement;
 class HandleUserInputEventResult;
 #endif
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-struct FrameGeometry;
+struct AXFrameGeometry;
 struct InheritedFrameState;
 #endif
 struct InteractionRegion;
@@ -2721,7 +2721,7 @@ private:
     void updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint);
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     void updateRemotePageAccessibilityInheritedState(WebCore::FrameIdentifier, const WebCore::InheritedFrameState&);
-    void updateRemotePageAccessibilityScreenPosition(WebCore::FrameIdentifier, const WebCore::FrameGeometry&);
+    void updateRemotePageAccessibilityScreenPosition(WebCore::FrameIdentifier, const WebCore::AXFrameGeometry&);
 #endif
     void resolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier, const WebCore::IntPoint&, CompletionHandler<void(String)>&&);
 #if PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -546,7 +546,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     UpdateRemotePageAccessibilityOffset(WebCore::FrameIdentifier frameID, WebCore::IntPoint offset);
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     UpdateRemotePageAccessibilityInheritedState(WebCore::FrameIdentifier frameID, struct WebCore::InheritedFrameState state);
-    UpdateRemotePageAccessibilityScreenPosition(WebCore::FrameIdentifier frameID, struct WebCore::FrameGeometry geometry);
+    UpdateRemotePageAccessibilityScreenPosition(WebCore::FrameIdentifier frameID, struct WebCore::AXFrameGeometry geometry);
 #endif
     ResolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier frameID, WebCore::IntPoint point) -> (String result)
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### 5a72101c1413a7572a96a26cc898f1bb1bd346b6
<pre>
AX: AXFrameGeometry should work for scrolling inside iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=311763">https://bugs.webkit.org/show_bug.cgi?id=311763</a>
<a href="https://rdar.apple.com/174356334">rdar://174356334</a>

Reviewed by Tyler Wilcock.

This PR fixes AXFrameGeometry to be more accurate in more cases. Prior, we were not accurately
computing the screen position for elements that were within a scrolled iframe. This was due to
double-applying the scroll position, via using contentsToView in AXFrameGeometry + the relative
frame, both of which applied the scroll position.

Now, we have much simpler math when computing screen position:
- AXFrameGeometry.screenPosition: the is the position of that frame *including* scroll (which
means, that the position is not necessarily the top left corner of the frame, since it may
be scrolled, but rather the position of the top left of that document).
- ElementRect: this is just the position of an element (without sccroll applied)
relative to the top left corner of it&apos;s document.

By adding these together, we can correctly compute the screen position, including when it is
nested. I&apos;ve added two tests to verify this behavior.

Tests: accessibility/mac/iframe-content-position-after-inner-scroll.html
       accessibility/mac/iframe-nested-scroll-position.html

* LayoutTests/accessibility/mac/iframe-content-position-after-inner-scroll-expected.txt: Added.
* LayoutTests/accessibility/mac/iframe-content-position-after-inner-scroll.html: Added.
* LayoutTests/accessibility/mac/iframe-nested-scroll-position-expected.txt: Added.
* LayoutTests/accessibility/mac/iframe-nested-scroll-position.html: Added.
* LayoutTests/accessibility/mac/iframe-position-after-div-move.html:
* LayoutTests/accessibility/mac/iframe-position-after-scroll.html:
* LayoutTests/resources/accessibility-helper.js:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::setFrameGeometry):
(WebCore::AXObjectCache::getAndUpdateFrameGeometry):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::convertFrameToSpace const):
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::frameGeometry const):
* Source/WebCore/accessibility/AccessibilityScrollView.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::convertFrameToSpace const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::create):
(WebCore::AXIsolatedTree::setFrameGeometry):
(WebCore::AXIsolatedTree::updateRootScreenRelativePosition):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::frameGeometry const):
* Source/WebCore/rendering/AccessibilityRegionContext.cpp:
(WebCore::AccessibilityRegionContext::takeBoundsInternal):
(WebCore::AccessibilityRegionContext::takeBounds):
(WebCore::AccessibilityRegionContext::onPaint):
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestFrameScreenPosition):
(WebKit::WebPageProxy::applyAccessibilityFrameScreenPosition):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updateRemotePageAccessibilityScreenPosition):
(WebKit::WebPage::didChangeScrollOffsetForFrame):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/310935@main">https://commits.webkit.org/310935@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d2831cbf06095db4fefa189497d4d990023ca22

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155331 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164100 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/97f3362c-d40a-4b41-8e2f-77a2abb2bab3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28441 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120215 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/60a98181-dba8-41f2-b79f-11729c0c6a7f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22468 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139498 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100905 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/154651 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21554 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19593 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11922 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131223 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17330 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166570 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18940 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128315 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28135 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128446 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34863 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28059 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139123 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85444 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23302 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15920 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27753 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91856 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27330 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27560 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27403 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->