### PR TITLE
Collapse single-case switch chains into prefix comparisons in generated NodeName.cpp

### DIFF
--- a/Source/WebCore/dom/make_names.pl
+++ b/Source/WebCore/dom/make_names.pl
@@ -1371,6 +1371,49 @@ sub candidatesWithStringLength
     return grep { length($_->{string}) == $expectedLength } @$candidates;
 }
 
+sub computeCommonPrefixLength
+{
+    my $candidates = shift;
+    my $startIndex = shift;
+    my $length = shift;
+
+    my $firstString = $candidates->[0]{string};
+    my $commonEnd = $length;
+    for my $candidate (@$candidates) {
+        my $string = $candidate->{string};
+        for (my $i = $startIndex; $i < $commonEnd; $i++) {
+            if (substr($string, $i, 1) ne substr($firstString, $i, 1)) {
+                $commonEnd = $i;
+                last;
+            }
+        }
+    }
+    return $commonEnd - $startIndex;
+}
+
+sub printPrefixCheck
+{
+    my $indent = shift;
+    my $startIndex = shift;
+    my $string = shift;
+    my $prefixLen = shift;
+
+    my $bufferStart = $startIndex > 0 ? "buffer.subspan($startIndex).data()" : "buffer.data()";
+    if ($prefixLen == 1) {
+        my $letter = substr($string, $startIndex, 1);
+        print F "${indent}if (buffer[$startIndex] == '$letter') {\n";
+    } elsif ($prefixLen <= 8) {
+        print F "${indent}if (compareCharacters($bufferStart";
+        for (my $index = $startIndex; $index < $startIndex + $prefixLen; $index++) {
+            my $letter = substr($string, $index, 1);
+            print F ", '$letter'";
+        }
+        print F ")) {\n";
+    } else {
+        print F "${indent}if (WTF::equal($bufferStart, \"". substr($string, $startIndex, $prefixLen) . "\"_span8)) {\n";
+    }
+}
+
 sub generateFindNameForLength
 {
     my $indent = shift;
@@ -1386,23 +1429,7 @@ sub generateFindNameForLength
         my $enumValue = $candidate->{enumValue};
         my $needsIfCheck = $currentIndex < $length;
         if ($needsIfCheck) {
-            my $lengthToCompare = $length - $currentIndex;
-            if ($lengthToCompare == 1) {
-                my $letter = substr($string, $currentIndex, 1);
-                print F "${indent}if (buffer[$currentIndex] == '$letter') {\n";
-            } else {
-                my $bufferStart = $currentIndex > 0 ? "buffer.subspan($currentIndex).data()" : "buffer.data()";
-                if ($lengthToCompare <= 8) {
-                    print F "${indent}if (compareCharacters($bufferStart";
-                    for (my $index = $currentIndex; $index < $length; $index = $index + 1) {
-                        my $letter = substr($string, $index, 1);
-                        print F ", '$letter'";
-                    }
-                    print F ")) {\n";
-                } else {
-                    print F "${indent}if (WTF::equal($bufferStart, \"". substr($string, $currentIndex, $length - $currentIndex) . "\"_span8)) {\n";
-                }
-            }
+            printPrefixCheck($indent, $currentIndex, $string, $length - $currentIndex);
             print F "$indent    return ${enumClass}::$enumValue;\n";
             print F "$indent}\n";
         } else {
@@ -1410,6 +1437,18 @@ sub generateFindNameForLength
         }
         return;
     }
+
+    # When all candidates share a common prefix at currentIndex, emit a single
+    # comparison for the shared prefix instead of single-case switches per character.
+    my $commonPrefixLen = computeCommonPrefixLength($candidates, $currentIndex, $length);
+    if ($commonPrefixLen > 1) {
+        printPrefixCheck($indent, $currentIndex, $candidates->[0]{string}, $commonPrefixLen);
+        generateFindNameForLength($indent . "    ", $candidates, $length, $currentIndex + $commonPrefixLen, $enumClass);
+        print F "${indent}    return ${enumClass}::Unknown;\n";
+        print F "$indent}\n";
+        return;
+    }
+
     print F "${indent}switch (buffer[$currentIndex]) {\n";
     for (my $i = 0; $i < $candidateCount;) {
         my $candidate = $candidates->[$i];
@@ -1468,7 +1507,7 @@ sub generateFindBody {
     }
     print F "    default:\n";
     print F "        break;\n";
-    print F "    };\n";
+    print F "    }\n";
     print F "    return ${enumClass}::Unknown;\n";
 }
 


### PR DESCRIPTION
#### b2bcb5ab9983735af83731aa5eb5fd8ada3f8f87
<pre>
Collapse single-case switch chains into prefix comparisons in generated NodeName.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=311785">https://bugs.webkit.org/show_bug.cgi?id=311785</a>

Reviewed by Darin Adler.

When multiple names share a long common prefix (e.g. vert-origin-x / vert-origin-y),
the generator was emitting one nested switch per shared character — up to 12 levels
deep — instead of a single compareCharacters() or WTF::equal() call for the shared
prefix. Detect common prefixes and emit a single comparison before recursing.

This did not show as an obvious progression on Speedometer (very close to noise
level) but it is theoretically more efficient and results in simpler / more concise
code so I think we should do it.

* Source/WebCore/dom/make_names.pl:
(computeCommonPrefixLength):
(printPrefixCheck):
(generateFindNameForLength):
(generateFindBody):

Canonical link: <a href="https://commits.webkit.org/310842@main">https://commits.webkit.org/310842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0028523439e00d35b31ee30338d9b734c12fa8eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163883 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156996 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28231 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120018 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158082 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139297 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100711 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/15debee7-cb4f-4e69-8f86-ed9720c19c9d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21358 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19407 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11709 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131020 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166361 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18748 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128121 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27927 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23446 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128259 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34799 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27851 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138932 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84560 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23127 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15727 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27544 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91647 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27122 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27352 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27195 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->