### PR TITLE
Move off of willBeginWritingToolsSession:forProofreadingReview:requestContexts:

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h
@@ -107,6 +107,12 @@ typedef NS_ENUM(NSInteger, WTCompositionSessionType) {
     WTCompositionSessionTypeProofread,
 };
 
+typedef NS_ENUM(NSInteger, WTProofreadingSessionType) {
+    WTProofreadingSessionTypeNone,
+    WTProofreadingSessionTypeUserInitiated,
+    WTProofreadingSessionTypeGrammarChecking,
+};
+
 typedef NS_ENUM(NSInteger, WTSessionType) {
     WTSessionTypeProofreading = 1,
     WTSessionTypeComposition,
@@ -116,6 +122,7 @@ typedef NS_ENUM(NSInteger, WTSessionType) {
 
 @property (nonatomic, readonly) NSUUID *uuid;
 @property (nonatomic, readonly) WTSessionType type;
+@property (nonatomic, readonly) WTProofreadingSessionType proofreadingSessionType;
 
 @property (nonatomic, weak) id<WTTextViewDelegate_Proposed_v1> textViewDelegate;
 

--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -259,6 +259,7 @@ request = "rdar://165789536"
 cleanup = "rdar://165842824"
 selectors = [
     { name = "requestProofreadingReviewOfString:range:language:options:completionHandler:", class = "UITextChecker" },
+    { name = "proofreadingSessionType", class = "WTSession" },
 ]
 
 [[staging]]

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2582,9 +2582,13 @@ static std::optional<WebCore::JSHandleIdentifier> jsHandleIdentifierInFrame(cons
     });
 }
 
+
 - (void)willBeginWritingToolsSession:(WTSession *)session requestContexts:(void (^)(NSArray<WTContext *> *))completion
 {
-    [self willBeginWritingToolsSession:session forProofreadingReview:NO requestContexts:completion];
+    BOOL proofreadingReview = NO;
+    if ([session respondsToSelector:@selector(proofreadingSessionType)] && [session proofreadingSessionType] == WTProofreadingSessionTypeGrammarChecking)
+        proofreadingReview = YES;
+    [self willBeginWritingToolsSession:session forProofreadingReview:proofreadingReview requestContexts:completion];
 }
 
 - (void)didBeginWritingToolsSession:(WTSession *)session contexts:(NSArray<WTContext *> *)contexts


### PR DESCRIPTION
#### c177a1016bb3a76c21b1495fde6daf3a66c6d924
<pre>
Move off of willBeginWritingToolsSession:forProofreadingReview:requestContexts:
<a href="https://bugs.webkit.org/show_bug.cgi?id=311794">https://bugs.webkit.org/show_bug.cgi?id=311794</a>
<a href="https://rdar.apple.com/174380999">rdar://174380999</a>

Reviewed by Abrar Rahman Protyasha.

This specific call is no longer needed, we will use willBeginWritingToolsSession:requestContexts:
with the requisite information about if this is for proofreading review on the session object.

* Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h:
* Source/WebKit/Configurations/AllowedSPI.toml:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView willBeginWritingToolsSession:requestContexts:]):

Canonical link: <a href="https://commits.webkit.org/310945@main">https://commits.webkit.org/310945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/861a346db1355f93431f1de09d7134e6f21e848d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164101 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c0d9a15c-e14e-4d1b-80d8-33cf7654217a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157212 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28449 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120213 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d784784-db94-4f8a-ac32-285220fcb58e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139504 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100903 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d4174b0e-e548-4c30-83b5-a8f93d3ac763) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21540 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19600 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11930 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131209 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166578 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10744 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18946 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128321 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28143 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23634 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128453 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34871 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28067 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139129 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85542 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23308 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15926 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27761 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91864 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27338 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27568 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27411 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->