### PR TITLE
base-select option hover style clipping with rotated transforms

### DIFF
--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1312,7 +1312,12 @@ void AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayou
             if (renderer) {
                 // FIXME: Remove the redundant anchorElements member. The mappings are available in anchorPositionedToAnchorMap.
                 state.anchorElements = findAnchorsForAnchorPositionedElement(*element, state.anchorNames, anchorsForAnchorName);
-                if (isLayoutTimeAnchorPositioned(renderer->style()))
+                bool hasRealAnchor = false;
+                for (auto& anchorNameAndElement : state.anchorElements) {
+                    if (anchorNameAndElement.value)
+                        hasRealAnchor = true;
+                }
+                if (hasRealAnchor && isLayoutTimeAnchorPositioned(renderer->style()))
                     renderer->setNeedsLayout();
 
                 Vector<ResolvedAnchor> anchors;
@@ -1349,7 +1354,7 @@ void AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayou
     }
 }
 
-void AnchorPositionEvaluator::updateAnchorPositionedStateForDefaultAnchorAndPositionVisibility(Element& element, const RenderStyle& style, AnchorPositionedStates& states)
+void AnchorPositionEvaluator::updateAnchorPositionedStateForDefaultAnchorAndPositionVisibility(Element& element, const RenderStyle& style, AnchorPositionedStates& states, const AnchorPositionedToAnchorMap& persistentMap)
 {
     auto shouldResolveDefaultAnchor = isAnchorPositioned(style);
 
@@ -1365,6 +1370,25 @@ void AnchorPositionEvaluator::updateAnchorPositionedStateForDefaultAnchorAndPosi
     auto& state = states.ensure({ &element, style.pseudoElementIdentifier() }, [&] {
         return makeUniqueRef<AnchorPositionedState>();
     }).iterator->value.get();
+
+    // Pre-seed from the persistent map to avoid restarting anchor resolution from scratch.
+    // This must happen after ensure() since the entry may have already been created by
+    // findAnchorForAnchorFunctionAndAttemptResolution during anchor() function evaluation.
+    if (state.stage == AnchorPositionResolutionStage::FindAnchors && state.anchorElements.isEmpty()) {
+        auto it = persistentMap.find(element);
+        if (it != persistentMap.end()) {
+            for (auto& anchor : it->value.anchors) {
+                auto* renderer = anchor.renderer.get();
+                auto* anchorElement = renderer ? renderer->element() : nullptr;
+                if (anchorElement) {
+                    state.anchorElements.add(anchor.name, *anchorElement);
+                    state.anchorNames.add(anchor.name);
+                }
+            }
+            if (!state.anchorNames.isEmpty())
+                state.stage = AnchorPositionResolutionStage::Positioned;
+        }
+    }
 
     if (shouldResolveDefaultAnchor) {
         // Always resolve the default anchor. Even if nothing is anchored to it we need it to compute the scroll compensation.

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -200,7 +200,7 @@ public:
 
     static void updateAnchorPositioningStatesAfterInterleavedLayout(Document&, AnchorPositionedStates&);
     static void updateScrollAdjustments(RenderView&);
-    static void updateAnchorPositionedStateForDefaultAnchorAndPositionVisibility(Element&, const RenderStyle&, AnchorPositionedStates&);
+    static void updateAnchorPositionedStateForDefaultAnchorAndPositionVisibility(Element&, const RenderStyle&, AnchorPositionedStates&, const AnchorPositionedToAnchorMap&);
 
     static LayoutRect computeAnchorRectRelativeToContainingBlock(CheckedRef<const RenderBoxModelObject> anchorBox, const RenderElement& containingBlock, const RenderBox& anchoredBox);
     static void captureScrollSnapshots(RenderBox& anchored, bool invalidateStyleForScrollPositionChanges = true);

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1560,7 +1560,7 @@ auto TreeResolver::updateAnchorPositioningState(Element& element, const RenderSt
     auto update = [&](const RenderStyle* style) {
         if (!style)
             return;
-        AnchorPositionEvaluator::updateAnchorPositionedStateForDefaultAnchorAndPositionVisibility(element, *style, m_treeResolutionState.anchorPositionedStates);
+        AnchorPositionEvaluator::updateAnchorPositionedStateForDefaultAnchorAndPositionVisibility(element, *style, m_treeResolutionState.anchorPositionedStates, m_document->styleScope().anchorPositionedToAnchorMap());
     };
 
     update(style);
@@ -1633,7 +1633,23 @@ void TreeResolver::generatePositionOptionsIfNeeded(const ResolvedStyle& resolved
     if (hasUnresolvedAnchorPosition(styleable))
         return;
 
-    m_positionOptions.add(positionOptionsKey, WTF::move(options));
+    auto addResult = m_positionOptions.add(positionOptionsKey, WTF::move(options));
+
+    // If the anchor state is already at Positioned (pre-seeded), try to immediately mark the
+    // last successful position option as chosen to avoid iterative position option trying.
+    if (hasResolvedAnchorPosition(styleable)) {
+        auto& addedOptions = addResult.iterator->value;
+        if (auto lastSuccessfulIndex = m_document->styleScope().lastSuccessfulPositionOptionIndexFor(styleable)) {
+            auto matchIndex = addedOptions.optionStyles.findIf([&](const auto& option) {
+                return option.style && option.style->usedPositionOptionIndex() == *lastSuccessfulIndex;
+            });
+            if (matchIndex != notFound) {
+                addedOptions.index = matchIndex;
+                addedOptions.chosen = true;
+                addedOptions.isFirstTry = false;
+            }
+        }
+    }
 }
 
 std::unique_ptr<RenderStyle> TreeResolver::generatePositionOption(const PositionTryFallback& fallback, const ResolvedStyle& resolvedStyle, const Styleable& styleable, const ResolutionContext& resolutionContext)

--- a/picker-bug-minimal.html
+++ b/picker-bug-minimal.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Picker overflow repaint bug</title>
+  <style>
+    select,
+    ::picker(select) {
+      appearance: base-select;
+    }
+
+    ::picker(select) {
+      overflow: visible;
+    }
+
+    option {
+      translate: 200px 0;
+    }
+
+    option:hover {
+      background: none;
+    }
+
+    option:hover span {
+      background: #eee;
+    }
+  </style>
+</head>
+<body>
+  <select>
+    <option value="one"><span>One</span></option>
+    <option value="two"><span>Two</span></option>
+  </select>
+</body>
+</html>

--- a/picker-bug-no-select.html
+++ b/picker-bug-no-select.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Picker overflow repaint bug — no select</title>
+  <style>
+    #picker {
+      overflow: visible; /* key: matches our ::picker(select) override */
+      position-area: block-end;
+    }
+
+    /* Simulate option styles */
+    .option {
+      translate: 400px 0;
+    }
+
+    span:hover {
+      background: lime;
+    }
+  </style>
+</head>
+<body>
+  <div id="picker" popover="manual">
+    <div class="option"><span>All this text should get a green background on hover</span></div>
+  </div>
+  <script>
+    picker.showPopover();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
#### 944721ab19141fbae2eff9be38d89f4fee57ee92
<pre>
base-select option hover style clipping with rotated transforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=311402">https://bugs.webkit.org/show_bug.cgi?id=311402</a>
<a href="https://rdar.apple.com/171933742">rdar://171933742</a>

Reviewed by NOBODY (OOPS!).

In <a href="https://patrickbrosset.com/lab/custom-select/folders/">https://patrickbrosset.com/lab/custom-select/folders/</a> the options
drawn outside the ::picker(select) rectangle have their :hover effect
clipped by the rectangle.

Strangely enough the cause of this is anchor positioning calling layout
too often and invalidating all the time.

(The hasRealAnchor change is only needed for picker-bug-no-select.html.
The other changes are needed for picker-bug-minimal.html.)
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/944721ab19141fbae2eff9be38d89f4fee57ee92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163915 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108717 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c39f8c13-e995-4d22-b28a-9f8627ebf5a8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157028 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28263 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120046 "Found 51 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-dynamic-reflow-root.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-positioned-containing-block-resize.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-001.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-005.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-chained-004.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-cleanup.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-js-expose.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-002.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-004.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84806 "1 flakes 51 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4ecd81a4-00f9-4812-a663-bfc7a1427225) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158114 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22295 "Found 1 new test failure: fast/css/css-anchor-position/position-visibility-add-no-overflow.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100743 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fce7db1c-4d1d-4bdf-a6ec-2f5d9a212eec) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21380 "Found 46 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-in-scroller-with-left-side-scrollbar.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-dynamic-reflow-root.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-positioned-containing-block-resize.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-001.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-005.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-chained-004.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-cleanup.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-002.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-004.html ... (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19437 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11741 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131042 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17171 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166393 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10630 "Found 1 new failure in style/AnchorPositionEvaluator.cpp") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18780 "Found 60 new test failures: fast/css/css-anchor-position/position-visibility-add-no-overflow.html fast/inline/rtl-negative-margins.html fast/scrolling/anchor-overscroll-fixed.html http/tests/performance/performance-resource-timing-cross-origin-media.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-dynamic-reflow-root.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-positioned-containing-block-resize.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-001.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-005.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-chained-004.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128150 "Found 52 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-dynamic-reflow-root.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-positioned-containing-block-resize.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-001.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-005.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-chained-004.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-cleanup.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-js-expose.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-002.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-004.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27959 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23474 "Found 60 new test failures: fast/css/css-anchor-position/position-visibility-add-no-overflow.html fast/scrolling/anchor-overscroll-fixed.html fullscreen/full-screen-keyboard-lock-option-enabled.html imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.serviceworker.html imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.worker.html imported/w3c/web-platform-tests/IndexedDB/nested-cloning-large-multiple.any.sharedworker.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-dynamic-reflow-root.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-positioned-containing-block-resize.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128287 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27883 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138964 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84592 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23150 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15760 "Found 60 new test failures: css3/masking/mask-base64.html fast/css/css-anchor-position/position-visibility-add-no-overflow.html fast/images/exif-orientation-element-object-fit.html fast/media/mq-prefers-contrast-live-update.html fast/scrolling/anchor-overscroll-fixed.html imported/w3c/web-platform-tests/IndexedDB/idbversionchangeevent.any.sharedworker.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-dynamic-reflow-root.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-positioned-containing-block-resize.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-001.html ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27576 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91680 "Found 1 new failure in style/AnchorPositionEvaluator.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27154 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27384 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27227 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->