### PR TITLE
Include all object elements in document named items

### DIFF
--- a/LayoutTests/fast/dom/HTMLDocument/object-by-name-or-id-expected.txt
+++ b/LayoutTests/fast/dom/HTMLDocument/object-by-name-or-id-expected.txt
@@ -1,4 +1,4 @@
-This tests when object elements are accessible by name or id directly as properties of the document object. IE allows this only if the object has not child nodes other than param and whitespace anonymous text. A PASS result means that behavior matches IE. WebKit’s results for comments differ.
+This tests that object elements are accessible by name or id directly as properties of the document object. Per the HTML spec and Chrome/Firefox behavior, an object element is “exposed” as long as it does not have an exposed object ancestor and does not contain any descendant object or embed elements.
 
 Results:
 

--- a/LayoutTests/fast/dom/HTMLDocument/object-by-name-or-id.html
+++ b/LayoutTests/fast/dom/HTMLDocument/object-by-name-or-id.html
@@ -1,8 +1,9 @@
 <body>
 
-<p>This tests when object elements are accessible by name or id directly as properties of the
-document object. IE allows this only if the object has not child nodes other than param and
-whitespace anonymous text. A PASS result means that behavior matches IE. WebKit&rsquo;s results for comments differ.
+<p>This tests that object elements are accessible by name or id directly as properties of the
+document object. Per the HTML spec and Chrome/Firefox behavior, an object element is &ldquo;exposed&rdquo;
+as long as it does not have an exposed object ancestor and does not contain any descendant
+object or embed elements.
 </p>
 
 <hr>
@@ -39,12 +40,12 @@ function print(x)
    document.getElementById("results").innerHTML += x;
 }
 
-function testProperty(description, propName, IE) {
+function testProperty(description, propName, expectedAccessible) {
     print(description);
     print(":");
     var propVal = document[propName];
 
-    print(!propVal == IE ? " FAIL" : " PASS");
+    print(!!propVal == expectedAccessible ? " PASS" : " FAIL");
     print("<br>");
 }
 
@@ -52,18 +53,18 @@ print("By name:<br>");
 testProperty("no children", "object1", true);
 testProperty("param", "object2", true);
 testProperty("param and whitespace", "object5", true);
-testProperty("param and empty comment", "object9", false);
-testProperty("param and non-empty comment", "object11", false);
-testProperty("param and text", "object6", false);
-testProperty("param and img", "object13", false);
+testProperty("param and empty comment", "object9", true);
+testProperty("param and non-empty comment", "object11", true);
+testProperty("param and text", "object6", true);
+testProperty("param and img", "object13", true);
 print("<br>By id:<br>");
 testProperty("no children", "object3", true);
 testProperty("param", "object4", true);
 testProperty("param and whitespace", "object8", true);
-testProperty("param and empty comment", "object10", false);
-testProperty("param and non-empty comment", "object12", false);
-testProperty("param and text", "object7", false);
-testProperty("param and img", "object14", false);
+testProperty("param and empty comment", "object10", true);
+testProperty("param and non-empty comment", "object12", true);
+testProperty("param and text", "object7", true);
+testProperty("param and img", "object14", true);
 
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-names-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-names-expected.txt
@@ -4,8 +4,8 @@ FAIL An embed name does not appears in a document's property names if the embed 
 PASS A form name appears in a document's property names.
 PASS An iframe name appears in a document's property names.
 PASS An img name appears in a document's property names when the img has no id.
-FAIL An object name appears in a document's property names if the object is exposed. assert_true: expected true got false
-FAIL An object id appears in a document's property names if the object is exposed. assert_true: expected true got false
+PASS An object name appears in a document's property names if the object is exposed.
+PASS An object id appears in a document's property names if the object is exposed.
 FAIL An object name does not appear in a document's property names if the object is inside another object. assert_false: expected false got true
 FAIL An object id does not appear in a document's property names if the object is inside another object. assert_false: expected false got true
 PASS An img name appears in a document's property names when the img has an id.
@@ -14,5 +14,5 @@ PASS An img id does not appear in a document's property names when the img has n
 PASS A document's property names can include integer strings.
 PASS A template name does not appear in a document's property names.
 PASS An img name does not appear in a document's property names when the img is in a template's document fragment.
-FAIL A document's property names appear in tree order. assert_greater_than: expected a number greater than 5 but got 0
+FAIL A document's property names appear in tree order. assert_greater_than: expected a number greater than 7 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-names.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-names.html
@@ -52,7 +52,7 @@ test(function() {
 }, "An img name appears in a document's property names when the img has no id.");
 
 test(function() {
-  assert_true(names.includes("exposed_object"))
+  assert_true(names.includes("exposed_object_with_name"))
 }, "An object name appears in a document's property names if the object is exposed.");
 
 test(function() {

--- a/Source/WebCore/html/HTMLDocument.cpp
+++ b/Source/WebCore/html/HTMLDocument.cpp
@@ -112,22 +112,27 @@ Ref<DocumentParser> HTMLDocument::createParser()
 // https://html.spec.whatwg.org/multipage/dom.html#dom-document-nameditem
 std::optional<Variant<Ref<WindowProxy>, Ref<Element>, Ref<HTMLCollection>>> HTMLDocument::namedItem(const AtomString& name)
 {
+    // hasDocumentNamedItem() is a fast-path that over-counts: it includes
+    // non-exposed object/embed elements. The collection applies isExposed()
+    // filtering, so it may end up empty even when the map has entries.
     if (name.isNull() || !hasDocumentNamedItem(name))
         return std::nullopt;
 
-    if (documentNamedItemContainsMultipleElements(name)) [[unlikely]] {
-        Ref collection = documentNamedItems(name);
-        ASSERT(collection->length() > 1);
-        return Variant<Ref<WindowProxy>, Ref<Element>, Ref<HTMLCollection>> { WTF::move(collection) };
+    Ref collection = documentNamedItems(name);
+    auto length = collection->length();
+    if (!length)
+        return std::nullopt;
+
+    if (length == 1) {
+        Ref element = *collection->item(0);
+        if (RefPtr iframe = dynamicDowncast<HTMLIFrameElement>(element)) [[unlikely]] {
+            if (RefPtr window = iframe->contentWindow())
+                return Variant<Ref<WindowProxy>, Ref<Element>, Ref<HTMLCollection>> { window.releaseNonNull() };
+        }
+        return Variant<Ref<WindowProxy>, Ref<Element>, Ref<HTMLCollection>> { WTF::move(element) };
     }
 
-    Ref element = *documentNamedItem(name);
-    if (RefPtr iframe = dynamicDowncast<HTMLIFrameElement>(element)) [[unlikely]] {
-        if (RefPtr window = iframe->contentWindow())
-            return Variant<Ref<WindowProxy>, Ref<Element>, Ref<HTMLCollection>> { window.releaseNonNull() };
-    }
-
-    return Variant<Ref<WindowProxy>, Ref<Element>, Ref<HTMLCollection>> { WTF::move(element) };
+    return Variant<Ref<WindowProxy>, Ref<Element>, Ref<HTMLCollection>> { WTF::move(collection) };
 }
 
 bool HTMLDocument::isSupportedPropertyName(const AtomString& name) const

--- a/Source/WebCore/html/HTMLEmbedElement.cpp
+++ b/Source/WebCore/html/HTMLEmbedElement.cpp
@@ -65,6 +65,16 @@ Ref<HTMLEmbedElement> HTMLEmbedElement::create(Document& document)
     return create(embedTag, document);
 }
 
+// https://html.spec.whatwg.org/multipage/dom.html#exposed
+bool HTMLEmbedElement::isExposed() const
+{
+    for (Ref ancestor : ancestorsOfType<HTMLObjectElement>(*this)) {
+        if (ancestor->isExposed())
+            return false;
+    }
+    return true;
+}
+
 static inline RenderWidget* findWidgetRenderer(const Node* node)
 {
     if (!node->renderer())

--- a/Source/WebCore/html/HTMLEmbedElement.h
+++ b/Source/WebCore/html/HTMLEmbedElement.h
@@ -33,6 +33,8 @@ public:
     static Ref<HTMLEmbedElement> create(Document&);
     static Ref<HTMLEmbedElement> create(const QualifiedName&, Document&);
 
+    bool isExposed() const;
+
 private:
     HTMLEmbedElement(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLNameCollection.cpp
+++ b/Source/WebCore/html/HTMLNameCollection.cpp
@@ -59,8 +59,11 @@ bool WindowNameCollection::elementMatches(const Element& element, const AtomStri
 
 static inline bool NODELETE isObjectElementForDocumentNameCollection(const Element& element)
 {
-    auto* objectElement = dynamicDowncast<HTMLObjectElement>(element);
-    return objectElement && objectElement->isExposed();
+    // This is used for supportedPropertyNames enumeration. All object elements
+    // are included unconditionally to match other browsers' behavior.
+    // The isExposed() check is applied later in elementMatches() when resolving
+    // a specific name to actual elements.
+    return is<HTMLObjectElement>(element);
 }
 
 bool DocumentNameCollection::elementMatchesIfIdAttributeMatch(const Element& element)
@@ -78,10 +81,21 @@ bool DocumentNameCollection::elementMatchesIfNameAttributeMatch(const Element& e
 
 bool DocumentNameCollection::elementMatches(const Element& element, const AtomString& name)
 {
-    // Find images, forms, applets, embeds, objects and iframes by name, applets and object by id, and images by id
-    // but only if they have a name attribute (this very strange rule matches IE).
-    return (elementMatchesIfNameAttributeMatch(element) && element.getNameAttribute() == name)
-        || (elementMatchesIfIdAttributeMatch(element) && element.getIdAttribute() == name);
+    // https://html.spec.whatwg.org/multipage/dom.html#dom-document-nameditem
+    // Only exposed object/embed elements should match when resolving a name.
+    // Note: elementMatchesIfNameAttributeMatch/elementMatchesIfIdAttributeMatch intentionally
+    // do not check isExposed() because they are used for supportedPropertyNames enumeration,
+    // where browsers include all object elements unconditionally.
+    if (auto* object = dynamicDowncast<HTMLObjectElement>(element))
+        return object->isExposed() && (element.getNameAttribute() == name || element.getIdAttribute() == name);
+    if (auto* embed = dynamicDowncast<HTMLEmbedElement>(element))
+        return embed->isExposed() && element.getNameAttribute() == name;
+
+    if (is<HTMLImageElement>(element)) {
+        const auto& nameValue = element.getNameAttribute();
+        return nameValue == name || (element.getIdAttribute() == name && !nameValue.isEmpty());
+    }
+    return isAnyOf<HTMLFormElement, HTMLIFrameElement>(element) && element.getNameAttribute() == name;
 }
 
 }

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -28,9 +28,11 @@
 #include "CSSValueKeywords.h"
 #include "CachedImage.h"
 #include "ContainerNodeInlines.h"
+#include "ElementAncestorIteratorInlines.h"
 #include "ElementChildIteratorInlines.h"
 #include "FrameLoader.h"
 #include "HTMLDocument.h"
+#include "HTMLEmbedElement.h"
 #include "HTMLFormElement.h"
 #include "HTMLImageLoader.h"
 #include "HTMLMetaElement.h"
@@ -50,7 +52,6 @@
 #include "Text.h"
 #include "Widget.h"
 #include <wtf/Ref.h>
-#include <wtf/RobinHoodHashSet.h>
 #include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -78,6 +79,20 @@ Ref<HTMLObjectElement> HTMLObjectElement::create(const QualifiedName& tagName, D
 HTMLObjectElement::~HTMLObjectElement()
 {
     clearForm();
+}
+
+// https://html.spec.whatwg.org/multipage/dom.html#exposed
+bool HTMLObjectElement::isExposed() const
+{
+    for (Ref ancestor : ancestorsOfType<HTMLObjectElement>(*this)) {
+        if (ancestor->isExposed())
+            return false;
+    }
+    for (auto& descendant : descendantsOfType<HTMLElement>(*this)) {
+        if (is<HTMLObjectElement>(descendant) || is<HTMLEmbedElement>(descendant))
+            return false;
+    }
+    return true;
 }
 
 int HTMLObjectElement::defaultTabIndex() const
@@ -259,7 +274,6 @@ void HTMLObjectElement::removingSteps(RemovalType removalType, ContainerNode& ol
 
 void HTMLObjectElement::childrenChanged(const ChildChange& change)
 {
-    updateExposedState();
     if (isConnected() && !m_useFallbackContent) {
         setNeedsWidgetUpdate(true);
         scheduleUpdateForAfterStyleResolution();
@@ -306,84 +320,6 @@ void HTMLObjectElement::renderFallbackContent()
     }
 
     m_useFallbackContent = true;
-}
-
-static inline bool preventsParentObjectFromExposure(const Element& child)
-{
-    static NeverDestroyed mostKnownTags = [] {
-        MemoryCompactLookupOnlyRobinHoodHashSet<QualifiedName> set;
-        auto tags = HTMLNames::getHTMLTags();
-        set.reserveInitialCapacity(tags.size());
-        for (auto* tagPtr : tags) {
-            auto& tag = *tagPtr;
-            // Only the param element was explicitly mentioned in the HTML specification rule
-            // we were trying to implement, but these are other known HTML elements that we
-            // have decided, over the years, to treat as children that do not prevent object
-            // names from being exposed.
-            if (tag == bgsoundTag
-                || tag == detailsTag
-                || tag == figcaptionTag
-                || tag == figureTag
-                || tag == paramTag
-                || tag == summaryTag
-                || tag == trackTag) {
-                continue;
-            }
-            set.add(tag);
-        }
-        return set;
-    }();
-    return mostKnownTags.get().contains(child.tagQName());
-}
-
-static inline bool preventsParentObjectFromExposure(const Node& child)
-{
-    if (auto* childElement = dynamicDowncast<Element>(child))
-        return preventsParentObjectFromExposure(*childElement);
-    if (auto* childText = dynamicDowncast<Text>(child))
-        return !childText->containsOnlyASCIIWhitespace();
-    return true;
-}
-
-static inline bool shouldBeExposed(const HTMLObjectElement& element)
-{
-    // FIXME: This should be redone to use the concept of an exposed object element,
-    // as documented in the HTML specification section describing DOM tree accessors.
-
-    // The rule we try to implement here, from older HTML specifications, is "object elements
-    // with no children other than param elements, unknown elements and whitespace can be found
-    // by name in a document, and other object elements cannot".
-
-    for (RefPtr child = element.firstChild(); child; child = child->nextSibling()) {
-        if (preventsParentObjectFromExposure(*child))
-            return false;
-    }
-    return true;
-}
-
-void HTMLObjectElement::updateExposedState()
-{
-    bool wasExposed = std::exchange(m_isExposed, shouldBeExposed(*this));
-
-    if (m_isExposed != wasExposed && isConnected() && !isInShadowTree()) {
-        if (RefPtr document = dynamicDowncast<HTMLDocument>(this->document())) {
-            auto& id = getIdAttribute();
-            if (!id.isEmpty()) {
-                if (m_isExposed)
-                    document->addDocumentNamedItem(id, *this);
-                else
-                    document->removeDocumentNamedItem(id, *this);
-            }
-
-            auto& name = getNameAttribute();
-            if (!name.isEmpty() && id != name) {
-                if (m_isExposed)
-                    document->addDocumentNamedItem(name, *this);
-                else
-                    document->removeDocumentNamedItem(name, *this);
-            }
-        }
-    }
 }
 
 void HTMLObjectElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const

--- a/Source/WebCore/html/HTMLObjectElement.h
+++ b/Source/WebCore/html/HTMLObjectElement.h
@@ -37,7 +37,7 @@ public:
 
     static Ref<HTMLObjectElement> create(const QualifiedName&, Document&, HTMLFormElement*);
 
-    bool isExposed() const { return m_isExposed; }
+    bool isExposed() const;
 
     bool hasFallbackContent() const;
     bool useFallbackContent() const final { return m_useFallbackContent; }
@@ -77,7 +77,6 @@ private:
     void addSubresourceAttributeURLs(ListHashSet<URL>&) const final;
 
     void updateWidget(CreatePlugins) final;
-    void updateExposedState();
 
     // FIXME: Better share code between <object> and <embed>.
     void parametersForPlugin(Vector<AtomString>& paramNames, Vector<AtomString>& paramValues);
@@ -100,7 +99,6 @@ private:
 
     bool canContainRangeEndPoint() const final;
 
-    bool m_isExposed { true };
     bool m_useFallbackContent { false };
 };
 


### PR DESCRIPTION
#### d03e9045af140d1da47cafa08fb19b01e2e56134
<pre>
Include all object elements in document named items
<a href="https://bugs.webkit.org/show_bug.cgi?id=311806">https://bugs.webkit.org/show_bug.cgi?id=311806</a>

Reviewed by Anne van Kesteren.

Get WebKit&apos;s document named item behavior closer to the HTML spec&apos;s
&quot;exposed&quot; concept and aligned with Chrome/Firefox:
- <a href="https://html.spec.whatwg.org/multipage/dom.html#exposed">https://html.spec.whatwg.org/multipage/dom.html#exposed</a>

Previously, WebKit used a non-standard algorithm that checked whether
an object element&apos;s children (text, comments, images, etc.) prevented
exposure. This differed from both the spec AND other browsers.

The spec says an object element is &quot;exposed&quot; if:
1. It has no exposed object ancestor, AND
2. It has no descendant object or embed elements.

This patch makes three key changes:

1. Re-implement isExposed() on HTMLObjectElement and HTMLEmbedElement
   to match the spec/Chrome algorithm (check for ancestor/descendant
   object/embed elements only, not arbitrary child types).

2. For supportedPropertyNames enumeration, include all object elements
   unconditionally (matching Chrome&apos;s GetNamedItemType() which returns
   kNameOrId without checking IsExposed()). For the actual named getter
   resolution in DocumentNameCollection::elementMatches(), apply the
   isExposed() filter (matching Chrome&apos;s DocumentNameCollection::
   ElementMatches()).

3. Update HTMLDocument::namedItem() to always go through the collection
   (which applies isExposed() filtering) rather than relying on the
   registration map counts, since the map includes all objects but the
   collection filters by exposure.

* LayoutTests/fast/dom/HTMLDocument/object-by-name-or-id-expected.txt:
* LayoutTests/fast/dom/HTMLDocument/object-by-name-or-id.html:
Updated to expect all object elements to be accessible (since none of
them contain descendant object/embed elements). I have verified that the
updated version of the test passes in both Chrome and Firefox.

* LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-names-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/documents/dom-tree-accessors/nameditem-names.html:
- Resync the WPT test from upsteam. It had a stale assertion checking for
&quot;exposed_object&quot; instead of &quot;exposed_object_with_name&quot;.
- Rebaseline the test now that we pass two more subtests. Our output
on this test is now identical to Chrome and Firefox&apos;s.

* Source/WebCore/html/HTMLDocument.cpp:
(WebCore::HTMLDocument::namedItem):
* Source/WebCore/html/HTMLEmbedElement.cpp:
(WebCore::HTMLEmbedElement::isExposed const):
* Source/WebCore/html/HTMLEmbedElement.h:
* Source/WebCore/html/HTMLNameCollection.cpp:
(WebCore::isObjectElementForDocumentNameCollection):
(WebCore::DocumentNameCollection::elementMatches):
* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::isExposed const):
(WebCore::HTMLObjectElement::childrenChanged):
(WebCore::preventsParentObjectFromExposure): Deleted.
(WebCore::shouldBeExposed): Deleted.
(WebCore::HTMLObjectElement::updateExposedState): Deleted.
* Source/WebCore/html/HTMLObjectElement.h:

Canonical link: <a href="https://commits.webkit.org/310974@main">https://commits.webkit.org/310974@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2588800b48f5e54412828a21fa0c1b0b1634095a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164258 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f650a683-3877-49b9-8d81-631e5e76baff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157369 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28606 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120343 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9431213d-638b-4bd2-b686-d48260d4026d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139632 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101033 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0039c6eb-98a4-4e83-a9cc-a2618a8b4e8f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21620 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19731 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12089 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131289 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17464 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166736 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10913 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19074 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128456 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28300 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23765 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128590 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34888 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28224 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139257 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85666 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23424 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16054 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27918 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92021 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27495 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27725 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27568 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->