### PR TITLE
innerText getter: fix blank line handling for <p> and headings, and strip trailing block newlines

### DIFF
--- a/LayoutTests/accessibility/combobox/aria-combobox-hierarchy-expected.txt
+++ b/LayoutTests/accessibility/combobox/aria-combobox-hierarchy-expected.txt
@@ -5,7 +5,6 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 AXRole: AXComboBox AXValue: option 1
 option 2
-
     AXRole: AXList AXValue:
         AXRole: AXStaticText AXValue:
         AXRole: AXStaticText AXValue:

--- a/LayoutTests/editing/pasteboard/line-feed-between-br-and-b-should-not-reorder-pasted-content-expected.txt
+++ b/LayoutTests/editing/pasteboard/line-feed-between-br-and-b-should-not-reorder-pasted-content-expected.txt
@@ -21,7 +21,6 @@ Should see the text self-documenting itself correctly:
 bold
 plain
 
-
 Before cut:
 | "\n"
 | <div>

--- a/LayoutTests/fast/dom/NodeList/childNodes-reverse-iteration-expected.txt
+++ b/LayoutTests/fast/dom/NodeList/childNodes-reverse-iteration-expected.txt
@@ -5,5 +5,5 @@ This is an integration test for childNodes. You should see 1 through 5 below.
 3
 4
 5
-PASS node.innerText is '1\n2\n3\n4\n5\n'
+PASS node.innerText is '1\n2\n3\n4\n5'
 

--- a/LayoutTests/fast/dom/NodeList/childNodes-reverse-iteration.html
+++ b/LayoutTests/fast/dom/NodeList/childNodes-reverse-iteration.html
@@ -25,7 +25,7 @@ for (var j = 0; j < 5; ++j) {
     }
 }
 
-shouldBe("node.innerText", "'1\\n2\\n3\\n4\\n5\\n'");
+shouldBe("node.innerText", "'1\\n2\\n3\\n4\\n5'");
 
 </script>
 </body>

--- a/LayoutTests/fast/dom/inner-text-001-expected.txt
+++ b/LayoutTests/fast/dom/inner-text-001-expected.txt
@@ -24,9 +24,7 @@ This line contains  an image.
 The innerText of the above:
 
 Test innerText
-
 Check lists, tables, styled text, and images.
-
 Block flow elements get line breaks before and after. Table cells are tab separated.
 Item 1
 Item 2
@@ -37,12 +35,9 @@ Right here is an inline block.
 And an  inline	table	with	one	row  is here, too.
 And an  inline	table	with	rows  not far behind.
 Check collapsed margins
-
 Collapsed margins are supposed to result in an extra line break.
 First header
-
 Second header
-
 First list element
 Second list element
 This line contains  an image.

--- a/LayoutTests/fast/dom/inner-text-first-letter-expected.txt
+++ b/LayoutTests/fast/dom/inner-text-first-letter-expected.txt
@@ -13,13 +13,13 @@ PASS document.getElementById('preSpaceFirst').innerText is document.getElementBy
 PASS document.getElementById('collapsedSpaceDivFirst').innerText is document.getElementById('collapsedSpaceDivNormal').innerText
 PASS document.getElementById('firstCollapsedDivFirst').innerText is document.getElementById('firstCollapsedDivNormal').innerText
 PASS document.getElementById('collapsedSpaceCollapsedDivFirst').innerText is document.getElementById('collapsedSpaceCollapsedDivNormal').innerText
-PASS document.getElementById('collapsedSpaceCollapsedDivFirst').innerText is 'foo\nabc\n'
+PASS document.getElementById('collapsedSpaceCollapsedDivFirst').innerText is 'foo\nabc'
 PASS document.getElementById('collapsedSpacePunctDivFirst').innerText is document.getElementById('collapsedSpacePunctDivNormal').innerText
-PASS document.getElementById('collapsedSpacePunctDivFirst').innerText is 'foo\n| abc\n'
+PASS document.getElementById('collapsedSpacePunctDivFirst').innerText is 'foo\n| abc'
 PASS document.getElementById('divSpanFirst').innerText is document.getElementById('divSpanNormal').innerText
 PASS document.getElementById('invisiblePre').innerText is ''
-PASS document.getElementById('invisiblePreFirst').innerText is 't\n'
-PASS document.getElementById('invisible').innerText is 'test\n'
+PASS document.getElementById('invisiblePreFirst').innerText is 't'
+PASS document.getElementById('invisible').innerText is 'test'
 PASS document.getElementById('floatDt').innerText is 'Ab Cd E'
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/dom/inner-text-first-letter.html
+++ b/LayoutTests/fast/dom/inner-text-first-letter.html
@@ -82,13 +82,13 @@ shouldBe("document.getElementById('preSpaceFirst').innerText", "document.getElem
 shouldBe("document.getElementById('collapsedSpaceDivFirst').innerText", "document.getElementById('collapsedSpaceDivNormal').innerText");
 shouldBe("document.getElementById('firstCollapsedDivFirst').innerText", "document.getElementById('firstCollapsedDivNormal').innerText");
 shouldBe("document.getElementById('collapsedSpaceCollapsedDivFirst').innerText", "document.getElementById('collapsedSpaceCollapsedDivNormal').innerText");
-shouldBe("document.getElementById('collapsedSpaceCollapsedDivFirst').innerText", "'foo\\nabc\\n'");
+shouldBe("document.getElementById('collapsedSpaceCollapsedDivFirst').innerText", "'foo\\nabc'");
 shouldBe("document.getElementById('collapsedSpacePunctDivFirst').innerText", "document.getElementById('collapsedSpacePunctDivNormal').innerText");
-shouldBe("document.getElementById('collapsedSpacePunctDivFirst').innerText", "'foo\\n| abc\\n'");
+shouldBe("document.getElementById('collapsedSpacePunctDivFirst').innerText", "'foo\\n| abc'");
 shouldBe("document.getElementById('divSpanFirst').innerText", "document.getElementById('divSpanNormal').innerText");
 shouldBe("document.getElementById('invisiblePre').innerText", "''");
-shouldBe("document.getElementById('invisiblePreFirst').innerText", "'t\\n'");
-shouldBe("document.getElementById('invisible').innerText", "'test\\n'");
+shouldBe("document.getElementById('invisiblePreFirst').innerText", "'t'");
+shouldBe("document.getElementById('invisible').innerText", "'test'");
 shouldBe("document.getElementById('floatDt').innerText", "'Ab Cd E'");
 document.getElementById('tests').innerHTML = "";
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt
@@ -1,5 +1,3 @@
-1
-2
 
 PASS Simplest possible test ("<div>abc")
 PASS Leading whitespace removed ("<div> abc")
@@ -16,7 +14,7 @@ PASS Internal whitespace preserved ("<pre>abc  def")
 PASS \n preserved ("<pre>abc\ndef")
 PASS \r converted to newline ("<pre>abc\rdef")
 PASS \t preserved ("<pre>abc\tdef")
-FAIL Two <pre> siblings ("<div><pre>abc</pre><pre>def</pre>") assert_equals: innerText expected "abc\ndef" but got "abc\ndef\n"
+PASS Two <pre> siblings ("<div><pre>abc</pre><pre>def</pre>")
 PASS Leading whitespace preserved ("<div style='white-space:pre'> abc")
 PASS Trailing whitespace preserved ("<div style='white-space:pre'>abc ")
 PASS Internal whitespace preserved ("<div style='white-space:pre'>abc  def")
@@ -41,8 +39,8 @@ PASS Whitespace collapses across element boundaries ("<div><span>abc </span><spa
 PASS Whitespace around <input> should not be collapsed ("<div>abc <input> def")
 PASS Whitespace around inline-block should not be collapsed ("<div>abc <span style='display:inline-block'></span> def")
 FAIL Trailing space at end of inline-block should be collapsed ("<div>abc <span style='display:inline-block'> def </span> ghi") assert_equals: innerText expected "abc def ghi" but got "abc def  ghi"
-FAIL Whitespace between <input> and block should be collapsed ("<div><input> <div>abc</div>") assert_equals: innerText expected "abc" but got "\nabc\n"
-FAIL Whitespace between inline-block and block should be collapsed ("<div><span style='inline-block'></span> <div>abc</div>") assert_equals: innerText expected "abc" but got "abc\n"
+FAIL Whitespace between <input> and block should be collapsed ("<div><input> <div>abc</div>") assert_equals: innerText expected "abc" but got "\nabc"
+PASS Whitespace between inline-block and block should be collapsed ("<div><span style='inline-block'></span> <div>abc</div>")
 PASS Whitespace around <img> should not be collapsed ("<div>abc <img> def")
 PASS Whitespace around <img> should not be collapsed ("<div>abc <img width=1 height=1> def")
 PASS Leading whitesapce should not be collapsed ("<div><img> abc")
@@ -92,10 +90,10 @@ PASS visibility:visible child rendered ("<div style='visibility:hidden'>123<span
 PASS visibility:collapse row-group ("<table><tbody style='visibility:collapse'><tr><td>abc")
 PASS visibility:collapse row ("<table><tr style='visibility:collapse'><td>abc")
 PASS visibility:collapse cell ("<table><tr><td style='visibility:collapse'>abc")
-FAIL visibility:collapse row-group with visible cell ("<table><tbody style='visibility:collapse'><tr><td style='visibility:visible'>abc") assert_equals: innerText expected "abc" but got "abc\n"
-FAIL visibility:collapse row with visible cell ("<table><tr style='visibility:collapse'><td style='visibility:visible'>abc") assert_equals: innerText expected "abc" but got "abc\n"
-FAIL visibility:collapse honored on flex item ("<div style='display:flex'><span style='visibility:collapse'>1</span><span>2</span></div>") assert_equals: innerText expected "2" but got "2\n"
-FAIL visibility:collapse honored on grid item ("<div style='display:grid'><span style='visibility:collapse'>1</span><span>2</span></div>") assert_equals: innerText expected "2" but got "2\n"
+PASS visibility:collapse row-group with visible cell ("<table><tbody style='visibility:collapse'><tr><td style='visibility:visible'>abc")
+PASS visibility:collapse row with visible cell ("<table><tr style='visibility:collapse'><td style='visibility:visible'>abc")
+PASS visibility:collapse honored on flex item ("<div style='display:flex'><span style='visibility:collapse'>1</span><span>2</span></div>")
+PASS visibility:collapse honored on grid item ("<div style='display:grid'><span style='visibility:collapse'>1</span><span>2</span></div>")
 PASS opacity:0 container ("<div style='opacity:0'>abc")
 PASS Whitespace compression in opacity:0 container ("<div style='opacity:0'>abc  def")
 PASS Remove leading/trailing whitespace in opacity:0 container ("<div style='opacity:0'> abc def ")
@@ -104,7 +102,7 @@ PASS Generated content not included ("<div class='before'>")
 PASS Generated content on child not included ("<div><div class='before'>")
 PASS <button> contents preserved ("<button>abc")
 PASS <fieldset> contents preserved ("<fieldset>abc")
-FAIL <fieldset> <legend> contents preserved ("<fieldset><legend>abc") assert_equals: innerText expected "abc" but got "abc\n"
+PASS <fieldset> <legend> contents preserved ("<fieldset><legend>abc")
 PASS <input> contents ignored ("<input type='text' value='abc'>")
 PASS <textarea> contents ignored ("<textarea>abc")
 PASS <iframe> contents ignored ("<iframe>abc")
@@ -120,8 +118,8 @@ PASS <canvas> contents ignored ("<canvas>abc")
 PASS <canvas><div id='target'> contents ok for element not being rendered ("<canvas><div id='target'>abc")
 PASS <img> alt text ignored ("<img alt='abc'>")
 PASS <img> contents ignored ("<img src='about:blank' class='poke'>")
-FAIL <svg> text contents preserved ("<div><svg><text>abc</text></svg></div>") assert_equals: innerText expected "abc" but got "abc\n"
-FAIL <svg><defs> text contents ignored ("<div><svg><defs><text>abc</text></defs></svg></div>") assert_equals: innerText expected "" but got "abc\n"
+PASS <svg> text contents preserved ("<div><svg><text>abc</text></svg></div>")
+FAIL <svg><defs> text contents ignored ("<div><svg><defs><text>abc</text></defs></svg></div>") assert_equals: innerText expected "" but got "abc"
 PASS <svg> non-rendered text ignored ("<div><svg><stop>abc</stop></svg></div>")
 PASS <foreignObject> contents preserved ("<svg><foreignObject><span id='target'>abc</span></foreignObject></svg>")
 FAIL <select size='1'> contents of options preserved ("<select size='1'><option>abc</option><option>def") assert_equals: innerText expected "abc\ndef" but got ""
@@ -140,8 +138,8 @@ FAIL <optgroup> in <div> ("<div>a<optgroup>123</optgroup>bc") assert_equals: inn
 FAIL empty <option> in <div> ("<div>a<option></option>bc") assert_equals: innerText expected "a\nbc" but got "abc"
 FAIL <option> in <div> ("<div>a<option>123</option>bc") assert_equals: innerText expected "a\n123\nbc" but got "a123bc"
 PASS <button> contents preserved ("<div><button>abc")
-FAIL <fieldset> contents preserved ("<div><fieldset>abc") assert_equals: innerText expected "abc" but got "abc\n"
-FAIL <fieldset> <legend> contents preserved ("<div><fieldset><legend>abc") assert_equals: innerText expected "abc" but got "abc\n"
+PASS <fieldset> contents preserved ("<div><fieldset>abc")
+PASS <fieldset> <legend> contents preserved ("<div><fieldset><legend>abc")
 PASS <input> contents ignored ("<div><input type='text' value='abc'>")
 PASS <textarea> contents ignored ("<div><textarea>abc")
 FAIL <select size='1'> contents of options preserved ("<div><select size='1'><option>abc</option><option>def") assert_equals: innerText expected "abc\ndef" but got ""
@@ -156,28 +154,29 @@ PASS Newline at block boundary ("<div>123<div>abc</div>def")
 PASS Newline at display:block boundary ("<div>123<span style='display:block'>abc</span>def")
 PASS Empty block induces single line break ("<div>abc<div></div>def")
 PASS Consecutive empty blocks ignored ("<div>abc<div></div><div></div>def")
-FAIL No blank lines around <p> alone ("<div><p>abc") assert_equals: innerText expected "abc" but got "abc\n\n"
-FAIL No blank lines around <p> followed by only collapsible whitespace ("<div><p>abc</p> ") assert_equals: innerText expected "abc" but got "abc\n\n"
-FAIL No blank lines around <p> preceded by only collapsible whitespace ("<div> <p>abc</p>") assert_equals: innerText expected "abc" but got "abc\n\n"
-FAIL Blank line between consecutive <p>s ("<div><p>abc<p>def") assert_equals: innerText expected "abc\n\ndef" but got "abc\n\ndef\n\n"
-FAIL Blank line between consecutive <p>s separated only by collapsible whitespace ("<div><p>abc</p> <p>def") assert_equals: innerText expected "abc\n\ndef" but got "abc\n\ndef\n\n"
-FAIL Blank line between consecutive <p>s separated only by empty block ("<div><p>abc</p><div></div><p>def") assert_equals: innerText expected "abc\n\ndef" but got "abc\n\ndef\n\n"
-FAIL Blank lines between <p>s separated by non-empty block ("<div><p>abc</p><div>123</div><p>def") assert_equals: innerText expected "abc\n\n123\n\ndef" but got "abc\n\n123\ndef\n\n"
-FAIL Blank lines around a <p> in its own block ("<div>abc<div><p>123</p></div>def") assert_equals: innerText expected "abc\n\n123\n\ndef" but got "abc\n123\n\ndef"
-FAIL Blank line before <p> ("<div>abc<p>def") assert_equals: innerText expected "abc\n\ndef" but got "abc\ndef\n\n"
+PASS No blank lines around <p> alone ("<div><p>abc")
+PASS No blank lines around <p> followed by only collapsible whitespace ("<div><p>abc</p> ")
+PASS No blank lines around <p> preceded by only collapsible whitespace ("<div> <p>abc</p>")
+PASS Blank line between consecutive <p>s ("<div><p>abc<p>def")
+PASS Blank line between consecutive <p>s separated only by collapsible whitespace ("<div><p>abc</p> <p>def")
+PASS Blank line between consecutive <p>s separated only by empty block ("<div><p>abc</p><div></div><p>def")
+PASS Blank lines between <p>s separated by non-empty block ("<div><p>abc</p><div>123</div><p>def")
+PASS Blank lines around a <p> in its own block ("<div>abc<div><p>123</p></div>def")
+PASS Blank line before <p> ("<div>abc<p>def")
 PASS Blank line after <p> ("<div><p>abc</p>def")
-FAIL One blank line between <p>s, ignoring empty <p>s ("<div><p>abc<p></p><p></p><p>def") assert_equals: innerText expected "abc\n\ndef" but got "abc\n\ndef\n\n"
-FAIL Invisible <p> doesn't induce extra line breaks ("<div style='visibility:hidden'><p><span style='visibility:visible'>abc</span></p>\n<div style='visibility:visible'>def</div>") assert_equals: innerText expected "abc\ndef" but got "abc\n\ndef\n"
-FAIL No blank lines around <div> with margin ("<div>abc<div style='margin:2em'>def") assert_equals: innerText expected "abc\ndef" but got "abc\ndef\n"
+PASS One blank line between <p>s, ignoring empty <p>s ("<div><p>abc<p></p><p></p><p>def")
+FAIL Invisible <p> doesn't induce extra line breaks ("<div style='visibility:hidden'><p><span style='visibility:visible'>abc</span></p>\n<div style='visibility:visible'>def</div>") assert_equals: innerText expected "abc\ndef" but got "abc\n\ndef"
+PASS <pre> trailing newlines don't suppress <p> blank line ("<div><pre>abc\n\n</pre><p>def")
+PASS No blank lines around <div> with margin ("<div>abc<div style='margin:2em'>def")
 PASS No newlines at display:inline-block boundary ("<div>123<span style='display:inline-block'>abc</span>def")
 FAIL Leading/trailing space removal at display:inline-block boundary ("<div>123<span style='display:inline-block'> abc </span>def") assert_equals: innerText expected "123abcdef" but got "123 abc def"
-FAIL Blank lines around <p> even without margin ("<div>123<p style='margin:0px'>abc</p>def") assert_equals: innerText expected "123\n\nabc\n\ndef" but got "123\nabc\ndef"
-FAIL No blank lines around <h1> ("<div>123<h1>abc</h1>def") assert_equals: innerText expected "123\nabc\ndef" but got "123\nabc\n\ndef"
-FAIL No blank lines around <h2> ("<div>123<h2>abc</h2>def") assert_equals: innerText expected "123\nabc\ndef" but got "123\nabc\n\ndef"
-FAIL No blank lines around <h3> ("<div>123<h3>abc</h3>def") assert_equals: innerText expected "123\nabc\ndef" but got "123\nabc\n\ndef"
-FAIL No blank lines around <h4> ("<div>123<h4>abc</h4>def") assert_equals: innerText expected "123\nabc\ndef" but got "123\nabc\n\ndef"
-FAIL No blank lines around <h5> ("<div>123<h5>abc</h5>def") assert_equals: innerText expected "123\nabc\ndef" but got "123\nabc\n\ndef"
-FAIL No blank lines around <h6> ("<div>123<h6>abc</h6>def") assert_equals: innerText expected "123\nabc\ndef" but got "123\nabc\n\ndef"
+PASS Blank lines around <p> even without margin ("<div>123<p style='margin:0px'>abc</p>def")
+PASS No blank lines around <h1> ("<div>123<h1>abc</h1>def")
+PASS No blank lines around <h2> ("<div>123<h2>abc</h2>def")
+PASS No blank lines around <h3> ("<div>123<h3>abc</h3>def")
+PASS No blank lines around <h4> ("<div>123<h4>abc</h4>def")
+PASS No blank lines around <h5> ("<div>123<h5>abc</h5>def")
+PASS No blank lines around <h6> ("<div>123<h6>abc</h6>def")
 PASS <span> boundaries are irrelevant ("<div>123<span>abc</span>def")
 PASS <span> boundaries are irrelevant ("<div>123 <span>abc</span> def")
 PASS <span> boundaries are irrelevant ("<div style='width:0'>123 <span>abc</span> def")
@@ -189,32 +188,32 @@ PASS <tt> gets no special treatment ("<div>123<tt>abc</tt>def")
 PASS <code> gets no special treatment ("<div>123<code>abc</code>def")
 PASS soft hyphen preserved ("<div>abc&shy;def")
 PASS soft hyphen preserved ("<div style='width:0'>abc&shy;def")
-FAIL Ignoring non-rendered table whitespace ("<div><table style='white-space:pre'>  <td>abc</td>  </table>") assert_equals: innerText expected "abc" but got "abc\n"
-FAIL Tab-separated table cells ("<div><table><tr><td>abc<td>def</table>") assert_equals: innerText expected "abc\tdef" but got "abc\tdef\n"
-FAIL Tab-separated table cells including empty cells ("<div><table><tr><td>abc<td><td>def</table>") assert_equals: innerText expected "abc\t\tdef" but got "abc\t\tdef\n"
-FAIL Tab-separated table cells including trailing empty cells ("<div><table><tr><td>abc<td><td></table>") assert_equals: innerText expected "abc\t\t" but got "abc\t\t\n"
-FAIL Newline-separated table rows ("<div><table><tr><td>abc<tr><td>def</table>") assert_equals: innerText expected "abc\ndef" but got "abc\ndef\n"
+PASS Ignoring non-rendered table whitespace ("<div><table style='white-space:pre'>  <td>abc</td>  </table>")
+PASS Tab-separated table cells ("<div><table><tr><td>abc<td>def</table>")
+PASS Tab-separated table cells including empty cells ("<div><table><tr><td>abc<td><td>def</table>")
+PASS Tab-separated table cells including trailing empty cells ("<div><table><tr><td>abc<td><td></table>")
+PASS Newline-separated table rows ("<div><table><tr><td>abc<tr><td>def</table>")
 PASS Newlines around table ("<div>abc<table><td>def</table>ghi")
-FAIL Tab-separated table cells in a border-collapse table ("<div><table style='border-collapse:collapse'><tr><td>abc<td>def</table>") assert_equals: innerText expected "abc\tdef" but got "abc\tdef\n"
+PASS Tab-separated table cells in a border-collapse table ("<div><table style='border-collapse:collapse'><tr><td>abc<td>def</table>")
 FAIL tfoot not reordered ("<div><table><tfoot>x</tfoot><tbody>y</tbody></table>") assert_equals: innerText expected "xy" but got "xy\n"
-FAIL  ("<table><tfoot><tr><td>footer</tfoot><thead><tr><td style='visibility:collapse'>thead</thead><tbody><tr><td>tbody</tbody></table>") assert_equals: innerText expected "footer\n\ntbody" but got "footer\ntbody\n"
+FAIL  ("<table><tfoot><tr><td>footer</tfoot><thead><tr><td style='visibility:collapse'>thead</thead><tbody><tr><td>tbody</tbody></table>") assert_equals: innerText expected "footer\n\ntbody" but got "footer\ntbody"
 PASS No tab on table-cell itself ("<table><tr><td id=target>abc</td><td>def</td>")
 PASS No newline on table-row itself ("<table><tr id=target><td>abc</td><td>def</td></tr><tr id=target><td>ghi</td><td>jkl</td></tr>")
-FAIL Newline between cells and caption ("<div><table><tr><td>abc<caption>def</caption></table>") assert_equals: innerText expected "abc\ndef" but got "abc\ndef\n"
-FAIL Tab-separated table cells ("<div><div class='table'><span class='cell'>abc</span>\n<span class='cell'>def</span></div>") assert_equals: innerText expected "abc\tdef" but got "abc\tdef\n"
-FAIL Newline-separated table rows ("<div><div class='table'><span class='row'><span class='cell'>abc</span></span>\n<span class='row'><span class='cell'>def</span></span></div>") assert_equals: innerText expected "abc\ndef" but got "abc\ndef\n"
+PASS Newline between cells and caption ("<div><table><tr><td>abc<caption>def</caption></table>")
+PASS Tab-separated table cells ("<div><div class='table'><span class='cell'>abc</span>\n<span class='cell'>def</span></div>")
+PASS Newline-separated table rows ("<div><div class='table'><span class='row'><span class='cell'>abc</span></span>\n<span class='row'><span class='cell'>def</span></span></div>")
 PASS Newlines around table ("<div>abc<div class='table'><span class='cell'>def</span></div>ghi")
-FAIL Tab-separated table cells ("<div><div class='itable'><span class='cell'>abc</span>\n<span class='cell'>def</span></div>") assert_equals: innerText expected "abc\tdef" but got "abc\tdef \n"
-FAIL Newline-separated table rows ("<div><div class='itable'><span class='row'><span class='cell'>abc</span></span>\n<span class='row'><span class='cell'>def</span></span></div>") assert_equals: innerText expected "abc\ndef" but got "abc\tdef \n"
+FAIL Tab-separated table cells ("<div><div class='itable'><span class='cell'>abc</span>\n<span class='cell'>def</span></div>") assert_equals: innerText expected "abc\tdef" but got "abc\tdef "
+FAIL Newline-separated table rows ("<div><div class='itable'><span class='row'><span class='cell'>abc</span></span>\n<span class='row'><span class='cell'>def</span></span></div>") assert_equals: innerText expected "abc\ndef" but got "abc\tdef "
 FAIL No newlines around inline-table ("<div>abc<div class='itable'><span class='cell'>def</span></div>ghi") assert_equals: innerText expected "abcdefghi" but got "abc def ghi"
 FAIL Single newline in two-row inline-table ("<div>abc<div class='itable'><span class='row'><span class='cell'>def</span></span>\n<span class='row'><span class='cell'>123</span></span></div>ghi") assert_equals: innerText expected "abcdef\n123ghi" but got "abc def\t123 ghi"
 PASS display:table-row on the element itself ("<div style='display:table-row'>")
 PASS display:table-cell on the element itself ("<div style='display:table-cell'>")
 PASS display:table-caption on the element itself ("<div style='display:table-caption'>")
-FAIL <ol> list items get no special treatment ("<div><ol><li>abc") assert_equals: innerText expected "abc" but got "abc\n"
-FAIL <ul> list items get no special treatment ("<div><ul><li>abc") assert_equals: innerText expected "abc" but got "abc\n"
-FAIL display:block <script> is rendered ("<div><script style='display:block'>abc") assert_equals: innerText expected "abc" but got "abc\n"
-FAIL display:block <style> is rendered ("<div><style style='display:block'>abc") assert_equals: innerText expected "abc" but got "abc\n"
+PASS <ol> list items get no special treatment ("<div><ol><li>abc")
+PASS <ul> list items get no special treatment ("<div><ul><li>abc")
+PASS display:block <script> is rendered ("<div><script style='display:block'>abc")
+PASS display:block <style> is rendered ("<div><style style='display:block'>abc")
 PASS display:block <noscript> is not rendered (it's not parsed!) ("<div><noscript style='display:block'>abc")
 PASS display:block <template> contents are not rendered (the contents are in a different document) ("<div><template style='display:block'>abc")
 PASS <br> induces line break ("<div>abc<br>def")
@@ -223,14 +222,14 @@ PASS <br> content ignored ("<div><br class='poke'>")
 PASS <hr> induces line break ("<div>abc<hr>def")
 PASS <hr><hr> induces just one line break ("<div>abc<hr><hr>def")
 PASS <hr><hr><hr> induces just one line break ("<div>abc<hr><hr><hr>def")
-FAIL <hr> content rendered ("<div><hr class='poke'>") assert_equals: innerText expected "abc" but got "abc\n"
+PASS <hr> content rendered ("<div><hr class='poke'>")
 PASS comment ignored ("<div>abc<!--comment-->def")
 PASS <br> ("<br>")
 PASS empty <p> ("<p>")
 PASS empty <div> ("<div>")
-FAIL text-transform is applied ("<div><div style='text-transform:uppercase'>abc") assert_equals: innerText expected "ABC" but got "ABC\n"
-FAIL text-transform handles es-zet ("<div><div style='text-transform:uppercase'>Maß") assert_equals: innerText expected "MASS" but got "MASS\n"
-FAIL text-transform handles Turkish casing ("<div><div lang='tr' style='text-transform:uppercase'>i ı") assert_equals: innerText expected "İ I" but got "İ I\n"
+PASS text-transform is applied ("<div><div style='text-transform:uppercase'>abc")
+PASS text-transform handles es-zet ("<div><div style='text-transform:uppercase'>Maß")
+PASS text-transform handles Turkish casing ("<div><div lang='tr' style='text-transform:uppercase'>i ı")
 PASS block-in-inline doesn't add unnecessary newlines ("<div>abc<span>123<div>456</div>789</span>def")
 FAIL floats induce a block boundary ("<div>abc<div style='float:left'>123</div>def") assert_equals: innerText expected "abc\n123\ndef" but got "abc123def"
 FAIL floats induce a block boundary ("<div>abc<span style='float:left'>123</span>def") assert_equals: innerText expected "abc\n123\ndef" but got "abc123def"
@@ -247,7 +246,7 @@ FAIL text-overflow:ellipsis ignored ("<div style='width:0; overflow:hidden; text
 PASS innerText not supported on SVG elements ("<svg>abc")
 PASS innerText not supported on MathML elements ("<math>abc")
 PASS <rt> and no <rp> ("<div><ruby>abc<rt>def</rt></ruby>")
-FAIL <rp> ("<div><ruby>abc<rp>(</rp><rt>def</rt><rp>)</rp></ruby>") assert_equals: innerText expected "abcdef" but got "abcdef\n"
+PASS <rp> ("<div><ruby>abc<rp>(</rp><rt>def</rt><rp>)</rp></ruby>")
 PASS Lone <rp> ("<div><rp>abc</rp>")
 PASS visibility:hidden <rp> ("<div><rp style='visibility:hidden'>abc</rp>")
 PASS display:block <rp> ("<div><rp style='display:block'>abc</rp>def")
@@ -255,8 +254,8 @@ PASS display:block <rp> with whitespace ("<div><rp style='display:block'> abc </
 PASS <rp> in a <select> ("<div><select class='poke-rp'></select>")
 PASS Shadow DOM contents ignored ("<div class='shadow'>")
 PASS Shadow DOM contents ignored ("<div><div class='shadow'>")
-FAIL CSS 'order' property ignored ("<div style='display:flex'><div style='order:1'>1</div><div>2</div></div>") assert_equals: innerText expected "1\n2" but got "1\n2\n"
-FAIL Flex items blockified ("<div style='display:flex'><span>1</span><span>2</span></div>") assert_equals: innerText expected "1\n2" but got "1\n2\n"
-FAIL CSS 'order' property ignored ("<div style='display:grid'><div style='order:1'>1</div><div>2</div></div>") assert_equals: innerText expected "1\n2" but got "1\n2\n"
-FAIL Grid items blockified ("<div style='display:grid'><span>1</span><span>2</span></div>") assert_equals: innerText expected "1\n2" but got "1\n2\n"
+PASS CSS 'order' property ignored ("<div style='display:flex'><div style='order:1'>1</div><div>2</div></div>")
+PASS Flex items blockified ("<div style='display:flex'><span>1</span><span>2</span></div>")
+PASS CSS 'order' property ignored ("<div style='display:grid'><div style='order:1'>1</div><div>2</div></div>")
+PASS Grid items blockified ("<div style='display:grid'><span>1</span><span>2</span></div>")
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-tests.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-tests.js
@@ -233,6 +233,7 @@ testText("<div><p>abc</p>def", "abc\n\ndef", "Blank line after <p>");
 testText("<div><p>abc<p></p><p></p><p>def", "abc\n\ndef", "One blank line between <p>s, ignoring empty <p>s");
 testText("<div style='visibility:hidden'><p><span style='visibility:visible'>abc</span></p>\n<div style='visibility:visible'>def</div>",
      "abc\ndef", "Invisible <p> doesn't induce extra line breaks");
+testText("<div><pre>abc\n\n</pre><p>def", "abc\n\n\n\ndef", "<pre> trailing newlines don't suppress <p> blank line");
 testText("<div>abc<div style='margin:2em'>def", "abc\ndef", "No blank lines around <div> with margin");
 testText("<div>123<span style='display:inline-block'>abc</span>def", "123abcdef", "No newlines at display:inline-block boundary");
 testText("<div>123<span style='display:inline-block'> abc </span>def", "123abcdef", "Leading/trailing space removal at display:inline-block boundary");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-object-element/object-in-display-none-load-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-object-element/object-in-display-none-load-event-expected.txt
@@ -1,15 +1,3 @@
 
-Test that an object in a display:none subtree does not block the load event
-
-
-
-  async_test(t => {
-    window.onload = t.step_func_done();
-    document.documentElement.offsetTop;
-  }, "Load event triggered on window");
-
-
-
-
-PASS Load event triggered on window
+PASS Load event triggered on window without the object element load
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-object-element/object-in-display-none-load-event.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-object-element/object-in-display-none-load-event.html
@@ -1,14 +1,22 @@
 <!doctype html>
-<html style="display:none">
+<html>
 <meta charset=utf-8>
 <title>Test that an object in a display:none subtree does not block the load event</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+  let objLoaded = false;
+  function objOnload() {
+    objLoaded = true;
+  }
   async_test(t => {
-    window.onload = t.step_func_done();
-    document.documentElement.offsetTop;
-  }, "Load event triggered on window");
+    addEventListener('load', t.step_func_done(() => {
+      assert_true(!!document.querySelector('object'));
+      assert_false(objLoaded);
+    }));
+  }, 'Load event triggered on window without the object element load');
 </script>
-<object data="data:text/html,"></object>
+<div style="display: none;">
+  <object data="data:text/html," onload="objOnload()"></object>
+</div>
 </html>

--- a/LayoutTests/platform/glib/accessibility/combobox/aria-combobox-hierarchy-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/combobox/aria-combobox-hierarchy-expected.txt
@@ -3,7 +3,7 @@ This verifies the accessibility tree of ARIA comboboxes.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-AXRole: AXComboBox AXValue: option 1<\n>option 2<\n>
+AXRole: AXComboBox AXValue: option 1<\n>option 2
     AXRole: AXListBox
         AXRole: AXListItem AXValue: option 1
         AXRole: AXListItem AXValue: option 2

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4508,7 +4508,7 @@ String Element::innerText()
     if (renderer()->isSkippedContent())
         return String();
 
-    return plainText(makeRangeSelectingNodeContents(*this));
+    return plainText(makeRangeSelectingNodeContents(*this), { TextIteratorBehavior::EmitsNewlinesPerInnerTextSpec });
 }
 
 String Element::outerText()

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -480,6 +480,7 @@ void TextIterator::advance()
     m_positionNode = nullptr;
     m_copyableText.reset();
     m_text = StringView();
+    m_isBlockNewline = false;
 
     // handle remembered node that needed a newline after the text node's newline
     if (RefPtr nodeForAdditionalNewline = std::exchange(m_nodeForAdditionalNewline, nullptr).get()) {
@@ -491,6 +492,7 @@ void TextIterator::advance()
         // iteration, instead of using m_needsAnotherNewline.
         RefPtr parentNode = nodeForAdditionalNewline->parentNode();
         emitCharacter('\n', WTF::move(parentNode), WTF::move(nodeForAdditionalNewline), 1, 1);
+        m_isBlockNewline = true;
         return;
     }
 
@@ -973,18 +975,20 @@ static bool NODELETE shouldEmitNewlineBeforeNode(Node& node)
     return shouldEmitNewlinesBeforeAndAfterNode(node); 
 }
 
-static bool shouldEmitExtraNewlineForNode(Node& node)
+static bool shouldEmitExtraNewlineForNode(Node& node, bool emitsNewlinesPerInnerTextSpec)
 {
-    // When there is a significant collapsed bottom margin, emit an extra
-    // newline for a more realistic result. We end up getting the right
-    // result even without margin collapsing. For example: <div><p>text</p></div>
-    // will work right even if both the <div> and the <p> have bottom margins.
-
     CheckedPtr renderBox = dynamicDowncast<RenderBox>(node.renderer());
     if (!renderBox || !renderBox->height())
         return false;
 
-    // NOTE: We only do this for a select set of nodes, and WinIE appears not to do this at all.
+    // Per the WHATWG spec, <p> elements get a required line break count of 2,
+    // meaning a blank line (two newlines) before and after, unconditionally.
+    // Heading elements (<h1>-<h6>) do NOT get this treatment.
+    if (emitsNewlinesPerInnerTextSpec)
+        return is<HTMLParagraphElement>(node);
+
+    // For non-innerText uses (accessibility, selection, etc.), use the original
+    // margin-based heuristic for both <p> and heading elements.
     RefPtr element = dynamicDowncast<HTMLElement>(node);
     if (!element || !isAnyOf<HTMLHeadingElement, HTMLParagraphElement>(*element))
         return false;
@@ -1097,9 +1101,24 @@ void TextIterator::representNodeOffsetZero()
             emitCharacter('\t', WTF::move(parentNode), WTF::move(currentNode), 0, 0);
         }
     } else if (shouldEmitNewlineBeforeNode(*currentNode)) {
+        bool emitsNewlinesPerInnerTextSpec = m_behaviors.contains(TextIteratorBehavior::EmitsNewlinesPerInnerTextSpec);
         if (shouldRepresentNodeOffsetZero()) {
             RefPtr parentNode = currentNode->parentNode();
             emitCharacter('\n', WTF::move(parentNode), WTF::move(currentNode), 0, 0);
+            // Per the spec, <p> elements require a blank line (2 newlines) before them.
+            if (emitsNewlinesPerInnerTextSpec && is<HTMLParagraphElement>(*m_currentNode))
+                m_nodeForAdditionalNewline = m_currentNode.get();
+        } else if (emitsNewlinesPerInnerTextSpec && is<HTMLParagraphElement>(*currentNode) && m_hasEmitted && m_consecutiveNewlineCount < 2) {
+            // shouldRepresentNodeOffsetZero() returned false because m_lastCharacter == '\n',
+            // but <p> requires a blank line. Emit one more newline if we don't have enough.
+            RefPtr parentNode = currentNode->parentNode();
+            emitCharacter('\n', WTF::move(parentNode), WTF::move(currentNode), 0, 0);
+            // If the preceding '\n' was a content newline (e.g. from <pre> text) rather
+            // than a block-boundary newline, m_consecutiveNewlineCount was reset to 0 by
+            // emitText and the single emitCharacter above only brings it to 1. Schedule
+            // one more so <p> gets its full required line break count of 2.
+            if (m_consecutiveNewlineCount < 2)
+                m_nodeForAdditionalNewline = m_currentNode.get();
         }
     } else if (shouldEmitSpaceBeforeAndAfterNode(*currentNode)) {
         if (shouldRepresentNodeOffsetZero()) {
@@ -1148,20 +1167,23 @@ void TextIterator::exitNode(Node* exitedNode)
     // See <rdar://problem/5428427> for an example of how this mismatch will cause problems.
     if (m_lastTextNode && shouldEmitNewlineAfterNode(*protect(m_currentNode), m_behaviors.contains(TextIteratorBehavior::EmitsCharactersBetweenAllVisiblePositions))) {
         // use extra newline to represent margin bottom, as needed
-        bool addNewline = shouldEmitExtraNewlineForNode(*protect(m_currentNode));
-        
+        bool addNewline = shouldEmitExtraNewlineForNode(*protect(m_currentNode), m_behaviors.contains(TextIteratorBehavior::EmitsNewlinesPerInnerTextSpec));
+
         // FIXME: We need to emit a '\n' as we leave an empty block(s) that
         // contain a VisiblePosition when doing selection preservation.
         if (m_lastCharacter != '\n') {
             // insert a newline with a position following this block's contents.
             emitCharacter('\n', protect(baseNode->parentNode()), baseNode.copyRef(), 1, 1);
+            m_isBlockNewline = true;
             // remember whether to later add a newline for the current node
             ASSERT(!m_nodeForAdditionalNewline);
             if (addNewline)
                 m_nodeForAdditionalNewline = baseNode.get();
-        } else if (addNewline)
+        } else if (addNewline) {
             // insert a newline with a position following this block's contents.
             emitCharacter('\n', protect(baseNode->parentNode()), baseNode.copyRef(), 1, 1);
+            m_isBlockNewline = true;
+        }
     }
     
     // If nothing was emitted, see if we need to emit a space.
@@ -1185,6 +1207,10 @@ void TextIterator::emitCharacter(char16_t character, RefPtr<Node>&& characterNod
     m_copyableText.set(character);
     m_text = m_copyableText.text();
     m_lastCharacter = character;
+    if (character == '\n')
+        ++m_consecutiveNewlineCount;
+    else
+        m_consecutiveNewlineCount = 0;
     m_lastTextNodeEndedWithCollapsedSpace = false;
 }
 
@@ -1210,6 +1236,10 @@ void TextIterator::emitText(Text& textNode, RenderText& renderer, int textStartO
     m_positionEndOffset = textEndOffset;
 
     m_lastCharacter = string[textEndOffset - 1];
+    // Reset to 0 even if the text ends with '\n', because content newlines
+    // (e.g. inside <pre>) are distinct from block-boundary newlines and should
+    // not suppress the extra newline required before <p> elements.
+    m_consecutiveNewlineCount = 0;
     m_copyableText.set(WTF::move(string), textStartOffset, textEndOffset - textStartOffset);
     m_text = m_copyableText.text();
 
@@ -2067,12 +2097,23 @@ String plainText(const SimpleRange& range, TextIteratorBehaviors defaultBehavior
     if (it.atEnd())
         return emptyString();
 
+    bool stripsTrailingBlockNewlines = behaviors.contains(TextIteratorBehavior::EmitsNewlinesPerInnerTextSpec);
     StringBuilder builder;
     builder.reserveCapacity(initialCapacity);
+    unsigned trailingBlockNewlines = 0;
 
     for (; !it.atEnd(); it.advance()) {
         it.appendTextToStringBuilder(builder);
+        if (stripsTrailingBlockNewlines) {
+            if (it.isBlockNewline())
+                ++trailingBlockNewlines;
+            else
+                trailingBlockNewlines = 0;
+        }
     }
+
+    if (trailingBlockNewlines)
+        builder.shrink(builder.length() - trailingBlockNewlines);
 
     if (builder.isEmpty())
         return emptyString();

--- a/Source/WebCore/editing/TextIterator.h
+++ b/Source/WebCore/editing/TextIterator.h
@@ -111,6 +111,10 @@ public:
     WEBCORE_EXPORT SimpleRange range() const;
     WEBCORE_EXPORT Node* node() const;
 
+    // Returns true when the current output is a newline emitted from exiting
+    // a block-level element, as opposed to text content or <br> newlines.
+    bool isBlockNewline() const { return m_isBlockNewline; }
+
     const TextIteratorCopyableText& copyableText() const LIFETIME_BOUND { ASSERT(!atEnd()); return m_copyableText; }
     void appendTextToStringBuilder(StringBuilder& builder) const { copyableText().appendToStringBuilder(builder); }
 
@@ -176,9 +180,11 @@ private:
     RefPtr<Text> m_lastTextNode;
     bool m_lastTextNodeEndedWithCollapsedSpace { false };
     char16_t m_lastCharacter { 0 };
+    unsigned m_consecutiveNewlineCount { 0 };
 
     // Used when deciding whether to emit a "positioning" (e.g. newline) before any other content
     bool m_hasEmitted { false };
+    bool m_isBlockNewline { false };
 
     // Used when deciding text fragment created by :first-letter should be looked into.
     bool m_handledFirstLetter { false };

--- a/Source/WebCore/editing/TextIteratorBehavior.h
+++ b/Source/WebCore/editing/TextIteratorBehavior.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum class TextIteratorBehavior : uint16_t {
+enum class TextIteratorBehavior : uint32_t {
     // Used by selection preservation code. There should be one character emitted between every VisiblePosition
     // in the Range used to create the TextIterator.
     // FIXME <rdar://problem/6028818>: This functionality should eventually be phased out when we rewrite
@@ -74,7 +74,13 @@ enum class TextIteratorBehavior : uint16_t {
     IgnoresFullSizeKana = 1 << 14,
 
     // Used when we want to make 'content-visibility: auto', auto-expanding `<details>` or `hidden=until-found` content discoverable.
-    EntersSkippedContentRelevantToUser = 1 << 15
+    EntersSkippedContentRelevantToUser = 1 << 15,
+
+    // Used by innerText to follow the WHATWG spec for newlines around block
+    // elements: <p> gets unconditional blank lines (not margin-dependent),
+    // <h1>-<h6> do not get extra blank lines, and trailing block newlines are
+    // stripped. Without this flag, the original margin-based heuristic is used.
+    EmitsNewlinesPerInnerTextSpec = 1 << 16
 };
 
 using TextIteratorBehaviors = OptionSet<TextIteratorBehavior>;

--- a/Source/WebCore/editing/cocoa/EditingHTMLConverter.h
+++ b/Source/WebCore/editing/cocoa/EditingHTMLConverter.h
@@ -31,7 +31,7 @@ namespace WebCore {
 
 class Node;
 
-enum class TextIteratorBehavior : uint16_t;
+enum class TextIteratorBehavior : uint32_t;
 
 // This alternate implementation of HTML conversion doesn't handle as many advanced features,
 // such as tables, and doesn't produce document attributes, but it does use TextIterator so

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -71,6 +71,7 @@
 #include <WebCore/ArchiveResource.h>
 #include <WebCore/CertificateInfo.h>
 #include <WebCore/Chrome.h>
+#include <WebCore/ContainerNodeInlines.h>
 #include <WebCore/ContextMenuController.h>
 #include <WebCore/DOMWrapperWorld.h>
 #include <WebCore/DocumentInlines.h>
@@ -82,6 +83,7 @@
 #include <WebCore/DocumentWindow.h>
 #include <WebCore/Editor.h>
 #include <WebCore/ElementChildIteratorInlines.h>
+#include <WebCore/ElementInlines.h>
 #include <WebCore/ElementTargetingController.h>
 #include <WebCore/EventHandler.h>
 #include <WebCore/File.h>
@@ -1523,9 +1525,20 @@ String WebFrame::frameTextForTesting(bool includeSubframes)
     if (!m_coreFrame)
         return { };
 
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
+    if (!localFrame || !localFrame->document() || !localFrame->document()->documentElement())
+        return { };
+
     StringBuilder builder;
 
-    String text = innerText();
+    // Use plainText() directly instead of innerText() to avoid the WHATWG
+    // spec-compliant newline changes (e.g. blank lines around <p>) that
+    // would require rebaselining hundreds of layout tests.
+    Ref documentElement = *protect(protect(localFrame->document())->documentElement());
+    protect(localFrame->document())->updateLayoutIgnorePendingStylesheets();
+    String text = documentElement->renderer()
+        ? plainText(makeRangeSelectingNodeContents(documentElement))
+        : documentElement->textContent(true);
     if (text.isNull())
         return { };
 

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -122,6 +122,7 @@
 #import <WebCore/ReportingScope.h>
 #import <WebCore/ScriptController.h>
 #import <WebCore/SecurityOrigin.h>
+#import <WebCore/SimpleRange.h>
 #import <WebCore/SmartReplace.h>
 #import <WebCore/SubframeLoader.h>
 #import <WebCore/TextIterator.h>
@@ -2373,6 +2374,23 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     if (RefPtr document = coreFrame->document())
         document->reportingScope().generateTestReport(message, group);
+}
+
+- (NSString *)_plainTextForTesting
+{
+    auto coreFrame = _private->coreFrame;
+    if (!coreFrame)
+        return @"";
+
+    RefPtr document = coreFrame->document();
+    if (!document || !document->documentElement())
+        return @"";
+
+    Ref documentElement = *document->documentElement();
+    document->updateLayoutIgnorePendingStylesheets();
+    if (!documentElement->renderer())
+        return documentElement->textContent(true).createNSString().autorelease();
+    return plainText(makeRangeSelectingNodeContents(documentElement)).createNSString().autorelease();
 }
 
 @end

--- a/Source/WebKitLegacy/mac/WebView/WebFramePrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebFramePrivate.h
@@ -292,4 +292,6 @@ typedef enum {
 
 - (void)_generateTestReport:(NSString *) message withGroup:(NSString *)group;
 
+- (NSString *)_plainTextForTesting;
+
 @end

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -81,6 +81,7 @@
 #import <WebKit/WebDocumentPrivate.h>
 #import <WebKit/WebEditingDelegate.h>
 #import <WebKit/WebFeature.h>
+#import <WebKit/WebFramePrivate.h>
 #import <WebKit/WebFrameView.h>
 #import <WebKit/WebHistory.h>
 #import <WebKit/WebHistoryItemPrivate.h>
@@ -1413,7 +1414,7 @@ static RetainPtr<NSString> dumpFramesAsText(WebFrame *frame)
     else
         result = adoptNS([[NSMutableString alloc] init]);
 
-    NSString *innerText = [documentElement innerText];
+    NSString *innerText = [frame _plainTextForTesting];
 
     // We use WTF::String::tryGetUTF8 to convert innerText to a UTF8 buffer since
     // it can handle dangling surrogates and the NSString


### PR DESCRIPTION
#### 87ee373497a302ba1bb60904474d2c7d037ce31b
<pre>
innerText getter: fix blank line handling for &lt;p&gt; and headings, and strip trailing block newlines
<a href="https://bugs.webkit.org/show_bug.cgi?id=311808">https://bugs.webkit.org/show_bug.cgi?id=311808</a>

Reviewed by Darin Adler.

Align the innerText getter with the WHATWG spec and match Chrome/Firefox
behavior, gated behind a new EmitsNewlinesPerInnerTextSpec TextIterator
behavior flag so that other TextIterator consumers (accessibility,
selection, test runners) are unaffected.

The flag enables three behavioral changes:

1. shouldEmitExtraNewlineForNode() unconditionally returns true for &lt;p&gt;
   and false for &lt;h1&gt;-&lt;h6&gt;. The spec gives &lt;p&gt; a required line break
   count of 2 regardless of margin, while headings use 1. Without the
   flag, the original margin-based heuristic is preserved.

2. representNodeOffsetZero() emits an extra newline *before* &lt;p&gt;
   elements, not just after. A new m_consecutiveNewlineCount counter
   prevents over-emitting when line breaks from adjacent blocks already
   provide enough newlines.

3. plainText() strips trailing block-boundary newlines from the result.
   TextIterator now tracks m_isBlockNewline to distinguish newlines
   emitted by exitNode() from intentional ones (e.g. &lt;br&gt;), so only
   the former are stripped.

To avoid rebaselining hundreds of layout tests whose text dump would
change, WebFrame::frameTextForTesting() (WebKit2) and a new
WebFrame._plainTextForTesting (WebKitLegacy) now call plainText()
directly without the flag, preserving the old output for test runners.

* LayoutTests/accessibility/combobox/aria-combobox-hierarchy-expected.txt:
* LayoutTests/editing/pasteboard/line-feed-between-br-and-b-should-not-reorder-pasted-content-expected.txt:
* LayoutTests/fast/dom/NodeList/childNodes-reverse-iteration-expected.txt:
* LayoutTests/fast/dom/NodeList/childNodes-reverse-iteration.html:
* LayoutTests/fast/dom/inner-text-001-expected.txt:
* LayoutTests/fast/dom/inner-text-first-letter-expected.txt:
* LayoutTests/fast/dom/inner-text-first-letter.html:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/the-innertext-and-outertext-properties/getter-tests.js:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-object-element/object-in-display-none-load-event-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-object-element/object-in-display-none-load-event.html:
* LayoutTests/platform/glib/accessibility/combobox/aria-combobox-hierarchy-expected.txt:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::innerText):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::advance):
(WebCore::shouldEmitExtraNewlineForNode):
(WebCore::TextIterator::representNodeOffsetZero):
(WebCore::TextIterator::exitNode):
(WebCore::TextIterator::emitCharacter):
(WebCore::TextIterator::emitText):
(WebCore::plainText):
* Source/WebCore/editing/TextIterator.h:
(WebCore::TextIterator::isBlockNewline const):
* Source/WebCore/editing/TextIteratorBehavior.h:
* Source/WebCore/editing/cocoa/EditingHTMLConverter.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::frameTextForTesting):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _plainTextForTesting]):
* Source/WebKitLegacy/mac/WebView/WebFramePrivate.h:
* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(dumpFramesAsText):

Canonical link: <a href="https://commits.webkit.org/311057@main">https://commits.webkit.org/311057@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a2c86407e786057bde105378e7fa4ef3a397596

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164732 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109840 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157841 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120747 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22953 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101436 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22036 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20176 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12562 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131699 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167212 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11386 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19513 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128868 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24225 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129000 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34931 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139695 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86573 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23823 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16493 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28537 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92493 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28064 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28292 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28188 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->