### PR TITLE
REGRESSION(310666@main): requestAnimationFrame and requestVideoFrameCallback callbacks are not fired in isolated worlds when JS is disabled in the main page.

### DIFF
--- a/LayoutTests/fast/animation/request-animation-frame-in-isolated-world-with-javascript-disabled-expected.html
+++ b/LayoutTests/fast/animation/request-animation-frame-in-isolated-world-with-javascript-disabled-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>rAF fires in isolated world when JavaScript is disabled - reference</title>
+<style>
+  #result {
+    width: 150px;
+    height: 150px;
+    background-color: green;
+  }
+</style>
+<p>The box below should be green.</p>
+<div id="result"></div>

--- a/LayoutTests/fast/animation/request-animation-frame-in-isolated-world-with-javascript-disabled.html
+++ b/LayoutTests/fast/animation/request-animation-frame-in-isolated-world-with-javascript-disabled.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>rAF fires in isolated world when JavaScript is disabled</title>
+<link rel="match" href="request-animation-frame-in-isolated-world-with-javascript-disabled-expected.html">
+<style>
+  #result {
+    width: 150px;
+    height: 150px;
+    background-color: red;
+  }
+</style>
+<p>The box below should be green.</p>
+<div id="result"></div>
+<script>
+if (window.testRunner) {
+    internals.settings.setScriptEnabled(false);
+
+    testRunner.evaluateScriptInIsolatedWorld(0,
+        "requestAnimationFrame(function() {\n" +
+        "    document.getElementById('result').style.backgroundColor = 'green';\n" +
+        "    document.documentElement.classList.remove('reftest-wait');\n" +
+        "});"
+    );
+}
+</script>
+</html>

--- a/LayoutTests/fast/animation/request-video-frame-callback-in-isolated-world-with-javascript-disabled-expected.html
+++ b/LayoutTests/fast/animation/request-video-frame-callback-in-isolated-world-with-javascript-disabled-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>requestVideoFrameCallback fires in isolated world when JavaScript is disabled - reference</title>
+<style>
+  #result {
+    width: 150px;
+    height: 150px;
+    background-color: green;
+  }
+</style>
+<p>The box below should be green.</p>
+<div id="result"></div>

--- a/LayoutTests/fast/animation/request-video-frame-callback-in-isolated-world-with-javascript-disabled.html
+++ b/LayoutTests/fast/animation/request-video-frame-callback-in-isolated-world-with-javascript-disabled.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>requestVideoFrameCallback fires in isolated world when JavaScript is disabled</title>
+<link rel="match" href="request-video-frame-callback-in-isolated-world-with-javascript-disabled-expected.html">
+<style>
+  #result {
+    width: 150px;
+    height: 150px;
+    background-color: red;
+  }
+</style>
+<p>The box below should be green.</p>
+<div id="result"></div>
+<video id="vid" src="../images/resources/animated-red-green-blue.mp4" style="display:none"></video>
+<script>
+if (window.testRunner) {
+    internals.settings.setScriptEnabled(false);
+
+    testRunner.evaluateScriptInIsolatedWorld(0,
+        "document.getElementById('vid').requestVideoFrameCallback(function() {\n" +
+        "    document.getElementById('result').style.backgroundColor = 'green';\n" +
+        "    document.documentElement.classList.remove('reftest-wait');\n" +
+        "});"
+    );
+}
+</script>
+</html>

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -4668,3 +4668,5 @@ imported/w3c/web-platform-tests/largest-contentful-paint/video-play-after-poster
 webkit.org/b/306256 editing/selection/modify-up-on-rtl-wrapping-text.html [ Failure ]
 
 fast/canvas/offscreen-webgl-transfer-after-navigation-crash.html [ Skip ] # Flaky failing test
+
+webkit.org/b/312135 fast/animation/request-video-frame-callback-in-isolated-world-with-javascript-disabled.html [ Timeout ]

--- a/Source/WebCore/dom/ScriptedAnimationController.cpp
+++ b/Source/WebCore/dom/ScriptedAnimationController.cpp
@@ -30,6 +30,7 @@
 #include "DocumentPage.h"
 #include "FrameDestructionObserverInlines.h"
 #include "InspectorInstrumentation.h"
+#include "JSRequestAnimationFrameCallback.h"
 #include "Logging.h"
 #include "OpportunisticTaskScheduler.h"
 #include "Page.h"
@@ -169,12 +170,23 @@ void ScriptedAnimationController::serviceRequestAnimationFrameCallbacks(ReducedR
         return;
 
     CheckedRef script = frame->script();
-    if (!script->canExecuteScripts(ReasonForCallingCanExecuteScripts::AboutToExecuteScript) || script->isPaused())
+    if (script->isPaused())
         return;
 
+    bool canExecuteScriptsInAnyWorld = false;
     for (auto& [callback, userGestureTokenToForward, scheduledWorkScope] : callbackDataList) {
         if (callback->m_firedOrCancelled)
             continue;
+
+        DOMWrapperWorld* world = nullptr;
+        if (RefPtr jsCallback = dynamicDowncast<JSRequestAnimationFrameCallback>(callback.get())) {
+            if (auto* globalObject = jsCallback->callbackData()->globalObject())
+                world = &globalObject->world();
+        }
+        if (!script->canExecuteScripts(ReasonForCallingCanExecuteScripts::AboutToExecuteScript, world))
+            continue;
+
+        canExecuteScriptsInAnyWorld = true;
         callback->m_firedOrCancelled = true;
 
         if (userGestureTokenToForward && Ref { *userGestureTokenToForward }->hasExpired(UserGestureToken::maximumIntervalForUserGestureForwarding))
@@ -186,6 +198,9 @@ void ScriptedAnimationController::serviceRequestAnimationFrameCallbacks(ReducedR
         Ref { callback }->invoke(highResNowMs);
         InspectorInstrumentation::didFireAnimationFrame(document, identifier);
     }
+
+    if (!canExecuteScriptsInAnyWorld)
+        return;
 
     // Remove any callbacks we fired from the list of pending callbacks.
     m_callbackDataList.removeAllMatching([](auto& data) {

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -41,6 +41,7 @@
 #include "HTMLNames.h"
 #include "ImageBuffer.h"
 #include "JSDOMPromiseDeferred.h"
+#include "JSVideoFrameRequestCallback.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "Logging.h"
@@ -810,7 +811,7 @@ void HTMLVideoElement::serviceRequestVideoFrameCallbacks(ReducedResolutionSecond
         return;
 
     CheckedRef script = frame->script();
-    if (!script->canExecuteScripts(ReasonForCallingCanExecuteScripts::AboutToExecuteScript) || script->isPaused())
+    if (script->isPaused())
         return;
 
     processVideoFrameMetadataTimestamps(*videoFrameMetadata, protect(document().window()->performance()));
@@ -819,6 +820,16 @@ void HTMLVideoElement::serviceRequestVideoFrameCallbacks(ReducedResolutionSecond
 
     m_videoFrameRequests.swap(m_servicedVideoFrameRequests);
     for (auto& request : m_servicedVideoFrameRequests) {
+        DOMWrapperWorld* world = nullptr;
+        if (request->callback) {
+            if (RefPtr jsCallback = dynamicDowncast<JSVideoFrameRequestCallback>(*request->callback)) {
+                if (auto* globalObject = jsCallback->callbackData()->globalObject())
+                    world = &globalObject->world();
+            }
+        }
+        if (!script->canExecuteScripts(ReasonForCallingCanExecuteScripts::AboutToExecuteScript, world))
+            continue;
+
         if (RefPtr callback = std::exchange(request->callback, { }))
             callback->invoke(std::round(now.milliseconds()), *videoFrameMetadata);
     }


### PR DESCRIPTION
#### e46c5005ecf3d56bf07f83b3889e2f8cd6aeb783
<pre>
REGRESSION(310666@main): requestAnimationFrame and requestVideoFrameCallback callbacks are not fired in isolated worlds when JS is disabled in the main page.
<a href="https://bugs.webkit.org/show_bug.cgi?id=311810">https://bugs.webkit.org/show_bug.cgi?id=311810</a>

Reviewed by Ryosuke Niwa.

310666@main added a new canExecuteScripts(AboutToExecuteScript) check to
serviceRequestAnimationFrameCallbacks and serviceRequestVideoFrameCallbacks.
This check returns false if JS is disabled in the main page, blocking all
rAF and requestVideoFrameCallback callbacks.

However canExecuteScripts() returns true for non-normal worlds, but since the
check was done without passing a world, isolated world callbacks were incorrectly
blocked.

This patch moves the canExecuteScripts() check inside the loop and passes the
DOMWrapperWorld obtained from each callback JSDOMGlobalObject, so that
isolated world callbacks (e.g. from browser extensions or injected scripts)
can run even when JS is disabled in the main page.

Tests: fast/animation/request-animation-frame-in-isolated-world-with-javascript-disabled.html
       fast/animation/request-video-frame-callback-in-isolated-world-with-javascript-disabled.html

* LayoutTests/fast/animation/request-animation-frame-in-isolated-world-with-javascript-disabled-expected.html: Added.
* LayoutTests/fast/animation/request-animation-frame-in-isolated-world-with-javascript-disabled.html: Added.
* LayoutTests/fast/animation/request-video-frame-callback-in-isolated-world-with-javascript-disabled-expected.html: Added.
* LayoutTests/fast/animation/request-video-frame-callback-in-isolated-world-with-javascript-disabled.html: Added.
* LayoutTests/platform/win/TestExpectations:
* Source/WebCore/dom/ScriptedAnimationController.cpp:
(WebCore::ScriptedAnimationController::serviceRequestAnimationFrameCallbacks):
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::serviceRequestVideoFrameCallbacks):

Canonical link: <a href="https://commits.webkit.org/311058@main">https://commits.webkit.org/311058@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/733ff79bc7da6e19e172a403165f577d19ad8f61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29343 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/22525 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/164770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157879 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29344 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/164770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158966 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/22988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/164770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/12601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/17936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167250 "Failed to checkout and rebase branch from PR 62348") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11424 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/19548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/167250 "Failed to checkout and rebase branch from PR 62348") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28944 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/167250 "Failed to checkout and rebase branch from PR 62348") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28866 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/139730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23740 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/23860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28575 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92532 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/28330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28226 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->