### PR TITLE
Remove sandbox parameter for message filtering

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -42,6 +42,14 @@
 #endif
 )
 
+(define have_message_filtering?
+#if PLATFORM(MAC) && USE(APPLE_INTERNAL_SDK)
+    TRUE
+#else
+    FALSE
+#endif
+)
+
 #if USE(SANDBOX_VERSION_3)
 (allow dynamic-code-generation)
 (with-filter (lockdown-mode)
@@ -933,9 +941,9 @@
 (define (notifyd-message-numbers) (message-number 1002 1010 1011 1012 1016 1017 1018 1021 1022 1025 1026 1028 1029 1030 1031 1032))
 (define (allow-notifyd)
     (allow ipc-posix-shm-read* (ipc-posix-name "apple.shm.notification_center"))
-    (when (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "NO")
+    (when (not have_message_filtering?)
         (allow mach-lookup (global-name "com.apple.system.notification_center")))
-    (when (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+    (when have_message_filtering?
         (allow mach-lookup (global-name "com.apple.system.notification_center")
             (apply-message-filter
                 (deny mach-message-send)
@@ -1387,7 +1395,7 @@
             (allow mach-message-send
                 (mach-bootstrap-message-numbers)))))
 
-(if (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (defined? 'mach-bootstrap))
+(if (and have_message_filtering? (defined? 'mach-bootstrap))
 #if HAVE(SANDBOX_STATE_FLAGS)
 (allow mach-bootstrap
     (apply-message-filter
@@ -1515,7 +1523,7 @@
         (with-filter (require-not (state-flag "BlockIOKitInWebContentSandbox"))
             (allow syscall-mig (kernel-mig-routines-downlevels-blocked-in-lockdown-mode)))))
 
-(if (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (and (defined? 'mach-kernel-endpoint) (not (defined? 'syscall-mig))))
+(if (and have_message_filtering? (and (defined? 'mach-kernel-endpoint) (not (defined? 'syscall-mig))))
     (allow mach-kernel-endpoint
         (apply-message-filter
             (deny mach-message-send)
@@ -1607,7 +1615,7 @@
     MSC_mach_voucher_extract_attr_recipe_trap
     MSC_swtch_pri))
 
-(when (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (defined? 'syscall-mach))
+(when (and have_message_filtering? (defined? 'syscall-mach))
     (deny syscall-mach)
     (allow syscall-mach (syscall-mach-in-use))
 #if HAVE(SANDBOX_STATE_FLAGS)


### PR DESCRIPTION
#### 0901b8c32730c178224afb3be4f50ecc7642c32f
<pre>
Remove sandbox parameter for message filtering
<a href="https://bugs.webkit.org/show_bug.cgi?id=311811">https://bugs.webkit.org/show_bug.cgi?id=311811</a>
<a href="https://rdar.apple.com/174399761">rdar://174399761</a>

Reviewed by Sihui Liu.

This will speed up sandbox compilation. There is no change in behavior from this patch.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/310909@main">https://commits.webkit.org/310909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9eb24246aad3061b5da5c8b0e43f917ec6428dfb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28451 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163951 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108886 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fc13a5c9-18dd-4000-b8cc-d727173cfc1d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120079 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84824 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a0388c0e-3e9d-447c-979f-379077d6bc8b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158150 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139364 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100774 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea734687-974f-4057-990e-81748404ee9e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21418 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19470 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11777 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131081 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166429 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10580 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18812 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128183 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27995 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23506 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128320 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27919 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138996 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84628 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23675 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23184 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15792 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27612 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91716 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27190 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27420 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27263 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->