### PR TITLE
Unreviewed, reverting 310823@main (67c60225f7c8)

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -32,12 +32,11 @@
 (define (lockdown-mode)
     (signing-identifier "com.apple.WebKit.WebContent.CaptivePortal"))
 
-#define TRUE #t
 #define FALSE #f
 
 (define webcontent_gpu_sandbox_extensions_blocking?
 #if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 140400 && defined(RC_XBS) && RC_XBS == 1
-    TRUE
+    (equal? (param "CPU") "arm64")
 #else
     FALSE
 #endif
@@ -575,46 +574,54 @@
     (deny iokit-get-properties (with no-report)
         (iokit-property "APTDevice")))
 
-(with-filter (iokit-registry-entry-class "AppleARMIODevice")
-    (deny iokit-get-properties (with no-report)
-        (iokit-property "supports-apt")))
+(if (equal? (param "CPU") "arm64")
+    (with-filter (iokit-registry-entry-class "AppleARMIODevice")
+        (deny iokit-get-properties (with no-report)
+            (iokit-property "supports-apt"))))
 
-(with-filter (iokit-registry-entry-class "AppleJPEGDriver")
-    (deny iokit-get-properties (with no-report)
-        (iokit-property "AppleJPEGNumCores")))
+(if (equal? (param "CPU") "arm64")
+    (with-filter (iokit-registry-entry-class "AppleJPEGDriver")
+        (deny iokit-get-properties (with no-report)
+            (iokit-property "AppleJPEGNumCores"))))
 
 ;; <rdar://problem/60088861>
-(allow iokit-get-properties
-    (iokit-property "ADSSupported")
-    (iokit-property "IOAVDHEVCDecodeCapabilities")
-    (iokit-property "IOGLESBundleName") ;; <rdar://problem/67473780>
-    (iokit-property "MetalPluginClassName") ;; <rdar://problem/67473780>
-    (iokit-property "MetalPluginName") ;; <rdar://problem/67473780>
-    (iokit-property "IOSurfaceAcceleratorCapabilitiesDict") ;; <rdar://problem/63696732>
-    (iokit-property "acoustic-id")) ;; <rdar://problem/65290967>
-
-(with-filter (iokit-registry-entry-class "IOService")
+(if (equal? (param "CPU") "arm64")
     (allow iokit-get-properties
-        (iokit-property "IORegistryEntryPropertyKeys")))
+        (iokit-property "ADSSupported")
+        (iokit-property "IOAVDHEVCDecodeCapabilities")
+        (iokit-property "IOGLESBundleName") ;; <rdar://problem/67473780>
+        (iokit-property "MetalPluginClassName") ;; <rdar://problem/67473780>
+        (iokit-property "MetalPluginName") ;; <rdar://problem/67473780>
+        (iokit-property "IOSurfaceAcceleratorCapabilitiesDict") ;; <rdar://problem/63696732>
+        (iokit-property "acoustic-id") ;; <rdar://problem/65290967>
+    ))
 
-(with-filter (iokit-registry-entry-class "IOMobileFramebuffer")
-    (allow iokit-get-properties
-        (iokit-property "AppleTV"
-                        "DisplayPipePlaneBaseAlignment"
-                        "DisplayPipeStrideRequirements"
-                        "dfr"
-                        "external"
-                        "hdcp-hoover-protocol")))
+(if (equal? (param "CPU") "arm64")
+    (with-filter (iokit-registry-entry-class "IOService")
+        (allow iokit-get-properties
+            (iokit-property "IORegistryEntryPropertyKeys"))))
 
-(with-filter (iokit-registry-entry-class "IOPlatformDevice")
-    (allow iokit-get-properties
-        (iokit-property "soc-generation")))
+(if (equal? (param "CPU") "arm64")
+    (with-filter (iokit-registry-entry-class "IOMobileFramebuffer")
+        (allow iokit-get-properties
+            (iokit-property "AppleTV"
+                            "DisplayPipePlaneBaseAlignment"
+                            "DisplayPipeStrideRequirements"
+                            "dfr"
+                            "external"
+                            "hdcp-hoover-protocol"))))
 
-(with-filter (iokit-registry-entry-class "IOService")
-    (allow iokit-get-properties
-        (iokit-property "chip-id"
-                        "display-rotation"
-                        "display-scale")))
+(if (equal? (param "CPU") "arm64")
+    (with-filter (iokit-registry-entry-class "IOPlatformDevice")
+        (allow iokit-get-properties
+            (iokit-property "soc-generation"))))
+
+(if (equal? (param "CPU") "arm64")
+    (with-filter (iokit-registry-entry-class "IOService")
+        (allow iokit-get-properties
+            (iokit-property "chip-id"
+                            "display-rotation"
+                            "display-scale"))))
 
 (deny mach-lookup (xpc-service-name-prefix ""))
 
@@ -1343,7 +1350,8 @@
 
 (with-filter (require-not (lockdown-mode))
     (allow syscall-unix (syscall-unix-blocked-in-lockdown-mode))
-    (allow syscall-unix (syscall-unix-apple-silicon))
+    (when (equal? (param "CPU") "arm64")
+        (allow syscall-unix (syscall-unix-apple-silicon)))
     (allow syscall-unix (with report) (with telemetry) (syscalls-rarely-used-blocked-in-lockdown-mode)))
 
 (when (defined? 'SYS_objc_bp_assist_cfg_np)
@@ -1362,7 +1370,8 @@
 (with-filter (lockdown-mode)
     (deny syscall-unix (with telemetry) (syscall-unix-blocked-in-lockdown-mode))
     (deny syscall-unix (with telemetry) (syscalls-rarely-used-blocked-in-lockdown-mode))
-    (deny syscall-unix (with telemetry) (syscall-unix-apple-silicon)))
+    (when (equal? (param "CPU") "arm64")
+        (deny syscall-unix (with telemetry) (syscall-unix-apple-silicon))))
 
 #if HAVE(SANDBOX_MESSAGE_FILTERING)
 (define (mach-bootstrap-message-numbers)
@@ -1473,9 +1482,12 @@
 
 (define (allow-mach-exceptions operation)
 #if HAVE(HARDENED_MACH_EXCEPTIONS)
-    (with-filter (require-not (webcontent-process-launched))
-        (allow operation (kernel-mig-routine task_register_hardened_exception_handler)))
-    (allow operation (kernel-mig-routine thread_adopt_exception_handler)))
+    (when (equal? (param "CPU") "arm64")
+        (with-filter (require-not (webcontent-process-launched))
+            (allow operation (kernel-mig-routine task_register_hardened_exception_handler)))
+        (allow operation (kernel-mig-routine thread_adopt_exception_handler)))
+    (when (not (equal? (param "CPU") "arm64"))
+        (allow operation (kernel-mig-routine thread_set_exception_ports))))
 #else
     (allow operation (kernel-mig-routine thread_set_exception_ports)))
 #endif


### PR DESCRIPTION
#### 1ca9f99ea5ae4de9ae246260d849d42da66e02d3
<pre>
Unreviewed, reverting 310823@main (67c60225f7c8)
<a href="https://bugs.webkit.org/show_bug.cgi?id=311816">https://bugs.webkit.org/show_bug.cgi?id=311816</a>
<a href="https://rdar.apple.com/174406429">rdar://174406429</a>

REGRESSION(310823@main): unbound variable: task_register_hardened_exception_handler at com.apple.WebProcess.sb.tmp

Reverted change:

    Remove CPU checks in WebContent process sandbox for arm64 on macOS
    <a href="https://bugs.webkit.org/show_bug.cgi?id=311711">https://bugs.webkit.org/show_bug.cgi?id=311711</a>
    <a href="https://rdar.apple.com/174299099">rdar://174299099</a>
    310823@main (67c60225f7c8)

Canonical link: <a href="https://commits.webkit.org/310843@main">https://commits.webkit.org/310843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f5a278e360c9c53c5f41fd908e63b9e959347d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28463 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/21622 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163963 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28311 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/120090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158162 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/22346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/139375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/100785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11789 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166441 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/18821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/128194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28007 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/23517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/128331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27931 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/139005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/84640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23648 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/23194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27624 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91728 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27202 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27432 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27275 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->