### PR TITLE
[WPE][Qt6] WPEQtView does not notify when an item gains or loses focus.

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
@@ -594,6 +594,24 @@ void WPEQtView::touchEvent(QTouchEvent* event)
     wpe_view_dispatch_touch_event(WPE_VIEW_QTQUICK(wpeView), event);
 }
 
+void WPEQtView::focusInEvent(QFocusEvent*)
+{
+    Q_D(WPEQtView);
+    if (!d->m_webView)
+        return;
+    auto* wpeView = webkit_web_view_get_wpe_view(d->m_webView.get());
+    wpe_view_focus_in(WPE_VIEW(wpeView));
+}
+
+void WPEQtView::focusOutEvent(QFocusEvent*)
+{
+    Q_D(WPEQtView);
+    if (!d->m_webView)
+        return;
+    auto* wpeView = webkit_web_view_get_wpe_view(d->m_webView.get());
+    wpe_view_focus_out(WPE_VIEW(wpeView));
+}
+
 void WPEQtView::invalidateSceneGraph()
 {
     Q_D(WPEQtView);

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h
@@ -105,6 +105,9 @@ protected:
 
     void touchEvent(QTouchEvent*) override;
 
+    void focusInEvent(QFocusEvent*) override;
+    void focusOutEvent(QFocusEvent*) override;
+
 private Q_SLOTS:
     void configureWindow();
     void createWebView();


### PR DESCRIPTION
#### 61aef66cb385807e0c45030b8ee75d3d2bc8238a
<pre>
[WPE][Qt6] WPEQtView does not notify when an item gains or loses focus.
<a href="https://bugs.webkit.org/show_bug.cgi?id=311814.">https://bugs.webkit.org/show_bug.cgi?id=311814.</a>

Reviewed by Adrian Perez de Castro.

WPEQtView calls forceActiveFocus() on mouse press, which makes Qt to
update its focus state. However, focusInEvent and focusOutEvent were
never overridden, so the underlying WPE view was never notified via
wpe_view_focus_in() or wpe_view_focus_out(). This caused JavaScript
focus events to malfunction.

* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp:
(WPEQtView::focusInEvent): Added. Calls wpe_view_focus_in().
(WPEQtView::focusOutEvent): Added. Calls wpe_view_focus_out().
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h: Declare the two
  overrides.

Canonical link: <a href="https://commits.webkit.org/310923@main">https://commits.webkit.org/310923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4de54fb93ecb996197beaa00748c58cfeafaeeba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21899 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164242 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28590 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120331 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139621 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101021 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12072 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166720 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19063 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128446 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28284 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23751 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128579 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34856 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28208 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139246 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85645 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23418 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27902 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92005 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27479 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27709 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27552 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->