### PR TITLE
Refactor Swift itemSkippingBackForwardItemsAddedByJSWithoutUserGesture

### DIFF
--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -836,7 +836,7 @@ WebBackForwardListItem* WebBackForwardListWrapper::forwardItem() const
 
 RefPtr<WebBackForwardListItem> WebBackForwardListWrapper::itemAtDeltaFromCurrentIndex(int index) const
 {
-    return m_impl->itemAtIndex(index);
+    return m_impl->itemAtDeltaFromCurrentIndex(index);
 }
 
 unsigned WebBackForwardListWrapper::backListCount() const

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -120,7 +120,7 @@ final class WebBackForwardList {
     var messageForwarder: RefWebBackForwardListMessageForwarder?
 
     var entries: [WebKit.WebBackForwardListItem] = []
-    var currentIndex: Array.Index?
+    var currentIndex: Int?
 
     private enum Direction {
         case backward
@@ -374,7 +374,7 @@ final class WebBackForwardList {
         return entries[currentIndex + 1]
     }
 
-    func itemAtIndex(index: Array.Index) -> WebKit.WebBackForwardListItem? {
+    func itemAtDeltaFromCurrentIndex(delta: Int) -> WebKit.WebBackForwardListItem? {
         assertValidIndex()
 
         guard page.__convertToBool() else {
@@ -385,19 +385,26 @@ final class WebBackForwardList {
             return nil
         }
 
-        // Do range checks without doing math on index to avoid overflow.
-        if index < 0 && -index > backListCount() {
+        if currentIndex + delta < 0 {
             return nil
         }
 
-        if index > 0 && index > forwardListCount() {
-            return nil
-        }
-
-        return entries[index + currentIndex]
+        return itemAtIndexWithoutSkipping(index: currentIndex + delta).item
     }
 
-    func backListCount() -> Array.Index {
+    func itemAtIndexWithoutSkipping(index: Int) -> (item: WebKit.WebBackForwardListItem?, index: Int) {
+        guard page.__convertToBool() else {
+            return (nil, index)
+        }
+
+        if index < 0 || index >= entries.count {
+            return (nil, index)
+        }
+
+        return (entries[index], index)
+    }
+
+    func backListCount() -> Int {
         assertValidIndex()
 
         guard page.__convertToBool() else {
@@ -411,7 +418,7 @@ final class WebBackForwardList {
         return currentIndex
     }
 
-    func forwardListCount() -> Array.Index {
+    func forwardListCount() -> Int {
         assertValidIndex()
 
         guard page.__convertToBool() else {
@@ -596,29 +603,30 @@ final class WebBackForwardList {
         #endif
     }
 
-    func goBackItemSkippingItemsWithoutUserGesture() -> WebKit.RefPtrWebBackForwardListItem {
-        itemSkippingBackForwardItemsAddedByJSWithoutUserGesture(direction: Direction.backward)
-    }
-
-    func goForwardItemSkippingItemsWithoutUserGesture() -> WebKit.RefPtrWebBackForwardListItem {
-        itemSkippingBackForwardItemsAddedByJSWithoutUserGesture(direction: Direction.forward)
-    }
-
-    private func itemSkippingBackForwardItemsAddedByJSWithoutUserGesture(direction: Direction) -> WebKit.RefPtrWebBackForwardListItem {
+    private func itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture(
+        direction: Direction,
+        startingIndex: Int
+    ) -> (item: WebKit.WebBackForwardListItem?, index: Int) {
+        if direction == .backward && startingIndex == 0 {
+            return (nil, 0)
+        }
         let delta =
             switch direction {
             case .backward: -1
             case .forward: 1
             }
-        var itemIndex = delta
-        let item = itemAtIndex(index: itemIndex)
-        guard var item = item else {
-            return WebKit.RefPtrWebBackForwardListItem()
+        var itemIndex = startingIndex + delta
+        if itemIndex >= entries.count {
+            return (nil, 0)
+        }
+        let maybeItem = itemAtIndexWithoutSkipping(index: itemIndex)
+        if maybeItem.item == nil {
+            assertionFailure("Should have an item by now")
         }
 
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
         if !WTF.linkedOnOrAfterSDKWithBehavior(WTF.SDKAlignedBehavior.UIBackForwardSkipsHistoryItemsWithoutUserGesture) {
-            return WebKit.RefPtrWebBackForwardListItem(item)
+            return maybeItem
         }
         #endif
 
@@ -628,21 +636,28 @@ final class WebBackForwardList {
         // However, if we're on Yahoo and navigate forward, we do want to skip items and end up on Google#b.
         // swift-format-ignore: NeverForceUnwrap
         if direction == Direction.backward && !currentItem()!.wasCreatedByJSWithoutUserInteraction() {
-            return WebKit.RefPtrWebBackForwardListItem(item)
+            return maybeItem
         }
+
+        let (definiteItem, index) = maybeItem
+        guard let definiteItem else {
+            // Matches C++ by not asserting in release mode until past the above two 'if's
+            preconditionFailure("Should have an item by now")
+        }
+        var item = (item: definiteItem, index: index)
 
         // For example:
         // Yahoo -> Yahoo#a (no userInteraction) -> Google -> Google#a (no user interaction) -> Google#b (no user interaction)
         // If we are on Google#b and navigate backwards, we want to skip over Google#a and Google, to end up on Yahoo#a.
         // If we are on Yahoo#a and navigate forwards, we want to skip over Google and Google#a, to end up on Google#b.
         let originalItem = item
-        while item.wasCreatedByJSWithoutUserInteraction() {
+        while item.item.wasCreatedByJSWithoutUserInteraction() {
             itemIndex += delta
-            let thisItem = itemAtIndex(index: itemIndex)
+            let (thisItem, thisItemIndex) = itemAtIndexWithoutSkipping(index: itemIndex)
             guard let thisItem else {
-                return WebKit.RefPtrWebBackForwardListItem(originalItem)
+                return originalItem
             }
-            item = thisItem
+            item = (thisItem, thisItemIndex)
 
             loadingReleaseLog(
                 "UI Navigation is skipping a WebBackForwardListItem because it was added by JavaScript without user interaction"
@@ -650,17 +665,17 @@ final class WebBackForwardList {
         }
 
         // We are now on the next item that has user interaction.
-        assert(!item.wasCreatedByJSWithoutUserInteraction())
+        assert(!item.item.wasCreatedByJSWithoutUserInteraction())
 
         if direction == Direction.backward {
             // If going backwards, skip over next item with user iteraction since this is the one the user
             // thinks they're on.
             itemIndex -= 1
-            let thisItem = itemAtIndex(index: itemIndex)
+            let (thisItem, thisItemIndex) = itemAtIndexWithoutSkipping(index: itemIndex)
             guard let thisItem else {
-                return WebKit.RefPtrWebBackForwardListItem(originalItem)
+                return originalItem
             }
-            item = thisItem
+            item = (thisItem, thisItemIndex)
 
             loadingReleaseLog(
                 "UI Navigation is skipping a WebBackForwardListItem that has user interaction because we started on an item that didn't have interaction"
@@ -668,14 +683,38 @@ final class WebBackForwardList {
         } else {
             // If going forward and there are items that we created by JS without user interaction, move forward to the last
             // one in the series.
-            var nextItem = itemAtIndex(index: itemIndex + 1)
-            while let unwrappedNextItem = nextItem, unwrappedNextItem.wasCreatedByJSWithoutUserInteraction() {
-                item = unwrappedNextItem
+            var nextItem = itemAtIndexWithoutSkipping(index: itemIndex + 1)
+            while case (let unwrappedNextItem?, let index) = nextItem, unwrappedNextItem.wasCreatedByJSWithoutUserInteraction() {
+                item = (unwrappedNextItem, index)
                 itemIndex += 1
-                nextItem = itemAtIndex(index: itemIndex + 1)
+                nextItem = itemAtIndexWithoutSkipping(index: itemIndex + 1)
             }
         }
-        return WebKit.RefPtrWebBackForwardListItem(item)
+        return item
+    }
+
+    func goBackItemSkippingItemsWithoutUserGesture() -> WebKit.RefPtrWebBackForwardListItem {
+        guard let currentIndex = currentIndex else {
+            return WebKit.RefPtrWebBackForwardListItem()
+        }
+        if currentIndex == 0 {
+            return WebKit.RefPtrWebBackForwardListItem()
+        }
+        return WebKit.RefPtrWebBackForwardListItem(
+            itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture(direction: Direction.backward, startingIndex: currentIndex).item
+        )
+    }
+
+    func goForwardItemSkippingItemsWithoutUserGesture() -> WebKit.RefPtrWebBackForwardListItem {
+        guard let currentIndex = currentIndex else {
+            return WebKit.RefPtrWebBackForwardListItem()
+        }
+        if currentIndex >= entries.count {
+            return WebKit.RefPtrWebBackForwardListItem()
+        }
+        return WebKit.RefPtrWebBackForwardListItem(
+            itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture(direction: Direction.forward, startingIndex: currentIndex).item
+        )
     }
 
     func findFrameStateInItem(
@@ -956,13 +995,13 @@ final class WebBackForwardList {
     }
 
     func backForwardItemAtIndex(
-        index: Int32,
+        delta: Int32,
         frameID: WebCore.FrameIdentifier,
         completionHandler: CompletionHandlers.WebBackForwardList.BackForwardItemAtIndexCompletionHandler
     ) {
         // FIXME: This should verify that the web process requesting the item hosts the specified frame.
-        let index = Int(index)
-        guard let item = itemAtIndex(index: index) else {
+        let delta = Int(delta)
+        guard let item = itemAtDeltaFromCurrentIndex(delta: delta) else {
             callCompletionHandler(completionHandler, consuming: WebKit.RefPtrFrameState())
             return
         }


### PR DESCRIPTION
#### 4e57ff18bbf22d9ff92742525167fb57ae206ef1
<pre>
Refactor Swift itemSkippingBackForwardItemsAddedByJSWithoutUserGesture
<a href="https://bugs.webkit.org/show_bug.cgi?id=311820">https://bugs.webkit.org/show_bug.cgi?id=311820</a>
<a href="https://rdar.apple.com/174410423">rdar://174410423</a>

Reviewed by Richard Robinson.

This has no intended functional changes. Like
<a href="https://commits.webkit.org/310378@main">https://commits.webkit.org/310378@main</a>, it refactors the WebBackForwardList
logic in preparation for future changes. That commit did the C++ version; this
commit does the Swift version.

Canonical link: <a href="https://commits.webkit.org/311190@main">https://commits.webkit.org/311190@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec2ebd7dcb8c402532e1548c77dff3769f681170

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164766 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109941 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29340 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120775 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85069 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140099 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101464 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22070 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20209 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12597 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131732 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167246 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11420 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19543 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128896 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28940 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24264 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129029 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35018 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28862 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139725 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86610 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23855 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16523 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28571 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92528 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28098 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28326 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28222 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->