### PR TITLE
[git-webkit] Support more calling idioms in claude

### DIFF
--- a/.claude/plugins/git-webkit/skills/checkout/SKILL.md
+++ b/.claude/plugins/git-webkit/skills/checkout/SKILL.md
@@ -2,7 +2,7 @@
 name: checkout-webkit-commit
 description: Use when the user wants to checkout a branch, checkout a PR, checkout a commit or move HEAD to a specific commit in the WebKit repository. The user can specify a pull requests by number or URL.
 user-invocable: true
-allowed-tools: Bash(git-webkit checkout:*), Bash(Tools/Scripts/git-webkit checkout:*), Bash(git-webkit find:*), Bash(Tools/Scripts/git-webkit find:*), Bash(git checkout:*),
+allowed-tools: Bash(git-webkit checkout:*), Bash(git webkit checkout:*), Bash(Tools/Scripts/git-webkit checkout:*), Bash(git-webkit find:*), Bash(git webkit find:*), Bash(Tools/Scripts/git-webkit find:*), Bash(git checkout:*),
 ---
 
 Use `git-webkit checkout` instead of `git checkout` to check out branches, commits, or pull requests when the string provided does not match a hash, branch or tag in the repository.

--- a/.claude/plugins/git-webkit/skills/classify/SKILL.md
+++ b/.claude/plugins/git-webkit/skills/classify/SKILL.md
@@ -2,7 +2,7 @@
 name: classify-webkit-commit
 description: Use when the user wants to classify a commit or understand what kind of change a commit represents in the WebKit repository.
 user-invocable: true
-allowed-tools: Bash(git-webkit classify:*), Bash(Tools/Scripts/git-webkit classify:*), Bash(git-webkit find:*), Bash(Tools/Scripts/git-webkit find:*)
+allowed-tools: Bash(git-webkit classify:*), Bash(git webkit classify:*), Bash(Tools/Scripts/git-webkit classify:*), Bash(git-webkit find:*), Bash(git webkit find:*), Bash(Tools/Scripts/git-webkit find:*)
 ---
 
 Use `git-webkit classify` to compute the classification of a given commit.

--- a/.claude/plugins/git-webkit/skills/find/SKILL.md
+++ b/.claude/plugins/git-webkit/skills/find/SKILL.md
@@ -2,7 +2,7 @@
 name: find-webkit-commit
 description: Convert between commit hashes and WebKit identifiers using git-webkit. Use when working with git commits, commit hashes, or commit references in the WebKit repository.
 user-invocable: false
-allowed-tools: Bash(git-webkit find:*), Bash(Tools/Scripts/git-webkit find:*), Bash(git-webkit log:*), Bash(Tools/Scripts/git-webkit log:*), Bash(git-webkit blame:*), Bash(Tools/Scripts/git-webkit blame:*), Bash(git-webkit show:*), Bash(Tools/Scripts/git-webkit show:*)
+allowed-tools: Bash(git-webkit find:*), Bash(git webkit find:*), Bash(Tools/Scripts/git-webkit find:*), Bash(git-webkit log:*), Bash(git webkit log:*), Bash(Tools/Scripts/git-webkit log:*), Bash(git-webkit blame:*), Bash(git webkit blame:*), Bash(Tools/Scripts/git-webkit blame:*), Bash(git-webkit show:*), Bash(git webkit show:*), Bash(Tools/Scripts/git-webkit show:*)
 ---
 
 When working in the WebKit repository, ALWAYS reference commits by their WebKit "identifier" rather than by hash.

--- a/.claude/plugins/git-webkit/skills/pull/SKILL.md
+++ b/.claude/plugins/git-webkit/skills/pull/SKILL.md
@@ -2,7 +2,7 @@
 name: update-webkit
 description: Use when the user wants to update, pull, or sync their WebKit repository or branch.
 user-invocable: true
-allowed-tools: Bash(git-webkit pull:*), Bash(Tools/Scripts/git-webkit pull:*), Bash(git-webkit find:*), Bash(Tools/Scripts/git-webkit find:*)
+allowed-tools: Bash(git-webkit pull:*), Bash(git webkit pull:*), Bash(Tools/Scripts/git-webkit pull:*), Bash(git-webkit find:*), Bash(git webkit find:*), Bash(Tools/Scripts/git-webkit find:*)
 ---
 
 Use `git-webkit pull` to update the current repository.


### PR DESCRIPTION
#### 758f7e6ccc9b117498c297d72bc66a0ca0a8f31d
<pre>
[git-webkit] Support more calling idioms in claude
<a href="https://bugs.webkit.org/show_bug.cgi?id=311822">https://bugs.webkit.org/show_bug.cgi?id=311822</a>
<a href="https://rdar.apple.com/174413518">rdar://174413518</a>

Reviewed by Aakash Jain.

Allow calling `git-webkit` via `git webkit` from `claude`.

* .claude/plugins/git-webkit/skills/checkout/SKILL.md:
* .claude/plugins/git-webkit/skills/classify/SKILL.md:
* .claude/plugins/git-webkit/skills/find/SKILL.md:
* .claude/plugins/git-webkit/skills/pull/SKILL.md:

Canonical link: <a href="https://commits.webkit.org/310862@main">https://commits.webkit.org/310862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/183c54f7b1ef4bd3d82e836dbbdce73cb487d1eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163975 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a589219f-6c30-4d6e-b138-8e1defffe15b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28323 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120102 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8d77a3c0-155b-40ad-85a8-96b96f5cf937) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22352 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139386 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100797 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/56dd47d4-7cf1-4851-a9e9-7a57afa81d41) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21438 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19491 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11801 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131103 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166453 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18832 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128205 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23526 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128342 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27943 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139016 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84652 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23661 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23204 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15812 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27636 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27214 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27444 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27287 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->