### PR TITLE
Variant WPT with a slash in the params cause a failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/event-upload-progress-crossorigin.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/event-upload-progress-crossorigin.any-expected.txt
@@ -1,6 +1,6 @@
 
-PASS Upload events registered on time (http://127.0.0.1:8800/xhr/resources/corsenabled.py)
-PASS Upload events registered on time (resources/redirect.py?code=307&location=http://127.0.0.1:8800/xhr/resources/corsenabled.py)
-PASS Upload events registered too late (http://127.0.0.1:8800/xhr/resources/corsenabled.py)
-PASS Upload events registered too late (resources/redirect.py?code=307&location=http://127.0.0.1:8800/xhr/resources/corsenabled.py)
+PASS Upload events registered on time (http://www1.web-platform.test:8800/xhr/resources/corsenabled.py)
+PASS Upload events registered on time (resources/redirect.py?code=307&location=http://www1.web-platform.test:8800/xhr/resources/corsenabled.py)
+PASS Upload events registered too late (http://www1.web-platform.test:8800/xhr/resources/corsenabled.py)
+PASS Upload events registered too late (resources/redirect.py?code=307&location=http://www1.web-platform.test:8800/xhr/resources/corsenabled.py)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/event-upload-progress-crossorigin.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/event-upload-progress-crossorigin.any.worker-expected.txt
@@ -1,6 +1,6 @@
 
-PASS Upload events registered on time (http://127.0.0.1:8800/xhr/resources/corsenabled.py)
-PASS Upload events registered on time (resources/redirect.py?code=307&location=http://127.0.0.1:8800/xhr/resources/corsenabled.py)
-PASS Upload events registered too late (http://127.0.0.1:8800/xhr/resources/corsenabled.py)
-PASS Upload events registered too late (resources/redirect.py?code=307&location=http://127.0.0.1:8800/xhr/resources/corsenabled.py)
+PASS Upload events registered on time (http://www1.web-platform.test:8800/xhr/resources/corsenabled.py)
+PASS Upload events registered on time (resources/redirect.py?code=307&location=http://www1.web-platform.test:8800/xhr/resources/corsenabled.py)
+PASS Upload events registered too late (http://www1.web-platform.test:8800/xhr/resources/corsenabled.py)
+PASS Upload events registered too late (resources/redirect.py?code=307&location=http://www1.web-platform.test:8800/xhr/resources/corsenabled.py)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-timeout-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-timeout-events-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL XMLHttpRequest: The send() method: timeout is not 0  assert_equals: expected 0 but got 857098
+PASS XMLHttpRequest: The send() method: timeout is not 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-aborted_aborted_20immediately_20after_20send()-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-aborted_aborted_20immediately_20after_20send()-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
+
+
+PASS Timeout test: time to abort is -1, timeout set at 2000
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-aborted_call_20abort()_20after_20TIME_NORMAL_LOAD-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-aborted_call_20abort()_20after_20TIME_NORMAL_LOAD-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
+
+
+PASS Timeout test: time to abort is 5000, timeout set at 2000
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-aborted_only_20open()ed,_20not_20aborted-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-aborted_only_20open()ed,_20not_20aborted-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
+
+
+PASS Timeout test: No events should fire for an unsent, unaborted request
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-abortedonmain_abort()_20from_20a_200ms_20timeout-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-abortedonmain_abort()_20from_20a_200ms_20timeout-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
+
+
+PASS Timeout test: time to abort is 0, timeout set at 2000
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-abortedonmain_aborted_20after_20TIME_DELAY-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-abortedonmain_aborted_20after_20TIME_DELAY-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
+
+
+PASS Timeout test: time to abort is 1000, timeout set at 2000
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overrides_timeout_20disabled_20after_20initially_20set-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overrides_timeout_20disabled_20after_20initially_20set-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
+
+
+PASS Timeout test: timeout disabled after initially set, original timeout at 5000, reset at 2000 to 0
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overrides_timeout_20enabled_20after_20initially_20disabled-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overrides_timeout_20enabled_20after_20initially_20disabled-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
+
+
+PASS Timeout test: timeout enabled after initially disabled, original timeout at 0, reset at 2000 to 50000
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overrides_timeout_20overrides_20load_20after_20a_20delay-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overrides_timeout_20overrides_20load_20after_20a_20delay-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
+
+
+PASS Timeout test: timeout overrides load after a delay, original timeout at 5000, reset at 1000 to 2000
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overridesexpires_timeout_20set_20to_20expired_20value_20before_20load_20fires-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overridesexpires_timeout_20set_20to_20expired_20value_20before_20load_20fires-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
+
+
+PASS Timeout test: timeout set to expired value before load fires, original timeout at 5000, reset at 2000 to 1100
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overridesexpires_timeout_20set_20to_20expiring_20value_20after_20load_20fires-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overridesexpires_timeout_20set_20to_20expiring_20value_20after_20load_20fires-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
+
+
+PASS Timeout test: timeout set to expiring value after load fires, original timeout at 5000, reset at 4000 to 1000
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overridesexpires_timeout_20set_20to_20non-expiring_20value_20after_20timeout_20fires-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overridesexpires_timeout_20set_20to_20non-expiring_20value_20after_20timeout_20fires-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
+
+
+PASS Timeout test: timeout set to non-expiring value after timeout fires, original timeout at 1000, reset at 2000 to 500
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-simple_load_20fires_20normally-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-simple_load_20fires_20normally-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
+
+
+PASS Timeout test: load fires normally, timeout scheduled at 5000
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-simple_no_20time_20out_20scheduled,_20load_20fires_20normally-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-simple_no_20time_20out_20scheduled,_20load_20fires_20normally-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
+
+
+PASS Timeout test: no time out scheduled, load fires normally, timeout scheduled at 0
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-simple_timeout_20hit_20before_20load-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-simple_timeout_20hit_20before_20load-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
+
+
+PASS Timeout test: timeout hit before load, timeout scheduled at 2000
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-synconmain_timeout_20after_20open-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-synconmain_timeout_20after_20open-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
+
+
+PASS Timeout test: Synchronous XHR must not allow a timeout to be set - setting timeout must throw
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-synconmain_timeout_20before_20open-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-synconmain_timeout_20before_20open-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
+
+
+PASS Timeout test: Synchronous XHR must not allow a timeout to be set - calling open() after timeout is set must throw
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-twice_load_20fires_20normally_20with_20no_20timeout_20set,_20twice-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-twice_load_20fires_20normally_20with_20no_20timeout_20set,_20twice-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
+
+
+PASS Timeout test: load fires normally with no timeout set, twice, original timeout at 0, reset at 2000 to 0
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-twice_load_20fires_20normally_20with_20same_20timeout_20set_20twice-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-twice_load_20fires_20normally_20with_20same_20timeout_20set_20twice-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
+
+
+PASS Timeout test: load fires normally with same timeout set twice, original timeout at 5000, reset at 2000 to 5000
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-twice_timeout_20fires_20normally_20with_20same_20timeout_20set_20twice-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-twice_timeout_20fires_20normally_20with_20same_20timeout_20set_20twice-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in async cases in document (i.e. non-worker) context.
+
+
+PASS Timeout test: timeout fires normally with same timeout set twice, original timeout at 2000, reset at 1000 to 2000
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-aborted_aborted_20immediately_20after_20send()-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-aborted_aborted_20immediately_20after_20send()-expected.txt
@@ -1,0 +1,9 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in in a worker context.
+
+
+PASS Timeout test: No events should fire for an unsent, unaborted request
+PASS Timeout test: time to abort is -1, timeout set at 2000
+PASS Timeout test: time to abort is 5000, timeout set at 2000
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-aborted_call_20abort()_20after_20TIME_NORMAL_LOAD-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-aborted_call_20abort()_20after_20TIME_NORMAL_LOAD-expected.txt
@@ -1,0 +1,9 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in in a worker context.
+
+
+PASS Timeout test: No events should fire for an unsent, unaborted request
+PASS Timeout test: time to abort is -1, timeout set at 2000
+PASS Timeout test: time to abort is 5000, timeout set at 2000
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-aborted_only_20open()ed,_20not_20aborted-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-aborted_only_20open()ed,_20not_20aborted-expected.txt
@@ -1,0 +1,9 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in in a worker context.
+
+
+PASS Timeout test: No events should fire for an unsent, unaborted request
+PASS Timeout test: time to abort is -1, timeout set at 2000
+PASS Timeout test: time to abort is 5000, timeout set at 2000
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overrides_timeout_20disabled_20after_20initially_20set-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overrides_timeout_20disabled_20after_20initially_20set-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in in a worker context.
+
+
+PASS Timeout test: timeout disabled after initially set, original timeout at 5000, reset at 2000 to 0
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overrides_timeout_20enabled_20after_20initially_20disabled-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overrides_timeout_20enabled_20after_20initially_20disabled-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in in a worker context.
+
+
+PASS Timeout test: timeout enabled after initially disabled, original timeout at 0, reset at 2000 to 50000
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overrides_timeout_20overrides_20load_20after_20a_20delay-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overrides_timeout_20overrides_20load_20after_20a_20delay-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in in a worker context.
+
+
+PASS Timeout test: timeout overrides load after a delay, original timeout at 5000, reset at 1000 to 2000
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpires_timeout_20set_20to_20expired_20value_20before_20load_20fires-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpires_timeout_20set_20to_20expired_20value_20before_20load_20fires-expected.txt
@@ -1,0 +1,9 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in in a worker context.
+
+
+PASS Timeout test: timeout set to expiring value after load fires, original timeout at 5000, reset at 4000 to 1000
+PASS Timeout test: timeout set to expired value before load fires, original timeout at 5000, reset at 2000 to 1100
+PASS Timeout test: timeout set to non-expiring value after timeout fires, original timeout at 1000, reset at 2000 to 500
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpires_timeout_20set_20to_20expiring_20value_20after_20load_20fires-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpires_timeout_20set_20to_20expiring_20value_20after_20load_20fires-expected.txt
@@ -1,0 +1,9 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in in a worker context.
+
+
+PASS Timeout test: timeout set to expiring value after load fires, original timeout at 5000, reset at 4000 to 1000
+PASS Timeout test: timeout set to expired value before load fires, original timeout at 5000, reset at 2000 to 1100
+PASS Timeout test: timeout set to non-expiring value after timeout fires, original timeout at 1000, reset at 2000 to 500
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpires_timeout_20set_20to_20non-expiring_20value_20after_20timeout_20fires-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpires_timeout_20set_20to_20non-expiring_20value_20after_20timeout_20fires-expected.txt
@@ -1,0 +1,9 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in in a worker context.
+
+
+PASS Timeout test: timeout set to expiring value after load fires, original timeout at 5000, reset at 4000 to 1000
+PASS Timeout test: timeout set to expired value before load fires, original timeout at 5000, reset at 2000 to 1100
+PASS Timeout test: timeout set to non-expiring value after timeout fires, original timeout at 1000, reset at 2000 to 500
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-simple_load_20fires_20normally-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-simple_load_20fires_20normally-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in in a worker context.
+
+
+PASS Timeout test: load fires normally, timeout scheduled at 5000
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-simple_no_20time_20out_20scheduled,_20load_20fires_20normally-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-simple_no_20time_20out_20scheduled,_20load_20fires_20normally-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in in a worker context.
+
+
+PASS Timeout test: no time out scheduled, load fires normally, timeout scheduled at 0
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-simple_timeout_20hit_20before_20load-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-simple_timeout_20hit_20before_20load-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in in a worker context.
+
+
+PASS Timeout test: timeout hit before load, timeout scheduled at 2000
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-synconworker_load_20fires_20normally-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-synconworker_load_20fires_20normally-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in in a worker context.
+
+
+PASS Timeout test: load fires normally, timeout scheduled at 5000
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-synconworker_no_20time_20out_20scheduled,_20load_20fires_20normally-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-synconworker_no_20time_20out_20scheduled,_20load_20fires_20normally-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in in a worker context.
+
+
+PASS Timeout test: no time out scheduled, load fires normally, timeout scheduled at 0
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-synconworker_timeout_20hit_20before_20load-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-synconworker_timeout_20hit_20before_20load-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in in a worker context.
+
+
+PASS Timeout test: Unexpected error: TimeoutError: The operation timed out.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-twice_load_20fires_20normally_20with_20no_20timeout_20set,_20twice-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-twice_load_20fires_20normally_20with_20no_20timeout_20set,_20twice-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in in a worker context.
+
+
+PASS Timeout test: load fires normally with no timeout set, twice, original timeout at 0, reset at 2000 to 0
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-twice_load_20fires_20normally_20with_20same_20timeout_20set_20twice-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-twice_load_20fires_20normally_20with_20same_20timeout_20set_20twice-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in in a worker context.
+
+
+PASS Timeout test: load fires normally with same timeout set twice, original timeout at 5000, reset at 2000 to 5000
+

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-twice_timeout_20fires_20normally_20with_20same_20timeout_20set_20twice-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-twice_timeout_20fires_20normally_20with_20same_20timeout_20set_20twice-expected.txt
@@ -1,0 +1,7 @@
+Description
+
+This test validates that the XHR2 timeout property behaves as expected in in a worker context.
+
+
+PASS Timeout test: timeout fires normally with same timeout set twice, original timeout at 2000, reset at 1000 to 2000
+

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer.py
@@ -79,7 +79,7 @@ class TestResultWriter(object):
         output_basename = ext_parts[0]
 
         if len(variant):
-            output_basename += "_" + re.sub(r'[|* <>:]', '_', variant)
+            output_basename += "_" + re.sub(r'[|* <>:/%]', '_', variant)
 
         return output_basename + modifier
 

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer_unittest.py
@@ -104,7 +104,7 @@ class TestResultWriterTest(unittest.TestCase):
             "template_test/pbkdf2.https.any.worker.html?a%20b", fs
         )
         self.assertEqual(
-            "template_test/pbkdf2.https.any.worker_a%20b-expected.txt", expected
+            "template_test/pbkdf2.https.any.worker_a_20b-expected.txt", expected
         )
 
         expected = test_result_writer.TestResultWriter.expected_filename(
@@ -119,6 +119,13 @@ class TestResultWriterTest(unittest.TestCase):
         )
         self.assertEqual(
             "template_test/pbkdf2.https.any.worker_1-1000#aaa-expected.txt", expected
+        )
+
+        expected = test_result_writer.TestResultWriter.expected_filename(
+            "css/css-backgrounds/box-shadow-radius-generated.html?width=200&height=40&spread=50&radius=100px%20/%2020px", fs
+        )
+        self.assertEqual(
+            "css/css-backgrounds/box-shadow-radius-generated_width=200&height=40&spread=50&radius=100px_20__2020px-expected.txt", expected
         )
 
     def test_actual_filename(self):


### PR DESCRIPTION
#### 1f940370c2996a3591bedf30bb8f4fd3ab493258
<pre>
Variant WPT with a slash in the params cause a failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=311823">https://bugs.webkit.org/show_bug.cgi?id=311823</a>
<a href="https://rdar.apple.com/174414453">rdar://174414453</a>

Reviewed by Anne van Kesteren.

WPT variant tests with slashes in the params cause failures creating the
expected files, because the slash is not converted to an underscore.
Also fix this for `%`.

This generates many new `xhr` test results.

* LayoutTests/imported/w3c/web-platform-tests/xhr/event-upload-progress-crossorigin.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/xhr/event-upload-progress-crossorigin.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/xhr/send-timeout-events-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-aborted_aborted_20immediately_20after_20send()-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-aborted_call_20abort()_20after_20TIME_NORMAL_LOAD-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-aborted_only_20open()ed,_20not_20aborted-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-abortedonmain_abort()_20from_20a_200ms_20timeout-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-abortedonmain_aborted_20after_20TIME_DELAY-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overrides_timeout_20disabled_20after_20initially_20set-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overrides_timeout_20enabled_20after_20initially_20disabled-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overrides_timeout_20overrides_20load_20after_20a_20delay-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overridesexpires_timeout_20set_20to_20expired_20value_20before_20load_20fires-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overridesexpires_timeout_20set_20to_20expiring_20value_20after_20load_20fires-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-overridesexpires_timeout_20set_20to_20non-expiring_20value_20after_20timeout_20fires-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-simple_load_20fires_20normally-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-simple_no_20time_20out_20scheduled,_20load_20fires_20normally-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-simple_timeout_20hit_20before_20load-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-synconmain_timeout_20after_20open-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-synconmain_timeout_20before_20open-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-twice_load_20fires_20normally_20with_20no_20timeout_20set,_20twice-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-twice_load_20fires_20normally_20with_20same_20timeout_20set_20twice-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-twice_timeout_20fires_20normally_20with_20same_20timeout_20set_20twice-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-aborted_aborted_20immediately_20after_20send()-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-aborted_call_20abort()_20after_20TIME_NORMAL_LOAD-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-aborted_only_20open()ed,_20not_20aborted-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overrides_timeout_20disabled_20after_20initially_20set-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overrides_timeout_20enabled_20after_20initially_20disabled-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overrides_timeout_20overrides_20load_20after_20a_20delay-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpires_timeout_20set_20to_20expired_20value_20before_20load_20fires-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpires_timeout_20set_20to_20expiring_20value_20after_20load_20fires-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpires_timeout_20set_20to_20non-expiring_20value_20after_20timeout_20fires-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-simple_load_20fires_20normally-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-simple_no_20time_20out_20scheduled,_20load_20fires_20normally-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-simple_timeout_20hit_20before_20load-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-synconworker_load_20fires_20normally-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-synconworker_no_20time_20out_20scheduled,_20load_20fires_20normally-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-synconworker_timeout_20hit_20before_20load-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-twice_load_20fires_20normally_20with_20no_20timeout_20set,_20twice-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-twice_load_20fires_20normally_20with_20same_20timeout_20set_20twice-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-twice_timeout_20fires_20normally_20with_20same_20timeout_20set_20twice-expected.txt: Added.
* Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer.py:
(TestResultWriter._modified_filename):
* Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer_unittest.py:
(TestResultWriterTest.test_expected_filename):

Canonical link: <a href="https://commits.webkit.org/310883@main">https://commits.webkit.org/310883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33f1ee466ef358c26a94a4bf42c617448459327d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155249 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28509 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164009 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cc61a842-9b7b-45b5-a42b-4249f093fa43) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28649 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28357 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120132 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e90fb66d-da1c-4b76-931f-9a1a38597c2c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158208 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22381 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139420 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100827 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/154569 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21467 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19525 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11835 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131133 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166488 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18864 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128234 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23559 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128371 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34826 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27977 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139048 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84686 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23233 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15845 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27670 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27248 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27478 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27321 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->