### PR TITLE
set-webkit-configuration should properly support the non-standard testing/release+assert builds

### DIFF
--- a/Makefile.shared
+++ b/Makefile.shared
@@ -187,12 +187,11 @@ release r: force
 	@$(call invoke_xcode,,)
 
 release+assert ra: force
-	@$(call set_webkit_configuration,--release)
+	@$(call set_webkit_configuration,--ra)
 	@$(call invoke_xcode,,)
-release+assert ra: override GCC_PREPROCESSOR_ADDITIONS += ASSERT_ENABLED=1
 
 testing t: force
-	@$(call set_webkit_configuration,--debug --force-optimization-level=O3)
+	@$(call set_webkit_configuration,--testing)
 	@$(call invoke_xcode,,)
 
 analyze:

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -1158,7 +1158,7 @@ sub determineConfigurationForVisualStudio
     return if defined $configurationForVisualStudio;
     determineConfiguration();
     # FIXME: We should detect when Debug_All or Production has been chosen.
-    $configurationForVisualStudio = "/p:Configuration=" . $configuration;
+    $configurationForVisualStudio = "/p:Configuration=" . baseConfiguration();
 }
 
 sub usesPerConfigurationBuildDirectory
@@ -1172,15 +1172,15 @@ sub determineConfigurationProductDir
     determineBaseProductDir();
     determineConfiguration();
     if (isWin() || isPlayStation() || (isJSCOnly() && isWindows())) {
-        $configurationProductDir = File::Spec->catdir($baseProductDir, $configuration);
+        $configurationProductDir = File::Spec->catdir($baseProductDir, baseConfiguration());
     } else {
         if (usesPerConfigurationBuildDirectory()) {
             $configurationProductDir = "$baseProductDir";
         } else {
             if (isGtk() or isWPE() or isJSCOnly() or shouldUseFlatpak() or shouldBuildForCrossTarget() or inCrossTargetEnvironment()) {
-                $configurationProductDir = "$baseProductDir/$portName/$configuration";
+                $configurationProductDir = "$baseProductDir/$portName/" . baseConfiguration();
             } else {
-                $configurationProductDir = "$baseProductDir/$configuration";
+                $configurationProductDir = "$baseProductDir/" . baseConfiguration();
             }
             $configurationProductDir .= "-" . xcodeSDKPlatformName() if isEmbeddedWebKit() || isMacCatalystWebKit();
         }
@@ -1253,6 +1253,14 @@ sub architecturesForProducts
 sub configuration()
 {
     determineConfiguration();
+    return $configuration;
+}
+
+sub baseConfiguration()
+{
+    determineConfiguration();
+    return "Release" if $configuration eq "Release+Assert";
+    return "Debug" if $configuration eq "Testing";
     return $configuration;
 }
 
@@ -1395,7 +1403,12 @@ sub XcodeOptions
     if (!checkForArgumentAndRemoveFromARGV("--no-use-workspace")) {
         push @options, ("-workspace", $configuredXcodeWorkspace) if $configuredXcodeWorkspace;
     }
-    push @options, ("-configuration", $configuration);
+    push @options, ("-configuration", baseConfiguration());
+    if ($configuration eq "Release+Assert") {
+        push @options, "GCC_PREPROCESSOR_DEFINITIONS=ASSERT_ENABLED=1 \$(inherited)";
+    } elsif ($configuration eq "Testing") {
+        push @options, "GCC_OPTIMIZATION_LEVEL=3";
+    }
     push @options, ("-destination", $destination) if $destination;
     # Be mindful of adding build settings here. Any settings which don't
     # *exactly* line up with build settings already provided by Xcode will
@@ -2831,7 +2844,7 @@ sub cmakeGeneratedBuildfile(@)
 sub generateBuildSystemFromCMakeProject
 {
     my ($prefixPath, @cmakeArgs) = @_;
-    my $config = configuration();
+    my $config = baseConfiguration();
     my $port = cmakeBasedPortName();
     my $buildPath = productDir();
     File::Path::mkpath($buildPath) unless -d $buildPath;
@@ -2973,7 +2986,7 @@ sub generateBuildSystemFromCMakeProject
 sub buildCMakeGeneratedProject($)
 {
     my (@makeArgs) = @_;
-    my $config = configuration();
+    my $config = baseConfiguration();
     my $buildPath = productDir();
     if (! -d $buildPath) {
         die "Must call generateBuildSystemFromCMakeProject() before building CMake project.";
@@ -3003,7 +3016,7 @@ sub buildCMakeGeneratedProject($)
 
 sub cleanCMakeGeneratedProject()
 {
-    my $config = configuration();
+    my $config = baseConfiguration();
     my $buildPath = productDir();
     if (-d $buildPath) {
         return systemVerbose("cmake", "--build", $buildPath, "--config", $config, "--target", "clean");


### PR DESCRIPTION
#### f647d7feb5649d42014b43f707fd4a92c92d28da
<pre>
set-webkit-configuration should properly support the non-standard testing/release+assert builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=311824">https://bugs.webkit.org/show_bug.cgi?id=311824</a>
<a href="https://rdar.apple.com/174414568">rdar://174414568</a>

Reviewed by Elliott Williams.

WIP

Right now when passing `--ra` or `--testing` to `set-webkit-configuration`
it silently sets the configuration to the wrong values so tools think
the product directory is WebKitBuild/Release+Assert or
WebKitBuild/Testing, which is not where things end up. This patch moves
the current `Makefile.shared` logic into `webkitdirs.pm`

This should also make `--ra`/`--testing` &quot;sticky&quot; like `--debug` and
`--release` are today.

* Makefile.shared:
* Tools/Scripts/webkitdirs.pm:
(determineConfigurationForVisualStudio):
(determineConfigurationProductDir):
(baseConfiguration):
(XcodeOptions):
(generateBuildSystemFromCMakeProject):
(buildCMakeGeneratedProject):
(cleanCMakeGeneratedProject):

Canonical link: <a href="https://commits.webkit.org/311091@main">https://commits.webkit.org/311091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/264fbf4f13320854f83d686b7d723d910f9623b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163983 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108933 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fc374dab-9f20-4921-9c79-00a24ed1f45e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28331 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120107 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84832 "2 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/90d6087f-127c-4f20-91ae-5dd13aa56fe8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22359 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139392 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100802 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21445 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19497 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11809 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147273 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131110 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17228 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166461 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16054 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18837 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128210 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28027 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128347 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34948 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27951 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139021 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84660 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23209 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15817 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187108 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27644 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47982 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27222 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27452 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27295 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->