### PR TITLE
Fix z-index creating stacking-context unconditionally

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5841,7 +5841,6 @@ webkit.org/b/225035 imported/w3c/web-platform-tests/css/css-will-change/will-cha
 imported/w3c/web-platform-tests/css/css-will-change/will-change-fixpos-cb-webkit-perspective-1.html [ ImageOnlyFailure ]
 webkit.org/b/224902 [ Debug ] imported/w3c/web-platform-tests/css/css-will-change/parsing/will-change-invalid.html [ Skip ]
 webkit.org/b/224899 imported/w3c/web-platform-tests/css/css-will-change/will-change-fixedpos-cb-005.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-will-change/will-change-stacking-context-z-index-4.html [ ImageOnlyFailure ]
 
 # Needs display box support.
 fast/layoutformattingcontext/ [ Skip ]

--- a/LayoutTests/fast/css/will-change/will-change-creates-stacking-context-inline-expected.html
+++ b/LayoutTests/fast/css/will-change/will-change-creates-stacking-context-inline-expected.html
@@ -46,7 +46,10 @@
         function doTest()
         {
             for (value of willChangeValues) {
-                makeStackingElement('opacity', value.stacking ? '0.999999' : '1');
+                // z-index only applies to positioned elements and flex/grid items.
+                // This test uses non-positioned inline elements.
+                var isStacking = value.property === 'z-index' ? false : value.stacking;
+                makeStackingElement('opacity', isStacking ? '0.999999' : '1');
             }
         }
         

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -585,6 +585,9 @@ void Adjuster::adjust(RenderStyle& style) const
         if ((m_element && m_document->documentElement() == m_element.get())
             || hasTransformRelatedProperty(style, m_element.get(), m_parentStyle)
             || shouldTreatAutoZIndexAsZero(style)
+            || (style.willChange().containsProperty(CSSPropertyZIndex)
+                && (style.position() != PositionType::Static
+                    || m_parentBoxStyle.display().isFlexibleOrGridFormattingContextBox()))
             || isInTopLayerOrBackdrop(style, m_element.get()))
             style.setUsedZIndex(0);
         else

--- a/Source/WebCore/style/values/will-change/StyleWillChange.cpp
+++ b/Source/WebCore/style/values/will-change/StyleWillChange.cpp
@@ -69,7 +69,6 @@ bool WillChangeAnimatableFeature::propertyCreatesStackingContext(CSSPropertyID p
     case CSSPropertyWebkitMask:
     case CSSPropertyOpacity:
     case CSSPropertyPosition:
-    case CSSPropertyZIndex:
     case CSSPropertyWebkitBoxReflect:
     case CSSPropertyMixBlendMode:
     case CSSPropertyIsolation:


### PR DESCRIPTION
#### 2614650422ca4906ae3ffbfe62c0d99ef4da6ae1
<pre>
Fix z-index creating stacking-context unconditionally
<a href="https://bugs.webkit.org/show_bug.cgi?id=311827">https://bugs.webkit.org/show_bug.cgi?id=311827</a>
<a href="https://rdar.apple.com/174187601">rdar://174187601</a>

Reviewed by NOBODY (OOPS!).

According to the CSS spec, will-change should only create a
stacking context if the non-initial value of the property
would create one. Since z-index only applies to positioned
elements and flex/grid items, will-change:z-index should
have no effect.

This commit removes z-index from the unconditional create
stacking context list and adds a conditional check which
only sets it if the element is positioned or flex/grid.

Updated existing tests and TestExpectations to verify
this behavior change.

* LayoutTests/TestExpectations:
* LayoutTests/fast/css/will-change/will-change-creates-stacking-context-inline-expected.html:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
* Source/WebCore/style/values/will-change/StyleWillChange.cpp:
(WebCore::Style::WillChangeAnimatableFeature::propertyCreatesStackingContext):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2614650422ca4906ae3ffbfe62c0d99ef4da6ae1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28495 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163995 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108991 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157108 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28343 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120118 "Found 1 new test failure: animations/stacking-context-unchanged-while-running.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84837 "2 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158194 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22370 "Found 2 new test failures: animations/stacking-context-unchanged-while-running.html compositing/repaint/compositing-toggle-in-overflow-scroll-repaint.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139407 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100813 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21456 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19510 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11821 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131122 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17243 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166473 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10663 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18852 "Found 2 new test failures: animations/stacking-context-unchanged-while-running.html compositing/repaint/compositing-toggle-in-overflow-scroll-repaint.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128222 "Found 1 new test failure: animations/stacking-context-unchanged-while-running.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28039 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23544 "Found 2 new test failures: animations/stacking-context-unchanged-while-running.html compositing/repaint/compositing-toggle-in-overflow-scroll-repaint.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128359 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27963 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139036 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84672 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23224 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15833 "Found 1 new test failure: animations/stacking-context-unchanged-while-running.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27656 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91760 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27234 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27464 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27307 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->