### PR TITLE
Reserve and/or give JSC vectors inline capacity

### DIFF
--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -264,6 +264,7 @@ public:
         : m_indexOfLastWatchpoint(INT_MIN)
         , m_indexOfTailOfLastWatchpoint(INT_MIN)
     {
+        m_jumpsToLink.reserveInitialCapacity(64);
     }
     
     AssemblerBuffer& buffer() LIFETIME_BOUND { return m_buffer; }

--- a/Source/JavaScriptCore/dfg/DFGFlowMap.h
+++ b/Source/JavaScriptCore/dfg/DFGFlowMap.h
@@ -44,6 +44,10 @@ public:
     FlowMap(Graph& graph)
         : m_graph(graph)
     {
+        unsigned initialCapacity = m_graph.maxNodeCount();
+        m_map.reserveInitialCapacity(initialCapacity);
+        if (m_graph.m_form == SSA)
+            m_shadowMap.reserveInitialCapacity(initialCapacity);
         resize();
     }
     

--- a/Source/JavaScriptCore/dfg/DFGVariableEventStream.h
+++ b/Source/JavaScriptCore/dfg/DFGVariableEventStream.h
@@ -70,7 +70,10 @@ class VariableEventStreamBuilder {
 public:
     static constexpr bool verbose = false;
 
-    VariableEventStreamBuilder() = default;
+    VariableEventStreamBuilder()
+    {
+        m_stream.reserveInitialCapacity(128);
+    }
 
     void appendAndLog(const VariableEvent& event)
     {

--- a/Source/JavaScriptCore/jit/JITSafepoint.h
+++ b/Source/JavaScriptCore/jit/JITSafepoint.h
@@ -74,7 +74,7 @@ public:
 private:
     VM* m_vm;
     JITPlan& m_plan;
-    Vector<Scannable*> m_scannables;
+    Vector<Scannable*, 1> m_scannables;
     bool m_didCallBegin;
     bool m_keepDependenciesLive;
     Result& m_result;


### PR DESCRIPTION
#### 65b433087d28eb484402a89c830cb99c11e1c50f
<pre>
Reserve and/or give JSC vectors inline capacity
<a href="https://bugs.webkit.org/show_bug.cgi?id=311828">https://bugs.webkit.org/show_bug.cgi?id=311828</a>
<a href="https://rdar.apple.com/174418657">rdar://174418657</a>

Reviewed by Keith Miller.

Reserve initial capacity for several Vectors in JSC based on
looking at benchmark samples. These Vectors previously started empty
and grew incrementally, causing repeated heap allocations on hot paths.

There is no functionality change associated with this commit.

* Source/JavaScriptCore/assembler/ARM64Assembler.h:
(JSC::ARM64Assembler::ARM64Assembler):
* Source/JavaScriptCore/dfg/DFGFlowMap.h:
(JSC::DFG::FlowMap::FlowMap):
* Source/JavaScriptCore/dfg/DFGVariableEventStream.h:
(JSC::DFG::VariableEventStreamBuilder::VariableEventStreamBuilder):
* Source/JavaScriptCore/jit/JITSafepoint.h:

Canonical link: <a href="https://commits.webkit.org/310939@main">https://commits.webkit.org/310939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9114cc5a8e54c25bd5c1d810c848e62398b309af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155239 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163999 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108996 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28639 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28347 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120124 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84838 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22379 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139421 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100819 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21465 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19518 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; run-api-tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11825 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147289 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131131 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17256 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166477 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16070 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10635 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18865 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128229 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28043 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128366 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34865 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27967 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139049 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84676 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23229 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15846 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187124 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27660 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91764 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47986 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27238 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27468 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27311 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->