### PR TITLE
Remove CPU checks in WebContent process sandbox for arm64 on macOS

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -37,7 +37,7 @@
 
 (define webcontent_gpu_sandbox_extensions_blocking?
 #if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 140400 && defined(RC_XBS) && RC_XBS == 1
-    (equal? (param "CPU") "arm64")
+    TRUE
 #else
     FALSE
 #endif
@@ -583,54 +583,46 @@
     (deny iokit-get-properties (with no-report)
         (iokit-property "APTDevice")))
 
-(if (equal? (param "CPU") "arm64")
-    (with-filter (iokit-registry-entry-class "AppleARMIODevice")
-        (deny iokit-get-properties (with no-report)
-            (iokit-property "supports-apt"))))
+(with-filter (iokit-registry-entry-class "AppleARMIODevice")
+    (deny iokit-get-properties (with no-report)
+        (iokit-property "supports-apt")))
 
-(if (equal? (param "CPU") "arm64")
-    (with-filter (iokit-registry-entry-class "AppleJPEGDriver")
-        (deny iokit-get-properties (with no-report)
-            (iokit-property "AppleJPEGNumCores"))))
+(with-filter (iokit-registry-entry-class "AppleJPEGDriver")
+    (deny iokit-get-properties (with no-report)
+        (iokit-property "AppleJPEGNumCores")))
 
 ;; <rdar://problem/60088861>
-(if (equal? (param "CPU") "arm64")
+(allow iokit-get-properties
+    (iokit-property "ADSSupported")
+    (iokit-property "IOAVDHEVCDecodeCapabilities")
+    (iokit-property "IOGLESBundleName") ;; <rdar://problem/67473780>
+    (iokit-property "MetalPluginClassName") ;; <rdar://problem/67473780>
+    (iokit-property "MetalPluginName") ;; <rdar://problem/67473780>
+    (iokit-property "IOSurfaceAcceleratorCapabilitiesDict") ;; <rdar://problem/63696732>
+    (iokit-property "acoustic-id")) ;; <rdar://problem/65290967>
+
+(with-filter (iokit-registry-entry-class "IOService")
     (allow iokit-get-properties
-        (iokit-property "ADSSupported")
-        (iokit-property "IOAVDHEVCDecodeCapabilities")
-        (iokit-property "IOGLESBundleName") ;; <rdar://problem/67473780>
-        (iokit-property "MetalPluginClassName") ;; <rdar://problem/67473780>
-        (iokit-property "MetalPluginName") ;; <rdar://problem/67473780>
-        (iokit-property "IOSurfaceAcceleratorCapabilitiesDict") ;; <rdar://problem/63696732>
-        (iokit-property "acoustic-id") ;; <rdar://problem/65290967>
-    ))
+        (iokit-property "IORegistryEntryPropertyKeys")))
 
-(if (equal? (param "CPU") "arm64")
-    (with-filter (iokit-registry-entry-class "IOService")
-        (allow iokit-get-properties
-            (iokit-property "IORegistryEntryPropertyKeys"))))
+(with-filter (iokit-registry-entry-class "IOMobileFramebuffer")
+    (allow iokit-get-properties
+        (iokit-property "AppleTV"
+                        "DisplayPipePlaneBaseAlignment"
+                        "DisplayPipeStrideRequirements"
+                        "dfr"
+                        "external"
+                        "hdcp-hoover-protocol")))
 
-(if (equal? (param "CPU") "arm64")
-    (with-filter (iokit-registry-entry-class "IOMobileFramebuffer")
-        (allow iokit-get-properties
-            (iokit-property "AppleTV"
-                            "DisplayPipePlaneBaseAlignment"
-                            "DisplayPipeStrideRequirements"
-                            "dfr"
-                            "external"
-                            "hdcp-hoover-protocol"))))
+(with-filter (iokit-registry-entry-class "IOPlatformDevice")
+    (allow iokit-get-properties
+        (iokit-property "soc-generation")))
 
-(if (equal? (param "CPU") "arm64")
-    (with-filter (iokit-registry-entry-class "IOPlatformDevice")
-        (allow iokit-get-properties
-            (iokit-property "soc-generation"))))
-
-(if (equal? (param "CPU") "arm64")
-    (with-filter (iokit-registry-entry-class "IOService")
-        (allow iokit-get-properties
-            (iokit-property "chip-id"
-                            "display-rotation"
-                            "display-scale"))))
+(with-filter (iokit-registry-entry-class "IOService")
+    (allow iokit-get-properties
+        (iokit-property "chip-id"
+                        "display-rotation"
+                        "display-scale")))
 
 (deny mach-lookup (xpc-service-name-prefix ""))
 
@@ -1359,8 +1351,7 @@
 
 (with-filter (require-not (lockdown-mode))
     (allow syscall-unix (syscall-unix-blocked-in-lockdown-mode))
-    (when (equal? (param "CPU") "arm64")
-        (allow syscall-unix (syscall-unix-apple-silicon)))
+    (allow syscall-unix (syscall-unix-apple-silicon))
     (allow syscall-unix (with report) (with telemetry) (syscalls-rarely-used-blocked-in-lockdown-mode)))
 
 (when (defined? 'SYS_objc_bp_assist_cfg_np)
@@ -1379,8 +1370,7 @@
 (with-filter (lockdown-mode)
     (deny syscall-unix (with telemetry) (syscall-unix-blocked-in-lockdown-mode))
     (deny syscall-unix (with telemetry) (syscalls-rarely-used-blocked-in-lockdown-mode))
-    (when (equal? (param "CPU") "arm64")
-        (deny syscall-unix (with telemetry) (syscall-unix-apple-silicon))))
+    (deny syscall-unix (with telemetry) (syscall-unix-apple-silicon)))
 
 #if HAVE(SANDBOX_MESSAGE_FILTERING)
 (define (mach-bootstrap-message-numbers)
@@ -1491,12 +1481,10 @@
 
 (define (allow-mach-exceptions operation)
 #if HAVE(HARDENED_MACH_EXCEPTIONS)
-    (when (equal? (param "CPU") "arm64")
+    (when (defined? 'task_register_hardened_exception_handler)
         (with-filter (require-not (webcontent-process-launched))
             (allow operation (kernel-mig-routine task_register_hardened_exception_handler)))
-        (allow operation (kernel-mig-routine thread_adopt_exception_handler)))
-    (when (not (equal? (param "CPU") "arm64"))
-        (allow operation (kernel-mig-routine thread_set_exception_ports))))
+        (allow operation (kernel-mig-routine thread_adopt_exception_handler))))
 #else
     (allow operation (kernel-mig-routine thread_set_exception_ports)))
 #endif


### PR DESCRIPTION
#### 98b109f66dfd08d124573eac7e9aaec8cdd733c7
<pre>
Remove CPU checks in WebContent process sandbox for arm64 on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=311711">https://bugs.webkit.org/show_bug.cgi?id=311711</a>
<a href="https://rdar.apple.com/174299099">rdar://174299099</a>

Reviewed by Sihui Liu.

After &lt;<a href="https://commits.webkit.org/310762@main">https://commits.webkit.org/310762@main</a>&gt;, which added an Intel specific sandbox,
we can remove CPU checks in the sandbox for arm64.

This was first landed in &lt;<a href="https://commits.webkit.org/310823@main">https://commits.webkit.org/310823@main</a>&gt;, and this patch is
the same, with an additional build fix.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/311055@main">https://commits.webkit.org/311055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d93bc3777e62f12502797bfc628fd790b7782829

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155971 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; check-webkit-style") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164733 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120748 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158929 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22946 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140066 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101437 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22029 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20170 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12563 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131692 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167213 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11387 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19510 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128869 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28907 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24219 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129001 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28829 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139692 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86574 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23739 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23824 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16490 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28538 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92494 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28065 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28293 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28189 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->