### PR TITLE
[Web Inspector] [Site Isolation] Add inspector test for Page.setEmulatedMedia with cross-origin iframes under site isolation

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/page/resources/emulated-media-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/resources/emulated-media-frame.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<style>
+body { color: blue; }
+@media print {
+    body { color: green; }
+}
+</style>
+<p>Cross-origin frame for emulated media test.</p>

--- a/LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-cross-origin-iframe-expected.txt
@@ -1,0 +1,23 @@
+Test that Page.setEmulatedMedia propagates to cross-origin iframes under site isolation.
+
+
+== Running test suite: SiteIsolation.Page.SetEmulatedMediaCrossOriginIFrame
+-- Running test case: SiteIsolation.Page.SetEmulatedMedia.DefaultMedia
+PASS: Added target should have Frame type.
+PASS: Main page should have screen styles (blue).
+PASS: Cross-origin iframe should have screen styles (blue).
+
+-- Running test case: SiteIsolation.Page.SetEmulatedMedia.EmulateAndReload
+Setting emulated media to print...
+Reloading...
+PASS: Main page should have print styles (green).
+Re-adding cross-origin iframe...
+PASS: Cross-origin iframe should have print styles (green).
+
+-- Running test case: SiteIsolation.Page.SetEmulatedMedia.ResetAndReload
+Resetting emulated media...
+Reloading...
+PASS: Main page should have screen styles restored (blue).
+Re-adding cross-origin iframe...
+PASS: Cross-origin iframe should have screen styles restored (blue).
+

--- a/LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-cross-origin-iframe.html
@@ -1,0 +1,120 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<style>
+body { color: blue; }
+@media print {
+    body { color: green; }
+}
+</style>
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+let iframe;
+
+function addCrossOriginIFrame() {
+    let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+    iframe = document.createElement("iframe");
+    iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/page/resources/emulated-media-frame.html`;
+    document.body.appendChild(iframe);
+}
+
+function test() {
+    async function addIFrameAndGetTarget() {
+        let targetAddedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
+        InspectorTest.evaluateInPage("addCrossOriginIFrame()");
+        let event = await targetAddedPromise;
+        return event.data.target;
+    }
+
+    async function getComputedColorInTarget(target) {
+        // Wait for the iframe document to fully load before checking computed styles.
+        // TargetAdded fires when the JS context is created, before DOM and CSS are ready.
+        await target.RuntimeAgent.evaluate.invoke({
+            expression: "new Promise(resolve => { if (document.readyState === 'complete') resolve(); else window.addEventListener('load', resolve); })",
+            objectGroup: "test",
+            awaitPromise: true,
+        });
+
+        let response = await target.RuntimeAgent.evaluate.invoke({expression: "window.getComputedStyle(document.body).getPropertyValue('color')", objectGroup: "test", returnByValue: true});
+        InspectorTest.assert(response.result.value, "Should be able to evaluate computed style in cross-origin target.");
+        return response.result.value;
+    }
+
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Page.SetEmulatedMediaCrossOriginIFrame");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.SetEmulatedMedia.DefaultMedia",
+        description: "Both the main page and cross-origin iframe should use screen media by default.",
+        async test() {
+            let target = await addIFrameAndGetTarget();
+            InspectorTest.expectEqual(target.type, WI.TargetType.Frame, "Added target should have Frame type.");
+
+            let mainPageColor = await InspectorTest.evaluateInPage(`getComputedStyle(document.body).color`);
+            InspectorTest.expectEqual(mainPageColor, "rgb(0, 0, 255)", "Main page should have screen styles (blue).");
+
+            let iframeColor = await getComputedColorInTarget(target);
+            InspectorTest.expectEqual(iframeColor, "rgb(0, 0, 255)", "Cross-origin iframe should have screen styles (blue).");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.SetEmulatedMedia.EmulateAndReload",
+        description: "Emulating print media and reloading should apply print styles in the cross-origin iframe.",
+        async test() {
+            InspectorTest.log("Setting emulated media to print...");
+            await PageAgent.setEmulatedMedia("print");
+
+            InspectorTest.log("Reloading...");
+            await InspectorTest.reloadPage();
+            await InspectorTest.awaitEvent(FrontendTestHarness.Event.TestPageDidLoad);
+
+            // Wait for the main page to fully load before checking computed styles.
+            await RuntimeAgent.evaluate.invoke({
+                expression: "new Promise(resolve => { if (document.readyState === 'complete') resolve(); else window.addEventListener('load', resolve); })",
+                objectGroup: "test",
+                awaitPromise: true,
+            });
+
+            let mainPageColor = await InspectorTest.evaluateInPage(`getComputedStyle(document.body).color`);
+            InspectorTest.expectEqual(mainPageColor, "rgb(0, 128, 0)", "Main page should have print styles (green).");
+
+            InspectorTest.log("Re-adding cross-origin iframe...");
+            let target = await addIFrameAndGetTarget();
+            let iframeColor = await getComputedColorInTarget(target);
+            InspectorTest.expectEqual(iframeColor, "rgb(0, 128, 0)", "Cross-origin iframe should have print styles (green).");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.SetEmulatedMedia.ResetAndReload",
+        description: "Resetting emulated media and reloading should restore screen styles in both frames.",
+        async test() {
+            InspectorTest.log("Resetting emulated media...");
+            await PageAgent.setEmulatedMedia("");
+
+            InspectorTest.log("Reloading...");
+            await InspectorTest.reloadPage();
+            await InspectorTest.awaitEvent(FrontendTestHarness.Event.TestPageDidLoad);
+
+            // Wait for the main page to fully load before checking computed styles.
+            await RuntimeAgent.evaluate.invoke({
+                expression: "new Promise(resolve => { if (document.readyState === 'complete') resolve(); else window.addEventListener('load', resolve); })",
+                objectGroup: "test",
+                awaitPromise: true,
+            });
+
+            let mainPageColor = await InspectorTest.evaluateInPage(`getComputedStyle(document.body).color`);
+            InspectorTest.expectEqual(mainPageColor, "rgb(0, 0, 255)", "Main page should have screen styles restored (blue).");
+
+            InspectorTest.log("Re-adding cross-origin iframe...");
+            let target = await addIFrameAndGetTarget();
+            let iframeColor = await getComputedColorInTarget(target);
+            InspectorTest.expectEqual(iframeColor, "rgb(0, 0, 255)", "Cross-origin iframe should have screen styles restored (blue).");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Test that Page.setEmulatedMedia propagates to cross-origin iframes under site isolation.</p>
+</body>

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -255,6 +255,7 @@ http/tests/site-isolation/inspector/debugger/pause-in-cross-origin-iframe.html [
 http/tests/site-isolation/inspector/debugger/scriptParsed-frame-target.html [ Pass ]
 http/tests/site-isolation/inspector/debugger/setBreakpoint-cross-origin-iframe.html [ Pass ]
 http/tests/site-isolation/inspector/page/override-setting-cross-origin-iframe.html [ Pass Failure ]
+webkit.org/b/311836 http/tests/site-isolation/inspector/page/set-emulated-media-cross-origin-iframe.html [ Pass Failure ]
 http/tests/site-isolation/inspector/worker/worker-in-cross-origin-iframe.html [ Pass ]
 http/tests/ssl/applepay/page-cache-active-apple-pay-session.html [ Failure ]
 http/tests/ssl/applepay/page-cache-inactive-apple-pay-session.html [ Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2416,6 +2416,7 @@ http/tests/site-isolation/inspector/runtime/evaluate-in-cross-origin-iframe.html
 http/tests/site-isolation/inspector/runtime/execution-context-from-frame-target.html [ Failure ]
 http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target.html [ Failure ]
 http/tests/site-isolation/inspector/page/override-setting-cross-origin-iframe.html [ Pass Failure ]
+webkit.org/b/311836 http/tests/site-isolation/inspector/page/set-emulated-media-cross-origin-iframe.html [ Pass Failure ]
 
 webkit.org/b/308165 [ Debug ] scrollingcoordinator/mac/latching/simple-page-rubberbands.html [ Pass Failure ]
 


### PR DESCRIPTION
#### 5a58e93edb20ab59cf9999c175eb72eee13e2adf
<pre>
[Web Inspector] [Site Isolation] Add inspector test for Page.setEmulatedMedia with cross-origin iframes under site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=311836">https://bugs.webkit.org/show_bug.cgi?id=311836</a>
<a href="https://rdar.apple.com/174427083">rdar://174427083</a>

Reviewed by BJ Burg.

Add a layout test that verifies Page.setEmulatedMedia propagates to
cross-origin iframes when site isolation is enabled. The test emulates
print media via Web Inspector, reloads, and confirms that @media print
styles in a cross-origin iframe (running in a separate process) are
correctly applied.

* LayoutTests/http/tests/site-isolation/inspector/page/resources/emulated-media-frame.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/set-emulated-media-cross-origin-iframe.html: Added.
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/311447@main">https://commits.webkit.org/311447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b8b9fc584823ab3d701769f5c094809e33aa676

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156895 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30231 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23422 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165718 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110977 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30234 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121516 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85332 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a39ff3d8-36be-478d-ab9d-146a0d85cfbf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140880 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102184 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8670bbc9-37b5-47af-817f-e4ba0a51b32c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22798 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21017 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13490 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132479 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18709 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168203 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20329 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129645 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29833 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129752 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35164 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29756 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140503 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87560 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24572 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17307 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29466 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28989 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29219 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29115 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->