### PR TITLE
Remove check for UI_BUTTON_PERFORM_PRIMARY_ACTION

### DIFF
--- a/Source/WebKit/Configurations/AllowedSPI-legacy.toml
+++ b/Source/WebKit/Configurations/AllowedSPI-legacy.toml
@@ -231,7 +231,6 @@ selectors = [
     { name = "_nsTextAlternative", class = "?" },
     { name = "_pageContentRect:", class = "?" },
     { name = "_preconnect", class = "?" },
-    { name = "_presentMenuAtLocation:", class = "?" },
     { name = "_privateLocalContext", class = "?" },
     { name = "_purgeDevice", class = "?" },
     { name = "_resolvedCNAMEChain", class = "?" },

--- a/Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.mm
+++ b/Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.mm
@@ -30,16 +30,6 @@
 
 #import <wtf/TZoneMallocInlines.h>
 
-@interface UIContextMenuInteraction (SPI)
-- (void)_presentMenuAtLocation:(CGPoint)location;
-@end
-
-#if HAVE(UI_BUTTON_PERFORM_PRIMARY_ACTION)
-@interface UIButton (Staging_112292156)
-- (void)performPrimaryAction;
-@end
-#endif
-
 @interface WKCompactContextMenuPresenterControl : UIControl <WKCompactContextMenuPresenter>
 @end
 
@@ -176,15 +166,7 @@ void CompactContextMenuPresenter::present(CGRect rectInRootView)
     if (![m_control superview])
         [rootView addSubview:m_control.get()];
 
-#if HAVE(UI_BUTTON_PERFORM_PRIMARY_ACTION)
-    static BOOL canPerformPrimaryAction = [UIControl instancesRespondToSelector:@selector(performPrimaryAction)];
-    if (canPerformPrimaryAction) {
-        [m_control performPrimaryAction];
-        return;
-    }
-#endif
-
-    [protect(interaction()) _presentMenuAtLocation:CGPointMake(CGRectGetMidX(rectInRootView), CGRectGetMidY(rectInRootView))];
+    [m_control performPrimaryAction];
 }
 
 void CompactContextMenuPresenter::dismiss()


### PR DESCRIPTION
#### 06ee2645b57e7df6966d6960d2014298241b5011
<pre>
Remove check for UI_BUTTON_PERFORM_PRIMARY_ACTION
<a href="https://bugs.webkit.org/show_bug.cgi?id=311839">https://bugs.webkit.org/show_bug.cgi?id=311839</a>
<a href="https://rdar.apple.com/174428665">rdar://174428665</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

Remove check for UI_BUTTON_PERFORM_PRIMARY_ACTION
as well as staging for performPrimaryAction,
as it exists in all supported OS/SDKs.

Also, remove _presentMenuAtLocation as it is no longer
used now.

* Source/WebKit/Configurations/AllowedSPI-legacy.toml:
* Source/WebKit/UIProcess/ios/CompactContextMenuPresenter.mm:
(WebKit::CompactContextMenuPresenter::present):

Canonical link: <a href="https://commits.webkit.org/310965@main">https://commits.webkit.org/310965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4aec349c66b4b54f21236eb27fd05fbfc87dc2fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155346 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164108 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28456 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120221 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22418 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139509 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100911 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21504 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19606 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11937 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131173 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166586 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10751 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18951 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128331 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28150 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23640 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128464 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28074 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139134 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85545 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23701 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23314 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15931 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27768 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91871 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27345 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27575 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27418 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->