### PR TITLE
[TestWebKitAPI] Make it possible to pass in gtest-formatted arguments to the CLI

### DIFF
--- a/Tools/TestWebKitAPI/Runner/GoogleTestsController.swift
+++ b/Tools/TestWebKitAPI/Runner/GoogleTestsController.swift
@@ -69,6 +69,8 @@ extension GoogleTestsController {
             result.append("--gtest_repeat=\(repetitions)")
         }
 
+        result.append(contentsOf: configuration.gTestLegacyArguments)
+
         return result
     }
 }

--- a/Tools/TestWebKitAPI/Runner/TestRunner.swift
+++ b/Tools/TestWebKitAPI/Runner/TestRunner.swift
@@ -38,6 +38,8 @@ struct TestRunnerConfiguration {
     let repetitions: Int?
     let force: Bool
     let parallel: Bool
+
+    let gTestLegacyArguments: [String]
 }
 
 extension TestRunner.Configuration {
@@ -71,5 +73,8 @@ extension TestRunner.Configuration {
         self.listTests = Self.flag(arguments, for: "--list-tests")
         self.pretty = Self.flag(arguments, for: "--pretty")
         self.parallel = Self.flag(arguments, for: "--parallel")
+
+        // Maintain backwards compatibility for the `--gtest_*=*` type arguments.
+        self.gTestLegacyArguments = arguments.dropFirst().filter { $0.contains("--gtest") }
     }
 }


### PR DESCRIPTION
#### d5aab03d975442a4e78f0ba0f43c5ec515ba0a28
<pre>
[TestWebKitAPI] Make it possible to pass in gtest-formatted arguments to the CLI
<a href="https://bugs.webkit.org/show_bug.cgi?id=311840">https://bugs.webkit.org/show_bug.cgi?id=311840</a>
<a href="https://rdar.apple.com/174430249">rdar://174430249</a>

Reviewed by NOBODY (OOPS!).

Find any &quot;--gtest&quot; arguments and pass them directly through to GTest

* Tools/TestWebKitAPI/Runner/GoogleTestsController.swift:
(GoogleTestsController.parseArguments(_:)):
* Tools/TestWebKitAPI/Runner/TestRunner.swift:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5aab03d975442a4e78f0ba0f43c5ec515ba0a28

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164040 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109076 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e415ca6c-7259-4601-9c4f-c2d3d0202b70) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157152 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28679 "Hash d5aab03d for PR 62376 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28389 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120158 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84849 "Build is in progress. Recent messages:") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158238 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/28679 "Hash d5aab03d for PR 62376 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139448 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100853 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/00d4b2cd-025a-4466-99cc-1fbe8129d241) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/28679 "Hash d5aab03d for PR 62376 does not build (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19550 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11865 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/28679 "Hash d5aab03d for PR 62376 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17282 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166518 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18891 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128262 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28083 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23584 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128399 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28007 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139075 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85398 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23258 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15872 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27701 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27278 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27508 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27351 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->