### PR TITLE
Web Inspector: Web Inspector: Layers tab async race conditions and null guards

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Controllers/LayerTreeManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/LayerTreeManager.js
@@ -186,7 +186,12 @@ WI.LayerTreeManager = class LayerTreeManager extends WI.Object
 
         let target = WI.assumingMainTarget();
         target.LayerTreeAgent.layersForNode(node.id, (error, layers) => {
-            callback(error ? [] : layers.map(WI.Layer.fromPayload));
+            if (error) {
+                WI.reportInternalError(error);
+                callback([]);
+                return;
+            }
+            callback(layers.map(WI.Layer.fromPayload));
         });
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/LayerDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LayerDetailsSidebarPanel.js
@@ -74,6 +74,11 @@ WI.LayerDetailsSidebarPanel = class LayerDetailsSidebarPanel extends WI.DetailsS
     {
         this._layerIdToSelect = null;
 
+        if (!this._dataGrid) {
+            this._layerIdToSelect = layerId;
+            return;
+        }
+
         let node = this._dataGridNodesByLayerId.get(layerId);
         if (node === this._dataGrid.selectedNode)
             return;

--- a/Source/WebInspectorUI/UserInterface/Views/LayerTreeDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LayerTreeDetailsSidebarPanel.js
@@ -75,8 +75,12 @@ WI.LayerTreeDetailsSidebarPanel = class LayerTreeDetailsSidebarPanel extends WI.
         if (!this.domNode || this.domNode.destroyed)
             return;
 
-        WI.layerTreeManager.layersForNode(this.domNode, (layers) => {
-            let layerForNode = layers[0] && layers[0].nodeId === this.domNode.id && !layers[0].isGeneratedContent ? layers[0] : null;
+        let domNode = this.domNode;
+        WI.layerTreeManager.layersForNode(domNode, (layers) => {
+            if (this.domNode !== domNode)
+                return;
+
+            let layerForNode = layers[0]?.nodeId === domNode.id && !layers[0].isGeneratedContent ? layers[0] : null;
             let childLayers = layers.slice(layerForNode ? 1 : 0);
             this._unfilteredChildLayers = childLayers;
             this._updateDisplayWithLayers(layerForNode, childLayers);
@@ -248,7 +252,7 @@ WI.LayerTreeDetailsSidebarPanel = class LayerTreeDetailsSidebarPanel extends WI.
         if (!layer)
             return;
 
-        this._layerInfoRows["Memory"].value = Number.bytesToString(layer.memory);
+        this._layerInfoRows["Memory"].value = Number.bytesToString(layer.memory || 0);
         this._layerInfoRows["Width"].value = layer.compositedBounds.width + "px";
         this._layerInfoRows["Height"].value = layer.compositedBounds.height + "px";
         this._layerInfoRows["Paints"].value = layer.paintCount + "";

--- a/Source/WebInspectorUI/UserInterface/Views/Layers3DContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/Layers3DContentView.js
@@ -538,6 +538,9 @@ WI.Layers3DContentView = class Layers3DContentView extends WI.ContentView
 
     _resetCamera()
     {
+        if (!this._layers.length)
+            return;
+
         let {x, y, width, height} = this._layers[0].bounds;
         this._controls.target.set(x + (width / 2), -y - (height / 2), 0);
         this._camera.position.set(x + (width / 2), -y - (height / 2), this._controls.maxDistance - WI.Layers3DContentView._zPadding / 2);
@@ -656,6 +659,9 @@ WI.Layers3DContentView = class Layers3DContentView extends WI.ContentView
         this._visibleDimensionsElement.textContent = `${layer.bounds.width}px ${multiplicationSign} ${layer.bounds.height}px`;
 
         WI.layerTreeManager.reasonsForCompositingLayer(layer, (compositingReasons) => {
+            if (this._selectedLayerGroup?.userData.layer.layerId !== layer.layerId)
+                return;
+
             this._updateReasonsList(compositingReasons);
             this._layerInfoElement.classList.remove("hidden");
         });


### PR DESCRIPTION
#### afc4a2a8a2c030e6675f5cb5014882dd55f9326a
<pre>
Web Inspector: Web Inspector: Layers tab async race conditions and null guards
<a href="https://bugs.webkit.org/show_bug.cgi?id=311841">https://bugs.webkit.org/show_bug.cgi?id=311841</a>
<a href="https://rdar.apple.com/174430948">rdar://174430948</a>

Reviewed by Devin Rousso and BJ Burg.

LayerTreeDetailsSidebarPanel.layout() re-reads this.domNode in the
layersForNode callback if the user switches nodes mid-request, the
old result is displayed for the new node. Capture domNode before the
call and bail if it changed.

Layers3DContentView._updateLayerInfoElement shows compositing reasons
for a deselected layer if the async callback fires late-check that the
selection still matches before updating.

LayerDetailsSidebarPanel.selectNodeByLayerId crashes if called before
the data grid is initialized. Defer via _layerIdToSelect.

Layers3DContentView._resetCamera crashes on this._layers[0] when the
layers array is empty. Add a length guard.

LayerTreeManager.layersForNode silently swallows protocol errors.
Report via WI.reportInternalError to match other error paths.

LayerTreeDetailsSidebarPanel._updateLayerInfoSection passes
layer.memory to Number.bytesToString without a fallback, producing
&quot;NaN&quot;. Add || 0.

* Source/WebInspectorUI/UserInterface/Controllers/LayerTreeManager.js:
(WI.LayerTreeManager.prototype.layersForNode):
* Source/WebInspectorUI/UserInterface/Views/LayerDetailsSidebarPanel.js:
(WI.LayerDetailsSidebarPanel.prototype.selectNodeByLayerId):
* Source/WebInspectorUI/UserInterface/Views/LayerTreeDetailsSidebarPanel.js:
(WI.LayerTreeDetailsSidebarPanel.prototype.layout):
(WI.LayerTreeDetailsSidebarPanel.prototype._updateLayerInfoSection):
* Source/WebInspectorUI/UserInterface/Views/Layers3DContentView.js:
(WI.Layers3DContentView.prototype._resetCamera):
(WI.Layers3DContentView.prototype._updateLayerInfoElement):

Canonical link: <a href="https://commits.webkit.org/311304@main">https://commits.webkit.org/311304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49d7b1505746fef715b232d26ec0924256b2170d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156610 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23129 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165433 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29949 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121299 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159568 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/23534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101967 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13205 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/18470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167916 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/12036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20087 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129415 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24852 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129525 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35080 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29471 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140264 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/24361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/17066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29179 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/93143 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/28934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/28829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->