### PR TITLE
Remove unnecessary Lock from IDBServer

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
@@ -36,7 +36,6 @@
 #include "SecurityOrigin.h"
 #include <algorithm>
 #include <wtf/CompletionHandler.h>
-#include <wtf/Locker.h>
 #include <wtf/MainThread.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -46,9 +45,8 @@ namespace IDBServer {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IDBBackingStore);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IDBServer);
 
-IDBServer::IDBServer(const String& databaseDirectoryPath, SpaceRequester&& spaceRequester, Lock& lock)
+IDBServer::IDBServer(const String& databaseDirectoryPath, SpaceRequester&& spaceRequester)
     : m_spaceRequester(WTF::move(spaceRequester))
-    , m_lock(lock)
 {
     ASSERT(!isMainThread());
     ASSERT(databaseDirectoryPath.isSafeToSendToAnotherThread());
@@ -75,7 +73,6 @@ void IDBServer::registerConnection(IDBConnectionToClient& connection)
 void IDBServer::unregisterConnection(IDBConnectionToClient& connection)
 {
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
     ASSERT(m_connectionMap.contains(connection.identifier()));
     ASSERT(m_connectionMap.get(connection.identifier()) == &connection);
 
@@ -87,7 +84,6 @@ void IDBServer::unregisterConnection(IDBConnectionToClient& connection)
 void IDBServer::registerTransaction(UniqueIDBDatabaseTransaction& transaction)
 {
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
     ASSERT(!m_transactions.contains(transaction.info().identifier()));
     m_transactions.set(transaction.info().identifier(), &transaction);
 }
@@ -95,7 +91,6 @@ void IDBServer::registerTransaction(UniqueIDBDatabaseTransaction& transaction)
 void IDBServer::unregisterTransaction(UniqueIDBDatabaseTransaction& transaction)
 {
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
     ASSERT(m_transactions.contains(transaction.info().identifier()));
     ASSERT(m_transactions.get(transaction.info().identifier()) == &transaction);
 
@@ -141,7 +136,6 @@ void IDBServer::openDatabase(const IDBOpenRequestData& requestData)
 {
     LOG(IndexedDB, "IDBServer::openDatabase");
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     CheckedRef uniqueIDBDatabase = getOrCreateUniqueIDBDatabase(requestData.databaseIdentifier());
 
@@ -163,7 +157,6 @@ void IDBServer::deleteDatabase(const IDBOpenRequestData& requestData)
 {
     LOG(IndexedDB, "IDBServer::deleteDatabase - %s", requestData.databaseIdentifier().loggingString().utf8().data());
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     auto connectionIdentifier = requestData.requestIdentifier().connectionIdentifier();
     if (!connectionIdentifier)
@@ -194,7 +187,6 @@ void IDBServer::abortTransaction(const IDBResourceIdentifier& transactionIdentif
 {
     LOG(IndexedDB, "IDBServer::abortTransaction");
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     RefPtr transaction = m_transactions.get(transactionIdentifier);
     if (!transaction) {
@@ -215,7 +207,6 @@ void IDBServer::createObjectStore(const IDBRequestData& requestData, const IDBOb
 {
     LOG(IndexedDB, "IDBServer::createObjectStore");
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
@@ -229,7 +220,6 @@ void IDBServer::deleteObjectStore(const IDBRequestData& requestData, const Strin
 {
     LOG(IndexedDB, "IDBServer::deleteObjectStore");
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
@@ -243,7 +233,6 @@ void IDBServer::renameObjectStore(const IDBRequestData& requestData, IDBObjectSt
 {
     LOG(IndexedDB, "IDBServer::renameObjectStore");
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
@@ -257,7 +246,6 @@ void IDBServer::clearObjectStore(const IDBRequestData& requestData, IDBObjectSto
 {
     LOG(IndexedDB, "IDBServer::clearObjectStore");
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
@@ -270,7 +258,6 @@ void IDBServer::createIndex(const IDBRequestData& requestData, const IDBIndexInf
 {
     LOG(IndexedDB, "IDBServer::createIndex");
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
@@ -284,7 +271,6 @@ void IDBServer::deleteIndex(const IDBRequestData& requestData, IDBObjectStoreIde
 {
     LOG(IndexedDB, "IDBServer::deleteIndex");
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
@@ -298,7 +284,6 @@ void IDBServer::renameIndex(const IDBRequestData& requestData, IDBObjectStoreIde
 {
     LOG(IndexedDB, "IDBServer::renameIndex");
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
@@ -312,7 +297,6 @@ void IDBServer::putOrAdd(const IDBRequestData& requestData, const IDBKeyData& ke
 {
     LOG(IndexedDB, "IDBServer::putOrAdd");
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
@@ -325,7 +309,6 @@ void IDBServer::getRecord(const IDBRequestData& requestData, const IDBGetRecordD
 {
     LOG(IndexedDB, "IDBServer::getRecord");
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
@@ -338,7 +321,6 @@ void IDBServer::getAllRecords(const IDBRequestData& requestData, const IDBGetAll
 {
     LOG(IndexedDB, "IDBServer::getAllRecords");
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
@@ -351,7 +333,6 @@ void IDBServer::getCount(const IDBRequestData& requestData, const IDBKeyRangeDat
 {
     LOG(IndexedDB, "IDBServer::getCount");
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
@@ -364,7 +345,6 @@ void IDBServer::deleteRecord(const IDBRequestData& requestData, const IDBKeyRang
 {
     LOG(IndexedDB, "IDBServer::deleteRecord");
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
@@ -377,7 +357,6 @@ void IDBServer::openCursor(const IDBRequestData& requestData, const IDBCursorInf
 {
     LOG(IndexedDB, "IDBServer::openCursor");
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
@@ -390,7 +369,6 @@ void IDBServer::iterateCursor(const IDBRequestData& requestData, const IDBIterat
 {
     LOG(IndexedDB, "IDBServer::iterateCursor");
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
@@ -403,7 +381,6 @@ void IDBServer::establishTransaction(IDBDatabaseConnectionIdentifier databaseCon
 {
     LOG(IndexedDB, "IDBServer::establishTransaction");
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     RefPtr databaseConnection = m_databaseConnections.get(databaseConnectionIdentifier);
     if (!databaseConnection)
@@ -424,7 +401,6 @@ void IDBServer::commitTransaction(const IDBResourceIdentifier& transactionIdenti
 {
     LOG(IndexedDB, "IDBServer::commitTransaction");
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     RefPtr transaction = m_transactions.get(transactionIdentifier);
     if (!transaction) {
@@ -440,7 +416,6 @@ void IDBServer::didFinishHandlingVersionChangeTransaction(IDBDatabaseConnectionI
 {
     LOG(IndexedDB, "IDBServer::didFinishHandlingVersionChangeTransaction - %s", transactionIdentifier.loggingString().utf8().data());
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     if (RefPtr connection = m_databaseConnections.get(databaseConnectionIdentifier))
         connection->didFinishHandlingVersionChange(transactionIdentifier);
@@ -450,7 +425,6 @@ void IDBServer::databaseConnectionPendingClose(IDBDatabaseConnectionIdentifier d
 {
     LOG(IndexedDB, "IDBServer::databaseConnectionPendingClose - %" PRIu64, databaseConnectionIdentifier.toUInt64());
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     auto* databaseConnection = m_databaseConnections.get(databaseConnectionIdentifier);
     if (!databaseConnection)
@@ -463,7 +437,6 @@ void IDBServer::databaseConnectionClosed(IDBDatabaseConnectionIdentifier databas
 {
     LOG(IndexedDB, "IDBServer::databaseConnectionClosed - %" PRIu64, databaseConnectionIdentifier.toUInt64());
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     RefPtr databaseConnection = m_databaseConnections.get(databaseConnectionIdentifier);
     if (!databaseConnection)
@@ -484,7 +457,6 @@ void IDBServer::abortOpenAndUpgradeNeeded(IDBDatabaseConnectionIdentifier databa
 {
     LOG(IndexedDB, "IDBServer::abortOpenAndUpgradeNeeded");
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     if (transactionIdentifier) {
         if (RefPtr transaction = m_transactions.get(*transactionIdentifier))
@@ -502,7 +474,6 @@ void IDBServer::didFireVersionChangeEvent(IDBDatabaseConnectionIdentifier databa
 {
     LOG(IndexedDB, "IDBServer::didFireVersionChangeEvent");
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     if (RefPtr databaseConnection = m_databaseConnections.get(databaseConnectionIdentifier))
         databaseConnection->didFireVersionChangeEvent(requestIdentifier, connectionClosed);
@@ -518,7 +489,6 @@ void IDBServer::openDBRequestCancelled(const IDBOpenRequestData& requestData)
 {
     LOG(IndexedDB, "IDBServer::openDBRequestCancelled");
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     IDBDatabaseIdentifier databaseIdentifier;
     {
@@ -551,7 +521,6 @@ static void getDatabaseNameAndVersionFromOriginDirectory(const String& directory
 void IDBServer::getAllDatabaseNamesAndVersions(IDBConnectionIdentifier serverConnectionIdentifier, const IDBResourceIdentifier& requestIdentifier, const ClientOrigin& origin)
 {
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     Vector<IDBDatabaseNameAndVersion> result;
     HashSet<String> visitedDatabasePaths;
@@ -598,7 +567,6 @@ static void collectOriginsForVersion(const String& versionPath, HashSet<WebCore:
 HashSet<SecurityOriginData> IDBServer::getOrigins() const
 {
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     if (m_databaseDirectoryPath.isEmpty())
         return { };
@@ -613,7 +581,6 @@ HashSet<SecurityOriginData> IDBServer::getOrigins() const
 void IDBServer::closeAndDeleteDatabasesModifiedSince(WallTime modificationTime)
 {
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     // If the modification time is in the future, don't both doing anything.
     if (modificationTime > WallTime::now())
@@ -633,7 +600,6 @@ void IDBServer::closeAndDeleteDatabasesModifiedSince(WallTime modificationTime)
 void IDBServer::closeDatabasesForOrigins(const Vector<SecurityOriginData>& targetOrigins, Function<bool(const SecurityOriginData&, const ClientOrigin&)>&& filter)
 {
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     HashSet<CheckedPtr<UniqueIDBDatabase>> openDatabases;
     for (auto& database : m_uniqueIDBDatabaseMap.values()) {
@@ -654,7 +620,6 @@ void IDBServer::closeDatabasesForOrigins(const Vector<SecurityOriginData>& targe
 void IDBServer::closeAndDeleteDatabasesForOrigins(const Vector<SecurityOriginData>& origins)
 {
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
     closeDatabasesForOrigins(origins, [](const SecurityOriginData& origin, const ClientOrigin& databaseOrigin) -> bool {
         return databaseOrigin.isRelated(origin);
@@ -776,15 +741,11 @@ void IDBServer::renameOrigin(const WebCore::SecurityOriginData& oldOrigin, const
         FileSystem::moveFile(oldOriginPath, newOriginPath);
 }
 
-void IDBServer::requestSpace(const ClientOrigin& origin, uint64_t taskSize, CompletionHandler<void(bool)>&& completionHandler) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
+void IDBServer::requestSpace(const ClientOrigin& origin, uint64_t taskSize, CompletionHandler<void(bool)>&& completionHandler)
 {
     ASSERT(!isMainThread());
-    ASSERT(m_lock.isHeld());
 
-    // Release lock because space requesting could be blocked.
-    m_lock.unlock();
     bool result = m_spaceRequester(origin, taskSize);
-    m_lock.lock();
 
     completionHandler(result);
 }

--- a/Source/WebCore/Modules/indexeddb/server/IDBServer.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBServer.h
@@ -35,7 +35,6 @@
 #include <pal/SessionID.h>
 #include <wtf/CrossThreadTaskHandler.h>
 #include <wtf/HashMap.h>
-#include <wtf/Lock.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -54,7 +53,7 @@ class IDBServer final : public UniqueIDBDatabaseManager {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IDBServer);
 public:
     using SpaceRequester = Function<bool(const ClientOrigin&, uint64_t spaceRequested)>;
-    WEBCORE_EXPORT IDBServer(const String& databaseDirectoryPath, SpaceRequester&&, Lock&);
+    WEBCORE_EXPORT IDBServer(const String& databaseDirectoryPath, SpaceRequester&&);
     WEBCORE_EXPORT ~IDBServer();
 
     WEBCORE_EXPORT void registerConnection(IDBConnectionToClient&);
@@ -127,8 +126,6 @@ private:
     String m_databaseDirectoryPath;
 
     SpaceRequester m_spaceRequester;
-
-    Lock& m_lock;
 };
 
 } // namespace IDBServer

--- a/Source/WebKitLegacy/Storage/InProcessIDBServer.cpp
+++ b/Source/WebKitLegacy/Storage/InProcessIDBServer.cpp
@@ -60,10 +60,8 @@ InProcessIDBServer::~InProcessIDBServer()
 {
     BinarySemaphore semaphore;
     dispatchTask([this, &semaphore] {
-        {
-            Locker locker { m_serverLock };
-            m_server = nullptr;
-        }
+        assertIsCurrent(m_queue.get());
+        m_server = nullptr;
         m_connectionToClient = nullptr;
         semaphore.signal();
     });
@@ -76,13 +74,13 @@ InProcessIDBServer::InProcessIDBServer(PAL::SessionID sessionID, const String& d
     ASSERT(isMainThread());
     m_connectionToServer = IDBClient::IDBConnectionToServer::create(*this, sessionID);
     dispatchTask([this, protectedThis = Ref { *this }, directory = databaseDirectoryPath.isolatedCopy()] () mutable {
+        assertIsCurrent(m_queue.get());
         Ref connectionToClient = IDBServer::IDBConnectionToClient::create(*this);
         m_connectionToClient = connectionToClient.copyRef();
 
-        Locker locker { m_serverLock };
         m_server = makeUnique<IDBServer::IDBServer>(directory, [](const ClientOrigin&, uint64_t) {
             return true;
-        }, m_serverLock);
+        });
         m_server->registerConnection(connectionToClient);
     });
 }
@@ -107,7 +105,7 @@ IDBServer::IDBConnectionToClient& InProcessIDBServer::connectionToClient() const
 void InProcessIDBServer::deleteDatabase(const WebCore::IDBOpenRequestData& requestData)
 {
     dispatchTask([this, protectedThis = Ref { *this }, requestData = requestData.isolatedCopy()] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->deleteDatabase(requestData);
     });
 }
@@ -122,7 +120,7 @@ void InProcessIDBServer::didDeleteDatabase(const IDBResultData& resultData)
 void InProcessIDBServer::openDatabase(const WebCore::IDBOpenRequestData& requestData)
 {
     dispatchTask([this, protectedThis = Ref { *this }, requestData = requestData.isolatedCopy()] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->openDatabase(requestData);
     });
 }
@@ -249,7 +247,7 @@ void InProcessIDBServer::didIterateCursor(const IDBResultData& resultData)
 void InProcessIDBServer::abortTransaction(const WebCore::IDBResourceIdentifier& resourceIdentifier)
 {
     dispatchTask([this, protectedThis = Ref { *this }, resourceIdentifier = resourceIdentifier.isolatedCopy()] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->abortTransaction(resourceIdentifier);
     });
 }
@@ -257,7 +255,7 @@ void InProcessIDBServer::abortTransaction(const WebCore::IDBResourceIdentifier& 
 void InProcessIDBServer::commitTransaction(const WebCore::IDBResourceIdentifier& resourceIdentifier, uint64_t pendingCountRequest)
 {
     dispatchTask([this, protectedThis = Ref { *this }, resourceIdentifier = resourceIdentifier.isolatedCopy(), pendingCountRequest] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->commitTransaction(resourceIdentifier, pendingCountRequest);
     });
 }
@@ -265,7 +263,7 @@ void InProcessIDBServer::commitTransaction(const WebCore::IDBResourceIdentifier&
 void InProcessIDBServer::didFinishHandlingVersionChangeTransaction(IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const WebCore::IDBResourceIdentifier& transactionIdentifier)
 {
     dispatchTask([this, protectedThis = Ref { *this }, databaseConnectionIdentifier, transactionIdentifier = transactionIdentifier.isolatedCopy()] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->didFinishHandlingVersionChangeTransaction(databaseConnectionIdentifier, transactionIdentifier);
     });
 }
@@ -273,7 +271,7 @@ void InProcessIDBServer::didFinishHandlingVersionChangeTransaction(IDBDatabaseCo
 void InProcessIDBServer::createObjectStore(const WebCore::IDBRequestData& resultData, const IDBObjectStoreInfo& info)
 {
     dispatchTask([this, protectedThis = Ref { *this }, resultData = resultData.isolatedCopy(), info = info.isolatedCopy()] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->createObjectStore(resultData, info);
     });
 }
@@ -281,7 +279,7 @@ void InProcessIDBServer::createObjectStore(const WebCore::IDBRequestData& result
 void InProcessIDBServer::deleteObjectStore(const WebCore::IDBRequestData& requestData, const String& objectStoreName)
 {
     dispatchTask([this, protectedThis = Ref { *this }, requestData = requestData.isolatedCopy(), objectStoreName = objectStoreName.isolatedCopy()] () mutable {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->deleteObjectStore(requestData, objectStoreName);
     });
 }
@@ -289,7 +287,7 @@ void InProcessIDBServer::deleteObjectStore(const WebCore::IDBRequestData& reques
 void InProcessIDBServer::renameObjectStore(const WebCore::IDBRequestData& requestData, WebCore::IDBObjectStoreIdentifier objectStoreIdentifier, const String& newName)
 {
     dispatchTask([this, protectedThis = Ref { *this }, requestData = requestData.isolatedCopy(), objectStoreIdentifier, newName = newName.isolatedCopy()] () mutable {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->renameObjectStore(requestData, objectStoreIdentifier, newName);
     });
 }
@@ -297,7 +295,7 @@ void InProcessIDBServer::renameObjectStore(const WebCore::IDBRequestData& reques
 void InProcessIDBServer::clearObjectStore(const WebCore::IDBRequestData& requestData, WebCore::IDBObjectStoreIdentifier objectStoreIdentifier)
 {
     dispatchTask([this, protectedThis = Ref { *this }, requestData = requestData.isolatedCopy(), objectStoreIdentifier] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->clearObjectStore(requestData, objectStoreIdentifier);
     });
 }
@@ -305,7 +303,7 @@ void InProcessIDBServer::clearObjectStore(const WebCore::IDBRequestData& request
 void InProcessIDBServer::createIndex(const WebCore::IDBRequestData& requestData, const IDBIndexInfo& info)
 {
     dispatchTask([this, protectedThis = Ref { *this }, requestData = requestData.isolatedCopy(), info = info.isolatedCopy()] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->createIndex(requestData, info);
     });
 }
@@ -313,7 +311,7 @@ void InProcessIDBServer::createIndex(const WebCore::IDBRequestData& requestData,
 void InProcessIDBServer::deleteIndex(const WebCore::IDBRequestData& requestData, WebCore::IDBObjectStoreIdentifier objectStoreIdentifier, const String& indexName)
 {
     dispatchTask([this, protectedThis = Ref { *this }, requestData = requestData.isolatedCopy(), objectStoreIdentifier, indexName = indexName.isolatedCopy()] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->deleteIndex(requestData, objectStoreIdentifier, indexName);
     });
 }
@@ -321,7 +319,7 @@ void InProcessIDBServer::deleteIndex(const WebCore::IDBRequestData& requestData,
 void InProcessIDBServer::renameIndex(const WebCore::IDBRequestData& requestData, WebCore::IDBObjectStoreIdentifier objectStoreIdentifier, WebCore::IDBIndexIdentifier indexIdentifier, const String& newName)
 {
     dispatchTask([this, protectedThis = Ref { *this }, requestData = requestData.isolatedCopy(), objectStoreIdentifier, indexIdentifier, newName = newName.isolatedCopy()] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->renameIndex(requestData, objectStoreIdentifier, indexIdentifier, newName);
     });
 }
@@ -329,7 +327,7 @@ void InProcessIDBServer::renameIndex(const WebCore::IDBRequestData& requestData,
 void InProcessIDBServer::putOrAdd(const WebCore::IDBRequestData& requestData, const IDBKeyData& keyData, const IDBValue& value, const IndexIDToIndexKeyMap& indexKeys, const IndexedDB::ObjectStoreOverwriteMode overwriteMode)
 {
     dispatchTask([this, protectedThis = Ref { *this }, requestData = requestData.isolatedCopy(), keyData = keyData.isolatedCopy(), value = value.isolatedCopy(), indexKeys = crossThreadCopy(indexKeys), overwriteMode] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->putOrAdd(requestData, keyData, value, indexKeys, overwriteMode);
     });
 }
@@ -337,7 +335,7 @@ void InProcessIDBServer::putOrAdd(const WebCore::IDBRequestData& requestData, co
 void InProcessIDBServer::getRecord(const WebCore::IDBRequestData& requestData, const IDBGetRecordData& getRecordData)
 {
     dispatchTask([this, protectedThis = Ref { *this }, requestData = requestData.isolatedCopy(), getRecordData = getRecordData.isolatedCopy()] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->getRecord(requestData, getRecordData);
     });
 }
@@ -345,7 +343,7 @@ void InProcessIDBServer::getRecord(const WebCore::IDBRequestData& requestData, c
 void InProcessIDBServer::getAllRecords(const WebCore::IDBRequestData& requestData, const IDBGetAllRecordsData& getAllRecordsData)
 {
     dispatchTask([this, protectedThis = Ref { *this }, requestData = requestData.isolatedCopy(), getAllRecordsData = getAllRecordsData.isolatedCopy()] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->getAllRecords(requestData, getAllRecordsData);
     });
 }
@@ -353,7 +351,7 @@ void InProcessIDBServer::getAllRecords(const WebCore::IDBRequestData& requestDat
 void InProcessIDBServer::getCount(const WebCore::IDBRequestData& requestData, const IDBKeyRangeData& keyRangeData)
 {
     dispatchTask([this, protectedThis = Ref { *this }, requestData = requestData.isolatedCopy(), keyRangeData = keyRangeData.isolatedCopy()] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->getCount(requestData, keyRangeData);
     });
 }
@@ -361,7 +359,7 @@ void InProcessIDBServer::getCount(const WebCore::IDBRequestData& requestData, co
 void InProcessIDBServer::deleteRecord(const WebCore::IDBRequestData& requestData, const IDBKeyRangeData& keyRangeData)
 {
     dispatchTask([this, protectedThis = Ref { *this }, requestData = requestData.isolatedCopy(), keyRangeData = keyRangeData.isolatedCopy()] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->deleteRecord(requestData, keyRangeData);
     });
 }
@@ -369,7 +367,7 @@ void InProcessIDBServer::deleteRecord(const WebCore::IDBRequestData& requestData
 void InProcessIDBServer::openCursor(const WebCore::IDBRequestData& requestData, const IDBCursorInfo& info)
 {
     dispatchTask([this, protectedThis = Ref { *this }, requestData = requestData.isolatedCopy(), info = info.isolatedCopy()] () mutable {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->openCursor(requestData, info);
     });
 }
@@ -377,7 +375,7 @@ void InProcessIDBServer::openCursor(const WebCore::IDBRequestData& requestData, 
 void InProcessIDBServer::iterateCursor(const WebCore::IDBRequestData& requestData, const IDBIterateCursorData& data)
 {
     dispatchTask([this, protectedThis = Ref { *this }, requestData = requestData.isolatedCopy(), data = data.isolatedCopy()] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->iterateCursor(requestData, data);
     });
 }
@@ -385,7 +383,7 @@ void InProcessIDBServer::iterateCursor(const WebCore::IDBRequestData& requestDat
 void InProcessIDBServer::establishTransaction(IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const IDBTransactionInfo& info)
 {
     dispatchTask([this, protectedThis = Ref { *this }, databaseConnectionIdentifier, info = info.isolatedCopy()] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->establishTransaction(databaseConnectionIdentifier, info);
     });
 }
@@ -428,7 +426,7 @@ void InProcessIDBServer::notifyOpenDBRequestBlocked(const WebCore::IDBResourceId
 void InProcessIDBServer::databaseConnectionPendingClose(IDBDatabaseConnectionIdentifier databaseConnectionIdentifier)
 {
     dispatchTask([this, protectedThis = Ref { *this }, databaseConnectionIdentifier] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->databaseConnectionPendingClose(databaseConnectionIdentifier);
     });
 }
@@ -436,7 +434,7 @@ void InProcessIDBServer::databaseConnectionPendingClose(IDBDatabaseConnectionIde
 void InProcessIDBServer::databaseConnectionClosed(IDBDatabaseConnectionIdentifier databaseConnectionIdentifier)
 {
     dispatchTask([this, protectedThis = Ref { *this }, databaseConnectionIdentifier] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->databaseConnectionClosed(databaseConnectionIdentifier);
     });
 }
@@ -447,7 +445,7 @@ void InProcessIDBServer::abortOpenAndUpgradeNeeded(IDBDatabaseConnectionIdentifi
     if (transactionIdentifier)
         transactionIdentifierCopy = transactionIdentifier->isolatedCopy();
     dispatchTask([this, protectedThis = Ref { *this }, databaseConnectionIdentifier, transactionIdentifier = WTF::move(transactionIdentifierCopy)] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->abortOpenAndUpgradeNeeded(databaseConnectionIdentifier, transactionIdentifier);
     });
 }
@@ -455,7 +453,7 @@ void InProcessIDBServer::abortOpenAndUpgradeNeeded(IDBDatabaseConnectionIdentifi
 void InProcessIDBServer::didFireVersionChangeEvent(IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, const IndexedDB::ConnectionClosedOnBehalfOfServer connectionClosed)
 {
     dispatchTask([this, protectedThis = Ref { *this }, databaseConnectionIdentifier, requestIdentifier = crossThreadCopy(requestIdentifier), connectionClosed] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->didFireVersionChangeEvent(databaseConnectionIdentifier, requestIdentifier, connectionClosed);
     });
 }
@@ -463,7 +461,7 @@ void InProcessIDBServer::didFireVersionChangeEvent(IDBDatabaseConnectionIdentifi
 void InProcessIDBServer::didGenerateIndexKeyForRecord(const IDBResourceIdentifier& transactionIdentifier, const IDBResourceIdentifier& requestIdentifier, const IDBIndexInfo& indexInfo, const IDBKeyData& key, const IndexKey& indexKey, std::optional<int64_t> recordID)
 {
     dispatchTask([this, protectedThis = Ref { *this }, transactionIdentifier = crossThreadCopy(transactionIdentifier), requestIdentifier = crossThreadCopy(requestIdentifier), indexInfo = crossThreadCopy(indexInfo), key = crossThreadCopy(key), indexKey = crossThreadCopy(indexKey), recordID] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->didGenerateIndexKeyForRecord(transactionIdentifier, requestIdentifier, indexInfo, key, indexKey, recordID);
     });
 }
@@ -471,7 +469,7 @@ void InProcessIDBServer::didGenerateIndexKeyForRecord(const IDBResourceIdentifie
 void InProcessIDBServer::openDBRequestCancelled(const WebCore::IDBOpenRequestData& requestData)
 {
     dispatchTask([this, protectedThis = Ref { *this }, requestData = requestData.isolatedCopy()] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->openDBRequestCancelled(requestData);
     });
 }
@@ -479,7 +477,7 @@ void InProcessIDBServer::openDBRequestCancelled(const WebCore::IDBOpenRequestDat
 void InProcessIDBServer::getAllDatabaseNamesAndVersions(const WebCore::IDBResourceIdentifier& requestIdentifier, const ClientOrigin& origin)
 {
     dispatchTask([this, protectedThis = Ref { *this }, identifier = m_connectionToServer->identifier(), requestIdentifier, origin = origin.isolatedCopy()] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->getAllDatabaseNamesAndVersions(identifier, requestIdentifier, origin);
     });
 }
@@ -494,7 +492,7 @@ void InProcessIDBServer::didGetAllDatabaseNamesAndVersions(const WebCore::IDBRes
 void InProcessIDBServer::closeAndDeleteDatabasesModifiedSince(WallTime modificationTime)
 {
     dispatchTask([this, protectedThis = Ref { *this }, modificationTime] {
-        Locker locker { m_serverLock };
+        assertIsCurrent(m_queue.get());
         m_server->closeAndDeleteDatabasesModifiedSince(modificationTime);
     });
 }

--- a/Source/WebKitLegacy/Storage/InProcessIDBServer.h
+++ b/Source/WebKitLegacy/Storage/InProcessIDBServer.h
@@ -66,7 +66,6 @@ public:
 
     WebCore::IDBClient::IDBConnectionToServer& NODELETE connectionToServer() const;
     WebCore::IDBServer::IDBConnectionToClient& NODELETE connectionToClient() const;
-    WebCore::IDBServer::IDBServer& server() { return *m_server; }
 
     void ref() const final { ThreadSafeRefCounted::ref(); }
     void deref() const final { ThreadSafeRefCounted::deref(); }
@@ -135,8 +134,7 @@ public:
 private:
     InProcessIDBServer(PAL::SessionID, const String& databaseDirectoryPath = nullString());
 
-    Lock m_serverLock;
-    std::unique_ptr<WebCore::IDBServer::IDBServer> m_server;
+    std::unique_ptr<WebCore::IDBServer::IDBServer> m_server WTF_GUARDED_BY_CAPABILITY(m_queue.get());
     RefPtr<WebCore::IDBClient::IDBConnectionToServer> m_connectionToServer;
     RefPtr<WebCore::IDBServer::IDBConnectionToClient> m_connectionToClient;
     const Ref<WTF::WorkQueue> m_queue;


### PR DESCRIPTION
#### 7e8331e7a471a3e91ee756d6a9d6c298502cea04
<pre>
Remove unnecessary Lock from IDBServer
<a href="https://bugs.webkit.org/show_bug.cgi?id=311842">https://bugs.webkit.org/show_bug.cgi?id=311842</a>
<a href="https://rdar.apple.com/174432158">rdar://174432158</a>

Reviewed by Chris Dumez.

The Lock on IDBServer was added to provide mutual exclusion between IDB background thread operations and main-thread
process suspension calls (stopDatabaseActivitiesOnMainThread / hasDatabaseActivitiesOnMainThread). Those suspension
methods were removed in 266976@main, and WebIDBServer (the network process caller) was deleted in 248127@main, leaving
InProcessIDBServer as the sole caller. Since all IDBServer methods are now called exclusively from InProcessIDBServer&apos;s
serial WorkQueue, the lock is redundant — the queue already guarantees single-threaded access.

Replace lock acquisitions with assertIsCurrent(m_queue.get()) and annotate m_server with
WTF_GUARDED_BY_CAPABILITY(m_queue.get()) to enforce thread confinement. Also remove the unused server() accessor from
InProcessIDBServer.

* Source/WebCore/Modules/indexeddb/server/IDBServer.cpp:
(WebCore::IDBServer::IDBServer::IDBServer):
(WebCore::IDBServer::IDBServer::unregisterConnection):
(WebCore::IDBServer::IDBServer::registerTransaction):
(WebCore::IDBServer::IDBServer::unregisterTransaction):
(WebCore::IDBServer::IDBServer::openDatabase):
(WebCore::IDBServer::IDBServer::deleteDatabase):
(WebCore::IDBServer::IDBServer::abortTransaction):
(WebCore::IDBServer::IDBServer::createObjectStore):
(WebCore::IDBServer::IDBServer::deleteObjectStore):
(WebCore::IDBServer::IDBServer::renameObjectStore):
(WebCore::IDBServer::IDBServer::clearObjectStore):
(WebCore::IDBServer::IDBServer::createIndex):
(WebCore::IDBServer::IDBServer::deleteIndex):
(WebCore::IDBServer::IDBServer::renameIndex):
(WebCore::IDBServer::IDBServer::putOrAdd):
(WebCore::IDBServer::IDBServer::getRecord):
(WebCore::IDBServer::IDBServer::getAllRecords):
(WebCore::IDBServer::IDBServer::getCount):
(WebCore::IDBServer::IDBServer::deleteRecord):
(WebCore::IDBServer::IDBServer::openCursor):
(WebCore::IDBServer::IDBServer::iterateCursor):
(WebCore::IDBServer::IDBServer::establishTransaction):
(WebCore::IDBServer::IDBServer::commitTransaction):
(WebCore::IDBServer::IDBServer::didFinishHandlingVersionChangeTransaction):
(WebCore::IDBServer::IDBServer::databaseConnectionPendingClose):
(WebCore::IDBServer::IDBServer::databaseConnectionClosed):
(WebCore::IDBServer::IDBServer::abortOpenAndUpgradeNeeded):
(WebCore::IDBServer::IDBServer::didFireVersionChangeEvent):
(WebCore::IDBServer::IDBServer::openDBRequestCancelled):
(WebCore::IDBServer::IDBServer::getAllDatabaseNamesAndVersions):
(WebCore::IDBServer::IDBServer::getOrigins const):
(WebCore::IDBServer::IDBServer::closeAndDeleteDatabasesModifiedSince):
(WebCore::IDBServer::IDBServer::closeDatabasesForOrigins):
(WebCore::IDBServer::IDBServer::closeAndDeleteDatabasesForOrigins):
(WebCore::IDBServer::IDBServer::requestSpace):
(): Deleted.
* Source/WebCore/Modules/indexeddb/server/IDBServer.h:
* Source/WebKitLegacy/Storage/InProcessIDBServer.cpp:
(InProcessIDBServer::~InProcessIDBServer):
(InProcessIDBServer::InProcessIDBServer):
(InProcessIDBServer::deleteDatabase):
(InProcessIDBServer::openDatabase):
(InProcessIDBServer::abortTransaction):
(InProcessIDBServer::commitTransaction):
(InProcessIDBServer::didFinishHandlingVersionChangeTransaction):
(InProcessIDBServer::createObjectStore):
(InProcessIDBServer::deleteObjectStore):
(InProcessIDBServer::renameObjectStore):
(InProcessIDBServer::clearObjectStore):
(InProcessIDBServer::createIndex):
(InProcessIDBServer::deleteIndex):
(InProcessIDBServer::renameIndex):
(InProcessIDBServer::putOrAdd):
(InProcessIDBServer::getRecord):
(InProcessIDBServer::getAllRecords):
(InProcessIDBServer::getCount):
(InProcessIDBServer::deleteRecord):
(InProcessIDBServer::openCursor):
(InProcessIDBServer::iterateCursor):
(InProcessIDBServer::establishTransaction):
(InProcessIDBServer::databaseConnectionPendingClose):
(InProcessIDBServer::databaseConnectionClosed):
(InProcessIDBServer::abortOpenAndUpgradeNeeded):
(InProcessIDBServer::didFireVersionChangeEvent):
(InProcessIDBServer::didGenerateIndexKeyForRecord):
(InProcessIDBServer::openDBRequestCancelled):
(InProcessIDBServer::getAllDatabaseNamesAndVersions):
(InProcessIDBServer::closeAndDeleteDatabasesModifiedSince):
* Source/WebKitLegacy/Storage/InProcessIDBServer.h:

Canonical link: <a href="https://commits.webkit.org/310901@main">https://commits.webkit.org/310901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0492df1d7e70013c2bcb6e727e98781ab46b9a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164046 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157158 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28395 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120165 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/459d85d2-bd6a-4086-817e-941312c4f7f9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22399 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139461 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100860 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4e500740-c395-42da-a113-36ae13b1499e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21485 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19555 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11871 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131153 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17294 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166524 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18904 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128269 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23589 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128406 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34841 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139087 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85527 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23266 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15884 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27707 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91810 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27284 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27514 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27357 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->