### PR TITLE
REGRESSION(302241@main): CSS "aspect-ratio" is not honored when window is zoomed in

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/aspect-ratio-height-with-automatic-minimum-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/aspect-ratio-height-with-automatic-minimum-size-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/aspect-ratio-height-with-automatic-minimum-size-tall-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/aspect-ratio-height-with-automatic-minimum-size-tall-expected.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+<style>
+.zoomed-container {
+  width: 50px;
+  zoom: 2;
+}
+.aspect-ratio {
+  aspect-ratio: 1/1;
+  background-color: green;
+}
+</style>
+<body>
+<p>PASSES if tall green box is shown.</p>
+<div style="width: 100px; height: 200px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/aspect-ratio-height-with-automatic-minimum-size-tall-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/aspect-ratio-height-with-automatic-minimum-size-tall-ref.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+<style>
+.zoomed-container {
+  width: 50px;
+  zoom: 2;
+}
+.aspect-ratio {
+  aspect-ratio: 1/1;
+  background-color: green;
+}
+</style>
+<body>
+<p>PASSES if tall green box is shown.</p>
+<div style="width: 100px; height: 200px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/aspect-ratio-height-with-automatic-minimum-size-tall.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/aspect-ratio-height-with-automatic-minimum-size-tall.html
@@ -1,0 +1,22 @@
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/#zoom-property">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-minimum">
+<link rel="match" href="aspect-ratio-height-with-automatic-minimum-size-tall-ref.html">
+<style>
+.zoomed-container {
+  width: 50px;
+  zoom: 2;
+}
+.aspect-ratio {
+  aspect-ratio: 1/1;
+  background-color: green;
+}
+</style>
+<body>
+<p>PASSES if tall green box is shown.</p>
+<div class="zoomed-container">
+  <div class="aspect-ratio"><div style="height: 100px"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/aspect-ratio-height-with-automatic-minimum-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/aspect-ratio-height-with-automatic-minimum-size.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/#zoom-property">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-minimum">
+<link rel="match" href="/reference/ref-filled-green-100px-square-only.html">
+<style>
+.zoomed-container {
+  width: 50px;
+  zoom: 2;
+}
+.aspect-ratio {
+  aspect-ratio: 1/1;
+  background-color: green;
+}
+</style>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="zoomed-container">
+  <div class="aspect-ratio">
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -789,7 +789,7 @@ LayoutUnit RenderBox::constrainLogicalHeightByMinMax(LayoutUnit logicalHeight, s
         auto heightFromAspectRatio = blockSizeFromAspectRatio(borderAndPaddingLogicalWidth(), borderAndPaddingLogicalHeight(), style().logicalAspectRatio(), style().boxSizingForAspectRatio(), logicalWidth(), style().aspectRatio(), isRenderReplaced()) - borderAndPaddingLogicalHeight();
         if (firstChild())
             heightFromAspectRatio = std::max(heightFromAspectRatio, *intrinsicContentHeight);
-        logicalMinHeight = Style::MinimumSize::Fixed { heightFromAspectRatio };
+        logicalMinHeight = Style::MinimumSize::Fixed { heightFromAspectRatio / styleToUse.usedZoomForLength().value };
         minimumSizeType = MinimumSizeIsAutomaticContentBased::Yes;
     }
     if (logicalMinHeight.isMinContent() || logicalMinHeight.isMaxContent())


### PR DESCRIPTION
#### 9ebcc420fbbe4fa37b5ea4856e08970eb0fb42df
<pre>
REGRESSION(302241@main): CSS &quot;aspect-ratio&quot; is not honored when window is zoomed in
<a href="https://bugs.webkit.org/show_bug.cgi?id=311689">https://bugs.webkit.org/show_bug.cgi?id=311689</a>
<a href="https://rdar.apple.com/174361289">rdar://174361289</a>

Reviewed by Alan Baradlay.

When we are computing a box&apos;s size in an axis (e.g. height) using an
aspect-ratio and its minimum size in that axis (e.g. min-height) is
auto, we need to compute its min-content size as the automatic minimum
size.
<a href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio-minimum">https://drafts.csswg.org/css-sizing-4/#aspect-ratio-minimum</a>

For the logical height, we have this behavior implemented in
RenderBox::constrainLogicalHeightByMinMax.

* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/aspect-ratio-height-with-automatic-minimum-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/aspect-ratio-height-with-automatic-minimum-size-tall-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/aspect-ratio-height-with-automatic-minimum-size-tall-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/aspect-ratio-height-with-automatic-minimum-size-tall.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/aspect-ratio-height-with-automatic-minimum-size.html: Added.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::constrainLogicalHeightByMinMax const):
When we are in the branch to compute the automatic minimum size we use
blockSizeFromAspectRatio to get the logical height we want from the
aspect-ratio. However, both this and intrinsicLogicalHeight are used
sizes, which means they are already zoomed. Constructing a
Style::MinimumSize::Fixed directly from these values results in the bug
since we will apply zoom *again* when it is evaluated. Instead, we
should remove the zoom from this value before constructing it.

Canonical link: <a href="https://commits.webkit.org/310931@main">https://commits.webkit.org/310931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d436078f164d76a996f9ca29eb5d44d427633512

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164058 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120174 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f022148f-213f-472c-bd54-8a3d87ce42d0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158256 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22404 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139473 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100869 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21490 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19565 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11884 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131158 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166536 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10697 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18916 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128281 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28101 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23599 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128417 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34861 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28025 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139099 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85410 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23275 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15896 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27719 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91822 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27296 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27526 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27369 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->