### PR TITLE
_WKSessionState should include the `wasCreatedByJSWithoutUserInteraction` bit

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/LegacySessionStateCoding.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/LegacySessionStateCoding.cpp
@@ -61,6 +61,7 @@ static const CFStringRef sessionHistoryEntryOriginalURLKey = CFSTR("SessionHisto
 static const CFStringRef sessionHistoryEntryDataKey = CFSTR("SessionHistoryEntryData");
 static const CFStringRef sessionHistoryEntryShouldOpenExternalURLsPolicyKey = CFSTR("SessionHistoryEntryShouldOpenExternalURLsPolicyKey");
 static const CFStringRef sessionHistoryEntryNavigatedFrameIDKey = CFSTR("SessionHistoryEntryNavigatedFrameID");
+static const CFStringRef sessionHistoryEntryWasCreatedByJSWithoutUserInteractionKey = CFSTR("SessionHistoryEntryWasCreatedByJSWithoutUserInteraction");
 
 // Session history entry data.
 const uint32_t sessionHistoryEntryDataVersion = 2;
@@ -437,6 +438,7 @@ static RetainPtr<CFDictionaryRef> encodeSessionHistory(const BackForwardListStat
         auto url = frameState->urlString.createCFString();
         auto title = frameState->title.createCFString();
         auto originalURL = frameState->originalURLString.createCFString();
+        auto createdByJS = frameState->wasCreatedByJSWithoutUserInteraction ? kCFBooleanTrue : kCFBooleanFalse;
 
         auto shouldOpenExternalURLsPolicyValue = static_cast<uint64_t>(frameState->shouldOpenExternalURLsPolicy);
         auto shouldOpenExternalURLsPolicy = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt64Type, &shouldOpenExternalURLsPolicyValue));
@@ -446,6 +448,7 @@ static RetainPtr<CFDictionaryRef> encodeSessionHistory(const BackForwardListStat
             { sessionHistoryEntryTitleKey, title.get() },
             { sessionHistoryEntryOriginalURLKey, originalURL.get() },
             { sessionHistoryEntryShouldOpenExternalURLsPolicyKey, shouldOpenExternalURLsPolicy.get() },
+            { sessionHistoryEntryWasCreatedByJSWithoutUserInteractionKey, createdByJS },
         }).get()));
 
         // We allow the first item to be unlimited in size. We refrain from serializing the data for subsequent items if they would cause us to trip over the maximumSessionStateDataSize limit.
@@ -1045,6 +1048,10 @@ static void decodeBackForwardTreeNode(HistoryEntryDataDecoder& decoder, FrameSta
             CFNumberGetValue(navigatedFrameIDNumber.get(), kCFNumberSInt64Type, &value);
             navigatedFrameID = WebCore::FrameIdentifier(value);
         }
+
+        RetainPtr createdByJS = dynamic_cf_cast<CFBooleanRef>(CFDictionaryGetValue(entryDictionary.get(), sessionHistoryEntryWasCreatedByJSWithoutUserInteractionKey));
+        if (createdByJS)
+            frameState->wasCreatedByJSWithoutUserInteraction = CFBooleanGetValue(createdByJS.get());
 
         entries.append({ WTF::move(frameState), navigatedFrameID });
     }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RestoreSessionStateWithoutNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RestoreSessionStateWithoutNavigation.mm
@@ -31,14 +31,17 @@
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/PlatformWebView.h"
 #import "Helpers/Test.h"
+#import <WebKit/WKBackForwardListItemPrivate.h>
 #import <WebKit/WKBackForwardListItemRef.h>
 #import <WebKit/WKBackForwardListRef.h>
 #import <WebKit/WKData.h>
+#import <WebKit/WKNavigationDelegatePrivate.h>
 #import <WebKit/WKPagePrivate.h>
 #import <WebKit/WKSessionStateRef.h>
 #import <WebKit/WKURL.h>
 #import <WebKit/WKURLCF.h>
 #import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/_WKSessionState.h>
 #import <wtf/RetainPtr.h>
 
 @interface WKWebView ()
@@ -47,7 +50,8 @@
 
 static bool didFinishNavigationForSessionState;
 static bool didChangeBackForwardList;
-    
+static bool didNavigate;
+
 @interface SessionStateDelegate : NSObject <WKNavigationDelegate>
 @end
 
@@ -56,6 +60,13 @@ static bool didChangeBackForwardList;
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
 {
     didFinishNavigationForSessionState = true;
+    didNavigate = true;
+}
+
+- (void)_webView:(WKWebView *)webView navigation:(WKNavigation *)navigation didSameDocumentNavigation:(_WKSameDocumentNavigationType)navigationType
+{
+    if (navigationType == _WKSameDocumentNavigationTypeSessionStatePush || navigationType == _WKSameDocumentNavigationTypeSessionStatePop)
+        didNavigate = true;
 }
 
 - (void)_webView:(WKWebView *)webView backForwardListItemAdded:(WKBackForwardListItem *)itemAdded removed:(NSArray<WKBackForwardListItem *> *)itemsRemoved
@@ -101,6 +112,40 @@ TEST(WebKit, RestoreSessionStateWithoutNavigation)
     auto expectedURL = adoptWK(WKURLCreateWithCFURL((__bridge CFURLRef)[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]));
     EXPECT_NOT_NULL(expectedURL);
     EXPECT_TRUE(WKURLIsEqual(currentItemURL.get(), expectedURL.get()));
+}
+
+TEST(WebKit, RestoreSessionStateWithoutNavigationPreservesWasCreatedByJSWithoutUserInteraction)
+{
+    auto delegate = adoptNS([SessionStateDelegate new]);
+    auto view = adoptNS([WKWebView new]);
+    [view setNavigationDelegate:delegate.get()];
+
+    [view loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
+    didNavigate = false;
+    Util::run(&didNavigate);
+
+    // Create some history entries via JS without a user gesture.
+    didNavigate = false;
+    [view _evaluateJavaScriptWithoutUserGesture:@"history.pushState(null, document.title, location.pathname + '#a');" completionHandler:nil];
+    Util::run(&didNavigate);
+    didNavigate = false;
+    [view _evaluateJavaScriptWithoutUserGesture:@"history.pushState(null, document.title, location.pathname + '#b');" completionHandler:nil];
+    Util::run(&didNavigate);
+
+    EXPECT_EQ([view backForwardList].backList.count, 2U);
+    EXPECT_FALSE([view backForwardList].backList[0]._wasCreatedByJSWithoutUserInteraction);
+    EXPECT_TRUE([view backForwardList].backList[1]._wasCreatedByJSWithoutUserInteraction);
+    EXPECT_TRUE([view backForwardList].currentItem._wasCreatedByJSWithoutUserInteraction);
+
+    // Restore session state into a new web view.
+    auto restoredView = adoptNS([WKWebView new]);
+    auto sessionState = adoptNS([[_WKSessionState alloc] initWithData:[view _sessionStateData]]);
+    [restoredView _restoreSessionState:sessionState.get() andNavigate:NO];
+
+    EXPECT_EQ([restoredView backForwardList].backList.count, 2U);
+    EXPECT_FALSE([restoredView backForwardList].backList[0]._wasCreatedByJSWithoutUserInteraction);
+    EXPECT_TRUE([restoredView backForwardList].backList[1]._wasCreatedByJSWithoutUserInteraction);
+    EXPECT_TRUE([restoredView backForwardList].currentItem._wasCreatedByJSWithoutUserInteraction);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 1fbd5aecc080760a01b0879dfebe5187811aec7d
<pre>
_WKSessionState should include the `wasCreatedByJSWithoutUserInteraction` bit
<a href="https://rdar.apple.com/174100057">rdar://174100057</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311850">https://bugs.webkit.org/show_bug.cgi?id=311850</a>

Reviewed by Andy Estes.

When adding support for this bit, take care to make sure it&apos;s backwards compatible with previous session state blobs.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RestoreSessionStateWithoutNavigation.mm

* Source/WebKit/UIProcess/Cocoa/LegacySessionStateCoding.cpp:
(WebKit::encodeSessionHistory):
(WebKit::decodeSessionHistoryEntries):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RestoreSessionStateWithoutNavigation.mm:
(-[SessionStateDelegate webView:didFinishNavigation:]):
(-[SessionStateDelegate _webView:navigation:didSameDocumentNavigation:]):
(TestWebKitAPI::TEST(WebKit, RestoreSessionStateWithoutNavigationPreservesWasCreatedByJSWithoutUserInteraction)):

Canonical link: <a href="https://commits.webkit.org/310872@main">https://commits.webkit.org/310872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb6a9342eb5296106676aef5a34176bfa1cc529a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21719 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164061 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/90bc182e-4f54-4253-98c8-428bff7a05be) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157173 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28410 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120178 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e9275e88-c0b7-42a9-b20d-f0dc708ed2f2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139467 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100873 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95dbbc21-af05-460d-bb5f-c9c77d527de4) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11887 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166539 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18910 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/128286 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28104 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/23604 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128419 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34817 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28028 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139093 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23277 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27722 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91825 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27299 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27529 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27372 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->