### PR TITLE
AX: Compute shrink-wrapped paths for multi-line text, links, and static-text-only labels

### DIFF
--- a/LayoutTests/accessibility/label-static-text-path-expected.txt
+++ b/LayoutTests/accessibility/label-static-text-path-expected.txt
@@ -1,0 +1,9 @@
+This test ensures labels remapped to StaticText get a multi-line path.
+
+PASS: textLabelSupportsPath === true
+PASS: pathSegmentCountOfID('label', 'Line to') > 4 === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This is a label containing only static text that spans several lines in this narrow container

--- a/LayoutTests/accessibility/label-static-text-path.html
+++ b/LayoutTests/accessibility/label-static-text-path.html
@@ -1,0 +1,26 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div style="width: 300px;">
+<label for="input" id="label">This is a label containing only static text that spans several lines in this narrow container</label>
+<input type="text" id="input" />
+</div>
+
+<script>
+var output = "This test ensures labels remapped to StaticText get a multi-line path.\n\n";
+
+if (window.accessibilityController) {
+    var textLabelSupportsPath = accessibilityController.accessibleElementById("label").isAttributeSupported("AXPath");
+    output += expect("textLabelSupportsPath", "true");
+    output += expect("pathSegmentCountOfID('label', 'Line to') > 4", "true");
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/bounds-for-range-expected.txt
+++ b/LayoutTests/accessibility/mac/bounds-for-range-expected.txt
@@ -30,7 +30,7 @@ AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 162}
 AXElementBusy: 0
 AXIntersectionWithSelectionRange: (null)
-AXPath: (null)
+AXPath: <AXStaticText>
 
 ----------------------
 AXUIElementForTextMarker

--- a/LayoutTests/accessibility/mac/element-paths-expected.txt
+++ b/LayoutTests/accessibility/mac/element-paths-expected.txt
@@ -1,12 +1,18 @@
-This tests that AXPath is correctly computed for SVG elements, image map areas, elements with border-radius, and elements with clip-path.
+This tests that AXPath is correctly computed for SVG elements, image map areas, elements with border-radius, elements with clip-path, and multi-line links with heuristics.
 
 PASS: svgSupportsPath === true
+PASS: pathSegmentCountOfID('singleline-link', 'Line to') === 0 === true
+PASS: pathSegmentCountOfID('link-with-image', 'Line to') === 0 === true
+PASS: pathSegmentCountOfID('link-with-div', 'Line to') === 0 === true
 PASS: noRadiusSupportsPath === false
 PASS: map1.isAttributeSupported('AXPath') === true
 PASS: map2.isAttributeSupported('AXPath') === true
 PASS: pathSegmentCountOfID('pill-button', 'Curve to') > 0 === true
 PASS: pathSegmentCountOfID('rounded-div', 'Curve to') > 0 === true
 PASS: pathSegmentCountOfID('clip-path-div', 'Line to') > 0 === true
+PASS: pathSegmentCountOfID('multiline-link', 'Line to') > 4 === true
+PASS: pathSegmentCountOfID('vertical-multiline-link', 'Line to') > 4 === true
+PASS: pathSegmentCountOfID('rtl-multiline-link', 'Line to') > 4 === true
 
 PASS successfullyParsed is true
 
@@ -15,3 +21,12 @@ TEST COMPLETE
 Rounded
 Sharp
 Diamond
+This is a long link that should wrap across multiple lines in a narrow container
+
+Short
+
+Click  here
+
+Block content inside a link
+Vertical wrap
+This is a long RTL link that should wrap across multiple lines in a narrow container

--- a/LayoutTests/accessibility/mac/element-paths.html
+++ b/LayoutTests/accessibility/mac/element-paths.html
@@ -25,14 +25,37 @@
 <!-- Clip-path test case -->
 <div id="clip-path-div" role="button" style="clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%); width: 100px; height: 100px;">Diamond</div>
 
+<!-- Multi-line link test cases -->
+<p style="width: 200px; font-size: 16px;"><a href="#" id="multiline-link">This is a long link that should wrap across multiple lines in a narrow container</a></p>
+<p><a href="#" id="singleline-link">Short</a></p>
+
+<!-- Link test cases -->
+<p><a href="#" id="link-with-image">Click <img src="resources/cake.png" alt="cake" width="10" height="10"> here</a></p>
+<a href="#" id="link-with-div" style="display: block; width: 200px;"><div>Block content inside a link</div></a>
+
+<!-- Vertical writing mode test cases -->
+<div style="writing-mode: vertical-rl; height: 40px; font-size: 16px;"><a href="#" id="vertical-multiline-link">Vertical wrap</a></div>
+
+<!-- RTL multi-line test cases -->
+<p dir="rtl" style="width: 200px; font-size: 16px;"><a href="#" id="rtl-multiline-link">This is a long RTL link that should wrap across multiple lines in a narrow container</a></p>
+
 <script>
-var output = "This tests that AXPath is correctly computed for SVG elements, image map areas, elements with border-radius, and elements with clip-path.\n\n";
+var output = "This tests that AXPath is correctly computed for SVG elements, image map areas, elements with border-radius, elements with clip-path, and multi-line links with heuristics.\n\n";
 
 if (window.accessibilityController) {
     window.jsTestIsAsync = true;
 
     var svgSupportsPath = accessibilityController.accessibleElementById("svg").isAttributeSupported("AXPath");
     output += expect("svgSupportsPath", "true");
+
+    // Single-line link: elementPath() returns empty (bounding rect is sufficient).
+    output += expect("pathSegmentCountOfID('singleline-link', 'Line to') === 0", "true");
+
+    // Link with non-text content (image): path is empty.
+    output += expect("pathSegmentCountOfID('link-with-image', 'Line to') === 0", "true");
+
+    // Link with block-flow descendant (div): path is empty.
+    output += expect("pathSegmentCountOfID('link-with-div', 'Line to') === 0", "true");
 
     // No border-radius: should not support AXPath.
     var noRadiusSupportsPath = accessibilityController.accessibleElementById("no-radius-div").isAttributeSupported("AXPath");
@@ -41,9 +64,9 @@ if (window.accessibilityController) {
     var map1 = accessibilityController.accessibleElementById("map1");
     var map2 = accessibilityController.accessibleElementById("map2");
     (async () => {
-        // Image map areas and border-radius paths are cached during paint
-        // in the isolated tree. Wait for the paths to become available
-        // before querying.
+        // Image map areas, border-radius paths, and multi-line link paths
+        // are cached during paint in the isolated tree. Wait for the paths
+        // to become available before querying.
         await waitUntilIDHasPathWith("pill-button", 1, "Curve to");
 
         output += expect("map1.isAttributeSupported('AXPath')", "true");
@@ -57,6 +80,20 @@ if (window.accessibilityController) {
 
         // Clip-path: diamond polygon should have line segments.
         output += expect("pathSegmentCountOfID('clip-path-div', 'Line to') > 0", "true");
+
+        // Multi-line link (2-3 lines, text-only): should have a non-rectangular shrink-wrapped path.
+        output += expect("pathSegmentCountOfID('multiline-link', 'Line to') > 4", "true");
+
+        // Scroll the vertical and RTL elements into view so they get painted
+        // (their text needs to be in the painted-text map for the isolated tree
+        // code path to produce paths).
+        document.getElementById("vertical-multiline-link").scrollIntoView();
+        await waitUntilIDHasPathWith("vertical-multiline-link", 5, "Line to");
+        output += expect("pathSegmentCountOfID('vertical-multiline-link', 'Line to') > 4", "true");
+
+        document.getElementById("rtl-multiline-link").scrollIntoView();
+        await waitUntilIDHasPathWith("rtl-multiline-link", 5, "Line to");
+        output += expect("pathSegmentCountOfID('rtl-multiline-link', 'Line to') > 4", "true");
 
         debug(output);
         finishJSTest();

--- a/LayoutTests/accessibility/statictext-path-expected.txt
+++ b/LayoutTests/accessibility/statictext-path-expected.txt
@@ -1,0 +1,9 @@
+This test verifies that multi-line static text has a non-empty AXPath.
+
+PASS: supportsPath === true
+PASS: hasPathSegments === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This is a paragraph of plain static text that spans several lines in this narrow container.

--- a/LayoutTests/accessibility/statictext-path.html
+++ b/LayoutTests/accessibility/statictext-path.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body style="max-width: 500px; font-size: 18px; line-height: 1.6;">
+
+<p id="test" style="font-size: 38px">This is a paragraph of plain static text that spans several lines in this narrow container.</p>
+
+<script>
+var output = "This test verifies that multi-line static text has a non-empty AXPath.\n\n";
+
+if (window.accessibilityController) {
+    var p = accessibilityController.accessibleElementById("test");
+    var child = p.childAtIndex(0);
+    var supportsPath = child.isAttributeSupported("AXPath");
+    output += expect("supportsPath", "true");
+
+    var pathDescription = child.pathDescription;
+    // Verify the path is non-empty and contains curve or line segments (not just "Start Path").
+    var hasPathSegments = pathDescription.indexOf("Line to") !== -1 || pathDescription.indexOf("Curve to") !== -1;
+    output += expect("hasPathSegments", "true");
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/stitched-text-path-expected.txt
+++ b/LayoutTests/accessibility/stitched-text-path-expected.txt
@@ -1,0 +1,9 @@
+This test ensures stitched text across inline elements gets a multi-line path.
+
+PASS: supportsPath === true
+PASS: hasPathSegments === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Some text with italic and bold formatting that wraps across several lines in this narrow container

--- a/LayoutTests/accessibility/stitched-text-path.html
+++ b/LayoutTests/accessibility/stitched-text-path.html
@@ -1,0 +1,31 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ AccessibilityTextStitchingEnabled=true ] -->
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="test" style="width: 200px; font-size: 16px;">Some text with <i>italic</i> and <b>bold</b> formatting that wraps across <i>several</i> lines in this <b>narrow</b> container</p>
+
+<script>
+var output = "This test ensures stitched text across inline elements gets a multi-line path.\n\n";
+
+if (window.accessibilityController) {
+    // The text "Some text with " + "italic" + " and " + "bold" + " formatting..."
+    // is stitched into a single StaticText. The stitch group representative
+    // should aggregate rects from all members and produce a multi-line path.
+    var p = accessibilityController.accessibleElementById("test");
+    var firstChild = p.childAtIndex(0);
+    var supportsPath = firstChild.isAttributeSupported("AXPath");
+    output += expect("supportsPath", "true");
+
+    var pathDescription = firstChild.pathDescription;
+    var hasPathSegments = pathDescription.indexOf("Line to") !== -1;
+    output += expect("hasPathSegments", "true");
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -902,6 +902,7 @@ accessibility/aria-owns-text-stitching.html [ Skip ]
 accessibility/dynamic-text-stitching.html [ Skip ]
 accessibility/hit-test-on-stitched-text.html [ Skip ]
 accessibility/list-marker-text-stitching.html [ Skip ]
+accessibility/stitched-text-path.html [ Skip ]
 accessibility/text-stitching-across-inline-elements.html [ Skip ]
 accessibility/text-stitching-after-atomic-inline.html [ Skip ]
 accessibility/text-stitching-end-text-marker.html [ Skip ]
@@ -1091,6 +1092,8 @@ webkit.org/b/215405 [ Release ] accessibility/roles-exposed.html [ Failure ]
 webkit.org/b/217260 accessibility/spinbutton-crash.html [ Failure ]
 
 webkit.org/b/217801 accessibility/text-element-path.html [ Failure ]
+accessibility/label-static-text-path.html [ Failure ]
+accessibility/statictext-path.html [ Failure ]
 
 # aria-braille* attributes are not implemented:
 webkit.org/b/220719 accessibility/braille-label-role.html [ Failure ]

--- a/Source/WebCore/accessibility/AXTextRun.cpp
+++ b/Source/WebCore/accessibility/AXTextRun.cpp
@@ -125,6 +125,46 @@ unsigned AXTextRuns::domOffset(unsigned renderedTextOffset) const
 
 FloatRect AXTextRuns::localRect(unsigned start, unsigned end, FontOrientation orientation) const
 {
+    auto perLineRects = localRectsPerLine(start, end, orientation);
+    if (!perLineRects.isEmpty()) {
+        auto result = perLineRects[0];
+        for (size_t i = 1; i < perLineRects.size(); ++i)
+            result.unite(perLineRects[i]);
+        return result;
+    }
+
+    // localRectsPerLine returns empty for collapsed ranges (start == end). For these,
+    // return a caret-width rect at the offset position, matching
+    // CaretRectComputation::caretWidth.
+    if (start == end) {
+        unsigned offset = start;
+        size_t runIndex = indexForOffset(offset, Affinity::Downstream);
+        if (runIndex == notFound)
+            return { };
+
+        const auto& run = at(runIndex);
+        float heightBeforeRun = 0;
+        for (size_t i = 0; i < runIndex; ++i)
+            heightBeforeRun += at(i).lineHeight;
+
+        unsigned offsetOfFirstCharacterInRun = !runIndex ? 0 : runLengthSumTo(runIndex - 1);
+        float xPosition = run.distanceFromBoundsInDirection;
+        const auto& advances = run.advances();
+        unsigned startInRun = offset - offsetOfFirstCharacterInRun;
+        for (unsigned i = 0; i < startInRun && i < advances.size(); ++i)
+            xPosition += static_cast<float>(advances[i]);
+
+        static constexpr float caretWidth = 2;
+        if (orientation == FontOrientation::Horizontal)
+            return { xPosition, heightBeforeRun, caretWidth, run.lineHeight };
+        return { heightBeforeRun, xPosition, run.lineHeight, caretWidth };
+    }
+
+    return { };
+}
+
+Vector<FloatRect> AXTextRuns::localRectsPerLine(unsigned start, unsigned end, FontOrientation orientation) const
+{
     unsigned smallerOffset = start;
     unsigned largerOffset = end;
     if (smallerOffset > largerOffset)
@@ -147,97 +187,6 @@ FloatRect AXTextRuns::localRect(unsigned start, unsigned end, FontOrientation or
         return totalAdvance;
     };
 
-    // FIXME: Probably want a special case for hard linebreaks (<br>s). Investigate how the main-thread does this.
-    // FIXME: We'll need to flip the result rect based on writing mode.
-    unsigned offsetFromOriginInDirection = 0;
-    unsigned maxWidthInDirection = 0;
-    float measuredHeightInDirection = 0.0f;
-    float heightBeforeRuns = 0.0f;
-    for (unsigned i = 0; i <= runIndexOfLargerOffset; i++) {
-        const auto& run = at(i);
-        if (i < runIndexOfSmallerOffset) {
-            // Each text run represents a line, so count up the height of lines prior to our range start.
-            heightBeforeRuns += run.lineHeight;
-        } else {
-            unsigned measuredWidthInDirection = 0;
-            if (i == runIndexOfSmallerOffset) {
-                unsigned offsetOfFirstCharacterInRun = !i ? 0 : runLengthSumTo(i - 1);
-                AX_ASSERT(smallerOffset >= offsetOfFirstCharacterInRun);
-                if (smallerOffset < offsetOfFirstCharacterInRun)
-                    smallerOffset = offsetOfFirstCharacterInRun;
-                // Measure the characters in this run (accomplished by smallerOffset - offsetOfFirstCharacterInRun)
-                // prior to the offset.
-                unsigned widthPriorToStart = 0;
-                if (smallerOffset - offsetOfFirstCharacterInRun > 0)
-                    widthPriorToStart = computeAdvance(run, offsetOfFirstCharacterInRun, offsetOfFirstCharacterInRun, smallerOffset);
-
-                // If the larger offset goes beyond this line, use the end of the current line to for computing this run's bounds.
-                unsigned endOffsetInLine = runIndexOfSmallerOffset == runIndexOfLargerOffset
-                    ? largerOffset
-                    : !i ? run.length() : runLengthSumTo(i - 1) + run.length();
-
-                if (endOffsetInLine - smallerOffset > 0)
-                    measuredWidthInDirection = computeAdvance(run, offsetOfFirstCharacterInRun, smallerOffset, endOffsetInLine);
-
-                if (!measuredWidthInDirection) {
-                    bool isCollapsedRange = (runIndexOfSmallerOffset == runIndexOfLargerOffset && smallerOffset == largerOffset);
-
-                    if (isCollapsedRange) {
-                        // If this is a collapsed range (start.offset == end.offset), we want to return the width of a cursor.
-                        // Use 2px for this, matching CaretRectComputation::caretWidth. This overall behavior for collapsed
-                        // ranges matches that of CaretRectComputation::computeLocalCaretRect, which is downstream of
-                        // the main-thread-text-implementation equivalent of this function, AXObjectCache::boundsForRange.
-                        measuredWidthInDirection = 2;
-                    } else {
-                        // There was no measured width in this run, so we should count this as a line before the actual rect starts.
-                        heightBeforeRuns += run.lineHeight;
-                    }
-                }
-
-                if (measuredWidthInDirection)
-                    offsetFromOriginInDirection = widthPriorToStart + run.distanceFromBoundsInDirection;
-            } else if (i == runIndexOfLargerOffset) {
-                // We're measuring the end of the range, so measure from the first character in the run up to largerOffset.
-                unsigned offsetOfFirstCharacterInRun = !i ? 0 : runLengthSumTo(i - 1);
-                AX_ASSERT(largerOffset >= offsetOfFirstCharacterInRun);
-                if (largerOffset < offsetOfFirstCharacterInRun)
-                    largerOffset = offsetOfFirstCharacterInRun;
-
-                measuredWidthInDirection = computeAdvance(run, offsetOfFirstCharacterInRun, offsetOfFirstCharacterInRun, largerOffset);
-                if (measuredWidthInDirection) {
-                    // If we have an offset from origin at this point, that means this range has wrapped from the previous line. We need
-                    // to adjust the width to now encompass the whole line, since the origin will be shifted left to 0.
-                    if (offsetFromOriginInDirection)
-                        measuredWidthInDirection = offsetFromOriginInDirection + maxWidthInDirection;
-                    // Because our rect now includes the beginning of a run, set |x| to be 0, indicating the rect is not
-                    // offset from its container.
-                    offsetFromOriginInDirection = 0;
-                }
-            } else {
-                // We're in some run between runIndexOfSmallerOffset and runIndexOfLargerOffset, so measure the whole run.
-                // For example, this could be the "bbb" runs:
-                // a|aa
-                // bbb
-                // cc|c
-                unsigned offsetOfFirstCharacterInRun = !i ? 0 : runLengthSumTo(i - 1);
-                measuredWidthInDirection = computeAdvance(run, offsetOfFirstCharacterInRun, offsetOfFirstCharacterInRun, offsetOfFirstCharacterInRun + run.length());
-                if (measuredWidthInDirection) {
-                    // Since we are measuring from the beginning of a run, x should be 0.
-                    offsetFromOriginInDirection = 0;
-                }
-            }
-
-            if (measuredWidthInDirection) {
-                // This run is within the range specified by |start| and |end|, so if we measured a width for it,
-                // also add to the height. It's important to only do this if we actually measured a width, as an
-                // offset pointing past the last character in a run will not add any width and thus should not
-                // contribute any height.
-                measuredHeightInDirection += run.lineHeight;
-            }
-            maxWidthInDirection = std::max(maxWidthInDirection, measuredWidthInDirection);
-        }
-    }
-
     // Compared to the main-thread implementation, we regularly produce rects that are 1-3px smaller due to the various
     // levels of float rounding that happen to get here. It's better to be a bit wider to ensure AT cursors capture the
     // entire range of text than it is to be too small. Concretely, too-wide is better than too-small for low-vision
@@ -245,11 +194,64 @@ FloatRect AXTextRuns::localRect(unsigned start, unsigned end, FontOrientation or
     // a bit too large, even favoring too-wide sizes, so only bump by 1px. This is especially impactful when navigating
     // character-by-character in small text.
     static constexpr unsigned sizeBump = 1;
+    // FIXME: Probably want a special case for hard linebreaks (<br>s). Investigate how the main-thread does this.
+    // FIXME: We'll need to flip the result rect based on writing mode.
+    Vector<FloatRect> result;
+    float heightBeforeRuns = 0;
 
-    if (orientation == FontOrientation::Horizontal)
-        return { static_cast<float>(offsetFromOriginInDirection), heightBeforeRuns, static_cast<float>(maxWidthInDirection) + sizeBump, measuredHeightInDirection };
+    for (unsigned i = 0; i <= runIndexOfLargerOffset; i++) {
+        const auto& run = at(i);
+        if (i < runIndexOfSmallerOffset) {
+            heightBeforeRuns += run.lineHeight;
+            continue;
+        }
 
-    return { heightBeforeRuns, static_cast<float>(offsetFromOriginInDirection), measuredHeightInDirection + sizeBump, static_cast<float>(maxWidthInDirection) };
+        float measuredWidth = 0;
+        float xOffset = 0;
+
+        if (i == runIndexOfSmallerOffset) {
+            unsigned offsetOfFirstCharacterInRun = !i ? 0 : runLengthSumTo(i - 1);
+            AX_ASSERT(smallerOffset >= offsetOfFirstCharacterInRun);
+            if (smallerOffset < offsetOfFirstCharacterInRun)
+                smallerOffset = offsetOfFirstCharacterInRun;
+
+            float widthPriorToStart = 0;
+            if (smallerOffset - offsetOfFirstCharacterInRun > 0)
+                widthPriorToStart = computeAdvance(run, offsetOfFirstCharacterInRun, offsetOfFirstCharacterInRun, smallerOffset);
+
+            unsigned endOffsetInLine = runIndexOfSmallerOffset == runIndexOfLargerOffset
+                ? largerOffset
+                : !i ? run.length() : runLengthSumTo(i - 1) + run.length();
+
+            if (endOffsetInLine - smallerOffset > 0)
+                measuredWidth = computeAdvance(run, offsetOfFirstCharacterInRun, smallerOffset, endOffsetInLine);
+
+            if (measuredWidth)
+                xOffset = widthPriorToStart + run.distanceFromBoundsInDirection;
+        } else if (i == runIndexOfLargerOffset) {
+            unsigned offsetOfFirstCharacterInRun = !i ? 0 : runLengthSumTo(i - 1);
+            AX_ASSERT(largerOffset >= offsetOfFirstCharacterInRun);
+            if (largerOffset < offsetOfFirstCharacterInRun)
+                largerOffset = offsetOfFirstCharacterInRun;
+
+            measuredWidth = computeAdvance(run, offsetOfFirstCharacterInRun, offsetOfFirstCharacterInRun, largerOffset);
+            xOffset = run.distanceFromBoundsInDirection;
+        } else {
+            unsigned offsetOfFirstCharacterInRun = !i ? 0 : runLengthSumTo(i - 1);
+            measuredWidth = computeAdvance(run, offsetOfFirstCharacterInRun, offsetOfFirstCharacterInRun, offsetOfFirstCharacterInRun + run.length());
+            xOffset = run.distanceFromBoundsInDirection;
+        }
+
+        if (measuredWidth) {
+            if (orientation == FontOrientation::Horizontal)
+                result.append({ xOffset, heightBeforeRuns, measuredWidth + sizeBump, run.lineHeight });
+            else
+                result.append({ heightBeforeRuns, xOffset, run.lineHeight + sizeBump, measuredWidth });
+        }
+        heightBeforeRuns += run.lineHeight;
+    }
+
+    return result;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AXTextRun.h
+++ b/Source/WebCore/accessibility/AXTextRun.h
@@ -180,6 +180,10 @@ public:
     //   {x: width_of_single_b, y: |lineHeight| * 1, width: width_of_two_b, height: |lineHeight * 1|}
     FloatRect localRect(unsigned start, unsigned end, FontOrientation) const;
 
+    // Like localRect(), but returns a separate rect for each line rather than a single union.
+    // Used to build non-rectangular (shrink-wrapped) paths for multi-line elements.
+    Vector<FloatRect> localRectsPerLine(unsigned start, unsigned end, FontOrientation) const;
+
     // Convenience methods for TextUnit movement.
     bool runStartsWithLineBreak(size_t runIndex) const { return text[runs[runIndex].startIndex] == '\n'; }
     bool runEndsWithLineBreak(size_t runIndex) const { return text[runs[runIndex].endIndex - 1] == '\n'; }

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -719,6 +719,44 @@ static Path computePathForRenderBox(const RenderBox& renderBox)
     return path;
 }
 
+// Checks if bounding rects span multiple lines by looking for rects at
+// different block-direction positions. For horizontal text, rects on different
+// lines have different Y positions. For vertical text, different columns have
+// different X positions.
+static bool rectsSpanMultipleLines(const Vector<LayoutRect>& rects, bool isHorizontal)
+{
+    for (size_t i = 1; i < rects.size(); ++i) {
+        if (isHorizontal) {
+            if (rects[i].y() != rects[0].y())
+                return true;
+        } else {
+            if (rects[i].x() != rects[0].x())
+                return true;
+        }
+    }
+    return false;
+}
+
+static Path computePathForMultiLineRenderInline(const RenderInline& renderInline)
+{
+    Vector<LayoutRect> rects;
+    renderInline.boundingRects(rects, flooredLayoutPoint(renderInline.localToAbsolute()));
+    // Single-line inlines don't need a path -- the bounding rect is sufficient.
+    if (rects.size() < 2)
+        return { };
+
+    CheckedRef style = renderInline.style();
+    if (!rectsSpanMultipleLines(rects, style->writingMode().isHorizontal()))
+        return { };
+
+    float deviceScaleFactor = renderInline.document().deviceScaleFactor();
+    Vector<FloatRect> pixelSnappedRects;
+    for (auto rect : rects)
+        pixelSnappedRects.append(snapRectToDevicePixels(rect, deviceScaleFactor));
+
+    return PathUtilities::pathWithShrinkWrappedRects(pixelSnappedRects, 0);
+}
+
 Path AccessibilityRenderObject::elementPath() const
 {
     if (!m_renderer)
@@ -726,29 +764,27 @@ Path AccessibilityRenderObject::elementPath() const
 
     if (CheckedPtr renderText = dynamicDowncast<RenderText>(*m_renderer)) {
         Vector<LayoutRect> rects;
-        renderText->boundingRects(rects, flooredLayoutPoint(renderText->localToAbsolute()));
+
+        if (std::optional group = stitchGroupIfRepresentative()) {
+            // Stitch group representatives aggregate rects from all group members.
+            if (CheckedPtr cache = axObjectCache()) {
+                for (AXID memberID : group->members()) {
+                    if (RefPtr member = cache->objectForID(memberID)) {
+                        if (CheckedPtr memberText = dynamicDowncast<RenderText>(member->renderer()))
+                            memberText->boundingRects(rects, flooredLayoutPoint(memberText->localToAbsolute()));
+                    }
+                }
+            }
+        } else
+            renderText->boundingRects(rects, flooredLayoutPoint(renderText->localToAbsolute()));
+
         // If only 1 rect, don't compute path since the bounding rect will be good enough.
         if (rects.size() < 2)
             return { };
 
-        // Compute the path only if this is the last part of a line followed by the beginning of the next line.
+        // Compute the path only if the rects span multiple lines.
         CheckedRef style = renderText->style();
-        bool rightToLeftText = style->writingMode().isBidiRTL();
-        static const auto xTolerance = 5_lu;
-        static const auto yTolerance = 5_lu;
-        bool needsPath = false;
-        auto unionRect = rects[0];
-        for (size_t i = 1; i < rects.size(); ++i) {
-            needsPath = absoluteValue(rects[i].y() - unionRect.maxY()) < yTolerance // This rect is in a new line.
-                && (rightToLeftText ? rects[i].x() - unionRect.x() > xTolerance
-                    : unionRect.x() - rects[i].x() > xTolerance); // And this rect is to right/left of all previous rects.
-
-            if (needsPath)
-                break;
-
-            unionRect.unite(rects[i]);
-        }
-        if (!needsPath)
+        if (!rectsSpanMultipleLines(rects, style->writingMode().isHorizontal()))
             return { };
 
         auto outlineOffset = Style::evaluate<float>(style->usedOutlineOffset(), Style::ZoomNeeded { });
@@ -812,6 +848,9 @@ Path AccessibilityRenderObject::elementPath() const
         if (renderBox->style().border().hasBorderRadius())
             return computePathForRenderBox(*renderBox);
     }
+
+    if (CheckedPtr renderInline = dynamicDowncast<RenderInline>(*m_renderer))
+        return computePathForMultiLineRenderInline(*renderInline);
 
     return { };
 }
@@ -1456,6 +1495,7 @@ AXTextRuns AccessibilityRenderObject::textRuns()
     StringBuilder lineString;
     Vector<uint16_t> characterWidths;
     float distanceFromBoundsInDirection = 0;
+    bool didComputeDistanceFromBounds = false;
     // Used to round an accumulated floating point value into an uint16, which is how we store character widths.
     float accumulatedDistanceFromStart = 0.0;
     float lineHeight = 0.0;
@@ -1483,21 +1523,18 @@ AXTextRuns AccessibilityRenderObject::textRuns()
             return;
         lineHeight = LineSelection::logicalRect(*lineBox).height();
 
-        CheckedPtr renderStyle = style();
-        if (renderStyle && renderStyle->textAlign() != Style::TextAlign::Left) {
-            // To serve the appropriate bounds for text, we need to offset them by a text run's position within its associated RenderText.
-            // Computing this requires the following:
-            //     1. Get the run's logical offset within the containing block (see note below).
-            //     2. Add the containing block's position to get an page-relative position.
-            //     3. Subtract the this object's (RenderText) position to get a distance relative to the RenderText.
-
-            // Note: For horizontal text, the contentLogicalLeft property accurately gets us the offset within the containing block.
-            // ContentLogicalLeft is wrong for vertical orientations, but xPos (only set in vertical mode) provides that same information accurately.
+        // Compute distanceFromBoundsInDirection only for the first text box on each
+        // line. Multiple text boxes can share a line (e.g. due to inline formatting
+        // splits), and we need the offset of the first one, not subsequent ones.
+        // distanceFromBoundsInDirection is reset to 0.0 at each line change, so a
+        // non-zero value indicates it was already set by an earlier text box.
+        if (!didComputeDistanceFromBounds) {
+            didComputeDistanceFromBounds = true;
             float containingBlockOffset = 0;
             if (CheckedPtr containingBlock = renderText->containingBlock())
                 containingBlockOffset = isHorizontal ? containingBlock->absoluteBoundingBoxRect().x() : containingBlock->absoluteBoundingBoxRect().y();
 
-            distanceFromBoundsInDirection = isHorizontal ? lineBox->contentLogicalLeft() + containingBlockOffset - elementRect().x() : -textRun.xPos() + containingBlockOffset - elementRect().y();
+            distanceFromBoundsInDirection = isHorizontal ? textRun.xPos() + lineBox->contentLogicalLeft() + containingBlockOffset - elementRect().x() : -textRun.xPos() + containingBlockOffset - elementRect().y();
         }
 
         // Populate GlyphBuffer with all of the glyphs for the text runs, enabling us to measure character widths.
@@ -1597,6 +1634,7 @@ AXTextRuns AccessibilityRenderObject::textRuns()
             accumulatedDistanceFromStart = 0.0;
             lineHeight = 0.0;
             distanceFromBoundsInDirection = 0.0;
+            didComputeDistanceFromBounds = false;
         }
         appendToLineString(textBox);
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -41,6 +41,7 @@
 #include "Element.h"
 #include "HTMLNames.h"
 #include "Logging.h"
+#include "PathUtilities.h"
 #include "RenderObject.h"
 #include "WebAnimation.h"
 #include <wtf/text/MakeString.h>
@@ -875,8 +876,226 @@ bool AXIsolatedObject::supportsPath() const
     return boolAttributeValue(AXProperty::SupportsPath) || AXCoreObject::supportsPath();
 }
 
+// Collects viewport-relative per-line rects for a text object, clamped to
+// the most recently painted (visible) lines. When trimming is enabled for a
+// side, one leading/trailing whitespace character is skipped so the
+// VoiceOver cursor hugs actual text content and doesn't clip adjacent elements.
+static Vector<FloatRect> collectPaintedLineRects(const AXIsolatedObject& object, const HashMap<AXID, LineRange>& paintedText, bool trimLeading = true, bool trimTrailing = true)
+{
+    const auto* runs = object.textRuns();
+    if (!runs || !runs->size())
+        return { };
+
+    unsigned start = 0;
+    unsigned end = runs->totalLength();
+    if (!paintedText.isEmpty()) {
+        // When paint data exists, only include lines that were actually painted
+        // (visible). If no paint data exists yet (e.g. before the first
+        // paint cycle), fall through and use all text so that paths are
+        // available immediately from text runs cached at tree-build time.
+        auto iterator = paintedText.find(object.objectID());
+        if (iterator == paintedText.end())
+            return { };
+        const auto& paintedRange = iterator->value;
+        start = paintedRange.startLineIndex ? runs->runLengthSumTo(paintedRange.startLineIndex - 1) : 0;
+        end = runs->runLengthSumTo(paintedRange.endLineIndex);
+        if (start >= end)
+            return { };
+    }
+
+    // Only skip the first/last whitespace, as multiple spaces may be intentional (e.g. &nbsp;)
+    // and thus should have some representation.
+    if (trimLeading && start < end && start < runs->text.length() && runs->text[start] == ' ')
+        ++start;
+    if (trimTrailing && end > start && end - 1 < runs->text.length() && runs->text[end - 1] == ' ')
+        --end;
+    if (start >= end)
+        return { };
+
+    auto rects = runs->localRectsPerLine(start, end, object.fontOrientation());
+    auto frame = object.relativeFrame();
+    for (auto& rect : rects)
+        rect.move(frame.x(), frame.y());
+    return rects;
+}
+
+// Clips, inflates, ensures overlap, and builds a shrink-wrapped path from
+// per-line rects. Returns an empty path if fewer than 2 rects remain, as
+// there's no point in exposing a path in that case (the element's rect is fine).
+static Path buildPathFromLineRects(Vector<FloatRect>&& rects, const FloatRect& clipRect, FontOrientation orientation)
+{
+    rects.removeAllMatching([&clipRect](auto& rect) {
+        return !rect.intersects(clipRect);
+    });
+
+    for (auto& rect : rects)
+        rect.intersect(clipRect);
+    if (rects.size() < 2)
+        return { };
+
+    // ATs like VoiceOver use the path to render their cursor.
+    // Add a bit of padding to guarantee we avoid visually clipping text
+    // underneath the cursor.
+    static constexpr float lineRectPadding = 2;
+    for (auto& rect : rects)
+        rect.inflate(lineRectPadding);
+
+    // Ensure adjacent line rects overlap by at least 1px in the block direction.
+    // Without this, pathWithShrinkWrappedRects may produce a path with hairline
+    // gaps between lines where the cursor appears to "break" visually.
+    bool isHorizontal = orientation == FontOrientation::Horizontal;
+    for (size_t i = 1; i < rects.size(); ++i) {
+        if (isHorizontal) {
+            float gap = rects[i].y() - rects[i - 1].maxY();
+            if (gap >= 0)
+                rects[i].shiftYEdgeTo(rects[i - 1].maxY() - 1);
+        } else {
+            // Columns may progress left-to-right (vertical-lr) or
+            // right-to-left (vertical-rl). Close gaps in either direction.
+            if (rects[i].x() > rects[i - 1].maxX())
+                rects[i].shiftXEdgeTo(rects[i - 1].maxX() - 1);
+            else if (rects[i].maxX() < rects[i - 1].x())
+                rects[i].shiftMaxXEdgeTo(rects[i - 1].x() + 1);
+        }
+    }
+
+    return PathUtilities::pathWithShrinkWrappedRects(rects, 0);
+}
+
+// Walks the link's entire subtree to determine if it qualifies for a
+// shrink-wrapped text path (2-3 lines of simple inline text). Returns an empty
+// path for non-qualifying links (non-text content, block-flow containers,
+// unignored groups, 1 or 4+ lines of text). We avoid 4+ line links because
+// sometimes authors put lots of content into one link, in which a case rect-cursor
+// looks better.
+static Path elementPathForLink(const AXIsolatedObject& link, AXIsolatedTree& tree, const HashMap<AXID, LineRange>& paintedText)
+{
+    // If the link has a cached path (border-radius, clip-path), use it.
+    if (RefPtr geometryManager = tree.geometryManager()) {
+        if (std::optional cachedPath = geometryManager->cachedPathForID(link.objectID()))
+            return *cachedPath;
+    }
+
+    // Walk the entire subtree collecting per-line rects from text descendants.
+    Vector<FloatRect> lineRects;
+    unsigned totalLines = 0;
+    bool bail = false;
+
+    auto walkDescendants = [&](const AXIsolatedObject& object, auto& self) -> void {
+        if (bail)
+            return;
+        for (const auto& child : const_cast<AXIsolatedObject&>(object).children()) {
+            if (bail)
+                return;
+
+            Ref isolatedChild = downcast<AXIsolatedObject>(child.get());
+            if (isolatedChild->isStaticText()) {
+                auto rects = collectPaintedLineRects(isolatedChild.get(), paintedText);
+                totalLines += rects.size();
+                lineRects.appendVector(WTF::move(rects));
+                if (totalLines >= 4) {
+                    bail = true;
+                    return;
+                }
+                continue;
+            }
+
+            // Pass through ignored, non-block-flow groups.
+            if (isolatedChild->isGroup() && isolatedChild->isIgnored() && !isolatedChild->isBlockFlow()) {
+                self(isolatedChild.get(), self);
+                continue;
+            }
+
+            // Non-text, unignored group, or block-flow group.
+            bail = true;
+            return;
+        }
+    };
+    walkDescendants(link, walkDescendants);
+
+    if (bail || totalLines <= 1)
+        return { };
+
+    // Build a shrink-wrapped path for 2-3 lines of text.
+    return buildPathFromLineRects(WTF::move(lineRects), link.relativeFrame(), link.fontOrientation());
+}
+
 Path AXIsolatedObject::elementPath() const
 {
+    const auto& paintedText = tree().mostRecentlyPaintedText();
+
+    // Stitch group representatives aggregate rects from all group members.
+    // Check this first because the representative's own text runs may not span
+    // multiple lines, even though the combined text of all members does.
+    if (auto group = stitchGroupIfRepresentative()) {
+        Vector<FloatRect> rects;
+        auto clipFrame = relativeFrame();
+        auto& members = group->members();
+        for (size_t i = 0; i < members.size(); ++i) {
+            RefPtr member = tree().objectForID(members[i]);
+            if (!member)
+                continue;
+            clipFrame.unite(member->relativeFrame());
+            // Only trim the leading space of the first member and trailing
+            // space of the last member. Internal spaces are part of the
+            // combined text and should not be trimmed.
+            bool isFirst = !i;
+            bool isLast = i == members.size() - 1;
+            rects.appendVector(collectPaintedLineRects(*member, paintedText, /* trimLeading */ isFirst, /* trimTrailing */ isLast));
+        }
+        auto path = buildPathFromLineRects(WTF::move(rects), clipFrame, fontOrientation());
+        if (!path.isEmpty())
+            return path;
+    }
+
+    // Multi-line text objects compute their path on-demand from text runs.
+    if (const auto* runs = textRuns(); runs && runs->size() >= 2) {
+        bool isMultiLine = false;
+        for (size_t i = 1; i < runs->size(); ++i) {
+            if (runs->lineID(i) != runs->lineID(i - 1)) {
+                isMultiLine = true;
+                break;
+            }
+        }
+        if (isMultiLine) {
+            auto rects = collectPaintedLineRects(*this, paintedText);
+            auto path = buildPathFromLineRects(WTF::move(rects), relativeFrame(), fontOrientation());
+            if (!path.isEmpty())
+                return path;
+        }
+    }
+
+    // Labels remapped to StaticText don't have their own text runs.
+    // Aggregate text runs from descendant objects (which may be ignored,
+    // since the label subsumes its text children).
+    if (isStaticTextLabel()) {
+        Vector<FloatRect> allRects;
+        auto clipFrame = relativeFrame();
+
+        auto collectFromDescendants = [&](const AXIsolatedObject& object, auto& self) -> void {
+            for (const auto& child : const_cast<AXIsolatedObject&>(object).children()) {
+                Ref isolatedChild = downcast<AXIsolatedObject>(child.get());
+                if (isolatedChild->isStaticText() && isolatedChild->textRuns()) {
+                    clipFrame.unite(isolatedChild->relativeFrame());
+                    allRects.appendVector(collectPaintedLineRects(isolatedChild.get(), paintedText));
+                } else
+                    self(isolatedChild.get(), self);
+            }
+        };
+        collectFromDescendants(*this, collectFromDescendants);
+
+        auto path = buildPathFromLineRects(WTF::move(allRects), clipFrame, fontOrientation());
+        if (!path.isEmpty())
+            return path;
+    }
+
+    // Links: build a shrink-wrapped path from descendant text if the link
+    // contains only simple inline text spanning 2-3 lines.
+    if (isLink())
+        return elementPathForLink(*this, tree(), paintedText);
+
+    // For other path types (border-radius, SVG, etc.), read from the geometry
+    // manager's cache.
     if (RefPtr geometryManager = tree().geometryManager()) {
         auto cachedPath = geometryManager->cachedPathForID(objectID());
         return cachedPath.value_or(Path { });

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -115,6 +115,8 @@ public:
     RetainPtr<CTFontRef> font() const final { return fontAttributeValue(AXProperty::Font); }
 #endif
 
+    bool isBlockFlow() const final { return boolAttributeValue(AXProperty::IsBlockFlow); }
+
 private:
     constexpr ProcessID processID() const final { return tree().processID(); }
     void detachRemoteParts(AccessibilityDetachmentType) final;
@@ -550,7 +552,6 @@ private:
     String titleAttribute() const final { return stringAttributeValue(AXProperty::TitleAttribute); }
 
     std::optional<String> textContent() const final;
-    bool isBlockFlow() const final { return boolAttributeValue(AXProperty::IsBlockFlow); }
     std::optional<AXStitchGroup> stitchGroup(IncludeGroupMembers = IncludeGroupMembers::Yes) const final;
     const Vector<AXStitchGroup>* stitchGroupsView() const;
 


### PR DESCRIPTION
#### ead5853ca2e28c58103a3c8345128bd5574e917a
<pre>
AX: Compute shrink-wrapped paths for multi-line text, links, and static-text-only labels
<a href="https://bugs.webkit.org/show_bug.cgi?id=311852">https://bugs.webkit.org/show_bug.cgi?id=311852</a>
<a href="https://rdar.apple.com/174436965">rdar://174436965</a>

Reviewed by Joshua Hoffman.

This commit adds on-demand path computation for multi-line static text, links,
and labels that contain only static text.

The core approach: collect per-line bounding rects from text runs, then
build a shrink-wrapped path via PathUtilities::pathWithShrinkWrappedRects.
This gives ATs like VoiceOver a tightly-fitting cursor around wrapped
text instead of a large rectangular bounding box that encompasses more
than the text being spoken / brailled.

AXTextRun changes:

  - Refactor localRect() to delegate to new localRectsPerLine(), which
returns a per-line rect vector instead of a single unioned rect.

  - Collapsed ranges (start == end) are handled directly in localRect()
with a caret-width rect.

AccessibilityRenderObject changes:

  - Add rectsSpanMultipleLines() to replace the old needsPath heuristic.
    This function respects vertical and RTL writing modes, unlike the old
    implementation.

  - Add computePathForMultiLineRenderInline() for main-thread inline element paths.

  - Fix textRuns() distanceFromBoundsInDirection: the old code only
    computed this for non-left-aligned text, but all alignments need
    it for accurate bounds. It also used lineBox-&gt;contentLogicalLeft()
    alone, which gives the line&apos;s content area offset but misses the
    run&apos;s position within the line. Adding textRun.xPos() fixes this.
    Finally, only compute the offset for the first text box on each
    line, since multiple text boxes can share a line (e.g. due to
    inline formatting splits like &lt;b&gt; or &lt;i&gt;), and the offset of a
    subsequent box would overwrite the correct value from the first.

* LayoutTests/accessibility/label-static-text-path-expected.txt: Added.
* LayoutTests/accessibility/label-static-text-path.html: Added.
* LayoutTests/accessibility/mac/bounds-for-range-expected.txt:
* LayoutTests/accessibility/mac/element-paths-expected.txt:
* LayoutTests/accessibility/mac/element-paths.html:
* LayoutTests/accessibility/statictext-path-expected.txt: Added.
* LayoutTests/accessibility/statictext-path.html: Added.
* LayoutTests/accessibility/stitched-text-path-expected.txt: Added.
* LayoutTests/accessibility/stitched-text-path.html: Added.
* Source/WebCore/accessibility/AXTextRun.cpp:
(WebCore::AXTextRuns::localRect const):
(WebCore::AXTextRuns::localRectsPerLine const):
* Source/WebCore/accessibility/AXTextRun.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::rectsSpanMultipleLines):
(WebCore::computePathForMultiLineRenderInline):
(WebCore::AccessibilityRenderObject::elementPath const):
(WebCore::AccessibilityRenderObject::textRuns):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::collectPaintedLineRects):
(WebCore::buildPathFromLineRects):
(WebCore::elementPathForLink):
(WebCore::AXIsolatedObject::elementPath const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:

Canonical link: <a href="https://commits.webkit.org/311136@main">https://commits.webkit.org/311136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b5d42cdcbb043c570ded0102b3803a2c287b6f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155526 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164288 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109323 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4a88b850-1133-4cb7-adcc-90866f06ae46) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157399 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28636 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120365 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84888 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 1 flakes 2 failures; Uploaded test results; 1 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22556 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139663 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101055 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/570aca9c-b4e2-4f3e-b3d5-8fd2270af81c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21642 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19759 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12119 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17495 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166766 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10944 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19106 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128480 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28330 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23793 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128614 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34978 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28254 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139288 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85697 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23445 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16085 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27948 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92051 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27525 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27755 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27598 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->