### PR TITLE
Accept anchor-* as aliases of anchors-* in position-visibility

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchor-valid.tentative-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchor-valid.tentative-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+  .anchor {
+    width: 100px;
+    height: 100px;
+    background: orange;
+  }
+  .target {
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+<div class="anchor">anchor1</div>
+<div class="target">target1</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchor-valid.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchor-valid.tentative.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Anchor Positioning Test: position-visibility: anchor-valid</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-visibility">
+<link rel="match" href="position-visibility-anchor-valid-ref.html">
+<style>
+  .anchor {
+    width: 100px;
+    height: 100px;
+    background: orange;
+    display: inline-block;
+  }
+
+  .target {
+    position: absolute;
+    position-visibility: anchor-valid;
+    position-area: block-end;
+    width: 100px;
+    height: 100px;
+    background: red;
+    inset: 0;
+  }
+</style>
+
+<!-- #target1 should be visible. -->
+<div class="anchor" style="anchor-name: --a1;">anchor1</div>
+<div id="target1" class="target" style="position-anchor: --a1; background: green">target1</div>
+
+<!-- #target2 should not be visible because anchor name does not exist. -->
+<div id="target2" class="target" style="top: anchor(--does-not-exist bottom);">target2</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchor-visible-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchor-visible-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+  #scroll-container {
+    overflow: hidden scroll;
+    width: 300px;
+    height: 100px;
+  }
+
+  #spacer {
+    height: 200px;
+  }
+</style>
+
+<div id="scroll-container">
+  <div id="spacer"></div>
+</div>
+
+<script>
+  const scroller = document.getElementById('scroll-container');
+  scroller.scrollTop = 100;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchor-visible.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchor-visible.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<meta name="assert" content="Position-visibility: anchors-visible should hide an element with an out-of-view anchor." />
+<title>CSS Anchor Positioning Test: position-visibility: anchors-visible</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-visibility">
+<link rel="match" href="position-visibility-anchors-visible-ref.html">
+<style>
+  #scroll-container {
+    overflow: hidden scroll;
+    width: 300px;
+    height: 100px;
+  }
+
+  #anchor {
+    anchor-name: --a1;
+    width: 100px;
+    height: 100px;
+    background: orange;
+  }
+
+  #spacer {
+    height: 100px;
+  }
+
+  #target {
+    position-anchor: --a1;
+    position-visibility: always;
+    position-visibility: anchor-visible;
+    position-area: bottom right;
+    width: 100px;
+    height: 100px;
+    background: red;
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+</style>
+
+<div id="scroll-container">
+  <div id="anchor">anchor</div>
+  <div id="spacer"></div>
+  <div id="target">target</div>
+</div>
+
+<script>
+  const scroller = document.getElementById('scroll-container');
+  scroller.scrollTop = 100;
+  // #target should not be visible because #anchor is scrolled out of view.
+</script>

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -13199,7 +13199,9 @@
             "initial": "anchors-visible",
             "values": [
                 "always",
+                "anchor-valid",
                 "anchors-valid",
+                "anchor-visible",
                 "anchors-visible",
                 "no-overflow"
             ],
@@ -13209,7 +13211,7 @@
                 "computed-style-storage-path": ["m_nonInheritedData", "rareData"],
                 "computed-style-storage-kind": "raw",
                 "computed-style-type": "Style::PositionVisibility",
-                "parser-grammar": "always | [ anchors-valid || anchors-visible || no-overflow ]@(no-single-item-opt)"
+                "parser-grammar": "always | [ [ anchors-valid | anchor-valid ] || [ anchors-visible | anchor-visible ] || no-overflow ]@(no-single-item-opt)"
             },
             "specification": {
                 "category": "css-anchor-position",

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1917,7 +1917,9 @@ span-self-inline-end
 // position-visibility
 // always
 anchors-valid
+anchor-valid
 anchors-visible
+anchor-visible
 no-overflow
 
 // view-transition-name

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -348,7 +348,7 @@ void AnchorPositionEvaluator::updateScrollAdjustments(RenderView& renderView)
                     shouldBeHidden = anchored->style().positionVisibility().contains(PositionVisibilityValue::NoOverflow);
             }
         }
-        if (!shouldBeHidden && anchored->style().positionVisibility().contains(PositionVisibilityValue::AnchorsVisible))
+        if (!shouldBeHidden && (anchored->style().positionVisibility().contains(PositionVisibilityValue::AnchorsVisible) || anchored->style().positionVisibility().contains(PositionVisibilityValue::AnchorVisible)))
             shouldBeHidden = AnchorPositionEvaluator::isDefaultAnchorInvisibleOrClippedByInterveningBoxes(*anchored);
 
         if (needsInvalidation || shouldBeHidden != adjuster.isHidden()) {

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1863,7 +1863,7 @@ void TreeResolver::updateForPositionVisibility(RenderStyle& style, const Styleab
         if (!anchored)
             return false;
 
-        if (style.positionVisibility().contains(PositionVisibilityValue::AnchorsVisible)) {
+        if (style.positionVisibility().contains(PositionVisibilityValue::AnchorsVisible) || style.positionVisibility().contains(PositionVisibilityValue::AnchorVisible)) {
             // "If the box has a default anchor box but that anchor box is invisible or clipped by intervening boxes, the box’s visibility property computes to force-hidden."
             if (AnchorPositionEvaluator::isDefaultAnchorInvisibleOrClippedByInterveningBoxes(*anchored))
                 return true;
@@ -1872,7 +1872,7 @@ void TreeResolver::updateForPositionVisibility(RenderStyle& style, const Styleab
             if (AnchorPositionEvaluator::overflowsInsetModifiedContainingBlock(*anchored))
                 return true;
         }
-        if (style.positionVisibility().contains(PositionVisibilityValue::AnchorsValid)) {
+        if (style.positionVisibility().contains(PositionVisibilityValue::AnchorsValid) || style.positionVisibility().contains(PositionVisibilityValue::AnchorValid)) {
             auto* anchorPositionedState = m_treeResolutionState.anchorPositionedStates.get(styleable);
             if (anchorPositionedState) {
                 for (auto& anchorElement : anchorPositionedState->anchorElements.values()) {

--- a/Source/WebCore/style/computed/data/StyleNonInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedRareData.h
@@ -233,7 +233,7 @@ public:
     PREFERRED_TYPE(TextBoxTrim) unsigned textBoxTrim : 2;
     PREFERRED_TYPE(OverflowAnchor) unsigned overflowAnchor : 1;
     PREFERRED_TYPE(PositionTryOrder) unsigned positionTryOrder : 3;
-    PREFERRED_TYPE(PositionVisibility) unsigned positionVisibility : 3;
+    PREFERRED_TYPE(PositionVisibility) unsigned positionVisibility : 5;
     PREFERRED_TYPE(FieldSizing) unsigned fieldSizing : 1;
     PREFERRED_TYPE(bool) unsigned nativeAppearanceDisabled : 1;
 #if HAVE(CORE_MATERIAL)

--- a/Source/WebCore/style/values/anchor-position/StylePositionVisibility.h
+++ b/Source/WebCore/style/values/anchor-position/StylePositionVisibility.h
@@ -34,7 +34,9 @@ namespace Style {
 
 enum class PositionVisibilityValue : uint8_t {
     AnchorsValid,
+    AnchorValid,
     AnchorsVisible,
+    AnchorVisible,
     NoOverflow,
 };
 

--- a/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
+++ b/Source/WebCore/style/values/primitives/StyleKeyword+Mappings.h
@@ -2316,7 +2316,7 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef FOR_EACH
 
 #define TYPE Style::PositionVisibilityValue
-#define FOR_EACH(CASE) CASE(AnchorsValid) CASE(AnchorsVisible) CASE(NoOverflow)
+#define FOR_EACH(CASE) CASE(AnchorsValid) CASE(AnchorValid) CASE(AnchorsVisible) CASE(AnchorVisible) CASE(NoOverflow)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH


### PR DESCRIPTION
#### b55bdc1fd5662f0c0f5e12a3a1d72308b40a054d
<pre>
Accept anchor-* as aliases of anchors-* in position-visibility
<a href="https://bugs.webkit.org/show_bug.cgi?id=311854">https://bugs.webkit.org/show_bug.cgi?id=311854</a>
<a href="https://rdar.apple.com/174438361">rdar://174438361</a>

Reviewed by Antti Koivisto.

In <a href="https://github.com/w3c/csswg-drafts/issues/10201">https://github.com/w3c/csswg-drafts/issues/10201</a> the `anchors-visible`
keyword was renamed to `anchor-visible` to better reflect its behavior.
Renaming `anchors-valid` to match wasn&apos;t considered, so this question
was returned to the WG for consideration.

While they figure out what to do, we should accept both spellings,
to minimize the chances of compat problems down the line.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchor-valid.tentative-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchor-valid.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchor-visible-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchor-visible.html: Added.

Add anchor-* variants of a couple tests to make sure it parses and behaves correctly.

* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::updateScrollAdjustments):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::updateForPositionVisibility):
* Source/WebCore/style/computed/data/StyleNonInheritedRareData.h:
* Source/WebCore/style/values/anchor-position/StylePositionVisibility.h:

Aliasing.

Canonical link: <a href="https://commits.webkit.org/312080@main">https://commits.webkit.org/312080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b7870416c21459d55b7f878523c0a66345dc202

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23602 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165898 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111157 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158946 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121649 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85420 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160033 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102317 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22953 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21181 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13670 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132633 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18882 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168383 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12542 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129776 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129884 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35541 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29936 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140676 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87757 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24712 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17480 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29647 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93661 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29169 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29399 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29296 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->