### PR TITLE
Extend 'collect-pgo-profiles' to support per benchmark invocation overwrite.

### DIFF
--- a/Tools/Scripts/collect-pgo-profiles
+++ b/Tools/Scripts/collect-pgo-profiles
@@ -25,14 +25,22 @@ def check_or_create_empty_directory(path):
     assert os.path.isdir(path) and len(os.listdir(path)) == 0, f'{path} is not empty or is not a directory'
 
 
-def collect_pgo_profiles(harness, benchmark, output_directory, run_benchmark_args, verbose):
+def collect_pgo_profiles(harness, benchmark, output_directory, run_benchmark_args, benchmark_overrides, verbose):
     benchmark_profile_directory = os.path.join(output_directory, benchmark)
     os.makedirs(benchmark_profile_directory)
     with tempfile.TemporaryDirectory() as temp_dir:
         output_file = os.path.join(temp_dir, f'{benchmark}.json')
-        command = [sys.executable, harness, '--plan', benchmark, '--diagnose-directory', benchmark_profile_directory,
-                   '--generate-pgo-profiles', '--http-server-type', 'twisted', '--count', '1',
-                   '--output-file', output_file, *run_benchmark_args]
+        options = {
+            'plan': benchmark,
+            'diagnose-directory': benchmark_profile_directory,
+            'http-server-type': 'twisted',
+            'count': '1',
+            'output-file': output_file,
+        }
+        options.update(benchmark_overrides.get(benchmark, {}))
+        command = [sys.executable, harness,
+                   *[part for k, v in options.items() for part in (f'--{k}', v)],
+                   '--generate-pgo-profiles', *run_benchmark_args]
         if verbose:
             command.append('--debug')
         logger.info(f'Running {benchmark} with {shlex.join(command)}')
@@ -61,17 +69,32 @@ def main():
                         help='Sub path under output directory for compressed PGO profiles.')
     parser.add_argument('-v', '--verbose', action='store_true', default=False,
                         help='Turn on debug logging')
+    parser.add_argument('--benchmark-custom-options', nargs='+', action='append',
+                        metavar=('BENCHMARK', 'KEY:VALUE'),
+                        help='Per-benchmark run-benchmark option overrides in KEY:VALUE format, '
+                             'overriding any conflicting global options.')
     args, run_benchmark_args = parser.parse_known_args()
 
     if args.verbose:
         logger.setLevel(logging.DEBUG)
+
+    benchmark_overrides = {}
+    for option in (args.benchmark_custom_options or []):
+        benchmark, *pairs = option
+        if benchmark in benchmark_overrides:
+            parser.error(f'Benchmark {benchmark} is specified multiple times via --benchmark-custom-options, please merge them into one argument.')
+        for pair in pairs:
+            key, separator, value = pair.partition(':')
+            if not separator:
+                parser.error(f'Invalid KEY:VALUE format {pair} for benchmark {benchmark}')
+            benchmark_overrides.setdefault(benchmark, {})[key] = value
 
     check_or_create_empty_directory(args.output_directory)
 
     combine_command = [sys.executable, PGO_PROFILE, 'combine']
     for benchmark in args.benchmarks:
         profile_directory = collect_pgo_profiles(args.run_benchmark_harness, benchmark, args.output_directory,
-                                                 run_benchmark_args, args.verbose)
+                                                 run_benchmark_args, benchmark_overrides, args.verbose)
         combine_command.extend([f'--{benchmark}', profile_directory])
 
     combined_profile_directory = os.path.join(args.output_directory, 'output')


### PR DESCRIPTION
#### a0d9c4de8a3bd88988b1453ce0322dc1bdadfbba
<pre>
Extend &apos;collect-pgo-profiles&apos; to support per benchmark invocation overwrite.
<a href="https://bugs.webkit.org/show_bug.cgi?id=311676">https://bugs.webkit.org/show_bug.cgi?id=311676</a>
<a href="https://rdar.apple.com/174220316">rdar://174220316</a>

Reviewed by NOBODY (OOPS!).

Add &apos;--benchmark-custom-option&apos; option to support overwriting a specific option for a particular benchmark.
For example: &apos;--benchmark-custom-option motionmark count:2&apos; will pass &apos;--count 2&apos; for motionmark run-benchmark invocation.

* Tools/Scripts/collect-pgo-profiles:
(check_or_create_empty_directory):
(collect_pgo_profiles):
(main):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0d9c4de8a3bd88988b1453ce0322dc1bdadfbba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164075 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/62cb7796-3cac-4018-9e4d-eb27053e685a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157187 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28714 "Hash a0d9c4de for PR 62385 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28424 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120197 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158273 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/28714 "Hash a0d9c4de for PR 62385 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139492 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100886 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de3ef298-1b55-4bec-a3fa-149540d6e429) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/28714 "Hash a0d9c4de for PR 62385 does not build (failure)") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11901 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/28714 "Hash a0d9c4de for PR 62385 does not build (failure)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/17324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166553 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18934 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128302 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28118 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23617 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128433 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34810 "") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28042 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139117 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23287 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27736 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27313 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/27543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27386 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->