### PR TITLE
AX: fix LayoutTests that fail with --site-isolation

### DIFF
--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -6,7 +6,7 @@ accessibility/isolated-tree [ Pass ]
 accessibility/content-editable-set-inner-text-generates-axvalue-notification.html [ Failure Pass ]
 accessibility/keyevents-for-actions-mimic-real-key-events.html [ Failure ]
 accessibility/keyevents-posted-for-increment-actions.html [ Failure ]
-accessibility/mac/focus-setting-selection-syncronizing-not-clearing.html [ Failure ]
+accessibility/mac/focus-setting-selection-syncronizing-not-clearing.html [ Crash ]
 # Fails because of (1) stale focus ID for the iFrame and (2) iFrame #2 being ignored.
 accessibility/mac/frame-with-title.html [ Failure ]
 accessibility/mac/pseudo-element-text-markers.html [ Failure ]

--- a/LayoutTests/accessibility/insert-children-assert-expected.txt
+++ b/LayoutTests/accessibility/insert-children-assert-expected.txt
@@ -3,11 +3,9 @@ c
 de
 This tests that we only insert valid children when building ax tree.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: valueOccuranceInElementTree(content, value) === 1
+PASS: valueOccuranceInElementTree(content, value) === 1
 
-
-PASS valueOccuranceInElementTree(content, value) is 1
-PASS valueOccuranceInElementTree(content, value) is 1
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/insert-children-assert.html
+++ b/LayoutTests/accessibility/insert-children-assert.html
@@ -3,9 +3,6 @@
 <head>
 <script src="../resources/js-test.js"></script>
 <script src="../resources/accessibility-helper.js"></script>
-<script>
-var successfullyParsed = false;
-</script>
 </head>
 <style>
 body {
@@ -22,53 +19,53 @@ body {
 <div id="console"></div>
 
 <script>
-    description("This tests that we only insert valid children when building ax tree.");
-    jsTestIsAsync = true;
+var output = "This tests that we only insert valid children when building ax tree.\n\n";
+jsTestIsAsync = true;
 
-    if ("webkitRequestFullScreen" in Element.prototype) {
-        var content = accessibilityController.accessibleElementById("content");
-        var value;
-        if (accessibilityController.platformName == "atspi")
-            value = "AXValue: ab<\\n>c<\\n>de<\\n>";
-        else
-            value = "AXValue: d";
-        document.body.offsetTop;
-        var span = document.getElementsByTagName('span')[0];
+function valueOccuranceInElementTree(element, value) {
+    if (!element)
+        return 0;
+    var count = 0;
+    if (element.stringValue == value)
+        count++;
+    var childrenCount = element.childrenCount;
+    for (var k = 0; k < childrenCount; k++)
+        count += valueOccuranceInElementTree(element.childAtIndex(k), value);
+    return count;
+}
 
-        var fullscreenChangeEvent = function(event) {
-            if (document.webkitIsFullScreen) {
-                setTimeout(function () {
-                    document.webkitCancelFullScreen();
-                }, 0)
-            } else
-                finishJSTest();
-            shouldBe("valueOccuranceInElementTree(content, value)", "1");
-        };
+if ("webkitRequestFullScreen" in Element.prototype) {
+    var content = accessibilityController.accessibleElementById("content");
+    var value;
+    if (accessibilityController.platformName == "atspi")
+        value = "AXValue: ab<\\n>c<\\n>de<\\n>";
+    else
+        value = "AXValue: d";
+    document.body.offsetTop;
+    var span = document.getElementsByTagName('span')[0];
 
-        document.addEventListener('webkitfullscreenchange', fullscreenChangeEvent);
-
-        document.addEventListener('keydown', function () {
-            span.webkitRequestFullScreen();
-        });
-        
-        shouldBe("valueOccuranceInElementTree(content, value)", "1");
-        if (window.eventSender)
-            eventSender.keyDown('a');
-    }
-    successfullyParsed = true;
-
-    function valueOccuranceInElementTree(element, value) {
-        if (!element) {
-            return 0;
+    var fullscreenChangeEvent = function(event) {
+        if (document.webkitIsFullScreen) {
+            setTimeout(function () {
+                document.webkitCancelFullScreen();
+            }, 0)
+        } else {
+            output += expect("valueOccuranceInElementTree(content, value)", "1");
+            debug(output);
+            finishJSTest();
         }
-        var count = 0;
-        if (element.stringValue == value)
-            count++;
-        var childrenCount = element.childrenCount;
-        for (var k = 0; k < childrenCount; k++)
-            count += valueOccuranceInElementTree(element.childAtIndex(k), value);
-        return count;
-    }
+    };
+
+    document.addEventListener('webkitfullscreenchange', fullscreenChangeEvent);
+
+    document.addEventListener('keydown', function () {
+        span.webkitRequestFullScreen();
+    });
+
+    output += expect("valueOccuranceInElementTree(content, value)", "1");
+    if (window.eventSender)
+        eventSender.keyDown('a');
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/accessibility/mac/focus-setting-selection-syncronizing-not-clearing-expected.txt
+++ b/LayoutTests/accessibility/mac/focus-setting-selection-syncronizing-not-clearing-expected.txt
@@ -1,17 +1,11 @@
-
- 1
- 2
 This tests that calling focus on a render object when it doesn't result in a selection change won't leave isSynchronizingSelection set to true.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
-PASS addedNotification is true
-PASS accessibilityController.focusedElement.isEqual(accessibilityController.accessibleElementById("1")) is true
-PASS axTextStateSyncOne is undefined
-PASS accessibilityController.accessibleElementById("1").isFocusable is true
-PASS axTextStateSyncTwo is undefined
+PASS: accessibilityController.focusedElement.isEqual(accessibilityController.accessibleElementById('1')) === true
+PASS: accessibilityController.accessibleElementById('1').isFocusable === true
+PASS: AXTextStateSync after tabbing is undefined, expected undefined
 PASS successfullyParsed is true
 
 TEST COMPLETE
 
+ 1
+ 2

--- a/LayoutTests/accessibility/mac/focus-setting-selection-syncronizing-not-clearing.html
+++ b/LayoutTests/accessibility/mac/focus-setting-selection-syncronizing-not-clearing.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
 
@@ -16,62 +17,49 @@
     </div>
 </fieldset>
 
-<p id="description"></p>
-<div id="console"></div>
-<div id="notifications"></div>
-
 <script>
+var output = "This tests that calling focus on a render object when it doesn't result in a selection change won't leave isSynchronizingSelection set to true.\n\n";
 
-    description("This tests that calling focus on a render object when it doesn't result in a selection change won't leave isSynchronizingSelection set to true.");
+if (window.accessibilityController) {
+    jsTestIsAsync = true;
 
-    var webArea = 0;
-    var axTextStateSyncOne = 0;
-    var axTextStateSyncTwo = 0;
-    var selectCount = 0;
-    var focusCount = 0;
+    accessibilityController.enableEnhancedAccessibility(true);
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
 
-    // Notification ordering:
-    // The first tab will result in a selection and focus notification pair         selectCount=1, focusCount=1
-    // takeFocus() will result in a focus notification                              selectCount=1, focusCount=2
-    // The second tab will result in another selection and focus notification pair  selectCount=2, focusCount=3
-    function notificationCallback(notification, userInfo) {
-        if (notification == "AXSelectedTextChanged") {
-            selectCount++;
-            if (selectCount == 1) {
-                axTextStateSyncOne = userInfo["AXTextStateSync"];
-                shouldBe("axTextStateSyncOne", "undefined");
+    setTimeout(async () => {
+        // Tab to input "1".
+        await waitForNotification(webArea, "AXSelectedTextChanged", () => {
+            eventSender.keyDown("\t");
+        });
+        output += expect("accessibilityController.focusedElement.isEqual(accessibilityController.accessibleElementById('1'))", "true");
 
-                shouldBe("accessibilityController.accessibleElementById(\"1\").isFocusable", "true");
-                accessibilityController.accessibleElementById("1").takeFocus();
-            } else if (selectCount == 2) {
-                axTextStateSyncTwo = userInfo["AXTextStateSync"];
-                shouldBe("axTextStateSyncTwo", "undefined");
+        // Call takeFocus() on input "1" (already focused). This should not
+        // leave isSynchronizingSelection set to true.
+        output += expect("accessibilityController.accessibleElementById('1').isFocusable", "true");
+        await waitForNotification(webArea, "AXFocusChanged", () => {
+            accessibilityController.accessibleElementById("1").takeFocus();
+        });
+
+        // Tab to input "2". Verify AXTextStateSync is not set, confirming
+        // isSynchronizingSelection was properly cleared.
+        var received = false;
+        var receivedUserInfo;
+        webArea.addNotificationListener((notification, userInfo) => {
+            if (notification == "AXSelectedTextChanged") {
+                receivedUserInfo = userInfo;
+                received = true;
             }
-        } else if (notification == "AXFocusChanged") {
-            focusCount++;
-            if (focusCount == 2) {
-                eventSender.scheduleAsynchronousKeyDown("\t");
-            }
-        }
-        if (selectCount == 2 && focusCount == 3) {
-            webArea.removeNotificationListener();
-            finishJSTest();
-        }
-    }
-
-    if (window.accessibilityController) {
-        jsTestIsAsync = true;
-
-        accessibilityController.enableEnhancedAccessibility(true);
-        webArea = accessibilityController.rootElement.childAtIndex(0);
-
-        var addedNotification = webArea.addNotificationListener(notificationCallback);
-        shouldBe("addedNotification", "true");
-
+        });
         eventSender.keyDown("\t");
-        shouldBe("accessibilityController.focusedElement.isEqual(accessibilityController.accessibleElementById(\"1\"))", "true");
-    }
+        await waitFor(() => received);
+        webArea.removeNotificationListener();
 
+        output += `PASS: AXTextStateSync after tabbing is ${receivedUserInfo["AXTextStateSync"]}, expected undefined`;
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/accessibility/press-targets-center-point.html
+++ b/LayoutTests/accessibility/press-targets-center-point.html
@@ -58,7 +58,7 @@
     
     function accessibilityPress(i) {
         if (i == targetCount)
-            finishJSTest();
+            return finishJSTest();
         
         accessibilityController.accessibleElementById("t" + i).press();
         setTimeout(function() {

--- a/LayoutTests/accessibility/press-works-on-control-types.html
+++ b/LayoutTests/accessibility/press-works-on-control-types.html
@@ -52,8 +52,8 @@ var items = ["button", "tab", "radio", "checkbox", "menuitem", "menuitemcheckbox
 var length = items.length;
 function accessibilityPress(k) {
    if (k == length)
-      finishJSTest();
-    
+      return finishJSTest();
+
    accessibilityController.accessibleElementById(items[k]).press();
    setTimeout(function() {
        accessibilityPress(k+1);

--- a/LayoutTests/accessibility/youtube-embed-accessibility-hierarchy-expected.txt
+++ b/LayoutTests/accessibility/youtube-embed-accessibility-hierarchy-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Blocked access to external URL https://www.youtube.com/embed/UF8uR6Z6KLc
 This test verifies that we don't hang when building the accessibility tree with a YouTube embed.
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/youtube-embed-accessibility-hierarchy.html
+++ b/LayoutTests/accessibility/youtube-embed-accessibility-hierarchy.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
 <head>
 <script src="../resources/js-test.js"></script>

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -121,10 +121,7 @@ webrtc/peerconnection-page-cache.html [ Timeout ]
 ########################
 # Tests that Text fail #
 ########################
-accessibility/insert-children-assert.html [ Failure ]
-accessibility/mac/stale-textmarker-crash.html [ Failure ]
-accessibility/press-works-on-control-types.html [ Failure ]
-accessibility/youtube-embed-accessibility-hierarchy.html [ Failure ]
+accessibility/youtube-embed-accessibility-hierarchy.html [ Failure Timeout ]
 animations/animation-multiple-callbacks-timestamp.html [ Failure ]
 editing/execCommand/delete-no-scroll.html [ Failure ]
 editing/inserting/insert-list-then-edit-command-crash.html [ Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1028,8 +1028,6 @@ webkit.org/b/207631 tiled-drawing/scrolling/fixed/fixed-during-rubberband.html [
 
 webkit.org/b/207635 fast/events/before-input-prevent-insert-replacement.html [ Pass Failure ]
 
-webkit.org/b/207728 [ Release ] accessibility/press-targets-center-point.html [ Pass Failure ]
-
 webkit.org/b/207796 [ Release ] fast/box-shadow/hidpi-box-shadow.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/207938 http/wpt/crypto/derive-hmac-key-crash.any.html [ Pass Crash ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2444,8 +2444,6 @@ webkit.org/b/301668 fast/repaint/iframe-avoid-redundant-repaint.html [ Pass Fail
 # List buttons no longer have tint color after the form control refresh.
 fast/css/accent-color/datalist.html [ Skip ]
 
-webkit.org/b/302273 accessibility/mac/focus-setting-selection-syncronizing-not-clearing.html [ Pass Timeout ]
-
 webkit.org/b/301013 http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html [ Pass Failure ]
 
 # webkit.org/b/301655 Internals animation toggle causes the Image global preference to change, unpausing animations in tests


### PR DESCRIPTION
#### 9e3d4b761644738175a74b78665a5d8b3eb893b2
<pre>
AX: fix LayoutTests that fail with --site-isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=311868">https://bugs.webkit.org/show_bug.cgi?id=311868</a>
<a href="https://rdar.apple.com/173713244">rdar://173713244</a>

Reviewed by Joshua Hoffman.

None of these tests that were failing with --site-isolation had iframes so they all just needed
some minor fixes or robustness.

A permissions issue remains with youtube-embed-accessibility-hierarchy, but let&apos;s fix the others.

* LayoutTests/accessibility-isolated-tree/TestExpectations:
* LayoutTests/accessibility/insert-children-assert-expected.txt:
* LayoutTests/accessibility/insert-children-assert.html:
* LayoutTests/accessibility/mac/focus-setting-selection-syncronizing-not-clearing-expected.txt:
* LayoutTests/accessibility/mac/focus-setting-selection-syncronizing-not-clearing.html:
* LayoutTests/accessibility/press-targets-center-point.html:
* LayoutTests/accessibility/press-works-on-control-types.html:
* LayoutTests/accessibility/youtube-embed-accessibility-hierarchy-expected.txt:
* LayoutTests/accessibility/youtube-embed-accessibility-hierarchy.html:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/310953@main">https://commits.webkit.org/310953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/334461176cd6559effa928b6eb378072e46dc191

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164287 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f3d2223e-4ddb-49c4-a771-de323d98fcec) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28635 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120364 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d3a83a32-2c85-4486-95f5-032205ed9893) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22554 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139657 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101054 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/07f82125-64e5-4f66-8c82-46bb874223dc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21640 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12118 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131309 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17489 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166765 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19100 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128481 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28329 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128615 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34876 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28253 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139282 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85696 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23443 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16079 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27947 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27524 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27754 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27597 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->