### PR TITLE
AX: align with other browsers on handling of focused elements and aria-hidden

### DIFF
--- a/LayoutTests/accessibility/aria-hidden-focus-not-overridden-when-caught-expected.txt
+++ b/LayoutTests/accessibility/aria-hidden-focus-not-overridden-when-caught-expected.txt
@@ -1,0 +1,11 @@
+This tests that aria-hidden is NOT overridden when a focus handler moves focus out before the next animation frame.
+
+PASS: !button1 || !button1.isValid === true
+PASS: accessibilityController.focusedElement.domIdentifier === 'outside'
+PASS: !button1 || !button1.isValid === true
+PASS: !button2 || !button2.isValid === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/aria-hidden-focus-not-overridden-when-caught.html
+++ b/LayoutTests/accessibility/aria-hidden-focus-not-overridden-when-caught.html
@@ -1,0 +1,61 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="content">
+<button id="outside">Outside</button>
+<div id="container" aria-hidden="true">
+    <button id="button1">Button 1</button>
+    <button id="button2">Button 2</button>
+</div>
+</div>
+
+<script>
+var output = "This tests that aria-hidden is NOT overridden when a focus handler moves focus out before the next animation frame.\n\n";
+
+if (window.accessibilityController) {
+    jsTestIsAsync = true;
+
+    // Install a focus handler that immediately moves focus back out.
+    document.getElementById("button1").addEventListener("focus", function() {
+        document.getElementById("outside").focus();
+    });
+
+    // Initially, buttons inside aria-hidden should not be accessible.
+    var button1 = accessibilityController.accessibleElementById("button1");
+    output += expect("!button1 || !button1.isValid", "true");
+
+    // Focus button1 inside the aria-hidden region. The focus handler will
+    // immediately move focus to "outside", before the next animation frame.
+    document.getElementById("button1").focus();
+
+    // Wait for focus to land on outside, then wait a reasonable amount of time
+    // to confirm the override does NOT take effect.
+    (async function() {
+        await waitFor(() => {
+            return accessibilityController.focusedElement.domIdentifier === "outside";
+        });
+        output += expect("accessibilityController.focusedElement.domIdentifier", "'outside'");
+
+        // Wait 100ms to give any pending rendering updates time to fire,
+        // then verify the override did not happen.
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        button1 = accessibilityController.accessibleElementById("button1");
+        output += expect("!button1 || !button1.isValid", "true");
+
+        var button2 = accessibilityController.accessibleElementById("button2");
+        output += expect("!button2 || !button2.isValid", "true");
+
+        document.getElementById("content").style.display = "none";
+        debug(output);
+        finishJSTest();
+    })();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/aria-hidden-focus-override-expected.txt
+++ b/LayoutTests/accessibility/aria-hidden-focus-override-expected.txt
@@ -1,0 +1,14 @@
+This tests that focusing inside an aria-hidden region permanently overrides aria-hidden after one animation frame.
+
+PASS: !button1 || !button1.isValid === true
+PASS: !button2 || !button2.isValid === true
+PASS: button2 && button2.isValid === true
+PASS: button1 && button1.isValid === true
+PASS: button1 && button1.isValid === true
+PASS: button2 && button2.isValid === true
+PASS: !button1 || !button1.isValid === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/aria-hidden-focus-override.html
+++ b/LayoutTests/accessibility/aria-hidden-focus-override.html
@@ -1,0 +1,78 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="content">
+<div id="container" aria-hidden="true">
+    <button id="button1">Button 1</button>
+    <button id="button2">Button 2</button>
+</div>
+<button id="outside">Outside</button>
+</div>
+
+<script>
+var output = "This tests that focusing inside an aria-hidden region permanently overrides aria-hidden after one animation frame.\n\n";
+
+if (window.accessibilityController) {
+    jsTestIsAsync = true;
+
+    // Initially, buttons inside aria-hidden should not be accessible.
+    var button1 = accessibilityController.accessibleElementById("button1");
+    output += expect("!button1 || !button1.isValid", "true");
+
+    var button2 = accessibilityController.accessibleElementById("button2");
+    output += expect("!button2 || !button2.isValid", "true");
+
+    // Focus button1 inside the aria-hidden region, then poll for the override
+    // to take effect. The override happens during the post-rendering update
+    // after at least one animation frame with focus still inside the region.
+    // We observe it by checking that button2 (unfocused) becomes accessible.
+    document.getElementById("button1").focus();
+
+    (async function() {
+        await waitFor(() => {
+            button2 = accessibilityController.accessibleElementById("button2");
+            return button2 && button2.isValid;
+        });
+        output += expect("button2 && button2.isValid", "true");
+
+        // Move focus to button2 (still inside the same aria-hidden region).
+        // button1 should remain accessible because the override is permanent.
+        document.getElementById("button2").focus();
+        await waitFor(() => {
+            button1 = accessibilityController.accessibleElementById("button1");
+            return button1 && button1.isValid;
+        });
+        output += expect("button1 && button1.isValid", "true");
+
+        // Move focus completely outside. Both buttons should remain accessible.
+        document.getElementById("outside").focus();
+        await waitFor(() => {
+            return accessibilityController.focusedElement.domIdentifier === "outside";
+        });
+        button1 = accessibilityController.accessibleElementById("button1");
+        output += expect("button1 && button1.isValid", "true");
+        button2 = accessibilityController.accessibleElementById("button2");
+        output += expect("button2 && button2.isValid", "true");
+
+        // Test reset: removing and re-adding aria-hidden should clear the override.
+        document.getElementById("container").removeAttribute("aria-hidden");
+        document.getElementById("container").setAttribute("aria-hidden", "true");
+        await waitFor(() => {
+            button1 = accessibilityController.accessibleElementById("button1");
+            return !button1 || !button1.isValid;
+        });
+        output += expect("!button1 || !button1.isValid", "true");
+
+        document.getElementById("content").style.display = "none";
+        debug(output);
+        finishJSTest();
+    })();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/focusable-inside-hidden-expected.txt
+++ b/LayoutTests/accessibility/focusable-inside-hidden-expected.txt
@@ -1,9 +1,8 @@
-This tests that a focusable object inside an aria-hidden is in the hieararchy only after it gains focus.
+This tests that a focusable object inside an aria-hidden is visible to accessibility when it gains focus.
 
 PASS: !button || !button.isValid === true
 PASS: button.description === 'AXDescription: BUTTON'
 PASS: button.description === 'AXDescription: BUTTON'
-PASS: !button || !button.isValid === true
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/focusable-inside-hidden.html
+++ b/LayoutTests/accessibility/focusable-inside-hidden.html
@@ -15,7 +15,7 @@
 </div>
 
 <script>
-var output = "This tests that a focusable object inside an aria-hidden is in the hieararchy only after it gains focus.\n\n";
+var output = "This tests that a focusable object inside an aria-hidden is visible to accessibility when it gains focus.\n\n";
 
 if (window.accessibilityController) {
     jsTestIsAsync = true;
@@ -41,14 +41,6 @@ if (window.accessibilityController) {
             output += expect("button.title", "'AXTitle: BUTTON'");
         else
             output += expect("button.description", "'AXDescription: BUTTON'");
-
-        // Lose focus and this element should be hidden again.
-        document.getElementById("otherbutton").focus();
-        await waitFor(() => {
-            button = accessibilityController.accessibleElementById("button");
-            return !button || !button.isValid;
-        });
-        output += expect("!button || !button.isValid", "true");
 
         debug(output);
         finishJSTest();

--- a/LayoutTests/platform/glib/accessibility/focusable-inside-hidden-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/focusable-inside-hidden-expected.txt
@@ -1,9 +1,8 @@
-This tests that a focusable object inside an aria-hidden is in the hieararchy only after it gains focus.
+This tests that a focusable object inside an aria-hidden is visible to accessibility when it gains focus.
 
 PASS: !button || !button.isValid === true
 PASS: button.title === 'AXTitle: BUTTON'
 PASS: button.title === 'AXTitle: BUTTON'
-PASS: !button || !button.isValid === true
 
 PASS successfullyParsed is true
 

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2350,6 +2350,63 @@ void AXObjectCache::handleFocusedUIElementChanged(Element* oldElement, Element* 
     setIsolatedTreeFocusedObject(focusedObjectForLocalFrame());
 #endif
     platformHandleFocusedUIElementChanged(getOrCreate(oldElement), getOrCreate(newElement));
+
+    // If focus landed inside an aria-hidden=true region, schedule a check for the next
+    // rendering update. This gives web developers one animation frame (via a focus event
+    // listener and requestAnimationFrame) to move focus out before we permanently override
+    // aria-hidden on the ancestor.
+    if (newElement) {
+        bool isInsideAriaHidden = false;
+        for (RefPtr ancestor = newElement; ancestor; ancestor = ancestor->parentElementInComposedTree()) {
+            if (equalLettersIgnoringASCIICase(ancestor->attributeWithDefaultARIA(aria_hiddenAttr), "true"_s)) {
+                isInsideAriaHidden = true;
+                break;
+            }
+        }
+        if (isInsideAriaHidden) {
+            m_pendingAriaHiddenFocusTarget = newElement;
+            m_needsAriaHiddenFocusCheck = true;
+            // Ensure a rendering update is scheduled so that onPostRenderingUpdate
+            // fires after animation frame callbacks have had a chance to run.
+            if (RefPtr page = this->page())
+                page->scheduleRenderingUpdate(RenderingUpdateStep::EventRegionUpdate);
+        } else {
+            m_pendingAriaHiddenFocusTarget = nullptr;
+            m_needsAriaHiddenFocusCheck = false;
+        }
+    }
+}
+
+void AXObjectCache::onPostRenderingUpdate()
+{
+    if (!m_needsAriaHiddenFocusCheck)
+        return;
+    m_needsAriaHiddenFocusCheck = false;
+
+    RefPtr focusTarget = m_pendingAriaHiddenFocusTarget.get();
+    m_pendingAriaHiddenFocusTarget = nullptr;
+    if (!focusTarget)
+        return;
+
+    // Verify focus is still on the same element.
+    RefPtr currentFocus = document()->focusedElement();
+    if (currentFocus != focusTarget)
+        return;
+
+    // Walk all ancestors, flagging every one that has aria-hidden=true so that the
+    // entire subtree of each becomes permanently visible.
+    for (RefPtr ancestor = focusTarget.get(); ancestor; ancestor = ancestor->parentElementInComposedTree()) {
+        auto tag = ancestor->localName();
+        if (tag == bodyTag || tag == htmlTag)
+            break;
+
+        if (!equalLettersIgnoringASCIICase(ancestor->attributeWithDefaultARIA(aria_hiddenAttr), "true"_s))
+            continue;
+
+        if (RefPtr axObject = getOrCreate(*ancestor))
+            axObject->setShouldIgnoreARIAHidden(true);
+        handleAriaHiddenChange(*ancestor);
+    }
 }
 
 void AXObjectCache::selectedChildrenChanged(Node* node)
@@ -3115,6 +3172,25 @@ void AXObjectCache::handleAriaExpandedChange(Element& element)
     }
 }
 
+void AXObjectCache::handleAriaHiddenChange(Element& element)
+{
+    if (RefPtr axObject = getOrCreate(element)) {
+#if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
+        axObject->recomputeIsIgnoredForDescendants(/* includeSelf */ true);
+#endif
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+        if (RefPtr tree = AXIsolatedTree::treeForFrameID(m_frameID))
+            tree->queueNodeUpdate(axObject->objectID(), { AXProperty::IsARIAHidden });
+#endif
+        updateCachedTextOfAssociatedObjects(*axObject);
+    }
+
+#if !ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
+    if (RefPtr parent = get(element.parentNode()))
+        childrenChanged(parent.get());
+#endif
+}
+
 void AXObjectCache::handleActiveDescendantChange(Element& element, const AtomString& oldValue, const AtomString& newValue)
 {
     AXTRACE("AXObjectCache::handleActiveDescendantChange"_s);
@@ -3555,22 +3631,12 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
     else if (attrName == aria_haspopupAttr)
         postNotification(element, AXNotification::HasPopupChanged);
     else if (attrName == aria_hiddenAttr) {
-        if (RefPtr axObject = getOrCreate(*element)) {
-#if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
-            axObject->recomputeIsIgnoredForDescendants(/* includeSelf */ true);
-#endif // ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
-#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-            if (RefPtr tree = AXIsolatedTree::treeForFrameID(m_frameID))
-                tree->queueNodeUpdate(axObject->objectID(), { AXProperty::IsARIAHidden });
-#endif
-            // aria-hidden can influence the text gathered as part of the accessibility-text algorithm.
-            updateCachedTextOfAssociatedObjects(*axObject);
+        // If aria-hidden was removed or set to a non-true value, clear the permanent override flag.
+        if (!equalLettersIgnoringASCIICase(element->attributeWithDefaultARIA(aria_hiddenAttr), "true"_s)) {
+            if (RefPtr axObject = getOrCreate(*element))
+                axObject->setShouldIgnoreARIAHidden(false);
         }
-
-#if !ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
-        if (RefPtr parent = get(element->parentNode()))
-            childrenChanged(parent.get());
-#endif // !ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
+        handleAriaHiddenChange(*element);
 
         if (RefPtr currentModalElement = m_currentModalElement.get(); currentModalElement && currentModalElement->isDescendantOf(element))
             deferModalChange(*currentModalElement);

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -519,6 +519,7 @@ public:
     void onValidityChange(Element&);
     void onTextCompositionChange(Node&, CompositionState, bool, const String&, size_t, bool);
     void onWidgetVisibilityChanged(RenderWidget&);
+    void onPostRenderingUpdate();
     void valueChanged(Element&);
     void checkedStateChanged(Element&);
     void autofillTypeChanged(HTMLInputElement&);
@@ -941,6 +942,7 @@ private:
     void handleScrollbarUpdate(ScrollView&);
     void handleActiveDescendantChange(Element&, const AtomString&, const AtomString&);
     void handleAriaExpandedChange(Element&);
+    void handleAriaHiddenChange(Element&);
     enum class UpdateModal : bool { No, Yes };
     void handleFocusedUIElementChanged(Element* oldFocus, Element* newFocus, UpdateModal = UpdateModal::Yes);
     void handleRemoteFrameGainedFocus(RemoteFrame&, Element* oldFocusedElement);
@@ -1114,6 +1116,12 @@ private:
     bool m_isSynchronizingSelection { false };
     bool m_performingDeferredCacheUpdate { false };
     double m_loadingProgress { 0 };
+
+    // Tracks focus landing inside an aria-hidden region. After one rendering update
+    // (giving web developers a chance to move focus in a rAF callback), if focus is
+    // still inside the aria-hidden region, the aria-hidden is permanently overridden.
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_pendingAriaHiddenFocusTarget;
+    bool m_needsAriaHiddenFocusCheck { false };
 
     unsigned m_cacheUpdateDeferredCount { 0 };
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -4005,6 +4005,9 @@ bool AccessibilityObject::isARIAHidden() const
     if (isFocused())
         return false;
 
+    if (shouldIgnoreARIAHidden())
+        return false;
+
     RefPtr node = this->node();
     RefPtr element = dynamicDowncast<Element>(node);
     AtomString tag = element ? element->localName() : nullAtom();

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -103,6 +103,19 @@ public:
     AXObjectRareData& ensureRareData();
     bool needsRareData() const { return isTable() || isExposedTableRow(); }
 
+    // Bit flags stored in the uint16_t portion of m_rareDataWithBitfields.
+    static constexpr uint16_t ignoreARIAHiddenBit = 1 << 0;
+    bool shouldIgnoreARIAHidden() const { return m_rareDataWithBitfields.type() & ignoreARIAHiddenBit; }
+    void setShouldIgnoreARIAHidden(bool value)
+    {
+        auto bits = m_rareDataWithBitfields.type();
+        if (value)
+            bits |= ignoreARIAHiddenBit;
+        else
+            bits &= ~ignoreARIAHiddenBit;
+        m_rareDataWithBitfields.setType(bits);
+    }
+
     bool hasDirtySubtree() const { return m_subtreeDirty; }
 
     bool isInDescriptionListDetail() const;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2483,6 +2483,12 @@ void Page::doAfterUpdateRendering()
     }
 #endif
 
+    // Check if focus is still inside an aria-hidden region after rAF callbacks
+    // have had a chance to run. This must happen after AnimationFrameCallbacks
+    // to give web developers a chance to move focus in a focus event handler.
+    if (CheckedPtr axObjectCache = existingAXObjectCache())
+        axObjectCache->onPostRenderingUpdate();
+
     DebugPageOverlays::doAfterUpdateRendering(*this);
 
     m_renderingUpdateRemainingSteps.last().remove(RenderingUpdateStep::PrepareCanvasesForDisplayOrFlush);


### PR DESCRIPTION
#### 75841772426172ad143ea178fd92d3cf49bd2f00
<pre>
AX: align with other browsers on handling of focused elements and aria-hidden
<a href="https://bugs.webkit.org/show_bug.cgi?id=311881">https://bugs.webkit.org/show_bug.cgi?id=311881</a>
<a href="https://rdar.apple.com/174449524">rdar://174449524</a>

Reviewed by Tyler Wilcock.

Discussed here:

<a href="https://github.com/w3c/aria/pull/2181#discussion_r2002079011">https://github.com/w3c/aria/pull/2181#discussion_r2002079011</a>

The consensus seems to be that if focus lands inside an aria-hidden
region, and an event handler doesn&apos;t move focus elsewhere before one
animation frame, then the aria-hidden flag should be ignored and that
region should be essentially permanently un-hidden.

This is essentially a workaround for an authoring error.

Previously, WebKit&apos;s behavior was to ignore aria-hidden when focus was
inside but not persist that change.

Tests: accessibility/aria-hidden-focus-not-overridden-when-caught.html
       accessibility/aria-hidden-focus-override.html

* LayoutTests/accessibility/aria-hidden-focus-not-overridden-when-caught-expected.txt: Added.
* LayoutTests/accessibility/aria-hidden-focus-not-overridden-when-caught.html: Added.
* LayoutTests/accessibility/aria-hidden-focus-override-expected.txt: Added.
* LayoutTests/accessibility/aria-hidden-focus-override.html: Added.
* LayoutTests/accessibility/focusable-inside-hidden-expected.txt:
* LayoutTests/accessibility/focusable-inside-hidden.html:
* LayoutTests/platform/glib/accessibility/focusable-inside-hidden-expected.txt:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleFocusedUIElementChanged):
(WebCore::AXObjectCache::onPostRenderingUpdate):
(WebCore::AXObjectCache::handleAriaHiddenChange):
(WebCore::AXObjectCache::handleAttributeChange):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::isARIAHidden const):
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::shouldIgnoreARIAHidden const):
(WebCore::AccessibilityObject::setShouldIgnoreARIAHidden):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::doAfterUpdateRendering):

Canonical link: <a href="https://commits.webkit.org/311648@main">https://commits.webkit.org/311648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2351089faf120630eaae013153dccd478d07528b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166375 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111633 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159422 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30890 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121994 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85692 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160509 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141463 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102663 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23334 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21591 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14146 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133013 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19291 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168864 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13255 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20911 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130154 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30490 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130265 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35291 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141085 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88410 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25100 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17890 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30123 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/94422 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29645 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29875 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29772 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->