### PR TITLE
Use WeakRef instead of raw pointer for MemoryBackingStoreTransaction::m_originalObjectStoreNames

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
@@ -125,8 +125,8 @@ void MemoryBackingStoreTransaction::objectStoreDeleted(Ref<MemoryObjectStore>&& 
 {
     ASSERT(m_objectStores.contains(&objectStore.get()));
     m_objectStores.remove(&objectStore.get());
-    if (m_originalObjectStoreNames.contains(&objectStore.get()))
-        m_originalObjectStoreNames.remove(&objectStore.get());
+    if (m_originalObjectStoreNames.contains(objectStore.get()))
+        m_originalObjectStoreNames.remove(objectStore.get());
     objectStore->deleteAllIndexes(*this);
 
     // If the store removed is previously added in this transaction, we don't need to
@@ -151,7 +151,7 @@ void MemoryBackingStoreTransaction::objectStoreRenamed(MemoryObjectStore& object
 
     // We only care about the first rename in a given transaction, because if the transaction is aborted we want
     // to go back to the first 'oldName'
-    m_originalObjectStoreNames.add(&objectStore, oldName);
+    m_originalObjectStoreNames.add(objectStore, oldName);
 }
 
 void MemoryBackingStoreTransaction::indexRenamed(MemoryIndex& index, const String& oldName)
@@ -199,8 +199,8 @@ void MemoryBackingStoreTransaction::abort()
     m_originalIndexNames.clear();
 
     // Restore renamed object stores.
-    for (const auto& iterator : m_originalObjectStoreNames)
-        m_backingStore->renameObjectStoreForVersionChangeAbort(Ref { *iterator.key }, iterator.value);
+    for (auto iterator : m_originalObjectStoreNames)
+        protect(m_backingStore)->renameObjectStoreForVersionChangeAbort(iterator.key, iterator.value);
     m_originalObjectStoreNames.clear();
 
     // Restore added object stores.

--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
@@ -35,6 +35,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakHashMap.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -99,7 +100,7 @@ private:
 
     HashMap<String, Ref<MemoryObjectStore>> m_deletedObjectStores;
     HashSet<Ref<MemoryIndex>> m_deletedIndexes;
-    HashMap<MemoryObjectStore*, String> m_originalObjectStoreNames;
+    WeakHashMap<MemoryObjectStore, String> m_originalObjectStoreNames;
     HashMap<Ref<MemoryIndex>, String> m_originalIndexNames;
 
     HashMap<IDBResourceIdentifier, WeakPtr<MemoryCursor>> m_cursors;


### PR DESCRIPTION
#### d2ef3504e98a80fe1b94576d8f9f8d39d75b6753
<pre>
Use WeakRef instead of raw pointer for MemoryBackingStoreTransaction::m_originalObjectStoreNames
<a href="https://bugs.webkit.org/show_bug.cgi?id=311880">https://bugs.webkit.org/show_bug.cgi?id=311880</a>
<a href="https://rdar.apple.com/174449757">rdar://174449757</a>

Reviewed by Ryosuke Niwa and Chris Dumez.

HashMap&lt;MemoryObjectStore*, String&gt; m_originalObjectStoreNames currently uses a raw pointer as key; replace it with
WeakHashMap to avoid potential use-after-free.

* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp:
(WebCore::IDBServer::MemoryBackingStoreTransaction::objectStoreDeleted):
(WebCore::IDBServer::MemoryBackingStoreTransaction::objectStoreRenamed):
(WebCore::IDBServer::MemoryBackingStoreTransaction::abort):
* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h:

Canonical link: <a href="https://commits.webkit.org/311121@main">https://commits.webkit.org/311121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea993eadcc24d628c5061609c8e4444b2089af47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156078 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29413 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/22595 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164899 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157949 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29414 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/120849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23056 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101533 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/12671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/18002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167378 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11494 "Found 1 new failure in Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/19614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/128966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129095 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34967 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/28936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/139796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/28936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28645 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92602 "Found 1 new failure in Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/28400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28296 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->