### PR TITLE
[AutoFill Debugging] Elide the type for extracted text fields when possible

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-all-container-uids-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-all-container-uids-expected.txt
@@ -9,14 +9,14 @@ root
     section uid=…
         button uid=… 'Click Me'
         'This button does nothing'
-        input 'text' uid=… placeholder='Enter text here'
+        input uid=… placeholder='Enter text here'
         'Clickable Div'
     section uid=…
         'Name Field'
         'Description'
-        input 'text' uid=… placeholder='Your name'
+        input uid=… placeholder='Your name'
         'This region is labeled by another element.'
-        input 'text' uid=… placeholder='Full name'
+        input uid=… placeholder='Full name'
         'User Profile'
         'Username:'
-        input 'text' uid=… label=Username:
+        input uid=… label=Username:

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-autofill-button-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-autofill-button-expected.txt
@@ -1,4 +1,4 @@
 root
-	input 'text' placeholder=Username
-	input 'email' placeholder=Email
-	input 'password' placeholder=Password secure
+	input placeholder=Username
+	input placeholder=Email
+	input placeholder=Password secure

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
@@ -9,18 +9,18 @@ root
         section label='Interactive Elements'
             button uid=… describedby='This button does nothing' label='Test button' 'Click Me' […]
             'This button does nothing' […]
-            input 'text' uid=… […] placeholder='Enter text here'
+            input uid=… […] placeholder='Enter text here'
             uid=… role=button 'Clickable Div' […]
         section label='ARIA Labeling Examples'
             'Name Field' […]
             'Description' […]
-            input 'text' uid=… […] labelledby='Name Field' placeholder='Your name'
+            input uid=… […] labelledby='Name Field' placeholder='Your name'
             role=region labelledby=Description 'This region is labeled by another element.' […]
-            input 'text' uid=… […] labelledby='Name Field' placeholder='Full name'
+            input uid=… […] labelledby='Name Field' placeholder='Full name'
             'User Profile' […]
             role=group labelledby='User Profile'
                 'Username:' […]
-                input 'text' uid=… […] label=Username:
+                input uid=… […] label=Username:
         section label='Content with Roles'
             article role=article
                 'Article Title' […]

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2-expected.txt
@@ -9,12 +9,12 @@ root
                 'This is some article content with highlighted text.'
             form autocomplete=on name=signup
                 'Sign up for our newsletter'
-                input 'checkbox' label='Remember me'
+                input checkbox label='Remember me'
                 'Remember me'
-                input 'text' placeholder=Username name=username minlength=3 maxlength=20 required
-                input 'password' placeholder=Password name=password minlength=3 maxlength=20 required secure
-                input 'text' placeholder=Email pattern=[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$ name=email required
-                input 'text' placeholder='Zip Code' pattern=[0-9]{5} name=zipcode minlength=5 maxlength=5
+                input placeholder=Username name=username minlength=3 maxlength=20 required
+                input placeholder=Password name=password minlength=3 maxlength=20 required secure
+                input placeholder=Email pattern=[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$ name=email required
+                input placeholder='Zip Code' pattern=[0-9]{5} name=zipcode minlength=5 maxlength=5
 
 -- html
 

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
@@ -11,7 +11,7 @@ root
         section label='Interactive Elements'
             button describedby='This button does nothing' label='Test button' 'Click Me'
             'This button does nothing'
-            input 'text' uid=… placeholder='Enter text here'
+            input uid=… placeholder='Enter text here'
             role=button title='Test action' 'Clickable Div'
         section label='Content with Roles'
             article role=article
@@ -33,9 +33,9 @@ root
                     link 'webkit.org'
             form autocomplete=on name=signup
                 'Sign up for our newsletter'
-                input 'text' uid=… placeholder=Username name=username minlength=3 maxlength=20 required
-                input 'text' uid=… placeholder=Email pattern=[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$ name=email required
-                input 'text' uid=… placeholder='Zip Code' pattern=[0-9]{5} name=zipcode minlength=5 maxlength=5
+                input uid=… placeholder=Username name=username minlength=3 maxlength=20 required
+                input uid=… placeholder=Email pattern=[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$ name=email required
+                input uid=… placeholder='Zip Code' pattern=[0-9]{5} name=zipcode minlength=5 maxlength=5
             select uid=…
                 option value=one 'Number 1'
                 option value=two 'Number 2'

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields-expected.txt
@@ -1,4 +1,4 @@
 root
-	input 'email' placeholder='Enter your email'
-	input 'password' placeholder='Enter your password' secure
-	input 'number' placeholder='Security code' '123456'
+	input placeholder='Enter your email'
+	input placeholder='Enter your password' secure
+	input number placeholder='Security code' '123456'

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-discretionary-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-discretionary-expected.txt
@@ -8,7 +8,7 @@ root
     section
         button 'Click Me'
         'This button does nothing'
-        input 'text' placeholder='Enter text here'
+        input placeholder='Enter text here'
         'Clickable Div'
     section
         article

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt
@@ -8,7 +8,7 @@ root
     section
         button 'Click Me'
         'This button does nothing'
-        input 'text' placeholder='Enter text here'
+        input placeholder='Enter text here'
         'Clickable Div'
     section
         article

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-offscreen-password-fields-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-offscreen-password-fields-expected.txt
@@ -8,16 +8,16 @@ root
                 'This is some visible content.'
         form autocomplete=on name=login
             'Log in to your account'
-            input 'text' placeholder=Username name=username required
-            input 'password' placeholder=Password name=password required secure
-            input 'password' placeholder='Confirm Password' name=confirm-password required secure
+            input placeholder=Username name=username required
+            input placeholder=Password name=password required secure
+            input placeholder='Confirm Password' name=confirm-password required secure
             button 'Log in'
         'Enter access code'
-        input 'password' placeholder='Access Code' name=access-code secure
+        input password placeholder='Access Code' name=access-code secure
         form autocomplete=on
             'Create account'
-            input 'text' placeholder=User name=user required
-        input 'password' placeholder=Password name=pass required secure
+            input placeholder=User name=user required
+        input placeholder=Password name=pass required secure
 
 -- html
 

--- a/LayoutTests/http/tests/text-extraction/debug-text-extraction-subframes-expected.txt
+++ b/LayoutTests/http/tests/text-extraction/debug-text-extraction-subframes-expected.txt
@@ -6,9 +6,9 @@ root
 				label=Heading 'Hello world'
 				form autocomplete=on
 					label='Sign in with email'
-						input 'email' placeholder='Enter your email'
+						input placeholder='Enter your email'
 						link url=javascript: 'Forgot your email?'
-					input 'password' placeholder='Enter your password' secure
+					input placeholder='Enter your password' secure
 				iframe origin=http://127.0.0.1:8000
 					contentEditable role=textbox focused
 						label=Heading 'Nested subframe'

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -1415,8 +1415,30 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
                 parts.append(WTF::move(tagName));
                 parts.appendVector(partsForItem(item, aggregator, includeRectForParentItem));
 
-                if (!controlData.controlType.isEmpty() && !equalIgnoringASCIICase(controlData.controlType, item.nodeName))
-                    parts.insert(1, makeString('\'', controlData.controlType, '\''));
+                bool shouldIncludeType = [&] {
+                    if (controlData.controlType.isEmpty())
+                        return false;
+
+                    if (equalIgnoringASCIICase(controlData.controlType, item.nodeName))
+                        return false;
+
+                    if (controlData.controlType == "text"_s)
+                        return false;
+
+                    if (controlData.editable.label.containsIgnoringASCIICase(controlData.controlType))
+                        return false;
+
+                    if (controlData.editable.placeholder.containsIgnoringASCIICase(controlData.controlType))
+                        return false;
+
+                    if (controlData.name.containsIgnoringASCIICase(controlData.controlType))
+                        return false;
+
+                    return true;
+                }();
+
+                if (shouldIncludeType)
+                    parts.insert(1, controlData.controlType);
 
                 if (!controlData.autocomplete.isEmpty())
                     parts.append(makeString("autocomplete="_s, quoteValue(controlData.autocomplete, streamlined)));


### PR DESCRIPTION
#### c0f0bacc3806c1c569cd78a452b9543295766d5e
<pre>
[AutoFill Debugging] Elide the type for extracted text fields when possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=311884">https://bugs.webkit.org/show_bug.cgi?id=311884</a>

Reviewed by Abrar Rahman Protyasha, Aditya Keerthi, and Megan Gardner.

Skip adding the `type` attribute for text fields, in the case where they&apos;re redundant with other DOM
attributes. Additionally, remove extraneous quotes around the type string.

* LayoutTests/fast/text-extraction/debug-text-extraction-all-container-uids-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-autofill-button-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-discretionary-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-offscreen-password-fields-expected.txt:
* LayoutTests/http/tests/text-extraction/debug-text-extraction-subframes-expected.txt:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::addPartsForItem):

Canonical link: <a href="https://commits.webkit.org/310903@main">https://commits.webkit.org/310903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af85891715b94649ec81ec443db855dff5511d07

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155365 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164127 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1492a905-78ee-4521-82fc-f803c0e8cbcb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28475 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120234 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1825dcdd-3878-4b2b-9d85-0469c717a32b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158324 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22424 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139518 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100924 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21510 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11956 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131179 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166605 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18960 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128345 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28169 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23655 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128480 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34839 "Found 1 new test failure: fast/block/transparent-outline-with-and-without-border-radius.html (failure)") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28093 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139143 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23673 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23335 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15940 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27787 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91890 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27364 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27594 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27437 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->