### PR TITLE
[Site Isolation] Context menu controlledImageBounds not converted to main-frame coordinates for cross-origin iframes

### DIFF
--- a/Source/WebKit/Shared/ContextMenuContextData.h
+++ b/Source/WebKit/Shared/ContextMenuContextData.h
@@ -126,6 +126,7 @@ public:
     bool isServicesMenu() const { return m_type == ContextMenuContextData::Type::ServicesMenu; }
     bool NODELETE controlledDataIsEditable() const;
     WebCore::IntRect controlledImageBounds() const { return m_controlledImageBounds; };
+    void setControlledImageBounds(WebCore::IntRect bounds) { m_controlledImageBounds = bounds; }
     String controlledImageAttachmentID() const { return m_controlledImageAttachmentID; };
     std::optional<WebCore::ElementContext> controlledImageElementContext() const { return m_controlledImageElementContext; }
     String controlledImageMIMEType() const { return m_controlledImageMIMEType; }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12282,14 +12282,23 @@ void WebPageProxy::showContextMenuFromFrame(FrameInfoData&& frameInfo, ContextMe
     if (!frame)
         return;
 
-    auto menuLocation = contextMenuContextData.menuLocation();
-    convertPointToMainFrameCoordinates(menuLocation, frame->rootFrame()->frameID(), [weakThis = WeakPtr { *this }, contextMenuContextData = WTF::move(contextMenuContextData), userData = WTF::move(userData), frameInfo = WTF::move(frameInfo)] (std::optional<FloatPoint> result) mutable {
+    Vector<FloatRect> rectsToConvert { FloatRect { FloatPoint { contextMenuContextData.menuLocation() }, FloatSize { } } };
+#if ENABLE(SERVICE_CONTROLS)
+    if (!contextMenuContextData.controlledImageBounds().isEmpty())
+        rectsToConvert.append(FloatRect { contextMenuContextData.controlledImageBounds() });
+#endif
+
+    auto rootFrameID = frame->rootFrame()->frameID();
+    convertRectsToMainFrameCoordinates(WTF::move(rectsToConvert), rootFrameID, [weakThis = WeakPtr { *this }, contextMenuContextData = WTF::move(contextMenuContextData), userData = WTF::move(userData), frameInfo = WTF::move(frameInfo)] (std::optional<Vector<FloatRect>> convertedRects) mutable {
         RefPtr protectedThis = weakThis.get();
-        if (!protectedThis)
+        if (!protectedThis || !convertedRects || convertedRects->isEmpty())
             return;
-        if (!result)
-            return;
-        contextMenuContextData.setMenuLocation(IntPoint(*result));
+
+        contextMenuContextData.setMenuLocation(IntPoint(convertedRects->first().location()));
+#if ENABLE(SERVICE_CONTROLS)
+        if (convertedRects->size() > 1)
+            contextMenuContextData.setControlledImageBounds(IntRect(convertedRects->last()));
+#endif
         protectedThis->showContextMenu(WTF::move(frameInfo), WTF::move(contextMenuContextData), userData);
     });
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -8472,6 +8472,91 @@ TEST(SiteIsolation, IframeImageTranslationIfIframeIsAddedAfterTranslationCall)
     gDidProcessRequestCount = 0;
 }
 
+#if ENABLE(SERVICE_CONTROLS)
+
+TEST(SiteIsolation, ImageServiceControlledImageBoundsInCrossOriginIframe)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0'><iframe style='margin: 100px; width: 400px; height: 300px; border: none;' src='https://webkit.org/iframe'></iframe></body>"_s } },
+        { "/iframe"_s, { "<!DOCTYPE html><body style='margin: 0'><img style='margin: 50px; width: 100px; height: 100px;' src='https://webkit.org/image.png'></body>"_s } },
+        { "/image.png"_s, { [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"large-red-square" withExtension:@"png"]] } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = createWebViewConfigurationWithTextRecognitionEnhancements();
+
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
+    [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    enableSiteIsolation(configuration.get());
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+    [[webView window] orderFrontRegardless];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    // Capture the screen-space rect that controlledImageBounds is converted to in setupServicesMenu().
+    __block bool sourceFrameSet = false;
+    __block NSRect capturedSourceFrame = NSZeroRect;
+    InstanceMethodSwizzler sourceFrameSwizzler {
+        NSClassFromString(@"WKSharingServicePickerDelegate"),
+        NSSelectorFromString(@"setSourceFrame:"),
+        imp_implementationWithBlock(^(id, NSRect frame) {
+            capturedSourceFrame = frame;
+            sourceFrameSet = true;
+        })
+    };
+
+    // getAttachmentIdentifier triggers setImageMenuEnabled(true), which causes the
+    // image-controls button to appear in the shadow root.
+    NSString *clickScript =
+        @"const img = document.querySelector('img');"
+        @"HTMLAttachmentElement.getAttachmentIdentifier(img);"
+        @"let button;"
+        @"do {"
+        @"    await new Promise(requestAnimationFrame);"
+        @"    const root = internals.shadowRoot(img);"
+        @"    button = root && root.getElementById('image-controls-button');"
+        @"} while (!button);"
+        @"button.click();";
+    [webView callAsyncJavaScript:clickScript arguments:nil inFrame:[webView firstChildFrame] inContentWorld:WKContentWorld.pageWorld completionHandler:^(id, NSError *error) {
+        EXPECT_NULL(error);
+    }];
+
+    // If the picker menu pops up (machines with registered image sharing services), dismiss it
+    // so we don't block in event-tracking mode.
+    RetainPtr cancelMenuTimer = [NSTimer timerWithTimeInterval:0.1 repeats:YES block:^(NSTimer *) {
+        if (NSMenu *menu = [webView _activeMenu])
+            [menu cancelTracking];
+    }];
+    [NSRunLoop.mainRunLoop addTimer:cancelMenuTimer.get() forMode:NSEventTrackingRunLoopMode];
+
+    // setSourceFrame: is called before popUpMenuPositioningItem:, so capturing it is sufficient.
+    bool *sourceFrameSetPtr = &sourceFrameSet;
+    EXPECT_TRUE(TestWebKitAPI::Util::waitFor([sourceFrameSetPtr] {
+        return *sourceFrameSetPtr;
+    }, 100));
+    [cancelMenuTimer invalidate];
+
+    // Image at (50, 50) in iframe coords + iframe at (100, 100) → (150, 150) in main frame.
+    NSRect expectedInWebView = NSMakeRect(150, 150, 100, 100);
+    NSRect expectedInWindow = [webView convertRect:expectedInWebView toView:nil];
+    NSRect expectedOnScreen = [[webView window] convertRectToScreen:expectedInWindow];
+    // Use a tolerance rather than exact equality: the coordinates round-trip through cross-process
+    // ContentsToRootViewRect IPC and window→screen conversion, which can introduce sub-pixel error.
+    EXPECT_NEAR(capturedSourceFrame.origin.x, expectedOnScreen.origin.x, 1);
+    EXPECT_NEAR(capturedSourceFrame.origin.y, expectedOnScreen.origin.y, 1);
+    EXPECT_NEAR(capturedSourceFrame.size.width, expectedOnScreen.size.width, 1);
+    EXPECT_NEAR(capturedSourceFrame.size.height, expectedOnScreen.size.height, 1);
+}
+
+#endif // ENABLE(SERVICE_CONTROLS)
+
 #endif // ENABLE(IMAGE_ANALYSIS)
 
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### 68d067fe56405b9ce60d0d21e21dbec844c7bca5
<pre>
[Site Isolation] Context menu controlledImageBounds not converted to main-frame coordinates for cross-origin iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=311885">https://bugs.webkit.org/show_bug.cgi?id=311885</a>
<a href="https://rdar.apple.com/174452222">rdar://174452222</a>

Reviewed by Alex Christensen.

When an image service click (image controls button) is triggered on an image
inside a site-isolated cross-origin iframe, the controlledImageBounds in
ContextMenuContextData contains coordinates relative to the subframe&apos;s content
area. In setupServicesMenu(), this rect is treated as if it were in main-frame
coordinates, causing the NSSharingServicePicker source frame to be wrong — the
sharing/markup popover appears at the wrong position.

The menuLocation point was already being converted to main-frame coordinates.
This patch converts the menuLocation and controlledImageBounds together in a
single convertRectsToMainFrameCoordinates roundtrip, staging the menuLocation as
a zero-size rect and appending controlledImageBounds when it is non-empty (like
for image service clicks).

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm

* Source/WebKit/Shared/ContextMenuContextData.h:
(WebKit::ContextMenuContextData::setControlledImageBounds):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::showContextMenuFromFrame):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, ImageServiceControlledImageBoundsInCrossOriginIframe)):

Canonical link: <a href="https://commits.webkit.org/316656@main">https://commits.webkit.org/316656@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55473f2de10d47c297391fdccfff839944597d53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172293 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181745 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129849 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7184ec2c-8fc1-4aba-a1cd-efc518ba084b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174158 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45948 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134005 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94535 "21 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/81f96ce8-7505-4aab-9cd5-d3eaa75194e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175251 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37432 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154546 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114476 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0da4c295-f30f-41e5-8ef4-80ca4e7c7046) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36066 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34406 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30350 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146496 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184278 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38609 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142771 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45883 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142652 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38684 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46561 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30899 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111288 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37718 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118312 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45078 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8999 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44478 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44710 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44537 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->