### PR TITLE
:has(:empty) still applied after the content is changed to not be empty

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/empty-pseudo-in-has-display-none-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/empty-pseudo-in-has-display-none-expected.txt
@@ -1,0 +1,13 @@
+This should be visible after the child div gets content.
+
+content
+
+PASS Initially hidden because #child is :empty
+PASS Visible after inserting text into #child
+PASS Hidden after inserting empty element into #child
+PASS Visible after inserting text into empty #child
+PASS Hidden again after removing all children from #child
+PASS Visible again after inserting text into empty #child
+PASS Hidden again after clearing text from #child
+PASS Visible after inserting non-empty element into #child
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/empty-pseudo-in-has-display-none.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/empty-pseudo-in-has-display-none.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Selectors Invalidation: :empty in :has() with display:none</title>
+<link rel="author" title="Simon Fraser" href="smfr@apple.com">
+<link rel="help" href="https://drafts.csswg.org/selectors/#relational">
+<link rel="help" href="https://drafts.csswg.org/selectors/#empty-pseudo">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #subject {
+    color: green;
+  }
+  #subject:has(:empty) {
+    display: none;
+  }
+</style>
+<div id="subject">
+  <p>This should be visible after the child div gets content.</p>
+  <div id="child"></div>
+</div>
+<script>
+const subject = document.getElementById("subject");
+const child = document.getElementById("child");
+
+function testVisibility(test_name, expectVisible) {
+  test(function() {
+    const rect = subject.getBoundingClientRect();
+    if (expectVisible) {
+      assert_not_equals(getComputedStyle(subject).display, "none", "display should not be none");
+      assert_greater_than(rect.width, 0, "width should be greater than 0");
+      assert_greater_than(rect.height, 0, "height should be greater than 0");
+    } else {
+      assert_equals(getComputedStyle(subject).display, "none", "display should be none");
+    }
+  }, test_name);
+}
+
+testVisibility("Initially hidden because #child is :empty", false);
+
+child.textContent = "text";
+testVisibility("Visible after inserting text into #child", true);
+
+{
+  let inner = document.createElement("div");
+  child.appendChild(inner);
+}
+testVisibility("Hidden after inserting empty element into #child", false);
+
+child.textContent = "text";
+testVisibility("Visible after inserting text into empty #child", true);
+
+child.replaceChildren();
+testVisibility("Hidden again after removing all children from #child", false);
+
+child.textContent = "text";
+testVisibility("Visible again after inserting text into empty #child", true);
+
+child.textContent = "";
+testVisibility("Hidden again after clearing text from #child", false);
+
+{
+  let inner = document.createElement("div");
+  inner.textContent = "content";
+  child.appendChild(inner);
+}
+testVisibility("Visible after inserting non-empty element into #child", true);
+</script>

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -132,8 +132,8 @@ void ChildChangeInvalidation::invalidateForHasBeforeMutation()
         invalidateForChangedElement(changedElement, matchingHasSelectors, ChangedElementRelation::SelfOrDescendant);
     });
 
-    // :empty is affected by text changes.
-    if (m_childChange.type == ContainerNode::ChildChange::Type::TextRemoved || m_childChange.type == ContainerNode::ChildChange::Type::AllChildrenRemoved)
+    // :empty is affected by child changes.
+    if (m_wasEmpty ? m_childChange.isInsertion() : !m_childChange.isInsertion())
         invalidateForChangedElement(parentElement(), matchingHasSelectors, ChangedElementRelation::SelfOrDescendant);
 
     auto firstChildStateWillStopMatching = [&] {
@@ -187,8 +187,7 @@ void ChildChangeInvalidation::invalidateForHasAfterMutation()
         invalidateForChangedElement(changedElement, matchingHasSelectors, ChangedElementRelation::SelfOrDescendant);
     });
 
-    // :empty is affected by text changes.
-    if (m_childChange.type == ContainerNode::ChildChange::Type::TextInserted && m_wasEmpty)
+    if (!m_childChange.isInsertion() && !parentElement().hasChildNodes())
         invalidateForChangedElement(parentElement(), matchingHasSelectors, ChangedElementRelation::SelfOrDescendant);
 
     auto firstChildStateWillStartMatching = [&](Element* elementAfterChange) {


### PR DESCRIPTION
#### 351ec3413efd3a4a9513bddccd9a52ff779455de
<pre>
:has(:empty) still applied after the content is changed to not be empty
<a href="https://bugs.webkit.org/show_bug.cgi?id=286403">https://bugs.webkit.org/show_bug.cgi?id=286403</a>
<a href="https://rdar.apple.com/143864358">rdar://143864358</a>

Reviewed by NOBODY (OOPS!).

`invalidateForHasBeforeMutation()` has to invalidate for both insertions and deletions,
and `invalidateForHasAfterMutation()` has to invalidate when a deletion removed all children
for `:has(:empty)` to be invalidated correctly.

Test: imported/w3c/web-platform-tests/css/selectors/invalidation/empty-pseudo-in-has-display-none.html

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/empty-pseudo-in-has-display-none-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/empty-pseudo-in-has-display-none.html: Added.
* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::ChildChangeInvalidation::invalidateForHasBeforeMutation):
(WebCore::Style::ChildChangeInvalidation::invalidateForHasAfterMutation):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/351ec3413efd3a4a9513bddccd9a52ff779455de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164138 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157249 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28486 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120246 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139533 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100936 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/47ba9000-daae-4d20-8e82-95f8f888713b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21530 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19631 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11967 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131199 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166616 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10784 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18975 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128355 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28180 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128491 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28104 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139158 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85489 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23328 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15955 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27798 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91901 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27375 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27605 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27448 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->