### PR TITLE
[JSC] RegExp exec/test should reload internal RegExp after ToLength(lastIndex)

### DIFF
--- a/JSTests/stress/regexp-exec-compile-in-lastindex-tolength.js
+++ b/JSTests/stress/regexp-exec-compile-in-lastindex-tolength.js
@@ -1,0 +1,46 @@
+function shouldBe(a, e, m) { if (a !== e) throw new Error(m + ": got " + a + ", expected " + e); }
+
+function testExec() {
+    let r = /a/g;
+    let called = 0;
+    r.lastIndex = { valueOf() { called++; r.compile("b", "g"); return 0; } };
+    let m = r.exec("b");
+    shouldBe(called, 1, "exec valueOf called once");
+    shouldBe(m && m[0], "b", "exec uses recompiled pattern");
+    shouldBe(r.lastIndex, 1, "exec lastIndex updated");
+}
+
+function testTest() {
+    let r = /a/g;
+    r.lastIndex = { valueOf() { r.compile("b", "g"); return 0; } };
+    shouldBe(r.test("b"), true, "test uses recompiled pattern");
+}
+
+function testFlagsChange() {
+    let r = /x/;
+    r.lastIndex = { valueOf() { r.compile("x", "g"); return 2; } };
+    let m = r.exec("__x");
+    shouldBe(m && m[0], "x", "exec matches");
+    shouldBe(r.lastIndex, 3, "non-global -> global: lastIndex updated");
+}
+
+function testFlagsChangeReverse() {
+    let r = /x/g;
+    r.lastIndex = { valueOf() { r.compile("x", ""); return 5; } };
+    let m = r.exec("x____");
+    shouldBe(m && m.index, 0, "global -> non-global: matches from 0");
+}
+
+function testNonGlobal() {
+    let r = /a/;
+    r.lastIndex = { valueOf() { r.compile("b"); return 0; } };
+    shouldBe(r.exec("b")[0], "b", "non-global exec uses recompiled");
+}
+
+for (let i = 0; i < testLoopCount; ++i) {
+    testExec();
+    testTest();
+    testFlagsChange();
+    testFlagsChangeReverse();
+    testNonGlobal();
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -882,12 +882,6 @@ test/staging/sm/PrivateName/modify-non-extensible.js:
 test/staging/sm/Proxy/revoked-get-function-realm-typeerror.js:
   default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
-test/staging/sm/RegExp/match-local-tolength-recompilation.js:
-  default: 'Test262Error: Expected SameValue(«false», «true») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«false», «true») to be true'
-test/staging/sm/RegExp/replace-local-tolength-recompilation.js:
-  default: 'Test262Error: Expected SameValue(«"b"», «"pass"») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«"b"», «"pass"») to be true'
 test/staging/sm/RegExp/replace-sticky-lastIndex.js:
   default: 'Test262Error: Expected SameValue(«"b"», «"a"») to be true'
   strict mode: 'Test262Error: Expected SameValue(«"b"», «"a"») to be true'

--- a/Source/JavaScriptCore/runtime/RegExpObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpObjectInlines.h
@@ -92,13 +92,14 @@ ALWAYS_INLINE JSValue RegExpObject::execInline(JSGlobalObject* globalObject, JSS
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    RegExp* regExp = this->regExp();
     auto input = string->view(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    bool globalOrSticky = regExp->globalOrSticky();
     unsigned lastIndex = getRegExpObjectLastIndexAsUnsigned(globalObject, this, input);
     RETURN_IF_EXCEPTION(scope, { });
+
+    RegExp* regExp = this->regExp();
+    bool globalOrSticky = regExp->globalOrSticky();
     if (lastIndex == UINT_MAX && globalOrSticky) {
         scope.release();
         setLastIndex(globalObject, 0);
@@ -131,12 +132,13 @@ ALWAYS_INLINE MatchResult RegExpObject::matchInline(JSGlobalObject* globalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    RegExp* regExp = this->regExp();
     auto input = string->view(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
     unsigned lastIndex = getRegExpObjectLastIndexAsUnsigned(globalObject, this, input);
     RETURN_IF_EXCEPTION(scope, { });
+
+    RegExp* regExp = this->regExp();
     if (!regExp->global() && !regExp->sticky()) {
         scope.release();
         return globalObject->regExpGlobalData().performMatch(globalObject, regExp, string, input, 0);


### PR DESCRIPTION
#### 24d4993f2796629fa71bde310c84c4a13340c5e3
<pre>
[JSC] RegExp exec/test should reload internal RegExp after ToLength(lastIndex)
<a href="https://bugs.webkit.org/show_bug.cgi?id=311887">https://bugs.webkit.org/show_bug.cgi?id=311887</a>

Reviewed by Yusuke Suzuki.

RegExpBuiltinExec performs ToLength on lastIndex before reading
[[OriginalFlags]] and invoking [[RegExpMatcher]] [1]. When lastIndex is an
object whose valueOf calls RegExp.prototype.compile on the receiver, the
internal RegExp is replaced. RegExpObject::execInline and matchInline
were caching this-&gt;regExp() and the global/sticky flags before resolving
lastIndex, so they matched against the stale pattern and flags.

Load the internal RegExp after getRegExpObjectLastIndexAsUnsigned. The
common path where lastIndex is already a UInt32 executes the same loads
in a different order, with no extra work.

[1]: <a href="https://tc39.es/ecma262/#sec-regexpbuiltinexec">https://tc39.es/ecma262/#sec-regexpbuiltinexec</a>

Test: JSTests/stress/regexp-exec-compile-in-lastindex-tolength.js

* JSTests/stress/regexp-exec-compile-in-lastindex-tolength.js: Added.
(shouldBe):
(testExec):
(testTest):
(testFlagsChange):
(testFlagsChangeReverse):
(testNonGlobal):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/RegExpObjectInlines.h:
(JSC::RegExpObject::execInline):
(JSC::RegExpObject::matchInline):

Canonical link: <a href="https://commits.webkit.org/310887@main">https://commits.webkit.org/310887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4b47f93273ffc5fc544a9fc582c7c8844fcd5ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164139 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120249 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22435 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/139532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100939 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11968 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147427 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166617 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16208 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18974 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/128357 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28181 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128493 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34829 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28105 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139157 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23329 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187262 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27799 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/91902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48012 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27376 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/27606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27449 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->