### PR TITLE
[JSC] Avoid rope resolution for single-char `startsWith` / `endsWith`

### DIFF
--- a/JSTests/microbenchmarks/rope-single-char-endsWith.js
+++ b/JSTests/microbenchmarks/rope-single-char-endsWith.js
@@ -1,0 +1,15 @@
+// (a + b) creates a fresh shallow rope each iteration; the single-char fast
+// path in endsWith uses JSString::tryGetCharAt to avoid resolving it.
+let base = "x".padEnd(1000, "hello ");
+base.charCodeAt(0);
+
+function testHit(a, b) { return (a + b).endsWith("d"); }
+noInline(testHit);
+
+function testMiss(a, b) { return (a + b).endsWith("?"); }
+noInline(testMiss);
+
+for (let i = 0; i < 1e5; ++i) {
+    testHit(base, "world");
+    testMiss(base, "world");
+}

--- a/JSTests/microbenchmarks/rope-single-char-startsWith.js
+++ b/JSTests/microbenchmarks/rope-single-char-startsWith.js
@@ -1,0 +1,15 @@
+// (a + b) creates a fresh shallow rope each iteration; the single-char fast
+// path in startsWith uses JSString::tryGetCharAt to avoid resolving it.
+let base = "-".padEnd(1000, "hello ");
+base.charCodeAt(0);
+
+function testHit(a, b) { return (a + b).startsWith("-"); }
+noInline(testHit);
+
+function testMiss(a, b) { return (a + b).startsWith("z"); }
+noInline(testMiss);
+
+for (let i = 0; i < 1e5; ++i) {
+    testHit(base, "world");
+    testMiss(base, "world");
+}

--- a/JSTests/stress/string-starts-ends-with-rope-single-char.js
+++ b/JSTests/stress/string-starts-ends-with-rope-single-char.js
@@ -1,0 +1,96 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("expected " + expected + " but got " + actual);
+}
+
+// Shallow rope (resolved + resolved), no position arg.
+{
+    let base = "A".padEnd(500, "x");
+    base.charCodeAt(0);
+    function sw(a, b, c) { return (a + b).startsWith(c); }
+    noInline(sw);
+    function ew(a, b, c) { return (a + b).endsWith(c); }
+    noInline(ew);
+    for (let i = 0; i < 1e4; ++i) {
+        shouldBe(sw(base, "TAIL", "A"), true);
+        shouldBe(sw(base, "TAIL", "x"), false);
+        shouldBe(sw(base, "TAIL", "T"), false);
+        shouldBe(ew(base, "TAIL", "L"), true);
+        shouldBe(ew(base, "TAIL", "x"), false);
+        shouldBe(ew(base, "TAIL", "I"), false);
+    }
+}
+
+// With position / endPosition (DFG WithIndex / WithEndPosition operations).
+{
+    let base = "ABC".padEnd(500, "x");
+    base.charCodeAt(0);
+    function swp(a, b, c, p) { return (a + b).startsWith(c, p); }
+    noInline(swp);
+    function ewp(a, b, c, p) { return (a + b).endsWith(c, p); }
+    noInline(ewp);
+    for (let i = 0; i < 1e4; ++i) {
+        shouldBe(swp(base, "TAIL", "B", 1), true);
+        shouldBe(swp(base, "TAIL", "B", 2), false);
+        shouldBe(swp(base, "TAIL", "L", 503), true);
+        shouldBe(swp(base, "TAIL", "?", 999), false);
+        shouldBe(swp(base, "TAIL", "A", -5), true);
+        shouldBe(ewp(base, "TAIL", "A", 1), true);
+        shouldBe(ewp(base, "TAIL", "B", 1), false);
+        shouldBe(ewp(base, "TAIL", "?", 0), false);
+        shouldBe(ewp(base, "TAIL", "?", -5), false);
+        shouldBe(ewp(base, "TAIL", "L", 999), true);
+    }
+}
+
+// Nested rope: first fiber is itself a rope -> tryGetCharAt returns nullopt
+// for index 0 (slow-path fallback), but last fiber is resolved so endsWith
+// still takes the fast path.
+{
+    let base = "A".padEnd(500, "x");
+    base.charCodeAt(0);
+    function sw(r, c) { return r.startsWith(c); }
+    noInline(sw);
+    function ew(r, c) { return r.endsWith(c); }
+    noInline(ew);
+    for (let i = 0; i < 1e4; ++i) {
+        let deep = (base + "Y") + "Z";
+        shouldBe(sw(deep, "A"), true);
+        shouldBe(sw(deep, "Z"), false);
+        shouldBe(ew(deep, "Z"), true);
+        shouldBe(ew(deep, "Y"), false);
+    }
+}
+
+// Substring rope as receiver (top-level isSubstring branch).
+{
+    let big = "Q".padEnd(1000, "abc");
+    big.charCodeAt(0);
+    function sw(s, c) { return s.startsWith(c); }
+    noInline(sw);
+    function ew(s, c) { return s.endsWith(c); }
+    noInline(ew);
+    for (let i = 0; i < 1e4; ++i) {
+        let sub = big.substring(1, 700);
+        shouldBe(sw(sub, "a"), true);
+        shouldBe(sw(sub, "Q"), false);
+        shouldBe(ew(sub, "c"), true);
+        shouldBe(ew(sub, "a"), false);
+    }
+}
+
+// 16-bit search character.
+{
+    let base = "\u3042".padEnd(500, "x");
+    base.charCodeAt(0);
+    function sw(a, b, c) { return (a + b).startsWith(c); }
+    noInline(sw);
+    function ew(a, b, c) { return (a + b).endsWith(c); }
+    noInline(ew);
+    for (let i = 0; i < 1e4; ++i) {
+        shouldBe(sw(base, "\u3044", "\u3042"), true);
+        shouldBe(sw(base, "\u3044", "\u3044"), false);
+        shouldBe(ew(base, "\u3044", "\u3044"), true);
+        shouldBe(ew(base, "\u3044", "x"), false);
+    }
+}

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3473,10 +3473,15 @@ JSC_DEFINE_JIT_OPERATION(operationStringStartsWith, bool, (JSGlobalObject* globa
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto baseView = base->view(globalObject);
+    auto prefixView = prefix->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, false);
 
-    auto prefixView = prefix->view(globalObject);
+    if (prefixView->length() == 1 && base->isRope() && base->length() >= JSString::minLengthForRopeWalk) {
+        if (auto character = base->tryGetCharAt(globalObject, 0))
+            OPERATION_RETURN(scope, *character == prefixView[0]);
+    }
+
+    auto baseView = base->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, false);
 
     OPERATION_RETURN(scope, baseView->startsWith(prefixView));
@@ -3490,16 +3495,23 @@ JSC_DEFINE_JIT_OPERATION(operationStringStartsWithWithIndex, bool, (JSGlobalObje
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto baseView = base->view(globalObject);
-    OPERATION_RETURN_IF_EXCEPTION(scope, false);
-
     auto prefixView = prefix->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, false);
 
-    int32_t length = baseView->length();
+    unsigned length = base->length();
     unsigned start = 0;
     if (position >= 0)
         start = std::min<uint32_t>(position, length);
+
+    if (prefixView->length() == 1 && base->isRope() && length >= JSString::minLengthForRopeWalk) {
+        if (start >= length)
+            OPERATION_RETURN(scope, false);
+        if (auto character = base->tryGetCharAt(globalObject, start))
+            OPERATION_RETURN(scope, *character == prefixView[0]);
+    }
+
+    auto baseView = base->view(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, false);
 
     OPERATION_RETURN(scope, baseView->hasInfixStartingAt(prefixView, start));
 }
@@ -3512,10 +3524,15 @@ JSC_DEFINE_JIT_OPERATION(operationStringEndsWith, bool, (JSGlobalObject* globalO
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto baseView = base->view(globalObject);
+    auto suffixView = suffix->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, false);
 
-    auto suffixView = suffix->view(globalObject);
+    if (suffixView->length() == 1 && base->isRope() && base->length() >= JSString::minLengthForRopeWalk) {
+        if (auto character = base->tryGetCharAt(globalObject, base->length() - 1))
+            OPERATION_RETURN(scope, *character == suffixView[0]);
+    }
+
+    auto baseView = base->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, false);
 
     OPERATION_RETURN(scope, baseView->endsWith(suffixView));
@@ -3529,10 +3546,19 @@ JSC_DEFINE_JIT_OPERATION(operationStringEndsWithWithEndPosition, bool, (JSGlobal
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto baseView = base->view(globalObject);
+    auto suffixView = suffix->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, false);
 
-    auto suffixView = suffix->view(globalObject);
+    if (suffixView->length() == 1 && base->isRope() && base->length() >= JSString::minLengthForRopeWalk) {
+        unsigned length = base->length();
+        unsigned end = endPosition >= 0 ? std::min<uint32_t>(endPosition, length) : 0;
+        if (!end)
+            OPERATION_RETURN(scope, false);
+        if (auto character = base->tryGetCharAt(globalObject, end - 1))
+            OPERATION_RETURN(scope, *character == suffixView[0]);
+    }
+
+    auto baseView = base->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, false);
 
     int32_t length = baseView->length();

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -282,6 +282,7 @@ public:
 
     ALWAYS_INLINE JSString* tryReplaceOneChar(JSGlobalObject*, char16_t, JSString* replacement);
     inline std::optional<size_t> tryFindOneChar(JSGlobalObject*, char16_t character, unsigned& startPosition) const;
+    ALWAYS_INLINE std::optional<char16_t> tryGetCharAt(JSGlobalObject*, unsigned index) const;
 
     bool isSubstring() const;
 protected:

--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -221,6 +221,41 @@ std::optional<size_t> JSString::tryFindOneChar(JSGlobalObject*, char16_t charact
     return WTF::notFound;
 }
 
+ALWAYS_INLINE std::optional<char16_t> JSString::tryGetCharAt(JSGlobalObject*, unsigned index) const
+{
+    ASSERT(isRope());
+    ASSERT(index < length());
+
+    if (isSubstring()) {
+        const JSRopeString* substringRope = static_cast<const JSRopeString*>(this);
+        return StringView(substringRope->substringBase()->valueInternal())[substringRope->substringOffset() + index];
+    }
+
+    const JSRopeString* rope = static_cast<const JSRopeString*>(this);
+    unsigned offset = 0;
+    for (unsigned i = 0; i < JSRopeString::s_maxInternalRopeLength; ++i) {
+        JSString* fiber = rope->fiber(i);
+        ASSERT(fiber);
+        unsigned fiberLength = fiber->length();
+        if (index >= offset + fiberLength) {
+            offset += fiberLength;
+            continue;
+        }
+
+        unsigned localIndex = index - offset;
+        if (!fiber->isRope())
+            return StringView(fiber->valueInternal())[localIndex];
+        if (fiber->isSubstring()) {
+            const JSRopeString* substringFiber = static_cast<const JSRopeString*>(fiber);
+            return StringView(substringFiber->substringBase()->valueInternal())[substringFiber->substringOffset() + localIndex];
+        }
+        return std::nullopt;
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+    return std::nullopt;
+}
+
 template<typename StringType>
 inline JSValue jsMakeNontrivialString(VM& vm, StringType&& string)
 {

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -1348,9 +1348,6 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncStartsWith, (JSGlobalObject* globalObjec
     auto* string = thisValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto stringToSearchIn = string->view(globalObject);
-    RETURN_IF_EXCEPTION(scope, { });
-
     JSValue a0 = callFrame->argument(0);
     bool isRegularExpression = isRegExp(vm, globalObject, a0);
     RETURN_IF_EXCEPTION(scope, { });
@@ -1360,11 +1357,8 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncStartsWith, (JSGlobalObject* globalObjec
     auto* search = a0.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto searchString = search->view(globalObject);
-    RETURN_IF_EXCEPTION(scope, { });
-
     JSValue positionArg = callFrame->argument(1);
-    unsigned length = stringToSearchIn->length();
+    unsigned length = string->length();
     unsigned start;
     if (positionArg.isInt32())
         start = std::min(clampTo<unsigned>(positionArg.asInt32()), length);
@@ -1372,6 +1366,20 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncStartsWith, (JSGlobalObject* globalObjec
         start = clampAndTruncateToUnsigned(positionArg.toIntegerOrInfinity(globalObject), 0, length);
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
     }
+
+    auto searchString = search->view(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if (searchString->length() == 1 && string->isRope() && length >= JSString::minLengthForRopeWalk) {
+        if (start >= length)
+            return JSValue::encode(jsBoolean(false));
+
+        if (auto character = string->tryGetCharAt(globalObject, start))
+            return JSValue::encode(jsBoolean(*character == searchString[0]));
+    }
+
+    auto stringToSearchIn = string->view(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
 
     return JSValue::encode(jsBoolean(stringToSearchIn->hasInfixStartingAt(searchString, start)));
 }
@@ -1388,9 +1396,6 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncEndsWith, (JSGlobalObject* globalObject,
     auto* string = thisValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto stringToSearchIn = string->view(globalObject);
-    RETURN_IF_EXCEPTION(scope, { });
-
     JSValue a0 = callFrame->argument(0);
     bool isRegularExpression = isRegExp(vm, globalObject, a0);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
@@ -1400,11 +1405,8 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncEndsWith, (JSGlobalObject* globalObject,
     auto* search = a0.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto searchString = search->view(globalObject);
-    RETURN_IF_EXCEPTION(scope, { });
-
     JSValue endPositionArg = callFrame->argument(1);
-    unsigned length = stringToSearchIn->length();
+    unsigned length = string->length();
     unsigned end;
     if (endPositionArg.isUndefined())
         end = length;
@@ -1414,6 +1416,20 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncEndsWith, (JSGlobalObject* globalObject,
         end = clampAndTruncateToUnsigned(endPositionArg.toIntegerOrInfinity(globalObject), 0, length);
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
     }
+
+    auto searchString = search->view(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if (searchString->length() == 1 && string->isRope() && length >= JSString::minLengthForRopeWalk) {
+        if (!end)
+            return JSValue::encode(jsBoolean(false));
+
+        if (auto character = string->tryGetCharAt(globalObject, end - 1))
+            return JSValue::encode(jsBoolean(*character == searchString[0]));
+    }
+
+    auto stringToSearchIn = string->view(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
 
     return JSValue::encode(jsBoolean(stringToSearchIn->hasInfixEndingAt(searchString, end)));
 }


### PR DESCRIPTION
#### fa83cf53f871966898862ed6dc7c08e51519de64
<pre>
[JSC] Avoid rope resolution for single-char `startsWith` / `endsWith`
<a href="https://bugs.webkit.org/show_bug.cgi?id=311891">https://bugs.webkit.org/show_bug.cgi?id=311891</a>

Reviewed by Yusuke Suzuki.

When the search string is a single character and the receiver is a rope
longer than minLengthForRopeWalk, we only need one character from the
rope to answer startsWith / endsWith. Resolving the whole rope just to
read that one character is wasteful.

This patch adds JSString::tryGetCharAt(), a sibling of tryFindOneChar()
that walks at most one level of fibers and returns the character at the
requested index.

                                     TipOfTree                  Patched

rope-single-char-startsWith       14.0873+-1.8901     ^      1.5065+-0.0736        ^ definitely 9.3512x faster
rope-single-char-endsWith         13.5408+-0.2436     ^      1.5653+-0.0427        ^ definitely 8.6505x faster

Tests: JSTests/microbenchmarks/rope-single-char-endsWith.js
       JSTests/microbenchmarks/rope-single-char-startsWith.js
       JSTests/stress/string-starts-ends-with-rope-single-char.js

* JSTests/microbenchmarks/rope-single-char-endsWith.js: Added.
(testHit):
(testMiss):
* JSTests/microbenchmarks/rope-single-char-startsWith.js: Added.
(testHit):
(testMiss):
* JSTests/stress/string-starts-ends-with-rope-single-char.js: Added.
(shouldBe):
(throw.new.Error.sw):
(throw.new.Error.ew):
(throw.new.Error):
(shouldBe.swp):
(shouldBe.ewp):
(shouldBe.sw):
(shouldBe.ew):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/JSString.h:
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::JSString::tryGetCharAt const):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/311521@main">https://commits.webkit.org/311521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b58077add83505e00e74e76c8ebf053d6352726

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30310 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165797 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111056 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30313 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121577 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85363 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140962 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102245 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22860 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21092 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13569 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149024 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132541 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168282 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17809 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12441 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129696 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25170 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129804 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35216 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29835 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140584 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87639 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24627 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17388 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188936 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29546 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93560 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48509 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29068 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29298 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29194 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->