### PR TITLE
calc() with percentage in margin/padding should resolve with 0% basis during intrinsic sizing

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4508,7 +4508,6 @@ imported/w3c/web-platform-tests/css/css-sizing/fit-content-length-percentage-014
 imported/w3c/web-platform-tests/css/css-sizing/fit-content-length-percentage-015.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-sizing/fit-content-length-percentage-016.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-sizing/hori-block-size-small-or-larger-than-container-with-min-or-max-content-1.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-sizing/inline-intrinsic-size-calc.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-sizing/max-content-input-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-sizing/replaced-aspect-ratio-intrinsic-size-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-sizing/vert-block-size-small-or-larger-than-container-with-min-or-max-content-1.html [ ImageOnlyFailure ]

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -106,10 +106,12 @@ static LayoutUnit usedValueOrZero(const Style::MarginEdge& marginEdge, std::opti
     if (auto fixed = marginEdge.tryFixed())
         return LayoutUnit { fixed->resolveZoom(zoomFactor) };
 
-    if (marginEdge.isAuto() || !availableWidth)
+    if (marginEdge.isAuto())
         return { };
 
-    return Style::evaluateMinimum<LayoutUnit>(marginEdge, *availableWidth, zoomFactor);
+    // During intrinsic sizing availableWidth is nullopt; resolve cyclic
+    // percentages with a 0 basis so that calc(0% + 30px) yields 30px.
+    return Style::evaluateMinimum<LayoutUnit>(marginEdge, availableWidth.value_or(0_lu), zoomFactor);
 }
 
 static LayoutUnit usedValueOrZero(const Style::PaddingEdge& paddingEdge, std::optional<LayoutUnit> availableWidth, Style::ZoomFactor usedZoom)
@@ -117,10 +119,9 @@ static LayoutUnit usedValueOrZero(const Style::PaddingEdge& paddingEdge, std::op
     if (auto fixed = paddingEdge.tryFixed())
         return LayoutUnit { fixed->resolveZoom(usedZoom) };
 
-    if (!availableWidth)
-        return { };
-
-    return Style::evaluateMinimum<LayoutUnit>(paddingEdge, *availableWidth, usedZoom);
+    // During intrinsic sizing availableWidth is nullopt; resolve cyclic
+    // percentages with a 0 basis so that calc(0% + 50px) yields 50px.
+    return Style::evaluateMinimum<LayoutUnit>(paddingEdge, availableWidth.value_or(0_lu), usedZoom);
 }
 
 static inline void adjustBorderForTableAndFieldset(const RenderBoxModelObject& renderer, RectEdges<LayoutUnit>& borderWidths)

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4722,14 +4722,17 @@ RenderObject* InlineMinMaxIterator::next()
 }
 
 template <typename SizeType>
-auto borderMarginOrPaddingWidth(LayoutUnit childValue, const SizeType& marginOrPadding, const Style::ZoomFactor& zoomFactor) -> LayoutUnit {
+auto borderMarginOrPaddingWidth(const SizeType& marginOrPadding, const Style::ZoomFactor& zoomFactor) -> LayoutUnit {
     if (auto fixed = marginOrPadding.tryFixed())
         return LayoutUnit(fixed->resolveZoom(zoomFactor));
     if constexpr (std::same_as<SizeType, Style::MarginEdge>) {
         if (marginOrPadding.isAuto())
             return { };
     }
-    return childValue;
+    // During intrinsic sizing, cyclic percentages resolve with a 0% basis.
+    // Evaluate calc() expressions (e.g. calc(0% + 30px)) with 0 as the
+    // percentage reference so the fixed portion is preserved.
+    return Style::evaluateMinimum<LayoutUnit>(marginOrPadding, 0_lu, zoomFactor);
 };
 
 static LayoutUnit getBorderPaddingMargin(const RenderBoxModelObject& child, bool endOfInline)
@@ -4738,12 +4741,12 @@ static LayoutUnit getBorderPaddingMargin(const RenderBoxModelObject& child, bool
     const auto& childZoomFactor = childStyle.usedZoomForLength();
 
     if (endOfInline) {
-        return borderMarginOrPaddingWidth(child.marginEnd(), childStyle.marginEnd(), childZoomFactor) +
-            borderMarginOrPaddingWidth(child.paddingEnd(), childStyle.paddingEnd(), childZoomFactor) +
+        return borderMarginOrPaddingWidth(childStyle.marginEnd(), childZoomFactor) +
+            borderMarginOrPaddingWidth(childStyle.paddingEnd(), childZoomFactor) +
             child.borderEnd();
     }
-    return borderMarginOrPaddingWidth(child.marginStart(), childStyle.marginStart(), childZoomFactor) +
-        borderMarginOrPaddingWidth(child.paddingStart(), childStyle.paddingStart(), childZoomFactor) +
+    return borderMarginOrPaddingWidth(childStyle.marginStart(), childZoomFactor) +
+        borderMarginOrPaddingWidth(childStyle.paddingStart(), childZoomFactor) +
         child.borderStart();
 }
 


### PR DESCRIPTION
#### 23d9997609b4ba1b43e4f6e089624c484705e546
<pre>
calc() with percentage in margin/padding should resolve with 0% basis during intrinsic sizing
<a href="https://bugs.webkit.org/show_bug.cgi?id=311893">https://bugs.webkit.org/show_bug.cgi?id=311893</a>
<a href="https://rdar.apple.com/174457804">rdar://174457804</a>

Reviewed by NOBODY (OOPS!).

Per specification [1], &quot;for the min size properties, as well as for
margins and paddings (and gutters), a cyclic percentage is resolved
against zero for determining intrinsic size contributions.&quot;

In the LayoutIntegration path, BoxGeometryUpdater::usedValueOrZero()
returned 0 when availableWidth was nullopt (intrinsic sizing), discarding
the fixed portion of calc() expressions entirely. For example,
calc(0% + 30px) yielded 0 instead of 30px. Fix by evaluating with
availableWidth.value_or(0) so percentages resolve to 0 while the fixed
component is preserved.

The same fix is applied to the legacy preferred-width path in
RenderBlockFlow::borderMarginOrPaddingWidth which is still used for
SVG inline text.

[1] <a href="https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution">https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution</a>

* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
(WebCore::LayoutIntegration::usedValueOrZero):
Evaluate with 0 basis instead of returning 0 when availableWidth is nullopt.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::borderMarginOrPaddingWidth):
(WebCore::getBorderPaddingMargin):
Use Style::evaluateMinimum with 0 basis instead of falling back to the
pre-computed child value which uses the actual containing block width.
* LayoutTests/TestExpectations: Progression
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23d9997609b4ba1b43e4f6e089624c484705e546

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22114 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164458 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109511 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157568 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120505 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84942 "3 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5bdb1a81-5f6e-4fa7-80e7-ad0d73804f52) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22681 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139812 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101194 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21767 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19908 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12288 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131436 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166939 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11113 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19255 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128623 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28499 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128755 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28423 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139437 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request; Passed layout tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86253 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23572 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16234 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28117 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92220 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27694 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27924 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27767 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->