### PR TITLE
Temporarily restore materialArchive

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
@@ -421,13 +421,16 @@ extension WKBridgeUpdateTexture {
 extension WKBridgeUpdateMaterial {
     let materialGraph: WKBridgeMaterialGraph?
     let identifier: WKBridgeTypedResourceId
+    let materialArchive: Data
 
     init(
         materialGraph: WKBridgeMaterialGraph?,
         identifier: WKBridgeTypedResourceId,
+        materialArchive: Data
     ) {
         self.materialGraph = materialGraph
         self.identifier = identifier
+        self.materialArchive = materialArchive
     }
 }
 

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
@@ -403,9 +403,10 @@ NS_SWIFT_SENDABLE
 
 @property (nonatomic, strong, readonly, nullable) WKBridgeMaterialGraph *materialGraph;
 @property (nonatomic, strong, readonly) WKBridgeTypedResourceId *identifier;
+@property (nonatomic, strong, readonly) NSData *materialArchive;
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithMaterialGraph:(nullable WKBridgeMaterialGraph *)materialGraph identifier:(WKBridgeTypedResourceId *)identifier NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithMaterialGraph:(nullable WKBridgeMaterialGraph *)materialGraph identifier:(WKBridgeTypedResourceId *)identifier materialArchive:(NSData *)materialArchive NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
@@ -103,6 +103,9 @@ void RemoteMesh::updateTexture(Vector<WebModel::UpdateTextureDescriptor>&& descr
 
 void RemoteMesh::updateMaterial(Vector<WebModel::UpdateMaterialDescriptor>&& descriptor, CompletionHandler<void(bool)>&& completionHandler)
 {
+    for (auto& descriptor : descriptors)
+        MESSAGE_CHECK(descriptor.materialArchive.size());
+
     m_backing->updateMaterial(WTF::move(descriptor));
     completionHandler(true);
 }

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -691,10 +691,13 @@ extension WKBridgeReceiver {
                 let identifier = data.identifier
                 logInfo("updateMaterial \(identifier)")
 
-                guard let shaderGraph = ShaderGraph._Proto_ShaderNodeGraph.fromWKDescriptor(data.materialGraph) else {
+                guard let shaderGraphIPC = ShaderGraph._Proto_ShaderNodeGraph.fromWKDescriptor(data.materialGraph) else {
                     fatalError("No materialGraph data provided for material \(identifier)")
                 }
 
+                // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
+                // swift-format-ignore: NeverForceUnwrap
+                let shaderGraph = try ShaderGraph._Proto_ShaderNodeGraph(from: data.materialArchive)
                 let shaderGraphOutput = try await renderContext.makeShaderGraphFunctions(shaderGraph: shaderGraph)
 
                 let geometryArguments = try makeParameters(
@@ -1385,7 +1388,8 @@ func webUpdateMaterialRequestFromUpdateMaterialRequest(
     let bridgeMaterialGraph = toWebMaterialGraph(request.shaderGraph)
     return WKBridgeUpdateMaterial(
         materialGraph: bridgeMaterialGraph,
-        identifier: .init(value: request.id.value, path: request.id.path, hashValue: request.id.hashValue)
+        identifier: .init(value: request.id.value, path: request.id.path, hashValue: request.id.hashValue),
+        materialArchive: request.materialSourceArchive ?? Data()
     )
 }
 

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
@@ -566,6 +566,15 @@ static NSData* convert(const Vector<T>& data)
 }
 
 template<typename T>
+static NSData* convertNonZeroSize(const Vector<T>& data)
+{
+    if (!data.size())
+        RELEASE_ASSERT_NOT_REACHED("data.size() should never be zero");
+
+    return [[NSData alloc] initWithBytes:data.span().data() length:data.sizeInBytes()];
+}
+
+template<typename T>
 static NSArray<NSData*> *convert(const Vector<Vector<T>>& data)
 {
     if (!data.size())
@@ -1102,7 +1111,7 @@ void WebMesh::updateTexture(Vector<WebModel::UpdateTextureDescriptor>&& inputArr
 #if ENABLE(GPU_PROCESS_MODEL)
 static WKBridgeUpdateMaterial *convert(const WebModel::UpdateMaterialDescriptor& input)
 {
-    return [WebKit::allocWKBridgeUpdateMaterialInstance() initWithMaterialGraph:WebModel::convert(input.materialGraph) identifier:convert(input.identifier)];
+    return [WebKit::allocWKBridgeUpdateMaterialInstance() initWithMaterialGraph:WebModel::convert(input.materialGraph) identifier:convert(input.identifier) materialArchive:WebModel::convertNonZeroSize(input.materialArchive)];
 }
 #endif
 

--- a/Source/WebKit/Shared/Model.serialization.in
+++ b/Source/WebKit/Shared/Model.serialization.in
@@ -70,6 +70,7 @@ header: <WebKit/ModelTypes.h>
 [AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebModel::UpdateMaterialDescriptor {
     WebModel::MaterialGraph materialGraph;
     WebModel::TypedResourceId identifier;
+    Vector<bool> materialArchive;
 };
 
 header: <WebKit/ModelTypes.h>

--- a/Source/WebKit/WebProcess/Model/ModelInlineConverters.h
+++ b/Source/WebKit/WebProcess/Model/ModelInlineConverters.h
@@ -891,7 +891,8 @@ static WebModel::UpdateMaterialDescriptor toCpp(WKBridgeUpdateMaterial *update)
 {
     return WebModel::UpdateMaterialDescriptor {
         .materialGraph = toCpp(update.materialGraph),
-        .identifier = toCpp(update.identifier)
+        .identifier = toCpp(update.identifier),
+        .materialArchive = toCpp<bool>(update.materialArchive)
     };
 }
 


### PR DESCRIPTION
#### cc97958f57d974b1616765fa8c06c192a31c0827
<pre>
Temporarily restore materialArchive
<a href="https://bugs.webkit.org/show_bug.cgi?id=311892">https://bugs.webkit.org/show_bug.cgi?id=311892</a>
<a href="https://rdar.apple.com/174458062">rdar://174458062</a>

Reviewed by NOBODY (OOPS!).

Temporarily restore materialArchive until the differences between shader graph reconstruction are isolated and addressed

* Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h:
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(updateMaterial(_:)):
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm:
(WebKit::convert):
* Source/WebKit/Shared/Model.serialization.in:
* Source/WebKit/WebProcess/Model/ModelInlineConverters.h:
(WebKit::toCpp):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc97958f57d974b1616765fa8c06c192a31c0827

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164340 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109374 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/049d6ee9-de9f-4ac5-8345-2de89059c47d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28687 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120404 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84903 "2 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22592 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139710 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101094 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e1e95ae5-51e7-46a9-819a-8912fa84d172) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21678 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19797 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12170 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131347 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166817 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10995 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19153 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128523 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28381 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23831 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128656 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28305 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139335 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85748 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23483 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16132 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27999 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92102 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27576 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27806 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27649 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->