### PR TITLE
AX: WebKit can fail to transfer deferred accessibility tokens, making content entirely inaccessible to assistive technologies

### DIFF
--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -1743,6 +1743,14 @@ void WebProcess::initializeAccessibility(Vector<SandboxExtension::Handle>&& hand
 
     [NSApplication _accessibilityInitialize];
 
+    // This flag may have been false at process creation (set from
+    // WebProcessCreationParameters). Update it now so that any WebPages
+    // created later in this process will send their accessibility remote
+    // token immediately rather than deferring it. Without this,
+    // deferred tokens are permanently lost because this method is
+    // only called once per process.
+    m_shouldInitializeAccessibility = true;
+
     // Now that the accessibility server is registered, send any deferred
     // remote tokens so the UI process can resolve the remote elements.
     for (auto& webPage : m_pageMap.values())


### PR DESCRIPTION
#### 4dbf78b80d347e72971ea77301bd400ce345eced
<pre>
AX: WebKit can fail to transfer deferred accessibility tokens, making content entirely inaccessible to assistive technologies
<a href="https://bugs.webkit.org/show_bug.cgi?id=311890">https://bugs.webkit.org/show_bug.cgi?id=311890</a>
<a href="https://rdar.apple.com/174457777">rdar://174457777</a>

Reviewed by NOBODY (OOPS!).

After <a href="https://commits.webkit.org/310711@main">310711@main</a>, web content can become entirely inaccessible to ATs with this sequence:

  1. Safari launches, prewarms a web content process with a default value
     of shouldInitializeAccessibility=false, even if an AT is active

  2. VoiceOver queries Safari, initializeAccessibilityIfNecessary fires and
     sends InitializeAccessibility to all processes, the prewarmed process
     receives it with 0 pages

  3. Press Cmd+T, type any URL and press enter, the prewarmed process from
     step 1 is used to render the webpage. This process has shouldInitializeAccessibility=false
     from step 1, and we already ran initializeAccessibility in step 2,
     so it will never run again. Thus the web content never sends it&apos;s
     token, preventing the link between that process and Safari, making
     the content entirely inaccessible.

Fix this by setting m_shouldInitializeAccessibility to true after running initializeAccessibility
so that future webpages spawned in this process won&apos;t defer their tokens.

* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dbf78b80d347e72971ea77301bd400ce345eced

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155391 "Failed to checkout and rebase branch from PR 62408") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28651 "Failed to checkout and rebase branch from PR 62408") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21810 "Failed to checkout and rebase branch from PR 62408") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164153 "Failed to checkout and rebase branch from PR 62408") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28791 "Failed to checkout and rebase branch from PR 62408") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28501 "Failed to checkout and rebase branch from PR 62408") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/164153 "Failed to checkout and rebase branch from PR 62408") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158350 "Failed to checkout and rebase branch from PR 62408") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/28791 "Failed to checkout and rebase branch from PR 62408") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/21810 "Failed to checkout and rebase branch from PR 62408") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/164153 "Failed to checkout and rebase branch from PR 62408") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/28791 "Failed to checkout and rebase branch from PR 62408") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/28501 "Failed to checkout and rebase branch from PR 62408") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/11982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/28791 "Failed to checkout and rebase branch from PR 62408") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/21810 "Failed to checkout and rebase branch from PR 62408") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166631 "Failed to checkout and rebase branch from PR 62408") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/21810 "Failed to checkout and rebase branch from PR 62408") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/166631 "Failed to checkout and rebase branch from PR 62408") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/28195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/28501 "Failed to checkout and rebase branch from PR 62408") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/166631 "Failed to checkout and rebase branch from PR 62408") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28119 "Failed to checkout and rebase branch from PR 62408") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/21810 "Failed to checkout and rebase branch from PR 62408") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/28119 "Failed to checkout and rebase branch from PR 62408") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/21810 "Failed to checkout and rebase branch from PR 62408") | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27813 "Failed to checkout and rebase branch from PR 62408") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/91916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/27390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/27620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27463 "Failed to checkout and rebase branch from PR 62408") | | | | 
<!--EWS-Status-Bubble-End-->