### PR TITLE
Use more C++17 if constexpr with init-statements in WebCore

### DIFF
--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Display.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Display.cpp
@@ -106,9 +106,7 @@ constexpr auto displayOutsideInsideMap = makeDisplayOutsideInsideMap();
 template<DisplayOutside outside, DisplayInside inside>
 RefPtr<CSSValue> NODELETE mappedDisplayValue()
 {
-    static constexpr auto result = displayOutsideInsideMap[outside][inside];
-
-    if constexpr (result.first == CSSValueInvalid && result.second == CSSValueInvalid)
+    if constexpr (static constexpr auto result = displayOutsideInsideMap[outside][inside]; result.first == CSSValueInvalid && result.second == CSSValueInvalid)
         return nullptr;
     else if constexpr (result.second == CSSValueInvalid)
         return CSSPrimitiveValue::create(result.first);

--- a/Source/WebCore/css/values/color/CSSColorConversion+Normalize.h
+++ b/Source/WebCore/css/values/color/CSSColorConversion+Normalize.h
@@ -40,9 +40,7 @@ namespace WebCore {
 template<typename Descriptor, unsigned Index>
 CSS::Number<> normalizeAndClampNumericComponents(CSS::NumberRaw<> number)
 {
-    constexpr auto info = std::get<Index>(Descriptor::components);
-
-    if constexpr (info.type == ColorComponentType::Angle)
+    if constexpr (constexpr auto info = std::get<Index>(Descriptor::components); info.type == ColorComponentType::Angle)
         return { normalizeHue(number.value) };
     else if constexpr (info.min == -std::numeric_limits<double>::infinity() && info.max == std::numeric_limits<double>::infinity())
         return { number.value };
@@ -57,9 +55,7 @@ CSS::Number<> normalizeAndClampNumericComponents(CSS::NumberRaw<> number)
 template<typename Descriptor, unsigned Index>
 CSS::Number<> normalizeAndClampNumericComponents(CSS::PercentageRaw<> percent)
 {
-    constexpr auto info = std::get<Index>(Descriptor::components);
-
-    if constexpr (info.min == -std::numeric_limits<double>::infinity() && info.max == std::numeric_limits<double>::infinity())
+    if constexpr (constexpr auto info = std::get<Index>(Descriptor::components); info.min == -std::numeric_limits<double>::infinity() && info.max == std::numeric_limits<double>::infinity())
         return { percent.value * info.percentMultiplier };
     else if constexpr (info.min == -std::numeric_limits<double>::infinity())
         return { std::min(percent.value * info.percentMultiplier, info.max) };
@@ -114,9 +110,7 @@ auto normalizeAndClampNumericComponentsIntoCanonicalRepresentation(const std::op
 template<typename Descriptor, unsigned Index>
 CSS::Number<> normalizeNumericComponents(CSS::NumberRaw<> number)
 {
-    constexpr auto info = std::get<Index>(Descriptor::components);
-
-    if constexpr (info.type == ColorComponentType::Angle)
+    if constexpr (constexpr auto info = std::get<Index>(Descriptor::components); info.type == ColorComponentType::Angle)
         return { normalizeHue(number.value) };
     else
         return { number.value };

--- a/Source/WebCore/platform/graphics/ColorInterpolation.h
+++ b/Source/WebCore/platform/graphics/ColorInterpolation.h
@@ -108,9 +108,8 @@ template<size_t I, typename InterpolationMethodColorSpace>
 float interpolateComponentUsingPremultipliedAlpha(InterpolationMethodColorSpace interpolationMethodColorSpace, ColorComponents<float, 4> colorComponents1, double color1Multiplier, ColorComponents<float, 4> colorComponents2, double color2Multiplier, PremultipliedAlphaState interpolatedAlpha)
 {
     using ColorType = typename InterpolationMethodColorSpace::ColorType;
-    constexpr auto componentInfo = ColorType::Model::componentInfo;
 
-    if constexpr (componentInfo[I].type == ColorComponentType::Angle)
+    if constexpr (constexpr auto componentInfo = ColorType::Model::componentInfo; componentInfo[I].type == ColorComponentType::Angle)
         return interpolateHue(interpolationMethodColorSpace, colorComponents1[I], color1Multiplier, colorComponents2[I], color2Multiplier);
     else {
         if (std::isnan(colorComponents1[I]))
@@ -140,9 +139,8 @@ template<size_t I, typename InterpolationMethodColorSpace>
 float interpolateComponentUsingUnpremultipliedAlpha(InterpolationMethodColorSpace interpolationMethodColorSpace, ColorComponents<float, 4> colorComponents1, double color1Multiplier, ColorComponents<float, 4> colorComponents2, double color2Multiplier)
 {
     using ColorType = typename InterpolationMethodColorSpace::ColorType;
-    constexpr auto componentInfo = ColorType::Model::componentInfo;
 
-    if constexpr (componentInfo[I].type == ColorComponentType::Angle)
+    if constexpr (constexpr auto componentInfo = ColorType::Model::componentInfo; componentInfo[I].type == ColorComponentType::Angle)
         return interpolateHue(interpolationMethodColorSpace, colorComponents1[I], color1Multiplier, colorComponents2[I], color2Multiplier);
     else
         return interpolateComponentAccountingForNaN(colorComponents1[I], color1Multiplier, colorComponents2[I], color2Multiplier);

--- a/Source/WebCore/platform/graphics/ColorTypes.h
+++ b/Source/WebCore/platform/graphics/ColorTypes.h
@@ -73,21 +73,16 @@ template<typename ColorType, unsigned Index, typename T> constexpr auto clampedC
 
 template<typename ColorType, unsigned Index> constexpr float clampedComponent(float c)
 {
-    constexpr auto componentInfo = ColorType::Model::componentInfo[Index];
-
-    if constexpr (componentInfo.type == ColorComponentType::Angle)
+    if constexpr (constexpr auto componentInfo = ColorType::Model::componentInfo[Index]; componentInfo.type == ColorComponentType::Angle)
         return std::fmod(std::fmod(c, 360.0) + 360.0, 360.0);
-
-    if constexpr (componentInfo.min == -std::numeric_limits<float>::infinity() && componentInfo.max == std::numeric_limits<float>::infinity())
+    else if constexpr (componentInfo.min == -std::numeric_limits<float>::infinity() && componentInfo.max == std::numeric_limits<float>::infinity())
         return c;
-
-    if constexpr (componentInfo.min == -std::numeric_limits<float>::infinity())
+    else if constexpr (componentInfo.min == -std::numeric_limits<float>::infinity())
         return std::min(c, componentInfo.max);
-
-    if constexpr (componentInfo.max == std::numeric_limits<float>::infinity())
+    else if constexpr (componentInfo.max == std::numeric_limits<float>::infinity())
         return std::max(c, componentInfo.min);
-
-    return std::clamp(c, componentInfo.min, componentInfo.max);
+    else
+        return std::clamp(c, componentInfo.min, componentInfo.max);
 }
 
 template<typename ColorType, unsigned Index, typename T> constexpr T clampedComponent(const ColorComponents<T, 4>& c)


### PR DESCRIPTION
#### fe593b9f4b0eda8a0a7d076c93289ad8e3892885
<pre>
Use more C++17 if constexpr with init-statements in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=311898">https://bugs.webkit.org/show_bug.cgi?id=311898</a>
<a href="https://rdar.apple.com/174462578">rdar://174462578</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Display.cpp:
(WebCore::CSSPropertyParserHelpers::mappedDisplayValue):
* Source/WebCore/css/values/color/CSSColorConversion+Normalize.h:
(WebCore::normalizeAndClampNumericComponents):
(WebCore::normalizeNumericComponents):
* Source/WebCore/platform/graphics/ColorInterpolation.h:
(WebCore::interpolateComponentUsingPremultipliedAlpha):
(WebCore::interpolateComponentUsingUnpremultipliedAlpha):
* Source/WebCore/platform/graphics/ColorTypes.h:
(WebCore::clampedComponent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe593b9f4b0eda8a0a7d076c93289ad8e3892885

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155399 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21818 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164161 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157272 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120269 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158358 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22459 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139551 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100959 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21545 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19649 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11990 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131214 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17383 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166639 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10807 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19075 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128378 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28203 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23683 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128514 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28127 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139176 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85564 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23349 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15973 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27821 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91924 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27398 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27628 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27471 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->