### PR TITLE
[JSC][WASM][Debugger] Generate meaningful module names from name section and source URL

### DIFF
--- a/JSTests/wasm/debugger/resources/wasm/named-streaming-module.js
+++ b/JSTests/wasm/debugger/resources/wasm/named-streaming-module.js
@@ -1,0 +1,66 @@
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic: \0asm
+    0x01, 0x00, 0x00, 0x00, // version: 1
+
+    // [0x08] Type section: 1 type
+    0x01, 0x04,             // section id=1, size=4
+    0x01,                   // 1 type
+    0x60, 0x00, 0x00,       // Type 0: (func [] -> [])
+
+    // [0x0e] Function section: 1 function
+    0x03, 0x02,             // section id=3, size=2
+    0x01,                   // 1 function
+    0x00,                   // function 0: type 0
+
+    // [0x12] Export section: export function 0 as "func_a"
+    0x07, 0x0a,             // section id=7, size=10
+    0x01,                   // 1 export
+    0x06, 0x66, 0x75, 0x6e, 0x63, 0x5f, 0x61, // name "func_a" (length=6)
+    0x00,                   // export kind: function
+    0x00,                   // function index 0
+
+    // [0x1e] Code section: 1 function body
+    0x0a, 0x04,             // section id=10, size=4
+    0x01,                   // 1 function body
+
+    // [0x21] func_a body
+    0x02,                   // body size=2
+    0x00,                   // 0 local declarations
+    0x0b,                   // [0x23] end
+
+    // [0x24] Name section: custom section "name", subsection 0 = module name "mymodule"
+    // payload = [0x04, 'n','a','m','e'] + [0x00, 0x09, 0x08, 'm','y','m','o','d','u','l','e']
+    // payload_size = 5 (name "name") + 11 (subsection 0) = 16 = 0x10
+    0x00, 0x10,             // section id=0 (custom), payload size=16
+    0x04, 0x6e, 0x61, 0x6d, 0x65,          // custom section name: "name" (length=4)
+    0x00, 0x09,             // subsection 0 (module name), subsection size=9
+    0x08,                   // module name length=8
+    0x6d, 0x79, 0x6d, 0x6f, 0x64, 0x75, 0x6c, 0x65, // "mymodule"
+]);
+
+async function main() {
+    var result = await $vm.createWasmStreamingCompilerForInstantiate(function(compiler) {
+        compiler.addBytes(wasm.slice(0, 16)); // chunk 1: header
+        compiler.addBytes(wasm.slice(16));    // chunk 2: sections (including name section)
+    });
+
+    print("Streaming module loaded");
+    print("Waiting for debugger — attach LLDB and type 'c' to continue.");
+    while (!$vm.hasDebuggerContinued()) { }
+    print("Debugger continued");
+
+    let iteration = 0;
+    for (;;) {
+        result.instance.exports.func_a();
+        iteration += 1;
+        if (iteration % 1e6 == 0)
+            print("iteration=", iteration);
+    }
+}
+
+main().catch(function(error) {
+    print(String(error));
+    print(String(error.stack));
+    $vm.abort();
+});

--- a/JSTests/wasm/debugger/resources/wasm/url-named-streaming-module.js
+++ b/JSTests/wasm/debugger/resources/wasm/url-named-streaming-module.js
@@ -1,0 +1,60 @@
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic: \0asm
+    0x01, 0x00, 0x00, 0x00, // version: 1
+
+    // [0x08] Type section: 1 type
+    0x01, 0x04,             // section id=1, size=4
+    0x01,                   // 1 type
+    0x60, 0x00, 0x00,       // Type 0: (func [] -> [])
+
+    // [0x0e] Function section: 1 function
+    0x03, 0x02,             // section id=3, size=2
+    0x01,                   // 1 function
+    0x00,                   // function 0: type 0
+
+    // [0x12] Export section: export function 0 as "func_b"
+    0x07, 0x0a,             // section id=7, size=10
+    0x01,                   // 1 export
+    0x06, 0x66, 0x75, 0x6e, 0x63, 0x5f, 0x62, // name "func_b" (length=6)
+    0x00,                   // export kind: function
+    0x00,                   // function index 0
+
+    // [0x1e] Code section: 1 function body
+    0x0a, 0x04,             // section id=10, size=4
+    0x01,                   // 1 function body
+
+    // [0x20] func_b body
+    0x02,                   // body size=2
+    0x00,                   // 0 local declarations
+    0x0b,                   // [0x23] end
+]);
+
+async function main() {
+    var result = await $vm.createWasmStreamingCompilerForInstantiateWithURL(
+        "https://cdn.example.com/path/canvaskit.wasm",
+        function(compiler) {
+            compiler.addBytes(wasm.slice(0, 16)); // chunk 1: header
+            compiler.addBytes(wasm.slice(16));    // chunk 2: sections
+        }
+    );
+
+    print("Streaming module loaded (URL path)");
+    print("Waiting for debugger — attach LLDB and type 'c' to continue.");
+    while (!$vm.hasDebuggerContinued()) { }
+    print("Debugger continued");
+
+    let iteration = 0;
+    for (;;) {
+        result.instance.exports.func_b();
+        iteration += 1;
+        if (iteration % 1e6 == 0)
+            print("iteration=", iteration);
+    }
+}
+
+main().catch(function(error) {
+    print(String(error));
+    print(String(error.stack));
+    $vm.abort();
+});

--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -2083,6 +2083,58 @@ class SwiftWasmDynamicModuleLoadTestCase(BaseTestCase):
         self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped", "func_b"])
 
 
+class ModuleNamingFromNameSectionTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/named-streaming-module.js", extra_jsc_options=["--useDollarVM=1"])
+
+        try:
+            self.test()
+
+        except Exception as e:
+            raise Exception(f"Test failed: {e}")
+
+    def test(self):
+        self.send_lldb_command_or_raise("image list", patterns=["mymodule"])
+
+        # Set a breakpoint at func_a's 'end' instruction by virtual address.
+        self.send_lldb_command_or_raise("b 0x4000000000000023", patterns=["Breakpoint 1"])
+
+        # Resume: stops at the breakpoint; disassembly confirms the module name in the frame.
+        self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped", "->  0x4000000000000023: end"])
+
+        self.send_lldb_command_or_raise("br del -f", patterns=["All breakpoints removed. (1 breakpoint)"])
+
+
+class StreamingModuleSourceURLTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/wasm/url-named-streaming-module.js", extra_jsc_options=["--useDollarVM=1"])
+
+        try:
+            self.test()
+
+        except Exception as e:
+            raise Exception(f"Test failed: {e}")
+
+    def test(self):
+        self.send_lldb_command_or_raise("image list", patterns=["cdn.example.com/path/canvaskit.wasm"])
+
+        # Set a breakpoint at func_b's 'end' instruction by virtual address.
+        self.send_lldb_command_or_raise("b 0x4000000000000023", patterns=["Breakpoint 1"])
+
+        # Resume: stops at the breakpoint in the URL-named streaming-compiled module.
+        self.send_lldb_command_or_raise("c", patterns=["Process 1 stopped", "->  0x4000000000000023: end"])
+
+        self.send_lldb_command_or_raise("br del -f", patterns=["All breakpoints removed. (1 breakpoint)"])
+
+
 class StreamingModuleLoadTestCase(BaseTestCase):
 
     def __init__(self, build_config: str = None, port: int = None):

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2023,20 +2023,20 @@ public:
         return &vm.destructibleObjectSpace();
     }
 
-    WasmStreamingCompiler(VM& vm, Structure* structure, Wasm::CompilerMode compilerMode, JSGlobalObject* globalObject, JSPromise* promise, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&& compileOptions, const SourceCode& source)
+    WasmStreamingCompiler(VM& vm, Structure* structure, Wasm::CompilerMode compilerMode, JSGlobalObject* globalObject, JSPromise* promise, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&& compileOptions, const SourceCode& source, String wasmSourceURL = { })
         : Base(vm, structure)
         , m_promise(promise, WriteBarrierEarlyInit)
-        , m_streamingCompiler(Wasm::StreamingCompiler::create(vm, compilerMode, globalObject, promise, importObject, WTF::move(compileOptions), source))
+        , m_streamingCompiler(Wasm::StreamingCompiler::create(vm, compilerMode, globalObject, promise, importObject, WTF::move(compileOptions), source, WTF::move(wasmSourceURL)))
     {
         DollarVMAssertScope assertScope;
     }
 
-    static WasmStreamingCompiler* create(VM& vm, JSGlobalObject* globalObject, Wasm::CompilerMode compilerMode, JSObject* importObject, const SourceCode& source)
+    static WasmStreamingCompiler* create(VM& vm, JSGlobalObject* globalObject, Wasm::CompilerMode compilerMode, JSObject* importObject, const SourceCode& source, String wasmSourceURL = { })
     {
         DollarVMAssertScope assertScope;
         JSPromise* promise = JSPromise::create(vm, globalObject->promiseStructure());
         Structure* structure = createStructure(vm, globalObject, jsNull());
-        WasmStreamingCompiler* result = new (NotNull, allocateCell<WasmStreamingCompiler>(vm)) WasmStreamingCompiler(vm, structure, compilerMode, globalObject, promise, importObject, std::nullopt, source);
+        WasmStreamingCompiler* result = new (NotNull, allocateCell<WasmStreamingCompiler>(vm)) WasmStreamingCompiler(vm, structure, compilerMode, globalObject, promise, importObject, std::nullopt, source, WTF::move(wasmSourceURL));
         result->finishCreation(vm);
         return result;
     }
@@ -2170,6 +2170,7 @@ static JSC_DECLARE_HOST_FUNCTION(functionCreateWasmStreamingCompilerForCompile);
 static JSC_DECLARE_HOST_FUNCTION(functionCreateWasmStreamingCompilerForInstantiate);
 #endif
 #if ENABLE(WEBASSEMBLY_DEBUGGER)
+static JSC_DECLARE_HOST_FUNCTION(functionCreateWasmStreamingCompilerForInstantiateWithURL);
 static JSC_DECLARE_HOST_FUNCTION(functionHasDebuggerContinued);
 #endif
 static JSC_DECLARE_HOST_FUNCTION(functionCreateStaticCustomAccessor);
@@ -3325,6 +3326,44 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateWasmStreamingCompilerForInstantiate, (JSG
 }
 #endif
 
+#if ENABLE(WEBASSEMBLY_DEBUGGER)
+JSC_DEFINE_HOST_FUNCTION(functionCreateWasmStreamingCompilerForInstantiateWithURL, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    DollarVMAssertScope assertScope;
+    VM& vm = globalObject->vm();
+    JSLockHolder lock(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue urlArgument = callFrame->argument(0);
+    if (!urlArgument.isString())
+        return throwVMTypeError(globalObject, scope, "First argument must be a URL string"_s);
+    String wasmSourceURL = urlArgument.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    auto callback = jsDynamicCast<JSFunction*>(callFrame->argument(1));
+    if (!callback)
+        return throwVMTypeError(globalObject, scope, "Second argument is not a JS function"_s);
+
+    JSValue importArgument = callFrame->argument(2);
+    JSObject* importObject = importArgument.getObject();
+    if (!importArgument.isUndefined() && !importObject) [[unlikely]]
+        return throwVMTypeError(globalObject, scope);
+
+    auto [taintedness, url] = sourceTaintedOriginFromStack(vm, callFrame);
+    auto source = makeSource("[wasm code]"_s, SourceOrigin(url), taintedness);
+
+    auto compiler = WasmStreamingCompiler::create(vm, globalObject, Wasm::CompilerMode::FullCompile, importObject, source, WTF::move(wasmSourceURL));
+    MarkedArgumentBuffer args;
+    args.append(compiler);
+    ASSERT(!args.hasOverflowed());
+    call(globalObject, callback, jsUndefined(), args, "You shouldn't see this..."_s);
+    TRY_CLEAR_EXCEPTION(scope, { });
+    compiler->streamingCompiler().finalize(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+    return JSValue::encode(compiler->promise());
+}
+#endif
+
 JSC_DEFINE_HOST_FUNCTION(functionCreateStaticCustomAccessor, (JSGlobalObject* globalObject, CallFrame*))
 {
     DollarVMAssertScope assertScope;
@@ -4432,6 +4471,7 @@ void JSDollarVM::finishCreation(VM& vm)
 #endif
 #if ENABLE(WEBASSEMBLY_DEBUGGER)
     addFunction(vm, "hasDebuggerContinued"_s, functionHasDebuggerContinued, 0);
+    addFunction(vm, "createWasmStreamingCompilerForInstantiateWithURL"_s, functionCreateWasmStreamingCompilerForInstantiateWithURL, 2);
 #endif
     addFunction(vm, "createStaticCustomAccessor"_s, functionCreateStaticCustomAccessor, 0);
     addFunction(vm, "createStaticCustomValue"_s, functionCreateStaticCustomValue, 0);

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
@@ -43,7 +43,7 @@
 
 namespace JSC { namespace Wasm {
 
-StreamingCompiler::StreamingCompiler(VM& vm, CompilerMode compilerMode, JSGlobalObject* globalObject, JSPromise* promise, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&& compileOptions, const SourceCode& source)
+StreamingCompiler::StreamingCompiler(VM& vm, CompilerMode compilerMode, JSGlobalObject* globalObject, JSPromise* promise, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&& compileOptions, const SourceCode& source, String wasmSourceURL)
     : m_vm(vm)
     , m_compilerMode(compilerMode)
     , m_compileOptions(WTF::move(compileOptions))
@@ -51,6 +51,14 @@ StreamingCompiler::StreamingCompiler(VM& vm, CompilerMode compilerMode, JSGlobal
     , m_parser(m_info.get(), *this)
     , m_source(source)
 {
+#if ENABLE(WEBASSEMBLY_DEBUGGER)
+    if (Options::enableWasmDebugger()) [[unlikely]] {
+        if (!wasmSourceURL.isEmpty())
+            m_info->debugInfo->sourceURL = WTF::move(wasmSourceURL);
+    }
+#else
+    UNUSED_PARAM(wasmSourceURL);
+#endif
     Vector<JSCell*> dependencies;
     dependencies.append(globalObject);
     if (importObject)
@@ -69,9 +77,9 @@ StreamingCompiler::~StreamingCompiler()
     }
 }
 
-Ref<StreamingCompiler> StreamingCompiler::create(VM& vm, CompilerMode compilerMode, JSGlobalObject* globalObject, JSPromise* promise, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&& compileOptions, const SourceCode& source)
+Ref<StreamingCompiler> StreamingCompiler::create(VM& vm, CompilerMode compilerMode, JSGlobalObject* globalObject, JSPromise* promise, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&& compileOptions, const SourceCode& source, String wasmSourceURL)
 {
-    return adoptRef(*new StreamingCompiler(vm, compilerMode, globalObject, promise, importObject, WTF::move(compileOptions), source));
+    return adoptRef(*new StreamingCompiler(vm, compilerMode, globalObject, promise, importObject, WTF::move(compileOptions), source, WTF::move(wasmSourceURL)));
 }
 
 bool StreamingCompiler::didReceiveFunctionData(FunctionCodeIndex functionIndex, const Wasm::FunctionData&)

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.h
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.h
@@ -49,7 +49,7 @@ class StreamingPlan;
 
 class StreamingCompiler final : public StreamingParserClient, public ThreadSafeRefCounted<StreamingCompiler> {
 public:
-    JS_EXPORT_PRIVATE static Ref<StreamingCompiler> create(VM&, CompilerMode, JSGlobalObject*, JSPromise*, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&&, const SourceCode&);
+    JS_EXPORT_PRIVATE static Ref<StreamingCompiler> create(VM&, CompilerMode, JSGlobalObject*, JSPromise*, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&&, const SourceCode&, String wasmSourceURL = { });
 
     JS_EXPORT_PRIVATE ~StreamingCompiler();
 
@@ -69,7 +69,7 @@ public:
     void didCompileFunction(StreamingPlan&);
 
 private:
-    JS_EXPORT_PRIVATE StreamingCompiler(VM&, CompilerMode, JSGlobalObject*, JSPromise*, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&&, const SourceCode&);
+    JS_EXPORT_PRIVATE StreamingCompiler(VM&, CompilerMode, JSGlobalObject*, JSPromise*, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&&, const SourceCode&, String wasmSourceURL);
 
     bool didReceiveFunctionData(FunctionCodeIndex, const FunctionData&) final;
     void didFinishParsing() final;

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.h
@@ -70,6 +70,7 @@ public:
     Ref<ModuleInformation> moduleInfo;
     uint32_t id { 0 };
     Vector<uint8_t> source;
+    String sourceURL;
     using FunctionIndexToData = UncheckedKeyHashMap<size_t, FunctionDebugInfo, DefaultHash<size_t>, WTF::UnsignedWithZeroKeyHashTraits<size_t>>;
     FunctionIndexToData functionIndexToData;
 };

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.cpp
@@ -43,6 +43,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <wtf/HexNumber.h>
 #include <wtf/IterationStatus.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/WTFString.h>
@@ -149,12 +150,44 @@ JSWebAssemblyInstance* ModuleManager::jsInstance(uint32_t instanceId)
     return instance;
 }
 
-static String generateModuleName(VirtualAddress address, const RefPtr<Module>&)
+static String generateModuleName(VirtualAddress address, const RefPtr<Module>& module)
 {
-    // FIXME: Maybe we should generate a more meaningful name?
-    String moduleName = WTF::makeString("wasm_module_0x"_s, address.hex(), ".wasm"_s);
-    dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][generateModuleName] Using fallback address-based name: ", moduleName);
-    return moduleName;
+    // LLDB's `image list` already appends the load address in parentheses, so module
+    // names do not need an address suffix for uniqueness.
+    if (module) {
+        const auto& moduleInfo = module->moduleInformation();
+
+        StringBuilder result;
+
+        const String& sourceURL = moduleInfo.debugInfo->sourceURL;
+        if (!sourceURL.isEmpty()) {
+            // LLDB normalizes "//" -> "/" in library names (FileSpec treats them as paths),
+            // so we strip the URL scheme and store only "host/path" to avoid mangling.
+            URL url { sourceURL };
+            if (url.isValid() && !url.host().isEmpty())
+                result.append(makeString(url.host(), url.path()));
+            else
+                result.append(sourceURL);
+        }
+
+        const auto& rawName = moduleInfo.nameSection->moduleName;
+        if (!rawName.isEmpty()) {
+            if (!result.isEmpty())
+                result.append(':');
+            result.append(rawName.span());
+        }
+
+        if (!result.isEmpty()) {
+            String name = result.toString();
+            dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][generateModuleName] ", name);
+            return name;
+        }
+    }
+
+    // Fallback for modules with neither a name section nor a response URL.
+    String fallback = WTF::makeString("0x"_s, address.hex(), ".wasm"_s);
+    dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][generateModuleName] fallback: ", fallback);
+    return fallback;
 }
 
 String ModuleManager::generateLibrariesXML() const

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -596,7 +596,7 @@ static JSC::JSPromise* handleResponseOnStreamingAction(JSC::JSGlobalObject* glob
         }
     }
 
-    auto compiler = JSC::Wasm::StreamingCompiler::create(vm, compilerMode, globalObject, jsCast<JSC::JSPromise*>(deferred->promise()), importObject, WTF::move(compileOptions), JSC::makeSource("handleResponseOnStreamingAction"_s, JSC::SourceOrigin(), JSC::SourceTaintedOrigin::Untainted));
+    auto compiler = JSC::Wasm::StreamingCompiler::create(vm, compilerMode, globalObject, jsCast<JSC::JSPromise*>(deferred->promise()), importObject, WTF::move(compileOptions), JSC::makeSource("handleResponseOnStreamingAction"_s, JSC::SourceOrigin(), JSC::SourceTaintedOrigin::Untainted), inputResponse->url());
 
     if (inputResponse->isBodyReceivedByChunk()) {
         inputResponse->consumeBodyReceivedByChunk([globalObject, compiler = WTF::move(compiler)](auto&& result) mutable {


### PR DESCRIPTION
#### 8cb887d80ffc989c28964ccfc461af3a3ff96861
<pre>
[JSC][WASM][Debugger] Generate meaningful module names from name section and source URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=311902">https://bugs.webkit.org/show_bug.cgi?id=311902</a>
<a href="https://rdar.apple.com/174465437">rdar://174465437</a>

Reviewed by Mark Lam.

generateModuleName() previously returned a bare address-based fallback name.
This patch teaches it to derive a human-readable name from two sources:

- WASM name section: parsed by the streaming compiler and already stored
  in ModuleInformation::nameSection-&gt;moduleName.
- Source URL: the fetch response URL for streaming-compiled modules
  (WebAssembly.compileStreaming and instantiateStreaming). Stored in a new
  ModuleDebugInfo::sourceURL field and threaded through StreamingCompiler
  via a new wasmSourceURL parameter on both create() and the constructor.
  JSDOMGlobalObject passes inputResponse-&gt;url() on the WebCore side.

The naming format is &quot;&lt;host/path&gt;:&lt;moduleName&gt;&quot; when both are present,
or either alone when only one is available. The URL scheme is stripped
(host + path only) because LLDB normalizes &quot;//&quot; to &quot;/&quot; in FileSpec-based
library names. The address suffix is omitted because LLDB&apos;s `image list`
already appends the load address in parentheses.

Example Output:

(lldb) image list
[  0] 0x4000000100000000 earth.google.com/static/single-threaded/versions/20260326_1200_RC01/assets/earthplugin_web_wasm/earthplugin_web.wasm (0x4000000100000000)
[  1] 0x4000000000000000 www.gstatic.com/flutter-canvaskit/08f951bccb4f84ab521db9dfce3e05d8701e846f/canvaskit.wasm (0x4000000000000000)

Adds $vm.createWasmStreamingCompilerForInstantiateWithURL(url, callback)
to JSDollarVM for testing the source URL path, along with two new WASM
debugger test cases:
ModuleNamingFromNameSectionTestCase
StreamingModuleSourceURLTestCase

Canonical link: <a href="https://commits.webkit.org/310961@main">https://commits.webkit.org/310961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f311bd1f92cf0481a1cfa53723d93727bf180750

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155418 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164180 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157291 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28528 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120278 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158377 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22466 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139567 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100968 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running run-api-tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21552 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19662 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12009 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147468 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131221 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166658 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16249 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10828 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19009 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128386 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28222 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23696 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128522 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28146 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139192 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85583 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23698 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23358 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15989 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187303 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27840 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91943 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48021 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27417 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27647 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27490 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->