### PR TITLE
[Grid] Crash under GridTrackSizingAlgorithm::copyUsedTrackSizesForSubgrid when paint containment changes on subgrid.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-paint-dynamic-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-paint-dynamic-001-expected.txt
@@ -1,6 +1,6 @@
 
 PASS contain: none
 PASS contain: paint
-FAIL switching contain from none to paint assert_equals: independent formatting context expected true but got false
-FAIL switching contain from paint to none assert_equals: independent formatting context expected false but got true
+PASS switching contain from none to paint
+PASS switching contain from paint to none
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-paint-containment-change-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-paint-containment-change-crash.html
@@ -1,0 +1,18 @@
+<html>
+<body>
+<div style="display: grid">
+  <div id="change" style="display: grid; grid-template-rows: subgrid [a] [b] [c];">
+    <div>one</div>
+    <foo style="display: grid; grid-template-rows: subgrid [a] [b] [c];">
+      <bar id="x">two</bar>
+    </foo>
+  </div>
+</div>
+</body>
+<script>
+  document.body.offsetHeight;
+  x.style.border = "1px solid red";
+  document.getElementById("change").style.contain = 'paint';
+</script>
+</html>
+

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -2087,7 +2087,6 @@ bool GridTrackSizingAlgorithm::copyUsedTrackSizesForSubgrid()
     auto span = outer->gridSpanForGridItem(*m_renderGrid, direction);
     auto& allTracks = tracks(m_direction);
     int numTracks = allTracks.size();
-    RELEASE_ASSERT((parentTracks.size()  - 1) >= (numTracks - 1 + span.startLine()));
     for (int i = 0; i < numTracks; i++)
         allTracks[i].get() = parentTracks[i + span.startLine()].get();
 

--- a/Source/WebCore/style/StyleDifference.cpp
+++ b/Source/WebCore/style/StyleDifference.cpp
@@ -276,7 +276,8 @@ public:
 
         if (a.usedContain().contains(ContainValue::Size) != b.usedContain().contains(ContainValue::Size)
             || a.usedContain().contains(ContainValue::InlineSize) != b.usedContain().contains(ContainValue::InlineSize)
-            || a.usedContain().contains(ContainValue::Layout) != b.usedContain().contains(ContainValue::Layout))
+            || a.usedContain().contains(ContainValue::Layout) != b.usedContain().contains(ContainValue::Layout)
+            || a.usedContain().contains(ContainValue::Paint) != b.usedContain().contains(ContainValue::Paint))
             return true;
 
         // content-visibility:hidden turns on contain:size which requires relayout.


### PR DESCRIPTION
#### 2cc90f478c7ea033b4638936bffd5b57daff9b49
<pre>
[Grid] Crash under GridTrackSizingAlgorithm::copyUsedTrackSizesForSubgrid when paint containment changes on subgrid.
<a href="https://bugs.webkit.org/show_bug.cgi?id=311942">https://bugs.webkit.org/show_bug.cgi?id=311942</a>
<a href="https://rdar.apple.com/172724120">rdar://172724120</a>

Reviewed by Alan Baradlay.

One effect of applying paint containment to a box is that it forces said
box to establish an independent formatting context.
<a href="https://drafts.csswg.org/css-contain/#containment-paint">https://drafts.csswg.org/css-contain/#containment-paint</a>

As a result, applying or removing this on a box has layout implications
so we need to make sure that it requires us to do layout. For example,
when a subgrid ends up establishing an independent formatting context
then that box is no longer a subgrid. Instead of sharing the tracks with
the parent grid and having its children participate in the track sizing
algorithm of the parent it acts as its own grid with its own track
sizing algorithm that runs. The parent grid then no longer sees it as a
subgrid but any other grid items. Another case is when you may have a
float that intrudes into a container and forcing the container to
establish an independent formatting context would push the float outside
of the bounds of the container, potentially resulting a much different
layout.

&lt;div style = &quot;width: 50px; height: 50px; float: left; background-color: magenta;&quot;&gt;&lt;/div&gt;
&lt;div style= &quot;width: 200px; height: 200px; outline: 1px solid blue;&quot; id=&quot;container&quot;&gt;
&lt;div&gt;
  foobar
&lt;/div&gt;
&lt;/div&gt;
Mutating the style on container here and adding paint containment should
result in the float getting pushed outside of container.

In terms of the crash, we end up bailing out early in RenderGrid::styleDidChange
since the style difference is not Style::DifferenceResult::Layout and
end up skipping the remaining invalidation in this function, which
includes checking for independent formatting context changes on
subgrids. That type of invalidation was added in 289038@main, which
catches changes to, for example, layout containment. If you end up
changing contain: paint to contain: layout in the new testcase we end up
recovering because of this.

* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::copyUsedTrackSizesForSubgrid):
The RELEASE_ASSERT here was redundant since it was trying to protect
from a bad Vector access, but WTF::Vector already RELEASE_ASSERTS when
this happens.
* Source/WebCore/style/StyleDifference.cpp:
We can fix this by adding a check for paint containment alongside the
other containment changes that require layout.

Canonical link: <a href="https://commits.webkit.org/310968@main">https://commits.webkit.org/310968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e2588a2cbf449300f3e53394b84a3553498bca2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28826 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164329 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/64ca1780-83a9-4b6f-a5d9-a316cd05c9ae) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157439 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28676 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120396 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4731dfa0-82d7-4468-a5ff-c047b0b07489) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22586 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101086 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/df3106e9-b602-45ba-9291-28cdac8ef754) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21672 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19791 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12159 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131341 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166806 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19143 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128514 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23825 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128647 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34883 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28294 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139325 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85737 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23472 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16122 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27988 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92091 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27565 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27795 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27638 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->