### PR TITLE
Setting URL's port to whitespace behaved incorrectly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-setters-a-area.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-setters-a-area.window-expected.txt
@@ -422,12 +422,12 @@ PASS <area>: Setting <https://domain.com:3000>.port = '
 	80
 	80
 	'
-FAIL <a>: Setting <https://domain.com:3000>.port = '
+PASS <a>: Setting <https://domain.com:3000>.port = '
 
-		' assert_equals: expected "3000" but got ""
-FAIL <area>: Setting <https://domain.com:3000>.port = '
+		'
+PASS <area>: Setting <https://domain.com:3000>.port = '
 
-		' assert_equals: expected "3000" but got ""
+		'
 PASS <a>: Setting <mailto:me@example.net>.pathname = '/foo' Opaque paths cannot be set
 PASS <area>: Setting <mailto:me@example.net>.pathname = '/foo' Opaque paths cannot be set
 PASS <a>: Setting <data:original>.pathname = 'new value'

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any.worker_exclude=(file_javascript_mailto)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any.worker_exclude=(file_javascript_mailto)-expected.txt
@@ -185,9 +185,9 @@ PASS URL: Setting <https://domain.com:3000>.port = '
 	80
 	80
 	'
-FAIL URL: Setting <https://domain.com:3000>.port = '
+PASS URL: Setting <https://domain.com:3000>.port = '
 
-		' assert_equals: expected "3000" but got ""
+		'
 PASS URL: Setting <data:original>.pathname = 'new value'
 PASS URL: Setting <sc:original>.pathname = 'new value'
 PASS URL: Setting <foo://somehost/some/path>.pathname = '' Non-special URLs can have their paths erased

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any_exclude=(file_javascript_mailto)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any_exclude=(file_javascript_mailto)-expected.txt
@@ -185,9 +185,9 @@ PASS URL: Setting <https://domain.com:3000>.port = '
 	80
 	80
 	'
-FAIL URL: Setting <https://domain.com:3000>.port = '
+PASS URL: Setting <https://domain.com:3000>.port = '
 
-		' assert_equals: expected "3000" but got ""
+		'
 PASS URL: Setting <data:original>.pathname = 'new value'
 PASS URL: Setting <sc:original>.pathname = 'new value'
 PASS URL: Setting <foo://somehost/some/path>.pathname = '' Non-special URLs can have their paths erased

--- a/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
@@ -160,15 +160,14 @@ ExceptionOr<String> canonicalizePort(StringView portValue, StringView protocolVa
     if (portValueType == BaseURLStringType::Pattern)
         return portValue.toString();
 
-    auto maybePort = URLDecomposition::parsePort(portValue, protocolValue);
+    auto maybePort = URLDecomposition::parsePort(portValue);
     if (!maybePort)
         return Exception { ExceptionCode::TypeError, "Invalid input to canonicalize a URL port string."_s };
 
-    auto maybePortNumber = *maybePort;
-    if (!maybePortNumber)
+    if (WTF::isDefaultPortForProtocol(*maybePort, protocolValue))
         return String { emptyString() };
 
-    return String::number(*maybePortNumber);
+    return String::number(*maybePort);
 }
 
 // https://urlpattern.spec.whatwg.org/#canonicalize-an-opaque-pathname

--- a/Source/WebCore/html/URLDecomposition.cpp
+++ b/Source/WebCore/html/URLDecomposition.cpp
@@ -120,8 +120,7 @@ String URLDecomposition::port() const
     return String::number(*port);
 }
 
-// Outer optional is whether we could parse at all. Inner optional is "no port specified".
-std::optional<std::optional<uint16_t>> URLDecomposition::parsePort(StringView string, StringView protocol)
+std::optional<uint16_t> URLDecomposition::parsePort(StringView string)
 {
     // https://url.spec.whatwg.org/#port-state with state override given.
     uint32_t port { 0 };
@@ -131,20 +130,16 @@ std::optional<std::optional<uint16_t>> URLDecomposition::parsePort(StringView st
         // https://infra.spec.whatwg.org/#ascii-tab-or-newline
         if (c == 0x0009 || c == 0x000A || c == 0x000D)
             continue;
-        if (isASCIIDigit(c)) {
-            port = port * 10 + c - '0';
-            foundDigit = true;
-            if (port > std::numeric_limits<uint16_t>::max())
-                return std::nullopt;
-            continue;
-        }
-        if (!foundDigit)
-            return std::nullopt;
-        break;
+        if (!isASCIIDigit(c))
+            break;
+        port = port * 10 + c - '0';
+        foundDigit = true;
+        if (port > std::numeric_limits<uint16_t>::max())
+            return { };
     }
-    if (!foundDigit || WTF::isDefaultPortForProtocol(static_cast<uint16_t>(port), protocol))
-        return std::optional<uint16_t> { std::nullopt };
-    return {{ static_cast<uint16_t>(port) }};
+    if (!foundDigit)
+        return { };
+    return static_cast<uint16_t>(port);
 }
 
 void URLDecomposition::setPort(StringView value)
@@ -152,10 +147,18 @@ void URLDecomposition::setPort(StringView value)
     auto fullURL = this->fullURL();
     if (fullURL.host().isEmpty() || fullURL.protocolIsFile())
         return;
-    auto port = URLDecomposition::parsePort(value, fullURL.protocol());
+    if (value.isEmpty()) {
+        fullURL.setPort(std::nullopt);
+        setFullURL(fullURL);
+        return;
+    }
+    auto port = URLDecomposition::parsePort(value);
     if (!port)
         return;
-    fullURL.setPort(*port);
+    if (WTF::isDefaultPortForProtocol(*port, fullURL.protocol()))
+        fullURL.setPort(std::nullopt);
+    else
+        fullURL.setPort(*port);
     setFullURL(fullURL);
 }
 

--- a/Source/WebCore/html/URLDecomposition.h
+++ b/Source/WebCore/html/URLDecomposition.h
@@ -60,7 +60,7 @@ public:
     WEBCORE_EXPORT String hash() const;
     void setHash(StringView);
 
-    static std::optional<std::optional<uint16_t>> parsePort(StringView, StringView protocol);
+    static std::optional<uint16_t> parsePort(StringView);
 
 protected:
     virtual ~URLDecomposition() = default;


### PR DESCRIPTION
#### 6143ea1821d1bfb6665e0b6b3f32ceb326e9d049
<pre>
Setting URL&apos;s port to whitespace behaved incorrectly
<a href="https://bugs.webkit.org/show_bug.cgi?id=311908">https://bugs.webkit.org/show_bug.cgi?id=311908</a>

Reviewed by Chris Dumez.

URL&apos;s port setter has a special case for the empty string. Everything
else is supposed to go through the parser.

To make this code more understandable we move the default scheme
handling out of the port parser and slightly restructure the loop in
the port parser so there is less duplication and nesting.

Covered by existing tests and test progressions.

Canonical link: <a href="https://commits.webkit.org/310919@main">https://commits.webkit.org/310919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/319d9a5e4f0d262cb8588954055d7aac5c14d6f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155428 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28688 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164190 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fe1febd8-987e-4e71-a488-bb9f768cff93) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157301 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28830 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28538 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120289 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/00e4b720-47a0-4efb-a1ee-417d37894e01) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22476 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139578 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100979 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; run-api-tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21562 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19675 "Build is in progress. Recent messages:") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12019 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131231 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17410 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166668 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19020 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128399 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23709 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128535 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28156 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139203 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85593 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23680 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23370 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16000 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27850 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91953 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27427 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27657 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27500 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->