### PR TITLE
[BFCache] Add multi-process suspension for BFCache with Site Isolation

### DIFF
--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -530,38 +530,40 @@ std::unique_ptr<CachedPage> BackForwardCache::trySuspendPage(Page& page, ForceSu
     return makeUnique<CachedPage>(page);
 }
 
-bool BackForwardCache::addIfCacheable(HistoryItem& item, Page* page)
+bool BackForwardCache::addIfCacheable(BackForwardFrameItemIdentifier identifier, Page& page)
 {
-    if (item.isInBackForwardCache())
+    if (isInBackForwardCache(identifier))
         return false;
 
-    if (!page)
-        return false;
-
-    // FIXME (rdar://173799983): Remove this workaround once the UIProcess has a
-    // mechanism to detach RemotePageProxy objects from the BrowsingContextGroup
-    // during in-process (same-origin) navigations. Cross-process suspension
-    // (suspendPage with ForceSuspension::Yes) already handles this via
-    // BrowsingContextGroup exchange in suspendCurrentPageIfPossible.
-    if (page->settings().siteIsolationEnabled())
-        return false;
-
-    auto cachedPage = trySuspendPage(*page, ForceSuspension::No);
+    auto cachedPage = trySuspendPage(page, ForceSuspension::No);
     if (!cachedPage)
         return false;
 
     {
-        // Make sure we don't fire any JS events in this scope.
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
-
-        m_cachedPageMap.set(item.frameItemID(), makeUniqueRefFromNonNullUniquePtr(WTF::move(cachedPage)));
-        m_items.add(item.frameItemID());
-        item.notifyChanged();
+        m_cachedPageMap.set(identifier, makeUniqueRefFromNonNullUniquePtr(WTF::move(cachedPage)));
+        m_items.add(identifier);
     }
     prune(PruningReason::ReachedMaxSize);
+    RELEASE_LOG(BackForwardCache, "BackForwardCache::addIfCacheable frameItemID: %s, size: %u / %u", identifier.toString().utf8().data(), pageCount(), maxSize());
+    return true;
+}
 
-    RELEASE_LOG(BackForwardCache, "BackForwardCache::addIfCacheable item: %s, size: %u / %u", item.itemID().toString().utf8().data(), pageCount(), maxSize());
+bool BackForwardCache::addIfCacheable(HistoryItem& item, Page* page)
+{
+    if (!page)
+        return false;
 
+    // Same-site BFCache is not yet supported under Site Isolation — same-origin
+    // navigations can leave stale RemotePageProxy objects in the BCG.
+    // Cross-site (multi-process) BFCache uses the other addIfCacheable overload
+    // which is only called when both SI and multiProcessBackForwardCache are enabled.
+    if (page->settings().siteIsolationEnabled())
+        return false;
+
+    if (!addIfCacheable(item.frameItemID(), *page))
+        return false;
+    item.notifyChanged();
     return true;
 }
 

--- a/Source/WebCore/history/BackForwardCache.h
+++ b/Source/WebCore/history/BackForwardCache.h
@@ -57,12 +57,13 @@ public:
 
     WEBCORE_EXPORT std::unique_ptr<CachedPage> suspendPage(Page&);
     WEBCORE_EXPORT bool addIfCacheable(HistoryItem&, Page*); // Prunes if maxSize() is exceeded.
+    WEBCORE_EXPORT bool addIfCacheable(BackForwardFrameItemIdentifier, Page&);
     WEBCORE_EXPORT void remove(BackForwardFrameItemIdentifier);
     WEBCORE_EXPORT void remove(HistoryItem&);
     CachedPage* get(HistoryItem&, Page*);
     std::unique_ptr<CachedPage> take(HistoryItem&, Page*);
 
-    void removeAllItemsForPage(Page&);
+    WEBCORE_EXPORT void removeAllItemsForPage(Page&);
 
     WEBCORE_EXPORT void clearEntriesForOrigins(const HashSet<Ref<SecurityOrigin>>&);
 

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -246,8 +246,18 @@ void BrowsingContextGroup::addRemotePage(WebPageProxy& page, Ref<RemotePageProxy
 void BrowsingContextGroup::removePage(WebPageProxy& page)
 {
     m_pages.remove(page);
+    closeRemotePagesForPage(page);
+}
+
+void BrowsingContextGroup::closeRemotePagesForPage(WebPageProxy& page)
+{
     for (auto& remotePage : m_remotePages.take(page))
-        remotePage->disconnect();
+        protect(remotePage)->disconnect();
+}
+
+bool BrowsingContextGroup::hasMultiplePages() const
+{
+    return m_pages.computeSize() > 1;
 }
 
 void BrowsingContextGroup::forEachRemotePage(const WebPageProxy& page, Function<void(RemotePageProxy&)>&& function)

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -74,6 +74,8 @@ public:
     void addPage(WebPageProxy&);
     void addRemotePage(WebPageProxy&, Ref<RemotePageProxy>&&);
     void removePage(WebPageProxy&);
+    void closeRemotePagesForPage(WebPageProxy&);
+    bool hasMultiplePages() const;
     void forEachRemotePage(const WebPageProxy&, Function<void(RemotePageProxy&)>&&);
 
     RefPtr<RemotePageProxy> remotePageInProcess(const WebPageProxy&, const WebProcessProxy&);

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -33,6 +33,7 @@
 #include "HandleMessage.h"
 #include "Logging.h"
 #include "MessageSenderInlines.h"
+#include "RemotePageProxy.h"
 #include "WebBackForwardCache.h"
 #include "WebBackForwardList.h"
 #include "WebBackForwardListMessages.h"
@@ -42,6 +43,7 @@
 #include "WebPageProxyMessages.h"
 #include "WebProcessMessages.h"
 #include "WebProcessPool.h"
+#include <wtf/CallbackAggregator.h>
 #include <wtf/DebugUtilities.h>
 #include <wtf/HexNumber.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -64,6 +66,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(SuspendedPageProxy);
 RefPtr<WebProcessProxy> SuspendedPageProxy::findReusableSuspendedPageProcess(WebProcessPool& processPool, const RegistrableDomain& registrableDomain, WebsiteDataStore& dataStore, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, const API::PageConfiguration& pageConfiguration)
 {
     for (Ref suspendedPage : allSuspendedPages()) {
+        if (!suspendedPage->hasSuspensionStarted())
+            continue;
         Ref process = suspendedPage->process();
         if (&process->processPool() == &processPool
             && process->site() && process->site()->domain() == registrableDomain
@@ -135,15 +139,6 @@ SuspendedPageProxy::SuspendedPageProxy(WebPageProxy& page, Ref<WebProcessProxy>&
 #endif
 {
     allSuspendedPages().add(*this);
-    m_process->addSuspendedPageProxy(*this);
-    m_messageReceiverRegistration.startReceivingMessages(m_process, m_webPageID, *this, *this);
-    m_suspensionTimeoutTimer.startOneShot(suspensionTimeout);
-    sendWithAsyncReply(Messages::WebPage::SetIsSuspended(true), [weakThis = WeakPtr { *this }](std::optional<bool> didSuspend) {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !didSuspend)
-            return;
-        protectedThis->didProcessRequestToSuspend(*didSuspend ? SuspensionState::Suspended : SuspensionState::FailedToSuspend);
-    });
 }
 
 template<typename M>
@@ -158,23 +153,58 @@ void SuspendedPageProxy::sendWithAsyncReply(M&& message, C&& completionHandler)
     m_process->sendWithAsyncReply(std::forward<M>(message), std::forward<C>(completionHandler), m_webPageID);
 }
 
+void SuspendedPageProxy::startSuspension(std::optional<BackForwardFrameItemIdentifier> mainFrameItemID)
+{
+    ASSERT(m_suspensionState == SuspensionState::BeforeStart);
+    ASSERT(!m_browsingContextGroup->hasMultiplePages());
+
+    m_process->addSuspendedPageProxy(*this);
+    m_suspensionState = SuspensionState::Suspending;
+
+    if (mainFrameItemID)
+        suspendSubframeProcesses(*mainFrameItemID);
+    else
+        m_allSubframesSuspended = true;
+
+    m_messageReceiverRegistration.startReceivingMessages(m_process, m_webPageID, *this, *this);
+    m_suspensionTimeoutTimer.startOneShot(suspensionTimeout);
+    sendWithAsyncReply(Messages::WebPage::SetIsSuspended(true), [weakThis = WeakPtr { *this }](std::optional<bool> didSuspend) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !didSuspend)
+            return;
+        protectedThis->didProcessRequestToSuspend(*didSuspend ? SuspensionState::Suspended : SuspensionState::FailedToSuspend);
+    });
+}
+
 SuspendedPageProxy::~SuspendedPageProxy()
+{
+    if (auto handler = std::exchange(m_readyToUnsuspendHandler, nullptr)) {
+        RunLoop::mainSingleton().dispatch([handler = WTF::move(handler)]() mutable {
+            handler(nullptr);
+        });
+    }
+    teardown();
+}
+
+void SuspendedPageProxy::teardown()
 {
     allSuspendedPages().remove(*this);
 
-    if (m_readyToUnsuspendHandler) {
-        RunLoop::mainSingleton().dispatch([readyToUnsuspendHandler = WTF::move(m_readyToUnsuspendHandler)]() mutable {
-            readyToUnsuspendHandler(nullptr);
-        });
+    if (RefPtr page = m_page.get()) {
+        if (hasSuspensionStarted()) {
+            m_browsingContextGroup->forEachRemotePage(*page, [suspendedPage = Ref { *this }](auto& remotePage) {
+                protect(remotePage.siteIsolatedProcess())->removeSuspendedPageProxy(suspendedPage);
+            });
+        }
+        if (m_suspensionState != SuspensionState::Resumed)
+            m_browsingContextGroup->closeRemotePagesForPage(*page);
     }
 
-    if (m_suspensionState != SuspensionState::Resumed) {
-        // If the suspended page was not consumed before getting destroyed, then close the corresponding page
-        // on the WebProcess side.
+    if (m_suspensionState != SuspensionState::Resumed)
         close();
-    }
 
-    m_process->removeSuspendedPageProxy(*this);
+    if (hasSuspensionStarted())
+        m_process->removeSuspendedPageProxy(*this);
 }
 
 void SuspendedPageProxy::didDestroyNavigation(WebCore::NavigationIdentifier navigationID)
@@ -201,6 +231,7 @@ void SuspendedPageProxy::waitUntilReadyToUnsuspend(CompletionHandler<void(Suspen
     case SuspensionState::Suspended:
         completionHandler(this);
         break;
+    case SuspensionState::BeforeStart:
     case SuspensionState::Resumed:
         ASSERT_NOT_REACHED();
         completionHandler(nullptr);
@@ -260,12 +291,10 @@ void SuspendedPageProxy::didProcessRequestToSuspend(SuspensionState newSuspensio
     LOG(ProcessSwapping, "SuspendedPageProxy %s from process %i finished transition to suspended", loggingString().utf8().data(), m_process->processID());
     RELEASE_LOG(ProcessSwapping, "%p - SuspendedPageProxy::didProcessRequestToSuspend() success? %d", this, newSuspensionState == SuspensionState::Suspended);
 
-    ASSERT(m_suspensionState == SuspensionState::Suspending);
     ASSERT(newSuspensionState == SuspensionState::Suspended || newSuspensionState == SuspensionState::FailedToSuspend);
 
-    m_suspensionState = newSuspensionState;
-
-    m_suspensionTimeoutTimer.stop();
+    if (m_suspensionState != SuspensionState::Suspending)
+        return;
 
 #if USE(RUNNINGBOARD)
     m_suspensionActivity = nullptr;
@@ -273,17 +302,95 @@ void SuspendedPageProxy::didProcessRequestToSuspend(SuspensionState newSuspensio
 
     m_messageReceiverRegistration.stopReceivingMessages();
 
-    if (m_suspensionState == SuspensionState::FailedToSuspend)
+    if (newSuspensionState == SuspensionState::FailedToSuspend) {
+        m_suspensionState = SuspensionState::FailedToSuspend;
+        m_suspensionTimeoutTimer.stop();
         closeWithoutFlashing();
+        if (auto handler = std::exchange(m_readyToUnsuspendHandler, nullptr))
+            handler(this);
+        return;
+    }
 
-    if (m_readyToUnsuspendHandler)
-        m_readyToUnsuspendHandler(this);
+    m_mainFrameSuspended = true;
+    maybeCompleteSuspension();
 }
 
 void SuspendedPageProxy::suspensionTimedOut()
 {
+    if (m_suspensionState != SuspensionState::Suspending)
+        return;
+
     RELEASE_LOG_ERROR(ProcessSwapping, "%p - SuspendedPageProxy::suspensionTimedOut() destroying the suspended page because it failed to suspend in time", this);
     protect(backForwardCache())->removeEntry(*this); // Will destroy |this|.
+}
+
+void SuspendedPageProxy::suspendSubframeProcesses(BackForwardFrameItemIdentifier mainFrameItemID)
+{
+    ASSERT(!m_allSubframesSuspended);
+    ASSERT(!m_readyToUnsuspendHandler);
+
+    RefPtr page = m_page.get();
+    if (!page) {
+        RELEASE_LOG_ERROR(ProcessSwapping, "%p - SuspendedPageProxy::suspendSubframeProcesses: page is null", this);
+        m_allSubframesSuspended = true;
+        return;
+    }
+
+    // The aggregator collects success/failure from all subframe processes.
+    // Its destructor fires the callback when all chain() handlers have been
+    // called (or destroyed). On failure, we remove the WebBackForwardCache
+    // entry, which is the sole owner of this SuspendedPageProxy — dropping
+    // it triggers our destructor -> teardown() -> process cleanup.
+    auto aggregator = MainRunLoopSuccessCallbackAggregator::create([weakThis = WeakPtr { *this }](bool success) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || protectedThis->m_suspensionState != SuspensionState::Suspending)
+            return;
+
+        if (!success) {
+            RELEASE_LOG_ERROR(ProcessSwapping, "%p - SuspendedPageProxy::suspendSubframeProcesses: failed, invalidating cache entry", protectedThis.get());
+            // removeEntry drops the WebBackForwardCache's Ref to this
+            // SuspendedPageProxy. If no other Ref exists, this triggers
+            // destruction -> teardown() -> subframe process cleanup.
+            protect(protectedThis->backForwardCache())->removeEntry(*protectedThis);
+            return;
+        }
+        protectedThis->m_allSubframesSuspended = true;
+        protectedThis->maybeCompleteSuspension();
+    });
+
+    m_browsingContextGroup->forEachRemotePage(*page, [suspendedPage = Ref { *this }, &aggregator, mainFrameItemID](auto& remotePage) {
+        Ref process = remotePage.siteIsolatedProcess();
+        process->addSuspendedPageProxy(suspendedPage);
+
+        RELEASE_LOG(ProcessSwapping, "%p - SuspendedPageProxy::suspendSubframeProcesses: Sending SetSubframesSuspended to pid %i", &suspendedPage, process->processID());
+
+        process->sendWithAsyncReply(Messages::WebPage::SetSubframesSuspended(true, mainFrameItemID), aggregator->chain(), remotePage.identifierInSiteIsolatedProcess());
+    });
+}
+
+bool SuspendedPageProxy::hasSubframeInProcess(WebCore::ProcessIdentifier processIdentifier) const
+{
+    // FIXME: Add WebFrameProxy::forEachDescendant() to avoid manual traverseNext() loops.
+    for (RefPtr frame = m_mainFrame->traverseNext().frame; frame; frame = frame->traverseNext().frame) {
+        if (protect(frame->process())->coreProcessIdentifier() == processIdentifier)
+            return true;
+    }
+    return false;
+}
+
+void SuspendedPageProxy::maybeCompleteSuspension()
+{
+    if (m_suspensionState != SuspensionState::Suspending)
+        return;
+
+    if (!m_mainFrameSuspended || !m_allSubframesSuspended)
+        return;
+
+    m_suspensionTimeoutTimer.stop();
+    m_suspensionState = SuspensionState::Suspended;
+
+    if (auto handler = std::exchange(m_readyToUnsuspendHandler, nullptr))
+        handler(this);
 }
 
 WebPageProxy* SuspendedPageProxy::page() const

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -28,9 +28,9 @@
 #include "Connection.h"
 #include "EnhancedSecurity.h"
 #include "ProcessThrottler.h"
-#include "WebBackForwardListItem.h"
 #include "WebPageProxyMessageReceiverRegistration.h"
 #include "WebProcessProxy.h"
+#include <WebCore/BackForwardFrameItemIdentifier.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/NavigationIdentifier.h>
 #include <wtf/RefCounted.h>
@@ -73,7 +73,8 @@ public:
     WebCore::PageIdentifier webPageID() const { return m_webPageID; }
     WebProcessProxy& process() const { return m_process.get(); }
     WebFrameProxy& mainFrame() { return m_mainFrame.get(); }
-    const BrowsingContextGroup& browsingContextGroup() { return m_browsingContextGroup.get(); }
+    const BrowsingContextGroup& browsingContextGroup() const { return m_browsingContextGroup.get(); }
+    BrowsingContextGroup& browsingContextGroup() { return m_browsingContextGroup.get(); }
 
     WebBackForwardCache& NODELETE backForwardCache() const;
 
@@ -81,8 +82,11 @@ public:
 
     bool NODELETE pageIsClosedOrClosing() const;
 
+    void startSuspension(std::optional<WebCore::BackForwardFrameItemIdentifier>);
     void waitUntilReadyToUnsuspend(CompletionHandler<void(SuspendedPageProxy*)>&&);
     void unsuspend();
+
+    bool hasSubframeInProcess(WebCore::ProcessIdentifier) const;
 
     void pageDidFirstLayerFlush();
     void closeWithoutFlashing();
@@ -101,11 +105,15 @@ public:
 private:
     SuspendedPageProxy(WebPageProxy&, Ref<WebProcessProxy>&&, Ref<WebFrameProxy>&& mainFrame, Ref<BrowsingContextGroup>&&, ShouldDelayClosingUntilFirstLayerFlush);
 
-    enum class SuspensionState : uint8_t { Suspending, FailedToSuspend, Suspended, Resumed };
+    enum class SuspensionState : uint8_t { BeforeStart, Suspending, FailedToSuspend, Suspended, Resumed };
+    bool hasSuspensionStarted() const { return m_suspensionState != SuspensionState::BeforeStart; }
     void didProcessRequestToSuspend(SuspensionState);
     void suspensionTimedOut();
+    void suspendSubframeProcesses(WebCore::BackForwardFrameItemIdentifier);
+    void maybeCompleteSuspension();
 
     void close();
+    void teardown();
     void didDestroyNavigation(WebCore::NavigationIdentifier);
 
     // IPC::MessageReceiver
@@ -125,9 +133,11 @@ private:
     ShouldDelayClosingUntilFirstLayerFlush m_shouldDelayClosingUntilFirstLayerFlush { ShouldDelayClosingUntilFirstLayerFlush::No };
     bool m_shouldCloseWhenEnteringAcceleratedCompositingMode { false };
 
-    SuspensionState m_suspensionState { SuspensionState::Suspending };
+    SuspensionState m_suspensionState { SuspensionState::BeforeStart };
     CompletionHandler<void(SuspendedPageProxy*)> m_readyToUnsuspendHandler;
     RunLoop::Timer m_suspensionTimeoutTimer;
+    bool m_mainFrameSuspended { false };
+    bool m_allSubframesSuspended { false };
 #if USE(RUNNINGBOARD)
     RefPtr<ProcessThrottler::BackgroundActivity> m_suspensionActivity;
 #endif

--- a/Source/WebKit/UIProcess/WebBackForwardCache.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.cpp
@@ -30,6 +30,7 @@
 #include "SuspendedPageProxy.h"
 #include "WebBackForwardCacheEntry.h"
 #include "WebBackForwardListFrameItem.h"
+#include "WebBackForwardListItem.h"
 #include "WebPageProxy.h"
 #include "WebProcessMessages.h"
 #include "WebProcessPool.h"
@@ -145,7 +146,19 @@ void WebBackForwardCache::removeEntriesForProcess(WebProcessProxy& process)
 {
     removeEntriesMatching([processIdentifier = process.coreProcessIdentifier()](auto& entry) {
         ASSERT(entry.backForwardCacheEntry());
-        return entry.backForwardCacheEntry()->processIdentifier() == processIdentifier;
+
+        // Check main process (existing behavior).
+        if (entry.backForwardCacheEntry()->processIdentifier() == processIdentifier)
+            return true;
+
+        // Check subframe processes (multi-process BFCache).
+        if (RefPtr suspendedPage = entry.suspendedPage()) {
+            if (suspendedPage->hasSubframeInProcess(processIdentifier)) {
+                RELEASE_LOG(ProcessSwapping, "WebBackForwardCache::removeEntriesForProcess: subframe process terminated while in BFCache, invalidating cache entry");
+                return true;
+            }
+        }
+        return false;
     });
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1468,6 +1468,11 @@ bool WebPageProxy::suspendCurrentPageIfPossible(API::Navigation& navigation, Ref
         return false;
     }
 
+    if (protect(m_browsingContextGroup)->hasMultiplePages()) {
+        WEBPAGEPROXY_RELEASE_LOG(ProcessSwapping, "suspendCurrentPageIfPossible: Not suspending current page for process pid %i because BrowsingContextGroup has multiple pages", m_legacyMainFrameProcess->processID());
+        return false;
+    }
+
     RefPtr fromItem = navigation.fromItem();
 
     // If the source and the destination back / forward list items are the same, then this is a client-side redirect. In this case,
@@ -1495,6 +1500,13 @@ bool WebPageProxy::suspendCurrentPageIfPossible(API::Navigation& navigation, Ref
     mainFrame->frameLoadState().didSuspend();
 
     Ref suspendedPage = SuspendedPageProxy::create(*this, protect(legacyMainFrameProcess()), mainFrame.releaseNonNull(), std::exchange(m_browsingContextGroup, BrowsingContextGroup::create()), shouldDelayClosingUntilFirstLayerFlush);
+    std::optional<BackForwardFrameItemIdentifier> mainFrameItemID;
+    if (fromItem && protect(preferences())->multiProcessBackForwardCacheEnabled())
+        mainFrameItemID = protect(fromItem)->mainFrameItem().identifier();
+    suspendedPage->startSuspension(mainFrameItemID);
+    // startSuspension() sends async IPCs to subframe processes. Failure is
+    // handled by the CallbackAggregator which removes the BFCache entry,
+    // destroying this SuspendedPageProxy and triggering teardown().
 
     LOG(ProcessSwapping, "WebPageProxy %" PRIu64 " created suspended page %s for process pid %i, back/forward item %s" PRIu64, identifier().toUInt64(), suspendedPage->loggingString().utf8().data(), m_legacyMainFrameProcess->processID(), fromItem ? fromItem->identifier().toString().utf8().data() : "0"_s);
 
@@ -5661,7 +5673,6 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
         // handles the update).
         if (*oldMainFrameID != frameID)
             backForwardList().updateFrameIdentifier(*oldMainFrameID, frameID);
-        mainFrameInPreviousProcess->removeChildFrames();
     }
 
     ASSERT(m_legacyMainFrameProcess.ptr() != &provisionalPage->process() || preferences->siteIsolationEnabled());
@@ -5682,6 +5693,10 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
     removeAllMessageReceivers();
     RefPtr navigation = m_navigationState->navigation(provisionalPage->navigationID());
     bool didSuspendPreviousPage = navigation ? suspendCurrentPageIfPossible(*navigation, WTF::move(mainFrameInPreviousProcess), shouldDelayClosingUntilFirstLayerFlush) : false;
+
+    if (!didSuspendPreviousPage && mainFrameInPreviousProcess && preferences->siteIsolationEnabled())
+        mainFrameInPreviousProcess->removeChildFrames();
+
     // Defer shutting down old process as it might lead WebPageProxy to be closed and removeWebPage to be invoked again.
     auto preventProcessShutdownScope = protect(legacyMainFrameProcess())->shutdownPreventingScope();
     protect(legacyMainFrameProcess())->removeWebPage(*this, m_websiteDataStore.ptr() == provisionalPage->process().websiteDataStore() ? WebProcessProxy::EndsUsingDataStore::No : WebProcessProxy::EndsUsingDataStore::Yes);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8554,6 +8554,36 @@ void WebPage::setIsSuspended(bool suspended, CompletionHandler<void(std::optiona
     suspendForProcessSwap(WTF::move(completionHandler));
 }
 
+void WebPage::setSubframesSuspended(bool suspended, BackForwardFrameItemIdentifier identifier, CompletionHandler<void(bool)>&& completionHandler)
+{
+    if (m_isSuspended == suspended)
+        return completionHandler(true);
+    m_isSuspended = suspended;
+
+    if (!suspended) {
+        // FIXME: Restore path (follow-up patch).
+        return completionHandler(true);
+    }
+
+    freezeLayerTree(LayerTreeFreezeReason::PageSuspended);
+    unfreezeLayerTree(LayerTreeFreezeReason::BackgroundApplication);
+    flushDeferredDidReceiveMouseEvent();
+
+    RefPtr page = corePage();
+    if (!page) {
+        WEBPAGE_RELEASE_LOG_ERROR(ProcessSwapping, "setSubframesSuspended: No corePage");
+        return completionHandler(false);
+    }
+
+    if (!BackForwardCache::singleton().addIfCacheable(identifier, *page)) {
+        WEBPAGE_RELEASE_LOG_ERROR(ProcessSwapping, "setSubframesSuspended: addIfCacheable failed");
+        return completionHandler(false);
+    }
+
+    WEBPAGE_RELEASE_LOG(ProcessSwapping, "setSubframesSuspended: Successfully cached page");
+    completionHandler(true);
+}
+
 void WebPage::hasStorageAccess(RegistrableDomain&& subFrameDomain, RegistrableDomain&& topFrameDomain, WebFrame& frame, CompletionHandler<void(bool)>&& completionHandler)
 {
     if (hasPageLevelStorageAccess(topFrameDomain, subFrameDomain)) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2629,6 +2629,7 @@ private:
     void setNeedsDOMWindowResizeEvent();
 
     void setIsSuspended(bool, CompletionHandler<void(std::optional<bool>)>&&);
+    void setSubframesSuspended(bool, WebCore::BackForwardFrameItemIdentifier, CompletionHandler<void(bool)>&&);
 
     RefPtr<WebImage> snapshotAtSize(const WebCore::IntRect&, const WebCore::IntSize& bitmapSize, SnapshotOptions, WebCore::LocalFrame&, WebCore::LocalFrameView&);
     RefPtr<WebImage> snapshotNode(WebCore::Node&, SnapshotOptions, unsigned maximumPixelCount = std::numeric_limits<unsigned>::max());

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -718,6 +718,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     URLSchemeTaskDidComplete(WebKit::WebURLSchemeHandlerIdentifier handlerIdentifier, WebCore::ResourceLoaderIdentifier taskIdentifier, WebCore::ResourceError error)
 
     SetIsSuspended(bool suspended) -> (std::optional<bool> didSuspend)
+    SetSubframesSuspended(bool suspended, WebCore::BackForwardFrameItemIdentifier identifier) -> (bool success)
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     InsertAttachment(String identifier, std::optional<uint64_t> fileSize, String fileName, String contentType) -> ()

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestNavigationDelegate.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestNavigationDelegate.h
@@ -57,6 +57,7 @@
 - (void)waitForDidStartProvisionalNavigation;
 - (void)waitForDidFinishNavigation;
 - (void)waitForDidFinishLoadInSubframe;
+- (void)waitForDidFinishNavigationAndLoadInSubframe;
 - (void)waitForDidFinishNavigationWithPreferences:(WKWebpagePreferences *)preferences;
 - (void)waitForDidSameDocumentNavigation;
 - (_WKProcessTerminationReason)waitForWebContentProcessDidTerminate;

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestNavigationDelegate.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestNavigationDelegate.mm
@@ -192,6 +192,29 @@
     self.didFinishLoadWithRequestInFrame = nil;
 }
 
+- (void)waitForDidFinishNavigationAndLoadInSubframe
+{
+    EXPECT_FALSE(self.didFinishNavigation);
+    EXPECT_FALSE(self.didFinishLoadWithRequestInFrame);
+
+    __block bool navigationFinished = false;
+    __block bool subframeLoaded = false;
+
+    self.didFinishNavigation = ^(WKWebView *, WKNavigation *) {
+        navigationFinished = true;
+    };
+    self.didFinishLoadWithRequestInFrame = ^(WKWebView *, NSURLRequest *, WKFrameInfo *frame) {
+        if (!frame.isMainFrame)
+            subframeLoaded = true;
+    };
+
+    TestWebKitAPI::Util::run(&navigationFinished);
+    TestWebKitAPI::Util::run(&subframeLoaded);
+
+    self.didFinishNavigation = nil;
+    self.didFinishLoadWithRequestInFrame = nil;
+}
+
 - (void)waitForDidSameDocumentNavigation
 {
     EXPECT_FALSE(self.didSameDocumentNavigation);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -8550,6 +8550,77 @@ TEST(SiteIsolation, OpenEmptySiteFromProcessWithNonEmptySite)
     Util::run(&openedFinishedLoading);
 }
 
+TEST(SiteIsolation, MultiProcessBFCacheIframeProcessSurvival)
+{
+    HTTPServer server({
+        { "/a"_s, { "<iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "iframe content"_s } },
+        { "/c"_s, { "page c"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
+
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    });
+
+    pid_t iframePID = findFramePID(frameTrees(webView.get()).get(), FrameType::Remote);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Iframe process must survive. Without multi-process suspension,
+    // removeChildFrames() sends WebPage::Close() and kills it.
+    EXPECT_TRUE(processStillRunning(iframePID));
+}
+
+// FIXME: Use openerAndOpenedViews() once MultiProcessBackForwardCacheEnabled is on by default.
+TEST(SiteIsolation, MultiProcessBFCacheOpenerSkipsBFCache)
+{
+    HTTPServer server({
+        { "/a"_s, { "<script>window.open('https://a.com/child');</script>"_s } },
+        { "/child"_s, { "child page"_s } },
+        { "/b"_s, { "page b"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    [webView setUIDelegate:uiDelegate.get()];
+    webView.get().configuration.preferences.javaScriptCanOpenWindowsAutomatically = YES;
+
+    __block RetainPtr<WKWebView> openedWebView;
+    uiDelegate.get().createWebViewWithConfiguration = ^WKWebView *(WKWebViewConfiguration *config, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
+        openedWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:config]);
+        return openedWebView.get();
+    };
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Set a BFCache marker on the opener page.
+    [webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker = true"];
+
+    // Navigate to a different site to trigger PSON.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://b.com/b"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Go back.
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Verify the marker is gone (full reload, not BFCache restore).
+    EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker ? true : false"] boolValue]);
+}
+
 #if PLATFORM(IOS_FAMILY)
 TEST(SiteIsolation, NoRedundantFocusPolicyCallbackAfterBlurAndRefocusInCrossOriginIframe)
 {


### PR DESCRIPTION
#### 41894db0ac68ab9f13087416e2579726077cee8f
<pre>
[BFCache] Add multi-process suspension for BFCache with Site Isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=311224">https://bugs.webkit.org/show_bug.cgi?id=311224</a>
<a href="https://rdar.apple.com/173743585">rdar://173743585</a>

Reviewed by Sihui Liu.

When site isolation is active and multi-process BFCache is enabled, suspend
subframe processes alongside the main frame when a page enters the
back/forward cache. Each subframe process receives a SetSubframesSuspended
IPC — along with the main frame&apos;s BackForwardFrameItemIdentifier — that
caches its page in the WebCore BackForwardCache. A CallbackAggregator tracks
completion across all processes; if any fails, the BFCache entry is removed
and teardown cleans up the subframe processes.

The UIProcess passes fromItem-&gt;mainFrameItem().identifier() to each iframe
process. This identifier is unique per navigation entry, stable across iframe
cross-site navigations, and the same for all iframe processes — no
per-process frame tree traversal needed. Each iframe process stores its
CachedPage under this key in its own per-process BackForwardCache singleton.

Also refactor BackForwardCache::addIfCacheable to share logic between the
existing HistoryItem-based overload and the new identifier-based overload
used by iframe processes.

Tests: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm

* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::BackForwardCache::addIfCacheable):
* Source/WebCore/history/BackForwardCache.h:
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::removePage):
(WebKit::BrowsingContextGroup::closeRemotePagesForPage):
(WebKit::BrowsingContextGroup::hasMultiplePages const):
* Source/WebKit/UIProcess/BrowsingContextGroup.h:
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::findReusableSuspendedPageProcess):
(WebKit::SuspendedPageProxy::SuspendedPageProxy):
(WebKit::SuspendedPageProxy::startSuspension):
(WebKit::SuspendedPageProxy::~SuspendedPageProxy):
(WebKit::SuspendedPageProxy::teardown):
(WebKit::SuspendedPageProxy::waitUntilReadyToUnsuspend):
(WebKit::SuspendedPageProxy::didProcessRequestToSuspend):
(WebKit::SuspendedPageProxy::suspensionTimedOut):
(WebKit::SuspendedPageProxy::suspendSubframeProcesses):
(WebKit::SuspendedPageProxy::hasSubframeInProcess const):
(WebKit::SuspendedPageProxy::maybeCompleteSuspension):
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Source/WebKit/UIProcess/WebBackForwardCache.cpp:
(WebKit::WebBackForwardCache::removeEntriesForProcess):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::suspendCurrentPageIfPossible):
(WebKit::WebPageProxy::commitProvisionalPage):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setSubframesSuspended):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Helpers/cocoa/TestNavigationDelegate.h:
* Tools/TestWebKitAPI/Helpers/cocoa/TestNavigationDelegate.mm:
(-[TestNavigationDelegate waitForDidFinishNavigationAndLoadInSubframe]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, MultiProcessBFCacheIframeProcessSurvival)):
(TestWebKitAPI::(SiteIsolation, MultiProcessBFCacheOpenerSkipsBFCache)):

Canonical link: <a href="https://commits.webkit.org/311727@main">https://commits.webkit.org/311727@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df2d66250fc70f3c2755308b471878a59b9f0dcf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166654 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159695 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31163 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/122218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24497 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/102884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14419 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169148 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13898 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21157 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/30907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/25909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/130503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35336 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/30845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141329 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88695 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/30845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/18135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30397 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95230 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29918 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30148 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30045 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->