### PR TITLE
Fix (more) some correctness issues for a few TestWebKitAPI tests

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm
@@ -864,7 +864,7 @@ static IterationStatus forEachCALayer(CALayer *layer, IterationStatus(^visitor)(
 #ifdef __cplusplus
 
 @implementation TestMessageHandler {
-    NSMutableDictionary<NSString *, dispatch_block_t> *_messageHandlers;
+    RetainPtr<NSMutableDictionary<NSString *, dispatch_block_t>> _messageHandlers;
     RetainPtr<NSMutableArray<NSString *>> _receivedMessages;
 }
 
@@ -873,7 +873,7 @@ static IterationStatus forEachCALayer(CALayer *layer, IterationStatus(^visitor)(
     if (!_messageHandlers)
         _messageHandlers = [NSMutableDictionary dictionary];
 
-    _messageHandlers[message] = adoptNS([handler copy]).autorelease();
+    _messageHandlers.get()[message] = adoptNS([handler copy]).autorelease();
 }
 
 - (void)removeMessage:(NSString *)message
@@ -887,7 +887,7 @@ static IterationStatus forEachCALayer(CALayer *layer, IterationStatus(^visitor)(
         _receivedMessages = adoptNS([[NSMutableArray alloc] init]);
     [_receivedMessages addObject:message.body];
 
-    if (dispatch_block_t handler = _messageHandlers[message.body])
+    if (dispatch_block_t handler = _messageHandlers.get()[message.body])
         handler();
     if (_didReceiveScriptMessage)
         _didReceiveScriptMessage(message.body);


### PR DESCRIPTION
#### acd3aedadb0ba11f04f4c1a4754005183c0ad5cf
<pre>
Fix (more) some correctness issues for a few TestWebKitAPI tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=311909">https://bugs.webkit.org/show_bug.cgi?id=311909</a>
<a href="https://rdar.apple.com/174473169">rdar://174473169</a>

Reviewed by Megan Gardner and Tim Horton.

Use RetainPtr instead of a raw pointer.

* Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm:
(-[TestMessageHandler addMessage:withHandler:]):
(-[TestMessageHandler userContentController:didReceiveScriptMessage:]):

Canonical link: <a href="https://commits.webkit.org/310947@main">https://commits.webkit.org/310947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2485e58bc2dbd8b22538dfede7b9c7a625cfbca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28694 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164196 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f80ebff-5ea0-4de6-9bd0-ac6fd19ba0a5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157307 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28544 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120293 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158393 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22482 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139581 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100983 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21568 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19679 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12025 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131237 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17413 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166674 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19023 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128403 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28238 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23713 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128539 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34872 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28162 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139206 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85599 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23374 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16003 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27856 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27433 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27663 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27506 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->