### PR TITLE
[JSC] Add Int32 array fast path to `FastStringifier` for `JSON.stringify`

### DIFF
--- a/JSTests/microbenchmarks/json-stringify-int32-array.js
+++ b/JSTests/microbenchmarks/json-stringify-int32-array.js
@@ -1,0 +1,8 @@
+var arr = [];
+for (var i = 0; i < 1000; i++)
+    arr.push(i);
+var json;
+for (var j = 0; j < 1e4; j++)
+    json = JSON.stringify(arr);
+if (json.length !== 3891)
+    throw new Error("Bad result: " + json.length);

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -712,7 +712,11 @@ public:
 private:
     explicit FastStringifier(JSGlobalObject&);
     void append(JSValue);
+    void appendInt32(int32_t);
+    void appendInt32Array(JSArray&);
     String result();
+
+    static constexpr unsigned maxInt32StringLength = ("-2147483648"_s).length();
 
     // FIXME These should probably just take an ASCIILiteral.
     void append(char, char, char, char);
@@ -1076,6 +1080,24 @@ inline void FastStringifier<CharType, bufferMode>::append(char a, char b, char c
     m_length += 5;
 }
 
+template<typename CharType, BufferMode bufferMode>
+ALWAYS_INLINE void FastStringifier<CharType, bufferMode>::appendInt32(int32_t number)
+{
+    if constexpr (sizeof(CharType) == 1) {
+        char* cursor = std::bit_cast<char*>(buffer()) + m_length;
+        auto result = std::to_chars(cursor, cursor + maxInt32StringLength, number);
+        ASSERT(result.ec != std::errc::value_too_large);
+        m_length += result.ptr - cursor;
+    } else {
+        std::array<char, maxInt32StringLength> temporary;
+        auto result = std::to_chars(temporary.data(), temporary.data() + maxInt32StringLength, number);
+        ASSERT(result.ec != std::errc::value_too_large);
+        unsigned lengthToCopy = result.ptr - temporary.data();
+        WTF::copyElements(spanReinterpretCast<uint16_t>(bufferSpan().subspan(m_length)), spanReinterpretCast<const uint8_t>(std::span { temporary }).first(lengthToCopy));
+        m_length += lengthToCopy;
+    }
+}
+
 template<typename CharType>
 static ALWAYS_INLINE bool stringCopySameType(std::span<const CharType> span, CharType* cursor)
 {
@@ -1200,25 +1222,11 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
     }
 
     if (value.isInt32()) {
-        auto number = value.asInt32();
-        constexpr unsigned maxInt32StringLength = 11; // -INT32_MIN, "-2147483648".
         if (!hasRemainingCapacity(maxInt32StringLength)) [[unlikely]] {
             recordBufferFull();
             return;
         }
-        if constexpr (sizeof(CharType) == 1) {
-            char* cursor = std::bit_cast<char*>(buffer()) + m_length;
-            auto result = std::to_chars(cursor, cursor + maxInt32StringLength, number);
-            ASSERT(result.ec != std::errc::value_too_large);
-            m_length += result.ptr - cursor;
-        } else {
-            std::array<char, maxInt32StringLength> temporary;
-            auto result = std::to_chars(temporary.data(), temporary.data() + maxInt32StringLength, number);
-            ASSERT(result.ec != std::errc::value_too_large);
-            unsigned lengthToCopy = result.ptr - temporary.data();
-            WTF::copyElements(spanReinterpretCast<uint16_t>(bufferSpan().subspan(m_length)), spanReinterpretCast<const uint8_t>(std::span { temporary }).first(lengthToCopy));
-            m_length += lengthToCopy;
-        }
+        appendInt32(value.asInt32());
         return;
     }
 
@@ -1449,6 +1457,17 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             return;
         }
         buffer()[m_length++] = '[';
+        if (hasInt32(array.indexingType())) {
+            appendInt32Array(array);
+            if (haveFailure()) [[unlikely]]
+                return;
+            if (!hasRemainingCapacity()) [[unlikely]] {
+                recordBufferFull();
+                return;
+            }
+            buffer()[m_length++] = ']';
+            return;
+        }
         for (unsigned i = 0, length = array.length(); i < length; ++i) {
             if (i) {
                 if (!hasRemainingCapacity()) [[unlikely]] {
@@ -1479,6 +1498,32 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
 
     default:
         recordFailure("object type"_s);
+    }
+}
+
+template<typename CharType, BufferMode bufferMode>
+NEVER_INLINE void FastStringifier<CharType, bufferMode>::appendInt32Array(JSArray& array)
+{
+    auto* butterfly = array.butterfly();
+    unsigned length = butterfly->publicLength();
+    if (length > butterfly->vectorLength()) [[unlikely]] {
+        recordFailure("!canGetIndexQuickly"_s);
+        return;
+    }
+    auto data = butterfly->contiguousInt32();
+    for (unsigned i = 0; i < length; ++i) {
+        JSValue element = data.at(&array, i).get();
+        if (!element) [[unlikely]] {
+            recordFailure("!canGetIndexQuickly"_s);
+            return;
+        }
+        if (!hasRemainingCapacity(1 + maxInt32StringLength)) [[unlikely]] {
+            recordBufferFull();
+            return;
+        }
+        if (i)
+            buffer()[m_length++] = ',';
+        appendInt32(element.asInt32());
     }
 }
 


### PR DESCRIPTION
#### 2ec81a993d3545b50fad8cca19ea0cb5d021df18
<pre>
[JSC] Add Int32 array fast path to `FastStringifier` for `JSON.stringify`
<a href="https://bugs.webkit.org/show_bug.cgi?id=311911">https://bugs.webkit.org/show_bug.cgi?id=311911</a>

Reviewed by Yusuke Suzuki.

For Int32-shaped arrays, FastStringifier currently calls canGetIndexQuickly +
getIndexQuickly per element (each switching on indexingType()) and then
re-enters the recursive append(JSValue) type-dispatch chain.

Add a NEVER_INLINE appendInt32Array() that walks the contiguousInt32 butterfly
directly and emits each element via std::to_chars. The Int32 emission body is
factored into ALWAYS_INLINE appendInt32() shared with the existing isInt32()
case.

                                              Before                   Patched

json-stringify-int32-array               61.2083+-0.5523     ^     19.8872+-0.1330        ^ definitely 3.0778x faster
json-stringify-empty-array               20.7855+-0.5127           20.7303+-0.1234
vanilla-todomvc-json-stringify           48.5458+-0.4959     ^     47.1891+-0.4344        ^ definitely 1.0288x faster

&lt;geometric&gt;                              48.9427+-0.2815     ^     40.2815+-0.1213        ^ definitely 1.2150x faster

Test: JSTests/microbenchmarks/json-stringify-int32-array.js

* JSTests/microbenchmarks/json-stringify-int32-array.js: Added.
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::bufferMode&gt;::appendInt32):
(JSC::bufferMode&gt;::append):
(JSC::bufferMode&gt;::appendInt32Array):

Canonical link: <a href="https://commits.webkit.org/311051@main">https://commits.webkit.org/311051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f32da268851b06072f88ed880fd82288cce0a9ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164713 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109765 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29287 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120730 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158909 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140046 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101419 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22011 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20152 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12543 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148000 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131676 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17878 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167193 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16785 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11367 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128851 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28887 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24199 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128983 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34928 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28809 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139672 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86552 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23804 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16470 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187834 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28518 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92474 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48300 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28045 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28273 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28169 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->