### PR TITLE
Proper IDL [Clamp] and Blob's slice() support

### DIFF
--- a/LayoutTests/http/tests/websocket/tests/hybi/close-expected.txt
+++ b/LayoutTests/http/tests/websocket/tests/hybi/close-expected.txt
@@ -31,30 +31,26 @@ Code 4294968296 must cause InvalidAccessError.
 PASS exceptionProto === DOMException.prototype is true
 PASS exceptionName is invalidAccessErr
 Invalid code test: 6
-Code 2999.9 must cause InvalidAccessError.
-PASS exceptionProto === DOMException.prototype is true
-PASS exceptionName is invalidAccessErr
-Invalid code test: 7
 Code NaN must cause InvalidAccessError.
 PASS exceptionProto === DOMException.prototype is true
 PASS exceptionName is invalidAccessErr
-Invalid code test: 8
+Invalid code test: 7
 Code 0 must cause InvalidAccessError.
 PASS exceptionProto === DOMException.prototype is true
 PASS exceptionName is invalidAccessErr
-Invalid code test: 9
+Invalid code test: 8
 Code 100 must cause InvalidAccessError.
 PASS exceptionProto === DOMException.prototype is true
 PASS exceptionName is invalidAccessErr
-Invalid code test: 10
+Invalid code test: 9
 Code Infinity must cause InvalidAccessError.
 PASS exceptionProto === DOMException.prototype is true
 PASS exceptionName is invalidAccessErr
-Invalid code test: 11
+Invalid code test: 10
 Code -Infinity must cause InvalidAccessError.
 PASS exceptionProto === DOMException.prototype is true
 PASS exceptionName is invalidAccessErr
-Invalid code test: 12
+Invalid code test: 11
 Code NaN must cause InvalidAccessError.
 PASS exceptionProto === DOMException.prototype is true
 PASS exceptionName is invalidAccessErr
@@ -87,19 +83,26 @@ PASS closeEvent.code is code
 PASS closeEvent.reason is reason
 Code and reason test: 1
 Code and reason must be
+  code  : 1000
+  reason: round-half-to-even
+PASS closeEvent.wasClean is true
+PASS closeEvent.code is code
+PASS closeEvent.reason is reason
+Code and reason test: 2
+Code and reason must be
   code  : 3000
   reason: 3000
 PASS closeEvent.wasClean is true
 PASS closeEvent.code is code
 PASS closeEvent.reason is reason
-Code and reason test: 2
+Code and reason test: 3
 Code and reason must be
   code  : 4000
   reason: code is 4000
 PASS closeEvent.wasClean is true
 PASS closeEvent.code is code
 PASS closeEvent.reason is reason
-Code and reason test: 3
+Code and reason test: 4
 Code and reason must be
   code  : 4999
   reason: © Google

--- a/LayoutTests/http/tests/websocket/tests/hybi/close.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/close.html
@@ -26,7 +26,7 @@ var ws;
 var testId;
 
 var codeTestCodes = [
-    999, 1001, 2999, 5000, 65536 + 1000, 0x100000000 + 1000, 2999.9, NaN, "0", "100", 1/0, -1/0, 0/0,
+    999, 1001, 2999, 5000, 65536 + 1000, 0x100000000 + 1000, NaN, "0", "100", 1/0, -1/0, 0/0,
     1000.0
 ];
 
@@ -152,12 +152,21 @@ function runCodeAndReasonTest()
 {
     var codes = [
         1000,
+        1000.5,
+        3000,
+        4000,
+        4999
+    ];
+    var expectedCodes = [
+        1000,
+        1000,
         3000,
         4000,
         4999
     ];
     var reasons = [
         "OK, Bye!",
+        "round-half-to-even",
         "3000",
         "code is 4000",
         "\u00a9 Google"
@@ -173,7 +182,7 @@ function runCodeAndReasonTest()
         ws.onclose = function (e)
         {
             closeEvent = e;
-            code = codes[id];
+            code = expectedCodes[id];
             reason = reasons[id];
             debug("Code and reason must be");
             debug("  code  : " + code);

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-slice.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-slice.any-expected.txt
@@ -30,23 +30,23 @@ PASS Slicing test: slice (0,8).
 PASS Slicing test (1,0).
 PASS Slicing test: slice (1,0).
 PASS Slicing test (1,1).
-FAIL Slicing test: slice (1,1). assert_equals: expected 2 but got 3
+PASS Slicing test: slice (1,1).
 PASS Slicing test (1,2).
 PASS Slicing test: slice (1,2).
 PASS Slicing test (1,3).
-FAIL Slicing test: slice (1,3). assert_equals: expected 0 but got 1
+PASS Slicing test: slice (1,3).
 PASS Slicing test (1,4).
 PASS Slicing test: slice (1,4).
 PASS Slicing test (1,5).
-FAIL Slicing test: slice (1,5). assert_equals: expected 2 but got 1
+PASS Slicing test: slice (1,5).
 PASS Slicing test (1,6).
 PASS Slicing test: slice (1,6).
 PASS Slicing test (1,7).
-FAIL Slicing test: slice (1,7). assert_equals: expected 4 but got 3
+PASS Slicing test: slice (1,7).
 PASS Slicing test (1,8).
-FAIL Slicing test: slice (1,8). assert_equals: expected 0 but got 1
+PASS Slicing test: slice (1,8).
 PASS Slicing test (1,9).
-FAIL Slicing test: slice (1,9). assert_equals: expected "cd" but got "bc"
+PASS Slicing test: slice (1,9).
 PASS Slicing test (2,0).
 PASS Slicing test: slice (2,0).
 PASS Slicing test (2,1).

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-slice.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/blob/Blob-slice.any.worker-expected.txt
@@ -30,23 +30,23 @@ PASS Slicing test: slice (0,8).
 PASS Slicing test (1,0).
 PASS Slicing test: slice (1,0).
 PASS Slicing test (1,1).
-FAIL Slicing test: slice (1,1). assert_equals: expected 2 but got 3
+PASS Slicing test: slice (1,1).
 PASS Slicing test (1,2).
 PASS Slicing test: slice (1,2).
 PASS Slicing test (1,3).
-FAIL Slicing test: slice (1,3). assert_equals: expected 0 but got 1
+PASS Slicing test: slice (1,3).
 PASS Slicing test (1,4).
 PASS Slicing test: slice (1,4).
 PASS Slicing test (1,5).
-FAIL Slicing test: slice (1,5). assert_equals: expected 2 but got 1
+PASS Slicing test: slice (1,5).
 PASS Slicing test (1,6).
 PASS Slicing test: slice (1,6).
 PASS Slicing test (1,7).
-FAIL Slicing test: slice (1,7). assert_equals: expected 4 but got 3
+PASS Slicing test: slice (1,7).
 PASS Slicing test (1,8).
-FAIL Slicing test: slice (1,8). assert_equals: expected 0 but got 1
+PASS Slicing test: slice (1,8).
 PASS Slicing test (1,9).
-FAIL Slicing test: slice (1,9). assert_equals: expected "cd" but got "bc"
+PASS Slicing test: slice (1,9).
 PASS Slicing test (2,0).
 PASS Slicing test: slice (2,0).
 PASS Slicing test (2,1).

--- a/Source/JavaScriptCore/runtime/MathCommon.cpp
+++ b/Source/JavaScriptCore/runtime/MathCommon.cpp
@@ -604,28 +604,6 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(f64_nearest, double, (double operand))
     return std::nearbyint(operand);
 }
 
-#if (OS(LINUX) && !defined(__GLIBC__)) || OS(HAIKU)
-static inline float roundevenf(float operand)
-{
-    float rounded = roundf(operand);
-    if (fabsf(operand - rounded) == 0.5f) {
-        if (fmod(rounded, 2.0f) != 0.0f)
-            return rounded - copysignf(1.0f, operand);
-    }
-    return rounded;
-}
-
-static inline double roundeven(double operand)
-{
-    double rounded = round(operand);
-    if (fabs(operand - rounded) == 0.5) {
-        if (fmod(rounded, 2.0) != 0.0)
-            return rounded - copysign(1.0, operand);
-    }
-    return rounded;
-}
-#endif
-
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(f32_roundeven, float, (float operand)) { return roundevenf(operand); }
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(f64_roundeven, double, (double operand)) { return roundeven(operand); }
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(f32_trunc, float, (float operand)) { return std::trunc(operand); }

--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -168,6 +168,27 @@ constexpr T fabsConstExpr(T value)
 inline double roundTowardsPositiveInfinity(double value) { return std::floor(value + 0.5); }
 inline float roundTowardsPositiveInfinity(float value) { return std::floor(value + 0.5f); }
 
+// C23 roundeven polyfill.
+inline float roundevenf(float value)
+{
+    float rounded = std::round(value);
+    if (std::fabs(value - rounded) == 0.5f) {
+        if (std::fmod(rounded, 2.0f) != 0.0f)
+            return rounded - std::copysign(1.0f, value);
+    }
+    return rounded;
+}
+
+inline double roundeven(double value)
+{
+    double rounded = std::round(value);
+    if (std::fabs(value - rounded) == 0.5) {
+        if (std::fmod(rounded, 2.0) != 0.0)
+            return rounded - std::copysign(1.0, value);
+    }
+    return rounded;
+}
+
 // std::numeric_limits<T>::min() returns the smallest positive value for floating point types
 template<typename T> consteval T defaultMinimumForClamp() { return std::numeric_limits<T>::min(); }
 template<> consteval float defaultMinimumForClamp() { return -std::numeric_limits<float>::max(); }

--- a/Source/WebCore/bindings/js/JSDOMConvertNumbers.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConvertNumbers.cpp
@@ -134,7 +134,7 @@ static inline ConversionResult<IDL> toSmallerInt(JSGlobalObject& lexicalGlobalOb
     } else if constexpr (configuration == IntegerConversionConfiguration::EnforceRange)
         return enforceRange<IDL>(lexicalGlobalObject, x, LimitsTrait::minValue, LimitsTrait::maxValue);
     else if constexpr (configuration == IntegerConversionConfiguration::Clamp)
-        return std::isnan(x) ? ConversionResult<IDL> { 0 } : ConversionResult<IDL> { clampTo<T>(x) };
+        return std::isnan(x) ? ConversionResult<IDL> { 0 } : ConversionResult<IDL> { clampTo<T>(roundeven(x)) };
 }
 
 template<typename IDL, IntegerConversionConfiguration configuration>
@@ -176,7 +176,7 @@ static inline ConversionResult<IDL> toSmallerUInt(JSGlobalObject& lexicalGlobalO
     } else if constexpr (configuration == IntegerConversionConfiguration::EnforceRange)
         return enforceRange<IDL>(lexicalGlobalObject, x, 0, LimitsTrait::maxValue);
     else if constexpr (configuration == IntegerConversionConfiguration::Clamp)
-        return std::isnan(x) ? 0 : clampTo<T>(x);
+        return std::isnan(x) ? 0 : clampTo<T>(roundeven(x));
 }
 
 template<> ConversionResult<IDLByte> convertToIntegerEnforceRange<IDLByte>(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
@@ -281,7 +281,7 @@ template<> ConversionResult<IDLLong> convertToIntegerClamp<IDLLong>(JSC::JSGloba
 
     RETURN_IF_EXCEPTION(scope, ConversionResult<IDLLong>::exception());
 
-    return std::isnan(x) ? 0 : clampTo<int32_t>(x);
+    return std::isnan(x) ? 0 : clampTo<int32_t>(roundeven(x));
 }
 
 template<> ConversionResult<IDLUnsignedLong> convertToIntegerClamp<IDLUnsignedLong>(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
@@ -296,7 +296,7 @@ template<> ConversionResult<IDLUnsignedLong> convertToIntegerClamp<IDLUnsignedLo
 
     RETURN_IF_EXCEPTION(scope, ConversionResult<IDLUnsignedLong>::exception());
 
-    return std::isnan(x) ? 0 : clampTo<uint32_t>(x);
+    return std::isnan(x) ? 0 : clampTo<uint32_t>(roundeven(x));
 }
 
 template<> ConversionResult<IDLLong> convertToInteger<IDLLong>(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
@@ -365,7 +365,7 @@ template<> ConversionResult<IDLLongLong> convertToIntegerClamp<IDLLongLong>(JSC:
 
     RETURN_IF_EXCEPTION(scope, ConversionResult<IDLLongLong>::exception());
 
-    return std::isnan(x) ? 0 : static_cast<int64_t>(std::min<double>(std::max<double>(x, -kJSMaxInteger), kJSMaxInteger));
+    return std::isnan(x) ? 0 : static_cast<int64_t>(roundeven(std::min<double>(std::max<double>(x, -kJSMaxInteger), kJSMaxInteger)));
 }
 
 template<> ConversionResult<IDLUnsignedLongLong> convertToIntegerClamp<IDLUnsignedLongLong>(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
@@ -380,7 +380,7 @@ template<> ConversionResult<IDLUnsignedLongLong> convertToIntegerClamp<IDLUnsign
 
     RETURN_IF_EXCEPTION(scope, ConversionResult<IDLUnsignedLongLong>::exception());
 
-    return std::isnan(x) ? 0 : static_cast<uint64_t>(std::min<double>(std::max<double>(x, 0), kJSMaxInteger));
+    return std::isnan(x) ? 0 : static_cast<uint64_t>(roundeven(std::min<double>(std::max<double>(x, 0), kJSMaxInteger)));
 }
 
 template<> ConversionResult<IDLLongLong> convertToInteger<IDLLongLong>(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)

--- a/Source/WebCore/fileapi/Blob.idl
+++ b/Source/WebCore/fileapi/Blob.idl
@@ -43,7 +43,7 @@ typedef (BufferSource or Blob or USVString) BlobPart;
     readonly attribute unsigned long long size;
     readonly attribute DOMString type;
 
-    [NewObject] Blob slice(optional long long start = 0, optional long long end = 0x7FFFFFFFFFFFFFFF, optional DOMString contentType = "");
+    [NewObject] Blob slice(optional [Clamp] long long start = 0, optional [Clamp] long long end = 0x7FFFFFFFFFFFFFFF, optional DOMString contentType = "");
 
     [NewObject] ReadableStream stream();
     [NewObject] Promise<USVString> text();


### PR DESCRIPTION
#### b3ec744f8a4b4caac750274fb23bb275fe72960f
<pre>
Proper IDL [Clamp] and Blob&apos;s slice() support
<a href="https://bugs.webkit.org/show_bug.cgi?id=311912">https://bugs.webkit.org/show_bug.cgi?id=311912</a>

Reviewed by Sam Weinig.

Fixed all [Clamp] integer conversion paths to round-half-to-even, as
required by IDL:

    <a href="https://webidl.spec.whatwg.org/#js-integer-types-abstract-ops">https://webidl.spec.whatwg.org/#js-integer-types-abstract-ops</a>

And then adopted [Clamp] for slice() as required by File API:

    <a href="https://w3c.github.io/FileAPI/#blob-section">https://w3c.github.io/FileAPI/#blob-section</a>

To implement round-half-to-even we implement C23&apos;s roundeven(f) which
have the semantics we want. We already had an implementation for them
in JSC though only for 32-bit code on a subset of platforms, so we move
that to WTF and make it more generic.

Canonical link: <a href="https://commits.webkit.org/310992@main">https://commits.webkit.org/310992@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e57106f81fb5d614c4180ffcb507ae5bc72de2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164304 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28652 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120388 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b56e84a-8cf0-4d63-b3f7-d5bfd30910e3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158501 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22574 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139685 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101078 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/757f06ba-0274-45be-9a3e-99a9a74e3fa0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21660 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19776 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12135 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147592 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131329 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17517 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166782 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16373 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10960 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19128 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128509 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28346 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23810 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128642 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28270 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139310 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85713 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23714 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23462 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16107 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187427 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27964 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92067 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48039 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27541 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27771 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27614 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->