### PR TITLE
[JSC] test262 failure: test/staging/sm/extensions/DataView-construct-arguments-detaching.js

### DIFF
--- a/JSTests/stress/dataview-constructor-bug-311903-weird-bytelength-detach-buffer.js
+++ b/JSTests/stress/dataview-constructor-bug-311903-weird-bytelength-detach-buffer.js
@@ -1,0 +1,51 @@
+function sameValue(a, b, testname) {
+    if (a !== b)
+        throw new Error(`${testname}: Expected ${b} but got ${a}`);
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const TEST_TARGET = [
+    DataView,
+];
+
+for (const targetCtor of TEST_TARGET) {
+    const name = targetCtor.name;
+    const label = name;
+
+    const buffer = new ArrayBuffer(4096);
+    const byteLength = {
+        valueOf: function () {
+            $.detachArrayBuffer(buffer);
+            $.gc();
+            return 2048;
+        }
+    };
+
+    //  By the spec (ECMA-262/April 10, 2026),
+    //
+    //  This behavior is deduced from the step 9 ~ 11 of the section _25.3.2.1_.
+    //  https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength
+    shouldThrow(`${label}: throw as expected`, () => {
+        new targetCtor(buffer, 2048, byteLength);
+    }, TypeError, 'Buffer is already detached');
+    sameValue(buffer.detached, true, `${label}: arrayBuffer is detached as expectedly`);
+    // The detached ArrayBuffer.byteLength should be set to 0.
+    //
+    //  - https://tc39.es/ecma262/#sec-detacharraybuffer
+    //  - https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.bytelength
+    sameValue(buffer.byteLength, 0, `${label}: arrayBuffer.byteLength is 0`);
+}

--- a/JSTests/stress/dataview-constructor-bug-311903-weird-byteoffset-detach-buffer.js
+++ b/JSTests/stress/dataview-constructor-bug-311903-weird-byteoffset-detach-buffer.js
@@ -1,0 +1,49 @@
+function sameValue(a, b, testname) {
+    if (a !== b)
+        throw new Error(`${testname}: Expected ${b} but got ${a}`);
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const TEST_TARGET = [
+    DataView,
+];
+
+for (const targetCtor of TEST_TARGET) {
+    const name = targetCtor.name;
+    const buffer = new ArrayBuffer(0x1000);
+    const byteOffset = {
+        valueOf: function () {
+            $.detachArrayBuffer(buffer);
+            $.gc();
+            return 0x800;
+        }
+    };
+
+    //  By the spec (ECMA-262/April 10, 2026),
+    //
+    //  This behavior is deduced from the step 3 ~ 4 of the section _25.3.2.1_ of the spec (ECMA-262/April 10, 2026)
+    //  https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength
+    shouldThrow(`${name}: should throw as the arrayBuffer is detached`, () => {
+        new targetCtor(buffer, byteOffset);
+    }, TypeError, 'Buffer is already detached');
+    sameValue(buffer.detached, true, `${name}: arrayBuffer is detached as expectedly`);
+    // The detached ArrayBuffer.byteLength should be set to 0.
+    //
+    //  - https://tc39.es/ecma262/#sec-detacharraybuffer
+    //  - https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.bytelength
+    sameValue(buffer.byteLength, 0, `${name}: arrayBuffer.byteLength is 0`);
+}

--- a/JSTests/stress/typedarray-constructor-bug-311903-weird-bytelength-detach-buffer.js
+++ b/JSTests/stress/typedarray-constructor-bug-311903-weird-bytelength-detach-buffer.js
@@ -1,0 +1,65 @@
+function sameValue(a, b, testname) {
+    if (a !== b)
+        throw new Error(`${testname}: Expected ${b} but got ${a}`);
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+];
+
+for (const targetCtor of TEST_TARGET) {
+    const name = targetCtor.name;
+    const label = name;
+
+    const buffer = new ArrayBuffer(4096);
+    const byteLength = {
+        valueOf: function () {
+            $.detachArrayBuffer(buffer);
+            $.gc();
+            return 2048;
+        }
+    };
+
+    //  By the spec (ECMA-262/April 10, 2026),
+    //  This behavior is deduced from the step 6 of
+    //  the section [23.2.5.1.3 InitializeTypedArrayFromArrayBuffer ( O, buffer, byteOffset, length )][initializetypedarrayfromarraybuffer],
+    //  which is called from the step 7-c-iii of the section [23.2.5.1 TypedArray ( ...args )][typedarray].
+    //
+    //  [initializetypedarrayfromarraybuffer]: https://tc39.es/ecma262/#sec-initializetypedarrayfromarraybuffer
+    //  [typedarray]: https://tc39.es/ecma262/#sec-typedarray
+    shouldThrow(`${label}: throw as expected`, () => {
+        new targetCtor(buffer, 2048, byteLength);
+    }, TypeError, 'Buffer is already detached');
+    sameValue(buffer.detached, true, `${label}: arrayBuffer is detached as expectedly`);
+    // The detached ArrayBuffer.byteLength should be set to 0.
+    //
+    //  - https://tc39.es/ecma262/#sec-detacharraybuffer
+    //  - https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.bytelength
+    sameValue(buffer.byteLength, 0, `${label}: arrayBuffer.byteLength is 0`);
+}

--- a/JSTests/stress/typedarray-constructor-bug-311903-weird-byteoffset-detach-buffer.js
+++ b/JSTests/stress/typedarray-constructor-bug-311903-weird-byteoffset-detach-buffer.js
@@ -1,0 +1,63 @@
+function sameValue(a, b, testname) {
+    if (a !== b)
+        throw new Error(`${testname}: Expected ${b} but got ${a}`);
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+];
+
+for (const targetCtor of TEST_TARGET) {
+    const name = targetCtor.name;
+    const buffer = new ArrayBuffer(0x1000);
+    const byteOffset = {
+        valueOf: function () {
+            $.detachArrayBuffer(buffer);
+            $.gc();
+            return 0x800;
+        }
+    };
+
+    //  By the spec (ECMA-262/April 10, 2026),
+    //  This behavior is deduced from the step 6 of
+    //  the section [23.2.5.1.3 InitializeTypedArrayFromArrayBuffer ( O, buffer, byteOffset, length )][initializetypedarrayfromarraybuffer],
+    //  which is called from the step 7-c-iii of the section [23.2.5.1 TypedArray ( ...args )][typedarray].
+    //
+    //  [initializetypedarrayfromarraybuffer]: https://tc39.es/ecma262/#sec-initializetypedarrayfromarraybuffer
+    //  [typedarray]: https://tc39.es/ecma262/#sec-typedarray
+    shouldThrow(`${name}: should throw as the arrayBuffer is detached`, () => {
+        new targetCtor(buffer, byteOffset);
+    }, TypeError, 'Buffer is already detached');
+    sameValue(buffer.detached, true, `${name}: arrayBuffer is detached as expectedly`);
+    // The detached ArrayBuffer.byteLength should be set to 0.
+    //
+    //  - https://tc39.es/ecma262/#sec-detacharraybuffer
+    //  - https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.bytelength
+    sameValue(buffer.byteLength, 0, `${name}: arrayBuffer.byteLength is 0`);
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -920,9 +920,6 @@ test/staging/sm/expressions/object-literal-computed-property-evaluation.js:
 test/staging/sm/expressions/short-circuit-compound-assignment-anon-fns.js:
   default: 'Test262Error: Expected SameValue(«"a"», «""») to be true'
   strict mode: 'Test262Error: Expected SameValue(«"a"», «""») to be true'
-test/staging/sm/extensions/DataView-construct-arguments-detaching.js:
-  default: 'Test262Error: byteOffset weirdness should have thrown Expected a TypeError but got a RangeError'
-  strict mode: 'Test262Error: byteOffset weirdness should have thrown Expected a TypeError but got a RangeError'
 test/staging/sm/extensions/function-caller-skips-eval-frames.js:
   default: 'Test262Error: Expected SameValue(«null», «function nest() { return eval("innermost();"); }») to be true'
 test/staging/sm/extensions/new-cross-compartment.js:

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
@@ -37,6 +37,7 @@
 #include "JSGlobalObject.h"
 #include "JSTypedArrays.h"
 #include "StructureInlines.h"
+#include <wtf/text/ASCIILiteral.h>
 
 namespace JSC {
 
@@ -111,6 +112,8 @@ inline JSObject* constructGenericTypedArrayViewFromIterator(JSGlobalObject* glob
     return result;
 }
 
+constinit const ASCIILiteral typedArrayErrorMessageBufferIsAlreadyDetached = "Buffer is already detached"_s;
+
 template<typename ViewClass>
 inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* globalObject, Structure* structure, JSValue firstValue, size_t offset, std::optional<size_t> lengthOpt)
 {
@@ -121,7 +124,7 @@ inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* glo
     if (JSArrayBuffer* jsBuffer = jsDynamicCast<JSArrayBuffer*>(firstValue)) {
         RefPtr<ArrayBuffer> buffer = jsBuffer->impl();
         if (buffer->isDetached()) {
-            throwTypeError(globalObject, scope, "Buffer is already detached"_s);
+            throwTypeError(globalObject, scope, typedArrayErrorMessageBufferIsAlreadyDetached);
             return nullptr;
         }
 
@@ -275,6 +278,11 @@ ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl(JSGlobalObject* 
 
             if constexpr (ViewClass::TypedArrayStorageType == TypeDataView) {
                 RefPtr<ArrayBuffer> buffer = arrayBuffer->impl();
+                if (buffer->isDetached()) [[unlikely]] {
+                    throwVMTypeError(globalObject, scope, typedArrayErrorMessageBufferIsAlreadyDetached);
+                    RETURN_IF_EXCEPTION(scope, { });
+                }
+
                 if (offset > buffer->byteLength()) [[unlikely]] {
                     throwRangeError(globalObject, scope, "byteOffset exceeds source ArrayBuffer byteLength"_s);
                     RETURN_IF_EXCEPTION(scope, { });


### PR DESCRIPTION
#### 435d83ec987a57aacab20ec49c92ae840245c1b0
<pre>
[JSC] test262 failure: test/staging/sm/extensions/DataView-construct-arguments-detaching.js
<a href="https://bugs.webkit.org/show_bug.cgi?id=311903">https://bugs.webkit.org/show_bug.cgi?id=311903</a>

Reviewed by Yusuke Suzuki.

By the spec (ECMA-262/April 10, 2026),
on invoking `new DataView(buffer, byteOffset)`,
if the 2nd argument `byteOffset` detachs `buffer` in `ToIndex(byteOffset)` step,
it should throw TypeError caused by buffer *first* is detached rather than RangeError
about `offset &gt; bufferByteLength`.

This corresponds to step 3 &amp; 4 of the section _25.3.2.1_ of the spec.
<a href="https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength">https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength</a>

-----

`DataView` and other TypedArrays&apos;s constructors behave different spec mechanism,
but they behave similarly and we share a part of underlying implementations.
This patch adds some tests:

1. `new DataView(buffer, byteOffset)` but `ToIndex(byteOffset)` detach the `buffer`.
    This fix this test&apos;s result. Without this change, JSC fails this test.

2. `new DataView(buffer, byteOffset, byteLength)` but `ToIndex(byteOffset)` detach the `buffer`.
    This is a later part of test/staging/sm/extensions/DataView-construct-arguments-detaching.js.
    as a regression test.
    JSC passes this test without this fix

3. `new SomeTypedArray(buffer, byteOffset)` but `ToIndex(byteOffset)` detach the `buffer`.
    This is just for regression test to keep the exist implementation which shares many parts with `DataView`&apos;s one.
    JSC passes this test without this fix

4. `new SomeTypedArray(buffer, byteOffset, byteLength)` but `ToIndex(byteLength)` detach the `buffer`.
    This is just for regression test to keep the exist implementation which shares many parts with `DataView`&apos;s one.
    JSC passes this test without this fix.

Tests: JSTests/stress/dataview-constructor-bug-311903-weird-bytelength-detach-buffer.js
       JSTests/stress/dataview-constructor-bug-311903-weird-byteoffset-detach-buffer.js
       JSTests/stress/typedarray-constructor-bug-311903-weird-bytelength-detach-buffer.js
       JSTests/stress/typedarray-constructor-bug-311903-weird-byteoffset-detach-buffer.js

Canonical link: <a href="https://commits.webkit.org/311188@main">https://commits.webkit.org/311188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c90aaf8a8e95d270ef85ddda92b6b362c50a11b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22715 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165019 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29666 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29536 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120956 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140269 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101629 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22231 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12791 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148248 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131892 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167498 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17032 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11614 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19713 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129078 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29134 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24456 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129196 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29056 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139894 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86823 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23784 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24006 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16693 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188081 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28765 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92722 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48353 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28292 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28520 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28416 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->