### PR TITLE
Remove LegacyNativeDictionaryRequiredInterfaceNullability from WebCodecs code

### DIFF
--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.idl
@@ -61,9 +61,9 @@
 
 [
     Conditional=WEB_CODECS,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AudioDataCopyToOptions {
-    [EnforceRange] unsigned long planeIndex;
+    // FIXME: planeIndex should be required.
+    [ImplementationDefaultValue=0, EnforceRange] unsigned long planeIndex;
     [EnforceRange] unsigned long frameOffset;
     [EnforceRange] unsigned long frameCount;
     AudioSampleFormat format;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -303,31 +303,40 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutio
     auto layoutOrException = computeLayoutAndAllocationSize(defaultRect, init.layout, pixelFormat);
     if (layoutOrException.hasException())
         return layoutOrException.releaseException();
-    
+
     auto layout = layoutOrException.releaseReturnValue();
     if (data.byteLength() < layout.allocationSize)
         return Exception { ExceptionCode::TypeError, makeString("Data is too small "_s, data.byteLength(), " / "_s, layout.allocationSize) };
 
     auto colorSpace = videoFramePickColorSpace(init.colorSpace, pixelFormat);
     RefPtr<VideoFrame> videoFrame;
-    if (pixelFormat == VideoPixelFormat::NV12) {
+    switch (pixelFormat) {
+    case VideoPixelFormat::NV12:
         if (auto exception = validateI420Sizes(init))
             return WTF::move(*exception);
         videoFrame = VideoFrame::createNV12(data.span(), parsedRect.width, parsedRect.height, layout.computedLayouts[0], layout.computedLayouts[1], WTF::move(colorSpace));
-    } else if (pixelFormat == VideoPixelFormat::RGBA || init.format == VideoPixelFormat::RGBX)
+        break;
+    case VideoPixelFormat::RGBA:
+    case VideoPixelFormat::RGBX:
         videoFrame = VideoFrame::createRGBA(data.span(), parsedRect.width, parsedRect.height, layout.computedLayouts[0], WTF::move(colorSpace));
-    else if (pixelFormat == VideoPixelFormat::BGRA || init.format == VideoPixelFormat::BGRX)
+        break;
+    case VideoPixelFormat::BGRA:
+    case VideoPixelFormat::BGRX:
         videoFrame = VideoFrame::createBGRA(data.span(), parsedRect.width, parsedRect.height, layout.computedLayouts[0], WTF::move(colorSpace));
-    else if (pixelFormat == VideoPixelFormat::I420) {
+        break;
+    case VideoPixelFormat::I420:
         if (auto exception = validateI420Sizes(init))
             return WTF::move(*exception);
         videoFrame = VideoFrame::createI420(data.span(), parsedRect.width, parsedRect.height, layout.computedLayouts[0], layout.computedLayouts[1], layout.computedLayouts[2], WTF::move(colorSpace));
-    } else if (pixelFormat == VideoPixelFormat::I420A) {
+        break;
+    case VideoPixelFormat::I420A:
         if (auto exception = validateI420Sizes(init))
             return WTF::move(*exception);
         videoFrame = VideoFrame::createI420A(data.span(), parsedRect.width, parsedRect.height, layout.computedLayouts[0], layout.computedLayouts[1], layout.computedLayouts[2], layout.computedLayouts[3], WTF::move(colorSpace));
-    } else
+        break;
+    default:
         return Exception { ExceptionCode::NotSupportedError, "VideoPixelFormat is not supported"_s };
+    }
 
     if (!videoFrame)
         return Exception { ExceptionCode::TypeError, "Unable to create internal resource from data"_s };

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl
@@ -68,11 +68,10 @@ typedef (HTMLImageElement
 
 [
     Conditional=WEB_CODECS,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary VideoFrameInit {
     unsigned long long duration;
     long long timestamp;
-    WebCodecsAlphaOption alpha;
+    WebCodecsAlphaOption alpha = "keep";
 
     DOMRectInit visibleRect;
 
@@ -82,7 +81,6 @@ typedef (HTMLImageElement
 
 [
     Conditional=WEB_CODECS,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary VideoFrameBufferInit {
     required VideoPixelFormat format;
     required [EnforceRange] unsigned long codedWidth;
@@ -102,7 +100,6 @@ typedef (HTMLImageElement
 
 [
     Conditional=WEB_CODECS,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary VideoFrameCopyToOptions {
   DOMRectInit rect;
   sequence<PlaneLayout> layout;


### PR DESCRIPTION
#### 111b14596e3d069b1f6d6903f93f8234e6e7b0aa
<pre>
Remove LegacyNativeDictionaryRequiredInterfaceNullability from WebCodecs code
<a href="https://bugs.webkit.org/show_bug.cgi?id=311920">https://bugs.webkit.org/show_bug.cgi?id=311920</a>

Reviewed by Brent Fulgham and Youenn Fablet.

Migrate to the modern bindings code.

Canonical link: <a href="https://commits.webkit.org/311066@main">https://commits.webkit.org/311066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ab3730432d6a484a1d83918d5b9b2dc82de9aa3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164247 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109282 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157358 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28595 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120337 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84880 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/62a2cbbb-d2f3-4230-9805-c42f0c362c11) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158444 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22528 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139625 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101027 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ad244c7-cffa-408f-b14e-36b6c86195ab) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21614 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19724 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12077 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131283 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17457 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166725 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10902 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19067 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128449 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28289 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23758 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128584 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28213 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139250 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85650 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23743 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23415 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16047 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27907 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92010 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27484 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27714 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27557 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->