### PR TITLE
:has(:empty) still applied after the content is changed to not be empty

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/empty-pseudo-in-has-display-none-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/empty-pseudo-in-has-display-none-expected.txt
@@ -1,0 +1,19 @@
+This should be visible after the child div gets content.
+
+content
+
+PASS Initially hidden because #child is :empty
+PASS Visible after inserting text into #child
+PASS Hidden after inserting empty element into #child
+PASS Visible after inserting text into empty #child
+PASS Hidden again after removing all children from #child
+PASS Visible again after inserting text into empty #child
+PASS Hidden again after clearing text from #child
+PASS Visible after inserting non-empty element into #child
+PASS :not(:empty) - Initially hidden because #child2 is :empty
+PASS :not(:empty) - Visible after inserting text into #child2
+PASS :not(:empty) - Hidden after clearing text from #child2
+PASS :not(:empty) - Visible again after inserting text into #child2
+PASS :not(:empty) - Hidden after removing all children from #child2
+PASS :not(:empty) - Visible after inserting element into #child2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/empty-pseudo-in-has-display-none.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/empty-pseudo-in-has-display-none.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Selectors Invalidation: :empty in :has() with display:none</title>
+<link rel="author" title="Simon Fraser" href="smfr@apple.com">
+<link rel="help" href="https://drafts.csswg.org/selectors/#relational">
+<link rel="help" href="https://drafts.csswg.org/selectors/#empty-pseudo">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #subject {
+    color: green;
+  }
+  #subject:has(:empty) {
+    display: none;
+  }
+</style>
+<div id="subject">
+  <p>This should be visible after the child div gets content.</p>
+  <div id="child"></div>
+</div>
+<script>
+const subject = document.getElementById("subject");
+const child = document.getElementById("child");
+
+function testVisibility(test_name, expectVisible) {
+  test(function() {
+    const rect = subject.getBoundingClientRect();
+    if (expectVisible) {
+      assert_not_equals(getComputedStyle(subject).display, "none", "display should not be none");
+      assert_greater_than(rect.width, 0, "width should be greater than 0");
+      assert_greater_than(rect.height, 0, "height should be greater than 0");
+    } else {
+      assert_equals(getComputedStyle(subject).display, "none", "display should be none");
+    }
+  }, test_name);
+}
+
+testVisibility("Initially hidden because #child is :empty", false);
+
+child.textContent = "text";
+testVisibility("Visible after inserting text into #child", true);
+
+{
+  let inner = document.createElement("div");
+  child.appendChild(inner);
+}
+testVisibility("Hidden after inserting empty element into #child", false);
+
+child.textContent = "text";
+testVisibility("Visible after inserting text into empty #child", true);
+
+child.replaceChildren();
+testVisibility("Hidden again after removing all children from #child", false);
+
+child.textContent = "text";
+testVisibility("Visible again after inserting text into empty #child", true);
+
+child.textContent = "";
+testVisibility("Hidden again after clearing text from #child", false);
+
+{
+  let inner = document.createElement("div");
+  inner.textContent = "content";
+  child.appendChild(inner);
+}
+testVisibility("Visible after inserting non-empty element into #child", true);
+</script>
+
+<!-- Test :has(:not(:empty)) with display:none -->
+<style>
+  #subject2 {
+    display: none;
+  }
+  #subject2:has(:not(:empty)) {
+    display: block;
+  }
+</style>
+<div id="subject2">
+  <div id="child2"></div>
+</div>
+<script>
+{
+  const subject2 = document.getElementById("subject2");
+  const child2 = document.getElementById("child2");
+
+  function testVisibility2(test_name, expectVisible) {
+    test(function() {
+      if (expectVisible) {
+        assert_not_equals(getComputedStyle(subject2).display, "none", "display should not be none");
+      } else {
+        assert_equals(getComputedStyle(subject2).display, "none", "display should be none");
+      }
+    }, test_name);
+  }
+
+  testVisibility2(":not(:empty) - Initially hidden because #child2 is :empty", false);
+
+  child2.textContent = "text";
+  testVisibility2(":not(:empty) - Visible after inserting text into #child2", true);
+
+  child2.textContent = "";
+  testVisibility2(":not(:empty) - Hidden after clearing text from #child2", false);
+
+  child2.textContent = "text";
+  testVisibility2(":not(:empty) - Visible again after inserting text into #child2", true);
+
+  child2.replaceChildren();
+  testVisibility2(":not(:empty) - Hidden after removing all children from #child2", false);
+
+  child2.appendChild(document.createElement("div"));
+  testVisibility2(":not(:empty) - Visible after inserting element into #child2", true);
+}
+</script>

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -39,7 +39,22 @@
 
 namespace WebCore::Style {
 
-void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElement, MatchingHasSelectors& matchingHasSelectors, ChangedElementRelation changedElementRelation)
+static bool rightmostCompoundContainsEmpty(const CSSSelector& selector)
+{
+    for (auto* simple = &selector; simple; simple = simple->precedingInCompound()) {
+        if (simple->match() == CSSSelector::Match::PseudoClass && simple->pseudoClass() == CSSSelector::PseudoClass::Empty)
+            return true;
+        if (auto* selectorList = simple->selectorList()) {
+            for (auto& inner : *selectorList) {
+                if (rightmostCompoundContainsEmpty(inner))
+                    return true;
+            }
+        }
+    }
+    return false;
+}
+
+void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElement, MatchingHasSelectors& matchingHasSelectors, ChangedElementRelation changedElementRelation, EmptyInvalidation emptyInvalidation)
 {
     auto& ruleSets = parentElement().styleResolver().ruleSets();
 
@@ -75,6 +90,10 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
         checkingContext.matchesAllHasScopes = true;
 
         for (auto& selector : invalidationRuleSet.invalidationSelectors) {
+            // For :empty invalidation only look for :empty selectors to avoid invalidating unnecessarily.
+            if (emptyInvalidation == EmptyInvalidation::Yes && !rightmostCompoundContainsEmpty(selector))
+                continue;
+
             if (isFirst && invalidationRuleSet.isNegation == IsNegation::No) {
                 // If this :has() matches ignoring this mutation, nothing actually changes and we don't need to invalidate.
                 // FIXME: We could cache this state across invalidations instead of just testing a single sibling.
@@ -133,9 +152,14 @@ void ChildChangeInvalidation::invalidateForHasBeforeMutation()
         invalidateForChangedElement(changedElement, matchingHasSelectors, ChangedElementRelation::SelfOrDescendant);
     });
 
-    // :empty is affected by text changes.
-    if (m_childChange.type == ContainerNode::ChildChange::Type::TextRemoved || m_childChange.type == ContainerNode::ChildChange::Type::AllChildrenRemoved)
-        invalidateForChangedElement(parentElement(), matchingHasSelectors, ChangedElementRelation::SelfOrDescendant);
+    auto emptyStateWillChange = [&] {
+        bool isEmpty = !parentElement().hasChildNodes();
+        return m_childChange.isInsertion() == isEmpty;
+    };
+
+    // :empty is special because insertions and removals can affect the matching state of the parent element.
+    if (emptyStateWillChange())
+        invalidateForChangedElement(parentElement(), matchingHasSelectors, ChangedElementRelation::SelfOrDescendant, EmptyInvalidation::Yes);
 
     auto firstChildStateWillStopMatching = [&] {
         if (!m_childChange.nextSiblingElement)
@@ -188,9 +212,14 @@ void ChildChangeInvalidation::invalidateForHasAfterMutation()
         invalidateForChangedElement(changedElement, matchingHasSelectors, ChangedElementRelation::SelfOrDescendant);
     });
 
-    // :empty is affected by text changes.
-    if (m_childChange.type == ContainerNode::ChildChange::Type::TextInserted && m_wasEmpty)
-        invalidateForChangedElement(parentElement(), matchingHasSelectors, ChangedElementRelation::SelfOrDescendant);
+    auto emptyStateDidChange = [&] {
+        bool isEmpty = !parentElement().hasChildNodes();
+        return m_childChange.isInsertion() != isEmpty;
+    };
+
+    // :empty is special because insertions and removals can affect the matching state of the parent element.
+    if (emptyStateDidChange())
+        invalidateForChangedElement(parentElement(), matchingHasSelectors, ChangedElementRelation::SelfOrDescendant, EmptyInvalidation::Yes);
 
     auto firstChildStateWillStartMatching = [&](Element* elementAfterChange) {
         if (!elementAfterChange)

--- a/Source/WebCore/style/ChildChangeInvalidation.h
+++ b/Source/WebCore/style/ChildChangeInvalidation.h
@@ -47,7 +47,8 @@ private:
     void checkForSiblingStyleChanges();
     using MatchingHasSelectors = HashSet<const CSSSelector*>;
     enum class ChangedElementRelation : uint8_t { SelfOrDescendant, Sibling };
-    void invalidateForChangedElement(Element&, MatchingHasSelectors&, ChangedElementRelation);
+    enum class EmptyInvalidation : bool { No, Yes };
+    void invalidateForChangedElement(Element&, MatchingHasSelectors&, ChangedElementRelation, EmptyInvalidation = EmptyInvalidation::No);
     void invalidateForChangeOutsideHasScope();
 
     template<typename Function> void traverseRemovedElements(Function&&);
@@ -61,7 +62,6 @@ private:
 
     const bool m_isEnabled;
     const bool m_needsHasInvalidation;
-    const bool m_wasEmpty;
 };
 
 inline ChildChangeInvalidation::ChildChangeInvalidation(ContainerNode& container, const ContainerNode::ChildChange& childChange)
@@ -69,7 +69,6 @@ inline ChildChangeInvalidation::ChildChangeInvalidation(ContainerNode& container
     , m_childChange(childChange)
     , m_isEnabled(m_parentElement && m_parentElement->needsStyleInvalidation())
     , m_needsHasInvalidation(m_isEnabled && Scope::forNode(*m_parentElement).usesHasPseudoClass())
-    , m_wasEmpty(!container.firstChild())
 {
     if (!m_isEnabled)
         return;


### PR DESCRIPTION
#### cc50c7dd8a0cf2a7c9a154a904bfc3971a85e1c2
<pre>
:has(:empty) still applied after the content is changed to not be empty
<a href="https://bugs.webkit.org/show_bug.cgi?id=286403">https://bugs.webkit.org/show_bug.cgi?id=286403</a>
<a href="https://rdar.apple.com/143864358">rdar://143864358</a>

Reviewed by Alan Baradlay.

We failed to invalidate in some cases where the empty state of the parent element changed.

:empty is special in terms of invalidation because insertions and removals can affect the matching state of the
parent element.

Test: imported/w3c/web-platform-tests/css/selectors/invalidation/empty-pseudo-in-has-display-none.html
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/empty-pseudo-in-has-display-none-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/empty-pseudo-in-has-display-none.html: Added.
* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::rightmostCompoundContainsEmpty):
(WebCore::Style::ChildChangeInvalidation::invalidateForChangedElement):

To avoid invalidating too much add :empty mode where we only check invalidation selectors that contain :empty
in the rightmost compound.

(WebCore::Style::ChildChangeInvalidation::invalidateForHasBeforeMutation):
(WebCore::Style::ChildChangeInvalidation::invalidateForHasAfterMutation):

Test for empty &lt;-&gt; non-empty transitions unconditionally on before and after for the parent element invalidation.
Also element changes need to be tested, not just text changes.

* Source/WebCore/style/ChildChangeInvalidation.h:
(WebCore::Style::ChildChangeInvalidation::ChildChangeInvalidation):

Canonical link: <a href="https://commits.webkit.org/310932@main">https://commits.webkit.org/310932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a1f71fdc9356c44c4ee600df6c5a04b80b9a670

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28731 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164233 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28581 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120323 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/28c24a91-df37-41b2-b8fe-147d04824866) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139611 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9224e5ab-0bdd-4b19-9cd3-ec20142a2222) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21604 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12063 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131273 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17443 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166711 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19053 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128434 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28275 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128571 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34862 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28199 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139236 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85636 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23408 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16033 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27893 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91996 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27470 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27700 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27543 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->