### PR TITLE
Remove LegacyNativeDictionaryRequiredInterfaceNullability from CaptionDisplaySettingsOptions

### DIFF
--- a/Source/WebCore/html/CaptionDisplaySettingsOptions.idl
+++ b/Source/WebCore/html/CaptionDisplaySettingsOptions.idl
@@ -23,12 +23,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://github.com/WebKit/explainers/tree/main/CaptionDisplaySettings
+
 typedef USVString CSSOMString;
 
 [
     Conditional=VIDEO,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary CaptionDisplaySettingsOptions {
-    Node? anchorNode;
-    CSSOMString? positionArea;
+    Node? anchorNode = null;
+    CSSOMString? positionArea = null;
 };

--- a/Source/WebCore/html/ResolvedCaptionDisplaySettingsOptions.idl
+++ b/Source/WebCore/html/ResolvedCaptionDisplaySettingsOptions.idl
@@ -23,6 +23,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// WebCore-internal resolved form of CaptionDisplaySettingsOptions, used to pass concrete geometry
+// over IPC to the UI process. Only exposed to JS for testing (MockCaptionDisplaySettingsClientCallback).
+
 enum ResolvedCaptionDisplaySettingsOptionsXPositionArea {
     "Center",
     "Left",
@@ -39,9 +42,8 @@ enum ResolvedCaptionDisplaySettingsOptionsYPositionArea {
     ExportMacro=WEBCORE_EXPORT,
     JSGenerateToJSObject,
     ImplementedAs=ResolvedCaptionDisplaySettingsOptionsWrapper,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ResolvedCaptionDisplaySettingsOptions {
-    DOMRect? anchorBounds;
-    ResolvedCaptionDisplaySettingsOptionsXPositionArea? xPositionArea;
-    ResolvedCaptionDisplaySettingsOptionsYPositionArea? yPositionArea;
+    DOMRect? anchorBounds = null;
+    ResolvedCaptionDisplaySettingsOptionsXPositionArea? xPositionArea = null;
+    ResolvedCaptionDisplaySettingsOptionsYPositionArea? yPositionArea = null;
 };

--- a/Source/WebCore/html/ResolvedCaptionDisplaySettingsOptionsWrapper.h
+++ b/Source/WebCore/html/ResolvedCaptionDisplaySettingsOptionsWrapper.h
@@ -38,15 +38,6 @@ struct ResolvedCaptionDisplaySettingsOptionsWrapper {
 
     using YPositionArea = ResolvedCaptionDisplaySettingsOptions::YPositionArea;
     std::optional<YPositionArea> yPositionArea;
-
-    ResolvedCaptionDisplaySettingsOptionsWrapper() = default;
-    ResolvedCaptionDisplaySettingsOptionsWrapper(const ResolvedCaptionDisplaySettingsOptions& options)
-        : xPositionArea { options.xPositionArea }
-        , yPositionArea { options.yPositionArea }
-    {
-        if (options.anchorBounds)
-            anchorBounds = DOMRect::create(*options.anchorBounds);
-    }
 };
 
 }

--- a/Source/WebCore/testing/MockCaptionDisplaySettingsClientCallback.cpp
+++ b/Source/WebCore/testing/MockCaptionDisplaySettingsClientCallback.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "MockCaptionDisplaySettingsClientCallback.h"
 
+#include "DOMRect.h"
 #include "ExceptionOr.h"
 #include "JSDOMPromise.h"
 
@@ -38,7 +39,13 @@ void MockCaptionDisplaySettingsClientCallback::showCaptionDisplaySettings(HTMLMe
         return;
     }
 
-    if (RefPtr promise = invoke(element, options).releaseReturnValue()) {
+    ResolvedCaptionDisplaySettingsOptionsWrapper wrapper {
+        options.anchorBounds ? RefPtr { DOMRect::create(*options.anchorBounds) } : nullptr,
+        options.xPositionArea,
+        options.yPositionArea,
+    };
+
+    if (RefPtr promise = invoke(element, wrapper).releaseReturnValue()) {
         promise->whenSettled([completionHandler = WTF::move(completionHandler)] () mutable {
             completionHandler({ });
         });


### PR DESCRIPTION
#### 27776de6ad5ea0eb792179207cd810a48ed100bc
<pre>
Remove LegacyNativeDictionaryRequiredInterfaceNullability from CaptionDisplaySettingsOptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=311921">https://bugs.webkit.org/show_bug.cgi?id=311921</a>

Reviewed by Ryosuke Niwa.

Modernize bindings code.

Canonical link: <a href="https://commits.webkit.org/310981@main">https://commits.webkit.org/310981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f4267b2d6bec7756da0cc97d08cd6fc8fa56677

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164327 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/90cdfac7-b3a7-4b7a-a953-83d9f8d6e2c1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28970 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28674 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120397 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a48a8df2-a36c-4653-98c3-cee061f28cb7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22585 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101087 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc08aebe-9c09-4c9b-abca-e68cbc8201dd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21671 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19786 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12157 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131340 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166804 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16395 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10982 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19140 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128513 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28368 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23820 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128646 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139322 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85735 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23708 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23476 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16119 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27986 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92089 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27563 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27793 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27636 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->