### PR TITLE
Remove LegacyNativeDictionaryRequiredInterfaceNullability from Web Inspector code

### DIFF
--- a/Source/WebCore/inspector/InspectorAuditResourcesObject.idl
+++ b/Source/WebCore/inspector/InspectorAuditResourcesObject.idl
@@ -33,15 +33,14 @@
 [
     JSGenerateToJSObject,
 ] dictionary Resource {
-    DOMString id;
-    DOMString url;
-    DOMString mimeType;
+    required DOMString id;
+    required DOMString url;
+    required DOMString mimeType;
 };
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ResourceContent {
-    DOMString data;
-    boolean base64Encoded;
+    required DOMString data;
+    required boolean base64Encoded;
 };

--- a/Source/WebCore/inspector/InspectorFrontendHost.idl
+++ b/Source/WebCore/inspector/InspectorFrontendHost.idl
@@ -131,20 +131,16 @@ enum SaveMode {
     "file-variants"
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary SaveData {
-    DOMString displayType;
-    DOMString url;
-    DOMString content;
-    boolean base64Encoded;
+dictionary SaveData {
+    required DOMString displayType;
+    required DOMString url;
+    required DOMString content;
+    required boolean base64Encoded;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ContextMenuItem {
-    DOMString type;
-    DOMString label;
+dictionary ContextMenuItem {
+    required DOMString type;
+    DOMString label = "";
     long id;
     boolean enabled;
     boolean checked;
@@ -153,11 +149,10 @@ enum SaveMode {
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary DebuggableInfo {
-    DOMString debuggableType;
-    DOMString targetPlatformName;
-    DOMString targetBuildVersion;
-    DOMString targetProductVersion;
-    boolean targetIsSimulator;
+    required DOMString debuggableType;
+    required DOMString targetPlatformName;
+    required DOMString targetBuildVersion;
+    required DOMString targetProductVersion;
+    required boolean targetIsSimulator;
 };


### PR DESCRIPTION
#### 152a4adbc0d9e04bec88e6f61355c5465a3e2ae5
<pre>
Remove LegacyNativeDictionaryRequiredInterfaceNullability from Web Inspector code
<a href="https://bugs.webkit.org/show_bug.cgi?id=311922">https://bugs.webkit.org/show_bug.cgi?id=311922</a>

Reviewed by Devin Rousso and Sam Weinig.

Modernize IDL.

This also changes Resource as it&apos;s always constructed through C++ and
its arguments are always provided. The same is probably possible for
ComputedProperties if corresponding struct changes are also made.

Canonical link: <a href="https://commits.webkit.org/310980@main">https://commits.webkit.org/310980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2030687c14ed9021e25278040499c2a26bf1107c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21929 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164272 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85bd1c93-518d-473a-b3a8-868e454fcc3b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157383 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28620 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120354 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/053b3319-fe36-4078-9796-d9c58fb4b3a4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22549 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139649 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101044 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/86d2a500-c677-4963-9762-9e97d36b9235) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21635 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19742 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12103 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131304 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166750 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10928 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19092 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128468 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28314 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23776 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128602 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28238 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139274 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85681 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23707 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23442 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16071 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27932 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92035 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27509 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27739 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27582 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->