### PR TITLE
Crash in `XPCEndpoint::XPCEndpoint` when running `WebKit.XPCEndpoint` and letting the test runner not terminate immediately

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -174,6 +174,9 @@ Ref<NetworkProcess> NetworkProcess::create(AuxiliaryProcessInitializationParamet
 
 NetworkProcess::NetworkProcess(AuxiliaryProcessInitializationParameters&& parameters)
     : m_downloadManager(*this)
+#if HAVE(LSDATABASECONTEXT)
+    , m_launchServicesDatabaseObserver(LaunchServicesDatabaseObserver::create())
+#endif
 #if ENABLE(CONTENT_EXTENSIONS)
     , m_networkContentRuleListManager(*this)
 #endif
@@ -190,9 +193,6 @@ NetworkProcess::NetworkProcess(AuxiliaryProcessInitializationParameters&& parame
     addSupplementWithoutRefCountedCheck<WebCookieManager>();
 #if ENABLE(LEGACY_CUSTOM_PROTOCOL_MANAGER)
     addSupplementWithoutRefCountedCheck<LegacyCustomProtocolManager>();
-#endif
-#if HAVE(LSDATABASECONTEXT)
-    addSupplement<LaunchServicesDatabaseObserver>();
 #endif
 #if PLATFORM(COCOA) && ENABLE(LEGACY_CUSTOM_PROTOCOL_MANAGER)
     LegacyCustomProtocolManager::networkProcessCreated(*this);
@@ -388,6 +388,10 @@ void NetworkProcess::initializeConnection(IPC::Connection* connection)
 
     for (auto& supplement : m_supplements.values())
         supplement->initializeConnection(connection);
+
+#if HAVE(LSDATABASECONTEXT)
+    m_launchServicesDatabaseObserver->initializeConnection(connection);
+#endif
 }
 
 void NetworkProcess::createNetworkConnectionToWebProcess(ProcessIdentifier identifier, PAL::SessionID sessionID, NetworkProcessConnectionParameters&& parameters, CompletionHandler<void(std::optional<IPC::Connection::Handle>&&, HTTPCookieAcceptPolicy)>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -112,6 +112,7 @@ struct ParentalControlsURLFilterParameters;
 namespace WebKit {
 
 class AuthenticationManager;
+class LaunchServicesDatabaseObserver;
 class NetworkConnectionToWebProcess;
 class NetworkProcessSupplement;
 class NetworkProximityManager;
@@ -641,6 +642,10 @@ private:
     // multiple requests to clear the cache can come in before previous requests complete, and we need to wait for all of them.
     // In the future using WorkQueue and a counting semaphore would work, as would WorkQueue supporting the libdispatch concept of "work groups".
     OSObjectPtr<dispatch_group_t> m_clearCacheDispatchGroup;
+#endif
+
+#if HAVE(LSDATABASECONTEXT)
+    const Ref<LaunchServicesDatabaseObserver> m_launchServicesDatabaseObserver;
 #endif
 
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h
@@ -25,25 +25,29 @@
 
 #pragma once
 
-#include "NetworkProcess.h"
-#include "NetworkProcessSupplement.h"
 #include "XPCEndpoint.h"
 #include <wtf/Lock.h>
 #include <wtf/OSObjectPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 
+namespace IPC {
+class Connection;
+}
+
 namespace WebKit {
 
-class LaunchServicesDatabaseObserver : public WebKit::XPCEndpoint, public NetworkProcessSupplement {
+class LaunchServicesDatabaseObserver : public WebKit::XPCEndpoint {
     WTF_MAKE_TZONE_ALLOCATED(LaunchServicesDatabaseObserver);
 public:
-    LaunchServicesDatabaseObserver(NetworkProcess&);
+    static Ref<LaunchServicesDatabaseObserver> create();
     virtual ~LaunchServicesDatabaseObserver();
 
-    static ASCIILiteral supplementName();
+    void initializeConnection(IPC::Connection*);
 
 private:
+    LaunchServicesDatabaseObserver();
+
     void startObserving(OSObjectPtr<xpc_connection_t>);
 
     // XPCEndpoint
@@ -51,9 +55,6 @@ private:
     ASCIILiteral xpcEndpointMessageName() const override;
     ASCIILiteral xpcEndpointNameKey() const override;
     void handleEvent(xpc_connection_t, xpc_object_t) override;
-
-    // NetworkProcessSupplement
-    void initializeConnection(IPC::Connection*) final;
 
     RetainPtr<id> m_observer;
     Lock m_connectionsLock;

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "LaunchServicesDatabaseObserver.h"
 
+#import "Connection.h"
 #import "LaunchServicesDatabaseXPCConstants.h"
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
 #import <wtf/BlockPtr.h>
@@ -38,7 +39,12 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LaunchServicesDatabaseObserver);
 
-LaunchServicesDatabaseObserver::LaunchServicesDatabaseObserver(NetworkProcess&)
+Ref<LaunchServicesDatabaseObserver> LaunchServicesDatabaseObserver::create()
+{
+    return adoptRef(*new LaunchServicesDatabaseObserver);
+}
+
+LaunchServicesDatabaseObserver::LaunchServicesDatabaseObserver()
 {
 #if HAVE(LSDATABASECONTEXT) && !HAVE(SYSTEM_CONTENT_LS_DATABASE)
     m_observer = [LSDatabaseContext.sharedDatabaseContext addDatabaseChangeObserver4WebKit:^(xpc_object_t change) {
@@ -54,11 +60,6 @@ LaunchServicesDatabaseObserver::LaunchServicesDatabaseObserver(NetworkProcess&)
         }
     }];
 #endif
-}
-
-ASCIILiteral LaunchServicesDatabaseObserver::supplementName()
-{
-    return "LaunchServicesDatabaseObserverSupplement"_s;
 }
 
 void LaunchServicesDatabaseObserver::startObserving(OSObjectPtr<xpc_connection_t> connection)

--- a/Source/WebKit/Shared/Cocoa/XPCEndpoint.h
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpoint.h
@@ -28,15 +28,15 @@
 #ifdef __cplusplus
 
 #include <WebKit/WKBase.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/darwin/XPCExtras.h>
 #include <wtf/darwin/XPCObjectPtr.h>
 #include <wtf/text/ASCIILiteral.h>
 
 namespace WebKit {
 
-class XPCEndpoint {
+class XPCEndpoint : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<XPCEndpoint, WTF::DestructionThread::MainRunLoop> {
 public:
-    WK_EXPORT XPCEndpoint();
     virtual ~XPCEndpoint() = default;
 
     WK_EXPORT void sendEndpointToConnection(xpc_connection_t);
@@ -44,6 +44,9 @@ public:
     WK_EXPORT OSObjectPtr<xpc_endpoint_t> endpoint() const;
 
     static constexpr auto xpcMessageNameKey = "message-name"_s;
+
+protected:
+    WK_EXPORT XPCEndpoint();
 
 private:
     virtual ASCIILiteral xpcEndpointMessageNameKey() const = 0;

--- a/Source/WebKit/Shared/Cocoa/XPCEndpoint.mm
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpoint.mm
@@ -27,6 +27,7 @@
 #import "XPCEndpoint.h"
 #import "XPCUtilities.h"
 
+#import <wtf/BlockPtr.h>
 #import <wtf/cocoa/Entitlements.h>
 #import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/ASCIILiteral.h>
@@ -71,9 +72,10 @@ XPCEndpoint::XPCEndpoint()
             }
 #endif // USE(APPLE_INTERNAL_SDK)
             xpc_connection_set_target_queue(connection.get(), mainDispatchQueueSingleton());
-            xpc_connection_set_event_handler(connection.get(), ^(xpc_object_t event) {
-                handleEvent(connection.get(), event);
-            });
+            xpc_connection_set_event_handler(connection.get(), makeBlockPtr([weakThis = ThreadSafeWeakPtr { *this }, connection](xpc_object_t event) {
+                if (RefPtr protectedThis = weakThis)
+                    protectedThis->handleEvent(connection.get(), event);
+            }).get());
             xpc_connection_resume(connection.get());
         }
     });

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/XPCEndpoint.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/XPCEndpoint.mm
@@ -38,7 +38,12 @@ static constexpr auto testMessageFromEndpoint = "test-message-from-endpoint"_s;
 static constexpr auto testMessageFromClient = "test-message-from-client"_s;
 
 class XPCEndpoint final : public WebKit::XPCEndpoint {
+public:
+    static Ref<XPCEndpoint> create() { return adoptRef(*new XPCEndpoint); }
+
 private:
+    XPCEndpoint() = default;
+
     ASCIILiteral xpcEndpointMessageNameKey() const final
     {
         return { };
@@ -86,10 +91,10 @@ private:
 
 TEST(WebKit, XPCEndpoint)
 {
-    XPCEndpoint xpcEndpoint;
+    Ref xpcEndpoint = XPCEndpoint::create();
     XPCEndpointClient xpcEndpointClient;
 
-    xpcEndpointClient.setEndpoint(xpcEndpoint.endpoint().get());
+    xpcEndpointClient.setEndpoint(xpcEndpoint->endpoint().get());
 
     TestWebKitAPI::Util::run(&clientConnectedToEndpoint);
     TestWebKitAPI::Util::run(&endpointReceivedMessageFromClient);


### PR DESCRIPTION
#### a026de3e0e568916c560b83cc7eb75664ad9c4ff
<pre>
Crash in `XPCEndpoint::XPCEndpoint` when running `WebKit.XPCEndpoint` and letting the test runner not terminate immediately
<a href="https://bugs.webkit.org/show_bug.cgi?id=311925">https://bugs.webkit.org/show_bug.cgi?id=311925</a>
<a href="https://rdar.apple.com/174457740">rdar://174457740</a>

Reviewed by Richard Robinson and Per Arne Vollan.

Make XPCEndpoint ThreadSafeRefCountedAndCanMakeWeakPtr so that we can
capture a ThreadSafeWeakPtr to it in the lambda we pass to
`xpc_connection_set_event_handler()`. Then convert the ThreadSafeWeakPtr
into a RefPtr before calling `handleEvent()` on the XPCEndpoint.

Without this, the lambda may run on a workqueue while the endpoint is
being destroyed on the main thread, in the context of the API tests.
Production code is fine because the only other XPCEndpoint subclass
is owned by a singleton.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/XPCEndpoint.mm

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::NetworkProcess):
(WebKit::NetworkProcess::initializeConnection):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h:
* Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm:
(WebKit::LaunchServicesDatabaseObserver::create):
(WebKit::LaunchServicesDatabaseObserver::LaunchServicesDatabaseObserver):
(WebKit::LaunchServicesDatabaseObserver::supplementName): Deleted.
* Source/WebKit/Shared/Cocoa/XPCEndpoint.h:
* Source/WebKit/Shared/Cocoa/XPCEndpoint.mm:
(WebKit::XPCEndpoint::XPCEndpoint):
* Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/XPCEndpoint.mm:
(TEST(WebKit, XPCEndpoint)):

Canonical link: <a href="https://commits.webkit.org/310972@main">https://commits.webkit.org/310972@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9c79d078b71693cf51760bbd4b05776de5e4084

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164265 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c7675f27-f9bb-42c1-a312-9315defe7961) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120347 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158462 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139637 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101037 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21623 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12096 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131292 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17469 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166743 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10921 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128459 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23773 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128593 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34886 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28231 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139262 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85673 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23427 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16059 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27925 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92028 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27502 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27732 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27575 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->