### PR TITLE
Implement `color_scheme_dark` manifest member

### DIFF
--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
@@ -82,7 +82,9 @@ struct ApplicationManifest {
     URL startURL;
     URL id;
     Color backgroundColor;
+    Color backgroundColorDark;
     Color themeColor;
+    Color themeColorDark;
     Vector<String> categories;
     Vector<Icon> icons;
     Vector<Shortcut> shortcuts;

--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
@@ -123,6 +123,11 @@ ApplicationManifest ApplicationManifestParser::parseManifest(const JSON::Object&
     parsedManifest.id = parseId(manifest, parsedManifest.startURL);
     parsedManifest.orientation = parseOrientation(manifest);
 
+    if (auto darkManifest = manifest.getObject("color_scheme_dark"_s)) {
+        parsedManifest.backgroundColorDark = parseColor(*darkManifest, "background_color"_s);
+        parsedManifest.themeColorDark = parseColor(*darkManifest, "theme_color"_s);
+    }
+
     if (m_document)
         m_document->processApplicationManifest(parsedManifest);
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1392,8 +1392,13 @@ const Color& Document::themeColor()
         if (m_activeThemeColorMetaElement)
             m_cachedThemeColor = m_activeThemeColorMetaElement->contentColor();
 
-        if (!m_cachedThemeColor.isValid())
-            m_cachedThemeColor = m_applicationManifestThemeColor;
+        if (!m_cachedThemeColor.isValid()) {
+            if (RefPtr page = this->page(); page && page->useDarkAppearance())
+                m_cachedThemeColor = m_applicationManifestThemeColorDark;
+
+            if (!m_cachedThemeColor.isValid())
+                m_cachedThemeColor = m_applicationManifestThemeColor;
+        }
     }
     return m_cachedThemeColor;
 }
@@ -5529,6 +5534,7 @@ void Document::processApplicationManifest(const ApplicationManifest& application
 {
     auto oldThemeColor = std::exchange(m_cachedThemeColor, Color());
     m_applicationManifestThemeColor = applicationManifest.themeColor;
+    m_applicationManifestThemeColorDark = applicationManifest.themeColorDark;
     if (themeColor() == oldThemeColor)
         return;
 
@@ -9882,6 +9888,12 @@ bool Document::useDarkAppearance([[maybe_unused]] const Style::ComputedStyle* st
 #endif
 
     return false;
+}
+
+void Document::appearanceDidChange()
+{
+    if (std::exchange(m_cachedThemeColor, Color()) != themeColor())
+        themeColorChanged();
 }
 
 bool Document::useElevatedUserInterfaceLevel() const

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -756,6 +756,7 @@ public:
     WEBCORE_EXPORT bool NODELETE useElevatedUserInterfaceLevel() const;
     WEBCORE_EXPORT bool useDarkAppearance(const RenderStyle*) const;
     WEBCORE_EXPORT bool useDarkAppearance(const Style::ComputedStyle*) const;
+    void appearanceDidChange();
 #if ENABLE(DARK_MODE_CSS)
     OptionSet<ColorScheme> resolvedColorScheme(const Style::ComputedStyle*) const;
 #endif
@@ -2335,6 +2336,7 @@ private:
     std::optional<Vector<WeakPtr<HTMLMetaElement, WeakPtrImplWithEventTargetData>>> m_metaThemeColorElements;
     WeakPtr<HTMLMetaElement, WeakPtrImplWithEventTargetData> m_activeThemeColorMetaElement;
     Color m_applicationManifestThemeColor;
+    Color m_applicationManifestThemeColorDark;
 
 #if ENABLE(WEB_PAGE_SPATIAL_BACKDROP)
     std::optional<SpatialBackdropSource> m_cachedSpatialBackdropSource;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4281,6 +4281,7 @@ void Page::appearanceDidChange()
         document.updateElementsAffectedByMediaQueries();
         document.scheduleRenderingUpdate(RenderingUpdateStep::MediaQueryEvaluation);
         document.invalidateScrollbars();
+        document.appearanceDidChange();
     });
 }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1308,7 +1308,9 @@ struct WebCore::ApplicationManifest {
     URL startURL
     URL id
     WebCore::Color backgroundColor
+    WebCore::Color backgroundColorDark
     WebCore::Color themeColor
+    WebCore::Color themeColorDark
     Vector<String> categories
     Vector<WebCore::ApplicationManifest::Icon> icons
     Vector<WebCore::ApplicationManifest::Shortcut> shortcuts

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -284,11 +284,13 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
     URL manifestURL = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"manifest_url"];
     URL startURL = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"start_url"];
     URL manifestId = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"manifestId"];
-    RetainPtr<WebCore::CocoaColor> backgroundColor = [aDecoder decodeObjectOfClass:[WebCore::CocoaColor class] forKey:@"background_color"];
-    RetainPtr<WebCore::CocoaColor> themeColor = [aDecoder decodeObjectOfClass:[WebCore::CocoaColor class] forKey:@"theme_color"];
     RetainPtr<NSArray<NSString *>> categories = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSArray class], [NSString class]]] forKey:@"categories"];
     RetainPtr<NSArray<_WKApplicationManifestIcon *>> icons = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSArray class], [_WKApplicationManifestIcon class]]] forKey:@"icons"];
     RetainPtr<NSArray<_WKApplicationManifestIcon *>> shortcuts = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSArray class], [_WKApplicationManifestShortcut class], [_WKApplicationManifestIcon class]]] forKey:@"shortcuts"];
+    RetainPtr<WebCore::CocoaColor> backgroundColorLight = [aDecoder decodeObjectOfClass:[WebCore::CocoaColor class] forKey:@"background_color_light"];
+    RetainPtr<WebCore::CocoaColor> backgroundColorDark = [aDecoder decodeObjectOfClass:[WebCore::CocoaColor class] forKey:@"background_color_dark"];
+    RetainPtr<WebCore::CocoaColor> themeColorLight = [aDecoder decodeObjectOfClass:[WebCore::CocoaColor class] forKey:@"theme_color_light"];
+    RetainPtr<WebCore::CocoaColor> themeColorDark = [aDecoder decodeObjectOfClass:[WebCore::CocoaColor class] forKey:@"theme_color_dark"];
 
     WebCore::ApplicationManifest coreApplicationManifest {
         WTF::move(rawJSON),
@@ -304,8 +306,10 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
         WTF::move(manifestURL),
         WTF::move(startURL),
         WTF::move(manifestId),
-        WebCore::roundAndClampToSRGBALossy(RetainPtr { backgroundColor.get().CGColor }.get()),
-        WebCore::roundAndClampToSRGBALossy(RetainPtr { themeColor.get().CGColor }.get()),
+        WebCore::roundAndClampToSRGBALossy(protect(backgroundColorLight.get().CGColor)),
+        WebCore::roundAndClampToSRGBALossy(protect(backgroundColorDark.get().CGColor)),
+        WebCore::roundAndClampToSRGBALossy(protect(themeColorLight.get().CGColor)),
+        WebCore::roundAndClampToSRGBALossy(protect(themeColorDark.get().CGColor)),
         makeVector<String>(categories.get()),
         makeVector<WebCore::ApplicationManifest::Icon>(icons.get()),
         makeVector<WebCore::ApplicationManifest::Shortcut>(shortcuts.get()),
@@ -344,11 +348,25 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
     [aCoder encodeObject:self.manifestURL forKey:@"manifest_url"];
     [aCoder encodeObject:self.startURL forKey:@"start_url"];
     [aCoder encodeObject:self.manifestId forKey:@"manifestId"];
-    [aCoder encodeObject:self.backgroundColor forKey:@"background_color"];
-    [aCoder encodeObject:self.themeColor forKey:@"theme_color"];
     [aCoder encodeObject:self.categories forKey:@"categories"];
     [aCoder encodeObject:self.icons forKey:@"icons"];
     [aCoder encodeObject:self.shortcuts forKey:@"shortcuts"];
+
+    auto encodeLightColors = ^{
+        [aCoder encodeObject:[WebCore::CocoaColor colorWithCGColor:protect(self.backgroundColor.CGColor)] forKey:@"background_color_light"];
+        [aCoder encodeObject:[WebCore::CocoaColor colorWithCGColor:protect(self.themeColor.CGColor)] forKey:@"theme_color_light"];
+    };
+    auto encodeDarkColors = ^{
+        [aCoder encodeObject:[WebCore::CocoaColor colorWithCGColor:protect(self.backgroundColor.CGColor)] forKey:@"background_color_dark"];
+        [aCoder encodeObject:[WebCore::CocoaColor colorWithCGColor:protect(self.themeColor.CGColor)] forKey:@"theme_color_dark"];
+    };
+#if PLATFORM(IOS_FAMILY)
+    [[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight] performAsCurrentTraitCollection:encodeLightColors];
+    [[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark] performAsCurrentTraitCollection:encodeDarkColors];
+#else
+    [[NSAppearance appearanceNamed:NSAppearanceNameAqua] performAsCurrentDrawingAppearance:encodeLightColors];
+    [[NSAppearance appearanceNamed:NSAppearanceNameDarkAqua] performAsCurrentDrawingAppearance:encodeDarkColors];
+#endif
 }
 
 + (_WKApplicationManifest *)applicationManifestFromJSON:(NSString *)json manifestURL:(NSURL *)manifestURL documentURL:(NSURL *)documentURL
@@ -430,12 +448,38 @@ static RetainPtr<NSString> nullableNSString(const WTF::String& string)
 
 - (WebCore::CocoaColor *)backgroundColor
 {
-    return cocoaColor(_applicationManifest->applicationManifest().backgroundColor).autorelease();
+    const auto& manifest = _applicationManifest->applicationManifest();
+    auto getColor = [color = manifest.backgroundColor, darkColor = manifest.backgroundColorDark] (bool isDark) {
+        return cocoaColor((isDark && darkColor.isValid()) ? darkColor : color).autorelease();
+    };
+#if PLATFORM(IOS_FAMILY)
+    return [UIColor colorWithDynamicProvider:[getColor = WTF::move(getColor)] (UITraitCollection *traitCollection) -> UIColor * {
+        return getColor(traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark);
+    }];
+#else
+    return [NSColor colorWithName:nil dynamicProvider:[getColor = WTF::move(getColor)] (NSAppearance *appearance) -> NSColor * {
+        RetainPtr appearanceName = [appearance bestMatchFromAppearancesWithNames:@[ NSAppearanceNameAqua, NSAppearanceNameDarkAqua ]];
+        return getColor([appearanceName isEqualToString:NSAppearanceNameDarkAqua]);
+    }];
+#endif
 }
 
 - (WebCore::CocoaColor *)themeColor
 {
-    return cocoaColor(_applicationManifest->applicationManifest().themeColor).autorelease();
+    const auto& manifest = _applicationManifest->applicationManifest();
+    auto getColor = [color = manifest.themeColor, darkColor = manifest.themeColorDark] (bool isDark) {
+        return cocoaColor((isDark && darkColor.isValid()) ? darkColor : color).autorelease();
+    };
+#if PLATFORM(IOS_FAMILY)
+    return [UIColor colorWithDynamicProvider:[getColor = WTF::move(getColor)] (UITraitCollection *traitCollection) -> UIColor * {
+        return getColor(traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark);
+    }];
+#else
+    return [NSColor colorWithName:nil dynamicProvider:[getColor = WTF::move(getColor)] (NSAppearance *appearance) -> NSColor * {
+        RetainPtr appearanceName = [appearance bestMatchFromAppearancesWithNames:@[ NSAppearanceNameAqua, NSAppearanceNameDarkAqua ]];
+        return getColor([appearanceName isEqualToString:NSAppearanceNameDarkAqua]);
+    }];
+#endif
 }
 
 - (_WKApplicationManifestDisplayMode)displayMode

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestCocoa.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestCocoa.h
@@ -66,8 +66,10 @@ bool operator==(const CGSize&, const CGSize&);
 std::ostream& operator<<(std::ostream&, const CGRect&);
 bool operator==(const CGRect&, const CGRect&);
 
+constexpr CGFloat blackColorComponents[4] = { 0, 0, 0, 1 };
 constexpr CGFloat redColorComponents[4] = { 1, 0, 0, 1 };
 constexpr CGFloat blueColorComponents[4] = { 0, 0, 1, 1 };
+constexpr CGFloat whiteColorComponents[4] = { 1, 1, 1, 1 };
 
 #endif
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp
@@ -250,10 +250,24 @@ public:
         EXPECT_EQ(expectedValue, value);
     }
 
+    void testBackgroundColorDark(const String& rawJSON, const Color& expectedValue, bool nested = true)
+    {
+        auto manifest = parseTopLevelProperty("color_scheme_dark"_s, nested ? makeString("{ \"background_color\" : "_s, rawJSON, " }"_s) : rawJSON);
+        auto value = manifest.backgroundColorDark;
+        EXPECT_EQ(expectedValue, value);
+    }
+
     void testThemeColor(const String& rawJSON, const Color& expectedValue)
     {
         auto manifest = parseTopLevelProperty("theme_color"_s, rawJSON);
         auto value = manifest.themeColor;
+        EXPECT_EQ(expectedValue, value);
+    }
+
+    void testThemeColorDark(const String& rawJSON, const Color& expectedValue, bool nested = true)
+    {
+        auto manifest = parseTopLevelProperty("color_scheme_dark"_s, nested ? makeString("{ \"theme_color\" : "_s, rawJSON, " }"_s) : rawJSON);
+        auto value = manifest.themeColorDark;
         EXPECT_EQ(expectedValue, value);
     }
 
@@ -678,6 +692,43 @@ TEST_F(ApplicationManifestParserTest, BackgroundColor)
     testBackgroundColor("\"hsla(0, 100%, 50%, 1)\""_s, Color::red);
 }
 
+TEST_F(ApplicationManifestParserTest, BackgroundColorDark)
+{
+    // nested inside "color_scheme_dark" object
+    testBackgroundColorDark("123"_s, Color());
+    testBackgroundColorDark("null"_s, Color());
+    testBackgroundColorDark("true"_s, Color());
+    testBackgroundColorDark("{ }"_s, Color());
+    testBackgroundColorDark("[ ]"_s, Color());
+    testBackgroundColorDark("\"\""_s, Color());
+    testBackgroundColorDark("\"garbage string\""_s, Color());
+    testBackgroundColorDark("\"red\""_s, Color::red);
+    testBackgroundColorDark("\"#f00\""_s, Color::red);
+    testBackgroundColorDark("\"#ff0000\""_s, Color::red);
+    testBackgroundColorDark("\"#ff0000ff\""_s, Color::red);
+    testBackgroundColorDark("\"rgb(255, 0, 0)\""_s, Color::red);
+    testBackgroundColorDark("\"rgba(255, 0, 0, 1)\""_s, Color::red);
+    testBackgroundColorDark("\"hsl(0, 100%, 50%)\""_s, Color::red);
+    testBackgroundColorDark("\"hsla(0, 100%, 50%, 1)\""_s, Color::red);
+
+    // set at top-level
+    testBackgroundColorDark("123"_s, Color(), false);
+    testBackgroundColorDark("null"_s, Color(), false);
+    testBackgroundColorDark("true"_s, Color(), false);
+    testBackgroundColorDark("{ }"_s, Color(), false);
+    testBackgroundColorDark("[ ]"_s, Color(), false);
+    testBackgroundColorDark("\"\""_s, Color(), false);
+    testBackgroundColorDark("\"garbage string\""_s, Color(), false);
+    testBackgroundColorDark("\"red\""_s, Color(), false);
+    testBackgroundColorDark("\"#f00\""_s, Color(), false);
+    testBackgroundColorDark("\"#ff0000\""_s, Color(), false);
+    testBackgroundColorDark("\"#ff0000ff\""_s, Color(), false);
+    testBackgroundColorDark("\"rgb(255, 0, 0)\""_s, Color(), false);
+    testBackgroundColorDark("\"rgba(255, 0, 0, 1)\""_s, Color(), false);
+    testBackgroundColorDark("\"hsl(0, 100%, 50%)\""_s, Color(), false);
+    testBackgroundColorDark("\"hsla(0, 100%, 50%, 1)\""_s, Color(), false);
+}
+
 TEST_F(ApplicationManifestParserTest, ThemeColor)
 {
     testThemeColor("123"_s, Color());
@@ -696,6 +747,43 @@ TEST_F(ApplicationManifestParserTest, ThemeColor)
     testThemeColor("\"rgba(255, 0, 0, 1)\""_s, Color::red);
     testThemeColor("\"hsl(0, 100%, 50%)\""_s, Color::red);
     testThemeColor("\"hsla(0, 100%, 50%, 1)\""_s, Color::red);
+}
+
+TEST_F(ApplicationManifestParserTest, ThemeColorDark)
+{
+    // nested inside "color_scheme_dark" object
+    testThemeColorDark("123"_s, Color());
+    testThemeColorDark("null"_s, Color());
+    testThemeColorDark("true"_s, Color());
+    testThemeColorDark("{ }"_s, Color());
+    testThemeColorDark("[ ]"_s, Color());
+    testThemeColorDark("\"\""_s, Color());
+    testThemeColorDark("\"garbage string\""_s, Color());
+    testThemeColorDark("\"red\""_s, Color::red);
+    testThemeColorDark("\"#f00\""_s, Color::red);
+    testThemeColorDark("\"#ff0000\""_s, Color::red);
+    testThemeColorDark("\"#ff0000ff\""_s, Color::red);
+    testThemeColorDark("\"rgb(255, 0, 0)\""_s, Color::red);
+    testThemeColorDark("\"rgba(255, 0, 0, 1)\""_s, Color::red);
+    testThemeColorDark("\"hsl(0, 100%, 50%)\""_s, Color::red);
+    testThemeColorDark("\"hsla(0, 100%, 50%, 1)\""_s, Color::red);
+
+    // set at top-level
+    testThemeColorDark("123"_s, Color(), false);
+    testThemeColorDark("null"_s, Color(), false);
+    testThemeColorDark("true"_s, Color(), false);
+    testThemeColorDark("{ }"_s, Color(), false);
+    testThemeColorDark("[ ]"_s, Color(), false);
+    testThemeColorDark("\"\""_s, Color(), false);
+    testThemeColorDark("\"garbage string\""_s, Color(), false);
+    testThemeColorDark("\"red\""_s, Color(), false);
+    testThemeColorDark("\"#f00\""_s, Color(), false);
+    testThemeColorDark("\"#ff0000\""_s, Color(), false);
+    testThemeColorDark("\"#ff0000ff\""_s, Color(), false);
+    testThemeColorDark("\"rgb(255, 0, 0)\""_s, Color(), false);
+    testThemeColorDark("\"rgba(255, 0, 0, 1)\""_s, Color(), false);
+    testThemeColorDark("\"hsl(0, 100%, 50%)\""_s, Color(), false);
+    testThemeColorDark("\"hsla(0, 100%, 50%, 1)\""_s, Color(), false);
 }
 
 TEST_F(ApplicationManifestParserTest, Categories)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ApplicationManifest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ApplicationManifest.mm
@@ -40,7 +40,7 @@ namespace TestWebKitAPI {
 
 TEST(ApplicationManifest, Coding)
 {
-    auto jsonString = @"{ \"name\": \"TestName\", \"short_name\": \"TestShortName\", \"description\": \"TestDescription\", \"scope\": \"https://test.com/app\", \"start_url\": \"https://test.com/app/index.html\", \"display\": \"minimal-ui\", \"theme_color\": \"red\" }";
+    auto jsonString = @"{ \"name\": \"TestName\", \"short_name\": \"TestShortName\", \"description\": \"TestDescription\", \"scope\": \"https://test.com/app\", \"start_url\": \"https://test.com/app/index.html\", \"display\": \"minimal-ui\", \"background_color\": \"white\", \"theme_color\": \"red\", \"color_scheme_dark\": { \"background_color\": \"black\", \"theme_color\": \"blue\" } }";
     RetainPtr<_WKApplicationManifest> manifest { [_WKApplicationManifest applicationManifestFromJSON:jsonString manifestURL:[NSURL URLWithString:@"https://test.com/manifest.json"] documentURL:[NSURL URLWithString:@"https://test.com/"]] };
 
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:manifest.get() requiringSecureCoding:YES error:nullptr];
@@ -55,8 +55,26 @@ TEST(ApplicationManifest, Coding)
     EXPECT_EQ(_WKApplicationManifestDisplayModeMinimalUI,  manifest.get().displayMode);
 
     RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr blackColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blackColorComponents));
     RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
-    EXPECT_TRUE(CGColorEqualToColor(manifest.get().themeColor.CGColor, redColor.get()));
+    RetainPtr blueColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blueColorComponents));
+    RetainPtr whiteColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), whiteColorComponents));
+
+    auto checkLightColors = ^{
+        EXPECT_TRUE(CGColorEqualToColor(manifest.get().backgroundColor.CGColor, whiteColor.get()));
+        EXPECT_TRUE(CGColorEqualToColor(manifest.get().themeColor.CGColor, redColor.get()));
+    };
+    auto checkDarkColors = ^{
+        EXPECT_TRUE(CGColorEqualToColor(manifest.get().backgroundColor.CGColor, blackColor.get()));
+        EXPECT_TRUE(CGColorEqualToColor(manifest.get().themeColor.CGColor, blueColor.get()));
+    };
+#if PLATFORM(IOS_FAMILY)
+    [[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight] performAsCurrentTraitCollection:checkLightColors];
+    [[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark] performAsCurrentTraitCollection:checkDarkColors];
+#else
+    [[NSAppearance appearanceNamed:NSAppearanceNameAqua] performAsCurrentDrawingAppearance:checkLightColors];
+    [[NSAppearance appearanceNamed:NSAppearanceNameDarkAqua] performAsCurrentDrawingAppearance:checkDarkColors];
+#endif
 }
 
 TEST(ApplicationManifest, Basic)
@@ -97,7 +115,12 @@ TEST(ApplicationManifest, Basic)
         @"description": @"Hello.",
         @"start_url": @"http://example.com/app/start",
         @"scope": @"http://example.com/app",
+        @"background_color": @"white",
         @"theme_color": @"red",
+        @"color_scheme_dark": @{
+            @"background_color": @"black",
+            @"theme_color": @"blue",
+        },
     };
     json = [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0];
     NSString *htmlString = [NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:text/plain;charset=utf-8;base64,%@\">", json];
@@ -111,8 +134,26 @@ TEST(ApplicationManifest, Basic)
         EXPECT_TRUE([manifest.scope isEqual:[NSURL URLWithString:@"http://example.com/app"]]);
 
         RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+        RetainPtr blackColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blackColorComponents));
         RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
-        EXPECT_TRUE(CGColorEqualToColor(manifest.themeColor.CGColor, redColor.get()));
+        RetainPtr blueColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blueColorComponents));
+        RetainPtr whiteColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), whiteColorComponents));
+
+        auto checkLightColors = ^{
+            EXPECT_TRUE(CGColorEqualToColor(manifest.backgroundColor.CGColor, whiteColor.get()));
+            EXPECT_TRUE(CGColorEqualToColor(manifest.themeColor.CGColor, redColor.get()));
+        };
+        auto checkDarkColors = ^{
+            EXPECT_TRUE(CGColorEqualToColor(manifest.backgroundColor.CGColor, blackColor.get()));
+            EXPECT_TRUE(CGColorEqualToColor(manifest.themeColor.CGColor, blueColor.get()));
+        };
+#if PLATFORM(IOS_FAMILY)
+        [[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight] performAsCurrentTraitCollection:checkLightColors];
+        [[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark] performAsCurrentTraitCollection:checkDarkColors];
+#else
+        [[NSAppearance appearanceNamed:NSAppearanceNameAqua] performAsCurrentDrawingAppearance:checkLightColors];
+        [[NSAppearance appearanceNamed:NSAppearanceNameDarkAqua] performAsCurrentDrawingAppearance:checkDarkColors];
+#endif
 
         done = true;
     }];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewThemeColor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewThemeColor.mm
@@ -290,16 +290,36 @@ TEST(WKWebViewThemeColor, ApplicationManifest)
 {
     RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
     RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+    RetainPtr blueColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blueColorComponents));
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView forceLightMode];
     EXPECT_TRUE(![webView themeColor]);
 
-    NSDictionary *manifestObject = @{ @"name": @"Test", @"theme_color": @"red" };
+    NSDictionary *manifestObject = @{
+        @"name": @"Test",
+        @"theme_color": @"red",
+        @"color_scheme_dark": @{
+            @"theme_color": @"blue",
+        }
+    };
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:[NSString stringWithFormat:@"<link rel='manifest' href='data:application/manifest+json;charset=utf-8;base64,%@'>", [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0]]];
 
     static bool didGetApplicationManifest = false;
     [webView _getApplicationManifestWithCompletionHandler:[&] (_WKApplicationManifest *manifest) {
-        EXPECT_TRUE(CGColorEqualToColor(manifest.themeColor.CGColor, redColor.get()));
+        auto checkLightColor = ^{
+            EXPECT_TRUE(CGColorEqualToColor(manifest.themeColor.CGColor, redColor.get()));
+        };
+        auto checkDarkColor = ^{
+            EXPECT_TRUE(CGColorEqualToColor(manifest.themeColor.CGColor, blueColor.get()));
+        };
+#if PLATFORM(IOS_FAMILY)
+        [[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight] performAsCurrentTraitCollection:checkLightColor];
+        [[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark] performAsCurrentTraitCollection:checkDarkColor];
+#else
+        [[NSAppearance appearanceNamed:NSAppearanceNameAqua] performAsCurrentDrawingAppearance:checkLightColor];
+        [[NSAppearance appearanceNamed:NSAppearanceNameDarkAqua] performAsCurrentDrawingAppearance:checkDarkColor];
+#endif
 
         didGetApplicationManifest = true;
     }];
@@ -307,18 +327,57 @@ TEST(WKWebViewThemeColor, ApplicationManifest)
 
     [webView waitForNextPresentationUpdate];
     EXPECT_TRUE(CGColorEqualToColor([webView themeColor].CGColor, redColor.get()));
+
+    [webView forceDarkMode];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_TRUE(CGColorEqualToColor([webView themeColor].CGColor, blueColor.get()));
 }
 
 TEST(WKWebViewThemeColor, MetaElementOverridesApplicationManifest)
 {
+    RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
+    RetainPtr blackColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blackColorComponents));
+    RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+    RetainPtr whiteColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), whiteColorComponents));
+
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView forceLightMode];
     EXPECT_TRUE(![webView themeColor]);
 
-    NSDictionary *manifestObject = @{ @"name": @"Test", @"theme_color": @"blue" };
+    NSDictionary *manifestObject = @{
+        @"name": @"Test",
+        @"theme_color": @"black",
+        @"color_scheme_dark": @{
+            @"theme_color": @"white",
+        }
+    };
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:[NSString stringWithFormat:@"<link rel='manifest' href='data:application/manifest+json;charset=utf-8;base64,%@'><meta name='theme-color' content='red'>", [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0]]];
 
-    RetainPtr sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    RetainPtr redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
+    static bool didGetApplicationManifest = false;
+    [webView _getApplicationManifestWithCompletionHandler:[&] (_WKApplicationManifest *manifest) {
+        auto checkLightColor = ^{
+            EXPECT_TRUE(CGColorEqualToColor(manifest.themeColor.CGColor, blackColor.get()));
+        };
+        auto checkDarkColor = ^{
+            EXPECT_TRUE(CGColorEqualToColor(manifest.themeColor.CGColor, whiteColor.get()));
+        };
+#if PLATFORM(IOS_FAMILY)
+        [[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight] performAsCurrentTraitCollection:checkLightColor];
+        [[UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark] performAsCurrentTraitCollection:checkDarkColor];
+#else
+        [[NSAppearance appearanceNamed:NSAppearanceNameAqua] performAsCurrentDrawingAppearance:checkLightColor];
+        [[NSAppearance appearanceNamed:NSAppearanceNameDarkAqua] performAsCurrentDrawingAppearance:checkDarkColor];
+#endif
+
+        didGetApplicationManifest = true;
+    }];
+    TestWebKitAPI::Util::run(&didGetApplicationManifest);
+
+    [webView waitForNextPresentationUpdate];
+    EXPECT_TRUE(CGColorEqualToColor([webView themeColor].CGColor, redColor.get()));
+
+    [webView forceDarkMode];
+    [webView waitForNextPresentationUpdate];
     EXPECT_TRUE(CGColorEqualToColor([webView themeColor].CGColor, redColor.get()));
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewUnderPageBackgroundColor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewUnderPageBackgroundColor.mm
@@ -279,8 +279,6 @@ TEST(WKWebViewUnderPageBackgroundColor, KVO)
 
 #if PLATFORM(IOS_FAMILY)
 
-constexpr CGFloat whiteColorComponents[4] = { 1, 1, 1, 1 };
-
 // There's no API/SPI to get the background color of the scroll area on macOS.
 
 TEST(WKWebViewUnderPageBackgroundColor, MatchesScrollView)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewTests.mm
@@ -52,9 +52,6 @@
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/darwin/DispatchExtras.h>
 
-constexpr CGFloat blackColorComponents[4] = { 0, 0, 0, 1 };
-constexpr CGFloat whiteColorComponents[4] = { 1, 1, 1, 1 };
-
 @interface UIView (TestWebKitAPI)
 - (BOOL)_appearsBeforeViewInSubviewOrder:(UIView *)view;
 @end


### PR DESCRIPTION
#### 4335716855bb893798267c14053068e6c8ad010e
<pre>
Implement `color_scheme_dark` manifest member
<a href="https://bugs.webkit.org/show_bug.cgi?id=311727">https://bugs.webkit.org/show_bug.cgi?id=311727</a>
&lt;<a href="https://rdar.apple.com/problem/174315709">rdar://problem/174315709</a>&gt;

Reviewed by Aditya Keerthi.

This allows developers to specify both a light and dark theme color (and background color) instead of only having a single color for both.

Tests: Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ApplicationManifest.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewThemeColor.mm

* Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::ApplicationManifestParser::parseManifest):
When parsing, look for a `color_scheme_dark` object and (if it exists) pull out additional `background_color` and `theme_color` properties.
Save them in separate member variables since the manifest itself has no knowledge of the system appearance (i.e. it just holds the data for someone else to use).

* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::themeColor):
(WebCore::Document::processApplicationManifest):
(WebCore::Document::appearanceDidChange): Added.
* Source/WebCore/page/Page.cpp:
(WebCore::Page::appearanceDidChange):
Notify the `Document` whenever the system appearance changes so that it can re-evaluate which `theme_color` to use from the manifest.

* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
(-[_WKApplicationManifest initWithCoder:]):
(-[_WKApplicationManifest encodeWithCoder:]):
(-[_WKApplicationManifest backgroundColor]):
(-[_WKApplicationManifest themeColor]):
Modify the existing SPI for these colors to use dynamic providers for the dark color (if given) is used when in dark mode.

* Tools/TestWebKitAPI/Helpers/cocoa/TestCocoa.h:
* Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp:
(ApplicationManifestParserTest::testBackgroundColorDark): Added.
(ApplicationManifestParserTest::testThemeColorDark): Added.
(TEST_F(ApplicationManifestParserTest, BackgroundColorDark)): Added.
(TEST_F(ApplicationManifestParserTest, ThemeColorDark)): Added.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ApplicationManifest.mm:
(TestWebKitAPI::TEST(ApplicationManifest, Coding)):
(TestWebKitAPI::TEST(ApplicationManifest, Basic)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewThemeColor.mm:
(TEST(WKWebViewThemeColor, ApplicationManifest)):
(TEST(WKWebViewThemeColor, MetaElementOverridesApplicationManifest)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewUnderPageBackgroundColor.mm:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewTests.mm:

Canonical link: <a href="https://commits.webkit.org/314109@main">https://commits.webkit.org/314109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f4b3273c8f8effbf91a118dc11a7c22c9e92f87

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172822 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121045 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37277 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127233 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89638 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147248 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107782 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28560 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27190 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20587 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138459 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24965 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175343 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28170 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26633 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135538 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31296 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135514 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36816 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37733 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146760 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99868 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30828 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23614 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36444 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109589 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35941 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1646 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36191 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36088 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->