### PR TITLE
Removed about 9% of #include statements from WTF

### DIFF
--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -28,7 +28,6 @@
 #include "config.h"
 #include <wtf/Assertions.h>
 
-#include <mutex>
 #include <stdio.h>
 #include <string.h>
 #include <wtf/Compiler.h>

--- a/Source/WTF/wtf/AvailableMemory.cpp
+++ b/Source/WTF/wtf/AvailableMemory.cpp
@@ -26,10 +26,8 @@
 #include "config.h"
 #include <wtf/AvailableMemory.h>
 
-#include <algorithm>
-#include <array>
 #include <mutex>
-#include <wtf/PageBlock.h>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
@@ -38,10 +36,8 @@
 #endif
 
 #if OS(DARWIN)
-#import <dispatch/dispatch.h>
 #import <mach/host_info.h>
 #import <mach/mach.h>
-#import <mach/mach_error.h>
 #import <math.h>
 #elif OS(UNIX)
 #if OS(FREEBSD) || OS(LINUX)

--- a/Source/WTF/wtf/BitVector.cpp
+++ b/Source/WTF/wtf/BitVector.cpp
@@ -29,7 +29,6 @@
 #include <algorithm>
 #include <string.h>
 #include <wtf/Assertions.h>
-#include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/SIMDHelpers.h>
 

--- a/Source/WTF/wtf/CompactPtr.cpp
+++ b/Source/WTF/wtf/CompactPtr.cpp
@@ -26,13 +26,6 @@
 #include "config.h"
 #include <wtf/CompactPtr.h>
 
-#include <wtf/AccessibleAddress.h>
-#include <wtf/HashMap.h>
-#include <wtf/Lock.h>
-#include <wtf/NeverDestroyed.h>
-#include <wtf/SegmentedVector.h>
-#include <wtf/Threading.h>
-
 namespace WTF {
 
 #if HAVE(36BIT_ADDRESS)

--- a/Source/WTF/wtf/CryptographicallyRandomNumber.cpp
+++ b/Source/WTF/wtf/CryptographicallyRandomNumber.cpp
@@ -32,7 +32,6 @@
 #include <wtf/CryptographicallyRandomNumber.h>
 
 #include <array>
-#include <mutex>
 #include <ranges>
 #include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>

--- a/Source/WTF/wtf/CurrentTime.cpp
+++ b/Source/WTF/wtf/CurrentTime.cpp
@@ -37,14 +37,10 @@
 #include <wtf/ContinuousTime.h>
 #include <wtf/MathExtras.h>
 #include <wtf/MonotonicTime.h>
-#include <wtf/StdLibExtras.h>
 #include <wtf/WallTime.h>
 
 #if OS(DARWIN)
-#include <mach/mach.h>
 #include <mach/mach_time.h>
-#include <mutex>
-#include <sys/time.h>
 #elif OS(WINDOWS)
 #include <windows.h>
 #include <math.h>

--- a/Source/WTF/wtf/FastMalloc.cpp
+++ b/Source/WTF/wtf/FastMalloc.cpp
@@ -30,11 +30,6 @@
 #include <string.h>
 #include <wtf/CheckedArithmetic.h>
 
-#if OS(DARWIN)
-#include <malloc/malloc.h>
-#include <wtf/darwin/DispatchExtras.h>
-#endif
-
 #if OS(WINDOWS)
 #include <windows.h>
 #include <psapi.h>

--- a/Source/WTF/wtf/Language.cpp
+++ b/Source/WTF/wtf/Language.cpp
@@ -36,10 +36,6 @@
 #include <wtf/text/TextStream.h>
 #include <wtf/text/WTFString.h>
 
-#if USE(CF)
-#include <CoreFoundation/CoreFoundation.h>
-#endif
-
 namespace WTF {
 
 static Lock languagesLock;

--- a/Source/WTF/wtf/Logger.cpp
+++ b/Source/WTF/wtf/Logger.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include <wtf/Logger.h>
 
-#include <mutex>
 #include <wtf/HexNumber.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WTF/wtf/MainThread.cpp
+++ b/Source/WTF/wtf/MainThread.cpp
@@ -30,14 +30,9 @@
 #include <wtf/MainThread.h>
 
 #include <mutex>
-#include <wtf/Deque.h>
-#include <wtf/Lock.h>
-#include <wtf/MonotonicTime.h>
-#include <wtf/NeverDestroyed.h>
 #include <wtf/RunLoop.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Threading.h>
-#include <wtf/WorkQueue.h>
 #include <wtf/threads/BinarySemaphore.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -29,7 +29,6 @@
 #include <algorithm>
 #include <atomic>
 #include <functional>
-#include <ranges>
 #include <wtf/Logging.h>
 #include <wtf/MathExtras.h>
 #include <wtf/MemoryFootprint.h>

--- a/Source/WTF/wtf/NumberOfCores.cpp
+++ b/Source/WTF/wtf/NumberOfCores.cpp
@@ -27,7 +27,6 @@
 #include <wtf/NumberOfCores.h>
 
 #include <cstdio>
-#include <mutex>
 #include <wtf/text/StringToIntegerConversion.h>
 
 #if OS(DARWIN)

--- a/Source/WTF/wtf/OSRandomSource.cpp
+++ b/Source/WTF/wtf/OSRandomSource.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include <wtf/OSRandomSource.h>
 
-#include <mutex>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RandomDevice.h>
 

--- a/Source/WTF/wtf/ParkingLot.cpp
+++ b/Source/WTF/wtf/ParkingLot.cpp
@@ -26,8 +26,6 @@
 #include "config.h"
 #include <wtf/ParkingLot.h>
 
-#include <mutex>
-#include <ranges>
 #include <wtf/DataLog.h>
 #include <wtf/FixedVector.h>
 #include <wtf/HashFunctions.h>

--- a/Source/WTF/wtf/RAMSize.cpp
+++ b/Source/WTF/wtf/RAMSize.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include <wtf/RAMSize.h>
 
-#include <mutex>
 #include <wtf/AvailableMemory.h>
 
 #if OS(WINDOWS)
@@ -34,7 +33,6 @@
 #elif OS(LINUX) || OS(FREEBSD)
 #include <sys/sysinfo.h>
 #elif OS(UNIX) || OS(HAIKU)
-#include <unistd.h>
 #endif
 
 #if OS(DARWIN)

--- a/Source/WTF/wtf/RefTrackerMixin.cpp
+++ b/Source/WTF/wtf/RefTrackerMixin.cpp
@@ -20,8 +20,6 @@
 #include "config.h"
 #include <wtf/RefTrackerMixin.h>
 
-#include <ranges>
-
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WTF {

--- a/Source/WTF/wtf/SHA1.cpp
+++ b/Source/WTF/wtf/SHA1.cpp
@@ -33,7 +33,6 @@
 #include <wtf/SHA1.h>
 
 #include <cstddef>
-#include <wtf/Assertions.h>
 #include <wtf/HexNumber.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WTF/wtf/SequesteredAutomaticThread.cpp
+++ b/Source/WTF/wtf/SequesteredAutomaticThread.cpp
@@ -26,9 +26,6 @@
 #include "config.h"
 #include <wtf/SequesteredAutomaticThread.h>
 
-#include <wtf/SequesteredImmortalHeap.h>
-#include <wtf/TZoneMallocInlines.h>
-
 namespace WTF {
 
 #if USE(PROTECTED_JIT_STACKS)

--- a/Source/WTF/wtf/SequesteredImmortalHeap.cpp
+++ b/Source/WTF/wtf/SequesteredImmortalHeap.cpp
@@ -25,9 +25,6 @@
 #include "config.h"
 #include <wtf/SequesteredImmortalHeap.h>
 
-#include <wtf/Compiler.h>
-#include <wtf/NeverDestroyed.h>
-
 #if USE(PROTECTED_JIT)
 
 #include <bmalloc/pas_scavenger.h>

--- a/Source/WTF/wtf/SequesteredMalloc.cpp
+++ b/Source/WTF/wtf/SequesteredMalloc.cpp
@@ -25,8 +25,6 @@
 #include "config.h"
 #include <wtf/SequesteredMalloc.h>
 
-#include <wtf/SequesteredAllocator.h>
-
 #if USE(PROTECTED_JIT)
 
 namespace WTF {

--- a/Source/WTF/wtf/SizeLimits.cpp
+++ b/Source/WTF/wtf/SizeLimits.cpp
@@ -31,9 +31,6 @@
 
 #include "config.h"
 
-#include <type_traits>
-#include <utility>
-#include <wtf/Assertions.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/ThreadAssertions.h>

--- a/Source/WTF/wtf/StackTrace.cpp
+++ b/Source/WTF/wtf/StackTrace.cpp
@@ -27,7 +27,6 @@
 #include "config.h"
 #include <wtf/StackTrace.h>
 
-#include <type_traits>
 #include <wtf/Assertions.h>
 #include <wtf/PrintStream.h>
 #include <wtf/StringPrintStream.h>

--- a/Source/WTF/wtf/StatisticsManager.cpp
+++ b/Source/WTF/wtf/StatisticsManager.cpp
@@ -30,7 +30,6 @@
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/ThreadMessage.cpp
+++ b/Source/WTF/wtf/ThreadMessage.cpp
@@ -26,8 +26,6 @@
 #include "config.h"
 #include <wtf/ThreadMessage.h>
 
-#include <wtf/Lock.h>
-#include <wtf/Locker.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/TimeWithDynamicClockType.cpp
+++ b/Source/WTF/wtf/TimeWithDynamicClockType.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include <wtf/TimeWithDynamicClockType.h>
 
-#include <cmath>
 #include <wtf/Condition.h>
 #include <wtf/PrintStream.h>
 #include <wtf/Lock.h>

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -27,10 +27,8 @@
 #include "config.h"
 #include <wtf/URL.h>
 
-#include <ranges>
 #include <stdio.h>
 #include <unicode/uidna.h>
-#include <wtf/FileSystem.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
@@ -39,7 +37,6 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/URLParser.h>
 #include <wtf/UUID.h>
-#include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringHash.h>

--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -36,7 +36,6 @@
 #include <unicode/uscript.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/URLParser.h>
-#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/WTFString.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -28,7 +28,6 @@
 
 #include <array>
 #include <functional>
-#include <mutex>
 #include <wtf/text/CodePointIterator.h>
 #include <wtf/text/MakeString.h>
 

--- a/Source/WTF/wtf/UUID.cpp
+++ b/Source/WTF/wtf/UUID.cpp
@@ -31,10 +31,7 @@
 #include "config.h"
 #include <wtf/UUID.h>
 
-#include <mutex>
-#include <wtf/ASCIICType.h>
 #include <wtf/CryptographicallyRandomNumber.h>
-#include <wtf/HexNumber.h>
 #include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/SHA1.h>

--- a/Source/WTF/wtf/WTFAssertions.cpp
+++ b/Source/WTF/wtf/WTFAssertions.cpp
@@ -29,11 +29,6 @@
 #include <wtf/Platform.h>
 #include <wtf/RefPtr.h>
 
-#if OS(DARWIN)
-#include <mach/vm_param.h>
-#include <mach/vm_types.h>
-#endif
-
 namespace WTF {
 
 namespace {

--- a/Source/WTF/wtf/WTFConfig.cpp
+++ b/Source/WTF/wtf/WTFConfig.cpp
@@ -28,9 +28,6 @@
 
 #include <cstdio>
 
-#include <wtf/FastMalloc.h>
-#include <wtf/Gigacage.h>
-#include <wtf/Lock.h>
 #include <wtf/MathExtras.h>
 #include <wtf/PageBlock.h>
 #include <wtf/StdLibExtras.h>
@@ -39,8 +36,6 @@
 #include <dlfcn.h>
 #include <mach-o/getsect.h>
 #include <mach-o/ldsyms.h>
-#include <mach/vm_param.h>
-#include "unistd.h"
 #endif
 
 #if OS(WINDOWS)
@@ -49,7 +44,6 @@
 
 #if defined(__has_include)
 #if __has_include(<libproc.h>)
-#include <libproc.h>
 #endif // __has_include(<libproc.h>)
 #endif // defined(__has_include)
 

--- a/Source/WTF/wtf/WorkQueue.cpp
+++ b/Source/WTF/wtf/WorkQueue.cpp
@@ -27,11 +27,7 @@
 #include "config.h"
 #include <wtf/WorkQueue.h>
 
-#include <mutex>
-#include <wtf/Condition.h>
-#include <wtf/Deque.h>
 #include <wtf/Function.h>
-#include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/NumberOfCores.h>
 #include <wtf/Ref.h>

--- a/Source/WTF/wtf/cf/LanguageCF.cpp
+++ b/Source/WTF/wtf/cf/LanguageCF.cpp
@@ -26,9 +26,6 @@
 #include "config.h"
 #include <wtf/Language.h>
 
-#include <CoreFoundation/CoreFoundation.h>
-#include <mutex>
-#include <unicode/uloc.h>
 #include <wtf/Assertions.h>
 #include <wtf/Logging.h>
 #include <wtf/RetainPtr.h>

--- a/Source/WTF/wtf/cf/RunLoopCF.cpp
+++ b/Source/WTF/wtf/cf/RunLoopCF.cpp
@@ -26,8 +26,6 @@
 #include "config.h"
 #include <wtf/RunLoop.h>
 
-#include <CoreFoundation/CoreFoundation.h>
-#include <dispatch/dispatch.h>
 #include <wtf/AutodrainedPool.h>
 #include <wtf/SchedulePair.h>
 

--- a/Source/WTF/wtf/cocoa/MainThreadCocoa.mm
+++ b/Source/WTF/wtf/cocoa/MainThreadCocoa.mm
@@ -29,17 +29,11 @@
 #import "config.h"
 #import <wtf/MainThread.h>
 
-#import <CoreFoundation/CoreFoundation.h>
-#import <Foundation/NSThread.h>
-#import <dispatch/dispatch.h>
 #import <stdio.h>
 #import <wtf/Assertions.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/Logging.h>
-#import <wtf/RetainPtr.h>
 #import <wtf/RunLoop.h>
-#import <wtf/SchedulePair.h>
-#import <wtf/Threading.h>
 
 #if USE(WEB_THREAD)
 #import <wtf/ios/WebCoreThread.h>

--- a/Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm
+++ b/Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm
@@ -31,7 +31,6 @@
 #import <malloc/malloc.h>
 #import <notify.h>
 #import <wtf/Logging.h>
-#import <wtf/ResourceUsage.h>
 #import <wtf/spi/darwin/DispatchSPI.h>
 
 #define ENABLE_FMW_FOOTPRINT_COMPARISON 0

--- a/Source/WTF/wtf/cocoa/NSURLExtras.mm
+++ b/Source/WTF/wtf/cocoa/NSURLExtras.mm
@@ -29,8 +29,6 @@
 #import "config.h"
 #import "NSURLExtras.h"
 
-#import <mutex>
-#import <wtf/Function.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/URL.h>

--- a/Source/WTF/wtf/cocoa/ResourceUsageCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/ResourceUsageCocoa.cpp
@@ -26,9 +26,7 @@
 #include "config.h"
 #include <wtf/ResourceUsage.h>
 
-#include <mach/mach_error.h>
 #include <mach/mach_init.h>
-#include <utility>
 #include <wtf/spi/cocoa/MachVMSPI.h>
 #include <wtf/text/MakeString.h>
 

--- a/Source/WTF/wtf/cocoa/SystemTracingCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/SystemTracingCocoa.cpp
@@ -28,8 +28,6 @@
 
 #if HAVE(OS_SIGNPOST)
 
-#import <dispatch/dispatch.h>
-#import <mach/mach_time.h>
 #import <wtf/ContinuousTime.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/OSObjectPtr.h>

--- a/Source/WTF/wtf/cocoa/URLCocoa.mm
+++ b/Source/WTF/wtf/cocoa/URLCocoa.mm
@@ -26,11 +26,8 @@
 #import "config.h"
 #import <wtf/URL.h>
 
-#import <wtf/URLParser.h>
 #import <wtf/cf/CFURLExtras.h>
-#import <wtf/cocoa/NSURLExtras.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
-#import <wtf/text/CString.h>
 
 @interface NSString (WTFNSURLExtras)
 - (BOOL)_web_looksLikeIPAddress;

--- a/Source/WTF/wtf/cocoa/UUIDCocoa.mm
+++ b/Source/WTF/wtf/cocoa/UUIDCocoa.mm
@@ -27,7 +27,6 @@
 #import <wtf/UUID.h>
 
 #import <wtf/RetainPtr.h>
-#import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
@@ -27,7 +27,6 @@
 #include <wtf/WorkQueue.h>
 
 #include <wtf/BlockPtr.h>
-#include <wtf/Ref.h>
 #include <wtf/darwin/DispatchExtras.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/darwin/OSLogPrintStream.mm
+++ b/Source/WTF/wtf/darwin/OSLogPrintStream.mm
@@ -27,7 +27,6 @@
 #include <wtf/darwin/OSLogPrintStream.h>
 
 #include <wtf/StdLibExtras.h>
-#include <wtf/text/ParsingUtilities.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/WTF/wtf/dtoa/cached-powers.cc
+++ b/Source/WTF/wtf/dtoa/cached-powers.cc
@@ -28,7 +28,6 @@
 #include "config.h"
 
 #include <array>
-#include <climits>
 #include <cmath>
 #include <cstdarg>
 

--- a/Source/WTF/wtf/dtoa/diy-fp.cc
+++ b/Source/WTF/wtf/dtoa/diy-fp.cc
@@ -28,7 +28,6 @@
 #include "config.h"
 
 #include <wtf/dtoa/diy-fp.h>
-#include <wtf/dtoa/utils.h>
 
 namespace WTF {
 namespace double_conversion {

--- a/Source/WTF/wtf/dtoa/double-conversion.cc
+++ b/Source/WTF/wtf/dtoa/double-conversion.cc
@@ -29,8 +29,6 @@
 #include "config.h"
 
 #include <climits>
-#include <locale>
-#include <cmath>
 
 #include <wtf/dtoa/double-conversion.h>
 

--- a/Source/WTF/wtf/dtoa/fixed-dtoa.cc
+++ b/Source/WTF/wtf/dtoa/fixed-dtoa.cc
@@ -27,7 +27,6 @@
 
 #include "config.h"
 
-#include <cmath>
 
 #include <wtf/dtoa/fixed-dtoa.h>
 #include <wtf/dtoa/ieee.h>

--- a/Source/WTF/wtf/dtoa/strtod.cc
+++ b/Source/WTF/wtf/dtoa/strtod.cc
@@ -27,7 +27,6 @@
 
 #include "config.h"
 
-#include <climits>
 #include <cstdarg>
 
 #include <wtf/dtoa/bignum.h>

--- a/Source/WTF/wtf/posix/CPUTimePOSIX.cpp
+++ b/Source/WTF/wtf/posix/CPUTimePOSIX.cpp
@@ -27,7 +27,6 @@
 #include <wtf/CPUTime.h>
 
 #include <sys/resource.h>
-#include <sys/time.h>
 #include <time.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/posix/FileHandlePOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileHandlePOSIX.cpp
@@ -31,12 +31,9 @@
 
 #include <sys/file.h>
 #include <sys/stat.h>
-#include <sys/types.h>
-#include <sys/uio.h>
 #include <unistd.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/FileSystem.h>
-#include <wtf/MallocSpan.h>
 #include <wtf/MappedFileData.h>
 
 namespace WTF::FileSystemImpl {

--- a/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
@@ -29,25 +29,16 @@
 #include "config.h"
 #include <wtf/FileSystem.h>
 
-#include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <fnmatch.h>
-#include <libgen.h>
 #include <stdio.h>
-#include <sys/file.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
-#include <sys/types.h>
 #include <unistd.h>
-#include <wtf/EnumTraits.h>
 #include <wtf/FileHandle.h>
-#include <wtf/MallocSpan.h>
-#include <wtf/MappedFileData.h>
 #include <wtf/SafeStrerror.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
-#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
+++ b/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
@@ -31,7 +31,6 @@
 #include <sys/mman.h>
 #include <wtf/Assertions.h>
 #include <wtf/DataLog.h>
-#include <wtf/MallocSpan.h>
 #include <wtf/MathExtras.h>
 #include <wtf/MmapSpan.h>
 #include <wtf/PageBlock.h>

--- a/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
+++ b/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
@@ -41,7 +41,6 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/ThreadingPrimitives.h>
 #include <wtf/WTFConfig.h>
-#include <wtf/WordLock.h>
 
 #if OS(HAIKU)
 #include <OS.h>

--- a/Source/WTF/wtf/text/AtomString.cpp
+++ b/Source/WTF/wtf/text/AtomString.cpp
@@ -23,7 +23,6 @@
 #include "config.h"
 #include <wtf/text/AtomString.h>
 
-#include <mutex>
 #include <wtf/dtoa.h>
 #include <wtf/text/IntegerToStringConversion.h>
 #include <wtf/text/StringBuilder.h>

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -27,7 +27,6 @@
 #include <wtf/Threading.h>
 #include <wtf/text/ASCIIFastPath.h>
 #include <wtf/text/AtomStringTable.h>
-#include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
 #if USE(WEB_THREAD)

--- a/Source/WTF/wtf/text/StringBuilderJSON.cpp
+++ b/Source/WTF/wtf/text/StringBuilderJSON.cpp
@@ -12,8 +12,6 @@
 #include "config.h"
 #include <wtf/text/StringBuilderJSON.h>
 
-#include <wtf/text/EscapedFormsForJSON.h>
-#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/WTFString.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -36,7 +36,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <wtf/ZippedRange.h>
 #include <wtf/text/AdaptiveStringSearcher.h>
 #include <wtf/text/MakeString.h>
-#include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/text/TextBreakIterator.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 

--- a/Source/WTF/wtf/text/TextBreakIterator.cpp
+++ b/Source/WTF/wtf/text/TextBreakIterator.cpp
@@ -25,7 +25,6 @@
 #include <wtf/Compiler.h>
 #include <wtf/text/TextBreakIteratorInternalICU.h>
 #include <wtf/text/icu/UTextProviderLatin1.h>
-#include <wtf/text/icu/UTextProviderUTF16.h>
 #include <atomic>
 #include <unicode/ubrk.h>
 

--- a/Source/WTF/wtf/text/TextStream.cpp
+++ b/Source/WTF/wtf/text/TextStream.cpp
@@ -32,7 +32,6 @@
 #include <wtf/Seconds.h>
 #include <wtf/URL.h>
 #include <wtf/UUID.h>
-#include <wtf/text/MakeString.h>
 #include <wtf/text/WTFString.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -24,8 +24,8 @@
 
 #include <wtf/ASCIICType.h>
 #include <wtf/DataLog.h>
+#include <wtf/Function.h>
 #include <wtf/HexNumber.h>
-#include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
 #include <wtf/dtoa.h>
@@ -34,7 +34,6 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringToIntegerConversion.h>
-#include <wtf/unicode/CharacterNames.h>
 #include <wtf/unicode/UTF8Conversion.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/text/cf/AtomStringImplCF.cpp
+++ b/Source/WTF/wtf/text/cf/AtomStringImplCF.cpp
@@ -28,9 +28,7 @@
 
 #if USE(CF)
 
-#include <CoreFoundation/CoreFoundation.h>
 #include <wtf/cf/VectorCF.h>
-#include <wtf/text/CString.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/text/cf/StringCF.cpp
+++ b/Source/WTF/wtf/text/cf/StringCF.cpp
@@ -23,7 +23,6 @@
 
 #if USE(CF)
 
-#include <CoreFoundation/CoreFoundation.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/cf/VectorCF.h>
 #include <wtf/text/StringBuffer.h>

--- a/Source/WTF/wtf/text/cf/StringImplCF.cpp
+++ b/Source/WTF/wtf/text/cf/StringImplCF.cpp
@@ -23,12 +23,10 @@
 
 #if USE(CF)
 
-#include <CoreFoundation/CoreFoundation.h>
 #include <wtf/DebugHeap.h>
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RetainPtr.h>
-#include <wtf/Threading.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/text/cf/StringViewCF.cpp
+++ b/Source/WTF/wtf/text/cf/StringViewCF.cpp
@@ -28,7 +28,6 @@
 
 #if USE(CF)
 
-#include <CoreFoundation/CoreFoundation.h>
 #include <wtf/RetainPtr.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/text/cocoa/StringCocoa.mm
+++ b/Source/WTF/wtf/text/cocoa/StringCocoa.mm
@@ -21,7 +21,6 @@
 #import "config.h"
 #import <wtf/text/WTFString.h>
 
-#import <CoreFoundation/CFString.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -35,7 +35,6 @@ extern "C" {
 #endif
 
 #include <cstdio>
-#include <mutex>
 #include <signal.h>
 #include <wtf/StdLibExtras.h>
 
@@ -49,20 +48,14 @@ extern "C" {
 #endif
 
 #if OS(DARWIN)
-#include <mach/vm_param.h>
 #endif
 
-#include <unistd.h>
-#include <wtf/Atomics.h>
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/DataLog.h>
-#include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/PlatformRegisters.h>
-#include <wtf/Scope.h>
 #include <wtf/ThreadGroup.h>
 #include <wtf/Threading.h>
-#include <wtf/TranslatedProcess.h>
 #include <wtf/WTFConfig.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/unicode/icu/CollatorICU.cpp
+++ b/Source/WTF/wtf/unicode/icu/CollatorICU.cpp
@@ -33,14 +33,12 @@
 
 #if !UCONFIG_NO_COLLATION
 
-#include <mutex>
 #include <unicode/ucol.h>
 #include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/StringView.h>
 
 #if OS(DARWIN) && USE(CF)
-#include <CoreFoundation/CoreFoundation.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/cf/TypeCastsCF.h>
 #endif

--- a/Source/WTF/wtf/unicode/icu/ICUHelpers.cpp
+++ b/Source/WTF/wtf/unicode/icu/ICUHelpers.cpp
@@ -28,7 +28,6 @@
 
 #include <mutex>
 #include <span>
-#include <unicode/uvernum.h>
 
 namespace WTF {
 namespace ICU {


### PR DESCRIPTION
#### 41539422d60fea533f8b9c9e09f9f786b1f20a6e
<pre>
Removed about 9% of #include statements from WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=311932">https://bugs.webkit.org/show_bug.cgi?id=311932</a>
<a href="https://rdar.apple.com/174494447">rdar://174494447</a>

Reviewed by Anne van Kesteren.

I used claude to run clang-include-cleaner + make debug in a loop.

It worked pretty well with two notable exceptions:
    * Doesn&apos;t see through macro usage like SOFT_LINK_XXX
    * Doesn&apos;t see through XXXInlines.h when the usage is indirect.

Canonical link: <a href="https://commits.webkit.org/310964@main">https://commits.webkit.org/310964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/296e6bd40b73d33f4dbc1f492fb1e6d01907283a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28899 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22058 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164402 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c85ddc5f-ca1e-417b-af02-05538a00b32d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28749 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120457 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/53fd725d-8620-497c-8041-f7461030548b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158598 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/22628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/139754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101146 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/421b0b57-4ef2-4ab5-bb52-92c8aa757003) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12232 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147689 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/17586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166881 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16471 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/11057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19197 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/128574 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/28443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/23886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128705 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28367 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139379 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23700 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/23524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187524 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28061 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/92164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/48063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/27638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/27868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27711 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->