### PR TITLE
[GStreamer][WebRTC] Un-mute incoming tracks when the track has received its first packet

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3010,6 +3010,7 @@ imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createAnswer.html [ Pas
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createDataChannel.html [ Skip ] # Timeout
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-description-attributes-timing.https.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-generateCertificate.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-getStats.https.html?rest [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-getStats-timestamp.https.html [ Pass Failure ]
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-getTransceivers.html [ Pass Failure Timeout ]
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-helper-test.html [ Pass ]
@@ -3055,6 +3056,7 @@ imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getCapabilities.html [ Pas
 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getContributingSources.https.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getParameters.html [ Failure ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getStats.https.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getStats.https.html?rest [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-jitterBufferTarget.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-track-settings.tentative.html [ Failure ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-video-anyCodec.html [ Failure ]

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -565,12 +565,6 @@ void PeerConnectionBackend::setRemoteDescriptionSucceeded(std::optional<Descript
                     DEBUG_LOG(LOGIDENTIFIER, "PeerConnection closed while dispatching track events");
                     return;
                 }
-
-#if USE(GSTREAMER_WEBRTC)
-                // FIXME: This should be done when the other peer has received its first packet.
-                // https://bugs.webkit.org/show_bug.cgi?id=311652
-                protect(track->source())->setMuted(false);
-#endif
             }
         }
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -1636,6 +1636,27 @@ void GStreamerMediaEndpoint::connectIncomingTrack(WebRTCTrackData& data)
     gst_element_set_state(m_pipeline.get(), GST_STATE_PLAYING);
 }
 
+void GStreamerMediaEndpoint::notifyFirstPacketReceived(WebRTCTrackData& data)
+{
+    auto peerConnectionBackend = this->peerConnectionBackend();
+    if (!peerConnectionBackend)
+        return;
+
+    RefPtr<RTCRtpTransceiver> transceiver = peerConnectionBackend->existingTransceiver([&](auto& backend) -> bool {
+        GUniqueOutPtr<char> mid;
+        g_object_get(backend.rtcTransceiver(), "mid", &mid.outPtr(), nullptr);
+        GST_DEBUG_OBJECT(m_pipeline.get(), "Checking if transceiver with mid %s matches the track mid", mid.get());
+        return data.mid == StringView::fromLatin1(mid.get());
+    });
+    if (!transceiver)
+        return;
+
+    GST_DEBUG_OBJECT(m_pipeline.get(), "Un-muting incoming track with MID %s", data.mid.ascii().data());
+    auto& track = transceiver->receiver().track();
+    auto& source = track.privateTrack().source();
+    source.setMuted(false);
+}
+
 void GStreamerMediaEndpoint::connectPad(GstPad* pad)
 {
     auto caps = adoptGRef(gst_pad_get_current_caps(pad));

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
@@ -119,6 +119,7 @@ public:
 #endif
 
     void connectIncomingTrack(WebRTCTrackData&);
+    void notifyFirstPacketReceived(WebRTCTrackData&);
 
     void startRTCLogs();
     void stopRTCLogs();

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
@@ -41,6 +41,7 @@ GStreamerIncomingTrackProcessor::GStreamerIncomingTrackProcessor()
     std::call_once(debugRegisteredFlag, [] {
         GST_DEBUG_CATEGORY_INIT(webkit_webrtc_incoming_track_processor_debug, "webkitwebrtcincomingtrackprocessor", 0, "WebKit WebRTC Incoming Track Processor");
     });
+    m_ntpCaps = adoptGRef(gst_caps_new_empty_simple("timestamp/x-ntp"));
 }
 
 void GStreamerIncomingTrackProcessor::configure(ThreadSafeWeakPtr<GStreamerMediaEndpoint>&& endPoint, GRefPtr<GstPad>&& pad)
@@ -212,31 +213,41 @@ GRefPtr<GstElement> GStreamerIncomingTrackProcessor::incomingTrackProcessor()
     GRefPtr<GstElement> decodebin = makeGStreamerElement("decodebin3"_s);
     m_isDecoding = true;
 
-    g_signal_connect(decodebin.get(), "deep-element-added", G_CALLBACK(+[](GstBin*, GstBin*, GstElement* element, gpointer userData) {
+    g_signal_connect_data(decodebin.get(), "deep-element-added", G_CALLBACK(+[](GstBin*, GstBin*, GstElement* element, gpointer userData) {
         String elementClass = unsafeSpan(gst_element_get_metadata(element, GST_ELEMENT_METADATA_KLASS));
         auto classifiers = elementClass.split('/');
         if (!classifiers.contains("Depayloader"_s))
             return;
 
+        RefPtr self = reinterpret_cast<ThreadSafeWeakPtr<GStreamerIncomingTrackProcessor>*>(userData)->get();
+        if (!self)
+            return;
+
         configureVideoRTPDepayloader(element);
-        auto self = reinterpret_cast<GStreamerIncomingTrackProcessor*>(userData);
         auto pad = adoptGRef(gst_element_get_static_pad(element, "sink"));
         self->installRtpBufferPadProbe(pad);
-    }), this);
+    }), new ThreadSafeWeakPtr { *this }, [](gpointer data, GClosure*) {
+        delete static_cast<ThreadSafeWeakPtr<GStreamerIncomingTrackProcessor>*>(data);
+    }, static_cast<GConnectFlags>(0));
 
-    g_signal_connect(decodebin.get(), "element-added", G_CALLBACK(+[](GstBin*, GstElement* element, gpointer userData) {
+    g_signal_connect_data(decodebin.get(), "element-added", G_CALLBACK(+[](GstBin*, GstElement* element, gpointer userData) {
         String elementClass = unsafeSpan(gst_element_get_metadata(element, GST_ELEMENT_METADATA_KLASS));
         auto classifiers = elementClass.split('/');
         if (!classifiers.contains("Decoder"_s) || !classifiers.contains("Video"_s))
             return;
 
-        auto self = reinterpret_cast<GStreamerIncomingTrackProcessor*>(userData);
+        RefPtr self = reinterpret_cast<ThreadSafeWeakPtr<GStreamerIncomingTrackProcessor>*>(userData)->get();
+        if (!self)
+            return;
+
         self->m_videoDecoderName = configureMediaStreamVideoDecoder(element);
         webkitGstTraceProcessingTimeForElement(element);
 
         auto sinkPad = adoptGRef(gst_element_get_static_pad(element, "sink"));
         gst_pad_add_probe(sinkPad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_BUFFER), [](GstPad*, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
-            auto self = reinterpret_cast<GStreamerIncomingTrackProcessor*>(userData);
+            RefPtr self = reinterpret_cast<ThreadSafeWeakPtr<GStreamerIncomingTrackProcessor>*>(userData)->get();
+            if (!self)
+                return GST_PAD_PROBE_REMOVE;
             auto buffer = GST_PAD_PROBE_INFO_BUFFER(info);
             if (!GST_BUFFER_FLAG_IS_SET(buffer, GST_BUFFER_FLAG_DELTA_UNIT))
                 self->m_decodedKeyFrames++;
@@ -246,7 +257,10 @@ GRefPtr<GstElement> GStreamerIncomingTrackProcessor::incomingTrackProcessor()
 
         auto pad = adoptGRef(gst_element_get_static_pad(element, "src"));
         gst_pad_add_probe(pad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_BUFFER | GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM), [](GstPad* pad, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
-            auto self = reinterpret_cast<GStreamerIncomingTrackProcessor*>(userData);
+            RefPtr self = reinterpret_cast<ThreadSafeWeakPtr<GStreamerIncomingTrackProcessor>*>(userData)->get();
+            if (!self)
+                return GST_PAD_PROBE_REMOVE;
+
             if (info->type & GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM) {
                 auto event = GST_PAD_PROBE_INFO_EVENT(info);
                 if (GST_EVENT_TYPE(event) == GST_EVENT_CAPS) {
@@ -274,31 +288,45 @@ GRefPtr<GstElement> GStreamerIncomingTrackProcessor::incomingTrackProcessor()
             self->m_totalVideoDecodeTime += processingTime;
             return GST_PAD_PROBE_OK;
         }, userData, nullptr);
-    }), this);
+    }), new ThreadSafeWeakPtr { *this }, [](gpointer data, GClosure*) {
+        delete static_cast<ThreadSafeWeakPtr<GStreamerIncomingTrackProcessor>*>(data);
+    }, static_cast<GConnectFlags>(0));
 
-    g_signal_connect_swapped(decodebin.get(), "pad-added", G_CALLBACK(+[](GStreamerIncomingTrackProcessor* self, GstPad* pad) {
+    g_signal_connect_data(decodebin.get(), "pad-added", G_CALLBACK(+[](GstElement*, GstPad* pad, gpointer userData) {
+        RefPtr self = reinterpret_cast<ThreadSafeWeakPtr<GStreamerIncomingTrackProcessor>*>(userData)->get();
+        if (!self)
+            return;
+
         auto queue = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(self->m_bin.get()), "queue"));
         auto sinkPad = adoptGRef(gst_element_get_static_pad(queue.get(), "sink"));
         gst_pad_link(pad, sinkPad.get());
         self->trackReady();
-    }), this);
+    }), new ThreadSafeWeakPtr { *this }, [](gpointer data, GClosure*) {
+        delete static_cast<ThreadSafeWeakPtr<GStreamerIncomingTrackProcessor>*>(data);
+    }, static_cast<GConnectFlags>(0));
+
     return decodebin;
 }
 
 GRefPtr<GstElement> GStreamerIncomingTrackProcessor::createParser()
 {
     GRefPtr<GstElement> parsebin = makeGStreamerElement("parsebin"_s);
-    g_signal_connect(parsebin.get(), "element-added", G_CALLBACK(+[](GstBin*, GstElement* element, gpointer userData) {
+    g_signal_connect_data(parsebin.get(), "element-added", G_CALLBACK(+[](GstBin*, GstElement* element, gpointer userData) {
         String elementClass = unsafeSpan(gst_element_get_metadata(element, GST_ELEMENT_METADATA_KLASS));
         auto classifiers = elementClass.split('/');
         if (!classifiers.contains("Depayloader"_s))
             return;
 
+        RefPtr self = reinterpret_cast<ThreadSafeWeakPtr<GStreamerIncomingTrackProcessor>*>(userData)->get();
+        if (!self)
+            return;
+
         configureVideoRTPDepayloader(element);
-        auto self = reinterpret_cast<GStreamerIncomingTrackProcessor*>(userData);
         auto pad = adoptGRef(gst_element_get_static_pad(element, "sink"));
         self->installRtpBufferPadProbe(pad);
-    }), this);
+    }), new ThreadSafeWeakPtr { *this }, [](gpointer data, GClosure*) {
+        delete static_cast<ThreadSafeWeakPtr<GStreamerIncomingTrackProcessor>*>(data);
+    }, static_cast<GConnectFlags>(0));
 
     auto& quirksManager = GStreamerQuirksManager::singleton();
     if (quirksManager.isEnabled()) {
@@ -316,42 +344,66 @@ GRefPtr<GstElement> GStreamerIncomingTrackProcessor::createParser()
         }), nullptr);
     }
 
-    g_signal_connect_swapped(parsebin.get(), "pad-added", G_CALLBACK(+[](GStreamerIncomingTrackProcessor* self, GstPad* pad) {
+    g_signal_connect_data(parsebin.get(), "pad-added", G_CALLBACK(+[](GstElement*, GstPad* pad, gpointer userData) {
+        RefPtr self = reinterpret_cast<ThreadSafeWeakPtr<GStreamerIncomingTrackProcessor>*>(userData)->get();
+        if (!self)
+            return;
         auto queue = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(self->m_bin.get()), "queue"));
         auto sinkPad = adoptGRef(gst_element_get_static_pad(queue.get(), "sink"));
         gst_pad_link(pad, sinkPad.get());
         self->trackReady();
-    }), this);
+    }), new ThreadSafeWeakPtr { *this }, [](gpointer data, GClosure*) {
+        delete static_cast<ThreadSafeWeakPtr<GStreamerIncomingTrackProcessor>*>(data);
+    }, static_cast<GConnectFlags>(0));
     return parsebin;
 }
 
 void GStreamerIncomingTrackProcessor::installRtpBufferPadProbe(const GRefPtr<GstPad>& pad)
 {
-    if (m_data.type == RealtimeMediaSource::Type::Audio)
-        return;
-
     gst_pad_add_probe(pad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_BUFFER), [](GstPad*, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
-        VideoFrameTimeMetadata videoFrameTimeMetadata;
-        videoFrameTimeMetadata.receiveTime = MonotonicTime::now().secondsSinceEpoch();
+        RefPtr self = reinterpret_cast<ThreadSafeWeakPtr<GStreamerIncomingTrackProcessor>*>(userData)->get();
+        if (!self)
+            return GST_PAD_PROBE_REMOVE;
 
+        std::optional<VideoFrameTimeMetadata> videoFrameTimeMetadata;
+
+        bool shouldNotifyFirstPacket = false;
         auto buffer = GST_PAD_PROBE_INFO_BUFFER(info);
         {
             GstMappedRtpBuffer rtpBuffer(buffer, GST_MAP_READ);
             if (!rtpBuffer) [[unlikely]]
                 return GST_PAD_PROBE_OK;
 
-            videoFrameTimeMetadata.rtpTimestamp = gst_rtp_buffer_get_timestamp(rtpBuffer.mappedData());
+            if (!self->m_hasReceivedFirstPacket && gst_rtp_buffer_get_marker(rtpBuffer.mappedData())) {
+                self->m_hasReceivedFirstPacket = true;
+                shouldNotifyFirstPacket = true;
+            }
+
+            if (self->m_data.type == RealtimeMediaSource::Type::Video) {
+                videoFrameTimeMetadata.emplace(VideoFrameTimeMetadata {
+                    .processingDuration { },
+                    .captureTime { },
+                    .receiveTime { MonotonicTime::now().secondsSinceEpoch() },
+                    .rtpTimestamp { gst_rtp_buffer_get_timestamp(rtpBuffer.mappedData()) }
+                });
+                if (auto referenceTimestampMeta = gst_buffer_get_reference_timestamp_meta(buffer, self->m_ntpCaps.get())) {
+                    auto ntpTimestamp = referenceTimestampMeta->timestamp;
+                    videoFrameTimeMetadata->captureTime = Seconds::fromNanoseconds(gst_rtcp_ntp_to_unix(ntpTimestamp));
+                }
+            }
         }
 
-        if (auto referenceTimestampMeta = gst_buffer_get_reference_timestamp_meta(buffer, GST_CAPS_CAST(userData))) {
-            auto ntpTimestamp = referenceTimestampMeta->timestamp;
-            videoFrameTimeMetadata.captureTime = Seconds::fromNanoseconds(gst_rtcp_ntp_to_unix(ntpTimestamp));
+        if (videoFrameTimeMetadata) {
+            auto modifiedBuffer = webkitGstBufferSetVideoFrameMetadata(GRefPtr(buffer), WTF::move(videoFrameTimeMetadata));
+            gst_pad_probe_info_set_buffer(info, modifiedBuffer.leakRef());
         }
+        if (shouldNotifyFirstPacket)
+            self->trackHasReceivedFirstPacket();
 
-        auto modifiedBuffer = webkitGstBufferSetVideoFrameMetadata(GRefPtr(buffer), videoFrameTimeMetadata);
-        gst_pad_probe_info_set_buffer(info, modifiedBuffer.leakRef());
         return GST_PAD_PROBE_OK;
-    }, gst_caps_new_empty_simple("timestamp/x-ntp"), reinterpret_cast<GDestroyNotify>(gst_caps_unref));
+    }, new ThreadSafeWeakPtr { *this }, reinterpret_cast<GDestroyNotify>(+[](gpointer data) {
+        delete static_cast<ThreadSafeWeakPtr<GStreamerIncomingTrackProcessor>*>(data);
+    }));
 }
 
 void GStreamerIncomingTrackProcessor::trackReady()
@@ -366,6 +418,20 @@ void GStreamerIncomingTrackProcessor::trackReady()
         if (endPoint->isStopped())
             return;
         endPoint->connectIncomingTrack(m_data);
+    });
+}
+
+void GStreamerIncomingTrackProcessor::trackHasReceivedFirstPacket()
+{
+    auto endPoint = m_endPoint.get();
+    if (!endPoint || endPoint->isStopped())
+        return;
+
+    GST_DEBUG_OBJECT(m_bin.get(), "MediaStream %s track %s on pad %" GST_PTR_FORMAT " has received its first packet", m_data.mediaStreamId.utf8().data(), m_data.trackId.utf8().data(), m_pad.get());
+    callOnMainThread([endPoint = Ref { *endPoint }, this] {
+        if (endPoint->isStopped())
+            return;
+        endPoint->notifyFirstPacketReceived(m_data);
     });
 }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h
@@ -23,12 +23,12 @@
 #include "GStreamerMediaEndpoint.h"
 #include "GStreamerWebRTCCommon.h"
 #include "GUniquePtrGStreamer.h"
-#include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
 
-class GStreamerIncomingTrackProcessor : public RefCounted<GStreamerIncomingTrackProcessor> {
+class GStreamerIncomingTrackProcessor : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerIncomingTrackProcessor, WTF::DestructionThread::Main> {
     WTF_MAKE_TZONE_ALLOCATED(GStreamerIncomingTrackProcessor);
 
 public:
@@ -61,6 +61,7 @@ private:
     void installRtpBufferPadProbe(const GRefPtr<GstPad>&);
 
     void trackReady();
+    void trackHasReceivedFirstPacket();
 
     ThreadSafeWeakPtr<GStreamerMediaEndpoint> m_endPoint;
     GRefPtr<GstPad> m_pad;
@@ -83,6 +84,10 @@ private:
     MediaTime m_totalVideoDecodeTime { MediaTime::zeroTime() };
 
     String m_videoDecoderName;
+
+    GRefPtr<GstCaps> m_ntpCaps;
+
+    bool m_hasReceivedFirstPacket { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
@@ -49,6 +49,7 @@ RealtimeOutgoingMediaSourceGStreamer::RealtimeOutgoingMediaSourceGStreamer(Type 
     initialize();
 
     m_track = track.privateTrack();
+    m_muted = m_track->muted();
     m_outgoingSource = webkitMediaStreamSrcNew();
     GST_DEBUG_OBJECT(m_bin.get(), "Created outgoing source %" GST_PTR_FORMAT, m_outgoingSource.get());
     gst_bin_add(GST_BIN_CAST(m_bin.get()), m_outgoingSource.get());
@@ -59,6 +60,7 @@ RealtimeOutgoingMediaSourceGStreamer::RealtimeOutgoingMediaSourceGStreamer(Type 
     : m_type(type)
     , m_mediaStreamId(createVersion4UUIDString())
     , m_trackId(emptyString())
+    , m_muted(true)
     , m_ssrcGenerator(ssrcGenerator)
 {
     initialize();


### PR DESCRIPTION
#### 49570663387cc8f0ea7bbab1cf42ad2bbc28ab9b
<pre>
[GStreamer][WebRTC] Un-mute incoming tracks when the track has received its first packet
<a href="https://bugs.webkit.org/show_bug.cgi?id=311652">https://bugs.webkit.org/show_bug.cgi?id=311652</a>

Reviewed by Xabier Rodriguez-Calvar.

Un-mute incoming source when they have received their first audio or video frame, improving our
compliance with the spec.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::PeerConnectionBackend::setRemoteDescriptionSucceeded):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::notifyFirstPacketReceived):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp:
(WebCore::GStreamerIncomingTrackProcessor::GStreamerIncomingTrackProcessor):
(WebCore::GStreamerIncomingTrackProcessor::incomingTrackProcessor):
(WebCore::GStreamerIncomingTrackProcessor::createParser):
(WebCore::GStreamerIncomingTrackProcessor::installRtpBufferPadProbe):
(WebCore::GStreamerIncomingTrackProcessor::trackHasReceivedFirstPacket):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::RealtimeOutgoingMediaSourceGStreamer):

Canonical link: <a href="https://commits.webkit.org/311098@main">https://commits.webkit.org/311098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97a0463f25c4f95a7ede505f1a15fddd43a093c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156045 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29380 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Running compile-webkit") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22562 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164866 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29381 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120814 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159003 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140139 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101501 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12638 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131772 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17971 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167340 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11461 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19583 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128932 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24311 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129065 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34952 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28903 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139765 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86660 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23895 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16563 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28612 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92569 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28139 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28367 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28263 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->