### PR TITLE
JSPI polish: look into getting rid of VM::m_evacuatedStacksLock

### DIFF
--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1192,7 +1192,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void VM::gatherEvacuatedStackRoots(ConservativeRoots& roots)
 {
-    Locker locker { m_evacuatedStacksLock };
+    ASSERT(heap.worldIsStopped());
     for (auto* slice : m_evacuatedStackSlices) {
         std::span<Register> slots = slice->slots();
         roots.add(slots.data(), slots.data() + slots.size());
@@ -1554,25 +1554,25 @@ bool VM::isScratchBuffer(void* ptr)
 
 void VM::addEvacuatedStackSlice(EvacuatedStackSlice* slice)
 {
-    Locker lock { m_evacuatedStacksLock };
+    ASSERT(currentThreadIsHoldingAPILock());
     m_evacuatedStackSlices.append(slice);
 }
 
 void VM::removeEvacuatedStackSlice(EvacuatedStackSlice* slice)
 {
-    Locker lock { m_evacuatedStacksLock };
+    ASSERT(currentThreadIsHoldingAPILock());
     m_evacuatedStackSlices.removeAll(slice);
 }
 
 void VM::addEvacuatedCalleeSaves(std::span<CPURegister> span)
 {
-    Locker lock { m_evacuatedStacksLock };
+    ASSERT(currentThreadIsHoldingAPILock());
     m_evacuatedCalleeSaves.constructAndAppend(span);
 }
 
 void VM::removeEvacuatedCalleeSaves(std::span<CPURegister> span)
 {
-    Locker lock { m_evacuatedStacksLock };
+    ASSERT(currentThreadIsHoldingAPILock());
     m_evacuatedCalleeSaves.removeAllMatching([&](const std::span<CPURegister>& existing) {
         return existing.data() == span.data() && existing.size() == span.size();
     });

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -1298,7 +1298,6 @@ private:
     Lock m_scratchBufferLock;
     Vector<ScratchBuffer*> m_scratchBuffers;
     size_t m_sizeOfLastScratchBuffer { 0 };
-    Lock m_evacuatedStacksLock;
     Vector<EvacuatedStackSlice*> m_evacuatedStackSlices;
     Vector<std::span<CPURegister>> m_evacuatedCalleeSaves;
     Vector<std::unique_ptr<CheckpointOSRExitSideState>, expectedMaxActiveSideStateCount> m_checkpointSideState;


### PR DESCRIPTION
#### 7b88589e9abd8178d7b9945414c2d76e4bb967cb
<pre>
JSPI polish: look into getting rid of VM::m_evacuatedStacksLock
<a href="https://bugs.webkit.org/show_bug.cgi?id=307562">https://bugs.webkit.org/show_bug.cgi?id=307562</a>
<a href="https://rdar.apple.com/170156013">rdar://170156013</a>

Reviewed by Keith Miller.

VM::m_evacuatedStacksLock protects access to m_evacuatedStackSlices and
m_evacuatedCalleeSaves. Those two collections are written by a mutator thread holding the
API lock and read while the world is stopped, so they don&apos;t actually need protection. This
patch removes the lock and replaces its uses with assertions of the expected system state.

Testing: covered by existing tests.
Canonical link: <a href="https://commits.webkit.org/310955@main">https://commits.webkit.org/310955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9b1f877678286712e82b39c7911a49599f95727

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155523 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164285 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28633 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120374 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158482 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22563 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139676 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101064 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12116 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147573 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131318 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166763 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16354 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128494 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128627 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34877 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28251 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139301 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85694 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23452 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16098 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187408 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27945 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92048 "Build is in progress. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Found 40682 issues") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48036 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27522 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27752 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27595 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->