### PR TITLE
Document `unsafe` use in WKSeparatedImageView

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/Separated/CALayer+CoreRE.swift
+++ b/Source/WebKit/UIProcess/Cocoa/Separated/CALayer+CoreRE.swift
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if HAVE_CORE_ANIMATION_SEPARATED_LAYERS
+
+#if canImport(CoreRE)
+@_weakLinked import CoreRE
+#endif
+@_weakLinked @_spi(Private) @_spi(RealityKit) import RealityKit
+
+extension CALayer {
+    @MainActor
+    var rootEntity: Entity? {
+        #if canImport(CoreRE)
+        // Safety: RECALayerGetCALayerClientComponent returns nil for layers without a
+        // client component (not separated).
+        // REComponentGetEntity returns the owning entity for a valid component.
+        // Entity.fromCore creates a managed Entity handle from the core entity reference,
+        // which is valid for the lifetime of the separated CALayer.
+        // Tracking radar: rdar://174496029
+        guard let component = unsafe RECALayerGetCALayerClientComponent(self) else {
+            return nil
+        }
+        return unsafe Entity.fromCore(REComponentGetEntity(component))
+        #else
+        return nil
+        #endif
+    }
+}
+
+#endif

--- a/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Generation.swift
+++ b/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Generation.swift
@@ -67,7 +67,7 @@ extension WKSeparatedImageView {
         try await Task.sleep(for: SeparatedImageViewConstants.cancellationDelay)
 
         try await Task { @MainActor [weak self] in
-            // The compiler can't guarantee (yet) this closure won't be called multiple times.
+            // Safety: older compiler versions can't guarantee this closure won't be called multiple times.
             nonisolated(unsafe) let captured = spatial3DImage
             guard let self, let imageHash = self.imageHash else { return }
 
@@ -75,6 +75,7 @@ extension WKSeparatedImageView {
             self.preparePortalEntity()
 
             let start = Date()
+            // FIXME: rdar://173256879
             try await unsafe captured.generate()
             Logger.separatedImage.log("\(self.logPrefix) - Generation took \(Date().timeIntervalSince(start))")
             ImagePresentationCache.shared[imageHash] =

--- a/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Rendering.swift
+++ b/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Rendering.swift
@@ -23,9 +23,6 @@
 
 #if HAVE_CORE_ANIMATION_SEPARATED_LAYERS
 
-#if canImport(CoreRE)
-@_weakLinked import CoreRE
-#endif
 import os
 @_weakLinked @_spi(Private) @_spi(RealityKit) import RealityKit
 @_weakLinked @_spi(Private) @_spi(ForUIKitOnly) import SwiftUI
@@ -106,12 +103,9 @@ extension WKSeparatedImageView {
         let scaleFactor = Float(bounds.size.height / layer.effectivePointsPerMeter)
         portalEntity.scale = SIMD3(scaleFactor, scaleFactor, 1.0)
 
-        #if canImport(CoreRE)
-        if let component = unsafe RECALayerGetCALayerClientComponent(layer) {
-            let rootEntity = unsafe Entity.fromCore(REComponentGetEntity(component))
+        if let rootEntity = layer.rootEntity {
             portalEntity.setParent(rootEntity)
         }
-        #endif
 
         Task { @MainActor [weak self] in
             await self?.nextDisplayLink()

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2097,6 +2097,7 @@
 		B6B1565E2B5E177A004F9894 /* WebExtensionStorageAccessLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = B6B1565A2B5E177A004F9894 /* WebExtensionStorageAccessLevel.h */; };
 		B6D031052AC1F241006C8E0B /* WebExtensionDynamicScripts.h in Headers */ = {isa = PBXBuildFile; fileRef = B6D031032AC1F240006C8E0B /* WebExtensionDynamicScripts.h */; };
 		B6D0310A2AC1F631006C8E0B /* WebExtensionScriptInjectionParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = B6D031082AC1F631006C8E0B /* WebExtensionScriptInjectionParameters.h */; };
+		B6DC00362F892F0300FD75E1 /* CALayer+CoreRE.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DC00352F892F0300FD75E1 /* CALayer+CoreRE.swift */; };
 		B6E5F2A5299C105500DBCEA3 /* WebExtensionAPILocalization.h in Headers */ = {isa = PBXBuildFile; fileRef = B6E5F2A4299C105500DBCEA3 /* WebExtensionAPILocalization.h */; };
 		B878B615133428DC006888E9 /* CorrectionPanel.h in Headers */ = {isa = PBXBuildFile; fileRef = B878B613133428DC006888E9 /* CorrectionPanel.h */; };
 		BC017D0716260FF4007054F5 /* WKDOMDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = BC017CFF16260FF4007054F5 /* WKDOMDocument.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -7865,6 +7866,7 @@
 		B6D031032AC1F240006C8E0B /* WebExtensionDynamicScripts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionDynamicScripts.h; sourceTree = "<group>"; };
 		B6D031042AC1F241006C8E0B /* WebExtensionDynamicScriptsCocoa.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = WebExtensionDynamicScriptsCocoa.mm; sourceTree = "<group>"; };
 		B6D031082AC1F631006C8E0B /* WebExtensionScriptInjectionParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionScriptInjectionParameters.h; sourceTree = "<group>"; };
+		B6DC00352F892F0300FD75E1 /* CALayer+CoreRE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+CoreRE.swift"; sourceTree = "<group>"; };
 		B6E5F2A3299C0FFB00DBCEA3 /* WebExtensionAPILocalization.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPILocalization.idl; sourceTree = "<group>"; };
 		B6E5F2A4299C105500DBCEA3 /* WebExtensionAPILocalization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebExtensionAPILocalization.h; path = WebProcess/Extensions/API/WebExtensionAPILocalization.h; sourceTree = SOURCE_ROOT; };
 		B6E5F2A6299C10B100DBCEA3 /* WebExtensionAPILocalizationCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPILocalizationCocoa.mm; sourceTree = "<group>"; };
@@ -15604,6 +15606,7 @@
 		B65437942EF31C3400ED9855 /* Separated */ = {
 			isa = PBXGroup;
 			children = (
+				B6DC00352F892F0300FD75E1 /* CALayer+CoreRE.swift */,
 				B66A6BD82EF5581200FC8EA5 /* WKSeparatedImageView+Analysis.swift */,
 				B66A6BDA2EF5582300FC8EA5 /* WKSeparatedImageView+Generation.swift */,
 				B66A6BD62EF557FC00FC8EA5 /* WKSeparatedImageView+Rendering.swift */,
@@ -21822,6 +21825,7 @@
 				5EEC72502DC1B32100D012DD /* BidiSessionAgent.cpp in Sources */,
 				5EEC724C2DC1B30700D012DD /* BidiStorageAgent.cpp in Sources */,
 				F3A94F012DB6F3310023CE9D /* BidiUserContext.cpp in Sources */,
+				B6DC00362F892F0300FD75E1 /* CALayer+CoreRE.swift in Sources */,
 				49DC1DE127E5129100C1CB36 /* CSPExtensionUtilities.mm in Sources */,
 				522F792C28D531970069B45B /* CtapAuthenticator.cpp in Sources */,
 				526C5723284ADCBC00E08955 /* CtapCcidDriver.cpp in Sources */,


### PR DESCRIPTION
#### 79351e06c010a4774a7db425276d8c8d0bc7c9e0
<pre>
Document `unsafe` use in WKSeparatedImageView
<a href="https://bugs.webkit.org/show_bug.cgi?id=311939">https://bugs.webkit.org/show_bug.cgi?id=311939</a>
&lt;<a href="https://rdar.apple.com/172930976">rdar://172930976</a>&gt;

Reviewed by Richard Robinson and Mike Wyrzykowski.

Extract the unsafe code in an extension with safety documentation.

* Source/WebKit/UIProcess/Cocoa/Separated/CALayer+CoreRE.swift: Added.
(CALayer.rootEntity):
* Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Generation.swift:
(WKSeparatedImageView.generate):
Reference the bug for the &quot;try&quot;.
Document the unsafe that won&apos;t be necessary with more recent compilers.
* Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Rendering.swift:
(WKSeparatedImageView.updatePortal):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
Introduce a CALayer extension for Entity parenting.

Canonical link: <a href="https://commits.webkit.org/310991@main">https://commits.webkit.org/310991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16849fee4a6e883d12098eb49d0346787f21589b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155569 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164332 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28679 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120400 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158528 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139703 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101090 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/57745a76-1865-48f5-8f78-48085a350efa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21676 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19794 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12162 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131345 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166809 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10987 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19146 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128518 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28373 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23828 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128651 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34894 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28297 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139328 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85740 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23478 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16125 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27991 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92094 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27568 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27798 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27641 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->