### PR TITLE
[BFCache] Add multi-process

### DIFF
--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -75,6 +75,11 @@ static inline void logBackForwardCacheFailureDiagnosticMessage(DiagnosticLogging
     client.logDiagnosticMessage(DiagnosticLoggingKeys::backForwardCacheFailureKey(), reason, ShouldSample::No);
 }
 
+static inline void logBackForwardCacheFailureDiagnosticMessage(Page& page, const String& reason)
+{
+    logBackForwardCacheFailureDiagnosticMessage(protect(page.diagnosticLoggingClient()), reason);
+}
+
 static inline void logBackForwardCacheFailureDiagnosticMessage(Page* page, const String& reason)
 {
     if (!page)
@@ -369,12 +374,12 @@ void BackForwardCache::dump() const
 bool BackForwardCache::canCache(Page& page) const
 {
     if (!m_maxSize) {
-        logBackForwardCacheFailureDiagnosticMessage(&page, DiagnosticLoggingKeys::isDisabledKey());
+        logBackForwardCacheFailureDiagnosticMessage(page, DiagnosticLoggingKeys::isDisabledKey());
         return false;
     }
 
     if (MemoryPressureHandler::singleton().isUnderMemoryPressure()) {
-        logBackForwardCacheFailureDiagnosticMessage(&page, DiagnosticLoggingKeys::underMemoryPressureKey());
+        logBackForwardCacheFailureDiagnosticMessage(page, DiagnosticLoggingKeys::underMemoryPressureKey());
         return false;
     }
     
@@ -537,12 +542,11 @@ bool BackForwardCache::addIfCacheable(HistoryItem& item, Page* page)
     if (!page)
         return false;
 
-    // FIXME (rdar://173799983): Remove this workaround once the UIProcess has a
-    // mechanism to detach RemotePageProxy objects from the BrowsingContextGroup
-    // during in-process (same-origin) navigations. Cross-process suspension
-    // (suspendPage with ForceSuspension::Yes) already handles this via
-    // BrowsingContextGroup exchange in suspendCurrentPageIfPossible.
-    if (page->settings().siteIsolationEnabled())
+    // When multi-process BFCache is enabled, the BrowsingContextGroup exchange
+    // in suspendCurrentPageIfPossible handles RemotePageProxy lifecycle, so
+    // in-process caching is safe. Without it, same-origin navigations can leave
+    // stale RemotePageProxy objects in the BCG.
+    if (page->settings().siteIsolationEnabled() && !page->settings().multiProcessBackForwardCacheEnabled())
         return false;
 
     auto cachedPage = trySuspendPage(*page, ForceSuspension::No);
@@ -591,6 +595,35 @@ std::unique_ptr<CachedPage> BackForwardCache::take(HistoryItem& item, Page* page
 
     if (cachedPage->hasExpired() || (page && page->isResourceCachingDisabledByWebInspector())) {
         LOG(BackForwardCache, "Not restoring page for %s from back/forward cache because cache entry has expired", item.url().string().ascii().data());
+        logBackForwardCacheFailureDiagnosticMessage(page, DiagnosticLoggingKeys::expiredKey());
+        return nullptr;
+    }
+
+    return cachedPage.moveToUniquePtr();
+}
+
+// FIXME: Unify with take(HistoryItem&, Page*) — both should take
+// BackForwardFrameItemIdentifier directly. The HistoryItem overload
+// can call notifyChanged() on the caller side instead.
+std::unique_ptr<CachedPage> BackForwardCache::takeByFrameItemID(BackForwardFrameItemIdentifier frameItemID, Page& page)
+{
+    auto it = m_cachedPageMap.find(frameItemID);
+    if (it == m_cachedPageMap.end())
+        return nullptr;
+    if (auto* pruningReason = std::get_if<PruningReason>(&it->value)) {
+        ASSERT(!m_items.contains(it->key));
+        if (*pruningReason != PruningReason::None)
+            logBackForwardCacheFailureDiagnosticMessage(page, pruningReasonToDiagnosticLoggingKey(*pruningReason));
+        return nullptr;
+    }
+
+    m_items.remove(frameItemID);
+    auto cachedPage = std::get<UniqueRef<CachedPage>>(m_cachedPageMap.take(it));
+
+    RELEASE_LOG(BackForwardCache, "BackForwardCache::takeByFrameItemID frameItem: %s, size: %u / %u", frameItemID.toString().utf8().data(), pageCount(), maxSize());
+
+    if (cachedPage->hasExpired() || page.isResourceCachingDisabledByWebInspector()) {
+        LOG(BackForwardCache, "Not restoring page from back/forward cache because cache entry has expired");
         logBackForwardCacheFailureDiagnosticMessage(page, DiagnosticLoggingKeys::expiredKey());
         return nullptr;
     }

--- a/Source/WebCore/history/BackForwardCache.h
+++ b/Source/WebCore/history/BackForwardCache.h
@@ -61,6 +61,7 @@ public:
     WEBCORE_EXPORT void remove(HistoryItem&);
     CachedPage* get(HistoryItem&, Page*);
     std::unique_ptr<CachedPage> take(HistoryItem&, Page*);
+    WEBCORE_EXPORT std::unique_ptr<CachedPage> takeByFrameItemID(BackForwardFrameItemIdentifier, Page&);
 
     void removeAllItemsForPage(Page&);
 

--- a/Source/WebCore/history/CachedFrame.cpp
+++ b/Source/WebCore/history/CachedFrame.cpp
@@ -95,14 +95,15 @@ void CachedFrameBase::pruneDetachedChildFrames()
 void CachedFrameBase::restore()
 {
     RefPtr view = m_view;
-    ASSERT(m_document->view() == view);
 
     if (m_isMainFrame)
         view->setParentVisible(true);
 
     Ref frame = view->frame();
     RefPtr localFrame = dynamicDowncast<LocalFrame>(frame.get());
-    {
+
+    if (m_document) {
+        ASSERT(m_document->view() == view);
         Ref document = *m_document;
         Style::PostResolutionCallbackDisabler disabler(document);
         WidgetHierarchyUpdatesSuspensionScope suspendWidgetHierarchyUpdates;
@@ -122,23 +123,23 @@ void CachedFrameBase::restore()
             protect(localFrame->script())->updatePlatformScriptObjects();
             localFrame->loader().client().didRestoreFromBackForwardCache();
         }
+    }
 
-        pruneDetachedChildFrames();
+    pruneDetachedChildFrames();
 
-        // Reconstruct the FrameTree. And open the child CachedFrames in their respective FrameLoaders.
-        for (auto& childFrame : m_childFrames) {
-            ASSERT(childFrame->view()->frame().page());
-            frame->tree().appendChild(protect(protect(childFrame->view())->frame()));
-            childFrame->open();
-            if (localFrame)
-                RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(m_document == localFrame->document());
-            else
-                RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!m_document);
-        }
+    // Reconstruct the FrameTree. And open the child CachedFrames in their respective FrameLoaders.
+    for (auto& childFrame : m_childFrames) {
+        ASSERT(childFrame->view()->frame().page());
+        frame->tree().appendChild(protect(protect(childFrame->view())->frame()));
+        childFrame->open();
+        if (localFrame)
+            RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(m_document == localFrame->document());
+        else
+            RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!m_document);
     }
 
 #if PLATFORM(IOS_FAMILY)
-    if (m_isMainFrame && localFrame) {
+    if (m_isMainFrame && localFrame && m_document) {
         localFrame->loader().client().didRestoreFrameHierarchyForCachedFrame();
 
         if (RefPtr window = m_document->window(); window && window->scrollEventListenerCount()) {
@@ -238,6 +239,13 @@ void CachedFrame::open()
 
     if (RefPtr localFrameView = dynamicDowncast<LocalFrameView>(m_view.get()))
         localFrameView->frame().loader().open(*this);
+    else {
+        // RemoteFrame main frame in iframe process — restore() handles
+        // frame tree reconstruction and opening child CachedFrames.
+        // FIXME: Unify with the LocalFrame path by moving restore() out
+        // of FrameLoader::open() into CachedFrame::open().
+        restore();
+    }
 }
 
 void CachedFrame::clear()

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -246,8 +246,18 @@ void BrowsingContextGroup::addRemotePage(WebPageProxy& page, Ref<RemotePageProxy
 void BrowsingContextGroup::removePage(WebPageProxy& page)
 {
     m_pages.remove(page);
+    closeRemotePagesForPage(page);
+}
+
+void BrowsingContextGroup::closeRemotePagesForPage(WebPageProxy& page)
+{
     for (auto& remotePage : m_remotePages.take(page))
-        remotePage->disconnect();
+        protect(remotePage)->disconnect();
+}
+
+bool BrowsingContextGroup::hasMultiplePages() const
+{
+    return m_pages.computeSize() > 1;
 }
 
 void BrowsingContextGroup::forEachRemotePage(const WebPageProxy& page, Function<void(RemotePageProxy&)>&& function)
@@ -257,6 +267,20 @@ void BrowsingContextGroup::forEachRemotePage(const WebPageProxy& page, Function<
         return;
     for (Ref remotePage : it->value)
         function(remotePage);
+}
+
+void BrowsingContextGroup::forEachFrameInRemotePage(WebPageProxy& page, WebFrameProxy& mainFrame, NOESCAPE const Function<void(RemotePageProxy&, WebFrameProxy&)>& callback) const
+{
+    auto it = m_remotePages.find(page);
+    if (it == m_remotePages.end())
+        return;
+    for (Ref remotePage : it->value) {
+        Ref process = remotePage->siteIsolatedProcess();
+        for (RefPtr frame = mainFrame.traverseNext().frame; frame; frame = frame->traverseNext().frame) {
+            if (&frame->process() == process.ptr())
+                callback(remotePage, *frame);
+        }
+    }
 }
 
 RefPtr<RemotePageProxy> BrowsingContextGroup::remotePageInProcess(const WebPageProxy& page, const WebProcessProxy& process)

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -49,6 +49,7 @@ namespace WebKit {
 class FrameProcess;
 class ProvisionalPageProxy;
 class RemotePageProxy;
+class WebFrameProxy;
 class WebPageProxy;
 class WebPreferences;
 class WebProcessPool;
@@ -74,7 +75,10 @@ public:
     void addPage(WebPageProxy&);
     void addRemotePage(WebPageProxy&, Ref<RemotePageProxy>&&);
     void removePage(WebPageProxy&);
+    void closeRemotePagesForPage(WebPageProxy&);
+    bool hasMultiplePages() const;
     void forEachRemotePage(const WebPageProxy&, Function<void(RemotePageProxy&)>&&);
+    void forEachFrameInRemotePage(WebPageProxy&, WebFrameProxy& mainFrame, NOESCAPE const Function<void(RemotePageProxy&, WebFrameProxy&)>&) const;
 
     RefPtr<RemotePageProxy> remotePageInProcess(const WebPageProxy&, const WebProcessProxy&);
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -124,10 +124,11 @@ ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<FrameProcess>
     // already exists and already has a main frame.
     if (suspendedPage) {
         ASSERT(&suspendedPage->process() == process.ptr());
-        suspendedPage->unsuspend();
+        suspendedPage->unsuspend(protect(navigation.targetItem()));
         m_mainFrame = suspendedPage->mainFrame();
         m_mainFrame->updateReferrerPolicy(ReferrerPolicy::EmptyString);
         m_needsMainFrameObserver = true;
+        m_isRestoringFromBFCache = true;
     } else if (m_shouldReuseMainFrame) {
         m_mainFrame = page.mainFrame();
         m_mainFrame->updateReferrerPolicy(ReferrerPolicy::EmptyString);
@@ -265,7 +266,7 @@ void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& webs
     if (websitePolicies)
         m_mainFrameWebsitePolicies = websitePolicies->copy();
 
-    if (preferences->siteIsolationEnabled()) {
+    if (preferences->siteIsolationEnabled() && !m_isRestoringFromBFCache) {
         if (RefPtr existingRemotePageProxy = m_browsingContextGroup->takeRemotePageInProcessForProvisionalPage(page, process)) {
             if (m_shouldReuseMainFrame) {
                 m_webPageID = existingRemotePageProxy->pageID();
@@ -287,7 +288,7 @@ void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& webs
 
     RefPtr mainFrame = m_mainFrame;
     auto creationParameters = page->creationParametersForProvisionalPage(process, *drawingArea, mainFrame->frameID());
-    if (preferences->siteIsolationEnabled()) {
+    if (preferences->siteIsolationEnabled() && !m_isRestoringFromBFCache) {
         creationParameters.remotePageParameters = RemotePageParameters {
             m_request.url(),
             mainFrame->frameTreeCreationParameters(),
@@ -495,7 +496,7 @@ void ProvisionalPageProxy::didCommitLoadForFrame(IPC::Connection& connection, Fr
         Site pageMainFrameSite { pageMainFrame->url() };
 
         bool frameProcessChanged = m_frameProcess.ptr() != pageMainFrameProcess.ptr();
-        if (frameProcessChanged)
+        if (frameProcessChanged && pageMainFrame == m_mainFrame)
             pageMainFrame->setProcess(m_frameProcess);
 
         // If the originating FrameProcess still has local frames and is still in the same

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -231,6 +231,7 @@ private:
     bool m_needsDidStartProvisionalLoad { true };
     bool m_shouldClosePage { true };
     bool m_needsMainFrameObserver { false };
+    bool m_isRestoringFromBFCache { false };
     bool m_didFailProvisionalLoad { false };
     URL m_provisionalLoadURL;
     WebPageProxyMessageReceiverRegistration m_messageReceiverRegistration;

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -33,8 +33,11 @@
 #include "HandleMessage.h"
 #include "Logging.h"
 #include "MessageSenderInlines.h"
+#include "RemotePageProxy.h"
 #include "WebBackForwardCache.h"
 #include "WebBackForwardList.h"
+#include "WebBackForwardListFrameItem.h"
+#include "WebBackForwardListItem.h"
 #include "WebBackForwardListMessages.h"
 #include "WebFrameProxy.h"
 #include "WebPageMessages.h"
@@ -134,16 +137,6 @@ SuspendedPageProxy::SuspendedPageProxy(WebPageProxy& page, Ref<WebProcessProxy>&
 #endif
 #endif
 {
-    allSuspendedPages().add(*this);
-    m_process->addSuspendedPageProxy(*this);
-    m_messageReceiverRegistration.startReceivingMessages(m_process, m_webPageID, *this, *this);
-    m_suspensionTimeoutTimer.startOneShot(suspensionTimeout);
-    sendWithAsyncReply(Messages::WebPage::SetIsSuspended(true), [weakThis = WeakPtr { *this }](std::optional<bool> didSuspend) {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !didSuspend)
-            return;
-        protectedThis->didProcessRequestToSuspend(*didSuspend ? SuspensionState::Suspended : SuspensionState::FailedToSuspend);
-    });
 }
 
 template<typename M>
@@ -158,21 +151,57 @@ void SuspendedPageProxy::sendWithAsyncReply(M&& message, C&& completionHandler)
     m_process->sendWithAsyncReply(std::forward<M>(message), std::forward<C>(completionHandler), m_webPageID);
 }
 
+bool SuspendedPageProxy::startSuspension(WebBackForwardListItem* fromItem)
+{
+    ASSERT(!protect(m_browsingContextGroup)->hasMultiplePages());
+
+    RefPtr page = m_page.get();
+    if (page && protect(page->preferences())->multiProcessBackForwardCacheEnabled()) {
+        // Iframe suspension is only needed when the page is being added to the
+        // back/forward cache (fromItem is non-null). When fromItem is null, the
+        // page is only kept temporarily to prevent a white flash during navigation.
+        if (fromItem && !suspendIframeProcesses(*fromItem))
+            return false;
+    }
+
+    m_messageReceiverRegistration.startReceivingMessages(m_process, m_webPageID, *this, *this);
+    m_suspensionTimeoutTimer.startOneShot(suspensionTimeout);
+    sendWithAsyncReply(Messages::WebPage::SetIsSuspended(true), [weakThis = WeakPtr { *this }](std::optional<bool> didSuspend) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !didSuspend)
+            return;
+        protectedThis->didProcessRequestToSuspend(*didSuspend ? SuspensionState::Suspended : SuspensionState::FailedToSuspend);
+    });
+
+    allSuspendedPages().add(*this);
+    m_process->addSuspendedPageProxy(*this);
+    return true;
+}
+
 SuspendedPageProxy::~SuspendedPageProxy()
+{
+    if (auto handler = std::exchange(m_readyToUnsuspendHandler, nullptr)) {
+        RunLoop::mainSingleton().dispatch([handler = WTF::move(handler)]() mutable {
+            handler(nullptr);
+        });
+    }
+    teardown();
+}
+
+void SuspendedPageProxy::teardown()
 {
     allSuspendedPages().remove(*this);
 
-    if (m_readyToUnsuspendHandler) {
-        RunLoop::mainSingleton().dispatch([readyToUnsuspendHandler = WTF::move(m_readyToUnsuspendHandler)]() mutable {
-            readyToUnsuspendHandler(nullptr);
+    if (RefPtr page = m_page.get()) {
+        m_browsingContextGroup->forEachRemotePage(*page, [suspendedPage = Ref { *this }](auto& remotePage) {
+            protect(remotePage.siteIsolatedProcess())->removeSuspendedPageProxy(suspendedPage);
         });
+        if (m_suspensionState != SuspensionState::Resumed)
+            m_browsingContextGroup->closeRemotePagesForPage(*page);
     }
 
-    if (m_suspensionState != SuspensionState::Resumed) {
-        // If the suspended page was not consumed before getting destroyed, then close the corresponding page
-        // on the WebProcess side.
+    if (m_suspensionState != SuspensionState::Resumed)
         close();
-    }
 
     m_process->removeSuspendedPageProxy(*this);
 }
@@ -198,6 +227,8 @@ void SuspendedPageProxy::waitUntilReadyToUnsuspend(CompletionHandler<void(Suspen
         m_readyToUnsuspendHandler = WTF::move(completionHandler);
         break;
     case SuspensionState::FailedToSuspend:
+        completionHandler(this);
+        break;
     case SuspensionState::Suspended:
         completionHandler(this);
         break;
@@ -263,27 +294,121 @@ void SuspendedPageProxy::didProcessRequestToSuspend(SuspensionState newSuspensio
     ASSERT(m_suspensionState == SuspensionState::Suspending);
     ASSERT(newSuspensionState == SuspensionState::Suspended || newSuspensionState == SuspensionState::FailedToSuspend);
 
-    m_suspensionState = newSuspensionState;
-
-    m_suspensionTimeoutTimer.stop();
-
 #if USE(RUNNINGBOARD)
     m_suspensionActivity = nullptr;
 #endif
 
     m_messageReceiverRegistration.stopReceivingMessages();
 
-    if (m_suspensionState == SuspensionState::FailedToSuspend)
+    if (newSuspensionState == SuspensionState::FailedToSuspend) {
+        m_suspensionState = SuspensionState::FailedToSuspend;
+        m_suspensionTimeoutTimer.stop();
         closeWithoutFlashing();
+        if (auto handler = std::exchange(m_readyToUnsuspendHandler, nullptr))
+            handler(this);
+        return;
+    }
 
-    if (m_readyToUnsuspendHandler)
-        m_readyToUnsuspendHandler(this);
+    m_mainFrameSuspended = true;
+    maybeCompleteSuspension();
 }
 
 void SuspendedPageProxy::suspensionTimedOut()
 {
     RELEASE_LOG_ERROR(ProcessSwapping, "%p - SuspendedPageProxy::suspensionTimedOut() destroying the suspended page because it failed to suspend in time", this);
     protect(backForwardCache())->removeEntry(*this); // Will destroy |this|.
+}
+
+bool SuspendedPageProxy::suspendIframeProcesses(WebBackForwardListItem& fromItem)
+{
+    RefPtr page = m_page.get();
+    if (!page)
+        return false;
+
+    Ref rootFrameItem = fromItem.mainFrameItem();
+
+    // Phase 1: Validate all frame items exist before sending any IPCs.
+    using SuspensionTarget = std::tuple<WebCore::BackForwardFrameItemIdentifier, Ref<WebProcessProxy>, WebCore::PageIdentifier>;
+    Vector<SuspensionTarget> targets;
+    bool missingFrameItem = false;
+
+    m_browsingContextGroup->forEachFrameInRemotePage(*page, m_mainFrame, [&](auto& remotePage, auto& frame) {
+        if (missingFrameItem)
+            return;
+        RefPtr frameItem = rootFrameItem->childItemForFrameID(frame.frameID());
+        if (!frameItem) {
+            RELEASE_LOG_ERROR(ProcessSwapping, "%p - SuspendedPageProxy::suspendIframeProcesses: No frame item found for frame %" PRIu64 " in process pid %i, skipping iframe suspension", this, frame.frameID().toUInt64(), remotePage.siteIsolatedProcess().processID());
+            missingFrameItem = true;
+            return;
+        }
+        targets.append({ frameItem->identifier(), remotePage.siteIsolatedProcess(), remotePage.identifierInSiteIsolatedProcess() });
+    });
+
+    if (missingFrameItem)
+        return false;
+
+    // Phase 2: Register with each iframe process and send suspension IPCs.
+    m_browsingContextGroup->forEachRemotePage(*page, [suspendedPage = Ref { *this }](auto& remotePage) {
+        protect(remotePage.siteIsolatedProcess())->addSuspendedPageProxy(suspendedPage);
+    });
+
+    m_expectedIframeSuspensions = targets.size();
+    for (auto& [frameItemIdentifier, process, remotePageIdentifier] : targets) {
+        RELEASE_LOG(ProcessSwapping, "%p - SuspendedPageProxy::suspendIframeProcesses: Sending SetIsSuspendedWithFrameItem to iframe process pid %i for frameItem %s", this, process->processID(), frameItemIdentifier.toString().utf8().data());
+
+        process->sendWithAsyncReply(Messages::WebPage::SetIsSuspendedWithFrameItem(true, frameItemIdentifier), [weakThis = WeakPtr { *this }](std::optional<bool> didSuspend) {
+            RefPtr protectedThis = weakThis.get();
+            if (protectedThis)
+                protectedThis->didIframeSuspensionComplete(didSuspend.value_or(false));
+        }, remotePageIdentifier);
+    }
+    return true;
+}
+
+bool SuspendedPageProxy::hasIframeInProcess(WebCore::ProcessIdentifier processIdentifier) const
+{
+    // FIXME: Add WebFrameProxy::forEachDescendant() to avoid manual traverseNext() loops.
+    for (RefPtr frame = m_mainFrame->traverseNext().frame; frame; frame = frame->traverseNext().frame) {
+        if (protect(frame->process())->coreProcessIdentifier() == processIdentifier)
+            return true;
+    }
+    return false;
+}
+
+void SuspendedPageProxy::didIframeSuspensionComplete(bool success)
+{
+    if (m_suspensionState == SuspensionState::Resumed || m_anyIframeSuspensionFailed)
+        return;
+
+    ++m_completedIframeSuspensions;
+    if (!success) {
+        m_anyIframeSuspensionFailed = true;
+        RELEASE_LOG_ERROR(ProcessSwapping, "%p - SuspendedPageProxy::didIframeSuspensionComplete: iframe suspension failed, invalidating cache entry", this);
+        protect(backForwardCache())->removeEntry(*this); // Will destroy |this|.
+        return;
+    }
+
+    if (m_completedIframeSuspensions < m_expectedIframeSuspensions)
+        return;
+
+    RELEASE_LOG(ProcessSwapping, "%p - SuspendedPageProxy::didIframeSuspensionComplete: All %u iframe suspensions completed", this, m_expectedIframeSuspensions);
+
+    maybeCompleteSuspension();
+}
+
+void SuspendedPageProxy::maybeCompleteSuspension()
+{
+    if (!m_mainFrameSuspended)
+        return;
+
+    if (m_completedIframeSuspensions < m_expectedIframeSuspensions)
+        return;
+
+    m_suspensionTimeoutTimer.stop();
+    m_suspensionState = SuspensionState::Suspended;
+
+    if (auto handler = std::exchange(m_readyToUnsuspendHandler, nullptr))
+        handler(this);
 }
 
 WebPageProxy* SuspendedPageProxy::page() const

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -239,13 +239,34 @@ void SuspendedPageProxy::waitUntilReadyToUnsuspend(CompletionHandler<void(Suspen
     }
 }
 
-void SuspendedPageProxy::unsuspend()
+void SuspendedPageProxy::unsuspend(WebBackForwardListItem* targetItem)
 {
     ASSERT(m_suspensionState == SuspensionState::Suspended);
 
     m_suspensionState = SuspensionState::Resumed;
     sendWithAsyncReply(Messages::WebPage::SetIsSuspended(false), [](std::optional<bool> didSuspend) {
         ASSERT(!didSuspend.has_value());
+    });
+
+    if (!targetItem)
+        return;
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    Ref rootFrameItem = targetItem->mainFrameItem();
+    m_browsingContextGroup->forEachFrameInRemotePage(*page, m_mainFrame, [&](auto& remotePage, auto& frame) {
+        RefPtr frameItem = rootFrameItem->childItemForFrameID(frame.frameID());
+        if (!frameItem) {
+            RELEASE_LOG_ERROR(ProcessSwapping, "%p - SuspendedPageProxy::unsuspend: No frame item for frame %" PRIu64, this, frame.frameID().toUInt64());
+            return;
+        }
+        RELEASE_LOG(ProcessSwapping, "%p - SuspendedPageProxy::unsuspend: Sending SetIsSuspendedWithFrameItem(false) to iframe process pid %i for frameItem %s", this, remotePage.siteIsolatedProcess().processID(), frameItem->identifier().toString().utf8().data());
+        protect(remotePage.siteIsolatedProcess())->sendWithAsyncReply(
+            Messages::WebPage::SetIsSuspendedWithFrameItem(false, frameItem->identifier()),
+            [](std::optional<bool>) { },
+            remotePage.identifierInSiteIsolatedProcess()
+        );
     });
 }
 

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -84,7 +84,7 @@ public:
 
     bool startSuspension(WebBackForwardListItem* fromItem);
     void waitUntilReadyToUnsuspend(CompletionHandler<void(SuspendedPageProxy*)>&&);
-    void unsuspend();
+    void unsuspend(WebBackForwardListItem* targetItem = nullptr);
 
     bool hasIframeInProcess(WebCore::ProcessIdentifier) const;
 

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -73,7 +73,8 @@ public:
     WebCore::PageIdentifier webPageID() const { return m_webPageID; }
     WebProcessProxy& process() const { return m_process.get(); }
     WebFrameProxy& mainFrame() { return m_mainFrame.get(); }
-    const BrowsingContextGroup& browsingContextGroup() { return m_browsingContextGroup.get(); }
+    const BrowsingContextGroup& browsingContextGroup() const { return m_browsingContextGroup.get(); }
+    BrowsingContextGroup& browsingContextGroup() { return m_browsingContextGroup.get(); }
 
     WebBackForwardCache& NODELETE backForwardCache() const;
 
@@ -81,8 +82,11 @@ public:
 
     bool NODELETE pageIsClosedOrClosing() const;
 
+    bool startSuspension(WebBackForwardListItem* fromItem);
     void waitUntilReadyToUnsuspend(CompletionHandler<void(SuspendedPageProxy*)>&&);
     void unsuspend();
+
+    bool hasIframeInProcess(WebCore::ProcessIdentifier) const;
 
     void pageDidFirstLayerFlush();
     void closeWithoutFlashing();
@@ -104,8 +108,12 @@ private:
     enum class SuspensionState : uint8_t { Suspending, FailedToSuspend, Suspended, Resumed };
     void didProcessRequestToSuspend(SuspensionState);
     void suspensionTimedOut();
+    bool suspendIframeProcesses(WebBackForwardListItem&);
+    void didIframeSuspensionComplete(bool success);
+    void maybeCompleteSuspension();
 
     void close();
+    void teardown();
     void didDestroyNavigation(WebCore::NavigationIdentifier);
 
     // IPC::MessageReceiver
@@ -128,6 +136,10 @@ private:
     SuspensionState m_suspensionState { SuspensionState::Suspending };
     CompletionHandler<void(SuspendedPageProxy*)> m_readyToUnsuspendHandler;
     RunLoop::Timer m_suspensionTimeoutTimer;
+    bool m_mainFrameSuspended { false };
+    unsigned m_expectedIframeSuspensions { 0 };
+    unsigned m_completedIframeSuspensions { 0 };
+    bool m_anyIframeSuspensionFailed { false };
 #if USE(RUNNINGBOARD)
     RefPtr<ProcessThrottler::BackgroundActivity> m_suspensionActivity;
 #endif

--- a/Source/WebKit/UIProcess/WebBackForwardCache.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.cpp
@@ -143,9 +143,22 @@ Ref<SuspendedPageProxy> WebBackForwardCache::takeSuspendedPage(WebBackForwardLis
 
 void WebBackForwardCache::removeEntriesForProcess(WebProcessProxy& process)
 {
-    removeEntriesMatching([processIdentifier = process.coreProcessIdentifier()](auto& entry) {
+    auto processIdentifier = process.coreProcessIdentifier();
+    removeEntriesMatching([&](auto& entry) {
         ASSERT(entry.backForwardCacheEntry());
-        return entry.backForwardCacheEntry()->processIdentifier() == processIdentifier;
+
+        // Check main process (existing behavior).
+        if (entry.backForwardCacheEntry()->processIdentifier() == processIdentifier)
+            return true;
+
+        // Check iframe processes (multi-process BFCache).
+        if (RefPtr suspendedPage = entry.suspendedPage()) {
+            if (suspendedPage->hasIframeInProcess(processIdentifier)) {
+                RELEASE_LOG(ProcessSwapping, "WebBackForwardCache::removeEntriesForProcess: iframe process terminated while in BFCache, invalidating cache entry");
+                return true;
+            }
+        }
+        return false;
     });
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1541,7 +1541,10 @@ void WebPageProxy::setBrowsingContextGroup(BrowsingContextGroup& browsingContext
 
     if (protect(preferences())->siteIsolationEnabled()) {
         protectedBrowsingContextGroup->removePage(*this);
-        browsingContextGroup.addPage(*this);
+        // Skip addPage() for BFCache restore — the page and its
+        // RemotePageProxies already exist in the target BCG.
+        if (!browsingContextGroup.hasRemotePages(*this))
+            browsingContextGroup.addPage(*this);
     }
 
     m_browsingContextGroup = browsingContextGroup;
@@ -5408,7 +5411,8 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
                 suspendedPage = nullptr;
 
             receivedPolicyDecision(policyAction, navigation.ptr(), std::nullopt, WTF::move(navigationAction), WillContinueLoadInNewProcess::Yes, std::nullopt, WTF::move(message), WTF::move(completionHandler));
-            continueNavigationInNewProcess(navigation, frame.get(), WTF::move(suspendedPage), browsingContextGroup, WTF::move(processNavigatingTo), processSwapRequestedByClient, ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision, std::nullopt, loadedWebArchive, navigationAction->data().navigationUpgradeToHTTPSBehavior, WebCore::ProcessSwapDisposition::None, replacedDataStoreForWebArchiveLoad.get());
+            Ref bcgForNavigation = suspendedPage ? suspendedPage->browsingContextGroup() : browsingContextGroup.get();
+            continueNavigationInNewProcess(navigation, frame.get(), WTF::move(suspendedPage), bcgForNavigation, WTF::move(processNavigatingTo), processSwapRequestedByClient, ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision, std::nullopt, loadedWebArchive, navigationAction->data().navigationUpgradeToHTTPSBehavior, WebCore::ProcessSwapDisposition::None, replacedDataStoreForWebArchiveLoad.get());
             return;
         }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1467,6 +1467,11 @@ bool WebPageProxy::suspendCurrentPageIfPossible(API::Navigation& navigation, Ref
         return false;
     }
 
+    if (protect(m_browsingContextGroup)->hasMultiplePages()) {
+        WEBPAGEPROXY_RELEASE_LOG(ProcessSwapping, "suspendCurrentPageIfPossible: Not suspending current page for process pid %i because BrowsingContextGroup has multiple pages", m_legacyMainFrameProcess->processID());
+        return false;
+    }
+
     RefPtr fromItem = navigation.fromItem();
 
     // If the source and the destination back / forward list items are the same, then this is a client-side redirect. In this case,
@@ -1494,6 +1499,10 @@ bool WebPageProxy::suspendCurrentPageIfPossible(API::Navigation& navigation, Ref
     mainFrame->frameLoadState().didSuspend();
 
     Ref suspendedPage = SuspendedPageProxy::create(*this, protect(legacyMainFrameProcess()), mainFrame.releaseNonNull(), std::exchange(m_browsingContextGroup, BrowsingContextGroup::create()), shouldDelayClosingUntilFirstLayerFlush);
+    if (!suspendedPage->startSuspension(fromItem.get())) {
+        WEBPAGEPROXY_RELEASE_LOG(ProcessSwapping, "suspendCurrentPageIfPossible: iframe suspension failed, not caching page for process pid %i", m_legacyMainFrameProcess->processID());
+        return false;
+    }
 
     LOG(ProcessSwapping, "WebPageProxy %" PRIu64 " created suspended page %s for process pid %i, back/forward item %s" PRIu64, identifier().toUInt64(), suspendedPage->loggingString().utf8().data(), m_legacyMainFrameProcess->processID(), fromItem ? fromItem->identifier().toString().utf8().data() : "0"_s);
 
@@ -5623,7 +5632,6 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
         // handles the update).
         if (*oldMainFrameID != frameID)
             backForwardList().updateFrameIdentifier(*oldMainFrameID, frameID);
-        mainFrameInPreviousProcess->removeChildFrames();
     }
 
     ASSERT(m_legacyMainFrameProcess.ptr() != &provisionalPage->process() || preferences->siteIsolationEnabled());
@@ -5644,6 +5652,10 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
     removeAllMessageReceivers();
     RefPtr navigation = m_navigationState->navigation(provisionalPage->navigationID());
     bool didSuspendPreviousPage = navigation ? suspendCurrentPageIfPossible(*navigation, WTF::move(mainFrameInPreviousProcess), shouldDelayClosingUntilFirstLayerFlush) : false;
+
+    if (!didSuspendPreviousPage && mainFrameInPreviousProcess && preferences->siteIsolationEnabled())
+        mainFrameInPreviousProcess->removeChildFrames();
+
     // Defer shutting down old process as it might lead WebPageProxy to be closed and removeWebPage to be invoked again.
     auto preventProcessShutdownScope = protect(legacyMainFrameProcess())->shutdownPreventingScope();
     protect(legacyMainFrameProcess())->removeWebPage(*this, m_websiteDataStore.ptr() == provisionalPage->process().websiteDataStore() ? WebProcessProxy::EndsUsingDataStore::No : WebProcessProxy::EndsUsingDataStore::Yes);

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2149,7 +2149,7 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
         return completionHandler(sourceProcess.copyRef(), nullptr, "Navigation is treated as same-site (archive load)"_s);
     }
 
-    if (siteIsolationEnabled && !site.isEmpty()) {
+    if (siteIsolationEnabled && !site.isEmpty() && (!navigation.targetItem() || !navigation.targetItem()->suspendedPage())) {
         ASSERT(frameInfo.isMainFrame ? site == mainFrameSite : Site(URL(protect(page.pageLoadState())->activeURL())) == mainFrameSite);
         if (!frame.isMainFrame() && site == mainFrameSite) {
             Ref mainFrameProcess = Ref { page.mainFrame()->process() };
@@ -2297,7 +2297,7 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
         && !(isRequestFromClientOrUserInput || siteIsolationEnabled))
         return { WTF::move(sourceProcess), nullptr, "Browsing context has opened other windows"_s };
 
-    if (RefPtr targetItem = navigation.targetItem(); targetItem && !siteIsolationEnabled) {
+    if (RefPtr targetItem = navigation.targetItem(); targetItem && (!siteIsolationEnabled || protect(page.preferences())->multiProcessBackForwardCacheEnabled())) {
         if (CheckedPtr suspendedPage = targetItem->suspendedPage()) {
             if (suspendedPage->process().state() != AuxiliaryProcessProxy::State::Terminated)
                 return { suspendedPage->process(), suspendedPage.get(), "Using target back/forward item's process and suspended page"_s };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8554,6 +8554,54 @@ void WebPage::setIsSuspended(bool suspended, CompletionHandler<void(std::optiona
     suspendForProcessSwap(WTF::move(completionHandler));
 }
 
+RefPtr<HistoryItem> WebPage::findHistoryItemByFrameItemID(BackForwardFrameItemIdentifier frameItemID)
+{
+    for (RefPtr frame = &corePage()->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        if (RefPtr item = localFrame->loader().history().currentItem()) {
+            if (item->frameItemID() == frameItemID)
+                return item;
+        }
+    }
+    return nullptr;
+}
+
+void WebPage::suspendForProcessSwapWithFrameItem(BackForwardFrameItemIdentifier frameItemID, CompletionHandler<void(std::optional<bool>)>&& completionHandler)
+{
+    flushDeferredDidReceiveMouseEvent();
+    RefPtr historyItem = findHistoryItemByFrameItemID(frameItemID);
+    if (!historyItem) {
+        WEBPAGE_RELEASE_LOG_ERROR(ProcessSwapping, "suspendForProcessSwapWithFrameItem: Failed to find history item for frameItemID %s", frameItemID.toString().utf8().data());
+        return completionHandler(false);
+    }
+    if (!BackForwardCache::singleton().addIfCacheable(*historyItem, protect(corePage()).get())) {
+        WEBPAGE_RELEASE_LOG_ERROR(ProcessSwapping, "suspendForProcessSwapWithFrameItem: BackForwardCache::addIfCacheable failed for frameItemID %s", frameItemID.toString().utf8().data());
+        return completionHandler(false);
+    }
+    WEBPAGE_RELEASE_LOG(ProcessSwapping, "suspendForProcessSwapWithFrameItem: Successfully cached page for frameItemID %s", frameItemID.toString().utf8().data());
+    completionHandler(true);
+}
+
+void WebPage::setIsSuspendedWithFrameItem(bool suspended, BackForwardFrameItemIdentifier frameItemID, CompletionHandler<void(std::optional<bool>)>&& completionHandler)
+{
+    if (m_isSuspended == suspended)
+        return completionHandler({ });
+    m_isSuspended = suspended;
+
+    if (!suspended) {
+        // FIXME: Restore path (implemented in a follow-up patch).
+        return completionHandler({ });
+    }
+
+    freezeLayerTree(LayerTreeFreezeReason::PageSuspended);
+    // Unlike the main-frame path in setIsSuspended, sendPrewarmInformation is
+    // intentionally omitted here because prewarming is a main-frame optimization.
+    unfreezeLayerTree(LayerTreeFreezeReason::BackgroundApplication);
+    suspendForProcessSwapWithFrameItem(frameItemID, WTF::move(completionHandler));
+}
+
 void WebPage::hasStorageAccess(RegistrableDomain&& subFrameDomain, RegistrableDomain&& topFrameDomain, WebFrame& frame, CompletionHandler<void(bool)>&& completionHandler)
 {
     if (hasPageLevelStorageAccess(topFrameDomain, subFrameDomain)) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8586,13 +8586,25 @@ void WebPage::suspendForProcessSwapWithFrameItem(BackForwardFrameItemIdentifier 
 
 void WebPage::setIsSuspendedWithFrameItem(bool suspended, BackForwardFrameItemIdentifier frameItemID, CompletionHandler<void(std::optional<bool>)>&& completionHandler)
 {
-    if (m_isSuspended == suspended)
+    RefPtr page = corePage();
+    if (!page || m_isSuspended == suspended)
         return completionHandler({ });
+
     m_isSuspended = suspended;
 
     if (!suspended) {
-        // FIXME: Restore path (implemented in a follow-up patch).
-        return completionHandler({ });
+        // Unlike the main-frame path (setIsSuspended), iframe processes don't
+        // receive goToBackForwardItem — they must restore explicitly here.
+        unfreezeLayerTree(LayerTreeFreezeReason::PageSuspended);
+
+        auto cachedPage = BackForwardCache::singleton().takeByFrameItemID(frameItemID, *page);
+        if (!cachedPage) {
+            WEBPAGE_RELEASE_LOG_ERROR(ProcessSwapping, "setIsSuspendedWithFrameItem: restore failed - no CachedPage for frameItemID %s", frameItemID.toString().utf8().data());
+            return completionHandler(false);
+        }
+        WEBPAGE_RELEASE_LOG(ProcessSwapping, "setIsSuspendedWithFrameItem: restoring CachedPage for frameItemID %s", frameItemID.toString().utf8().data());
+        cachedPage->restore(*page);
+        return completionHandler(true);
     }
 
     freezeLayerTree(LayerTreeFreezeReason::PageSuspended);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2632,6 +2632,9 @@ private:
     void setNeedsDOMWindowResizeEvent();
 
     void setIsSuspended(bool, CompletionHandler<void(std::optional<bool>)>&&);
+    void setIsSuspendedWithFrameItem(bool suspended, WebCore::BackForwardFrameItemIdentifier, CompletionHandler<void(std::optional<bool>)>&&);
+    void suspendForProcessSwapWithFrameItem(WebCore::BackForwardFrameItemIdentifier, CompletionHandler<void(std::optional<bool>)>&&);
+    RefPtr<WebCore::HistoryItem> findHistoryItemByFrameItemID(WebCore::BackForwardFrameItemIdentifier);
 
     RefPtr<WebImage> snapshotAtSize(const WebCore::IntRect&, const WebCore::IntSize& bitmapSize, SnapshotOptions, WebCore::LocalFrame&, WebCore::LocalFrameView&);
     RefPtr<WebImage> snapshotNode(WebCore::Node&, SnapshotOptions, unsigned maximumPixelCount = std::numeric_limits<unsigned>::max());

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -718,6 +718,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     URLSchemeTaskDidComplete(WebKit::WebURLSchemeHandlerIdentifier handlerIdentifier, WebCore::ResourceLoaderIdentifier taskIdentifier, WebCore::ResourceError error)
 
     SetIsSuspended(bool suspended) -> (std::optional<bool> didSuspend)
+    SetIsSuspendedWithFrameItem(bool suspended, WebCore::BackForwardFrameItemIdentifier frameItemID) -> (std::optional<bool> didSuspend)
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     InsertAttachment(String identifier, std::optional<uint64_t> fileSize, String fileName, String contentType) -> ()

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -8572,4 +8572,47 @@ TEST(SiteIsolation, MultiProcessBFCacheOpenerSkipsBFCache)
     EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker ? true : false"] boolValue]);
 }
 
+TEST(SiteIsolation, MultiProcessBFCacheIframeRestoration)
+{
+    HTTPServer server({
+        { "/a"_s, { "<iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "<script>window.__bfcacheMarker = true;</script>iframe content"_s } },
+        { "/c"_s, { "page c"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    });
+
+    pid_t iframePID = findFramePID(frameTrees(webView.get()).get(), FrameType::Remote);
+
+    // Navigate away to trigger BFCache suspension.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_TRUE(processStillRunning(iframePID));
+
+    // Go back — BFCache should restore the page with iframe.
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Verify the frame tree is restored with site isolation.
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    });
+
+    // Verify iframe is in the same process (restored from BFCache, not reloaded).
+    pid_t restoredIframePID = findFramePID(frameTrees(webView.get()).get(), FrameType::Remote);
+    EXPECT_EQ(iframePID, restoredIframePID);
+}
+
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -8501,4 +8501,75 @@ TEST(SiteIsolation, OpenEmptySiteFromProcessWithNonEmptySite)
     Util::run(&openedFinishedLoading);
 }
 
+TEST(SiteIsolation, MultiProcessBFCacheIframeProcessSurvival)
+{
+    HTTPServer server({
+        { "/a"_s, { "<iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "iframe content"_s } },
+        { "/c"_s, { "page c"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    });
+
+    pid_t iframePID = findFramePID(frameTrees(webView.get()).get(), FrameType::Remote);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Iframe process must survive. Without multi-process suspension,
+    // removeChildFrames() sends WebPage::Close() and kills it.
+    EXPECT_TRUE(processStillRunning(iframePID));
+}
+
+// FIXME: Use openerAndOpenedViews() once MultiProcessBackForwardCacheEnabled is on by default.
+TEST(SiteIsolation, MultiProcessBFCacheOpenerSkipsBFCache)
+{
+    HTTPServer server({
+        { "/a"_s, { "<script>window.open('https://a.com/child');</script>"_s } },
+        { "/child"_s, { "child page"_s } },
+        { "/b"_s, { "page b"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    [webView setUIDelegate:uiDelegate.get()];
+    webView.get().configuration.preferences.javaScriptCanOpenWindowsAutomatically = YES;
+
+    __block RetainPtr<WKWebView> openedWebView;
+    uiDelegate.get().createWebViewWithConfiguration = ^WKWebView *(WKWebViewConfiguration *config, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
+        openedWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:config]);
+        return openedWebView.get();
+    };
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Set a BFCache marker on the opener page.
+    [webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker = true"];
+
+    // Navigate to a different site to trigger PSON.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://b.com/b"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Go back.
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Verify the marker is gone (full reload, not BFCache restore).
+    EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker ? true : false"] boolValue]);
+}
+
 }


### PR DESCRIPTION
#### a4bcaeeafde0d4c508a985de961abdbd04a8ca16
<pre>
[BFCache] Add multi-process restoration for BFCache with Site Isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=311224">https://bugs.webkit.org/show_bug.cgi?id=311224</a>
<a href="https://rdar.apple.com/173743585">rdar://173743585</a>

Reviewed by NOBODY (OOPS!).

Implement iframe process restoration for BFCache with Site Isolation.
When going back to a page with cross-origin iframes, all processes
are restored from BFCache — the main frame via goToBackForwardItem,
and each iframe process via SetIsSuspendedWithFrameItem(false) IPC.
The original BrowsingContextGroup (with its live RemotePageProxy
objects) is swapped back onto the page, avoiding BCG reconnection.

Covered by existing tests.

* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::BackForwardCache::addIfCacheable): Gate SI workaround on
multiProcessBackForwardCacheEnabled instead of blocking unconditionally.
(WebCore::BackForwardCache::takeByFrameItemID): Added. Looks up
CachedPage by BackForwardFrameItemIdentifier directly, bypassing
HistoryItem lookup (needed because the frame tree is dismantled).
* Source/WebCore/history/BackForwardCache.h:
* Source/WebCore/history/CachedFrame.cpp:
(WebCore::CachedFrameBase::restore): Guard document-specific code
with m_document null check to support RemoteFrame main frames in
iframe processes.
(WebCore::CachedFrame::open): Add else branch for RemoteFrame —
call restore() to reconstruct frame tree and open child CachedFrames.
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy): Set
m_isRestoringFromBFCache, pass targetItem to unsuspend().
(WebKit::ProvisionalPageProxy::initializeWebPage): Skip SI-specific
blocks (takeRemotePageInProcessForProvisionalPage,
remotePageParameters) when restoring from BFCache.
(WebKit::ProvisionalPageProxy::didCommitLoadForFrame): Guard
setProcess() on pageMainFrame == m_mainFrame to prevent FrameProcess
contamination during BFCache restore.
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::unsuspend): Send
SetIsSuspendedWithFrameItem(false) to each iframe process when
targetItem is provided.
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setBrowsingContextGroup): Skip addPage() when
target BCG already has RemotePageProxies for this page (BFCache
swap-back).
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision): Pass
suspended page&apos;s BCG to continueNavigationInNewProcess for BFCache
restore.
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigation): Skip BCG process
lookup when target item has a suspended page.
(WebKit::WebProcessPool::processForNavigationInternal): Allow BFCache
path with SI when multiProcessBackForwardCacheEnabled.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setIsSuspendedWithFrameItem): Implement restore
path — unfreeze layer tree, take CachedPage by frameItemID, restore.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::SiteIsolation_MultiProcessBFCacheIframeRestoration):
</pre>
----------------------------------------------------------------------
#### 8da5823d5a585f9eed846cd41c57768f1fd595e4
<pre>
[BFCache] Add multi-process suspension for BFCache with Site Isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=311224">https://bugs.webkit.org/show_bug.cgi?id=311224</a>
<a href="https://rdar.apple.com/173743585">rdar://173743585</a>

Reviewed by NOBODY (OOPS!).

Implement iframe process suspension for BFCache with Site Isolation.
Navigating away from a page with cross-origin iframes correctly
suspends all iframe processes alongside the main frame. Cache entries
are created but not yet consumed on goBack (full page reload).
Restoration is implemented in a follow-up patch.

Key changes:
- SuspendedPageProxy::startSuspension() orchestrates the full suspension
  lifecycle: validates iframe frame items, registers with iframe processes,
  sends suspension IPCs, then suspends the main frame.
- Suspension state semantics: m_suspensionState stays Suspending until ALL
  processes (main + iframes) respond, then transitions to Suspended.
- BrowsingContextGroup::forEachFrameInRemotePage() iterates descendant
  frames matched to their remote page&apos;s process.
- SuspendedPageProxy constructor is lightweight (member init only);
  all registration and IPC happens in startSuspension().
- suspendIframeProcesses() validates all frame items before sending any
  IPCs to avoid partial suspension state.
- Timeout timer covers the full suspension (main + iframes), not just
  the main frame.
- SetIsSuspendedWithFrameItem IPC for iframe process suspension.
- WebFrameProxy tree survival (conditional removeChildFrames).
- Opener relationship guard (hasMultiplePages) to prevent BFCache with
  window.open pages.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::removePage):
(WebKit::BrowsingContextGroup::closeRemotePagesForPage):
(WebKit::BrowsingContextGroup::hasMultiplePages const):
(WebKit::BrowsingContextGroup::forEachFrameInRemotePage const):
* Source/WebKit/UIProcess/BrowsingContextGroup.h:
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::SuspendedPageProxy):
(WebKit::SuspendedPageProxy::startSuspension):
(WebKit::SuspendedPageProxy::~SuspendedPageProxy):
(WebKit::SuspendedPageProxy::teardown):
(WebKit::SuspendedPageProxy::waitUntilReadyToUnsuspend):
(WebKit::SuspendedPageProxy::didProcessRequestToSuspend):
(WebKit::SuspendedPageProxy::suspendIframeProcesses):
(WebKit::SuspendedPageProxy::hasIframeInProcess const):
(WebKit::SuspendedPageProxy::didIframeSuspensionComplete):
(WebKit::SuspendedPageProxy::maybeCompleteSuspension):
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Source/WebKit/UIProcess/WebBackForwardCache.cpp:
(WebKit::WebBackForwardCache::removeEntriesForProcess):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::suspendCurrentPageIfPossible):
(WebKit::WebPageProxy::commitProvisionalPage):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::findHistoryItemByFrameItemID):
(WebKit::WebPage::suspendForProcessSwapWithFrameItem):
(WebKit::WebPage::setIsSuspendedWithFrameItem):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, MultiProcessBFCacheIframeProcessSurvival)):
(TestWebKitAPI::(SiteIsolation, MultiProcessBFCacheOpenerSkipsBFCache)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4bcaeeafde0d4c508a985de961abdbd04a8ca16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164462 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109515 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157572 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29106 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28809 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120508 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84945 "3 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1041bc74-58f0-443a-b4df-2545c1e558d3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158658 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22685 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139811 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101197 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21771 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19910 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.MultiProcessBFCacheIframeRestoration (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12292 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131440 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166943 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11117 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Checked out pull request; Found 41184 issues") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19254 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128626 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28503 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23944 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128758 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28427 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139436 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86257 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23575 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16233 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28121 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92224 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27698 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27928 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27771 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->