### PR TITLE
[AutoFill Debugging] Text extractions should indicate whether text form controls were AutoFilled

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-autofilled-attributes-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-autofilled-attributes-expected.txt
@@ -1,0 +1,5 @@
+root
+	input placeholder='Normal field' 'hello'
+	input placeholder='Autofilled field' autofilled 'test@webkit.org'
+	input password placeholder='Viewable field' secure autofilled
+	input password placeholder='Obscured field' secure autofilled

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-autofilled-attributes.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-autofilled-attributes.html
@@ -1,0 +1,56 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+<style>
+body {
+    white-space: pre-wrap;
+}
+
+input {
+    font-size: 18px;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<div><input id="normal" type="text" placeholder="Normal field"></div>
+<div><input id="autofilled" type="text" placeholder="Autofilled field"></div>
+<div><input id="viewable" type="password" placeholder="Viewable field"></div>
+<div><input id="obscured" type="password" placeholder="Obscured field"></div>
+<script>
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    const normalField = document.getElementById("normal");
+    const autofilledField = document.getElementById("autofilled");
+    const viewableField = document.getElementById("viewable");
+    const obscuredField = document.getElementById("obscured");
+
+    normalField.value = "hello";
+    autofilledField.value = "test@webkit.org";
+    viewableField.value = "hunter2";
+    obscuredField.value = "secret123";
+
+    internals.setAutofilled(autofilledField, true);
+    internals.setAutofilledAndViewable(viewableField, true);
+    internals.setAutofilledAndObscured(obscuredField, true);
+
+    document.body.textContent = await UIHelper.requestDebugText({
+        includeRects: false,
+        includeURLs: false,
+        nodeIdentifierInclusion: "none",
+        includeTextInAutoFilledControls: true,
+    });
+
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields-expected.txt
@@ -1,4 +1,4 @@
 root
-	input placeholder='Enter your email'
-	input placeholder='Enter your password' secure
+	input placeholder='Enter your email' autofilled
+	input placeholder='Enter your password' secure autofilled
 	input number placeholder='Security code' '123456'

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -645,6 +645,7 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
                 .isReadonly = input && input->isReadOnly(),
                 .isDisabled = control->isDisabled(),
                 .isChecked = input && input->checked(),
+                .isAutofilled = input && (input->autofilled() || input->autofilledAndViewable() || input->autofilledAndObscured()),
             } };
         }
     }

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -171,6 +171,7 @@ struct TextFormControlData {
     bool isReadonly { false };
     bool isDisabled { false };
     bool isChecked { false };
+    bool isAutofilled { false };
 };
 
 struct SelectOptionData {

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -1091,6 +1091,8 @@ static void populateJSONForItem(JSON::Object& jsonObject, const TextExtraction::
                 jsonObject.setBoolean("secure"_s, true);
             if (controlData.editable.isFocused)
                 jsonObject.setBoolean("focused"_s, true);
+            if (controlData.isAutofilled)
+                jsonObject.setBoolean("autofilled"_s, true);
         },
         [&](const TextExtraction::FormData& formData) {
             if (!formData.autocomplete.isEmpty())
@@ -1488,6 +1490,9 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
 
                 if (controlData.editable.isFocused)
                     parts.append("focused"_s);
+
+                if (controlData.isAutofilled)
+                    parts.append("autofilled"_s);
             }
 
             aggregator.addResult(line, WTF::move(parts));

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6841,6 +6841,7 @@ header: <WebCore/TextExtractionTypes.h>
     bool isReadonly;
     bool isDisabled;
     bool isChecked;
+    bool isAutofilled;
 };
 
 header: <WebCore/TextExtractionTypes.h>


### PR DESCRIPTION
#### d4ddf1824cc7d3509baeba4675997715da06b9d3
<pre>
[AutoFill Debugging] Text extractions should indicate whether text form controls were AutoFilled
<a href="https://bugs.webkit.org/show_bug.cgi?id=311936">https://bugs.webkit.org/show_bug.cgi?id=311936</a>
<a href="https://rdar.apple.com/174497026">rdar://174497026</a>

Reviewed by Aditya Keerthi.

Add an attribute for the text-tree format, indicating that a text field was modified via AutoFill.

Test: fast/text-extraction/debug-text-extraction-autofilled-attributes.html

* LayoutTests/fast/text-extraction/debug-text-extraction-autofilled-attributes-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-autofilled-attributes.html: Added.
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItemData):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::populateJSONForItem):
(WebKit::addPartsForItem):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/310951@main">https://commits.webkit.org/310951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6c5d94721098faf7d87d9cf23f2d96e1fa6e010

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28803 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164305 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157416 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28653 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120379 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; 5 flakes 1 failures; Uploaded test results; 1 flakes; Passed layout tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/36bcf1f2-40df-4705-8bfe-b6c7cbe27122) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22573 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/139677 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101069 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/154863 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12136 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147593 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166783 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16374 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19120 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128499 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/154943 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128632 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34874 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28271 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139302 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23459 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187428 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27965 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92068 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48040 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27542 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/27772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27615 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->