### PR TITLE
Handle WebExtension pending tasks when worker gets stopped

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
@@ -32,9 +32,11 @@
 #include "WebExtensionAPIRuntime.h"
 #include "WebFrame.h"
 #include "WebPage.h"
+#include <JavaScriptCore/APICast.h>
 #include <JavaScriptCore/JSClassRef.h>
 #include <JavaScriptCore/JSObjectRef.h>
 #include <JavaScriptCore/JSWeakObjectMapRefPrivate.h>
+#include <WebCore/JSDOMGlobalObject.h>
 
 namespace WebKit {
 
@@ -106,6 +108,12 @@ JSValueRef callWithArguments(JSObjectRef callbackFunction, JSRetainPtr<JSGlobalC
 {
     if (!globalContext || !callbackFunction)
         return nil;
+
+    auto* globalObject = toJS(globalContext.get());
+    RefPtr context = globalObject ? JSC::jsCast<JSDOMGlobalObject*>(globalObject)->scriptExecutionContext() : nullptr;
+    if (!context || context->activeDOMObjectsAreStopped())
+        return nil;
+
     return JSObjectCallAsFunction(globalContext.get(), callbackFunction, nullptr, ArgumentCount, arguments.data(), nullptr);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIExtension.mm
@@ -29,6 +29,22 @@
 
 #import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/cocoa/WebExtensionUtilities.h"
+#import <WebKit/WKNavigationDelegatePrivate.h>
+#import <WebKit/WKProcessPoolPrivate.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
+
+static bool didProcessCrash = false;
+
+@interface CrashDetectionDelegate : NSObject <WKNavigationDelegate>
+@end
+
+@implementation CrashDetectionDelegate
+
+- (void)_webView:(WKWebView *)webView webContentProcessDidTerminateWithReason:(_WKProcessTerminationReason)reason
+{
+    didProcessCrash = true;
+}
+@end
 
 namespace TestWebKitAPI {
 
@@ -410,6 +426,37 @@ TEST(WKWebExtensionAPIExtension, GetViewsExcludesServiceWorkerBackground)
     Util::loadAndRunExtension(extensionServiceWorkerManifest, @{
         @"background.js": backgroundScript,
     });
+}
+
+TEST(WKWebExtensionAPIExtension, HandlePendingExtensionTasksWhileStopped)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"function doTest() {",
+        @"  browser.extension.isAllowedIncognitoAccess(() => {",
+        @"    Promise.resolve().then(() => { })",
+        @"    doTest()",
+        @"  })",
+        @"}",
+        @"doTest()",
+        @"browser.test.notifyPass()",
+    ]);
+
+    auto extension = Util::loadExtension(extensionServiceWorkerManifest, @{
+        @"background.js": backgroundScript,
+    });
+    [extension run];
+
+    auto *view = [extension context]._backgroundWebView;
+    EXPECT_TRUE(!!view);
+
+    didProcessCrash = false;
+    auto navigationDelegate = adoptNS([[CrashDetectionDelegate alloc] init]);
+    [view setNavigationDelegate:navigationDelegate.get()];
+
+    [[extension context].webViewConfiguration.processPool _terminateServiceWorkers];
+
+    TestWebKitAPI::Util::runFor(0.5_s);
+    EXPECT_FALSE(didProcessCrash);
 }
 
 TEST(WKWebExtensionAPIExtension, InIncognitoContext)


### PR DESCRIPTION
#### 66c0b678a65f5e9bdd76f466d40ceb38c68b8285
<pre>
Handle WebExtension pending tasks when worker gets stopped
<a href="https://rdar.apple.com/174046043">rdar://174046043</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311938">https://bugs.webkit.org/show_bug.cgi?id=311938</a>

Reviewed by Chris Dumez.

We usually queue a task when going back to a worker from IPC.
This handles automatically the case of worker being terminated.
For web extension workers, we need to explicitly check the case of worker being terminated.
We do so in callWithArguments.

Covered by a test which is creating a web extension service worker that is doing nothing but triggering a pending task everytime the previous one is completed.
We then terminate the service worker, the test is passing as long as the web process is not crashing.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp:
(WebKit::callWithArguments):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIExtension, HandlePendingExtensionTasksWhileStopped)):
(TestWebKitAPI::TEST(WKWebExtensionAPIExtension, GetViewsExcludesServiceWorkerBackground)): Deleted.

Canonical link: <a href="https://commits.webkit.org/311071@main">https://commits.webkit.org/311071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40a436af5af865e3eb14b4337291a2778bb575ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155994 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22511 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164756 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157865 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29462 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29330 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120767 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158952 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22971 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140092 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101456 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22054 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20197 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12587 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131716 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17924 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167236 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11410 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19536 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128887 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28930 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24250 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129020 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34939 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28852 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139718 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86600 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23843 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16516 "Too many flaky failures: http/tests/contentextensions/text-track-blocked.html, http/tests/cookies/same-site/user-load-cross-site-redirect.py, http/tests/media/clearkey/clear-key-hls-aes128.html, http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/resourceLoadStatistics/omit-referrer-for-navigation-ephemeral.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/multipart-two-part.py, http/tests/security/mixedContent/redirect-http-to-https-iframe-in-main-frame.html, http/tests/site-isolation/frame-index.html, http/tests/storageAccess/deny-storage-access-under-opener-ephemeral.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28561 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92518 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28088 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28316 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28212 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->