### PR TITLE
Exiting Fullscreen after Docking sometimes clips content

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -664,6 +664,7 @@ static constexpr CGFloat kWindowTranslationDuration = 0.6;
 @property (nonatomic, readonly) Class windowClass;
 @property (nonatomic, readonly) CGSize sceneSize;
 @property (nonatomic, readonly) CGSize sceneMinimumSize;
+@property (nonatomic, readonly) CGSize sceneMaximumSize;
 @property (nonatomic, readonly) RSSSceneChromeOptions sceneChromeOptions;
 @property (nonatomic, readonly) MRUISceneResizingBehavior sceneResizingBehavior;
 @property (nonatomic, readonly) WKSurroundingsEffectType preferredSurroundingsEffect;
@@ -693,6 +694,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     _sceneSize = windowScene.coordinateSpace.bounds.size;
 ALLOW_DEPRECATED_DECLARATIONS_END
     _sceneMinimumSize = windowScene.sizeRestrictions.minimumSize;
+    _sceneMaximumSize = windowScene.sizeRestrictions.maximumSize;
     _sceneChromeOptions = windowScene.mrui_placement.preferredChromeOptions;
     _sceneResizingBehavior = windowScene.mrui_placement.preferredResizingBehavior;
 
@@ -2294,6 +2296,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         } completion:animationCompletionBlock.get()];
     });
 
+    if (!enter)
+        [inWindow windowScene].sizeRestrictions.maximumSize = [originalState sceneMaximumSize];
+
     if (!shouldAnimateResizeScene || enter)
         animationBlock();
     else
@@ -2328,6 +2333,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         scene.mrui_placement.preferredChromeOptions = [_parentWindowState sceneChromeOptions];
         scene.mrui_placement.preferredResizingBehavior = [_parentWindowState sceneResizingBehavior];
         scene.sizeRestrictions.minimumSize = [_parentWindowState sceneMinimumSize];
+        scene.sizeRestrictions.maximumSize = [_parentWindowState sceneMaximumSize];
 
         _lastKnownParentWindow = nil;
         _parentWindowState = nil;


### PR DESCRIPTION
#### 0422248ec3078c58e58d97e76d68cf0999e3c462
<pre>
Exiting Fullscreen after Docking sometimes clips content
<a href="https://bugs.webkit.org/show_bug.cgi?id=311886">https://bugs.webkit.org/show_bug.cgi?id=311886</a>
<a href="https://rdar.apple.com/173447754">rdar://173447754</a>

Reviewed by Abrar Rahman Protyasha.

Previously, the fullscreen window controller only set and restored the minimum window
size restrictions for the scene. When entering fullscreen and then docking the video
after, this can cause the max window size restriction to change. If the inWindow
has a larger size than that maximum size, this causes the subsequent call to
requestSize in the exit animation to return the wrong size, causing the window
to clip.

To ensure that the maximum window size restriction is restored correctly, we set the
maximum size restrictions before requesting a scene resize for the exit animation.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenParentWindowState initWithWindow:]):
(-[WKFullScreenWindowController _performSpatialFullScreenTransition:completionHandler:]):
(-[WKFullScreenWindowController bestVideoFullscreenModeChanged]):

Canonical link: <a href="https://commits.webkit.org/311954@main">https://commits.webkit.org/311954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25b6f2bfb94f5873d6cd1389a7a0a95beb7015e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167205 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112459 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31789 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122664 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86098 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142261 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103334 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23970 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22355 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14977 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133658 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169696 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15325 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21665 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130848 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31492 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26419 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130962 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35477 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141834 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89313 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25652 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18640 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30949 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96743 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30469 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30742 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->