### PR TITLE
[GStreamer] Add a C++ wrapper for pad probes handling

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -27,10 +27,12 @@
 #include <gst/gst.h>
 #include <gst/video/video-format.h>
 #include <gst/video/video-info.h>
+#include <wtf/Lock.h>
 #include <wtf/Logger.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/text/CStringView.h>
 
 #if USE(GSTREAMER_GL)
@@ -391,6 +393,68 @@ void dumpBinToDotFile(GstBin*, const String&, GstDebugGraphDetails = GST_DEBUG_G
 void dumpBinToDotFile(const GRefPtr<GstElement>&, const String&, GstDebugGraphDetails = GST_DEBUG_GRAPH_SHOW_ALL);
 
 GstDebugLevel gstDebugLevelFromWTFLogLevel(WTFLogLevel);
+
+template<class T>
+class PadProbeHandle : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PadProbeHandle<T>, WTF::DestructionThread::Main> {
+public:
+    using PadProbeCallback = Function<GstPadProbeReturn(const RefPtr<T>&, const GRefPtr<GstPad>&, GstPadProbeInfo*)>;
+    static Ref<PadProbeHandle> create(const T& owner, GRefPtr<GstPad>&& pad, GstPadProbeType probeType, PadProbeCallback&& callback)
+    {
+        return adoptRef(*new PadProbeHandle<T>(owner, WTF::move(pad), probeType, WTF::move(callback)));
+    }
+
+    ~PadProbeHandle()
+    {
+        Locker locker { m_lock };
+        if (!m_id)
+            return;
+        gst_pad_remove_probe(m_pad.get(), m_id);
+    }
+
+private:
+    PadProbeHandle(const T& owner, GRefPtr<GstPad>&& pad, GstPadProbeType probeType, PadProbeCallback&& callback)
+        : m_pad(WTF::move(pad))
+        , m_owner(owner)
+        , m_callback(WTF::move(callback))
+    {
+        // The m_lock cannot be taken right away because if we are adding an idle probe its callback
+        // might be triggered during the add_probe_call, potentially leading to a deadlock in cases
+        // where owner is nullptr and where result is GST_PAD_PROBE_REMOVE.
+        auto id = gst_pad_add_probe(m_pad.get(), probeType, reinterpret_cast<GstPadProbeCallback>(+[](GstPad*, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
+            RefPtr self = reinterpret_cast<ThreadSafeWeakPtr<PadProbeHandle<T>>*>(userData)->get();
+            if (!self)
+                return GST_PAD_PROBE_REMOVE;
+
+            RefPtr owner = self->m_owner.get();
+            if (!owner) {
+                self->setId(0);
+                return GST_PAD_PROBE_REMOVE;
+            }
+
+            auto result = self->m_callback(owner, self->m_pad, info);
+            if (result == GST_PAD_PROBE_REMOVE)
+                self->setId(0);
+
+            return result;
+        }), new ThreadSafeWeakPtr<PadProbeHandle<T>> { this }, reinterpret_cast<GDestroyNotify>(+[](gpointer data) {
+            delete static_cast<ThreadSafeWeakPtr<PadProbeHandle<T>>*>(data);
+        }));
+
+        setId(id);
+    }
+
+    void setId(unsigned long id)
+    {
+        Locker locker { m_lock };
+        m_id = id;
+    }
+
+    Lock m_lock;
+    unsigned long m_id WTF_GUARDED_BY_LOCK(m_lock);
+    GRefPtr<GstPad> m_pad;
+    WTF::ThreadSafeWeakPtr<T> m_owner;
+    PadProbeCallback m_callback;
+};
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
@@ -170,8 +170,7 @@ void TrackDataHolder::setPad(GRefPtr<GstPad>&& pad)
 {
     ASSERT(isMainThread());
 
-    if (m_bestUpstreamPad && m_eventProbe)
-        gst_pad_remove_probe(m_bestUpstreamPad.get(), m_eventProbe);
+    m_eventProbeClient = nullptr;
 
     g_clear_signal_handler(&m_padTagsNotifyHandlerId, m_pad.get());
     g_clear_signal_handler(&m_padCapsNotifyHandlerId, m_pad.get());
@@ -185,11 +184,7 @@ void TrackDataHolder::setPad(GRefPtr<GstPad>&& pad)
     if (!m_bestUpstreamPad)
         return;
 
-    m_eventProbe = gst_pad_add_probe(m_bestUpstreamPad.get(), GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, reinterpret_cast<GstPadProbeCallback>(+[](GstPad*, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
-        RefPtr holder = reinterpret_cast<ThreadSafeWeakPtr<TrackDataHolder>*>(userData)->get();
-        if (!holder)
-            return GST_PAD_PROBE_REMOVE;
-
+    m_eventProbeClient = PadProbeHandle<TrackDataHolder>::create(*this, GRefPtr(m_bestUpstreamPad), GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, [](const auto& holder, const auto&, auto info) -> GstPadProbeReturn {
         auto event = gst_pad_probe_info_get_event(info);
         switch (GST_EVENT_TYPE(event)) {
         case GST_EVENT_TAG:
@@ -217,9 +212,7 @@ void TrackDataHolder::setPad(GRefPtr<GstPad>&& pad)
             break;
         }
         return GST_PAD_PROBE_OK;
-    }), new ThreadSafeWeakPtr<TrackDataHolder> { this }, reinterpret_cast<GDestroyNotify>(+[](gpointer data) {
-        delete static_cast<ThreadSafeWeakPtr<TrackDataHolder>*>(data);
-    }));
+    });
 }
 
 void TrackDataHolder::setStream(GRefPtr<GstStream>&& stream)
@@ -311,9 +304,8 @@ void TrackDataHolder::disconnect()
 
     m_notifier->cancelPendingNotifications();
 
-    if (m_bestUpstreamPad && m_eventProbe) {
-        gst_pad_remove_probe(m_bestUpstreamPad.get(), m_eventProbe);
-        m_eventProbe = 0;
+    if (m_bestUpstreamPad && m_eventProbeClient) {
+        m_eventProbeClient = nullptr;
         m_bestUpstreamPad.clear();
     }
 

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
@@ -92,7 +92,7 @@ public:
     GRefPtr<GstPad> m_pad;
     GRefPtr<GstPad> m_bestUpstreamPad;
     GRefPtr<GstStream> m_stream;
-    unsigned long m_eventProbe { 0 };
+    RefPtr<PadProbeHandle<TrackDataHolder>> m_eventProbeClient;
     GRefPtr<GstCaps> m_initialCaps;
     AbortableTaskQueue m_taskQueue;
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
@@ -92,6 +92,7 @@ void GStreamerCapturer::tearDown(bool disconnectSignals)
     {
         Locker locker { m_lock };
         m_src = nullptr;
+        m_pipewireProbe = nullptr;
     }
     m_capsfilter = nullptr;
     m_sink = nullptr;
@@ -144,11 +145,6 @@ void GStreamerCapturer::forEachObserver(NOESCAPE const Function<void(GStreamerCa
     m_observers.forEach(apply);
 }
 
-struct CapturerProbeData {
-    ThreadSafeWeakPtr<GStreamerCapturer> capturer;
-};
-WEBKIT_DEFINE_ASYNC_DATA_STRUCT(CapturerProbeData);
-
 GstElement* GStreamerCapturer::createSource() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
     if (m_pipewireDevice) {
@@ -169,16 +165,13 @@ GstElement* GStreamerCapturer::createSource() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     GST_DEBUG_OBJECT(m_pipeline.get(), "Source element created: %" GST_PTR_FORMAT " (factory: %" GST_PTR_FORMAT ")", m_src.get(), gst_element_get_factory(m_src.get()));
 
     if (gstElementFactoryEquals(m_src.get(), "pipewiresrc"_s)) {
-        auto data = createCapturerProbeData();
-        data->capturer = this;
         auto srcPad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
-        gst_pad_add_probe(srcPad.get(), GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, [](GstPad*, GstPadProbeInfo* info, void* userData) -> GstPadProbeReturn {
-            auto* event = gst_pad_probe_info_get_event(info);
+        m_pipewireProbe = PadProbeHandle<GStreamerCapturer>::create(*this, WTF::move(srcPad), GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, [](const auto& self, const auto&, auto info) -> GstPadProbeReturn {
+            auto event = gst_pad_probe_info_get_event(info);
             if (GST_EVENT_TYPE(event) != GST_EVENT_CAPS)
                 return GST_PAD_PROBE_OK;
 
-            auto probeData = reinterpret_cast<CapturerProbeData*>(userData);
-            callOnMainThread([event = GRefPtr(event), weakThis = probeData->capturer] {
+            callOnMainThread([event = GRefPtr(event), weakThis = ThreadSafeWeakPtr { *self }] {
                 RefPtr protectedThis = weakThis.get();
                 if (!protectedThis)
                     return;
@@ -190,7 +183,7 @@ GstElement* GStreamerCapturer::createSource() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
                 });
             });
             return GST_PAD_PROBE_OK;
-        }, data, reinterpret_cast<GDestroyNotify>(destroyCapturerProbeData));
+        });
     }
 
     if (gstElementMatchesFactoryAndHasProperty(m_src.get(), "pipewiresrc"_s, "use-bufferpool"_s))

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
@@ -111,6 +111,7 @@ private:
     Lock m_lock;
     CaptureDevice::DeviceType m_deviceType;
     WeakHashSet<GStreamerCapturerObserver> m_observers;
+    RefPtr<PadProbeHandle<GStreamerCapturer>> m_pipewireProbe;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 292c0717fc0d5653201819bc42c6516824fe35b1
<pre>
[GStreamer] Add a C++ wrapper for pad probes handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=311945">https://bugs.webkit.org/show_bug.cgi?id=311945</a>

Reviewed by Xabier Rodriguez-Calvar.

By using this new PadProbeHandle class in more places we will reduce duplicated code in
GStreamer-related files. For now we use it only in the TrackPrivateBase class and in the Capturer
base class.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
(WebCore::PadProbeHandle::create):
(WebCore::PadProbeHandle::~PadProbeHandle):
(WebCore::PadProbeHandle::PadProbeHandle):
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp:
(WebCore::TrackDataHolder::setPad):
(WebCore::TrackDataHolder::disconnect):
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp:
(WebCore::GStreamerCapturer::tearDown):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h:

Canonical link: <a href="https://commits.webkit.org/314530@main">https://commits.webkit.org/314530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6d385f400c18141430edf2bd19c1066c814efc3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175239 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123447 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168058 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39686 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129177 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90983 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31554 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149323 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109703 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30531 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29224 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23380 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140500 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177772 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30674 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28726 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137525 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39751 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33369 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137453 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37077 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40439 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148816 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103068 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32743 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25683 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38950 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112024 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38347 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3769 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38592 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38490 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->