### PR TITLE
Ornaments sometimes drifts when Entering and Exiting Element Fullscreen

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -2179,14 +2179,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     WKFullScreenWindowController *controller = self;
     UIWindow *inWindow = enter ? _window.get() : _lastKnownParentWindow.get();
     UIWindow *outWindow = enter ? _lastKnownParentWindow.get() : _window.get();
-    CGRect inWindowBounds = [inWindow bounds];
-    CGRect outWindowBounds = [outWindow bounds];
     WKFullScreenParentWindowState *originalState = _parentWindowState.get();
 
     const BOOL shouldAnimateResizeScene = [self _shouldAnimateResizeScene];
 
-    CGFloat sceneWidthDifference = inWindowBounds.size.width - outWindowBounds.size.width;
-    CGFloat sceneHeightDifference = inWindowBounds.size.height - outWindowBounds.size.height;
     CGSize targetSceneSize = [inWindow bounds].size;
 
     if (shouldAnimateResizeScene && enter)
@@ -2249,7 +2245,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             resizeCompletionBlock();
     });
 
-    auto animationBlock = makeBlockPtr([inWindow, outWindow, originalState, enter, allowSceneGeometryUpdates, sceneWidthDifference, sceneHeightDifference, shouldAnimateResizeScene, self, weakSelf = WTF::move(weakSelf), animationCompletionBlock = WTF::move(animationCompletionBlock)] mutable {
+    auto animationBlock = makeBlockPtr([inWindow, outWindow, originalState, enter, allowSceneGeometryUpdates, shouldAnimateResizeScene, self, weakSelf = WTF::move(weakSelf), animationCompletionBlock = WTF::move(animationCompletionBlock)] mutable {
         if (shouldAnimateResizeScene && !enter)
             [self _updateFullscreenWindowOrigin];
 
@@ -2276,23 +2272,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         [UIView animateWithDuration:kWindowTranslationDuration delay:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
             inWindow.transform3D = originalState.transform3D;
         } completion:nil];
-
-        if (shouldAnimateResizeScene) {
-            [UIView animateWithDuration:kWindowTranslationDuration delay:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
-                if (enter) {
-                    for (MRUIPlatterOrnament *ornament in [originalState ornamentProperties]) {
-                        CGPoint originalOffset2D = [[[_parentWindowState ornamentProperties] objectForKey:ornament] offset2D];
-                        ornament.offset2D = CGPointMake(
-                            originalOffset2D.x + sceneWidthDifference * (0.5 - ornament.sceneAnchorPoint.x),
-                            originalOffset2D.y + sceneHeightDifference * (0.5 - ornament.sceneAnchorPoint.y)
-                        );
-                    }
-                } else {
-                    for (MRUIPlatterOrnament *ornament in [originalState ornamentProperties])
-                        ornament.offset2D = [[[originalState ornamentProperties] objectForKey:ornament] offset2D];
-                }
-            } completion:nil];
-        }
 
         for (MRUIPlatterOrnament *ornament in originalState.ornamentProperties) {
             CGFloat originalDepth = [[originalState.ornamentProperties objectForKey:ornament] depthDisplacement];


### PR DESCRIPTION
#### 6fbf6ca8821d3a1bef684fecfc554526fd070375
<pre>
Ornaments sometimes drifts when Entering and Exiting Element Fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=311947">https://bugs.webkit.org/show_bug.cgi?id=311947</a>
<a href="https://rdar.apple.com/174454497">rdar://174454497</a>

Reviewed by Abrar Rahman Protyasha.

With the change made in 310001@main, we no longer
need to apply an animated transform to ornaments during the animation to counteract
the transformation during the animated scene resize. This change removes an extraneous
transform we apply to ornaments for this reason that would cause it to sometimes occlude
the window depending on the inWindow&apos;s height relative to that of the fullscreen video
window.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController _performSpatialFullScreenTransition:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/311814@main">https://commits.webkit.org/311814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86eadf65e3ff84e61f69b1579e3ae4a50f38c46a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166593 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111851 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31241 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122165 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85787 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141671 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102834 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23501 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21790 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14364 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133182 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169082 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13773 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21105 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130331 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30852 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25860 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130448 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35399 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30790 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141277 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88638 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25207 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18083 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30342 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95099 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29863 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30093 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29990 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->