### PR TITLE
Stop using all caps in log identifiers in WebKit log definitions

### DIFF
--- a/Source/WebKit/Platform/LogMessages.in
+++ b/Source/WebKit/Platform/LogMessages.in
@@ -24,59 +24,59 @@
 #
 # Identifier, format string, parameters, Log type (DEFAULT, INFO, ERROR, FAULT), Category (Default, Process, Loading, etc) 
 
-RECEIVED_LAUNCH_SERVICES_DATABASE, "Received Launch Services database", (), INFO, Loading
-WAITING_FOR_LAUNCH_SERVICES_DATABASE_UPDATE_TOOK_F_SECONDS, "Waiting for Launch Services database update took %f seconds", (double), ERROR, Loading
-TIMED_OUT_WAITING_FOR_LAUNCH_SERVICES_DATABASE_UPDATE, "Timed out waiting for Launch Services database update", (), FAULT, Loading
+ReceivedLaunchServicesDatabase, "Received Launch Services database", (), INFO, Loading
+WaitingForLaunchServicesDatabaseUpdateTookFSeconds, "Waiting for Launch Services database update took %f seconds", (double), ERROR, Loading
+TimedOutWaitingForLaunchServicesDatabaseUpdate, "Timed out waiting for Launch Services database update", (), FAULT, Loading
 
-PLATFORM_INITIALIZE_WEBPROCESS, "WebProcess::platformInitializeWebProcess", (), DEFAULT, Process
+PlatformInitializeWebProcess, "WebProcess::platformInitializeWebProcess", (), DEFAULT, Process
 
-WEBRESOURCELOADER_CONSTRUCTOR, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::WebResourceLoader", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
-WEBRESOURCELOADER_WILLSENDREQUEST, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::willSendRequest", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
-WEBRESOURCELOADER_WILLSENDREQUEST_NO_CORELOADER, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::willSendRequest: exiting early because no coreloader or identifier", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
-WEBRESOURCELOADER_WILLSENDREQUEST_CONTINUE, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::willSendRequest: returning ContinueWillSendRequest", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
-WEBRESOURCELOADER_DIDRECEIVERESPONSE, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::didReceiveResponse: (httpStatusCode=%d)", (uint64_t, uint64_t, uint64_t, int), DEFAULT, Network
-WEBRESOURCELOADER_DIDRECEIVERESPONSE_NOT_CONTINUING_LOAD, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::didReceiveResponse: not continuing load because no coreLoader or no ID", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
-WEBRESOURCELOADER_DIDRECEIVERESPONSE_NOT_CONTINUING_INTERCEPT_LOAD, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::didReceiveResponse: not continuing intercept load because no coreLoader or no ID", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
-WEBRESOURCELOADER_DIDRECEIVEDATA, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::didReceiveData: Started receiving data", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
-WEBRESOURCELOADER_DIDFINISHRESOURCELOAD, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::didFinishResourceLoad: (length=%" PRIu64 ")", (uint64_t, uint64_t, uint64_t, uint64_t), DEFAULT, Network
-WEBRESOURCELOADER_SERVICEWORKERDIDNOTHANDLE, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::serviceWorkerDidNotHandle", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
-WEBRESOURCELOADER_DIDFAILRESOURCELOAD, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::didFailResourceLoad", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
-WEBRESOURCELOADER_DIDBLOCKAUTHENTICATIONCHALLENGE, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::didBlockAuthenticationChallenge", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
-WEBRESOURCELOADER_STOPLOADINGAFTERSECURITYPOLICYDENIED, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
-WEBRESOURCELOADER_DIDRECEIVERESOURCE, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::didReceiveResource", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
-WEBRESOURCELOADER_DIDRECEIVERESOURCE_UNABLE_TO_CREATE_FRAGMENTEDSHAREDBUFFER, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::didReceiveResource: Unable to create FragmentedSharedBuffer", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
+WebResourceLoaderConstructor, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::WebResourceLoader", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
+WebResourceLoaderWillSendRequest, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::willSendRequest", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
+WebResourceLoaderWillSendRequestNoCoreLoader, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::willSendRequest: exiting early because no coreloader or identifier", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
+WebResourceLoaderWillSendRequestContinue, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::willSendRequest: returning ContinueWillSendRequest", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
+WebResourceLoaderDidReceiveResponse, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::didReceiveResponse: (httpStatusCode=%d)", (uint64_t, uint64_t, uint64_t, int), DEFAULT, Network
+WebResourceLoaderDidReceiveResponseNotContinuingLoad, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::didReceiveResponse: not continuing load because no coreLoader or no ID", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
+WebResourceLoaderDidReceiveResponseNotContinuingInterceptLoad, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::didReceiveResponse: not continuing intercept load because no coreLoader or no ID", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
+WebResourceLoaderDidReceiveData, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::didReceiveData: Started receiving data", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
+WebResourceLoaderDidFinishResourceLoad, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::didFinishResourceLoad: (length=%" PRIu64 ")", (uint64_t, uint64_t, uint64_t, uint64_t), DEFAULT, Network
+WebResourceLoaderServiceWorkerDidNotHandle, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::serviceWorkerDidNotHandle", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
+WebResourceLoaderDidFailResourceLoad, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::didFailResourceLoad", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
+WebResourceLoaderDidBlockAuthenticationChallenge, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::didBlockAuthenticationChallenge", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
+WebResourceLoaderStopLoadingAfterSecurityPolicyDenied, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
+WebResourceLoaderDidReceiveResource, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::didReceiveResource", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
+WebResourceLoaderDidReceiveResourceUnableToCreateFragmentedSharedBuffer, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebResourceLoader::didReceiveResource: Unable to create FragmentedSharedBuffer", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
 
-WEBLOADERSTRATEGY_SCHEDULELOAD, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebLoaderStrategy::scheduleLoad: URL will be scheduled with the NetworkProcess", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
-WEBLOADERSTRATEGY_SCHEDULELOAD_URL_LOADED_AS_DATA, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebLoaderStrategy::scheduleLoad: URL will be loaded as data", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
-WEBLOADERSTRATEGY_SCHEDULELOAD_RESOURCE_SCHEDULED_WITH_NETWORKPROCESS, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebLoaderStrategy::scheduleLoad: Resource is being scheduled with the NetworkProcess (priority=%d, existingNetworkResourceLoadIdentifierToResume=%" PRIu64 ")", (uint64_t, uint64_t, uint64_t, int, uint64_t), DEFAULT, Network
+WebLoaderStrategyScheduleLoad, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebLoaderStrategy::scheduleLoad: URL will be scheduled with the NetworkProcess", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
+WebLoaderStrategyScheduleLoadUrlLoadedAsData, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebLoaderStrategy::scheduleLoad: URL will be loaded as data", (uint64_t, uint64_t, uint64_t), DEFAULT, Network
+WebLoaderStrategyScheduleLoadResourceScheduledWithNetworkProcess, "[webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 "] WebLoaderStrategy::scheduleLoad: Resource is being scheduled with the NetworkProcess (priority=%d, existingNetworkResourceLoadIdentifierToResume=%" PRIu64 ")", (uint64_t, uint64_t, uint64_t, int, uint64_t), DEFAULT, Network
 
-WEBFRAMELOADERCLIENT_NAVIGATIONACTIONDATA_NO_WEBPAGE, "[webFrameID=%" PRIu64 ", webPageID=%" PRIu64 "] WebFrameLoaderClient::navigationActionData: returning std::nullopt because there's no web page", (uint64_t, uint64_t), DEFAULT, Network
-WEBFRAMELOADERCLIENT_NAVIGATIONACTIONDATA_EMPTY_REQUEST, "[webFrameID=%" PRIu64 ", webPageID=%" PRIu64 "] WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction: returning std::nullopt because request is empty", (uint64_t, uint64_t), DEFAULT, Network
-WEBFRAMELOADERCLIENT_NAVIGATIONACTIONDATA_NO_FRAME, "[webFrameID=%" PRIu64 ", webPageID=%" PRIu64 "] WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction: returning std::nullopt because frame does not exist", (uint64_t, uint64_t), DEFAULT, Network
-WEBFRAMELOADERCLIENT_DISPATCHDECIDEPOLICYFORNAVIGATIONACTION_SYNC_IPC_FAILED, "[webFrameID=%" PRIu64 ", webPageID=%" PRIu64 "] WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction: ignoring because of failing to send sync IPC, error = %hhu", (uint64_t, uint64_t, uint8_t), DEFAULT, Network
-WEBFRAMELOADERCLIENT_DISPATCHDECIDEPOLICYFORNAVIGATIONACTION_GOT_POLICYACTION_FROM_SYNC_IPC, "[webFrameID=%" PRIu64 ", webPageID=%" PRIu64 "] WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction: Got policyAction %" PUBLIC_LOG_STRING " from sync IPC", (uint64_t, uint64_t, CString), DEFAULT, Network
-WEBFRAMELOADERCLIENT_DISPATCHDECIDEPOLICYFORNAVIGATIONACTION_GOT_POLICYACTION_FROM_ASYNC_IPC, "[webFrameID=%" PRIu64 ", webPageID=%" PRIu64 "] WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction: Got policyAction %" PUBLIC_LOG_STRING " from async IPC", (uint64_t, uint64_t, CString), DEFAULT, Network
+WebFrameLoaderClientNavigationActionDataNoWebPage, "[webFrameID=%" PRIu64 ", webPageID=%" PRIu64 "] WebFrameLoaderClient::navigationActionData: returning std::nullopt because there's no web page", (uint64_t, uint64_t), DEFAULT, Network
+WebFrameLoaderClientNavigationActionDataEmptyRequest, "[webFrameID=%" PRIu64 ", webPageID=%" PRIu64 "] WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction: returning std::nullopt because request is empty", (uint64_t, uint64_t), DEFAULT, Network
+WebFrameLoaderClientNavigationActionDataNoFrame, "[webFrameID=%" PRIu64 ", webPageID=%" PRIu64 "] WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction: returning std::nullopt because frame does not exist", (uint64_t, uint64_t), DEFAULT, Network
+WebFrameLoaderClientDispatchDecidePolicyForNavigationActionSyncIpcFailed, "[webFrameID=%" PRIu64 ", webPageID=%" PRIu64 "] WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction: ignoring because of failing to send sync IPC, error = %hhu", (uint64_t, uint64_t, uint8_t), DEFAULT, Network
+WebFrameLoaderClientDispatchDecidePolicyForNavigationActionGotPolicyActionFromSyncIpc, "[webFrameID=%" PRIu64 ", webPageID=%" PRIu64 "] WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction: Got policyAction %" PUBLIC_LOG_STRING " from sync IPC", (uint64_t, uint64_t, CString), DEFAULT, Network
+WebFrameLoaderClientDispatchDecidePolicyForNavigationActionGotPolicyActionFromAsyncIpc, "[webFrameID=%" PRIu64 ", webPageID=%" PRIu64 "] WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction: Got policyAction %" PUBLIC_LOG_STRING " from async IPC", (uint64_t, uint64_t, CString), DEFAULT, Network
 
-WEBPAGE_MARK_LAYERS_VOLATILE, "[webPageID=%" PRIu64 "] WebPage::markLayersVolatile", (uint64_t), DEFAULT, Layers
-WEBPAGE_FREEZE_LAYER_TREE, "[webPageID=%" PRIu64 "] WebPage::freezeLayerTree: Adding a reason to freeze layer tree (reason=%d, new=%d, old=%d)", (uint64_t, int, int, int), DEFAULT, ProcessSuspension
-WEBPAGE_UNFREEZE_LAYER_TREE, "[webPageID=%" PRIu64 "] WebPage::unfreezeLayerTree: Removing a reason to freeze layer tree (reason=%d, new=%d, old=%d)", (uint64_t, int, int, int), DEFAULT, ProcessSuspension
-WEBPAGE_FAILED_TO_MARK_ALL_LAYERS_VOLATILE, "[webPageID=%" PRIu64 "] WebPage::markLayersVolatile: Failed to mark all layers as volatile, will retry in %g ms", (uint64_t, double), DEFAULT, ProcessSuspension
-WEBPAGE_LOADREQUEST, "[webPageID=%" PRIu64 "] WebPage::loadRequest: navigationID=%" PRIu64 ", shouldTreatAsContinuingLoad=%u, lastNavigationWasAppInitiated=%d, existingNetworkResourceLoadIdentifierToResume=%" PRIu64, (uint64_t, uint64_t, unsigned, int, uint64_t), DEFAULT, Loading
-WEBPAGE_CLOSE, "[webPageID=%" PRIu64 "] WebPage::close", (uint64_t), DEFAULT, Loading
+WebPageMarkLayersVolatile, "[webPageID=%" PRIu64 "] WebPage::markLayersVolatile", (uint64_t), DEFAULT, Layers
+WebPageFreezeLayerTree, "[webPageID=%" PRIu64 "] WebPage::freezeLayerTree: Adding a reason to freeze layer tree (reason=%d, new=%d, old=%d)", (uint64_t, int, int, int), DEFAULT, ProcessSuspension
+WebPageUnfreezeLayerTree, "[webPageID=%" PRIu64 "] WebPage::unfreezeLayerTree: Removing a reason to freeze layer tree (reason=%d, new=%d, old=%d)", (uint64_t, int, int, int), DEFAULT, ProcessSuspension
+WebPageFailedToMarkAllLayersVolatile, "[webPageID=%" PRIu64 "] WebPage::markLayersVolatile: Failed to mark all layers as volatile, will retry in %g ms", (uint64_t, double), DEFAULT, ProcessSuspension
+WebPageLoadRequest, "[webPageID=%" PRIu64 "] WebPage::loadRequest: navigationID=%" PRIu64 ", shouldTreatAsContinuingLoad=%u, lastNavigationWasAppInitiated=%d, existingNetworkResourceLoadIdentifierToResume=%" PRIu64, (uint64_t, uint64_t, unsigned, int, uint64_t), DEFAULT, Loading
+WebPageClose, "[webPageID=%" PRIu64 "] WebPage::close", (uint64_t), DEFAULT, Loading
 
-WEBPROCESS_PREPARE_TO_SUSPEND, "[sessionID=%" PRIu64 "] WebProcess::prepareToSuspend: isSuspensionImminent=%d, remainingRunTime=%fs", (uint64_t, int, double), DEFAULT, ProcessSuspension
-WEBPROCESS_FREEZE_ALL_LAYER_TREES, "[sessionID=%" PRIu64 "] WebProcess::freezeAllLayerTrees: WebProcess is freezing all layer trees", (uint64_t), DEFAULT, ProcessSuspension
-WEBPROCESS_DESTROY_RENDERING_RESOURCES, "[sessionID=%" PRIu64 "] WebProcess::destroyRenderingResources: took %.2fms", (uint64_t, double), DEFAULT, ProcessSuspension
-WEBPROCESS_MARK_ALL_LAYERS_VOLATILE, "[sessionID=%" PRIu64 "] WebProcess::markAllLayersVolatile:", (uint64_t), DEFAULT, ProcessSuspension
-WEBPROCESS_READY_TO_SUSPEND, "[sessionID=%" PRIu64 "] WebProcess::prepareToSuspend: Process is ready to suspend", (uint64_t), DEFAULT, ProcessSuspension
+WebProcessPrepareToSuspend, "[sessionID=%" PRIu64 "] WebProcess::prepareToSuspend: isSuspensionImminent=%d, remainingRunTime=%fs", (uint64_t, int, double), DEFAULT, ProcessSuspension
+WebProcessFreezeAllLayerTrees, "[sessionID=%" PRIu64 "] WebProcess::freezeAllLayerTrees: WebProcess is freezing all layer trees", (uint64_t), DEFAULT, ProcessSuspension
+WebProcessDestroyRenderingResources, "[sessionID=%" PRIu64 "] WebProcess::destroyRenderingResources: took %.2fms", (uint64_t, double), DEFAULT, ProcessSuspension
+WebProcessMarkAllLayersVolatile, "[sessionID=%" PRIu64 "] WebProcess::markAllLayersVolatile:", (uint64_t), DEFAULT, ProcessSuspension
+WebProcessReadyToSuspend, "[sessionID=%" PRIu64 "] WebProcess::prepareToSuspend: Process is ready to suspend", (uint64_t), DEFAULT, ProcessSuspension
 
-WEBLOCALFRAMELOADERCLIENT_COMPLETE_PAGE_TRANSITION_IF_NEEDED, "[webFrameID=%" PRIu64 ", webPageID=%" PRIu64 "] WebLocalFrameLoaderClient::completePageTransitionIfNeeded: dispatching didCompletePageTransition", (uint64_t, uint64_t), DEFAULT, Layout
-WEBLOCALFRAMELOADERCLIENT_DISPATCH_DID_FIRST_LAYOUT_FOR_FRAME, "[webFrameID=%" PRIu64 ", webPageID=%" PRIu64 "] WebLocalFrameLoaderClient::dispatchDidReachLayoutMilestone: dispatching DidFirstLayoutForFrame", (uint64_t, uint64_t), DEFAULT, Layout
-WEBLOCALFRAMELOADERCLIENT_DISPATCH_DID_REACH_LAYOUT_MILESTONE, "[webFrameID=%" PRIu64 ", webPageID=%" PRIu64 "] WebLocalFrameLoaderClient::dispatchDidReachLayoutMilestone: dispatching DidReachLayoutMilestone (milestones=%" PUBLIC_LOG_STRING ")", (uint64_t, uint64_t, CString), DEFAULT, Layout
-WEBLOCALFRAMELOADERCLIENT_DISPATCH_DID_FIRST_VISUALLY_NONEMPTY_LAYOUT, "[webFrameID=%" PRIu64 ", webPageID=%" PRIu64 "] WebLocalFrameLoaderClient::dispatchDidReachLayoutMilestone: dispatching DidFirstVisuallyNonEmptyLayoutForFrame", (uint64_t, uint64_t), DEFAULT, Layout
+WebLocalFrameLoaderClientCompletePageTransitionIfNeeded, "[webFrameID=%" PRIu64 ", webPageID=%" PRIu64 "] WebLocalFrameLoaderClient::completePageTransitionIfNeeded: dispatching didCompletePageTransition", (uint64_t, uint64_t), DEFAULT, Layout
+WebLocalFrameLoaderClientDispatchDidFirstLayoutForFrame, "[webFrameID=%" PRIu64 ", webPageID=%" PRIu64 "] WebLocalFrameLoaderClient::dispatchDidReachLayoutMilestone: dispatching DidFirstLayoutForFrame", (uint64_t, uint64_t), DEFAULT, Layout
+WebLocalFrameLoaderClientDispatchDidReachLayoutMilestone, "[webFrameID=%" PRIu64 ", webPageID=%" PRIu64 "] WebLocalFrameLoaderClient::dispatchDidReachLayoutMilestone: dispatching DidReachLayoutMilestone (milestones=%" PUBLIC_LOG_STRING ")", (uint64_t, uint64_t, CString), DEFAULT, Layout
+WebLocalFrameLoaderClientDispatchDidFirstVisuallyNonEmptyLayout, "[webFrameID=%" PRIu64 ", webPageID=%" PRIu64 "] WebLocalFrameLoaderClient::dispatchDidReachLayoutMilestone: dispatching DidFirstVisuallyNonEmptyLayoutForFrame", (uint64_t, uint64_t), DEFAULT, Layout
 
-REMOTE_RENDERING_BACKEND_PROXY_CREATED_RENDERING_BACKEND, "[renderingBackend=%" PRIu64 "] Created rendering backend for pageProxyID=%" PRIu64 ", webPageID=%" PRIu64, (uint64_t, uint64_t, uint64_t), DEFAULT, RemoteLayerBuffers
+RemoteRenderingBackendProxyCreatedRenderingBackend, "[renderingBackend=%" PRIu64 "] Created rendering backend for pageProxyID=%" PRIu64 ", webPageID=%" PRIu64, (uint64_t, uint64_t, uint64_t), DEFAULT, RemoteLayerBuffers
 
-VIDEOPRESENTATIONMANAGER_SETVIDEOLAYERFRAMEFENCED, "VideoPresentationManager::setVideoLayerFrameFenced(%" PRIu64 "): send right %d, fence data size %" PRIu64, (uint64_t, int, uint64_t), INFO, Media
+VideoPresentationManagerSetVideoLayerFrameFenced, "VideoPresentationManager::setVideoLayerFrameFenced(%" PRIu64 "): send right %d, fence data size %" PRIu64, (uint64_t, int, uint64_t), INFO, Media
 
-MEDIAPLAYERPRIVATEREMOTE_LAYERHOSTINGCONTEXTCHANGED, "MediaPlayerPrivateRemote::layerHostingContextChanged", (), DEFAULT, Media
+MediaPlayerPrivateRemoteLayerHostingContextChanged, "MediaPlayerPrivateRemote::layerHostingContextChanged", (), DEFAULT, Media

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -68,7 +68,7 @@ using namespace WebCore;
 Ref<RemoteRenderingBackendProxy> RemoteRenderingBackendProxy::create(WebPage& webPage)
 {
     Ref instance = adoptRef(*new RemoteRenderingBackendProxy(RunLoop::mainSingleton()));
-    RELEASE_LOG_FORWARDABLE(RemoteLayerBuffers, REMOTE_RENDERING_BACKEND_PROXY_CREATED_RENDERING_BACKEND, instance->renderingBackendIdentifier().toUInt64(),  webPage.webPageProxyIdentifier().toUInt64(), webPage.identifier().toUInt64());
+    RELEASE_LOG_FORWARDABLE(RemoteLayerBuffers, RemoteRenderingBackendProxyCreatedRenderingBackend, instance->renderingBackendIdentifier().toUInt64(),  webPage.webPageProxyIdentifier().toUInt64(), webPage.identifier().toUInt64());
     return instance;
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm
@@ -82,7 +82,7 @@ WebCore::DestinationColorSpace MediaPlayerPrivateRemote::colorSpace()
 
 void MediaPlayerPrivateRemote::layerHostingContextChanged(WebCore::HostingContext&& inlineLayerHostingContext, const FloatSize& presentationSize)
 {
-    RELEASE_LOG_FORWARDABLE(Media, MEDIAPLAYERPRIVATEREMOTE_LAYERHOSTINGCONTEXTCHANGED);
+    RELEASE_LOG_FORWARDABLE(Media, MediaPlayerPrivateRemoteLayerHostingContextChanged);
 
     RefPtr player = m_player.get();
     if (!player)

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -248,7 +248,7 @@ void WebLoaderStrategy::scheduleLoad(ResourceLoader& resourceLoader, CachedResou
 
     if (resourceLoader.request().url().protocolIsData()) {
         LOG(NetworkScheduling, "(WebProcess) WebLoaderStrategy::scheduleLoad, url '%s' will be loaded as data.", resourceLoader.url().string().utf8().data());
-        WEBLOADERSTRATEGY_RELEASE_LOG_FORWARDABLE(WEBLOADERSTRATEGY_SCHEDULELOAD_URL_LOADED_AS_DATA);
+        WEBLOADERSTRATEGY_RELEASE_LOG_FORWARDABLE(WebLoaderStrategyScheduleLoadUrlLoadedAsData);
         startLocalLoad(resourceLoader);
         return;
     }
@@ -302,7 +302,7 @@ void WebLoaderStrategy::scheduleLoad(ResourceLoader& resourceLoader, CachedResou
         return;
     }
 
-    WEBLOADERSTRATEGY_RELEASE_LOG_FORWARDABLE(WEBLOADERSTRATEGY_SCHEDULELOAD);
+    WEBLOADERSTRATEGY_RELEASE_LOG_FORWARDABLE(WebLoaderStrategyScheduleLoad);
     scheduleLoadFromNetworkProcess(resourceLoader, resourceLoader.request(), *trackingParameters, shouldClearReferrerOnHTTPSToHTTPRedirect, maximumBufferingTime(resource));
 }
 
@@ -633,7 +633,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
     std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume;
     if (loadParameters.isMainFrameNavigation)
         existingNetworkResourceLoadIdentifierToResume = std::exchange(m_existingNetworkResourceLoadIdentifierToResume, std::nullopt);
-    WEBLOADERSTRATEGY_RELEASE_LOG_FORWARDABLE(WEBLOADERSTRATEGY_SCHEDULELOAD_RESOURCE_SCHEDULED_WITH_NETWORKPROCESS, static_cast<int>(resourceLoader.request().priority()), existingNetworkResourceLoadIdentifierToResume ? existingNetworkResourceLoadIdentifierToResume->toUInt64() : 0);
+    WEBLOADERSTRATEGY_RELEASE_LOG_FORWARDABLE(WebLoaderStrategyScheduleLoadResourceScheduledWithNetworkProcess, static_cast<int>(resourceLoader.request().priority()), existingNetworkResourceLoadIdentifierToResume ? existingNetworkResourceLoadIdentifierToResume->toUInt64() : 0);
 
     loadParameters.isInitiatedByDedicatedWorker = resourceLoader.options().initiatorContext == InitiatorContext::Worker && std::holds_alternative<std::monostate>(resourceLoader.options().workerIdentifier);
     if (WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::ScheduleResourceLoad(WTF::move(loadParameters), existingNetworkResourceLoadIdentifierToResume), 0) != IPC::Error::NoError) {

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -81,7 +81,7 @@ WebResourceLoader::WebResourceLoader(Ref<WebCore::ResourceLoader>&& coreLoader, 
     , m_trackingParameters(trackingParameters)
     , m_loadStart(MonotonicTime::now())
 {
-    WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_CONSTRUCTOR);
+    WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderConstructor);
 }
 
 WebResourceLoader::~WebResourceLoader() = default;
@@ -129,7 +129,7 @@ void WebResourceLoader::willSendRequest(ResourceRequest&& proposedRequest, IPC::
     proposedRequest.setHTTPBody(proposedRequestBody.takeData());
 
     LOG(Network, "(WebProcess) WebResourceLoader::willSendRequest to '%s'", proposedRequest.url().string().latin1().data());
-    WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_WILLSENDREQUEST);
+    WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderWillSendRequest);
     
     if (RefPtr frame = coreLoader->frame()) {
         if (RefPtr page = frame->page()) {
@@ -141,11 +141,11 @@ void WebResourceLoader::willSendRequest(ResourceRequest&& proposedRequest, IPC::
     coreLoader->willSendRequest(WTF::move(proposedRequest), redirectResponse, [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)] (ResourceRequest&& request) mutable {
         RefPtr coreLoader = m_coreLoader;
         if (!m_coreLoader || !coreLoader->identifier()) {
-            WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_WILLSENDREQUEST_NO_CORELOADER);
+            WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderWillSendRequestNoCoreLoader);
             return completionHandler({ }, false);
         }
 
-        WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_WILLSENDREQUEST_CONTINUE);
+        WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderWillSendRequestContinue);
         completionHandler(WTF::move(request), coreLoader->isAllowedToAskUserForCredentials());
     });
 }
@@ -192,7 +192,7 @@ void WebResourceLoader::didReceiveResponse(ResourceResponse&& response, PrivateR
 {
     RefPtr coreLoader = m_coreLoader;
     LOG(Network, "(WebProcess) WebResourceLoader::didReceiveResponse for '%s'. Status %d.", coreLoader->url().string().latin1().data(), response.httpStatusCode());
-    WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDRECEIVERESPONSE, response.httpStatusCode());
+    WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderDidReceiveResponse, response.httpStatusCode());
 
     Ref<WebResourceLoader> protectedThis(*this);
 
@@ -218,7 +218,7 @@ void WebResourceLoader::didReceiveResponse(ResourceResponse&& response, PrivateR
             if (m_coreLoader && coreLoader->identifier())
                 send(Messages::NetworkResourceLoader::ContinueDidReceiveResponse());
             else
-                WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDRECEIVERESPONSE_NOT_CONTINUING_LOAD);
+                WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderDidReceiveResponseNotContinuingLoad);
         };
     }
 
@@ -229,7 +229,7 @@ void WebResourceLoader::didReceiveResponse(ResourceResponse&& response, PrivateR
         InspectorInstrumentationWebKit::interceptResponse(frame.get(), response, interceptedRequestIdentifier, [this, protectedThis = Ref { *this }, interceptedRequestIdentifier, policyDecisionCompletionHandler = WTF::move(policyDecisionCompletionHandler)](const ResourceResponse& inspectorResponse, RefPtr<FragmentedSharedBuffer> overrideData) mutable {
             RefPtr coreLoader = m_coreLoader;
             if (!m_coreLoader || !coreLoader->identifier()) {
-                WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDRECEIVERESPONSE_NOT_CONTINUING_INTERCEPT_LOAD);
+                WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderDidReceiveResponseNotContinuingInterceptLoad);
                 m_interceptController.continueResponse(interceptedRequestIdentifier);
                 return;
             }
@@ -277,7 +277,7 @@ void WebResourceLoader::didReceiveData(IPC::SharedBufferReference&& data, uint64
 
     bool isFirstDidReceiveData = !m_numBytesReceived;
     if (isFirstDidReceiveData)
-        WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDRECEIVEDATA);
+        WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderDidReceiveData);
     m_numBytesReceived += data.size();
 
     auto delta = calculateBytesTransferredOverNetworkDelta(bytesTransferredOverNetwork);
@@ -310,7 +310,7 @@ void WebResourceLoader::didFinishResourceLoad(NetworkLoadMetrics&& networkLoadMe
 {
     RefPtr coreLoader = m_coreLoader;
     LOG(Network, "(WebProcess) WebResourceLoader::didFinishResourceLoad for '%s'", coreLoader->url().string().latin1().data());
-    WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDFINISHRESOURCELOAD, static_cast<uint64_t>(m_numBytesReceived));
+    WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderDidFinishResourceLoad, static_cast<uint64_t>(m_numBytesReceived));
 
     if (m_interceptController.isIntercepting(*coreLoader->identifier())) [[unlikely]] {
         m_interceptController.defer(*coreLoader->identifier(), [this, protectedThis = Ref { *this }, networkLoadMetrics = WTF::move(networkLoadMetrics)]() mutable {
@@ -353,7 +353,7 @@ void WebResourceLoader::didFailServiceWorkerLoad(const ResourceError& error)
 void WebResourceLoader::serviceWorkerDidNotHandle()
 {
     RefPtr coreLoader = m_coreLoader;
-    WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_SERVICEWORKERDIDNOTHANDLE);
+    WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderServiceWorkerDidNotHandle);
 
     ASSERT(coreLoader->options().serviceWorkersMode == ServiceWorkersMode::Only);
     auto error = internalError(coreLoader->request().url());
@@ -371,7 +371,7 @@ void WebResourceLoader::didFailResourceLoad(const ResourceError& error)
 {
     RefPtr coreLoader = m_coreLoader;
     LOG(Network, "(WebProcess) WebResourceLoader::didFailResourceLoad for '%s'", coreLoader->url().string().latin1().data());
-    WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDFAILRESOURCELOAD);
+    WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderDidFailResourceLoad);
 
     if (m_interceptController.isIntercepting(*coreLoader->identifier())) [[unlikely]] {
         m_interceptController.defer(*coreLoader->identifier(), [this, protectedThis = Ref { *this }, error]() mutable {
@@ -390,7 +390,7 @@ void WebResourceLoader::didBlockAuthenticationChallenge()
 {
     RefPtr coreLoader = m_coreLoader;
     LOG(Network, "(WebProcess) WebResourceLoader::didBlockAuthenticationChallenge for '%s'", coreLoader->url().string().latin1().data());
-    WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDBLOCKAUTHENTICATIONCHALLENGE);
+    WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderDidBlockAuthenticationChallenge);
 
     coreLoader->didBlockAuthenticationChallenge();
 }
@@ -399,7 +399,7 @@ void WebResourceLoader::stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDeni
 {
     RefPtr coreLoader = m_coreLoader;
     LOG(Network, "(WebProcess) WebResourceLoader::stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied for '%s'", coreLoader->url().string().latin1().data());
-    WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_STOPLOADINGAFTERSECURITYPOLICYDENIED);
+    WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderStopLoadingAfterSecurityPolicyDenied);
 
     protect(coreLoader->documentLoader())->stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied(*coreLoader->identifier(), response);
 }
@@ -409,13 +409,13 @@ void WebResourceLoader::didReceiveResource(ShareableResource::Handle&& handle)
 {
     RefPtr coreLoader = m_coreLoader;
     LOG(Network, "(WebProcess) WebResourceLoader::didReceiveResource for '%s'", coreLoader->url().string().latin1().data());
-    WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDRECEIVERESOURCE);
+    WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderDidReceiveResource);
 
     RefPtr<SharedBuffer> buffer = WTF::move(handle).tryWrapInSharedBuffer();
 
     if (!buffer) {
         LOG_ERROR("Unable to create buffer from ShareableResource sent from the network process.");
-        WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDRECEIVERESOURCE_UNABLE_TO_CREATE_FRAGMENTEDSHAREDBUFFER);
+        WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderDidReceiveResourceUnableToCreateFragmentedSharedBuffer);
         if (RefPtr frame = coreLoader->frame()) {
             if (RefPtr page = frame->page())
                 protect(page->diagnosticLoggingClient())->logDiagnosticMessage(WebCore::DiagnosticLoggingKeys::internalErrorKey(), WebCore::DiagnosticLoggingKeys::createSharedBufferFailedKey(), WebCore::ShouldSample::No);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -70,13 +70,13 @@ std::optional<NavigationActionData> WebFrameLoaderClient::navigationActionData(c
 {
     RefPtr webPage = m_frame->page();
     if (!webPage) {
-        WebFrameLoaderClient_RELEASE_LOG_ERROR(WEBFRAMELOADERCLIENT_NAVIGATIONACTIONDATA_NO_WEBPAGE);
+        WebFrameLoaderClient_RELEASE_LOG_ERROR(WebFrameLoaderClientNavigationActionDataNoWebPage);
         return std::nullopt;
     }
 
     // Always ignore requests with empty URLs.
     if (request.isEmpty()) {
-        WebFrameLoaderClient_RELEASE_LOG_ERROR(WEBFRAMELOADERCLIENT_NAVIGATIONACTIONDATA_EMPTY_REQUEST);
+        WebFrameLoaderClient_RELEASE_LOG_ERROR(WebFrameLoaderClientNavigationActionDataEmptyRequest);
         return std::nullopt;
     }
 
@@ -87,7 +87,7 @@ std::optional<NavigationActionData> WebFrameLoaderClient::navigationActionData(c
 
     auto& requester = *navigationAction.requester();
     if (!requester.frameID) {
-        WebFrameLoaderClient_RELEASE_LOG_ERROR(WEBFRAMELOADERCLIENT_NAVIGATIONACTIONDATA_NO_FRAME);
+        WebFrameLoaderClient_RELEASE_LOG_ERROR(WebFrameLoaderClientNavigationActionDataNoFrame);
         return std::nullopt;
     }
 
@@ -202,13 +202,13 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const Navigat
         if (navigationAction.processingUserGesture() || navigationAction.isFromNavigationAPI() || shouldUseSyncIPCForFragmentNavigations) {
             auto sendResult = webPage->sendSync(Messages::WebPageProxy::DecidePolicyForNavigationActionSync(*navigationActionData));
             if (!sendResult.succeeded()) {
-                WebFrameLoaderClient_RELEASE_LOG_ERROR(WEBFRAMELOADERCLIENT_DISPATCHDECIDEPOLICYFORNAVIGATIONACTION_SYNC_IPC_FAILED, (uint8_t)sendResult.error());
+                WebFrameLoaderClient_RELEASE_LOG_ERROR(WebFrameLoaderClientDispatchDecidePolicyForNavigationActionSyncIpcFailed, (uint8_t)sendResult.error());
                 m_frame->didReceivePolicyDecision(listenerID, PolicyDecision { });
                 return;
             }
 
             auto [policyDecision] = sendResult.takeReply();
-            WebFrameLoaderClient_RELEASE_LOG(WEBFRAMELOADERCLIENT_DISPATCHDECIDEPOLICYFORNAVIGATIONACTION_GOT_POLICYACTION_FROM_SYNC_IPC, toString(policyDecision.policyAction).characters());
+            WebFrameLoaderClient_RELEASE_LOG(WebFrameLoaderClientDispatchDecidePolicyForNavigationActionGotPolicyActionFromSyncIpc, toString(policyDecision.policyAction).characters());
             m_frame->didReceivePolicyDecision(listenerID, PolicyDecision { policyDecision.isNavigatingToAppBoundDomain, policyDecision.policyAction, { }, policyDecision.downloadID });
             return;
         }
@@ -223,7 +223,7 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const Navigat
         if (!frame)
             return;
 
-        RELEASE_LOG_FORWARDABLE(Network, WEBFRAMELOADERCLIENT_DISPATCHDECIDEPOLICYFORNAVIGATIONACTION_GOT_POLICYACTION_FROM_ASYNC_IPC, frame->frameID().toUInt64(), webPageID, toString(policyDecision.policyAction).characters());
+        RELEASE_LOG_FORWARDABLE(Network, WebFrameLoaderClientDispatchDecidePolicyForNavigationActionGotPolicyActionFromAsyncIpc, frame->frameID().toUInt64(), webPageID, toString(policyDecision.policyAction).characters());
 
         frame->didReceivePolicyDecision(listenerID, WTF::move(policyDecision));
     });

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -805,7 +805,7 @@ void WebLocalFrameLoaderClient::completePageTransitionIfNeeded()
     // we eventually dispatch when the transition is complete.
     fireLayoutRelatedMilestonesIfNeeded();
 
-    WebLocalFrameLoaderClient_RELEASE_LOG_FORWARDABLE(Layout, WEBLOCALFRAMELOADERCLIENT_COMPLETE_PAGE_TRANSITION_IF_NEEDED);
+    WebLocalFrameLoaderClient_RELEASE_LOG_FORWARDABLE(Layout, WebLocalFrameLoaderClientCompletePageTransitionIfNeeded);
 }
 
 bool WebLocalFrameLoaderClient::shouldSuppressLayoutMilestones() const
@@ -844,7 +844,7 @@ void WebLocalFrameLoaderClient::dispatchDidReachLayoutMilestone(OptionSet<WebCor
     RefPtr<API::Object> userData;
 
     if (milestones & WebCore::LayoutMilestone::DidFirstLayout) {
-        WebLocalFrameLoaderClient_RELEASE_LOG_FORWARDABLE(Layout, WEBLOCALFRAMELOADERCLIENT_DISPATCH_DID_FIRST_LAYOUT_FOR_FRAME);
+        WebLocalFrameLoaderClient_RELEASE_LOG_FORWARDABLE(Layout, WebLocalFrameLoaderClientDispatchDidFirstLayoutForFrame);
 
         // FIXME: We should consider removing the old didFirstLayout API since this is doing double duty with the
         // new didLayout API.
@@ -871,7 +871,7 @@ void WebLocalFrameLoaderClient::dispatchDidReachLayoutMilestone(OptionSet<WebCor
     addIfSet(WebCore::LayoutMilestone::DidRenderSignificantAmountOfText, "DidRenderSignificantAmountOfText"_s);
     addIfSet(WebCore::LayoutMilestone::DidFirstMeaningfulPaint, "DidFirstMeaningfulPaint"_s);
 
-    WebLocalFrameLoaderClient_RELEASE_LOG_FORWARDABLE(Layout, WEBLOCALFRAMELOADERCLIENT_DISPATCH_DID_REACH_LAYOUT_MILESTONE, builder.toString().utf8().data());
+    WebLocalFrameLoaderClient_RELEASE_LOG_FORWARDABLE(Layout, WebLocalFrameLoaderClientDispatchDidReachLayoutMilestone, builder.toString().utf8().data());
 #endif
 
     // Send this after DidFirstLayout-specific calls since some clients expect to get those messages first.
@@ -880,7 +880,7 @@ void WebLocalFrameLoaderClient::dispatchDidReachLayoutMilestone(OptionSet<WebCor
     if (milestones & WebCore::LayoutMilestone::DidFirstVisuallyNonEmptyLayout) {
         ASSERT(!m_frame->isMainFrame() || webPage->corePage()->settings().suppressesIncrementalRendering() || m_didCompletePageTransition);
         // FIXME: We should consider removing the old didFirstVisuallyNonEmptyLayoutForFrame API since this is doing double duty with the new didLayout API.
-        WebLocalFrameLoaderClient_RELEASE_LOG_FORWARDABLE(Layout, WEBLOCALFRAMELOADERCLIENT_DISPATCH_DID_FIRST_VISUALLY_NONEMPTY_LAYOUT);
+        WebLocalFrameLoaderClient_RELEASE_LOG_FORWARDABLE(Layout, WebLocalFrameLoaderClientDispatchDidFirstVisuallyNonEmptyLayout);
         webPage->injectedBundleLoaderClient().didFirstVisuallyNonEmptyLayoutForFrame(*webPage, m_frame, userData);
         webPage->send(Messages::WebPageProxy::DidFirstVisuallyNonEmptyLayoutForFrame(m_frame->frameID(), UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get()), WallTime::now()));
     }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2031,7 +2031,7 @@ void WebPage::close()
 
     flushDeferredDidReceiveMouseEvent();
 
-    WEBPAGE_RELEASE_LOG_FORWARDABLE(Loading, WEBPAGE_CLOSE);
+    WEBPAGE_RELEASE_LOG_FORWARDABLE(Loading, WebPageClose);
 
     if (RefPtr networkProcessConnection = WebProcess::singleton().existingNetworkProcessConnection())
         networkProcessConnection->connection().send(Messages::NetworkConnectionToWebProcess::ClearPageSpecificData(m_identifier), 0);
@@ -2228,7 +2228,7 @@ void WebPage::loadDidCommitInAnotherProcess(WebCore::FrameIdentifier frameID, st
 
 void WebPage::loadRequest(LoadParameters&& loadParameters)
 {
-    WEBPAGE_RELEASE_LOG_FORWARDABLE(Loading, WEBPAGE_LOADREQUEST, loadParameters.navigationID ? loadParameters.navigationID->toUInt64() : 0, static_cast<unsigned>(loadParameters.shouldTreatAsContinuingLoad), loadParameters.request.isAppInitiated(), loadParameters.existingNetworkResourceLoadIdentifierToResume ? loadParameters.existingNetworkResourceLoadIdentifierToResume->toUInt64() : 0);
+    WEBPAGE_RELEASE_LOG_FORWARDABLE(Loading, WebPageLoadRequest, loadParameters.navigationID ? loadParameters.navigationID->toUInt64() : 0, static_cast<unsigned>(loadParameters.shouldTreatAsContinuingLoad), loadParameters.request.isAppInitiated(), loadParameters.existingNetworkResourceLoadIdentifierToResume ? loadParameters.existingNetworkResourceLoadIdentifierToResume->toUInt64() : 0);
 
     RefPtr frame = loadParameters.frameIdentifier ? WebProcess::singleton().webFrame(*loadParameters.frameIdentifier) : m_mainFrame.ptr();
     if (!frame) {
@@ -3551,7 +3551,7 @@ void WebPage::freezeLayerTree(LayerTreeFreezeReason reason)
     auto oldReasons = m_layerTreeFreezeReasons.toRaw();
     UNUSED_PARAM(oldReasons);
     m_layerTreeFreezeReasons.add(reason);
-    WEBPAGE_RELEASE_LOG_FORWARDABLE(ProcessSuspension, WEBPAGE_FREEZE_LAYER_TREE, static_cast<unsigned>(reason), m_layerTreeFreezeReasons.toRaw(), oldReasons);
+    WEBPAGE_RELEASE_LOG_FORWARDABLE(ProcessSuspension, WebPageFreezeLayerTree, static_cast<unsigned>(reason), m_layerTreeFreezeReasons.toRaw(), oldReasons);
     updateDrawingAreaLayerTreeFreezeState();
 }
 
@@ -3560,7 +3560,7 @@ void WebPage::unfreezeLayerTree(LayerTreeFreezeReason reason)
     auto oldReasons = m_layerTreeFreezeReasons.toRaw();
     UNUSED_PARAM(oldReasons);
     m_layerTreeFreezeReasons.remove(reason);
-    WEBPAGE_RELEASE_LOG_FORWARDABLE(ProcessSuspension, WEBPAGE_UNFREEZE_LAYER_TREE, static_cast<unsigned>(reason), m_layerTreeFreezeReasons.toRaw(), oldReasons);
+    WEBPAGE_RELEASE_LOG_FORWARDABLE(ProcessSuspension, WebPageUnfreezeLayerTree, static_cast<unsigned>(reason), m_layerTreeFreezeReasons.toRaw(), oldReasons);
     updateDrawingAreaLayerTreeFreezeState();
 }
 
@@ -3626,7 +3626,7 @@ void WebPage::layerVolatilityTimerFired()
 
 void WebPage::markLayersVolatile(CompletionHandler<void(bool)>&& completionHandler)
 {
-    WEBPAGE_RELEASE_LOG_FORWARDABLE(Layers, WEBPAGE_MARK_LAYERS_VOLATILE);
+    WEBPAGE_RELEASE_LOG_FORWARDABLE(Layers, WebPageMarkLayersVolatile);
 
     if (m_layerVolatilityTimer.isActive())
         m_layerVolatilityTimer.stop();
@@ -3675,7 +3675,7 @@ void WebPage::tryMarkLayersVolatileCompletionHandler(MarkLayersVolatileDontRetry
         return;
     }
 
-    WEBPAGE_RELEASE_LOG_FORWARDABLE(Layers, WEBPAGE_FAILED_TO_MARK_ALL_LAYERS_VOLATILE, m_layerVolatilityTimerInterval.milliseconds());
+    WEBPAGE_RELEASE_LOG_FORWARDABLE(Layers, WebPageFailedToMarkAllLayersVolatile, m_layerVolatilityTimerInterval.milliseconds());
     m_layerVolatilityTimer.startOneShot(m_layerVolatilityTimerInterval);
 }
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1782,7 +1782,7 @@ void WebProcess::prepareToSuspend(bool isSuspensionImminent, MonotonicTime estim
     double remainingRunTime = nowTime > estimatedSuspendTime ? (nowTime - estimatedSuspendTime).value() : 0.0;
 #endif
 
-    WEBPROCESS_RELEASE_LOG_FORWARDABLE(ProcessSuspension, WEBPROCESS_PREPARE_TO_SUSPEND, isSuspensionImminent, remainingRunTime);
+    WEBPROCESS_RELEASE_LOG_FORWARDABLE(ProcessSuspension, WebProcessPrepareToSuspend, isSuspensionImminent, remainingRunTime);
     SetForScope allowExitScope(m_allowExitOnMemoryPressure, false);
     m_processIsSuspended = true;
 
@@ -1790,7 +1790,7 @@ void WebProcess::prepareToSuspend(bool isSuspensionImminent, MonotonicTime estim
 
 #if PLATFORM(COCOA)
     if (m_processType == ProcessType::PrewarmedWebContent) {
-        WEBPROCESS_RELEASE_LOG_FORWARDABLE(ProcessSuspension, WEBPROCESS_READY_TO_SUSPEND);
+        WEBPROCESS_RELEASE_LOG_FORWARDABLE(ProcessSuspension, WebProcessReadyToSuspend);
         return completionHandler();
     }
 #endif
@@ -1823,7 +1823,7 @@ void WebProcess::prepareToSuspend(bool isSuspensionImminent, MonotonicTime estim
 #endif
 
     markAllLayersVolatile([this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)]() mutable {
-        WEBPROCESS_RELEASE_LOG_FORWARDABLE(ProcessSuspension, WEBPROCESS_READY_TO_SUSPEND);
+        WEBPROCESS_RELEASE_LOG_FORWARDABLE(ProcessSuspension, WebProcessReadyToSuspend);
         completionHandler();
     });
 }
@@ -1844,7 +1844,7 @@ void WebProcess::accessibilityRelayProcessSuspended(bool suspended)
 
 void WebProcess::markAllLayersVolatile(CompletionHandler<void()>&& completionHandler)
 {
-    WEBPROCESS_RELEASE_LOG_FORWARDABLE(ProcessSuspension, WEBPROCESS_MARK_ALL_LAYERS_VOLATILE);
+    WEBPROCESS_RELEASE_LOG_FORWARDABLE(ProcessSuspension, WebProcessMarkAllLayersVolatile);
     auto callbackAggregator = CallbackAggregator::create(WTF::move(completionHandler));
     for (auto& page : m_pageMap.values()) {
         page->markLayersVolatile([this, protectedThis = Ref { *this }, callbackAggregator, pageID = page->identifier()] (bool succeeded) {
@@ -1865,7 +1865,7 @@ void WebProcess::cancelMarkAllLayersVolatile()
 
 void WebProcess::freezeAllLayerTrees()
 {
-    WEBPROCESS_RELEASE_LOG_FORWARDABLE(ProcessSuspension, WEBPROCESS_FREEZE_ALL_LAYER_TREES);
+    WEBPROCESS_RELEASE_LOG_FORWARDABLE(ProcessSuspension, WebProcessFreezeAllLayerTrees);
     for (auto& page : m_pageMap.values())
         page->freezeLayerTree(WebPage::LayerTreeFreezeReason::ProcessSuspended);
 }

--- a/Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm
@@ -49,7 +49,7 @@ void LaunchServicesDatabaseManager::handleEvent(xpc_object_t message)
 #if HAVE(LSDATABASECONTEXT)
         OSObjectPtr<xpc_object_t> database = xpc_dictionary_get_value(message, LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseKey);
 
-        RELEASE_LOG_FORWARDABLE(Loading, RECEIVED_LAUNCH_SERVICES_DATABASE);
+        RELEASE_LOG_FORWARDABLE(Loading, ReceivedLaunchServicesDatabase);
 
         if (database)
             [LSDatabaseContext.sharedDatabaseContext observeDatabaseChange4WebKit:database.get()];
@@ -90,10 +90,10 @@ void LaunchServicesDatabaseManager::waitForDatabaseUpdate()
     bool databaseUpdated = waitForDatabaseUpdate(waitTime);
     auto elapsedTime = MonotonicTime::now() - startTime;
     if (elapsedTime > 0.5_s)
-        RELEASE_LOG_ERROR_FORWARDABLE(Loading, WAITING_FOR_LAUNCH_SERVICES_DATABASE_UPDATE_TOOK_F_SECONDS, elapsedTime.value());
+        RELEASE_LOG_ERROR_FORWARDABLE(Loading, WaitingForLaunchServicesDatabaseUpdateTookFSeconds, elapsedTime.value());
 
     if (!databaseUpdated)
-        RELEASE_LOG_FAULT_FORWARDABLE(Loading, TIMED_OUT_WAITING_FOR_LAUNCH_SERVICES_DATABASE_UPDATE);
+        RELEASE_LOG_FAULT_FORWARDABLE(Loading, TimedOutWaitingForLaunchServicesDatabaseUpdate);
 }
 
 }

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -920,7 +920,7 @@ void VideoPresentationManager::setCurrentVideoFullscreenMode(VideoPresentationIn
 
 void VideoPresentationManager::setVideoLayerFrameFenced(WebCore::MediaPlayerClientIdentifier contextId, WebCore::FloatRect bounds, WTF::MachSendRightAnnotated&& sendRightAnnotated)
 {
-    RELEASE_LOG_FORWARDABLE(Media, VIDEOPRESENTATIONMANAGER_SETVIDEOLAYERFRAMEFENCED, contextId.toUInt64(), sendRightAnnotated.sendRight.sendRight(), static_cast<uint64_t>(sendRightAnnotated.data.size()));
+    RELEASE_LOG_FORWARDABLE(Media, VideoPresentationManagerSetVideoLayerFrameFenced, contextId.toUInt64(), sendRightAnnotated.sendRight.sendRight(), static_cast<uint64_t>(sendRightAnnotated.data.size()));
 
     auto [model, interface] = ensureModelAndInterface(contextId);
 

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -403,7 +403,7 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
         setNotifyState(name, state);
 #endif
 
-    RELEASE_LOG_FORWARDABLE(Process, PLATFORM_INITIALIZE_WEBPROCESS);
+    RELEASE_LOG_FORWARDABLE(Process, PlatformInitializeWebProcess);
 
 #if USE(EXTENSIONKIT)
     // Workaround for crash seen when running tests. See rdar://118186487.
@@ -1219,7 +1219,7 @@ void WebProcess::destroyRenderingResources()
 #if !RELEASE_LOG_DISABLED
     MonotonicTime endTime = MonotonicTime::now();
 #endif
-    WEBPROCESS_RELEASE_LOG_FORWARDABLE(ProcessSuspension, WEBPROCESS_DESTROY_RENDERING_RESOURCES, (endTime - startTime).milliseconds());
+    WEBPROCESS_RELEASE_LOG_FORWARDABLE(ProcessSuspension, WebProcessDestroyRenderingResources, (endTime - startTime).milliseconds());
 }
 
 void WebProcess::releaseSystemMallocMemory()


### PR DESCRIPTION
#### 7102afe2713b40a28b31e225f5e7daf77af971a5
<pre>
Stop using all caps in log identifiers in WebKit log definitions
<a href="https://bugs.webkit.org/show_bug.cgi?id=311949">https://bugs.webkit.org/show_bug.cgi?id=311949</a>
<a href="https://rdar.apple.com/174504118">rdar://174504118</a>

Reviewed by Rupin Mittal.

This is to improve readability.

* Source/WebKit/Platform/LogMessages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::create):
* Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm:
(WebKit::MediaPlayerPrivateRemote::layerHostingContextChanged):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoad):
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::WebResourceLoader):
(WebKit::WebResourceLoader::willSendRequest):
(WebKit::WebResourceLoader::didReceiveResponse):
(WebKit::WebResourceLoader::didReceiveData):
(WebKit::WebResourceLoader::didFinishResourceLoad):
(WebKit::WebResourceLoader::serviceWorkerDidNotHandle):
(WebKit::WebResourceLoader::didFailResourceLoad):
(WebKit::WebResourceLoader::didBlockAuthenticationChallenge):
(WebKit::WebResourceLoader::stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied):
(WebKit::WebResourceLoader::didReceiveResource):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::navigationActionData const):
(WebKit::WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::completePageTransitionIfNeeded):
(WebKit::WebLocalFrameLoaderClient::dispatchDidReachLayoutMilestone):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::close):
(WebKit::WebPage::loadRequest):
(WebKit::WebPage::freezeLayerTree):
(WebKit::WebPage::unfreezeLayerTree):
(WebKit::WebPage::markLayersVolatile):
(WebKit::WebPage::tryMarkLayersVolatileCompletionHandler):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::prepareToSuspend):
(WebKit::WebProcess::markAllLayersVolatile):
(WebKit::WebProcess::freezeAllLayerTrees):
* Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm:
(WebKit::LaunchServicesDatabaseManager::handleEvent):
(WebKit::LaunchServicesDatabaseManager::waitForDatabaseUpdate):
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::setVideoLayerFrameFenced):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):

Canonical link: <a href="https://commits.webkit.org/311047@main">https://commits.webkit.org/311047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71e78bdb734eb9df7ae3decf04a5471fc3bd796f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164328 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109362 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61523e13-815b-471a-9bb6-fcfd0a1bdb0c) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28971 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28675 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120398 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 9 flakes 7 failures; Uploaded test results; 1 flakes; Passed layout tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84898 "2 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139698 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101088 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21674 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19789 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12158 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131343 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166805 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10983 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19141 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128515 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28369 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23823 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128648 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139323 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85736 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23736 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23474 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16120 "Passed tests") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27987 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92090 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27564 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27794 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27637 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->