### PR TITLE
[GFC] Make item placement avoidance reasons more fine grained

### DIFF
--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -71,8 +71,21 @@ enum class GridAvoidanceReason : uint8_t {
     GridItemHasUnsupportedBlockAxisAlignment,
     GridItemHasNonVisibleOverflow,
     GridItemHasContainsSize,
-    GridItemHasUnsupportedColumnPlacement,
-    GridItemHasUnsupportedRowPlacement,
+
+    GridItemColumnStartHasLineName,
+    GridItemColumnStartHasNegativeLineNumber,
+    GridItemColumnStartHasSpan,
+    GridItemHasColumnStartOutsideExplicitGrid,
+    GridItemHasUnsupportedColumnEnd,
+
+    GridNeedsImplicitColumnsForItemsLockedToRow,
+    GridItemHasAutomaticRowStartPlacement,
+    GridItemRowStartHasLineName,
+    GridItemRowStartHasNegativeLineNumber,
+    GridItemRowStartHasSpan,
+    GridItemHasRowStartOutsideExplicitGrid,
+    GridItemHasUnsupportedRowEnd,
+
     GridItemHasUnsupportedWidthValue,
     GridItemHasUnsupportedAutomaticInlineSizing,
     GridItemHasUnsupportedHeightValue,
@@ -82,6 +95,37 @@ enum class GridAvoidanceReason : uint8_t {
     NotAGrid,
     GridFormattingContextIntegrationDisabled,
 };
+
+#if ASSERT_ENABLED
+static bool avoidanceReasonIsColumnPlacementRelated(GridAvoidanceReason gridAvoidanceReason)
+{
+    switch (gridAvoidanceReason) {
+    case GridAvoidanceReason::GridItemColumnStartHasLineName:
+    case GridAvoidanceReason::GridItemColumnStartHasNegativeLineNumber:
+    case GridAvoidanceReason::GridItemColumnStartHasSpan:
+    case GridAvoidanceReason::GridItemHasColumnStartOutsideExplicitGrid:
+    case GridAvoidanceReason::GridItemHasUnsupportedColumnEnd:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static bool avoidanceReasonIsRowPlacementRelated(GridAvoidanceReason gridAvoidanceReason)
+{
+    switch (gridAvoidanceReason) {
+    case GridAvoidanceReason::GridItemHasAutomaticRowStartPlacement:
+    case GridAvoidanceReason::GridItemRowStartHasLineName:
+    case GridAvoidanceReason::GridItemRowStartHasNegativeLineNumber:
+    case GridAvoidanceReason::GridItemRowStartHasSpan:
+    case GridAvoidanceReason::GridItemHasRowStartOutsideExplicitGrid:
+    case GridAvoidanceReason::GridItemHasUnsupportedRowEnd:
+        return true;
+    default:
+        return false;
+    }
+}
+#endif
 
 #ifndef NDEBUG
 #define ADD_REASON_AND_RETURN_IF_NEEDED(reason, reasons, reasonCollectionMode) { \
@@ -96,7 +140,6 @@ enum class GridAvoidanceReason : uint8_t {
         return reasons; \
     }
 #endif
-
 
 static bool hasValidColumnEnd(const Style::GridPositionExplicit& explicitColumnStart, const Style::GridPosition columnEnd, size_t linesFromGridTemplateColumnsCount)
 {
@@ -429,42 +472,51 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
             [&](const CSS::Keyword::Auto& autoPosition) -> std::optional<GridAvoidanceReason> {
                 auto& columnEnd = gridItemStyle->gridItemColumnEnd();
                 if (!hasValidColumnEnd(autoPosition, columnEnd))
-                    return GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement;
+                    return GridAvoidanceReason::GridItemHasUnsupportedColumnEnd;
                 return { };
             },
             [&](const Style::GridPositionExplicit& explicitPosition) -> std::optional<GridAvoidanceReason> {
-                if (!columnStart.namedGridLine().isEmpty() || columnStart.explicitPosition() < 0 || columnStart.explicitPosition() > static_cast<int>(linesFromGridTemplateColumnsCount))
-                    return GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement;
+                auto columnStartLineNumber = explicitPosition.position.value;
+                if (!columnStart.namedGridLine().isEmpty())
+                    return GridAvoidanceReason::GridItemColumnStartHasLineName;
+                if (columnStartLineNumber < 0)
+                    return GridAvoidanceReason::GridItemColumnStartHasNegativeLineNumber;
+                if (columnStartLineNumber > static_cast<int>(linesFromGridTemplateColumnsCount))
+                    return GridAvoidanceReason::GridItemHasColumnStartOutsideExplicitGrid;
                 if (!hasValidColumnEnd(explicitPosition, gridItemStyle->gridItemColumnEnd(), linesFromGridTemplateColumnsCount))
-                    return GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement;
+                    return GridAvoidanceReason::GridItemHasUnsupportedColumnEnd;
                 return { };
             },
             [&](const Style::GridPositionSpan&) -> std::optional<GridAvoidanceReason> {
-                return GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement;
+                return GridAvoidanceReason::GridItemColumnStartHasSpan;
             },
             [&](const Style::CustomIdent&) -> std::optional<GridAvoidanceReason> {
-                return GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement;
+                return GridAvoidanceReason::GridItemColumnStartHasLineName;
             }
         );
 
         if (columnPositioningAvoidanceReason) {
-            ASSERT(columnPositioningAvoidanceReason == GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement);
+            ASSERT(avoidanceReasonIsColumnPlacementRelated(*columnPositioningAvoidanceReason));
             ADD_REASON_AND_RETURN_IF_NEEDED(*columnPositioningAvoidanceReason, reasons, reasonCollectionMode);
         }
 
         auto& rowStart = gridItemStyle->gridItemRowStart();
         auto rowPositioningAvoidanceReason = WTF::switchOn(rowStart,
             [&](const CSS::Keyword::Auto&) -> std::optional<GridAvoidanceReason> {
-                return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
+                return GridAvoidanceReason::GridItemHasAutomaticRowStartPlacement;
             },
             [&](const Style::GridPositionExplicit& explicitPosition) -> std::optional<GridAvoidanceReason> {
                 auto rowStartLineNumber = explicitPosition.position.value;
-                if (!rowStart.namedGridLine().isEmpty() || rowStartLineNumber < 0 || rowStartLineNumber > static_cast<int>(linesFromGridTemplateRowsCount))
-                    return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
+                if (!rowStart.namedGridLine().isEmpty())
+                    return GridAvoidanceReason::GridItemRowStartHasLineName;
+                if (rowStartLineNumber < 0)
+                    return GridAvoidanceReason::GridItemRowStartHasNegativeLineNumber;
+                if (rowStartLineNumber > static_cast<int>(linesFromGridTemplateRowsCount))
+                    return GridAvoidanceReason::GridItemHasRowStartOutsideExplicitGrid;
 
                 auto rowEnd = gridItemStyle->gridItemRowEnd();
                 if (!hasValidRowEnd(explicitPosition, rowEnd, linesFromGridTemplateRowsCount))
-                    return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
+                    return GridAvoidanceReason::GridItemHasUnsupportedRowEnd;
 
                 ASSERT(rowEnd.isExplicit());
                 size_t rowIndex = rowStartLineNumber + 1;
@@ -475,15 +527,15 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
                 return { };
             },
             [&](const Style::GridPositionSpan&) -> std::optional<GridAvoidanceReason> {
-                return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
+                return GridAvoidanceReason::GridItemRowStartHasSpan;
             },
             [&](const Style::CustomIdent&) -> std::optional<GridAvoidanceReason> {
-                return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
+                return GridAvoidanceReason::GridItemRowStartHasLineName;
             }
         );
 
         if (rowPositioningAvoidanceReason) {
-            ASSERT(rowPositioningAvoidanceReason == GridAvoidanceReason::GridItemHasUnsupportedRowPlacement);
+            ASSERT(avoidanceReasonIsRowPlacementRelated(*rowPositioningAvoidanceReason));
             ADD_REASON_AND_RETURN_IF_NEEDED(*rowPositioningAvoidanceReason, reasons, reasonCollectionMode);
         }
 
@@ -495,7 +547,7 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
             return itemsInRowCount >= linesFromGridTemplateColumnsCount;
         });
         if (ineligibleRowIndex != notFound)
-            ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasUnsupportedRowPlacement, reasons, reasonCollectionMode);
+            ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridNeedsImplicitColumnsForItemsLockedToRow, reasons, reasonCollectionMode);
 
         if (gridItemStyle->writingMode().isVertical())
             ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridItemHasVerticalWritingMode, reasons, reasonCollectionMode);
@@ -641,11 +693,41 @@ static void printReason(GridAvoidanceReason reason, TextStream& stream)
     case GridAvoidanceReason::GridItemHasContainsSize:
         stream << "grid item has contains: size";
         break;
-    case GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement:
-        stream << "grid item has unsupported column placement";
+    case GridAvoidanceReason::GridItemColumnStartHasLineName:
+        stream << "grid item column start has line name";
         break;
-    case GridAvoidanceReason::GridItemHasUnsupportedRowPlacement:
-        stream << "grid item has unsupported row placement";
+    case GridAvoidanceReason::GridItemColumnStartHasNegativeLineNumber:
+        stream << "grid item column start has negative line number";
+        break;
+    case GridAvoidanceReason::GridItemColumnStartHasSpan:
+        stream << "grid item column start has span";
+        break;
+    case GridAvoidanceReason::GridItemHasColumnStartOutsideExplicitGrid:
+        stream << "grid item has column start outside explicit grid";
+        break;
+    case GridAvoidanceReason::GridItemHasUnsupportedColumnEnd:
+        stream << "grid item has unsupported column end";
+        break;
+    case GridAvoidanceReason::GridNeedsImplicitColumnsForItemsLockedToRow:
+        stream << "grid needs implicit columns for items locked to row";
+        break;
+    case GridAvoidanceReason::GridItemHasAutomaticRowStartPlacement:
+        stream << "grid item has automatic row start placement";
+        break;
+    case GridAvoidanceReason::GridItemRowStartHasLineName:
+        stream << "grid item row start has line name";
+        break;
+    case GridAvoidanceReason::GridItemRowStartHasNegativeLineNumber:
+        stream << "grid item row start has negative line number";
+        break;
+    case GridAvoidanceReason::GridItemRowStartHasSpan:
+        stream << "grid item row start has span";
+        break;
+    case GridAvoidanceReason::GridItemHasRowStartOutsideExplicitGrid:
+        stream << "grid item has row start outside explicit grid";
+        break;
+    case GridAvoidanceReason::GridItemHasUnsupportedRowEnd:
+        stream << "grid item has unsupported row end";
         break;
     case GridAvoidanceReason::GridItemHasUnsupportedMinWidth:
         stream << "grid item has unsupported min-width";
@@ -653,7 +735,8 @@ static void printReason(GridAvoidanceReason reason, TextStream& stream)
     case GridAvoidanceReason::GridItemHasUnsupportedMinHeight:
         stream << "grid item has unsupported min-height";
         break;
-    default:
+    case GridAvoidanceReason::NotAGrid:
+        stream << "not a grid";
         break;
     }
 }


### PR DESCRIPTION
#### 539dfd8d9289e830ff89b6e4f7b527547731f5a7
<pre>
[GFC] Make item placement avoidance reasons more fine grained
<a href="https://bugs.webkit.org/show_bug.cgi?id=311950">https://bugs.webkit.org/show_bug.cgi?id=311950</a>
<a href="https://rdar.apple.com/174504708">rdar://174504708</a>

Reviewed by Brent Fulgham and Vitor Roriz.

Right now we have two generic avoidance reasons for column and row and
item placement of grid items. However, there are quite a few different
reasons we may return these values since placement is a bit complex. As
a result, we cannot actually know the specific reason we bail out of GFC
due to how an item is supposed to be placed.

By making these more fine grained we can look at how different types of
content are using the placement properties to figure out which are more
common than others.

Canonical link: <a href="https://commits.webkit.org/310984@main">https://commits.webkit.org/310984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fe820e36e3201223521cb828e11b632542fa28f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164424 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29068 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120475 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ae57e609-f01d-4296-933d-85f673ed3a09) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22647 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139773 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101164 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12254 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131402 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166903 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/11079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19216 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128593 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28465 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23908 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128725 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34891 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28389 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139398 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23537 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16195 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28083 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92186 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27660 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27890 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27733 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->