### PR TITLE
[JSC] Wasm stack results should match arguments

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -946,14 +946,10 @@ if ASSERT_ENABLED
     clobberVolatileRegisters()
 end
 
-    # Restore SP
-    loadp Callee[cfr], ws0 # CalleeBits(JSToWasmCallee*)
-    unboxWasmCallee(ws0, ws1)
-
-    loadi Wasm::JSToWasmCallee::m_frameSize[ws0], ws1
-    subp cfr, ws1, ws1
-    move ws1, sp
-    subp constexpr Wasm::JSToWasmCallee::SpillStackSpaceAligned, sp
+    # Don't restore SP to original position, stack results live above calleeSP.
+    # After a tail call the callee's frame may differ, so derive from actual SP.
+    # Just allocate register spill space below the callee's actual SP.
+    subp constexpr Wasm::JSToWasmCallee::RegisterStackSpaceAligned, sp
 
 if ASSERT_ENABLED
     repeat(ws0, macro (i)

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -11407,33 +11407,18 @@ _wasm_trampoline_wasm_ipint_call_wide32:
 _wasm_ipint_call_return_location:
 _wasm_ipint_call_return_location_wide16:
 _wasm_ipint_call_return_location_wide32:
-    # Restore the stack pointer
+    # Compute sc3 (pointing to saved caller info) using the saved SP value,
+    # without restoring SP yet. We need callee's SP to read stack results
+    # which are at the bottom of the arg/result area (SP + headerSize).
+    loadi IPInt::CallReturnMetadata::stackFrameSize[MC], sc3
     loadp ThisArgumentOffset[cfr], sc0
     addp cfr, sc0
-    move sc0, sp
-
-    # <first non-arg>   <- first_non_arg_addr
-    # arg
-    # ...
-    # arg
-    # arg
-    # reserved
-    # reserved
-    # (first_non_arg_addr - cfr), PC
-    # (PL - cfr), wasmInstance  <- sc3
-    # call frame return
-    # call frame return
-    # call frame
-    # call frame
-    # call frame
-    # call frame        <- sp
-
-    loadi IPInt::CallReturnMetadata::stackFrameSize[MC], sc3
-    leap [sp, sc3], sc3
+    addp sc0, sc3
 
     const mintRetSrc = sc1
     const mintRetDst = sc2
 
+    # mintRetSrc: read stack results from the callee's SP (current SP)
     loadi IPInt::CallReturnMetadata::firstStackResultSPOffset[MC], mintRetSrc
     advanceMC(IPInt::CallReturnMetadata::resultBytecode)
     leap [sp, mintRetSrc], mintRetSrc
@@ -11584,12 +11569,10 @@ mintAlign(_end)
     # return result     <- mintRetDst => new SP
     # (first_non_arg_addr - cfr), PC
     # (PL - cfr), wasmInstance  <- sc3
-    # call frame return <- mintRetSrc
-    # call frame return
     # call frame
     # call frame
     # call frame
-    # call frame        <- sp
+    # call frame        <- callee's SP (not yet restored)
 
     # note: we don't care about t3 anymore
 if ARM64 or ARM64E

--- a/Source/JavaScriptCore/offlineasm/parser.rb
+++ b/Source/JavaScriptCore/offlineasm/parser.rb
@@ -955,6 +955,9 @@ end
 def readTextFile(fileName)
     data = IO::read(fileName)
 
+    # https://commits.webkit.org/310937@main broke builds because the files contained non-ASCII characters. Let's forbid non-ASCII early so we don't hit problems downstream.
+    raise "#{fileName} contains non-ASCII characters" unless data.ascii_only?
+
     # On Windows, files may contain CRLF line endings (for example, git client might
     # automatically replace \n with \r\n on Windows) which will fail our parsing.
     # Thus, we'll just remove all \r from the data (keeping just the \n characters)

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -4344,20 +4344,6 @@ void BBQJIT::returnValuesFromCall(Vector<Value, N>& results, const FunctionSigna
             ASSERT(!currentBinding.isScratch());
         } else {
             ASSERT(returnLocation.isStackArgument());
-            // FIXME: Ideally, we would leave these values where they are but a subsequent call could clobber them before they are used.
-            // That said, stack results are very rare so this isn't too painful.
-            // Even if we did leave them where they are, we'd need to flush them to their canonical location at the next branch otherwise
-            // we could have something like (assume no result regs for simplicity):
-            // call (result i32 i32) $foo
-            // if (result i32) // Stack: i32(StackArgument:8) i32(StackArgument:0)
-            //   // Stack: i32(StackArgument:8)
-            // else
-            //   call (result i32 i32) $bar // Stack: i32(StackArgument:8) we have to flush the stack argument to make room for the result of bar
-            //   drop // Stack: i32(Stack:X) i32(StackArgument:8) i32(StackArgument:0)
-            //   drop // Stack: i32(Stack:X) i32(StackArgument:8)
-            // end
-            // return // Stack i32(*Conflicting locations*)
-
             Location canonicalLocation = canonicalSlot(result);
             emitMoveMemory(result.type(), returnLocation, canonicalLocation);
             returnLocation = canonicalLocation;
@@ -4521,7 +4507,11 @@ void BBQJIT::emitTailCall(FunctionSpaceIndex functionIndexSpace, const TypeDefin
         });
     }
 
-    // Our callee could have tail called someone else and changed SP so we need to restore it. Do this before restoring our results since results are stored at the top of the reserved stack space.
+    // Push return value(s) onto the expression stack. Read results before restoring SP
+    // since results are at the bottom of the arg/result area, addressable from the callee's SP.
+    returnValuesFromCall(results, functionType, callInfo);
+
+    // Our callee could have tail called someone else and changed SP so we need to restore it.
     m_frameSizeLabels.append(m_jit.moveWithPatch(TrustedImmPtr(nullptr), wasmScratchGPR));
 #if CPU(ARM64)
     m_jit.subPtr(GPRInfo::callFrameRegister, wasmScratchGPR, MacroAssembler::stackPointerRegister);
@@ -4529,9 +4519,6 @@ void BBQJIT::emitTailCall(FunctionSpaceIndex functionIndexSpace, const TypeDefin
     m_jit.subPtr(GPRInfo::callFrameRegister, wasmScratchGPR, wasmScratchGPR);
     m_jit.move(wasmScratchGPR, MacroAssembler::stackPointerRegister);
 #endif
-
-    // Push return value(s) onto the expression stack
-    returnValuesFromCall(results, functionType, callInfo);
 
     if (m_info.callCanClobberInstance(functionIndexSpace) || m_info.isImportedFunctionFromFunctionIndexSpace(functionIndexSpace))
         restoreWebAssemblyGlobalStateAfterWasmCall();
@@ -4604,8 +4591,12 @@ void BBQJIT::emitIndirectCall(const char* opcode, unsigned callProfileIndex, con
     m_jit.loadPtr(CCallHelpers::Address(importableFunction, WasmToWasmImportableFunction::offsetOfEntrypointLoadLocation()), wasmScratchGPR);
     m_jit.call(CCallHelpers::Address(wasmScratchGPR), WasmEntryPtrTag);
 
-    // Our callee could have tail called someone else and changed SP so we need to restore it. Do this before restoring our results since results are stored at the top of the reserved stack space.
+    // Read results before restoring SP since results are at the bottom of the
+    // arg/result area, addressable from the callee's SP.
     afterCall.link(m_jit);
+    returnValuesFromCall(results, *signature.as<FunctionSignature>(), wasmCalleeInfo);
+
+    // Our callee could have tail called someone else and changed SP so we need to restore it.
     m_frameSizeLabels.append(m_jit.moveWithPatch(TrustedImmPtr(nullptr), wasmScratchGPR));
 #if CPU(ARM64)
     m_jit.subPtr(GPRInfo::callFrameRegister, wasmScratchGPR, MacroAssembler::stackPointerRegister);
@@ -4613,8 +4604,6 @@ void BBQJIT::emitIndirectCall(const char* opcode, unsigned callProfileIndex, con
     m_jit.subPtr(GPRInfo::callFrameRegister, wasmScratchGPR, wasmScratchGPR);
     m_jit.move(wasmScratchGPR, MacroAssembler::stackPointerRegister);
 #endif
-
-    returnValuesFromCall(results, *signature.as<FunctionSignature>(), wasmCalleeInfo);
 
     restoreWebAssemblyGlobalStateAfterWasmCall();
 

--- a/Source/JavaScriptCore/wasm/WasmCallingConvention.h
+++ b/Source/JavaScriptCore/wasm/WasmCallingConvention.h
@@ -187,57 +187,6 @@ private:
         RELEASE_ASSERT_NOT_REACHED();
     }
 
-    uint32_t numberOfStackResults(const FunctionSignature& signature) const
-    {
-        const uint32_t gprCount = jsrArgs.size();
-        const uint32_t fprCount = fprArgs.size();
-        uint32_t gprIndex = 0;
-        uint32_t fprIndex = 0;
-        uint32_t stackCount = 0;
-        for (uint32_t i = 0; i < signature.returnCount(); i++) {
-            switch (signature.returnType(i).kind) {
-            case TypeKind::I32:
-            case TypeKind::I64:
-            case TypeKind::Exnref:
-            case TypeKind::Externref:
-            case TypeKind::Funcref:
-            case TypeKind::RefNull:
-            case TypeKind::Ref:
-                if (gprIndex < gprCount)
-                    ++gprIndex;
-                else
-                    ++stackCount;
-                break;
-            case TypeKind::F32:
-            case TypeKind::F64:
-            case TypeKind::V128:
-                if (fprIndex < fprCount)
-                    ++fprIndex;
-                else
-                    ++stackCount;
-                break;
-            case TypeKind::Void:
-            case TypeKind::Func:
-            case TypeKind::Struct:
-            case TypeKind::Structref:
-            case TypeKind::Array:
-            case TypeKind::Arrayref:
-            case TypeKind::Eqref:
-            case TypeKind::Anyref:
-            case TypeKind::Noexnref:
-            case TypeKind::Noneref:
-            case TypeKind::Nofuncref:
-            case TypeKind::Noexternref:
-            case TypeKind::I31ref:
-            case TypeKind::Sub:
-            case TypeKind::Subfinal:
-            case TypeKind::Rec:
-                RELEASE_ASSERT_NOT_REACHED();
-            }
-        }
-        return stackCount;
-    }
-
 public:
 
     CallInformation callInformationFor(const TypeDefinition& type, CallRole role = CallRole::Caller) const
@@ -262,22 +211,17 @@ public:
             [&](unsigned index) {
                 return marshallLocation(role, signature.argumentType(index), gpArgumentCount, fpArgumentCount, argStackOffset);
             });
-        uint32_t stackArgsInBytes = argStackOffset - headerSize;
 
         gpArgumentCount = 0;
         fpArgumentCount = 0;
-        size_t stackResults = numberOfStackResults(signature);
-        // N.B. this is inaccurate for vector results. In that case and when the actual result space is larger than the argument space, there is a quirk in
-        // the calling convention where the argument and result space is not minimal, i.e. arguments and results don't overlap as much as they could.
-        uint32_t estimatedStackResultsInBytes = stackResults * sizeof(Register);
-        uint32_t estimatedTotalArgAndResultsInBytes = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(std::max(stackArgsInBytes, estimatedStackResultsInBytes));
-        size_t resultStackOffset = headerSize + estimatedTotalArgAndResultsInBytes - estimatedStackResultsInBytes;
+        size_t resultStackOffset = headerSize;
         Vector<ArgumentLocation, 1> results(signature.returnCount(),
             [&](unsigned index) {
                 return marshallLocation(role, signature.returnType(index), gpArgumentCount, fpArgumentCount, resultStackOffset);
             });
-        size_t totalFrameSize = resultStackOffset;
-        ASSERT(totalFrameSize >= argStackOffset);
+
+        ASSERT(!(headerSize % stackAlignmentBytes()));
+        size_t totalFrameSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(std::max(argStackOffset, resultStackOffset));
 
         return { thisArgument, WTF::move(params), WTF::move(results), totalFrameSize, headerSize };
     }
@@ -550,21 +494,17 @@ public:
                 ASSERT(!argumentType.isV128());
                 return marshallLocation(role, argumentType, gpArgumentCount, fpArgumentCount, argStackOffset);
             });
-        uint32_t stackArgs = argStackOffset - headerSize;
-        size_t stackArgsCount = numberOfStackArguments(signature);
 
         gpArgumentCount = 0;
         fpArgumentCount = 0;
-        size_t stackResultsCount = numberOfStackResults(signature);
-        uint32_t stackResults = stackResultsCount * sizeof(Register);
-        uint32_t stackCountAligned = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(std::max(stackArgs, stackResults));
-        size_t resultStackOffset = headerSize + stackCountAligned - stackResults;
+        size_t resultStackOffset = headerSize;
         Vector<ArgumentLocation, 1> results(signature.returnCount(),
             [&](unsigned index) {
                 ASSERT(!signature.returnType(index).isV128());
                 return marshallLocation(role, signature.returnType(index), gpArgumentCount, fpArgumentCount, resultStackOffset);
             });
-        return { thisArgument, WTF::move(params), WTF::move(results), std::max(argStackOffset, resultStackOffset), std::max(stackArgsCount, stackResultsCount) };
+        size_t totalFrameSize = headerSize + WTF::roundUpToMultipleOf<stackAlignmentBytes()>(std::max(argStackOffset - headerSize, resultStackOffset - headerSize));
+        return { thisArgument, WTF::move(params), WTF::move(results), totalFrameSize, headerSize };
     }
 
     const Vector<GPRReg> gprArgs;

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -1825,6 +1825,52 @@ void OMGIRGenerator::fillCallResults(Value* callResult, const TypeDefinition& si
     }
 }
 
+
+// After a wasm call returns, move stack results from the callee's SP-relative
+// convention offsets to wherever B3 placed them (register or FP-relative slot),
+// then restore SP to cfr - frameSize.
+static void emitWasmCallStackResultsAndSPRestore(CCallHelpers& jit,
+    const B3::StackmapGenerationParams& params,
+    const TypeDefinition& signature,
+    const CallInformation& wasmCalleeInfo)
+{
+    auto frameSize = params.code().frameSize();
+
+    for (unsigned i = 0; i < wasmCalleeInfo.results.size(); ++i) {
+        auto& loc = wasmCalleeInfo.results[i];
+        if (!loc.location.isStackArgument())
+            continue;
+
+        auto src = CCallHelpers::Address(MacroAssembler::stackPointerRegister, loc.location.offsetFromSP());
+        auto& rep = params[i];
+
+        auto wasmType = signature.as<FunctionSignature>()->returnType(i);
+        if (rep.isGPR()) {
+            if (wasmType.isI32())
+                jit.load32(src, rep.gpr());
+            else
+                jit.load64(src, rep.gpr());
+        } else if (rep.isFPR()) {
+            if (wasmType.isF32())
+                jit.loadFloat(src, rep.fpr());
+            else if (wasmType.isF64())
+                jit.loadDouble(src, rep.fpr());
+            else {
+                ASSERT(wasmType.isV128());
+                jit.loadVector(src, rep.fpr());
+            }
+        } else {
+            ASSERT(rep.isStack());
+            if (wasmType.isV128())
+                jit.transferVector(src, CCallHelpers::Address(GPRInfo::callFrameRegister, rep.offsetFromFP()));
+            else
+                jit.transfer64(src, CCallHelpers::Address(GPRInfo::callFrameRegister, rep.offsetFromFP()));
+        }
+    }
+
+    jit.addPtr(CCallHelpers::TrustedImm32(-frameSize), GPRInfo::callFrameRegister, MacroAssembler::stackPointerRegister);
+}
+
 auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, Value* boxedCalleeCallee, const TypeDefinition& signature, const ArgumentList& args, ValueResults& results, CallType callType) -> PartialResult
 {
     const bool isTailCallRootCaller = callType == CallType::TailCall && !m_inlineParent;
@@ -1911,7 +1957,7 @@ auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, 
     patchpoint->append(calleeCode, ValueRep::SomeRegister);
     patchpoint->append(boxedCalleeCallee, ValueRep::SomeRegister);
     patchArgsIndex += m_proc.resultCount(patchpoint->type());
-    patchpoint->setGenerator([this, handle = handle, prepareForCall = prepareForCall, patchArgsIndex](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
+    patchpoint->setGenerator([this, handle = handle, prepareForCall = prepareForCall, patchArgsIndex, signature = Ref<const TypeDefinition>(signature), wasmCalleeInfo = WTF::move(wasmCalleeInfo)](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
         AllowMacroScratchRegisterUsage allowScratch(jit);
         if (prepareForCall)
             prepareForCall->run(jit, params);
@@ -1920,8 +1966,7 @@ auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, 
 
         jit.storeWasmCalleeToCalleeCallFrame(params[patchArgsIndex + 1].gpr());
         jit.call(params[patchArgsIndex].gpr(), WasmEntryPtrTag);
-        // Restore the stack pointer since it may have been lowered if our callee did a tail call.
-        jit.addPtr(CCallHelpers::TrustedImm32(-params.code().frameSize()), GPRInfo::callFrameRegister, MacroAssembler::stackPointerRegister);
+        emitWasmCallStackResultsAndSPRestore(jit, params, signature, wasmCalleeInfo);
     });
     fillCallResults(patchpoint, signature, results);
 
@@ -5324,8 +5369,15 @@ auto OMGIRGenerator::createCallPatchpoint(BasicBlock* block, const TypeDefinitio
     const Vector<ArgumentLocation, 1>& constrainedResultLocations = wasmCalleeInfo.results;
     if (returnType != B3::Void) {
         Vector<B3::ValueRep, 1> resultConstraints;
-        for (auto valueLocation : constrainedResultLocations)
-            resultConstraints.append(B3::ValueRep(valueLocation.location));
+        for (auto valueLocation : constrainedResultLocations) {
+            // FIXME: Graph Coloring has an issue where it runs out of "colors" (aka registers) when passing as an Any so instead place results where they would canonically go.
+            // Even though the expected location is SP relative it still works with emitWasmCallStackResultsAndSPRestore because "SP" means FP - frameSize not the semi-random SP we got back from our callee.
+            if (valueLocation.location.isStackArgument() && Options::airUseGreedyRegAlloc()) {
+                // FIXME: Should these results be ColdAny? The argument in favor of Warm is that we have to move the values anyway so we might as well put in a register if that's what B3 wants
+                resultConstraints.append(B3::ValueRep::WarmAny);
+            } else
+                resultConstraints.append(B3::ValueRep(valueLocation.location));
+        }
         patchpoint->resultConstraints = WTF::move(resultConstraints);
     }
     block->append(patchpoint);
@@ -6005,7 +6057,7 @@ auto OMGIRGenerator::emitDirectCall(unsigned callProfileIndex, FunctionSpaceInde
             // FIXME: We shouldn't have to do this: https://bugs.webkit.org/show_bug.cgi?id=172181
             patchpoint->clobberLate(RegisterSet::wasmPinnedRegisters());
             patchArgsIndex += m_proc.resultCount(patchpoint->type());
-            patchpoint->setGenerator([this, patchArgsIndex, handle, isTailCallRootCaller, tailCallStackOffsetFromFP, prepareForCall](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
+            patchpoint->setGenerator([this, patchArgsIndex, handle, isTailCallRootCaller, tailCallStackOffsetFromFP, prepareForCall, signature = Ref<const TypeDefinition>(signature), wasmCalleeInfo](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
                 AllowMacroScratchRegisterUsage allowScratch(jit);
                 if (prepareForCall)
                     prepareForCall->run(jit, params);
@@ -6016,8 +6068,7 @@ auto OMGIRGenerator::emitDirectCall(unsigned callProfileIndex, FunctionSpaceInde
                     jit.farJump(params[patchArgsIndex].gpr(), WasmEntryPtrTag);
                 else {
                     jit.call(params[patchArgsIndex].gpr(), WasmEntryPtrTag);
-                    // Restore the stack pointer since it may have been lowered if our callee did a tail call.
-                    jit.addPtr(CCallHelpers::TrustedImm32(-params.code().frameSize()), GPRInfo::callFrameRegister, MacroAssembler::stackPointerRegister);
+                    emitWasmCallStackResultsAndSPRestore(jit, params, signature, wasmCalleeInfo);
                 }
             });
         };
@@ -6051,7 +6102,7 @@ auto OMGIRGenerator::emitDirectCall(unsigned callProfileIndex, FunctionSpaceInde
     Vector<UnlinkedWasmToWasmCall>* unlinkedWasmToWasmCalls = &m_unlinkedWasmToWasmCalls;
 
     auto emitUnlinkedWasmToWasmCall = [&, this](PatchpointValue* patchpoint, RefPtr<PatchpointExceptionHandle> handle, RefPtr<B3::StackmapGenerator> prepareForCall) -> void {
-        patchpoint->setGenerator([this, handle, unlinkedWasmToWasmCalls, functionIndexSpace, isTailCallRootCaller, tailCallStackOffsetFromFP, prepareForCall](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
+        patchpoint->setGenerator([this, handle, unlinkedWasmToWasmCalls, functionIndexSpace, isTailCallRootCaller, tailCallStackOffsetFromFP, prepareForCall, signature = Ref<const TypeDefinition>(signature), wasmCalleeInfo](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
             AllowMacroScratchRegisterUsage allowScratch(jit);
             if (prepareForCall)
                 prepareForCall->run(jit, params);
@@ -6072,7 +6123,8 @@ auto OMGIRGenerator::emitDirectCall(unsigned callProfileIndex, FunctionSpaceInde
             jit.addLinkTask([unlinkedWasmToWasmCalls, call, functionIndexSpace](LinkBuffer& linkBuffer) {
                 unlinkedWasmToWasmCalls->append({ linkBuffer.locationOfNearCall<WasmEntryPtrTag>(call), functionIndexSpace });
             });
-            jit.addPtr(CCallHelpers::TrustedImm32(-params.code().frameSize()), GPRInfo::callFrameRegister, MacroAssembler::stackPointerRegister);
+            if (!isTailCallRootCaller)
+                emitWasmCallStackResultsAndSPRestore(jit, params, signature, wasmCalleeInfo);
         });
     };
 

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -144,7 +144,7 @@ JSC_DEFINE_JIT_OPERATION(operationJSToWasmEntryWrapperBuildFrame, JSToWasmCallee
     OPERATION_RETURN(scope, callee);
 }
 
-// We don't actually return anything, but we can't compile with a ExceptionOperationResult<void> as the return type.
+// Marshalls wasm return values into JS: a single JSValue for one result, or a JSArray for multi-value.
 JSC_DEFINE_JIT_OPERATION(operationJSToWasmEntryWrapperBuildReturnFrame, EncodedJSValue, (void* sp, CallFrame* callFrame))
 {
     dataLogLnIf(WasmOperationsInternal::verbose, "operationJSToWasmEntryWrapperBuildReturnFrame sp: ", RawPointer(sp), " fp: ", RawPointer(callFrame));
@@ -222,7 +222,11 @@ JSC_DEFINE_JIT_OPERATION(operationJSToWasmEntryWrapperBuildReturnFrame, EncodedJ
         OPERATION_RETURN(scope, encodedJSValue());
     }
 
-    auto calleeSPOffsetFromFP = -(static_cast<intptr_t>(callee->frameSize()) + JSToWasmCallee::SpillStackSpaceAligned - JSToWasmCallee::RegisterStackSpaceAligned);
+    // calleeSP = sp + RegisterStackSpaceAligned (we only subtracted RegisterStackSpace from callee's actual SP)
+    // This is correct even after tail calls, where the callee's frame size may differ from the original.
+    auto calleeSPOffsetFromFP = reinterpret_cast<intptr_t>(sp)
+        + static_cast<intptr_t>(JSToWasmCallee::RegisterStackSpaceAligned)
+        - reinterpret_cast<intptr_t>(callFrame);
 
     for (unsigned i = 0; i < functionSignature.returnCount(); ++i) {
         ValueLocation loc = wasmFrameConvention.results[i].location;

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -45,7 +45,7 @@
 namespace JSC {
 namespace Wasm {
 
-static void marshallJSResult(CCallHelpers& jit, const FunctionSignature& signature, const CallInformation& wasmFrameConvention, const RegisterAtOffsetList& savedResultRegisters, CCallHelpers::JumpList& exceptionChecks)
+static void marshallJSResult(CCallHelpers& jit, const FunctionSignature& signature, const CallInformation& wasmFrameConvention, const RegisterAtOffsetList& savedResultRegisters, CCallHelpers::JumpList& exceptionChecks, int32_t stackResultReadOffset = 0)
 {
     auto boxNativeCalleeResult = [](CCallHelpers& jit, Type type, ValueLocation src, JSValueRegs dst) {
         JIT_COMMENT(jit, "boxNativeCalleeResult ", type);
@@ -143,28 +143,29 @@ static void marshallJSResult(CCallHelpers& jit, const FunctionSignature& signatu
                 }
             } else {
                 if (!type.isI64()) {
-                    auto location = CCallHelpers::Address(CCallHelpers::stackPointerRegister, loc.offsetFromSP());
+                    auto readLocation = CCallHelpers::Address(CCallHelpers::stackPointerRegister, loc.offsetFromSP() + stackResultReadOffset);
+                    auto writeLocation = CCallHelpers::Address(CCallHelpers::stackPointerRegister, loc.offsetFromSP());
                     ValueLocation tmp;
                     switch (type.kind) {
                     case TypeKind::F32:
                         tmp = ValueLocation { fprScratch };
-                        jit.loadFloat(location, fprScratch);
+                        jit.loadFloat(readLocation, fprScratch);
                         break;
                     case TypeKind::F64:
                         tmp = ValueLocation { fprScratch };
-                        jit.loadDouble(location, fprScratch);
+                        jit.loadDouble(readLocation, fprScratch);
                         break;
                     case TypeKind::I32:
                         tmp = ValueLocation { scratchJSR };
-                        jit.load32(location, scratchJSR.payloadGPR());
+                        jit.load32(readLocation, scratchJSR.payloadGPR());
                         break;
                     default:
                         tmp = ValueLocation { scratchJSR };
-                        jit.loadValue(location, scratchJSR);
+                        jit.loadValue(readLocation, scratchJSR);
                         break;
                     }
                     boxNativeCalleeResult(jit, type, tmp, scratchJSR);
-                    jit.storeValue(scratchJSR, location);
+                    jit.storeValue(scratchJSR, writeLocation);
                 }
             }
 
@@ -193,16 +194,21 @@ static void marshallJSResult(CCallHelpers& jit, const FunctionSignature& signatu
 
                 constexpr JSValueRegs valueJSR = preferredArgumentJSR<decltype(operationConvertToBigInt), 1>();
 
-                CCallHelpers::Address address { CCallHelpers::stackPointerRegister };
+                CCallHelpers::Address readAddress { CCallHelpers::stackPointerRegister };
+                CCallHelpers::Address writeAddress { CCallHelpers::stackPointerRegister };
                 if (loc.isGPR() || loc.isFPR()) {
 #if USE(JSVALUE32_64)
                     ASSERT(savedResultRegisters.find(loc.jsr().payloadGPR())->offset() + 4 == savedResultRegisters.find(loc.jsr().tagGPR())->offset());
 #endif
-                    address = address.withOffset(savedResultRegisters.find(loc.jsr().payloadGPR())->offset() + wasmFrameConvention.headerAndArgumentStackSizeInBytes);
-                } else
-                    address = address.withOffset(loc.offsetFromSP());
+                    auto offset = savedResultRegisters.find(loc.jsr().payloadGPR())->offset() + wasmFrameConvention.headerAndArgumentStackSizeInBytes;
+                    readAddress = readAddress.withOffset(offset);
+                    writeAddress = writeAddress.withOffset(offset);
+                } else {
+                    readAddress = readAddress.withOffset(loc.offsetFromSP() + stackResultReadOffset);
+                    writeAddress = writeAddress.withOffset(loc.offsetFromSP());
+                }
 
-                jit.loadValue(address, valueJSR);
+                jit.loadValue(readAddress, valueJSR);
                 jit.prepareWasmCallOperation(GPRInfo::wasmContextInstancePointer);
                 jit.setupArguments<decltype(operationConvertToBigInt)>(GPRInfo::wasmContextInstancePointer, valueJSR);
                 jit.callOperation<OperationPtrTag>(operationConvertToBigInt);
@@ -213,7 +219,7 @@ static void marshallJSResult(CCallHelpers& jit, const FunctionSignature& signatu
                 jit.loadPtr(CCallHelpers::Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfVM()), GPRInfo::nonPreservedNonReturnGPR);
                 exceptionChecks.append(jit.branchTestPtr(CCallHelpers::NonZero, CCallHelpers::Address(GPRInfo::nonPreservedNonReturnGPR, VM::exceptionOffset())));
 #endif
-                jit.storeValue(JSRInfo::returnValueJSR, address);
+                jit.storeValue(JSRInfo::returnValueJSR, writeAddress);
             }
         }
 
@@ -390,20 +396,11 @@ MacroAssemblerCodeRef<JITThunkPtrTag> createJSToWasmJITShared()
 
         jit.call(GPRInfo::regWS0, WasmEntryPtrTag);
 
-        // Restore SP
-
-        // Callee[cfr]
-        jit.loadPtr(CCallHelpers::addressFor(CallFrameSlot::callee), GPRInfo::regWS0);
-        jit.unboxNativeCallee(GPRInfo::regWS0, GPRInfo::regWS0);
-
-        jit.load32(CCallHelpers::Address(GPRInfo::regWS0, JSToWasmCallee::offsetOfFrameSize()), GPRInfo::regWS1);
-        jit.addPtr(CCallHelpers::TrustedImmPtr(JSToWasmCallee::SpillStackSpaceAligned), GPRInfo::regWS1);
-#if CPU(ARM64)
-        jit.subPtr(GPRInfo::callFrameRegister, GPRInfo::regWS1, CCallHelpers::stackPointerRegister);
-#else
-        jit.subPtr(GPRInfo::callFrameRegister, GPRInfo::regWS1, GPRInfo::regWS1);
-        jit.move(GPRInfo::regWS1, CCallHelpers::stackPointerRegister);
-#endif
+        // Don't restore SP to original position — stack results are above calleeSP.
+        // After a tail call the callee's frame may differ, so derive from actual SP.
+        // Just allocate register spill space below the callee's actual SP.
+        jit.subPtr(CCallHelpers::TrustedImmPtr(JSToWasmCallee::RegisterStackSpaceAligned),
+            CCallHelpers::stackPointerRegister);
 
         // Save return registers
 #if CPU(ARM64)
@@ -572,10 +569,12 @@ CodePtr<JSEntryPtrTag> FunctionSignature::jsToWasmICEntrypoint() const
     Wasm::CallInformation jsCallInfo = Wasm::jsCallingConvention().callInformationFor(*this, Wasm::CallRole::Callee);
     RegisterAtOffsetList savedResultRegisters = wasmCallInfo.computeResultsOffsetList();
 
+    unsigned resultAreaSize = wasmCallInfo.headerAndArgumentStackSizeInBytes + savedResultRegisters.sizeOfAreaInBytes();
+    unsigned resultAreaSizeAligned = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(resultAreaSize);
+
     unsigned totalFrameSize = registersToSpill.sizeOfAreaInBytes();
     totalFrameSize += sizeof(CPURegister); // Slot for the VM's previous wasm instance.
     totalFrameSize += wasmCallInfo.headerAndArgumentStackSizeInBytes;
-    totalFrameSize += savedResultRegisters.sizeOfAreaInBytes();
     totalFrameSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(totalFrameSize);
 
 #if USE(JSVALUE32_64)
@@ -803,13 +802,18 @@ CodePtr<JSEntryPtrTag> FunctionSignature::jsToWasmICEntrypoint() const
     JIT_COMMENT(jit, "Make the call");
     jit.call(stackLimitGPR, WasmEntryPtrTag);
 
-    // Restore stack pointer after call. We want to do this before marshalling results since stack results are stored at the top of the frame we created.
-    jit.addPtr(MacroAssembler::TrustedImm32(-static_cast<int32_t>(totalFrameSize)), MacroAssembler::framePointerRegister, MacroAssembler::stackPointerRegister);
+    jit.subPtr(CCallHelpers::TrustedImm32(resultAreaSizeAligned),
+        CCallHelpers::stackPointerRegister);
 
     CCallHelpers::JumpList exceptionChecks;
 
+    // Read results before restoring SP. Results are at the bottom of the arg/result
+    // area (at callee's SP + headerSize), so we must read them before restoring SP.
     // FIXME: This assumes we don't have tag registers but we could just rematerialize them here since we already saved them.
-    marshallJSResult(jit, *this, wasmCallInfo, savedResultRegisters, exceptionChecks);
+    marshallJSResult(jit, *this, wasmCallInfo, savedResultRegisters, exceptionChecks, resultAreaSizeAligned);
+
+    // Restore stack pointer after call.
+    jit.addPtr(MacroAssembler::TrustedImm32(-static_cast<int32_t>(totalFrameSize)), MacroAssembler::framePointerRegister, MacroAssembler::stackPointerRegister);
 
     ASSERT(!RegisterSet::runtimeTagRegisters().contains(GPRInfo::nonPreservedNonReturnGPR, IgnoreVectors));
 


### PR DESCRIPTION
#### 599f35b6714354280079b1e8dc68ebea70e731eb
<pre>
[JSC] Wasm stack results should match arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=311838">https://bugs.webkit.org/show_bug.cgi?id=311838</a>
<a href="https://rdar.apple.com/174428575">rdar://174428575</a>

Reviewed by Yusuke Suzuki.

Rework how stack results are read after wasm calls so that they match
the location of equivalent arguments. This is preliminary work so tail
calls don&apos;t require whole-module analysis to determine where to restore
instance/memory pinned registers. In that world there may or may not be
an injected frame between any caller and callee shift the result
location by some constant. This makes the current calling convention
difficult to maintain as we don&apos;t know exactly which of the two offsets
to find results.

In this patch we go back to the original multi-value calling convention,
where arguments and results match. Any caller should copy stack results
before restoring SP.

Extracting the results differs based on the caller. For BBQ/IPInt we
move the stack results to their canonical location. In OMG,
createCallPatchpoint stack return value constraints use WarmAny so B3
can place results whereever it wants as they have to be copied anyway.
Due to an outstanding issue when graph coloring is enabled where we run
out of colors (aka registers) we use still use the argument&apos;s stack slot.

JSToWasm makes space for registers below the callee frame and fills the
register results there then calls to the appropriate operation to build
the result Array.

Old Wasm calling convention (before this patch):
Stack results were offset to the top of the area, so resultK was NOT at
the same address as argK:

    +----------------------------+
    |  result1  |  arg3          |   &lt;- resultStackOffset = headerSize + aligned - resultSize
    +----------------------------+
    |  result0  |  arg2          |   &lt;- results shifted, don&apos;t align with args
    +----------------------------+
    |           |  arg1          |
    +----------------------------+
    |           |  arg0          |   &lt;- argStackOffset = headerSize
    +----------------------------+
    |         instance           |
    +----------------------------+
    |        wasmCallee          |
    +----------------------------+
    |       returnAddress        |
    +----------------------------+
    |        callerFrame         |  &lt;- cfr
    +----------------------------+

New Wasm calling convention (this patch):
Arguments and results share the same stack addresses. argK and resultK
occupy the same slot. The area is sized to max(args, results):

    +----------------------------+   higher addresses
    |          ......            |   |
    +----------------------------+   |
    |     arg/result N           |   |
    +----------------------------+   |
    |          ...               |   |
    +----------------------------+   |
    |     arg/result 1           |   |
    +----------------------------+   |
    |     arg/result 0           |   &lt;- headerSize (args &amp; results start here)
    +----------------------------+   v  lower addresses
    |         instance           |
    +----------------------------+
    |        wasmCallee          |
    +----------------------------+
    |       returnAddress        |
    +----------------------------+
    |        callerFrame         |  &lt;- cfr
    +----------------------------+

The Nth stack argument and the Nth stack result are at the exact same
address.

Also, this broke internal builds since a non-ASCII character was added
to the IPInt .asm file. Add a check we don&apos;t make the same mistake again.

No new tests, no behavior change, covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/310952@main">https://commits.webkit.org/310952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e086e1df15cfa34742507391c6dd1e70923653d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155588 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/28848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/22007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/164351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/28994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28698 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/164351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158547 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/28994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/22007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/164351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/28994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/12181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/147638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/28994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/22007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166828 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/16420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/11006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/22007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/128533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/28392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/23843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/128666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/28316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/22007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23694 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/28316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/22007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/187473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/28010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/92113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/187473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/27587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/27817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/27660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->