### PR TITLE
[JSC][WASM][Debugger] Fix DebugState incorrectly reporting VM as stopped during non-debugger VM traps

### DIFF
--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
@@ -164,7 +164,7 @@ struct StopData {
 struct DebugState {
     WTF_MAKE_STRUCT_TZONE_ALLOCATED(DebugState);
 
-    // Why the VM stopped. Always set when isStopped(). Drives GDB wire protocol signal and reason.
+    // Why the VM stopped. Always set when isStopped. Drives GDB wire protocol signal and reason.
     enum class Reason : uint8_t {
         // Debugger-imposed stop: passive VM (no WASM context) or WASM function prologue.
         // Also used for new module load stops (isNewModuleLoad flag is set in that case).
@@ -234,18 +234,18 @@ struct DebugState {
     {
         stopReason = std::nullopt;
         isNewModuleLoad = false;
+        isStopped = false;
         stopData = nullptr;
     }
 
-    // No-op for the debuggee VM (stopReason already set); sets Interrupted on VMs with no stop reason.
     void setStopped()
     {
+        // Sets Interrupted on VMs with no stop reason.
         if (!stopReason.has_value())
             stopReason = Reason::Interrupted;
+        isStopped = true;
     }
 
-    bool isStopped() const { return stopReason.has_value(); }
-    bool isRunning() const { return !stopReason.has_value(); }
 
     bool hasStepIntoEvent() { return stepIntoEvent.hasAny(); }
     void setStepIntoCall() { stepIntoEvent.set(StepIntoEvent::StepIntoCall); }
@@ -255,6 +255,7 @@ struct DebugState {
 
     std::optional<Reason> stopReason;
     bool isNewModuleLoad { false };
+    bool isStopped { false }; // FIXME: There is better design (rdar://174508321) for code efficiency.
     std::unique_ptr<StopData> stopData { nullptr };
 
     // Step-into tracking (for step debugging behavior)

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
@@ -245,8 +245,8 @@ StopTheWorldStatus ExecutionHandler::handleStopTheWorld(VM& debuggee, StopTheWor
         return STW_RESUME_ALL();
     case ExecutionHandler::ResumeMode::Switch:
         RELEASE_ASSERT(m_debuggee != &debuggee);
-        RELEASE_ASSERT(debuggee.debugState()->isStopped());
-        RELEASE_ASSERT(m_debuggee->debugState()->isStopped());
+        RELEASE_ASSERT(debuggee.debugState()->isStopped);
+        RELEASE_ASSERT(m_debuggee->debugState()->isStopped);
         return STW_CONTEXT_SWITCH(m_debuggee);
     }
     RELEASE_ASSERT_NOT_REACHED();
@@ -264,7 +264,7 @@ void ExecutionHandler::selectDebuggeeIfNeeded(VM& fallbackVM) WTF_REQUIRES_LOCK(
     VM* selectedVM = nullptr;
     VMManager::forEachVM([&](VM& vm) {
         auto* debugState = vm.debugState();
-        if (vm.debugState()->isStopped() && debugState->isStoppedAtPrologue()) {
+        if (vm.debugState()->isStopped && debugState->isStoppedAtPrologue()) {
             selectedVM = &vm;
             return IterationStatus::Done;
         }
@@ -324,7 +324,7 @@ void ExecutionHandler::resumeImpl(Locker<Lock>& locker)
     RELEASE_ASSERT(Thread::currentSingleton().uid() == debugServerThreadId());
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Continue] Start");
 
-    RELEASE_ASSERT(debuggeeState()->isStopped());
+    RELEASE_ASSERT(debuggeeState()->isStopped);
     m_debuggerState = DebuggerState::ContinueRequested;
     m_debuggeeContinue.notifyOne(); // Notify debuggee VM with resume all command.
 
@@ -344,7 +344,7 @@ static inline VM* findVM(uint64_t threadId)
 {
     VM* result = nullptr;
     VMManager::forEachVM([&](VM& vm) {
-        if (vm.debugState()->isStopped() && threadId == ExecutionHandler::threadId(vm)) {
+        if (vm.debugState()->isStopped && threadId == ExecutionHandler::threadId(vm)) {
             result = &vm;
             return IterationStatus::Done;
         }
@@ -365,14 +365,14 @@ void ExecutionHandler::switchTarget(uint64_t threadId)
     if (m_debuggee == newDebuggee)
         return;
 
-    RELEASE_ASSERT(debuggeeState()->isStopped());
+    RELEASE_ASSERT(debuggeeState()->isStopped);
     m_debuggee = newDebuggee;
     m_debuggerState = DebuggerState::SwitchRequested;
     m_debuggeeContinue.notifyOne(); // Notify to switch VM context.
 
     dataLogLnIf(Options::verboseWasmDebugger(), "[Code][SwitchVM] Notified code to continue and switch VM, waiting...");
     m_debuggerContinue.wait(locker); // Wait for new debuggee VM to stop.
-    RELEASE_ASSERT(debuggeeState()->isStopped());
+    RELEASE_ASSERT(debuggeeState()->isStopped);
     dataLogLnIf(Options::verboseWasmDebugger(), "[Code][SwitchVM] Code is stopped");
 }
 
@@ -389,7 +389,7 @@ void ExecutionHandler::interrupt()
     // Our WebKit implementation handles each interrupt request by activating StopWorld via VM traps.
 
     {
-        RELEASE_ASSERT(!m_debuggee || debuggeeState()->isRunning());
+        RELEASE_ASSERT(!m_debuggee || !debuggeeState()->isStopped);
         m_debuggerState = DebuggerState::InterruptRequested;
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Interrupt] Calling VMManager::requestStopAll()...");
         VMManager::singleton().requestStopAll(VMManager::StopReason::WasmDebugger);
@@ -409,7 +409,7 @@ void ExecutionHandler::step()
 
     Locker locker { m_lock };
     auto* state = debuggeeState();
-    RELEASE_ASSERT(m_debuggerState == DebuggerState::Replied && state->isStopped());
+    RELEASE_ASSERT(m_debuggerState == DebuggerState::Replied && state->isStopped);
 
     bool resumeAll = false;
     if (state->isStoppedAtSystemCall() || state->isStoppedDueToWasmTrap()) {
@@ -773,13 +773,13 @@ void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t t
         return;
     }
 
-    RELEASE_ASSERT(state->isStopped());
+    RELEASE_ASSERT(state->isStopped);
 
     // Collect all stopped threads; swap event thread to index 0 so thread-pcs[i] aligns with threads[i].
     Vector<ThreadInfo> allThreads;
     VMManager::forEachVM([&](VM& vm) {
         auto* state = vm.debugState();
-        if (!state->isStopped())
+        if (!state->isStopped)
             return IterationStatus::Continue;
         uint64_t tid = ExecutionHandler::threadId(vm);
         allThreads.append({ tid, getStopPC(*state), getThreadName(*state, tid), stopReasonToInfo(*state).reasonSuffix });
@@ -891,7 +891,7 @@ void ExecutionHandler::reset()
     Locker locker { m_lock };
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Handling client disconnection in ExecutionHandler");
 
-    if (m_debuggee && debuggeeState()->isStopped())
+    if (m_debuggee && debuggeeState()->isStopped)
         resumeImpl(locker);
 
     m_breakpointManager->clearAllBreakpoints();
@@ -938,7 +938,7 @@ String ExecutionHandler::callStackStringFor(uint64_t threadId)
     }
 
     auto* state = targetVM->debugState();
-    RELEASE_ASSERT(state->isStopped());
+    RELEASE_ASSERT(state->isStopped);
 
     if (state->stopData) {
         auto& stopData = *state->stopData;

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.cpp
@@ -145,7 +145,7 @@ JSWebAssemblyInstance* ModuleManager::jsInstance(uint32_t instanceId)
         return nullptr;
     }
 
-    RELEASE_ASSERT(instance->vm().debugState()->isStopped(), "Instance exists but VM is not stopped");
+    RELEASE_ASSERT(instance->vm().debugState()->isStopped, "Instance exists but VM is not stopped");
     return instance;
 }
 

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
@@ -105,7 +105,7 @@ static void validateStop()
     CHECK(info.targetVM == executionHandler->debuggeeVM(), "VMManager's targetVM should match ExecutionHandler's debuggee VM");
     uint32_t stoppedCount = 0;
     VMManager::forEachVM([&](VM& vm) {
-        CHECK(vm.debugState()->isStopped(), "VM should be stopped");
+        CHECK(vm.debugState()->isStopped, "VM should be stopped");
         stoppedCount++;
         return IterationStatus::Continue;
     });
@@ -125,7 +125,7 @@ static void resume()
     CHECK(info.worldMode == VMManager::Mode::RunAll, "All VMs should be running");
     uint32_t runningCount = 0;
     VMManager::forEachVM([&](VM& vm) {
-        CHECK(vm.debugState()->isRunning(), "VM should be running");
+        CHECK(!vm.debugState()->isStopped, "VM should be running");
         runningCount++;
         return IterationStatus::Continue;
     });


### PR DESCRIPTION
#### adf99e02d9c168980713487c36abb07dad875de0
<pre>
[JSC][WASM][Debugger] Fix DebugState incorrectly reporting VM as stopped during non-debugger VM traps
<a href="https://bugs.webkit.org/show_bug.cgi?id=311952">https://bugs.webkit.org/show_bug.cgi?id=311952</a>
<a href="https://rdar.apple.com/174508321">rdar://174508321</a>

Reviewed by Mark Lam.

DebugState::isStopped()/isRunning() were based on stopReason.has_value(),
relying on the assumption that a set stopReason means the VM is stopped.
This held for setBreakpointStopData() and setTrapStopData(), which are
always immediately followed by stopTheWorld(). However, setPrologueStopData()
is called speculatively in check_stack_and_vm_traps before
handleTrapsIfNeeded() — which may service a non-debugger trap (e.g. GC)
and return without triggering a world stop or clearStop(). This left
stopReason dirty on a still-running VM, breaking the assumption.

Fix: replace isStopped()/isRunning() with a dedicated bool isStopped field
written only by setStopped() and clearStop(). Now, stopReason remains the WHY
of a stop; isStopped is the authoritative IS indicator.

Canonical link: <a href="https://commits.webkit.org/310960@main">https://commits.webkit.org/310960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a66bb6e17c24855cc00093bf1303cbe3a9d3969f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28902 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/22061 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/164405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/29049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28752 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/164405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158601 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/29049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/139759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/164405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/29049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/12235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/147692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/29049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/17591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/166884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/16474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/11060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/19202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/166884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/28446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/23891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/166884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/28370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/139384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23697 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/28370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187527 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/28064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/92167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/48064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/27641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/27871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/27714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->