### PR TITLE
[JSC][JSPI polish] Use std::unique_ptr for EvacuatedStackSlice ownership in PinballHandlerContext

### DIFF
--- a/Source/JavaScriptCore/runtime/PinballCompletion.cpp
+++ b/Source/JavaScriptCore/runtime/PinballCompletion.cpp
@@ -28,15 +28,12 @@
 
 #if ENABLE(WEBASSEMBLY)
 
-#include "CallFrameInlines.h"
 #include "EvacuatedStack.h"
 #include "Exception.h"
 #include "JSCellInlines.h"
 #include "JSPIContextInlines.h"
 #include "JSPromise.h"
 #include "PinballHandlerContext.h"
-#include "StackAlignment.h"
-#include "StructureInlines.h"
 #include "TopExceptionScope.h"
 
 #include <wtf/StdLibExtras.h>
@@ -160,8 +157,6 @@ static void pinballHandlerInitContext(JSGlobalObject* globalObject, CallFrame* c
     ASSERT(callFrame->argumentCount() == 1);
     PinballCompletion* pinball = jsCast<PinballCompletion*>(self->getField(JSFunctionWithFields::Field::PromiseHandlerPinballCompletion));
     ASSERT(pinball->hasSlices());
-    auto* slice = pinball->takeTopSlice().release();
-
 #if ASSERT_ENABLED
     context->magic = 0xBA11FEED;
 #endif
@@ -169,8 +164,8 @@ static void pinballHandlerInitContext(JSGlobalObject* globalObject, CallFrame* c
     context->vm = &vm;
     context->handler = self;
     new (&context->jspiContext) JSPIContext(JSPIContext::Purpose::Completing, vm, callFrame, pinball->resultPromise());
-    context->slice = slice;
-    context->sliceByteSize = slice->size() * sizeof(Register);
+    new (&context->slice) std::unique_ptr<EvacuatedStackSlice>(pinball->takeTopSlice()); // context is uninitialized, can't assign
+    context->sliceByteSize = context->slice->size() * sizeof(Register);
     ASSERT(!(context->sliceByteSize % stackAlignmentBytes())); // asm code assumes alignment is not needed
     context->evacuatedCalleeSaves = pinball->calleeSaves();
 #if ASSERT_ENABLED
@@ -206,14 +201,13 @@ void pinballHandlerImplantSlice(PinballHandlerContext* context, Register *base, 
     VM& vm = context->globalObject->vm();
     PinballCompletion* pinball = jsCast<PinballCompletion*>(context->handler->getField(JSFunctionWithFields::Field::PromiseHandlerPinballCompletion));
 
-    auto* slice = context->slice;
+    auto* slice = context->slice.get();
     CallFrame* bottommostImplantedFrame = slice->implant(base, sentinelFrame);
     returnFrame->callerFrame = bottommostImplantedFrame;
     returnFrame->returnPC = relocateReturnPC(const_cast<void*>(slice->entryPC()), reinterpret_cast<const CallerFrameAndPC*>(slice->entryPCFrame()), returnFrame);
 
     vm.removeEvacuatedStackSlice(slice); // the slice data is now scanned as part of the stack
-    delete slice;
-    context->slice = nullptr;
+    context->slice.reset();
     // At this point callee saves have been loaded into the registers and it is safe for the VM to forget them.
     // We end up doing it multiple times, which is okay. Repeat removals do nothing.
     vm.removeEvacuatedCalleeSaves(std::span(pinball->calleeSaves(), NUMBER_OF_CALLEE_SAVES_REGISTERS));
@@ -245,9 +239,8 @@ UCPURegister pinballHandlerFulfillFunctionContinue(PinballHandlerContext* contex
 
     if (pinball->hasSlices()) {
         RELEASE_ASSERT(!scope.exception()); // multi-slice completion is not yet prepared to handle exceptions; we should never encounter one at this point
-        auto* slice = pinball->takeTopSlice().release();
-        context->slice = slice;
-        context->sliceByteSize = slice->size() * sizeof(Register);
+        context->slice = pinball->takeTopSlice();
+        context->sliceByteSize = context->slice->size() * sizeof(Register);
         return 1;
     }
 

--- a/Source/JavaScriptCore/runtime/PinballHandlerContext.h
+++ b/Source/JavaScriptCore/runtime/PinballHandlerContext.h
@@ -31,6 +31,8 @@
 #include <JavaScriptCore/GPRInfo.h>
 #include <JavaScriptCore/JSPIContext.h>
 
+#include <memory>
+
 namespace JSC {
 
 class EvacuatedStackSlice;
@@ -54,7 +56,7 @@ public:
     JSGlobalObject* globalObject;
     VM* vm;
     JSFunctionWithFields* handler;
-    EvacuatedStackSlice* slice;
+    std::unique_ptr<EvacuatedStackSlice> slice;
     size_t sliceByteSize;
     JSPIContext jspiContext;
     // Callee saves to restore before entering the evacuated code (points into the PinballCompletion held by the handler).


### PR DESCRIPTION
#### 9bd681fd28d88578c4a2855fca1e4fb4207ed5a0
<pre>
[JSC][JSPI polish] Use std::unique_ptr for EvacuatedStackSlice ownership in PinballHandlerContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=307578">https://bugs.webkit.org/show_bug.cgi?id=307578</a>
<a href="https://rdar.apple.com/170164096">rdar://170164096</a>

Reviewed by Marcus Plutowski.

The patch makes ownership of EvacuatedStackSlice explicit in PinballHandlerContext by
changing the raw pointer field to std::unique_ptr. The context owns the slice between
takeTopSlice() and implant(), and the type now reflects that.

A few unused `#include`s are removed in PinballCompletion.cpp.

Testing: covered by existing tests.
Canonical link: <a href="https://commits.webkit.org/310966@main">https://commits.webkit.org/310966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e2fe90a361f601e43edad4354a2fee349191b83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22004 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164348 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/858a4721-7a37-4515-a932-7bbe8bf89cc8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120413 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0ef230f6-526e-4799-a52c-b3a95b79dc11) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22598 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139715 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101102 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/367cff31-4713-47e9-a861-734f4c46de9c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12178 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147635 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131353 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166825 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16416 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/11003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128530 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28389 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23841 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128663 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34881 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28313 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139340 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/85760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23488 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16137 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187470 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28007 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92110 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48049 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27584 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27814 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27657 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->