### PR TITLE
Remove LegacyNativeDictionaryRequiredInterfaceNullability from PointerEventInit

### DIFF
--- a/Source/WebCore/dom/PointerEvent.cpp
+++ b/Source/WebCore/dom/PointerEvent.cpp
@@ -136,7 +136,7 @@ auto PointerEvent::tiltFromAngle(double altitudeAngle, double azimuthAngle) -> P
 
 PointerEvent::PointerEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
     : MouseEvent(EventInterfaceType::PointerEvent, type, initializer, isTrusted)
-    , m_pointerId(initializer.pointerId)
+    , m_pointerId(static_cast<PointerID>(initializer.pointerId))
     , m_width(initializer.width)
     , m_height(initializer.height)
     , m_pressure(initializer.pressure)

--- a/Source/WebCore/dom/PointerEvent.h
+++ b/Source/WebCore/dom/PointerEvent.h
@@ -53,7 +53,7 @@ class PointerEvent : public MouseEvent {
     WTF_MAKE_TZONE_ALLOCATED(PointerEvent);
 public:
     struct Init : MouseEventInit {
-        PointerID pointerId { mousePointerID };
+        long pointerId { mousePointerID };
         double width { 1 };
         double height { 1 };
         float pressure { 0 };

--- a/Source/WebCore/dom/PointerEvent.idl
+++ b/Source/WebCore/dom/PointerEvent.idl
@@ -23,19 +23,20 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary PointerEventInit : MouseEventInit {
+// https://w3c.github.io/pointerevents/
+
+// FIXME: The specification does not have defaults for tiltX, tiltY, altitudeAngle, and azimuthAngle, but it should.
+dictionary PointerEventInit : MouseEventInit {
     long pointerId = 0;
     double width = 1;
     double height = 1;
     float pressure = 0;
     float tangentialPressure = 0;
-    long tiltX = 0;
-    long tiltY = 0;
+    [ImplementationDefaultValue=0] long tiltX;
+    [ImplementationDefaultValue=0] long tiltY;
     long twist = 0;
-    [EnabledBySetting=AltitudeAngleEnabled] double altitudeAngle;
-    [EnabledBySetting=AzimuthAngleEnabled] double azimuthAngle;
+    [EnabledBySetting=AltitudeAngleEnabled, ImplementationDefaultValue=piOverTwoDouble] double altitudeAngle;
+    [EnabledBySetting=AzimuthAngleEnabled, ImplementationDefaultValue=0] double azimuthAngle;
     DOMString pointerType = "";
     boolean isPrimary = false;
     sequence<PointerEvent> coalescedEvents = [];
@@ -66,4 +67,3 @@
     [SecureContext] sequence<PointerEvent> getCoalescedEvents();
     sequence<PointerEvent> getPredictedEvents();
 };
-


### PR DESCRIPTION
#### 5e5808268ed98db7878fb047a45d658ef29613d4
<pre>
Remove LegacyNativeDictionaryRequiredInterfaceNullability from PointerEventInit
<a href="https://bugs.webkit.org/show_bug.cgi?id=311955">https://bugs.webkit.org/show_bug.cgi?id=311955</a>

Reviewed by Ryosuke Niwa and Abrar Rahman Protyasha.

Modernize the bindings code.

Canonical link: <a href="https://commits.webkit.org/311050@main">https://commits.webkit.org/311050@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7d92e56c055f5f43ae868af39f4b303cf12ded4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155592 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164355 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109413 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/baf7b576-7aa1-4114-96b9-c25fb10371fb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157465 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120417 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84908 "4 flakes 4 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b9afeb8c-67f0-4440-88da-7e51ba5bbd79) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139719 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101106 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0551b980-7937-43da-a69d-f1b37b400ede) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21688 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19811 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12185 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131357 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17551 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166833 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11010 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19162 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128535 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23845 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128668 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28320 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139344 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86155 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23737 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23490 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16141 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28014 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92117 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27591 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27821 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27664 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->