### PR TITLE
Add cycle detection and object de-dupe logic to JavaScriptEvaluationResult::ObjCExtractor

### DIFF
--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
@@ -89,11 +89,13 @@ class JavaScriptEvaluationResult::APIExtractor {
 public:
     Map NODELETE takeMap() { return WTF::move(m_map); }
     JSObjectID addObjectToMap(API::Object&);
+    bool failed() const { return m_failed; }
 private:
     Value toValue(API::Object&);
 
     HashMap<Ref<API::Object>, JSObjectID> m_objectsInMap;
     Map m_map;
+    bool m_failed { false };
 };
 
 class JavaScriptEvaluationResult::APIInserter {
@@ -139,33 +141,6 @@ RefPtr<API::Object> JavaScriptEvaluationResult::APIInserter::toAPI(Value&& root)
     });
 }
 
-static bool isSerializable(API::Object* object)
-{
-    if (!object)
-        return false;
-
-    switch (object->type()) {
-    case API::Object::Type::String:
-    case API::Object::Type::Boolean:
-    case API::Object::Type::Double:
-    case API::Object::Type::UInt64:
-    case API::Object::Type::Int64:
-    case API::Object::Type::JSHandle:
-    case API::Object::Type::SerializedNode:
-        return true;
-    case API::Object::Type::Array:
-        return std::ranges::all_of(downcast<API::Array>(object)->elements(), [] (const RefPtr<API::Object>& element) {
-            return isSerializable(element.get());
-        });
-    case API::Object::Type::Dictionary:
-        return std::ranges::all_of(downcast<API::Dictionary>(object)->map(), [] (const KeyValuePair<String, RefPtr<API::Object>>& pair) {
-            return isSerializable(pair.value.get());
-        });
-    default:
-        return false;
-    }
-}
-
 auto JavaScriptEvaluationResult::APIExtractor::toValue(API::Object& object) -> Value
 {
     switch (object.type()) {
@@ -200,8 +175,7 @@ auto JavaScriptEvaluationResult::APIExtractor::toValue(API::Object& object) -> V
         return { WTF::move(map) };
     }
     default:
-        // This object has been null checked and went through isSerializable which only supports these types.
-        ASSERT_NOT_REACHED();
+        m_failed = true;
         return EmptyType::Undefined;
     }
 }
@@ -210,10 +184,10 @@ std::optional<JavaScriptEvaluationResult> JavaScriptEvaluationResult::extract(AP
 {
     if (!object)
         return jsUndefined();
-    if (!isSerializable(object))
-        return std::nullopt;
     APIExtractor extractor;
     auto root = extractor.addObjectToMap(*object);
+    if (extractor.failed())
+        return std::nullopt;
     return JavaScriptEvaluationResult { root, extractor.takeMap() };
 }
 

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
@@ -37,11 +37,13 @@ class JavaScriptEvaluationResult::ObjCExtractor {
 public:
     Map NODELETE takeMap() { return WTF::move(m_map); }
     JSObjectID addObjectToMap(id);
+    bool failed() const { return m_failed; }
 private:
     Value toValue(id);
 
     Map m_map;
     HashMap<RetainPtr<id>, JSObjectID> m_objectsInMap;
+    bool m_failed { false };
 };
 
 class JavaScriptEvaluationResult::ObjCInserter {
@@ -165,8 +167,7 @@ auto JavaScriptEvaluationResult::ObjCExtractor::toValue(id object) -> Value
     if ([object isKindOfClass:_WKJSHandle.class])
         return makeUniqueRef<JSHandleInfo>(((_WKJSHandle *)object)->_ref->info());
 
-    // This object has been null checked and went through isSerializable which only supports these types.
-    ASSERT_NOT_REACHED();
+    m_failed = true;
     return EmptyType::Undefined;
 }
 
@@ -184,58 +185,15 @@ JSObjectID JavaScriptEvaluationResult::ObjCExtractor::addObjectToMap(id object)
     return identifier;
 }
 
-static bool isSerializable(id argument)
-{
-    if (!argument)
-        return true;
-
-    if ([argument isKindOfClass:NSString.class]
-        || [argument isKindOfClass:NSNumber.class]
-        || [argument isKindOfClass:NSDate.class]
-        || [argument isKindOfClass:NSNull.class]
-        || [argument isKindOfClass:_WKJSHandle.class]
-        || [argument isKindOfClass:_WKSerializedNode.class])
-        return true;
-
-    if ([argument isKindOfClass:[NSArray class]]) {
-        __block BOOL valid = true;
-
-        [argument enumerateObjectsUsingBlock:^(id object, NSUInteger, BOOL *stop) {
-            if (!isSerializable(object)) {
-                valid = false;
-                *stop = YES;
-            }
-        }];
-
-        return valid;
-    }
-
-    if ([argument isKindOfClass:[NSDictionary class]]) {
-        __block bool valid = true;
-
-        [argument enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
-            if (!isSerializable(key) || !isSerializable(value)) {
-                valid = false;
-                *stop = YES;
-            }
-        }];
-
-        return valid;
-    }
-
-    return false;
-}
-
 std::optional<JavaScriptEvaluationResult> JavaScriptEvaluationResult::extract(id object)
 {
     if (!object)
         return jsUndefined();
 
-    if (!isSerializable(object))
-        return std::nullopt;
-
     ObjCExtractor extractor;
     auto root = extractor.addObjectToMap(object);
+    if (extractor.failed())
+        return std::nullopt;
     return JavaScriptEvaluationResult { root, extractor.takeMap() };
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AsyncFunction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AsyncFunction.mm
@@ -321,6 +321,46 @@ TEST(AsyncFunction, PromiseDetachedFrame)
     EXPECT_EQ([webView _webProcessIdentifier], pid);
 }
 
+TEST(AsyncFunction, CircularArgumentReference)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    NSError *error;
+
+    // Test circular references in dictionaries and arrays.
+    // Before cycle detection, these would blow out the stack and crash.
+    auto circularDictionary = adoptNS([[NSMutableDictionary alloc] init]);
+    [circularDictionary setObject:@"value" forKey:@"key"];
+    [circularDictionary setObject:circularDictionary.get() forKey:@"self"];
+
+    id result = [webView objectByCallingAsyncFunction:@"return a.key" withArguments:@{ @"a" : circularDictionary.get() } error:&error];
+    EXPECT_NULL(error);
+    EXPECT_TRUE([result isEqualToString:@"value"]);
+
+    auto circularArray = adoptNS([[NSMutableArray alloc] init]);
+    [circularArray addObject:@"value"];
+    [circularArray addObject:circularArray.get()];
+
+    result = [webView objectByCallingAsyncFunction:@"return a[0]" withArguments:@{ @"a" : circularArray.get() } error:&error];
+    EXPECT_NULL(error);
+    EXPECT_TRUE([result isEqualToString:@"value"]);
+}
+
+TEST(AsyncFunction, StructuralSharingPerformance)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    NSError *error;
+
+    // Build an object graph with 51 unique objects but 2^50 paths through the tree.
+    // Before de-duping logic this would hang "indefinitely"
+    id shared = @"baz";
+    for (int i = 0; i < 50; i++)
+        shared = @{ @"foo" : shared, @"bar" : shared };
+
+    id result = [webView objectByCallingAsyncFunction:@"return 'ok'" withArguments:@{ @"a" : shared } error:&error];
+    EXPECT_NULL(error);
+    EXPECT_TRUE([result isEqualToString:@"ok"]);
+}
+
 TEST(AsyncFunction, TransientActivation)
 {
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];


### PR DESCRIPTION
#### 8283a18bb89df2edfdb91f272b80dfd85bdf02e9
<pre>
Add cycle detection and object de-dupe logic to JavaScriptEvaluationResult::ObjCExtractor
<a href="https://rdar.apple.com/173737060">rdar://173737060</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311957">https://bugs.webkit.org/show_bug.cgi?id=311957</a>

Reviewed by Ryosuke Niwa.

When we moved away from `SerializedScriptValue` in <a href="https://commits.webkit.org/298898@main">https://commits.webkit.org/298898@main</a> and started walking
the Obj-C object graph with `JavaScriptEvaluationResult`, we added an explicit `isSerializable` step.

While the main serialization path had object de-duping and cycle detection, the `isSerializable` step did not.
This could cause huge runtime explosion with certain types of object graphs.

This patch gets rid of that step and instead just teaches the actual serialization pass to abort early if
it runs across a non-serializable object.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AsyncFunction.mm

* Source/WebKit/Shared/JavaScriptEvaluationResult.cpp:
(WebKit::JavaScriptEvaluationResult::APIExtractor::failed const):
(WebKit::JavaScriptEvaluationResult::APIExtractor::toValue):
(WebKit::JavaScriptEvaluationResult::extract):
(WebKit::isSerializable): Deleted.
* Source/WebKit/Shared/JavaScriptEvaluationResult.mm:
(WebKit::JavaScriptEvaluationResult::ObjCExtractor::failed const):
(WebKit::JavaScriptEvaluationResult::ObjCExtractor::toValue):
(WebKit::JavaScriptEvaluationResult::extract):
(WebKit::isSerializable): Deleted.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AsyncFunction.mm:
(TestWebKitAPI::TEST(AsyncFunction, CircularArgumentReference)):
(TestWebKitAPI::TEST(AsyncFunction, StructuralSharingPerformance)):

Canonical link: <a href="https://commits.webkit.org/310967@main">https://commits.webkit.org/310967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3aa0d5ba1ebd6b5edf41c22dfdcda59ad474d9f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155609 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22026 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164370 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3834ff85-a9dd-445a-82e7-a9046b2b7705) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157480 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28717 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120427 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139732 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101116 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9fa86cc6-d57f-4850-a7c5-9c013bf283e5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12200 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131362 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/17564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166849 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/11025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19175 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128545 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23858 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128678 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34882 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139357 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23499 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28029 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92132 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27606 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27836 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27679 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->