### PR TITLE
outlook.live.com: Unable to change selected text

### DIFF
--- a/LayoutTests/editing/selection/ios/touchmove-to-change-selection-with-prevent-default-expected.txt
+++ b/LayoutTests/editing/selection/ios/touchmove-to-change-selection-with-prevent-default-expected.txt
@@ -1,0 +1,3 @@
+PASS: Has selection after long press
+PASS: Selection expanded after dragging handle down
+

--- a/LayoutTests/editing/selection/ios/touchmove-to-change-selection-with-prevent-default.html
+++ b/LayoutTests/editing/selection/ios/touchmove-to-change-selection-with-prevent-default.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/basic-gestures.js"></script>
+<style>
+body {
+    margin: 0;
+    font-size: 30px;
+    font-family: monospace;
+}
+#target {
+    width: 300px;
+    padding: 10px;
+    background-color: silver;
+}
+</style>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+document.addEventListener("touchmove", (e) => {
+    e.preventDefault();
+}, { passive: false });
+
+async function runTest()
+{
+    if (!window.testRunner)
+        return;
+
+    var output = "";
+    var fontHeight = 30;
+
+    var target = document.getElementById("target");
+    var targetRect = target.getBoundingClientRect();
+    var pressPointX = targetRect.x + targetRect.width / 2;
+    var pressPointY = targetRect.y + targetRect.height / 2;
+
+    await longPressAtPoint(pressPointX, pressPointY);
+    await UIHelper.waitForSelectionToAppear();
+
+    var initialSelection = document.getSelection().toString();
+    if (initialSelection.length > 0)
+        output += "PASS: Has selection after long press<br>";
+    else
+        output += "FAIL: No selection after long press<br>";
+
+    var grabberRect = await UIHelper.getSelectionEndGrabberViewRect();
+    var grabberX = grabberRect.left + (grabberRect.width / 2);
+    var grabberY = grabberRect.top + (grabberRect.height / 2);
+
+    await touchAndDragFromPointToPoint(grabberX, grabberY, grabberX, grabberY + (fontHeight * 2));
+
+    var newSelection = document.getSelection().toString();
+    if (newSelection.length > initialSelection.length)
+        output += "PASS: Selection expanded after dragging handle down<br>";
+    else
+        output += "FAIL: Selection did not expand (initial: " + initialSelection.length + ", new: " + newSelection.length + ")<br>";
+
+    document.getElementById("target").innerHTML = output;
+    testRunner.notifyDone();
+}
+
+window.addEventListener("load", runTest);
+</script>
+</head>
+<body>
+<div id="target">
+    <p>Here's to the crazy ones. The misfits. The rebels. The troublemakers.</p>
+    <p>The round pegs in the square holes. The ones who see things differently.</p>
+</div>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -368,6 +368,7 @@ struct ImageAnalysisContextMenuActionData {
     RetainPtr<WKTouchEventsGestureRecognizer> _touchEventGestureRecognizer;
 
     BOOL _touchEventsCanPreventNativeGestures;
+    BOOL _touchStartedNearSelectionHandle;
     BOOL _preventsPanningInXAxis;
     BOOL _preventsPanningInYAxis;
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -2229,6 +2229,9 @@ typedef NS_ENUM(NSInteger, EndEditingReason) {
         [self doAfterPositionInformationUpdate:[assistant = WeakObjCPtr<WKActionSheetAssistant>(_actionSheetAssistant.get())] (WebKit::InteractionInformationAtPosition information) {
             [assistant.get() interactionDidStartWithPositionInformation:information];
         } forRequest:positionInformationRequest];
+
+        if (_touchEventsCanPreventNativeGestures && [self _isTouchNearSelectionHandle:lastTouchEvent.locationInRootViewCoordinates])
+            _touchStartedNearSelectionHandle = YES;
     }
 
 #if ENABLE(TOUCH_EVENTS)
@@ -2237,13 +2240,17 @@ typedef NS_ENUM(NSInteger, EndEditingReason) {
 
     [self _handleTouchActionsForTouchEvent:nativeWebTouchEvent];
 
-    if (_touchEventsCanPreventNativeGestures)
+    if (_touchStartedNearSelectionHandle && lastTouchEvent.type != WebKit::WKTouchEventType::Begin) {
+        if (lastTouchEvent.type == WebKit::WKTouchEventType::Change || lastTouchEvent.type == WebKit::WKTouchEventType::End)
+            [self _doneDeferringTouchMove:NO];
+    } else if (_touchEventsCanPreventNativeGestures)
         _page->handlePreventableTouchEvent(nativeWebTouchEvent);
     else
         _page->handleUnpreventableTouchEvent(nativeWebTouchEvent);
 
     if (nativeWebTouchEvent.allTouchPointsAreReleased()) {
         _touchEventsCanPreventNativeGestures = YES;
+        _touchStartedNearSelectionHandle = NO;
 
         if (!_page->isScrollingOrZooming())
             [self _resetPanningPreventionFlags];
@@ -3385,6 +3392,38 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return _page->dataDetectionResults();
 }
 #endif
+
+- (BOOL)_isTouchNearSelectionHandle:(WebCore::FloatPoint)touchPoint
+{
+    if (_lastSelectionDrawingInfo.type != WebCore::SelectionType::Range)
+        return NO;
+
+    if (_suppressSelectionAssistantReasons)
+        return NO;
+
+    if (![_textInteractionWrapper areSelectionHandlesVisible])
+        return NO;
+
+    RefPtr page = _page;
+    if (!page)
+        return NO;
+
+    auto& editorState = page->editorState();
+    if (!editorState.visualData)
+        return NO;
+
+    static constexpr float handleHitTestPadding = 44;
+    auto inflatedContainsPoint = [&](WebCore::IntRect caretRect) -> bool {
+        if (caretRect.isEmpty())
+            return false;
+        WebCore::FloatRect hitArea(caretRect);
+        hitArea.inflate(handleHitTestPadding);
+        return hitArea.contains(touchPoint);
+    };
+
+    return inflatedContainsPoint(editorState.visualData->caretRectAtStart)
+        || inflatedContainsPoint(editorState.visualData->caretRectAtEnd);
+}
 
 - (BOOL)_pointIsInsideSelectionRect:(CGPoint)point outBoundingRect:(WebCore::FloatRect *)outBoundingRect
 {
@@ -10562,6 +10601,9 @@ static WebCore::DataOwnerType coreDataOwnerType(_UIDataOwner platformType)
         return NO;
 
     if (gestureRecognizer == _touchEventGestureRecognizer)
+        return NO;
+
+    if (_touchStartedNearSelectionHandle)
         return NO;
 
 #if HAVE(UIKIT_WITH_MOUSE_SUPPORT)

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h
@@ -71,6 +71,7 @@
 @property (nonatomic, readonly) NSArray<UIView *> *managedTextSelectionViews;
 @property (nonatomic, readonly) UIWKTextInteractionAssistant *textInteractionAssistant;
 @property (nonatomic, readonly) UIView *selectionHighlightView;
+@property (nonatomic, readonly) BOOL areSelectionHandlesVisible;
 
 @end
 

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
@@ -203,6 +203,17 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HideEditMenuScope);
 #endif
 }
 
+- (BOOL)areSelectionHandlesVisible
+{
+#if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
+    for (UIView *handleView in [self textSelectionDisplayInteraction].handleViews) {
+        if (!handleView.hidden)
+            return YES;
+    }
+#endif
+    return NO;
+}
+
 - (void)prepareToMoveSelectionContainer:(UIView *)newContainer
 {
     RetainPtr contentView = _view;


### PR DESCRIPTION
#### 6ada1137f92bbf920f4c657cdb44251f3ea5aa41
<pre>
outlook.live.com: Unable to change selected text
<a href="https://rdar.apple.com/151851274">rdar://151851274</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311961">https://bugs.webkit.org/show_bug.cgi?id=311961</a>

Reviewed by Wenson Hsieh.

When on outlook.live.com looking at a received or sent email on iOS,
you can create a selection, but it is tedious to change the selected text.
This is because the outlook JS has an event listener for touch events
that are used to transform: translate3d the page. In that listener callback
they call preventDefault, which blocks WebKit from using the touch
event to move the selection.

To solve this issue, I added a check to touchstart to see if it is near
a selection handle. If it is, then we set some state on the view, and
ensure that the touch start cannot prevent native gestures. Then, all
subsequent touchmove events will not be sent to JS, so they can be used
to adjust the text selection.

After all fingers are lifted, the state is reset, and touch events will
go back to normal until another touch start is near a selection handle.

Test: editing/selection/ios/touchmove-to-change-selection-with-prevent-default.html

* LayoutTests/editing/selection/ios/touchmove-to-change-selection-with-prevent-default-expected.txt: Added.
* LayoutTests/editing/selection/ios/touchmove-to-change-selection-with-prevent-default.html: Added.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _touchEventsRecognized]):
(-[WKContentView _doneDeferringTouchStart:]):
(-[WKContentView _doneDeferringTouchMove:]):
(-[WKContentView _isTouchNearSelectionHandle:]):

Canonical link: <a href="https://commits.webkit.org/311216@main">https://commits.webkit.org/311216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bab74dd97e5e90cdf219cd601f4a65b9052e1a85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164940 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157990 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29455 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120877 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23085 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140202 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101558 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22164 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20316 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12712 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131824 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18034 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167419 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11535 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19646 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128997 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29055 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129121 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35028 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28977 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139828 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86744 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23946 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16627 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28686 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92643 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28213 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28441 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28337 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->