### PR TITLE
[AI Experiment, Do Not Review, Opus Generated] [JSC][DFG] Disable peephole branch fusion for HeapBigIntUse comparisons

### DIFF
--- a/JSTests/stress/heap-bigint-compare-does-gc-validation.js
+++ b/JSTests/stress/heap-bigint-compare-does-gc-validation.js
@@ -1,0 +1,12 @@
+//@ runDefault("--jitPolicyScale=0.1", "--watchdog-exception-ok", "--watchdog=5000", "--useLLInt=0", "--validateExceptionChecks=1", "--useConcurrentJIT=0", "--useConcurrentGC=0", "--forceGCSlowPaths=1", "--useOSREntryToFTL=0")
+
+// Regression test for HeapBigInt comparison in DFG peephole branch fusion.
+// CompareLess with HeapBigIntUse was falling through to genericJSValuePeepholeBranch
+// (GC-capable) instead of the correct non-peephole path, violating doesGC()=false.
+// The for-loop structure triggers peephole fusion of CompareLess + Branch.
+// The watchdog causes JSLock re-acquisition which triggers DoesGCCheck validation.
+
+for (let i = 0; i < 2000000; i++) {
+    for (let j = 0n; j < 2n ** 2n;)
+        break;
+}

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -2027,6 +2027,9 @@ bool SpeculativeJIT::compilePeepHoleBranch(Node* node, RelationalCondition condi
         else if (node->isBinaryUseKind(StringUse) || node->isBinaryUseKind(StringIdentUse)) {
             // Use non-peephole comparison, for now.
             return false;
+        } else if (node->isBinaryUseKind(HeapBigIntUse)) {
+            // Use non-peephole comparison, for now.
+            return false;
         } else if (node->isBinaryUseKind(DoubleRepUse))
             compilePeepHoleDoubleBranch(node, branchNode, doubleCondition);
         else if (node->op() == CompareEq) {


### PR DESCRIPTION
#### d7a9cbaa31edccf5c58930f02bf951035a22f51b
<pre>
[Opus Generated] [JSC][DFG] Disable peephole branch fusion for HeapBigIntUse comparisons
<a href="https://bugs.webkit.org/show_bug.cgi?id=311974">https://bugs.webkit.org/show_bug.cgi?id=311974</a>
<a href="https://rdar.apple.com/174517383">rdar://174517383</a>

Reviewed by NOBODY (OOPS!).

compilePeepHoleBranch() has no case for HeapBigIntUse, so comparison
nodes with HeapBigInt operands fall through to genericJSValuePeepholeBranch,
which uses GC-capable operations instead of the specialized NOEXCEPT
HeapBigInt comparison path. Return false for HeapBigIntUse to disable
peephole fusion and route through the correct non-peephole path,
matching the existing StringUse/StringIdentUse convention.

Test: JSTests/stress/heap-bigint-compare-does-gc-validation.js

* JSTests/stress/heap-bigint-compare-does-gc-validation.js: Added.
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compilePeepHoleBranch):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7a9cbaa31edccf5c58930f02bf951035a22f51b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155620 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164381 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109434 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9aa4277f-5def-451d-8deb-0a5abf04023f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120436 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84915 "2 flakes 3 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d1770f1c-def3-4c4c-b4c3-c9a922e29e20) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158577 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22616 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139733 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101125 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/233d5aea-2a6d-4391-b7f4-f602f53a1503) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21702 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19833 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12211 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147668 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131371 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17565 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166860 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16450 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11036 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19176 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128555 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28422 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23867 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128686 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28346 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139358 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86175 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23513 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16155 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187503 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28040 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92143 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48059 "Found 1 new JSC stress test failure: stress/heap-bigint-compare-does-gc-validation.js.default (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27617 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27847 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27690 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->