### PR TITLE
XML parser hangs in trying to expand deeply nested entity references

### DIFF
--- a/LayoutTests/fast/parser/xml-entity-reference-expansion-2-expected.txt
+++ b/LayoutTests/fast/parser/xml-entity-reference-expansion-2-expected.txt
@@ -1,0 +1,4 @@
+This tests parsing deeply nested entity references. WebKit should not hang or crash.
+
+PASS
+

--- a/LayoutTests/fast/parser/xml-entity-reference-expansion-2.html
+++ b/LayoutTests/fast/parser/xml-entity-reference-expansion-2.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This tests parsing deeply nested entity references. WebKit should not hang or crash.</p>
+<div id="result">Running</div>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+const blob = new Blob([`<?xml version="1.0" standalone="no"?>
+<!DOCTYPE html [
+  <!ENTITY j "&i;&i;&i;&i;&i;&i;&i;&i;&i;&i;">
+  <!ENTITY i "&h;&h;&h;&h;&h;&h;&h;&h;&h;&h;">
+  <!ENTITY h "&g;&g;&g;&g;&g;&g;&g;&g;&g;&g;">
+  <!ENTITY g "&f;&f;&f;&f;&f;&f;&f;&f;&f;&f;">
+  <!ENTITY f "&e;&e;&e;&e;&e;&e;&e;&e;&e;&e;">
+  <!ENTITY e "&d;&d;&d;&d;&d;&d;&d;&d;&d;&d;">
+  <!ENTITY d "&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;">
+  <!ENTITY c "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">
+  <!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">
+  <!ENTITY a "aaaa ">
+]>
+<html xmlns="http://www.w3.org/1999/xhtml"><body>&j;</body></html>`], {type: "application/xml"});
+
+const iframe = document.createElement('iframe');
+iframe.onload = () => result.textContent = 'PASS';
+iframe.src = URL.createObjectURL(blob);
+document.body.appendChild(iframe);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/parser/xml-entity-reference-expansion-3-expected.txt
+++ b/LayoutTests/fast/parser/xml-entity-reference-expansion-3-expected.txt
@@ -1,0 +1,4 @@
+This tests parsing deeply nested entity references. WebKit should not hang or crash.
+
+PASS
+

--- a/LayoutTests/fast/parser/xml-entity-reference-expansion-3.html
+++ b/LayoutTests/fast/parser/xml-entity-reference-expansion-3.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This tests parsing deeply nested entity references. WebKit should not hang or crash.</p>
+<div id="result">Running</div>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+const blob = new Blob([`<?xml version="1.0" standalone="no"?>
+<!DOCTYPE html [
+  <!ENTITY a "aaaa ">
+  <!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">
+  <!ENTITY c "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">
+  <!ENTITY d "&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;">
+  <!ENTITY e "&d;&d;&d;&d;&d;&d;&d;&d;&d;&d;">
+  <!ENTITY f "&e;&e;&e;&e;&e;&e;&e;&e;&e;&e;">
+  <!ENTITY g "&f;&f;&f;&f;&f;&f;&f;&f;&f;&f;">
+  <!ENTITY h "&g;&g;&g;&g;&g;&g;&g;&g;&g;&g;">
+  <!ENTITY i "&h;&h;&h;&h;&h;&h;&h;&h;&h;&h;">
+  <!ENTITY j "&i;&i;&i;&i;&i;&i;&i;&i;&i;&i;">
+  <!ENTITY j "a">
+]>
+<html xmlns="http://www.w3.org/1999/xhtml"><body>&j;</body></html>`], {type: "application/xml"});
+
+const iframe = document.createElement('iframe');
+iframe.onload = () => result.textContent = 'PASS';
+iframe.src = URL.createObjectURL(blob);
+document.body.appendChild(iframe);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/parser/xml-entity-reference-expansion-expected.txt
+++ b/LayoutTests/fast/parser/xml-entity-reference-expansion-expected.txt
@@ -1,0 +1,4 @@
+This tests parsing deeply nested entity references. WebKit should not hang or crash.
+
+PASS
+

--- a/LayoutTests/fast/parser/xml-entity-reference-expansion.html
+++ b/LayoutTests/fast/parser/xml-entity-reference-expansion.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This tests parsing deeply nested entity references. WebKit should not hang or crash.</p>
+<div id="result">Running</div>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+const blob = new Blob([`<?xml version="1.0" standalone="no"?>
+<!DOCTYPE html [
+  <!ENTITY a "aaaa ">
+  <!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">
+  <!ENTITY c "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">
+  <!ENTITY d "&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;">
+  <!ENTITY e "&d;&d;&d;&d;&d;&d;&d;&d;&d;&d;">
+  <!ENTITY f "&e;&e;&e;&e;&e;&e;&e;&e;&e;&e;">
+  <!ENTITY g "&f;&f;&f;&f;&f;&f;&f;&f;&f;&f;">
+  <!ENTITY h "&g;&g;&g;&g;&g;&g;&g;&g;&g;&g;">
+  <!ENTITY i "&h;&h;&h;&h;&h;&h;&h;&h;&h;&h;">
+  <!ENTITY j "&i;&i;&i;&i;&i;&i;&i;&i;&i;&i;">
+]>
+<html xmlns="http://www.w3.org/1999/xhtml"><body>&j;</body></html>`], {type: "application/xml"});
+
+const iframe = document.createElement('iframe');
+iframe.onload = () => result.textContent = 'PASS';
+iframe.src = URL.createObjectURL(blob);
+document.body.appendChild(iframe);
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -272,6 +272,12 @@ MaximumSourceBufferSize:
     WebCore:
       default: SettingsBase::defaultMaximumSourceBufferSize()
 
+MaximumXMLParserEntityExpansionCount:
+  type: uint32_t
+  defaultValue:
+    WebCore:
+      default: SettingsBase::defaultMaximumXMLParserEntityExpansionCount
+
 MediaKeysStorageDirectory:
   type: String
   defaultValue:

--- a/Source/WebCore/page/SettingsBase.h
+++ b/Source/WebCore/page/SettingsBase.h
@@ -71,6 +71,7 @@ public:
 #endif
 
     static const unsigned defaultMaximumHTMLParserDOMTreeDepth = 512;
+    static const unsigned defaultMaximumXMLParserEntityExpansionCount = 512;
     static const unsigned defaultMaximumRenderTreeDepth = 512;
 
     virtual FontGenericFamilies& fontGenericFamilies() LIFETIME_BOUND = 0;

--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -140,9 +140,13 @@ public:
     void startDocument(const xmlChar* version, const xmlChar* encoding, int standalone);
     void internalSubset(const xmlChar* name, const xmlChar* externalID, const xmlChar* systemID);
     void endDocument();
+    xmlEntityPtr getEntity(const xmlChar* name);
+    void entityDecl(const xmlChar* name, int type, const xmlChar* publicId, const xmlChar* systemId, xmlChar* content);
 
 private:
     void initializeParserContext(const CString& chunk = CString());
+    void flushDeferredEntityDeclarations();
+    uint64_t computeTransitiveEntityReferenceCount(const AtomString& name, const HashMap<AtomString, String>& entityContents, HashSet<AtomString>& visiting);
 
     void pushCurrentNode(ContainerNode*);
     void popCurrentNode();
@@ -179,6 +183,19 @@ private:
     bool m_parserPaused { false };
     bool m_requestingScript { false };
     bool m_finishCalled { false };
+
+    const uint64_t m_maxEntityExpansionCount;
+
+    struct DeferredEntityDeclaration {
+        String name;
+        int type;
+        String publicId;
+        String systemId;
+        String content;
+    };
+    Vector<DeferredEntityDeclaration> m_deferredEntityDeclarations;
+    bool m_deferredEntityDeclarationsFlushed { false };
+    HashMap<AtomString, uint64_t> m_entityTransitiveReferenceCounts;
 
     std::unique_ptr<XMLErrors> m_xmlErrors;
 

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -661,6 +661,7 @@ XMLDocumentParser::XMLDocumentParser(Document& document, IsInFrameView isInFrame
     , m_isInFrameView(isInFrameView)
     , m_pendingCallbacks(makeUniqueRef<PendingCallbacks>())
     , m_currentNode(&document)
+    , m_maxEntityExpansionCount(document.settings().maximumXMLParserEntityExpansionCount())
     , m_scriptStartPosition(TextPosition::belowRangePosition())
 {
 }
@@ -669,6 +670,7 @@ XMLDocumentParser::XMLDocumentParser(DocumentFragment& fragment, HashMap<AtomStr
     : ScriptableDocumentParser(fragment.document(), parserContentPolicy)
     , m_pendingCallbacks(makeUniqueRef<PendingCallbacks>())
     , m_currentNode(&fragment)
+    , m_maxEntityExpansionCount(fragment.document().settings().maximumXMLParserEntityExpansionCount())
     , m_scriptStartPosition(TextPosition::belowRangePosition())
     , m_parsingFragment(true)
     , m_prefixToNamespaceMap(WTF::move(prefixToNamespaceMap))
@@ -1280,24 +1282,131 @@ static xmlEntityPtr getXHTMLEntity(const xmlChar* name)
     return entity;
 }
 
-static xmlEntityPtr getEntityHandler(void* closure, const xmlChar* name)
+xmlEntityPtr XMLDocumentParser::getEntity(const xmlChar* name)
 {
-    xmlParserCtxtPtr ctxt = static_cast<xmlParserCtxtPtr>(closure);
-
     xmlEntityPtr ent = xmlGetPredefinedEntity(name);
     if (ent) {
         RELEASE_ASSERT(ent->etype == XML_INTERNAL_PREDEFINED_ENTITY);
         return ent;
     }
 
-    ent = xmlGetDocEntity(ctxt->myDoc, name);
-    if (!ent && getParser(closure)->isXHTMLDocument()) {
+    if (!m_deferredEntityDeclarationsFlushed)
+        flushDeferredEntityDeclarations();
+
+    ent = xmlGetDocEntity(context()->myDoc, name);
+    if (!ent && isXHTMLDocument()) {
         ent = getXHTMLEntity(name);
         if (ent)
             ent->etype = XML_INTERNAL_GENERAL_ENTITY;
     }
 
     return ent;
+}
+
+void XMLDocumentParser::entityDecl(const xmlChar* name, int type, const xmlChar* publicId, const xmlChar* systemId, xmlChar* content)
+{
+    auto contentString = toString(content);
+    if (type == XML_INTERNAL_GENERAL_ENTITY && contentString.contains('&')) {
+        m_deferredEntityDeclarations.append({
+            toString(name),
+            type,
+            toString(publicId),
+            toString(systemId),
+            WTF::move(contentString),
+        });
+        m_deferredEntityDeclarationsFlushed = false;
+        return;
+    }
+    xmlSAX2EntityDecl(context(), name, type, publicId, systemId, content);
+}
+
+void XMLDocumentParser::flushDeferredEntityDeclarations()
+{
+    m_deferredEntityDeclarationsFlushed = true;
+
+    // Clear cached counts since new entities may have been added.
+    m_entityTransitiveReferenceCounts.clear();
+
+    // Build a map from entity name to content for transitive count computation.
+    HashMap<AtomString, String> entityContents;
+    for (auto& decl : m_deferredEntityDeclarations)
+        entityContents.add(AtomString(decl.name), decl.content);
+
+    // Compute transitive reference counts and register only safe entities.
+    for (auto& decl : m_deferredEntityDeclarations) {
+        auto entityName = AtomString(decl.name);
+        HashSet<AtomString> visiting;
+        if (computeTransitiveEntityReferenceCount(entityName, entityContents, visiting) > m_maxEntityExpansionCount) {
+            handleError(XMLErrors::Type::Fatal, "Entity reference expansion limit reached", textPosition());
+            return;
+        }
+
+        auto nameUTF8 = decl.name.utf8();
+        if (xmlGetDocEntity(context()->myDoc, byteCast<xmlChar>(nameUTF8.data())))
+            continue;
+        auto publicIdUTF8 = decl.publicId.utf8();
+        auto systemIdUTF8 = decl.systemId.utf8();
+        auto contentUTF8 = decl.content.utf8();
+        xmlSAX2EntityDecl(context(),
+            byteCast<xmlChar>(nameUTF8.data()),
+            decl.type,
+            byteCast<xmlChar>(publicIdUTF8.data()),
+            byteCast<xmlChar>(systemIdUTF8.data()),
+            const_cast<xmlChar*>(byteCast<xmlChar>(contentUTF8.data())));
+    }
+}
+
+uint64_t XMLDocumentParser::computeTransitiveEntityReferenceCount(const AtomString& name, const HashMap<AtomString, String>& entityContents, HashSet<AtomString>& visiting)
+{
+    if (name.isEmpty())
+        return 0;
+
+    auto it = m_entityTransitiveReferenceCounts.find(name);
+    if (it != m_entityTransitiveReferenceCounts.end())
+        return it->value;
+
+    if (!visiting.add(name).isNewEntry)
+        return 0;
+
+    auto contentIt = entityContents.find(name);
+    if (contentIt == entityContents.end()) {
+        m_entityTransitiveReferenceCounts.set(name, 0);
+        return 0;
+    }
+
+    auto& content = contentIt->value;
+    CheckedUint64 count = 0;
+    size_t i = 0;
+    while (i < content.length()) {
+        if (content[i] != '&') {
+            ++i;
+            continue;
+        }
+        size_t nameStart = i + 1;
+        size_t nameEnd = nameStart;
+        while (nameEnd < content.length() && content[nameEnd] != ';')
+            ++nameEnd;
+        if (nameEnd >= content.length())
+            break;
+        ++count;
+        auto referencedName = AtomString(content.substring(nameStart, nameEnd - nameStart));
+        count += computeTransitiveEntityReferenceCount(referencedName, entityContents, visiting);
+        i = nameEnd + 1;
+    }
+
+    uint64_t result = count.hasOverflowed() ? std::numeric_limits<uint64_t>::max() : count.value();
+    m_entityTransitiveReferenceCounts.set(name, result);
+    return result;
+}
+
+static void entityDeclHandler(void* closure, const xmlChar* name, int type, const xmlChar* publicId, const xmlChar* systemId, xmlChar* content)
+{
+    protect(getParser(closure))->entityDecl(name, type, publicId, systemId, content);
+}
+
+static xmlEntityPtr getEntityHandler(void* closure, const xmlChar* name)
+{
+    return protect(getParser(closure))->getEntity(name);
 }
 
 static void startDocumentHandler(void* closure)
@@ -1364,7 +1473,7 @@ void XMLDocumentParser::initializeParserContext(const CString& chunk)
     sax.internalSubset = internalSubsetHandler;
     sax.externalSubset = externalSubsetHandler;
     sax.ignorableWhitespace = ignorableWhitespaceHandler;
-    sax.entityDecl = xmlSAX2EntityDecl;
+    sax.entityDecl = entityDeclHandler;
     sax.initialized = XML_SAX2_MAGIC;
     DocumentParser::startParsing();
     m_sawError = false;


### PR DESCRIPTION
#### d093ebaadad5f7e594752921acafcdb552b301c3
<pre>
XML parser hangs in trying to expand deeply nested entity references
<a href="https://bugs.webkit.org/show_bug.cgi?id=311973">https://bugs.webkit.org/show_bug.cgi?id=311973</a>
<a href="https://rdar.apple.com/173731253">rdar://173731253</a>

Reviewed by David Kilzer and Wenson Hsieh.

XML documents can define internal entities that reference other entities,
creating exponential expansion, exhausting available memory or causing a hang.

This PR prevents this issue by deferring internal general entity registration.
During DTD processing, the custom entityDecl SAX handler stores all the entity
declarations in a list instead of registering the entity with the parser
synchronously via xmlSAX2EntityDecl when the content includes &quot;&amp;&quot;. When the
entity reference is used via getEntity (during document body parsing after all
entities have been declared) or during parsing of the rest of DTD, we flush the
transitive expansion count. i.e. for each entity, we compute the total number
of entity references that would be transitively resolved during expansion,
using memoized recursion over the stored content strings. Only entities whose
transitive reference count is within the configurable limit (default 512) are
registered via xmlSAX2EntityDecl. Dangerous entities are never registered and
results in a parser error instead, so xmlGetDocEntity does not find them.

Deferred registration is necessary because entities may be declared in any order
(forward references would not yet be available during DTD processing).
By waiting until all declarations are collected, the transitive computation
handles both forward and backward references correctly.

Note that in the worst case scenario, we can have O(n^2) processing time for
entity reference declarations because every declaration of an entity reference
can trigger an entity resolution and call flushDeferredEntityDeclarations,
which traverses all the entity references and updates the expansion counts.
This is, unfortunately, unavoidable because entity reference can appear out of
order (e.g. a declaration of an entity reference may refer to an entity
reference only declared later in the document), and the expansion count needs
to be updated whenever a new entity reference definition is encountered.

We must scan for &amp;name; patterns in entity content ourselves because libxml2
does not provide an API to enumerate entity references in a string without
also expanding them. xmlStringDecodeEntities recursively expands entity content,
which would itself trigger the same out-of-memory error or hung. In entityDecl
SAX handler, libxml2 has already resolved character references (&amp;#...;) in the
content, so every &quot;&amp;&quot; in the string is guaranteed to be the start of a general
entity reference.

Returning nullptr from the getEntity SAX callback or nullifying entity content
fields is insufficient because libxml2&apos;s xmlParseBalancedChunkMemoryInternal
creates nested parser contexts that bypasses the SAX getEntity callback and look
up entities directly via xmlGetDocEntity.

An alternative solution would be to use xmlCtxtSetMaxAmplification, which
enforces an expansion ratio limit inside libxml2&apos;s own recursive expansion.
However, this API is only available in libxml2 2.13+ and is not present in the
version of libxml2 shipped with macOS.

The change co-authored with Claude AI.

Tests: fast/parser/xml-entity-reference-expansion-2.html
       fast/parser/xml-entity-reference-expansion.html

* LayoutTests/fast/parser/xml-entity-reference-expansion-2-expected.txt: Added.
* LayoutTests/fast/parser/xml-entity-reference-expansion-2.html: Added.
* LayoutTests/fast/parser/xml-entity-reference-expansion-expected.txt: Added.
* LayoutTests/fast/parser/xml-entity-reference-expansion.html: Added.
* Source/WebCore/page/Settings.yaml:
* Source/WebCore/page/SettingsBase.h:
* Source/WebCore/xml/parser/XMLDocumentParser.h:
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::XMLDocumentParser):
(WebCore::XMLDocumentParser::getEntity):
(WebCore::XMLDocumentParser::entityDecl):
(WebCore::XMLDocumentParser::flushDeferredEntityDeclarations):
(WebCore::XMLDocumentParser::computeTransitiveEntityReferenceCount):
(WebCore::entityDeclHandler):
(WebCore::getEntityHandler):
(WebCore::XMLDocumentParser::initializeParserContext):

Canonical link: <a href="https://commits.webkit.org/311014@main">https://commits.webkit.org/311014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/744afc87fbf0591b48e5ba3b594a0a75209f93a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155771 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164533 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157642 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29176 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28879 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120572 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158728 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22759 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139885 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101261 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21845 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19982 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12363 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17717 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167013 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11187 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19328 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128692 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128824 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28497 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139510 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86331 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23723 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Reviewed by David Kilzer and Wenson Hsieh; Canonicalized commit; Pushed commit to WebKit repository") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23647 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16308 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28191 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92294 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27768 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27998 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27841 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->