### PR TITLE
[Cocoa] Exception thrown by -[AVCapturePhotoOutput setMaxPhotoDimensions:]

### DIFF
--- a/Source/WebCore/platform/mediastream/cocoa/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/cocoa/AVVideoCaptureSource.h
@@ -71,7 +71,7 @@ public:
     void captureSessionEndInterruption(RetainPtr<NSNotification>);
     void deviceDisconnected(RetainPtr<NSNotification>);
 
-    AVCaptureSession* session() const { return m_session.get(); }
+    AVCaptureSession* session() const;
 
     void captureSessionIsRunningDidChange(bool);
     void captureSessionRuntimeError(RetainPtr<NSError>);
@@ -128,7 +128,7 @@ private:
 
     IntSize sizeForPreset(NSString*);
 
-    AVCaptureDevice* device() const { return m_device.get(); }
+    AVCaptureDevice* device() const;
 
     IntDegrees sensorOrientationFromVideoOutput();
 
@@ -157,9 +157,8 @@ private:
 
     void rejectPendingPhotoRequest(const String&);
     void resolvePendingPhotoRequest(Vector<uint8_t>&&, const String&);
-    RetainPtr<AVCapturePhotoSettings> photoConfiguration(const PhotoSettings&);
+    RetainPtr<AVCapturePhotoSettings> photoConfiguration(const PhotoSettings&, AVCapturePhotoOutput*);
     IntSize maxPhotoSizeForCurrentPreset(IntSize requestedSize) const;
-    IntSize maxPhotoSizeForActiveFormat(AVCaptureDeviceFormat *, IntSize) const;
     AVCapturePhotoOutput* photoOutput();
 
     RefPtr<VideoFrame> m_buffer;
@@ -169,19 +168,19 @@ private:
     IntDegrees m_deviceOrientation { 0 };
     VideoFrameRotation m_videoFrameRotation { };
 
-    std::optional<RealtimeMediaSourceSettings> m_currentSettings;
-    std::optional<RealtimeMediaSourceCapabilities> m_capabilities;
-    std::optional<PhotoCapabilities> m_photoCapabilities;
+    std::optional<RealtimeMediaSourceSettings> m_currentSettings WTF_GUARDED_BY_CAPABILITY(RunLoop::mainSingleton());
+    std::optional<RealtimeMediaSourceCapabilities> m_capabilities WTF_GUARDED_BY_CAPABILITY(RunLoop::mainSingleton());
+    std::optional<PhotoCapabilities> m_photoCapabilities WTF_GUARDED_BY_CAPABILITY(RunLoop::mainSingleton());
     RetainPtr<WebCoreAVVideoCaptureSourceObserver> m_objcObserver;
-    RetainPtr<AVCaptureSession> m_session;
-    RetainPtr<AVCaptureDevice> m_device;
+    RetainPtr<AVCaptureSession> m_session WTF_GUARDED_BY_CAPABILITY(RunLoop::mainSingleton());
+    RetainPtr<AVCaptureDevice> m_device WTF_GUARDED_BY_CAPABILITY(RunLoop::mainSingleton());
 
     RetainPtr<AVCapturePhotoOutput> m_photoOutput WTF_GUARDED_BY_CAPABILITY(RunLoop::mainSingleton());
     std::unique_ptr<TakePhotoNativePromise::Producer> m_photoProducer WTF_GUARDED_BY_LOCK(m_photoLock);
 
     Lock m_photoLock;
-    std::optional<VideoPreset> m_currentPreset;
-    std::optional<VideoPreset> m_appliedPreset;
+    std::optional<VideoPreset> m_currentPreset WTF_GUARDED_BY_CAPABILITY(RunLoop::mainSingleton());
+    std::optional<VideoPreset> m_appliedPreset WTF_GUARDED_BY_CAPABILITY(RunLoop::mainSingleton());
 
     double m_currentFrameRate { 0 };
     double m_currentZoom { 1 };

--- a/Source/WebCore/platform/mediastream/cocoa/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/cocoa/AVVideoCaptureSource.mm
@@ -193,6 +193,27 @@ static MeteringMode NODELETE meteringModeFromAVCaptureWhiteBalanceMode(AVCapture
     return MeteringMode::None;
 }
 
+static IntSize maxPhotoSizeForFormat(AVCaptureDeviceFormat *format, IntSize requestedSize)
+{
+    ASSERT([format respondsToSelector:@selector(supportedMaxPhotoDimensions)]);
+
+    NSArray<NSValue*> *maxPhotoDimensions = format.supportedMaxPhotoDimensions;
+    if (!maxPhotoDimensions.count)
+        return { };
+
+    auto bestMaxPhotoSize = maxPhotoDimensions.firstObject.CMVideoDimensionsValue;
+    for (NSValue *value in maxPhotoDimensions) {
+        CMVideoDimensions dimensions = value.CMVideoDimensionsValue;
+        if (dimensions.width >= requestedSize.width() && dimensions.height >= requestedSize.height()) {
+            if (dimensions.width * dimensions.height < bestMaxPhotoSize.width * bestMaxPhotoSize.height)
+                bestMaxPhotoSize = dimensions;
+        }
+    }
+
+    return { bestMaxPhotoSize.width, bestMaxPhotoSize.height };
+}
+
+
 std::optional<double> AVVideoCaptureSource::computeMinZoom() const
 {
 #if PLATFORM(IOS_FAMILY)
@@ -270,6 +291,7 @@ AVVideoCaptureSource::AVVideoCaptureSource(AVCaptureDevice* avDevice, const Capt
 
 AVVideoCaptureSource::~AVVideoCaptureSource()
 {
+    assertIsCurrent(RunLoop::mainSingleton());
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
 
     [m_objcObserver disconnect];
@@ -327,18 +349,20 @@ void AVVideoCaptureSource::startupTimerFired()
 
 void AVVideoCaptureSource::clearSession()
 {
+    assertIsCurrent(RunLoop::mainSingleton());
+
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     ASSERT(m_session);
     [m_session removeObserver:m_objcObserver.get() forKeyPath:@"running"];
     m_session = nullptr;
+    m_photoOutput = nullptr;
 }
 
 void AVVideoCaptureSource::startProducingData()
 {
-    if (!m_session) {
-        if (!setupSession())
-            return;
-    }
+    assertIsCurrent(RunLoop::mainSingleton());
+    if (!m_session && !setupSession())
+        return;
 
     bool isRunning = !![m_session isRunning];
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, isRunning);
@@ -361,6 +385,7 @@ void AVVideoCaptureSource::startProducingData()
 
 void AVVideoCaptureSource::stopProducingData()
 {
+    assertIsCurrent(RunLoop::mainSingleton());
     if (!m_session)
         return;
 
@@ -377,6 +402,7 @@ void AVVideoCaptureSource::stopProducingData()
 
 void AVVideoCaptureSource::stopSession()
 {
+    assertIsCurrent(RunLoop::mainSingleton());
     ASSERT(!m_beginConfigurationCount);
 
     @try {
@@ -414,6 +440,7 @@ void AVVideoCaptureSource::beginConfigurationForConstraintsIfNeeded()
 
 void AVVideoCaptureSource::beginConfiguration()
 {
+    assertIsCurrent(RunLoop::mainSingleton());
     if (++m_beginConfigurationCount > 1)
         return;
 
@@ -423,6 +450,7 @@ void AVVideoCaptureSource::beginConfiguration()
 
 void AVVideoCaptureSource::commitConfiguration()
 {
+    assertIsCurrent(RunLoop::mainSingleton());
     ASSERT(m_beginConfigurationCount);
     if (!m_beginConfigurationCount || --m_beginConfigurationCount > 0)
         return;
@@ -433,6 +461,7 @@ void AVVideoCaptureSource::commitConfiguration()
 
 void AVVideoCaptureSource::settingsDidChange(OptionSet<RealtimeMediaSourceSettings::Flag> settings)
 {
+    assertIsCurrent(RunLoop::mainSingleton());
     m_currentSettings = std::nullopt;
 
     bool whiteBalanceModeChanged = settings.contains(RealtimeMediaSourceSettings::Flag::WhiteBalanceMode);
@@ -454,6 +483,7 @@ void AVVideoCaptureSource::settingsDidChange(OptionSet<RealtimeMediaSourceSettin
 
 void AVVideoCaptureSource::configurationChanged()
 {
+    assertIsCurrent(RunLoop::mainSingleton());
     m_currentSettings = { };
     m_capabilities = { };
 
@@ -484,6 +514,7 @@ static Vector<MeteringMode> supportedWhiteBalanceModes(AVCaptureDevice* device)
 
 const RealtimeMediaSourceSettings& AVVideoCaptureSource::settings()
 {
+    assertIsCurrent(RunLoop::mainSingleton());
     if (m_currentSettings)
         return *m_currentSettings;
 
@@ -549,6 +580,7 @@ const RealtimeMediaSourceSettings& AVVideoCaptureSource::settings()
 
 const RealtimeMediaSourceCapabilities& AVVideoCaptureSource::capabilities()
 {
+    assertIsCurrent(RunLoop::mainSingleton());
     if (m_capabilities)
         return *m_capabilities;
 
@@ -599,24 +631,35 @@ const RealtimeMediaSourceCapabilities& AVVideoCaptureSource::capabilities()
     return *m_capabilities;
 }
 
+AVCaptureDevice* AVVideoCaptureSource::device() const
+{
+    assertIsCurrent(RunLoop::mainSingleton());
+    return m_device.get();
+}
+
+AVCaptureSession* AVVideoCaptureSource::session() const
+{
+    assertIsCurrent(RunLoop::mainSingleton());
+    return m_session.get();
+}
+
 AVCapturePhotoOutput* AVVideoCaptureSource::photoOutput()
 {
     assertIsCurrent(RunLoop::mainSingleton());
 
+    if (m_photoOutput)
+        return m_photoOutput.get();
+
+    m_photoOutput = adoptNS([PAL::allocAVCapturePhotoOutputInstance() init]);
     if (!m_photoOutput) {
-        m_photoOutput = adoptNS([PAL::allocAVCapturePhotoOutputInstance() init]);
-
-        if (!m_photoOutput) {
-            ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "unable to allocate AVCapturePhotoOutput");
-            return nullptr;
-        }
-
-        if (![session() canAddOutput:m_photoOutput.get()]) {
-            ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "unable to add photo output");
-            return nullptr;
-        }
-        [session() addOutput:m_photoOutput.get()];
+        ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "unable to allocate AVCapturePhotoOutput");
+        return nullptr;
     }
+    if (![session() canAddOutput:m_photoOutput.get()]) {
+        ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "unable to add photo output");
+        return nullptr;
+    }
+    [session() addOutput:m_photoOutput.get()];
 
     return m_photoOutput.get();
 }
@@ -648,11 +691,11 @@ void AVVideoCaptureSource::rejectPendingPhotoRequest(const String& error)
 
 IntSize AVVideoCaptureSource::maxPhotoSizeForCurrentPreset(IntSize requestedSize) const
 {
-    ASSERT(isMainThread());
+    assertIsCurrent(RunLoop::mainSingleton());
 
-    auto *format = [m_device activeFormat];
+    auto *format = [device() activeFormat];
     if ([format respondsToSelector:@selector(supportedMaxPhotoDimensions)])
-        return maxPhotoSizeForActiveFormat(format, requestedSize);
+        return maxPhotoSizeForFormat(format, requestedSize);
 
     if (m_currentPreset)
         return m_currentPreset->size();
@@ -660,58 +703,43 @@ IntSize AVVideoCaptureSource::maxPhotoSizeForCurrentPreset(IntSize requestedSize
     return { };
 }
 
-IntSize AVVideoCaptureSource::maxPhotoSizeForActiveFormat(AVCaptureDeviceFormat *format, IntSize requestedSize) const
-{
-    ASSERT([format respondsToSelector:@selector(supportedMaxPhotoDimensions)]);
-
-    NSArray<NSValue*> *maxPhotoDimensions = format.supportedMaxPhotoDimensions;
-    if (!maxPhotoDimensions.count)
-        return { };
-
-    auto bestMaxPhotoSize = maxPhotoDimensions.firstObject.CMVideoDimensionsValue;
-    for (NSValue *value in maxPhotoDimensions) {
-        CMVideoDimensions dimensions = value.CMVideoDimensionsValue;
-        if (dimensions.width >= requestedSize.width() && dimensions.height >= requestedSize.height()) {
-            if (dimensions.width * dimensions.height < bestMaxPhotoSize.width * bestMaxPhotoSize.height)
-                bestMaxPhotoSize = dimensions;
-        }
-    }
-
-    return { bestMaxPhotoSize.width, bestMaxPhotoSize.height };
-}
-
-RetainPtr<AVCapturePhotoSettings> AVVideoCaptureSource::photoConfiguration(const PhotoSettings& photoSettings)
+RetainPtr<AVCapturePhotoSettings> AVVideoCaptureSource::photoConfiguration(const PhotoSettings& photoSettings, AVCapturePhotoOutput* photoOutput)
 {
     assertIsCurrent(RunLoop::mainSingleton());
 
-    IntSize requestedPhotoDimensions = { 0, 0 };
-    if (photoSettings.imageHeight && photoSettings.imageWidth)
-        requestedPhotoDimensions = { static_cast<int>(*photoSettings.imageWidth), static_cast<int>(*photoSettings.imageHeight) };
+    RetainPtr<AVCapturePhotoSettings> avPhotoSettings;
 
-    AVCapturePhotoSettings* avPhotoSettings = [PAL::getAVCapturePhotoSettingsClassSingleton() photoSettingsWithFormat:@{
-        AVVideoCodecKey : AVVideoCodecTypeJPEG,
-        AVVideoCompressionPropertiesKey : @{ AVVideoQualityKey : @(1) }
-    }];
+    @try {
+        avPhotoSettings = [PAL::getAVCapturePhotoSettingsClassSingleton() photoSettingsWithFormat:@{
+            AVVideoCodecKey : AVVideoCodecTypeJPEG,
+            AVVideoCompressionPropertiesKey : @{ AVVideoQualityKey : @(1) }
+        }];
 
 #if PLATFORM(IOS_FAMILY)
-    auto* photoOutput = this->photoOutput();
-    ASSERT(photoOutput);
-    if (!photoOutput)
-        return nullptr;
+        if (photoSettings.fillLightMode) {
+            auto flashMode = toAVCaptureFlashMode(*photoSettings.fillLightMode);
+            if ([[photoOutput supportedFlashModes] containsObject:@(flashMode)])
+                [avPhotoSettings setFlashMode:flashMode];
+        }
 
-    if (photoSettings.fillLightMode) {
-        auto flashMode = toAVCaptureFlashMode(*photoSettings.fillLightMode);
-        if ([photoOutput.supportedFlashModes containsObject:@(flashMode)])
-            [avPhotoSettings setFlashMode:flashMode];
-    }
-
-    if (photoSettings.redEyeReduction && photoOutput.isAutoRedEyeReductionSupported)
-        [avPhotoSettings setAutoRedEyeReductionEnabled:!!photoSettings.redEyeReduction.value()];
+        if (photoSettings.redEyeReduction && [photoOutput isAutoRedEyeReductionSupported])
+            [avPhotoSettings setAutoRedEyeReductionEnabled:!!photoSettings.redEyeReduction.value()];
+#else
+        UNUSED_PARAM(photoOutput);
 #endif
 
-    requestedPhotoDimensions = maxPhotoSizeForCurrentPreset(requestedPhotoDimensions);
-    if (!requestedPhotoDimensions.isEmpty() && [avPhotoSettings respondsToSelector:@selector(setMaxPhotoDimensions:)])
-        [avPhotoSettings setMaxPhotoDimensions: { requestedPhotoDimensions.width(), requestedPhotoDimensions.height() }];
+        if ([avPhotoSettings respondsToSelector:@selector(setMaxPhotoDimensions:)]) {
+            IntSize requestedPhotoDimensions;
+            if (photoSettings.imageHeight && photoSettings.imageWidth)
+                requestedPhotoDimensions = roundedIntSize(FloatSize(*photoSettings.imageWidth, *photoSettings.imageHeight));
+            requestedPhotoDimensions = maxPhotoSizeForCurrentPreset(requestedPhotoDimensions);
+            if (!requestedPhotoDimensions.isEmpty())
+                [avPhotoSettings setMaxPhotoDimensions:toCMVideoDimensions(requestedPhotoDimensions)];
+        }
+    } @catch(NSException *exception) {
+        ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "error configuring photoSettings ", [[exception name] UTF8String], ", reason : ", [exception reason]);
+        return nullptr;
+    }
 
     return avPhotoSettings;
 }
@@ -720,6 +748,7 @@ auto AVVideoCaptureSource::takePhotoInternal(PhotoSettings&& photoSettings) -> R
 {
     assertIsCurrent(RunLoop::mainSingleton());
 
+    auto identifier = LOGIDENTIFIER;
     RetainPtr<AVCapturePhotoOutput> photoOutput = this->photoOutput();
     if (!photoOutput)
         return TakePhotoNativePromise::createAndReject("Internal error"_s);
@@ -728,7 +757,7 @@ auto AVVideoCaptureSource::takePhotoInternal(PhotoSettings&& photoSettings) -> R
     {
         Locker lock { m_photoLock };
         if (m_photoProducer) {
-            ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "m_photoProducer should be NULL!");
+            ERROR_LOG_IF_POSSIBLE(identifier, "m_photoProducer should be NULL!");
             return TakePhotoNativePromise::createAndReject("Internal error"_s);
         }
 
@@ -736,25 +765,41 @@ auto AVVideoCaptureSource::takePhotoInternal(PhotoSettings&& photoSettings) -> R
         promise = static_cast<Ref<TakePhotoNativePromise>>(*m_photoProducer);
     }
 
-    RetainPtr<AVCapturePhotoSettings> avPhotoSettings = photoConfiguration(photoSettings);
+    RetainPtr<AVCapturePhotoSettings> avPhotoSettings = photoConfiguration(photoSettings, photoOutput.get());
     if (!avPhotoSettings) {
-        ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "photoConfiguration() failed");
+        ERROR_LOG_IF_POSSIBLE(identifier, "photoConfiguration() failed");
         return TakePhotoNativePromise::createAndReject("Internal error"_s);
     }
 
-    photoQueueSingleton().dispatch([protectedThis = Ref { *this }, this, avPhotoSettings = WTF::move(avPhotoSettings), photoOutput = WTF::move(photoOutput), device = m_device] {
-        ASSERT(!isMainThread());
+    photoQueueSingleton().dispatch([protectedThis = Ref { *this }, this, photoOutput = WTF::move(photoOutput), avPhotoSettings = WTF::move(avPhotoSettings), identifier = WTF::move(identifier)] mutable {
+        assertIsCurrent(photoQueueSingleton());
 
-        if ([avPhotoSettings respondsToSelector:@selector(setMaxPhotoDimensions:)]) {
-            auto *format = [device activeFormat];
-            auto maxDimensions = [avPhotoSettings maxPhotoDimensions];
-
-            auto requestedPhotoDimensions = maxPhotoSizeForActiveFormat(format, toIntSize(maxDimensions));
-            if (!requestedPhotoDimensions.isEmpty())
-                [photoOutput setMaxPhotoDimensions:toCMVideoDimensions(requestedPhotoDimensions)];
+        @try {
+            if ([avPhotoSettings respondsToSelector:@selector(setMaxPhotoDimensions:)]) {
+                auto requestedPhotoDimensions = toIntSize([avPhotoSettings maxPhotoDimensions]);
+                if (!requestedPhotoDimensions.isEmpty()) {
+                    auto maxOutputDimensions = toIntSize([photoOutput maxPhotoDimensions]);
+                    if (requestedPhotoDimensions.width() > maxOutputDimensions.width() || requestedPhotoDimensions.height() > maxOutputDimensions.height())
+                        [photoOutput setMaxPhotoDimensions:toCMVideoDimensions(requestedPhotoDimensions)];
+                }
+            }
+        } @catch(NSException *exception) {
+            RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis), identifier = WTF::move(identifier), exception = RetainPtr { exception }] mutable {
+                ERROR_LOG_WITH_THIS_IF_POSSIBLE(protectedThis, identifier, "error configuring photo output ", [[exception name] UTF8String], ", reason : ", [exception reason]);
+                protectedThis->rejectPendingPhotoRequest("setMaxPhotoDimensions failed"_s);
+            });
+            return;
         }
 
-        [photoOutput capturePhotoWithSettings:avPhotoSettings.get() delegate:m_objcObserver.get()];
+        @try {
+            [photoOutput capturePhotoWithSettings:avPhotoSettings.get() delegate:m_objcObserver.get()];
+        } @catch(NSException *exception) {
+            RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis), identifier = WTF::move(identifier), exception = RetainPtr { exception }] mutable {
+                ERROR_LOG_WITH_THIS_IF_POSSIBLE(protectedThis, identifier, "error taking photo ", [[exception name] UTF8String], ", reason : ", [exception reason]);
+                protectedThis->rejectPendingPhotoRequest("capturePhotoWithSettings failed"_s);
+            });
+        }
+
     });
 
     return promise.releaseNonNull();
@@ -762,6 +807,7 @@ auto AVVideoCaptureSource::takePhotoInternal(PhotoSettings&& photoSettings) -> R
 
 auto AVVideoCaptureSource::getPhotoCapabilities() -> Ref<PhotoCapabilitiesNativePromise>
 {
+    assertIsCurrent(RunLoop::mainSingleton());
     if (m_photoCapabilities)
         return PhotoCapabilitiesNativePromise::createAndResolve(*m_photoCapabilities);
 
@@ -842,6 +888,7 @@ double AVVideoCaptureSource::facingModeFitnessScoreAdjustment() const
 
 void AVVideoCaptureSource::applyFrameRateAndZoomWithPreset(double requestedFrameRate, double requestedZoom, std::optional<VideoPreset>&& preset)
 {
+    assertIsCurrent(RunLoop::mainSingleton());
     requestedZoom *= m_zoomScaleFactor;
     bool isSamePresetAndFrameRate = m_currentFrameRate == requestedFrameRate && preset && m_currentPreset && preset->format() == m_currentPreset->format();
     if (isSamePresetAndFrameRate && m_currentZoom == requestedZoom)
@@ -901,6 +948,7 @@ static bool isFrameRateMatching(double frameRate, AVCaptureDevice* device)
 
 bool AVVideoCaptureSource::areSettingsMatching() const
 {
+    assertIsCurrent(RunLoop::mainSingleton());
     return m_appliedPreset && m_appliedPreset->format() == m_currentPreset->format()
 #if PLATFORM(IOS_FAMILY)
         && device().videoZoomFactor == m_currentZoom
@@ -910,6 +958,7 @@ bool AVVideoCaptureSource::areSettingsMatching() const
 
 void AVVideoCaptureSource::setSessionSizeFrameRateAndZoom()
 {
+    assertIsCurrent(RunLoop::mainSingleton());
     ASSERT(m_beginConfigurationCount);
     if (!m_session)
         return;
@@ -1035,6 +1084,7 @@ bool AVVideoCaptureSource::lockForConfiguration()
 
 void AVVideoCaptureSource::updateWhiteBalanceMode()
 {
+    assertIsCurrent(RunLoop::mainSingleton());
     if (!m_isRunning) {
         m_needsWhiteBalanceReconfiguration = true;
         return;
@@ -1058,6 +1108,7 @@ void AVVideoCaptureSource::updateWhiteBalanceMode()
 
 void AVVideoCaptureSource::updateTorch()
 {
+    assertIsCurrent(RunLoop::mainSingleton());
     if (!m_isRunning) {
         m_needsTorchReconfiguration = true;
         return;
@@ -1100,6 +1151,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 bool AVVideoCaptureSource::setupSession()
 {
+    assertIsCurrent(RunLoop::mainSingleton());
     if (m_session)
         return true;
 
@@ -1170,6 +1222,7 @@ AVFrameRateRange* AVVideoCaptureSource::frameDurationForFrameRate(double rate)
 
 bool AVVideoCaptureSource::setupCaptureSession()
 {
+    assertIsCurrent(RunLoop::mainSingleton());
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
 
     beginConfiguration();
@@ -1368,7 +1421,7 @@ void AVVideoCaptureSource::captureDeviceSuspendedDidChange()
 {
 #if !PLATFORM(IOS_FAMILY)
     scheduleDeferredTask([protectedThis = Ref { *this }, this, logIdentifier = LOGIDENTIFIER] {
-        m_interrupted = [m_device isSuspended];
+        m_interrupted = [device() isSuspended];
         ALWAYS_LOG_WITH_THIS_IF_POSSIBLE(protectedThis, logIdentifier, !!m_interrupted);
 
         updateVerifyCapturingTimer();
@@ -1425,6 +1478,7 @@ void AVVideoCaptureSource::generatePresets()
 #if PLATFORM(IOS_FAMILY)
 void AVVideoCaptureSource::captureSessionRuntimeError(RetainPtr<NSError> error)
 {
+    assertIsCurrent(RunLoop::mainSingleton());
     auto identifier = LOGIDENTIFIER;
     ERROR_LOG_IF_POSSIBLE(identifier, [error code], ", ", error.get());
 
@@ -1434,8 +1488,8 @@ void AVVideoCaptureSource::captureSessionRuntimeError(RetainPtr<NSError> error)
     scheduleDeferredTask([protectedThis = Ref { *this }, this, identifier] {
         // Try to restart the session, but reset m_isRunning immediately so if it fails we won't try again.
         ERROR_LOG_WITH_THIS_IF_POSSIBLE(protectedThis, identifier, "restarting session");
-        [m_session startRunning];
-        m_isRunning = [m_session isRunning];
+        [session() startRunning];
+        m_isRunning = [session() isRunning];
     });
 }
 


### PR DESCRIPTION
#### 960cc2745175abf2a027af86de66673a8f35ac55
<pre>
[Cocoa] Exception thrown by -[AVCapturePhotoOutput setMaxPhotoDimensions:]
<a href="https://bugs.webkit.org/show_bug.cgi?id=311754">https://bugs.webkit.org/show_bug.cgi?id=311754</a>
<a href="https://rdar.apple.com/170593863">rdar://170593863</a>

Reviewed by Youenn Fablet.

Catch exceptions thrown while using AVCapture objects while taking a photo. We were
unintentionally using the AVCapture device on both the main thread and the photo capture
queue, so restructure the code to not do that and add WTF_GUARDED_BY_CAPABILITY
annotations to the non-POD ivars to ensure they are used correctly.

* Source/WebCore/platform/mediastream/cocoa/AVVideoCaptureSource.h:
(WebCore::AVVideoCaptureSource::session const): Deleted.
(WebCore::AVVideoCaptureSource::device const): Deleted.
* Source/WebCore/platform/mediastream/cocoa/AVVideoCaptureSource.mm:
(WebCore::maxPhotoSizeForFormat):
(WebCore::AVVideoCaptureSource::~AVVideoCaptureSource):
(WebCore::AVVideoCaptureSource::clearSession):
(WebCore::AVVideoCaptureSource::startProducingData):
(WebCore::AVVideoCaptureSource::stopProducingData):
(WebCore::AVVideoCaptureSource::stopSession):
(WebCore::AVVideoCaptureSource::beginConfiguration):
(WebCore::AVVideoCaptureSource::commitConfiguration):
(WebCore::AVVideoCaptureSource::settingsDidChange):
(WebCore::AVVideoCaptureSource::configurationChanged):
(WebCore::AVVideoCaptureSource::settings):
(WebCore::AVVideoCaptureSource::capabilities):
(WebCore::AVVideoCaptureSource::device const):
(WebCore::AVVideoCaptureSource::session const):
(WebCore::AVVideoCaptureSource::photoOutput):
(WebCore::AVVideoCaptureSource::maxPhotoSizeForCurrentPreset const):
(WebCore::AVVideoCaptureSource::photoConfiguration):
(WebCore::AVVideoCaptureSource::takePhotoInternal):
(WebCore::AVVideoCaptureSource::getPhotoCapabilities):
(WebCore::AVVideoCaptureSource::applyFrameRateAndZoomWithPreset):
(WebCore::AVVideoCaptureSource::areSettingsMatching const):
(WebCore::AVVideoCaptureSource::setSessionSizeFrameRateAndZoom):
(WebCore::AVVideoCaptureSource::updateWhiteBalanceMode):
(WebCore::AVVideoCaptureSource::updateTorch):
(WebCore::AVVideoCaptureSource::setupSession):
(WebCore::AVVideoCaptureSource::setupCaptureSession):
(WebCore::AVVideoCaptureSource::captureDeviceSuspendedDidChange):
(WebCore::AVVideoCaptureSource::captureSessionRuntimeError):
(WebCore::AVVideoCaptureSource::maxPhotoSizeForActiveFormat const): Deleted.

Canonical link: <a href="https://commits.webkit.org/312333@main">https://commits.webkit.org/312333@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c3655ea333d2122b91d7ac482c4594e60cfd112

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33041 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168421 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161443 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33146 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33045 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123636 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162531 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143323 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104288 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16185 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21095 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170908 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16942 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22728 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/131891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27479 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131953 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35713 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142888 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90787 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26596 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19702 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32214 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/98610 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31711 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31958 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31862 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->