### PR TITLE
[AI Experiment, Do Not Review, Opus Generated][YARR] Bail to interpreter when Greedy/NonGreedy backtrack has null ParenContext

### DIFF
--- a/JSTests/stress/yarr-jit-null-paren-context-backtrack.js
+++ b/JSTests/stress/yarr-jit-null-paren-context-backtrack.js
@@ -1,0 +1,7 @@
+// Regression test for rdar://173140757
+// YARR JIT null ParenContext crash in Greedy/NonGreedy backtrack path
+// of ParenthesesSubpatternBegin. A NonGreedy (*?) group nested inside
+// a FixedCount ({3}) group with multiple alternatives can backtrack
+// with a null ParenContext when no iteration ever executed.
+var r = new RegExp(unescape('%28%28%28%29%28%29%28%28%28%29%28%29%2A%2E%7C%28%29%28%68%3E%28%28%28%29%28%29%28%29%28%29%29%2F%6C%2E%28%1F%28%29%28%2D%28%00%5B%5C%44%C3%5D%6F%5E%8E%28%29%29%28%29%21%29%28%29%29%29%38%7E%29%40%77%EB%29%2A%3F%28%28%3F%3A%2E%29%3F%3F%29%29%5B%0A%61%2D%63%5D%29%29%7B%33%7D%63%70'));
+r.exec('aaaaaaa');

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -5042,6 +5042,8 @@ class YarrGenerator final : public YarrJITInfo {
                 }
 
                 // Greedy/NonGreedy path: restore from context and try fewer iterations
+                MacroAssembler::Jump noGreedyContext = m_jit.branchTestPtr(MacroAssembler::Zero, currParenContextReg);
+
                 restoreParenContext(currParenContextReg, m_regs.regT2, term->parentheses.subpatternId, term->parentheses.lastSubpatternId, parenthesesFrameLocation);
 
                 m_jit.loadPtr(MacroAssembler::Address(currParenContextReg, ParenContext::nextOffset()), newParenContextReg);
@@ -5081,6 +5083,8 @@ class YarrGenerator final : public YarrJITInfo {
                     break;
                 }
                 }
+                noGreedyContext.link(&m_jit);
+                m_abortExecution.append(m_jit.jump());
                 m_backtrackingState.fallthrough();
 #else // !YARR_JIT_ALL_PARENS_EXPRESSIONS
                 RELEASE_ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### 6367ff007bba6391e97a250f9f294d912231bd4a
<pre>
[Opus Generated][YARR] Bail to interpreter when Greedy/NonGreedy backtrack has null ParenContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=311977">https://bugs.webkit.org/show_bug.cgi?id=311977</a>
<a href="https://rdar.apple.com/174520105">rdar://174520105</a>

Reviewed by NOBODY (OOPS!).

The Greedy/NonGreedy backtrack path in ParenthesesSubpatternBegin calls
restoreParenContext without checking for a null ParenContext pointer. For
NonGreedy (*?) subpatterns nested inside FixedCount ({3}) groups with
multiple alternatives, backtracking can reach this path when no iteration
ever executed, leaving parenContextHead as null. The FixedCount path has
a null guard (line 4881); the Greedy/NonGreedy path does not.

Add a null check on currParenContextReg and bail to the bytecode
interpreter via m_abortExecution when null. The interpreter handles this
edge case correctly.

Test: Added JSTests/stress/yarr-jit-null-paren-context-backtrack.js

* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::YarrGenerator::backtrackParenthesesSubpatternBegin):
* JSTests/stress/yarr-jit-null-paren-context-backtrack.js: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6367ff007bba6391e97a250f9f294d912231bd4a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155628 "Failed to checkout and rebase branch from PR 62486") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28886 "Failed to checkout and rebase branch from PR 62486") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22045 "Failed to checkout and rebase branch from PR 62486") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164389 "Failed to checkout and rebase branch from PR 62486") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109442 "Failed to checkout and rebase branch from PR 62486") | ⏳ 🛠 ios-apple 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29033 "Failed to checkout and rebase branch from PR 62486") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28736 "Failed to checkout and rebase branch from PR 62486") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/164389 "Failed to checkout and rebase branch from PR 62486") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/109442 "Failed to checkout and rebase branch from PR 62486") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158585 "Failed to checkout and rebase branch from PR 62486") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/29033 "Failed to checkout and rebase branch from PR 62486") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/22045 "Failed to checkout and rebase branch from PR 62486") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/164389 "Failed to checkout and rebase branch from PR 62486") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/29033 "Failed to checkout and rebase branch from PR 62486") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/28736 "Failed to checkout and rebase branch from PR 62486") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12219 "Failed to checkout and rebase branch from PR 62486") | | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147676 "Failed to checkout and rebase branch from PR 62486") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/29033 "Failed to checkout and rebase branch from PR 62486") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/22045 "Failed to checkout and rebase branch from PR 62486") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166868 "Failed to checkout and rebase branch from PR 62486") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16458 "Failed to checkout and rebase branch from PR 62486") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11044 "Failed to checkout and rebase branch from PR 62486") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/22045 "Failed to checkout and rebase branch from PR 62486") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/166868 "Failed to checkout and rebase branch from PR 62486") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28430 "Failed to checkout and rebase branch from PR 62486") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/28736 "Failed to checkout and rebase branch from PR 62486") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/166868 "Failed to checkout and rebase branch from PR 62486") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28354 "Failed to checkout and rebase branch from PR 62486") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/22045 "Failed to checkout and rebase branch from PR 62486") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86183 "Failed to checkout and rebase branch from PR 62486") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/28354 "Failed to checkout and rebase branch from PR 62486") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/22045 "Failed to checkout and rebase branch from PR 62486") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187511 "Failed to checkout and rebase branch from PR 62486") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28048 "Failed to checkout and rebase branch from PR 62486") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92151 "Failed to checkout and rebase branch from PR 62486") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/187511 "Failed to checkout and rebase branch from PR 62486") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27625 "Failed to checkout and rebase branch from PR 62486") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27855 "Failed to checkout and rebase branch from PR 62486") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27698 "Failed to checkout and rebase branch from PR 62486") | | | | 
<!--EWS-Status-Bubble-End-->