### PR TITLE
[threaded-animations] REGRESSION: Flickery animations on https://pudding.cool/2026/03/ivf/

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-additive-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-additive-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Fill mode is not adjusted for effects that participate in composition due to a composite operation.
+

--- a/LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-additive.html
+++ b/LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-additive.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<body>
+<style>
+
+#target {
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background-color: black;
+}
+
+</style>
+
+<div id="target"></div>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script src="threaded-animations-utils.js"></script>
+
+<script>
+
+promise_test(async t => {
+    const target = document.getElementById("target");
+
+    const duration = 1000 * 1000;
+    const animations = [
+        target.animate({ translate: ["100px", "200px"] }, duration),
+        target.animate({ translate: ["300px", "400px"] }, { duration, composite: "add" }),
+        target.animate({ scale: [1, 2] }, duration),
+        target.animate({ scale: [3, 4] }, { duration, composite: "add" })
+    ];
+
+    await Promise.all(animations.map(animation => animationAcceleration(animation)));
+
+    const remoteAnimationStack = await UIHelper.remoteAnimationStackForElement(target);
+    const remoteAnimations = remoteAnimationStack.animations;
+    assert_equals(remoteAnimations.length, 4, "We have the expected number of animations in the remote layer tree");
+    assert_equals(remoteAnimations[0].timing.fill, 'auto', 'Omitted fill mode is preserved for effect that is composed with another effect further up the stack');
+    assert_equals(remoteAnimations[1].timing.fill, 'forwards', 'Omitted fille mode is set to "forwards" for the last effect animating a given property');
+    assert_equals(remoteAnimations[2].timing.fill, 'auto', 'Omitted fill mode is preserved for effect that is composed with another effect further up the stack');
+    assert_equals(remoteAnimations[3].timing.fill, 'forwards', 'Omitted fille mode is set to "forwards" for last effect animating a given property');
+}, "Fill mode is not adjusted for effects that participate in composition due to a composite operation.");
+
+</script>
+</body>

--- a/LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-adjust-effect-with-non-composed-properties-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-adjust-effect-with-non-composed-properties-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Fill mode is adjusted to be forward-filling for effects that do not participate in composition.
+

--- a/LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-adjust-effect-with-non-composed-properties.html
+++ b/LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-adjust-effect-with-non-composed-properties.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<body>
+<style>
+
+#target {
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background-color: black;
+}
+
+</style>
+
+<div id="target"></div>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script src="threaded-animations-utils.js"></script>
+
+<script>
+
+promise_test(async t => {
+    const target = document.getElementById("target");
+
+    const duration = 1000 * 1000;
+    const animations = [
+        target.animate({ opacity: 0 }, duration),
+        target.animate({ translate: "100px" }, { duration, fill : "backwards" }),
+        target.animate({ rotate: "45deg" }, { duration, fill : "none" }),
+        target.animate({ transform: "translateX(50px)" }, { duration, fill : "both" }),
+        target.animate({ scale: 2 }, duration)
+    ];
+
+    await Promise.all(animations.map(animation => animationAcceleration(animation)));
+    
+    const remoteAnimationStack = await UIHelper.remoteAnimationStackForElement(target);
+    const remoteAnimations = remoteAnimationStack.animations;
+    assert_equals(remoteAnimations.length, 5, "We have the expected number of animations in the remote layer tree");
+    assert_equals(remoteAnimations[0].timing.fill, "forwards", 'Omitted fill mode is set to "forwards"');
+    assert_equals(remoteAnimations[1].timing.fill, "both", '"backwards" is set to "both"');
+    assert_equals(remoteAnimations[2].timing.fill, "forwards", '"none" is set to "forwards"');
+    assert_equals(remoteAnimations[3].timing.fill, "both", '"both" is preserved');
+    assert_equals(remoteAnimations[4].timing.fill, "forwards", 'Omitted fill mode is set to "forwards"');
+}, "Fill mode is adjusted to be forward-filling for effects that do not participate in composition.");
+
+</script>
+</body>

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -645,6 +645,37 @@ void AcceleratedEffect::clearProperty(AcceleratedEffectProperty property)
         keyframe.clearProperty(property);
 }
 
+void AcceleratedEffect::makeForwardsFilling()
+{
+    m_timing.fill = (m_timing.fill == FillMode::Backwards) ? FillMode::Both : FillMode::Forwards;
+}
+
+const OptionSet<AcceleratedEffectProperty> AcceleratedEffect::composedProperties() const
+{
+    // If the effect is marked as additive entirely, all of its properties are composed.
+    if (m_compositeOperation != CompositeOperation::Replace)
+        return m_animatedProperties;
+
+    // Otherwise, we need to go through the effect's keyframes to see which one may compose.
+    OptionSet<AcceleratedEffectProperty> additiveOrAccumulativeProperties;
+    OptionSet<AcceleratedEffectProperty> propertiesWithExplicitFromValue;
+    OptionSet<AcceleratedEffectProperty> propertiesWithExplicitToValue;
+    for (auto& keyframe : m_keyframes) {
+        if (keyframe.compositeOperation() == CompositeOperation::Add || keyframe.compositeOperation() == CompositeOperation::Accumulate)
+            additiveOrAccumulativeProperties.add(keyframe.animatedProperties());
+        else {
+            if (!keyframe.offset())
+                propertiesWithExplicitFromValue.add(keyframe.animatedProperties());
+            if (keyframe.offset() == 1.0)
+                propertiesWithExplicitToValue.add(keyframe.animatedProperties());
+        }
+    }
+
+    auto propertiesWithImplicitFromValue = m_animatedProperties ^ propertiesWithExplicitFromValue;
+    auto propertiesWithImplicitToValue = m_animatedProperties ^ propertiesWithExplicitToValue;
+    return additiveOrAccumulativeProperties | propertiesWithImplicitFromValue | propertiesWithImplicitToValue;
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(THREADED_ANIMATIONS)

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -86,6 +86,7 @@ public:
     WEBCORE_EXPORT ResolvedEffectTiming resolvedTimingForTesting(WebAnimationTime timelineTime, std::optional<WebAnimationTime> timelineDuration) const;
 
     void clearProperty(AcceleratedEffectProperty);
+    void makeForwardsFilling();
 
     // Encoding and decoding support
     const AnimationEffectTiming& timing() const LIFETIME_BOUND { return m_timing; }
@@ -103,6 +104,7 @@ public:
 
     const OptionSet<AcceleratedEffectProperty>& disallowedProperties() const LIFETIME_BOUND { return m_disallowedProperties; }
     const OptionSet<AcceleratedEffectProperty>& replacedProperties() const LIFETIME_BOUND { return m_replacedProperties; }
+    const OptionSet<AcceleratedEffectProperty> composedProperties() const;
 
     bool NODELETE animatesTransformRelatedProperty() const;
     WEBCORE_EXPORT bool NODELETE hasHighImpact() const;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -4663,6 +4663,31 @@ void RenderLayerBacking::updateAcceleratedEffectsAndBaseValues(HashSet<Ref<Accel
         baseValues.backdropFilter = { };
     }
 
+    // Accelerated effects remain in the remote layer tree as long as they are interpolating. Once their
+    // associated animation reaches its natural end, their target's accelerated effect stack will be update
+    // and a new remote layer tree transaction will be committed to remove that accelerated effect. However,
+    // in the case where that effect does not fill forwards, there could be a moment between the moment it
+    // finished naturally in the remote layer tree and the moment it is indeed removed where the associated
+    // layer is in an unwanted state for a frame (or more if the Web process is under heavy load). As such,
+    // we must make such effects forward-filling. It is important however not to do so for effects that will
+    // be used as input for other effects further up the stack.
+    OptionSet<AcceleratedEffectProperty> composedAcceleratedProperties;
+    for (auto& effect : acceleratedEffects | std::views::reverse) {
+        // Nothing to do if the effect is not associated with a monotonic timeline.
+        if (!effect->timeline()->isMonotonic())
+            continue;
+        // Nothing to do if the effect is forward-filling already.
+        const auto& fill = effect->timing().fill;
+        if (fill == FillMode::Forwards || fill == FillMode::Both)
+            continue;
+        // We only want to force the effect to be forward-filling if none of its
+        // animated properties affect other effects up the stack.
+        auto shouldBecomeForwardsFilling = !composedAcceleratedProperties.containsAny(effect->animatedProperties());
+        composedAcceleratedProperties.add(effect->composedProperties());
+        if (shouldBecomeForwardsFilling)
+            effect->makeForwardsFilling();
+    }
+
     m_graphicsLayer->setAcceleratedEffectsAndBaseValues(WTF::move(acceleratedEffects), WTF::move(baseValues));
 
     m_owningLayer.setNeedsPostLayoutCompositingUpdate();


### PR DESCRIPTION
#### ebfab2641e503a33176756a1cc21e3a454de21a5
<pre>
[threaded-animations] REGRESSION: Flickery animations on <a href="https://pudding.cool/2026/03/ivf/">https://pudding.cool/2026/03/ivf/</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310806">https://bugs.webkit.org/show_bug.cgi?id=310806</a>
<a href="https://rdar.apple.com/173154867">rdar://173154867</a>

Reviewed by Simon Fraser.

This website uses the &quot;Svelte&quot; web development framework which provides some built-in transitions.
Specifically, it uses the &quot;fly&quot; transition [0] which allows to animate an element newly added to
the DOM with an &quot;opacity&quot; and &quot;transform&quot; animation, with an optional delay which this page uses.

The way Svelte implements its notion of such animations is by generating two successive animations
using the Web Animations JavaScript APIs. A first animation implements the &quot;delay&quot; phase by running
for the duration specified by the delay and setting the &quot;0&quot; and &quot;1&quot; keyframes to the initial value [1].
Then a second animation implements the actual interpolation [2] (although Svelte opts to generate one
keyframe per animation frame instead of delegating the blending to the browser, though that is not
directly relevant to this bug). The second animation is started in the `onfinish` callback of the
first animation.

The way threaded animations work, we update the list of animations in the remote layer tree for a given
node when its associated element in the DOM tree has its set of active animations change. So in this case,
there is an update when the &quot;delay&quot; animation starts, a second update when that animation ends and the
&quot;active&quot; animation starts, and finally when the &quot;active&quot; animation ends. This process happens in the Web
process.

By the time the &quot;delay&quot; animation is found to be finished in the Web process, its counterpart running
in the remote layer tree may have reached its natural end, and depending on how busy the Web process is,
this could take more than a single animation frame. This is not much of an issue if the animation is set
to be forward-filling, but in this case the &quot;delay&quot; animation is not and as the remote animation reaches
its natural end, it will cease to have any effect in the remote layer tree, meaning that for however long
it will take the updated accelerated effect stack to reach the remote layer tree, the animated state will
be incorrect.

In the accelerated animation code predating threaded animations, this was dealt with in `GraphicsLayerCA::setupAnimation()`
where we would override any accelerated animation&apos;s specified fill mode to be forward-filling, specifically
to avoid flashing in similar circumstances.

We now implement a similar behavior for threaded animations, although with more nuance. Indeed, with threaded
animations, we support non-replacing composite operations (&quot;add&quot; and &quot;accumulate&quot;) as well as full support for
implicit &quot;from&quot; and &quot;to&quot; values in keyframes. Because of this, we can&apos;t just override the fill mode in all
circumstances. So we add logic to `RenderLayerBacking::updateAcceleratedEffectsAndBaseValues()` to only override
the fill mode for animations that will _not_ generate a value that will be used as input by a another animation
further up the stack.

[0] <a href="https://svelte.dev/docs/svelte/svelte-transition#fly">https://svelte.dev/docs/svelte/svelte-transition#fly</a>
[1] <a href="https://github.com/sveltejs/svelte/blob/0e9e76f29262b5f64ac7a5d4db37ec83c9181634/packages/svelte/src/internal/client/dom/elements/transitions.js#L379">https://github.com/sveltejs/svelte/blob/0e9e76f29262b5f64ac7a5d4db37ec83c9181634/packages/svelte/src/internal/client/dom/elements/transitions.js#L379</a>
[2] <a href="https://github.com/sveltejs/svelte/blob/0e9e76f29262b5f64ac7a5d4db37ec83c9181634/packages/svelte/src/internal/client/dom/elements/transitions.js#L440">https://github.com/sveltejs/svelte/blob/0e9e76f29262b5f64ac7a5d4db37ec83c9181634/packages/svelte/src/internal/client/dom/elements/transitions.js#L440</a>

Tests: webanimations/threaded-animations/fill-mode-adjustment-additive.html
       webanimations/threaded-animations/fill-mode-adjustment-adjust-effect-with-non-composed-properties.html

* LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-additive-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-additive.html: Added.
* LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-adjust-effect-with-non-composed-properties-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/fill-mode-adjustment-adjust-effect-with-non-composed-properties.html: Added.
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::makeForwardsFilling):
(WebCore::AcceleratedEffect::composedProperties const):
* Source/WebCore/platform/animation/AcceleratedEffect.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAcceleratedEffectsAndBaseValues):

Canonical link: <a href="https://commits.webkit.org/310985@main">https://commits.webkit.org/310985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbb578dbfd7729636308984a58e688a690795bec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164391 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28738 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120448 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/beaf65d0-6e0e-43dd-a33d-fb60fa109b6b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158587 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139745 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101137 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21723 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19843 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12221 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131392 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17577 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166870 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11046 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128568 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28432 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128699 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28356 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139370 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86185 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23709 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23515 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16167 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28050 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92153 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27627 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27857 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27700 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->