### PR TITLE
ShaderGraph does not get correctly reconstructed after passed over IPC

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
@@ -454,21 +454,18 @@ extension WKBridgeUpdateMaterial {
 extension WKBridgeInputOutput {
     let type: WKBridgeDataType
     let name: String
-    let semanticType: WKBridgeDataType
-    let hasSemanticType: Bool
+    let semanticTypeName: String?
     let defaultValue: WKBridgeConstantContainer?
 
     init(
         type: WKBridgeDataType,
         name: String,
-        semanticType: WKBridgeDataType,
-        hasSemanticType: Bool,
+        semanticTypeName: String?,
         defaultValue: WKBridgeConstantContainer?
     ) {
         self.type = type
         self.name = name
-        self.semanticType = semanticType
-        self.hasSemanticType = hasSemanticType
+        self.semanticTypeName = semanticTypeName
         self.defaultValue = defaultValue
     }
 }
@@ -572,27 +569,41 @@ extension WKBridgeNode {
 @objc
 @implementation
 extension WKBridgeMaterialGraph {
+    let graphName: String
     let nodes: [WKBridgeNode]
     let edges: [WKBridgeEdge]
     let arguments: WKBridgeNode
     let results: WKBridgeNode
     let inputs: [WKBridgeInputOutput]
     let outputs: [WKBridgeInputOutput]
+    // Parallel arrays for _Proto_ShaderNodeGraph.primvarMappings: maps primvar names to texcoord names.
+    let primvarMappingPrimvarNames: [String]
+    let primvarMappingTexcoordNames: [String]
+    // Names of graph inputs driven by runtime function constants (_Proto_ShaderNodeGraph.functionConstantInputs).
+    let functionConstantInputNames: [String]
 
     init(
+        graphName: String = "",
         nodes: [WKBridgeNode],
         edges: [WKBridgeEdge],
         arguments: WKBridgeNode,
         results: WKBridgeNode,
         inputs: [WKBridgeInputOutput],
-        outputs: [WKBridgeInputOutput]
+        outputs: [WKBridgeInputOutput],
+        primvarMappingPrimvarNames: [String] = [],
+        primvarMappingTexcoordNames: [String] = [],
+        functionConstantInputNames: [String] = []
     ) {
+        self.graphName = graphName
         self.nodes = nodes
         self.edges = edges
         self.arguments = arguments
         self.results = results
         self.inputs = inputs
         self.outputs = outputs
+        self.primvarMappingPrimvarNames = primvarMappingPrimvarNames
+        self.primvarMappingTexcoordNames = primvarMappingTexcoordNames
+        self.functionConstantInputNames = functionConstantInputNames
     }
 }
 

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
@@ -132,7 +132,7 @@ class Renderer {
     }
 
     internal func setBackgroundColor(_ color: simd_float3) {
-        clearColor = MTLClearColor(red: Double(color.x), green: Double(color.y), blue: Double(color.z), alpha: 1)
+        clearColor = MTLClearColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
     }
 
     internal func setCameraTransform(_ transform: CameraTransform) {

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
@@ -208,9 +208,9 @@ typedef NS_ENUM(NSInteger, WKBridgeDataType) {
     WKBridgeDataTypeInt3,
     WKBridgeDataTypeInt4,
     WKBridgeDataTypeFloat,
-    WKBridgeDataTypeColor3f,
+    WKBridgeDataTypeCgColor3,
+    WKBridgeDataTypeCgColor4,
     WKBridgeDataTypeColor3h,
-    WKBridgeDataTypeColor4f,
     WKBridgeDataTypeColor4h,
     WKBridgeDataTypeFloat2,
     WKBridgeDataTypeFloat3,
@@ -240,12 +240,11 @@ typedef NS_ENUM(NSInteger, WKBridgeDataType) {
 
 @property (nonatomic, readonly) WKBridgeDataType type;
 @property (nonatomic, readonly) NSString *name;
-@property (nonatomic, readonly) WKBridgeDataType semanticType;
-@property (nonatomic, readonly) BOOL hasSemanticType;
+@property (nonatomic, readonly, nullable) NSString *semanticTypeName;
 @property (nonatomic, readonly, nullable) WKBridgeConstantContainer *defaultValue;
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithType:(WKBridgeDataType)dataType name:(NSString *)name semanticType:(WKBridgeDataType)semanticType hasSemanticType:(BOOL)hasSemanticType defaultValue:(nullable WKBridgeConstantContainer *)defaultValue NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithType:(WKBridgeDataType)dataType name:(NSString *)name semanticTypeName:(nullable NSString *)semanticTypeName defaultValue:(nullable WKBridgeConstantContainer *)defaultValue NS_DESIGNATED_INITIALIZER;
 
 @end
 
@@ -282,14 +281,19 @@ typedef NS_ENUM(NSInteger, WKBridgeConstant) {
     WKBridgeConstantNormal3h,
     WKBridgeConstantVector3f,
     WKBridgeConstantVector3h,
-    WKBridgeConstantColor3f,
-    WKBridgeConstantColor3h,
-    WKBridgeConstantColor4f,
-    WKBridgeConstantColor4h,
+    WKBridgeConstantCgColor3,
+    WKBridgeConstantCgColor4,
     WKBridgeConstantTexCoord2h,
     WKBridgeConstantTexCoord2f,
     WKBridgeConstantTexCoord3h,
-    WKBridgeConstantTexCoord3f
+    WKBridgeConstantTexCoord3f,
+
+    // USD/MaterialX native color types encoded as float components (not through CGColor).
+    // color4f/color4h both encode as 4 floats; color3f/color3h both encode as 3 floats.
+    WKBridgeConstantColor4f,
+    WKBridgeConstantColor4h,
+    WKBridgeConstantColor3f,
+    WKBridgeConstantColor3h,
 };
 
 typedef NS_ENUM(NSInteger, WKBridgeNodeType) {
@@ -346,15 +350,19 @@ typedef NS_ENUM(NSInteger, WKBridgeNodeType) {
 NS_SWIFT_SENDABLE
 @interface WKBridgeMaterialGraph : NSObject
 
+@property (nonatomic, strong, readonly) NSString *graphName;
 @property (nonatomic, strong, readonly) NSArray<WKBridgeNode *> *nodes;
 @property (nonatomic, strong, readonly) NSArray<WKBridgeEdge *> *edges;
 @property (nonatomic, strong, readonly) WKBridgeNode *arguments;
 @property (nonatomic, strong, readonly) WKBridgeNode *results;
 @property (nonatomic, strong, readonly) NSArray<WKBridgeInputOutput *> *inputs;
 @property (nonatomic, strong, readonly) NSArray<WKBridgeInputOutput *> *outputs;
+@property (nonatomic, strong, readonly) NSArray<NSString *> *primvarMappingPrimvarNames;
+@property (nonatomic, strong, readonly) NSArray<NSString *> *primvarMappingTexcoordNames;
+@property (nonatomic, strong, readonly) NSArray<NSString *> *functionConstantInputNames;
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithNodes:(NSArray<WKBridgeNode *> *)nodes edges:(NSArray<WKBridgeEdge *> *)edges arguments:(WKBridgeNode *)arguments results:(WKBridgeNode *)results inputs:(NSArray<WKBridgeInputOutput *> *)inputs outputs:(NSArray<WKBridgeInputOutput *> *)outputs NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithGraphName:(NSString *)graphName nodes:(NSArray<WKBridgeNode *> *)nodes edges:(NSArray<WKBridgeEdge *> *)edges arguments:(WKBridgeNode *)arguments results:(WKBridgeNode *)results inputs:(NSArray<WKBridgeInputOutput *> *)inputs outputs:(NSArray<WKBridgeInputOutput *> *)outputs primvarMappingPrimvarNames:(NSArray<NSString *> *)primvarMappingPrimvarNames primvarMappingTexcoordNames:(NSArray<NSString *> *)primvarMappingTexcoordNames functionConstantInputNames:(NSArray<NSString *> *)functionConstantInputNames NS_DESIGNATED_INITIALIZER;
 
 @end
 
@@ -687,7 +695,7 @@ struct ConstantContainer {
 struct InputOutput {
     DataType type;
     String name;
-    std::optional<DataType> semanticType;
+    std::optional<String> semanticTypeName;
     std::optional<ConstantContainer> defaultValue;
 };
 
@@ -703,12 +711,16 @@ struct Node {
 };
 
 struct MaterialGraph {
+    String graphName;
     Vector<Node> nodes;
     Vector<Edge> edges;
     Node arguments;
     Node results;
     Vector<InputOutput> inputs;
     Vector<InputOutput> outputs;
+    Vector<String> primvarMappingPrimvarNames;
+    Vector<String> primvarMappingTexcoordNames;
+    Vector<String> functionConstantInputNames;
 };
 
 struct TypedResourceId {

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
@@ -27,7 +27,7 @@ import DirectResource
 import Metal
 import USDKit
 @_spi(UsdLoaderAPI) import _USDKit_RealityKit
-@_spi(RealityCoreRendererAPI) import RealityKit
+@_spi(Private) @_spi(RealityCoreRendererAPI) import RealityKit
 @_spi(SGInternal) import RealityKit
 
 final class MeshInstancePool {
@@ -294,6 +294,30 @@ internal func debugPrintShaderGraph(_ graph: _Proto_ShaderNodeGraph?, prefix: St
     for (index, edge) in graph.edges.enumerated() {
         logInfo("\(nextIndent)  [\(index)] \(edge.outputNode):\(edge.outputPort) -> \(edge.inputNode):\(edge.inputPort)")
     }
+
+    // Print underlying SGGraph
+    let sgGraph = graph.sgGraph
+    logInfo("\(nextIndent)SGGraph:")
+    let sgIndent = nextIndent + "  "
+    logInfo("\(sgIndent)Name: \(sgGraph.name)")
+    logInfo("\(sgIndent)Inputs (\(sgGraph.inputs.count)):")
+    for (index, input) in sgGraph.inputs.enumerated() {
+        logInfo("\(sgIndent)  [\(index)] name: \(input.name), type: \(input.type)")
+    }
+    logInfo("\(sgIndent)Outputs (\(sgGraph.outputs.count)):")
+    for (index, output) in sgGraph.outputs.enumerated() {
+        logInfo("\(sgIndent)  [\(index)] name: \(output.name), type: \(output.type)")
+    }
+    logInfo("\(sgIndent)Nodes (\(sgGraph.childNodes.count)):")
+    for node in sgGraph.childNodes {
+        let inputNames = node.inputs.map { "\($0.name): \($0.type)" }.joined(separator: ", ")
+        let outputNames = node.outputs.map { "\($0.name): \($0.type)" }.joined(separator: ", ")
+        logInfo("\(sgIndent)  \(node.name) inputs=[\(inputNames)] outputs=[\(outputNames)]")
+    }
+    logInfo("\(sgIndent)Edges (\(sgGraph.edges.count))")
+    if let dot = try? sgGraph.createDotRepresentation() {
+        logInfo("\(sgIndent)DOT representation:\n\(dot)")
+    }
 }
 
 private func debugPrintNode(_ node: _Proto_ShaderNodeGraph.Node, indent: String = "") {
@@ -361,15 +385,15 @@ private func debugPrintValue(_ value: _Proto_ShaderGraphValue, indent: String = 
         logInfo("\(indent)Value: int4(\(val.x), \(val.y), \(val.z), \(val.w))")
     case .cgColor3(let color):
         if let components = color.components {
-            logInfo("\(indent)Value: color3(r:\(components[0]), g:\(components[1]), b:\(components[2]))")
+            logInfo("\(indent)Value: cgColor3(\(components[0]), \(components[1]), \(components[2]))")
         } else {
-            logInfo("\(indent)Value: color3(invalid)")
+            fatalError("\(indent)Value: cgColor3(invalid)")
         }
     case .cgColor4(let color):
         if let components = color.components {
-            logInfo("\(indent)Value: color4(r:\(components[0]), g:\(components[1]), b:\(components[2]), a:\(components[3]))")
+            logInfo("\(indent)Value: cgColor4(\(components[0]), \(components[1]), \(components[2]), \(components[3]))")
         } else {
-            logInfo("\(indent)Value: color4(invalid)")
+            fatalError("\(indent)Value: cgColor4(invalid)")
         }
     case .float2x2(let col0, let col1):
         logInfo("\(indent)Value: float2x2(")
@@ -533,8 +557,8 @@ internal func compareShaderGraphs(
 
 private func nodeDataTypeString(_ data: _Proto_ShaderNodeGraph.Node.NodeData) -> String {
     switch data {
-    case .constant:
-        return "constant"
+    case .constant(let value):
+        return "constant(\(value))"
     case .definition(let def):
         return "definition(\(def.name))"
     case .graph:

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -32,7 +32,7 @@ import simd
 @_spi(RealityCoreTextureProcessingAPI) import RealityCoreTextureProcessing
 import USDKit
 @_spi(SwiftAPI) import DirectResource
-import RealityKit
+@_spi(Private) import RealityKit
 @_spi(SGPrivate) import ShaderGraph
 import RealityCoreDeformation
 
@@ -1161,21 +1161,19 @@ private func constantValues(_ constant: _Proto_ShaderGraphValue) -> ([WKBridgeVa
             ], .int4
         )
     case .cgColor3(let color3):
-        // Extract RGB components from CGColor
         guard let components = color3.components, components.count >= 3 else {
-            return ([], .asset)
+            fatalError("constantValues: CGColor3 has fewer than 3 components")
         }
         return (
             [
                 WKBridgeValueString(number: NSNumber(value: Float(components[0]))),
                 WKBridgeValueString(number: NSNumber(value: Float(components[1]))),
                 WKBridgeValueString(number: NSNumber(value: Float(components[2]))),
-            ], .color3f
+            ], .cgColor3
         )
     case .cgColor4(let color4):
-        // Extract RGBA components from CGColor
         guard let components = color4.components, components.count >= 4 else {
-            return ([], .asset)
+            fatalError("constantValues: CGColor4 has fewer than 4 components")
         }
         return (
             [
@@ -1183,7 +1181,7 @@ private func constantValues(_ constant: _Proto_ShaderGraphValue) -> ([WKBridgeVa
                 WKBridgeValueString(number: NSNumber(value: Float(components[1]))),
                 WKBridgeValueString(number: NSNumber(value: Float(components[2]))),
                 WKBridgeValueString(number: NSNumber(value: Float(components[3]))),
-            ], .color4f
+            ], .cgColor4
         )
     case .float3x3(let col0, let col1, let col2):
         // Extract 9 float values from the 3x3 matrix (3 columns of 3 rows each)
@@ -1223,26 +1221,22 @@ private func constantValues(_ constant: _Proto_ShaderGraphValue) -> ([WKBridgeVa
             ], .matrix4f
         )
     default:
-        // For any unsupported types, return empty asset
-        return ([], .asset)
+        fatalError("constantValues: unhandled ShaderGraphValue type \(constant)")
     }
 }
 
-private func toWKBridgeConstantContainer(_ node: _Proto_ShaderNodeGraph.Node) -> WKBridgeConstantContainer {
+private func toWKBridgeConstantContainer(
+    _ node: _Proto_ShaderNodeGraph.Node,
+    colorOverride: WKBridgeConstant? = nil
+) -> WKBridgeConstantContainer {
     // Extract constant value if this is a constant node
     switch node.data {
     case .constant(let value):
-        let converted = constantValues(value)
-        return WKBridgeConstantContainer(constant: converted.1, constantValues: converted.0, name: node.name)
+        let (values, defaultType) = constantValues(value)
+        return WKBridgeConstantContainer(constant: colorOverride ?? defaultType, constantValues: values, name: node.name)
     case .definition, .graph:
         return WKBridgeConstantContainer(constant: .asset, constantValues: [], name: node.name)
     default: fatalError("toWKBridgeConstantContainer - unknown _Proto_ShaderNodeGraph.Node.data type")
-    }
-}
-
-private func toWebNodes(_ nodes: [_Proto_ShaderNodeGraph.Node]) -> [WKBridgeNode] {
-    nodes.map { e in
-        WKBridgeNode(bridgeNodeType: toWKBridgeNodeType(e), builtin: toWKBridgeBuiltin(e), constant: toWKBridgeConstantContainer(e))
     }
 }
 
@@ -1275,10 +1269,29 @@ private func toWKBridgeDataType(_ dataType: _Proto_ShaderDataType) -> WKBridgeDa
     case .surfaceShader: .surfaceShader
     case .geometryModifier: .geometryModifier
     case .postLightingShader: .postLightingShader
-    case .cgColor3: .color3f // Assuming float color
-    case .cgColor4: .color4f // Assuming float color
+    case .cgColor3: .cgColor3
+    case .cgColor4: .cgColor4
     case .filename: .asset
     @unknown default: .asset
+    }
+}
+
+// SGDataType rawValues for color variants that _Proto_ShaderDataType collapses.
+private enum SGDataTypeRawValue {
+    static let color3f: UInt = 41
+    static let color3h: UInt = 42
+    static let color4f: UInt = 44
+    static let color4h: UInt = 45
+}
+
+// Maps an SGDataType rawValue to WKBridgeDataType, preserving half-precision color variants
+// (color3h=42, color4h=45) that _Proto_ShaderDataType collapses to cgColor3/cgColor4.
+// Falls back to the proto-level type for all other types.
+private func toWKBridgeDataTypeFromSGRawValue(_ rawValue: UInt, fallback: WKBridgeDataType) -> WKBridgeDataType {
+    switch rawValue {
+    case SGDataTypeRawValue.color3h: .color3h
+    case SGDataTypeRawValue.color4h: .color4h
+    default: fallback
     }
 }
 
@@ -1293,23 +1306,11 @@ private func createInputOutput(
         return WKBridgeConstantContainer(constant: constantType, constantValues: values, name: "")
     }
 
-    let (actualType, hasSemanticType) =
-        semanticType.map { semantic in
-            let semanticName = semantic.name.lowercased()
-            if semanticName.contains("color4") || semanticName == "color4f" {
-                return (WKBridgeDataType.color4f, true)
-            } else if semanticName.contains("color3") || semanticName == "color3f" {
-                return (WKBridgeDataType.color3f, true)
-            } else {
-                return (toWKBridgeDataType(type), true)
-            }
-        } ?? (toWKBridgeDataType(type), false)
-
+    let actualType = toWKBridgeDataType(type)
     return WKBridgeInputOutput(
         type: actualType,
         name: name,
-        semanticType: actualType,
-        hasSemanticType: hasSemanticType,
+        semanticTypeName: semanticType?.name,
         defaultValue: defaultValueContainer
     )
 }
@@ -1336,8 +1337,12 @@ private func toWebOutputs(_ outputs: [_Proto_ShaderGraphNodeDefinition.Output]) 
     }
 }
 
-private func toWebNode(_ e: _Proto_ShaderNodeGraph.Node) -> WKBridgeNode {
-    WKBridgeNode(bridgeNodeType: toWKBridgeNodeType(e), builtin: toWKBridgeBuiltin(e), constant: toWKBridgeConstantContainer(e))
+private func toWebNode(_ e: _Proto_ShaderNodeGraph.Node, colorOverride: WKBridgeConstant? = nil) -> WKBridgeNode {
+    WKBridgeNode(
+        bridgeNodeType: toWKBridgeNodeType(e),
+        builtin: toWKBridgeBuiltin(e),
+        constant: toWKBridgeConstantContainer(e, colorOverride: colorOverride)
+    )
 }
 
 private func toWebEdges(_ edges: [_Proto_ShaderNodeGraph.Edge]) -> [WKBridgeEdge] {
@@ -1351,10 +1356,39 @@ private func toWebEdges(_ edges: [_Proto_ShaderNodeGraph.Edge]) -> [WKBridgeEdge
     }
 }
 
+private func texcoordName(for coord: _Proto_TextureCoordinate) -> String {
+    switch coord {
+    case .uv0: "UV0"
+    case .uv1: "UV1"
+    case .uv2: "UV2"
+    case .uv3: "UV3"
+    case .uv4: "UV4"
+    case .uv5: "UV5"
+    case .uv6: "UV6"
+    case .uv7: "UV7"
+    @unknown default: "UV0"
+    }
+}
+
+private func textureCoordinate(from name: String) -> _Proto_TextureCoordinate? {
+    switch name {
+    case "UV0": .uv0
+    case "UV1": .uv1
+    case "UV2": .uv2
+    case "UV3": .uv3
+    case "UV4": .uv4
+    case "UV5": .uv5
+    case "UV6": .uv6
+    case "UV7": .uv7
+    default: nil
+    }
+}
+
 private func toWebMaterialGraph(_ material: _Proto_ShaderNodeGraph?) -> WKBridgeMaterialGraph {
     guard let material else {
         // Return empty material graph if nil
         return WKBridgeMaterialGraph(
+            graphName: "",
             nodes: [],
             edges: [],
             arguments: WKBridgeNode(
@@ -1368,12 +1402,32 @@ private func toWebMaterialGraph(_ material: _Proto_ShaderNodeGraph?) -> WKBridge
                 constant: WKBridgeConstantContainer(constant: .asset, constantValues: [], name: "")
             ),
             inputs: [],
-            outputs: []
+            outputs: [],
+            primvarMappingPrimvarNames: [],
+            primvarMappingTexcoordNames: [],
+            functionConstantInputNames: []
         )
     }
 
+    // Pre-compute color type overrides for constant nodes by inspecting the sgGraph.
+    // The proto layer collapses color4f/color4h/color3f/color3h to float4/float3, losing
+    // the exact SGDataType. Read it back from the sgGraph's output type for each constant node.
+    var constantColorOverrides: [String: WKBridgeConstant] = [:]
+    let sgNodesByName = Dictionary(uniqueKeysWithValues: material.sgGraph.childNodes.map { ($0.name, $0) })
+    for (nodeName, node) in material.nodes {
+        guard case .constant(let value) = node.data else { continue }
+        guard let rawValue = sgNodesByName[nodeName]?.outputs.first?.type.rawValue else { continue }
+        switch rawValue {
+        case SGDataTypeRawValue.color4f: if case .float4 = value { constantColorOverrides[nodeName] = .color4f }
+        case SGDataTypeRawValue.color4h: if case .float4 = value { constantColorOverrides[nodeName] = .color4h }
+        case SGDataTypeRawValue.color3f: if case .float3 = value { constantColorOverrides[nodeName] = .color3f }
+        case SGDataTypeRawValue.color3h: if case .float3 = value { constantColorOverrides[nodeName] = .color3h }
+        default: break
+        }
+    }
+
     // Convert nodes dictionary to array
-    let nodes = material.nodes.values.map(toWebNode)
+    let nodes = material.nodes.values.map { toWebNode($0, colorOverride: constantColorOverrides[$0.name]) }
 
     // Convert edges
     let edges = toWebEdges(material.edges)
@@ -1388,13 +1442,23 @@ private func toWebMaterialGraph(_ material: _Proto_ShaderNodeGraph?) -> WKBridge
     // Convert outputs
     let outputs = toWebOutputs(material.outputs)
 
+    // Serialize primvarMappings as parallel arrays (sorted for determinism).
+    // _Proto_TextureCoordinate.name is internal so we map to the canonical UV name string.
+    let sortedPrimvarKeys = material.primvarMappings.keys.sorted()
+    let primvarPrimvarNames = sortedPrimvarKeys
+    let primvarTexcoordNames = sortedPrimvarKeys.map { texcoordName(for: material.primvarMappings[$0]!) }
+
     return WKBridgeMaterialGraph(
+        graphName: material.sgGraph.name,
         nodes: nodes,
         edges: edges,
         arguments: argumentsNode,
         results: resultsNode,
         inputs: inputs,
-        outputs: outputs
+        outputs: outputs,
+        primvarMappingPrimvarNames: primvarPrimvarNames,
+        primvarMappingTexcoordNames: primvarTexcoordNames,
+        functionConstantInputNames: material.functionConstantInputs
     )
 }
 
@@ -1402,6 +1466,7 @@ func webUpdateMaterialRequestFromUpdateMaterialRequest(
     _ request: _Proto_MaterialDataUpdate_v1
 ) -> WKBridgeUpdateMaterial {
     let bridgeMaterialGraph = toWebMaterialGraph(request.shaderGraph)
+
     return WKBridgeUpdateMaterial(
         materialGraph: bridgeMaterialGraph,
         identifier: .init(value: request.id.value, path: request.id.path, hashValue: request.id.hashValue)
@@ -1409,202 +1474,205 @@ func webUpdateMaterialRequestFromUpdateMaterialRequest(
 }
 
 extension ShaderGraph._Proto_ShaderNodeGraph {
+    // Reconstructs the graph from the IPC bridge representation using the SGGraph API directly.
+    // This bypasses _Proto_ShaderDataType (which collapses color3h/color4h to cgColor3/cgColor4)
+    // and instead uses SGNode.create(nodeDefName:name:) for builtin nodes (preserving MaterialX
+    // half-precision color types: color3h/color4h) and SGNode.create(value:type:) for constant
+    // nodes (preserving the exact SGDataType transmitted over IPC, e.g. color4f).
     static func fromWKDescriptor(_ descriptor: WKBridgeMaterialGraph?) -> _Proto_ShaderNodeGraph? {
         guard let descriptor else { return nil }
 
         do {
-            // Create the shader graph with name, inputs, and outputs
             let graph = try _Proto_ShaderNodeGraph(
-                named: "MaterialGraph",
-                inputs: descriptor.inputs.map { input in
-                    // Create SemanticType if hasSemanticType is true
-                    let semanticType: _Proto_ShaderGraphNodeDefinition.SemanticType?
-                    let actualType: _Proto_ShaderDataType
-
-                    if input.hasSemanticType {
-                        // Determine the semantic type name from the WKBridgeDataType
-                        let semanticName: String
-                        switch input.semanticType {
-                        case .color3f, .color3h:
-                            semanticName = "color3f"
-                            actualType = .cgColor3
-                        case .color4f, .color4h:
-                            semanticName = "color4f"
-                            actualType = .cgColor4
-                        default:
-                            semanticName = "\(input.semanticType)"
-                            actualType = fromWKBridgeDataType(input.type)
-                        }
-                        semanticType = _Proto_ShaderGraphNodeDefinition.SemanticType(name: semanticName, values: nil)
-                    } else {
-                        semanticType = nil
-                        actualType = fromWKBridgeDataType(input.type)
-                    }
-
-                    let defaultValue: _Proto_ShaderGraphValue?
-                    if let container = input.defaultValue {
-                        defaultValue = fromWKBridgeConstant(container)
-                    } else {
-                        defaultValue = nil
-                    }
-
-                    return _Proto_ShaderGraphNodeDefinition.Input(
-                        name: input.name,
-                        type: actualType,
-                        semanticType: semanticType,
-                        defaultValue: defaultValue
+                named: descriptor.graphName.isEmpty ? "MaterialGraph" : descriptor.graphName,
+                inputs: descriptor.inputs.map {
+                    _Proto_ShaderGraphNodeDefinition.Input(
+                        name: $0.name,
+                        type: fromWKBridgeDataType($0.type),
+                        semanticType: $0.semanticTypeName.map { .init(name: $0) }
                     )
                 },
-                outputs: descriptor.outputs.map { output in
-                    // Create SemanticType if hasSemanticType is true
-                    let semanticType: _Proto_ShaderGraphNodeDefinition.SemanticType?
-                    let actualType: _Proto_ShaderDataType
-
-                    if output.hasSemanticType {
-                        // Determine the semantic type name from the WKBridgeDataType
-                        let semanticName: String
-                        switch output.semanticType {
-                        case .color3f, .color3h:
-                            semanticName = "color3f"
-                            actualType = .cgColor3
-                        case .color4f, .color4h:
-                            semanticName = "color4f"
-                            actualType = .cgColor4
-                        default:
-                            semanticName = "\(output.semanticType)"
-                            actualType = fromWKBridgeDataType(output.type)
-                        }
-                        semanticType = _Proto_ShaderGraphNodeDefinition.SemanticType(name: semanticName, values: nil)
-                    } else {
-                        semanticType = nil
-                        actualType = fromWKBridgeDataType(output.type)
-                    }
-
-                    let defaultValue: _Proto_ShaderGraphValue?
-                    if let container = output.defaultValue {
-                        defaultValue = fromWKBridgeConstant(container)
-                    } else {
-                        defaultValue = nil
-                    }
-
-                    return _Proto_ShaderGraphNodeDefinition.Output(
-                        name: output.name,
-                        type: actualType,
-                        semanticType: semanticType,
-                        defaultValue: defaultValue
+                outputs: descriptor.outputs.map {
+                    _Proto_ShaderGraphNodeDefinition.Output(
+                        name: $0.name,
+                        type: fromWKBridgeDataType($0.type),
+                        semanticType: $0.semanticTypeName.map { .init(name: $0) }
                     )
                 }
             )
 
-            // Get the shared shader graph library for looking up builtin definitions
-            let library = _Proto_ShaderNodeGraphLibrary.shared
-            // First pass: build a map to look up which edges connect to which inputs
-            // This helps us determine the expected type for constant nodes
-            var constantToInputType: [String: _Proto_ShaderDataType] = [:]
-            for edge in descriptor.edges {
-                // Find the definition of the input node to get the expected input type
-                if let inputNodeBridge = descriptor.nodes.first(where: { ($0.builtin?.name ?? $0.constant?.name) == edge.inputNode }),
-                    let builtin = inputNodeBridge.builtin,
-                    !builtin.definition.isEmpty,
-                    let definition = library.definition(named: builtin.definition)
-                {
-                    // Find the input port in the definition
-                    if let input = definition.inputs.first(where: { $0.name == edge.inputPort }) {
-                        constantToInputType[edge.outputNode] = input.type
-                    }
-                }
-            }
+            let sgGraph = graph.sgGraph
+            let argumentsName = graph.arguments.name
+            let resultsName = graph.results.name
 
-            // Convert bridge nodes to a dictionary of nodes
-            var nodesDictionary: [String: _Proto_ShaderNodeGraph.Node] = [:]
+            // Build nodes using the SGGraph API to preserve MaterialX type precision.
+            var sgNodes: [SGNode] = []
             for bridgeNode in descriptor.nodes {
-                let nodeName = bridgeNode.builtin?.name ?? bridgeNode.constant?.name ?? "unknown"
-
                 switch bridgeNode.bridgeNodeType {
                 case .constant:
-                    // Handle constant nodes
-                    if let constant = bridgeNode.constant {
-                        // Check if this constant feeds into an input that expects a color type
-                        var value = fromWKBridgeConstant(constant)
-                        // If this constant is float4 but connects to a cgColor4 input, convert it
-                        if case .float4(let vec) = value,
-                            let expectedType = constantToInputType[nodeName],
-                            expectedType == .cgColor4
-                        {
-                            value = .cgColor4(
-                                CGColor(
-                                    red: CGFloat(vec.x),
-                                    green: CGFloat(vec.y),
-                                    blue: CGFloat(vec.z),
-                                    alpha: CGFloat(vec.w)
-                                )
-                            )
-                        }
-                        let node = _Proto_ShaderNodeGraph.Node(name: nodeName, data: .constant(value))
-                        nodesDictionary[nodeName] = node
+                    if let constant = bridgeNode.constant,
+                        let sgNode = try? makeConstantSGNode(from: constant)
+                    {
+                        sgNodes.append(sgNode)
                     }
-
-                case .builtin, .arguments, .results:
-                    // Handle builtin, arguments, and results nodes
-                    if let builtin = bridgeNode.builtin, !builtin.definition.isEmpty {
-                        if let definition = library.definition(named: builtin.definition) {
-                            let node = _Proto_ShaderNodeGraph.Node(name: nodeName, data: .definition(definition))
-                            nodesDictionary[nodeName] = node
-                        } else {
-                            logError("Could not find builtin definition named '\(builtin.definition)' for node '\(nodeName)'")
-                            // Don't add this node to the dictionary - it will be filtered out later
-                        }
-                    } else {
-                        // For arguments/results nodes without definitions, skip them
-                        // These are special node types that don't need explicit nodes in the graph
-                        logInfo("Skipping \(bridgeNode.bridgeNodeType) node '\(nodeName)' (no definition)")
+                case .builtin:
+                    if let builtin = bridgeNode.builtin, !builtin.definition.isEmpty,
+                        let sgNode = try? SGNode.create(nodeDefName: builtin.definition, name: builtin.name)
+                    {
+                        sgNodes.append(sgNode)
                     }
-
+                case .arguments, .results:
+                    break
                 @unknown default:
-                    fatalError("Unknown node type for node '\(nodeName)'")
+                    let name = bridgeNode.builtin?.name ?? bridgeNode.constant?.name ?? "unknown"
+                    fatalError("Unknown node type '\(name)'")
                 }
             }
+            try sgGraph.insert(sgNodes)
 
-            // Build a set of valid node names (excluding special nodes like arguments/results)
-            let validNodeNames = Set(nodesDictionary.keys)
-
-            // Get the names of arguments and results nodes from the descriptor fields
-            // These are stored separately in descriptor.arguments and descriptor.results, not in descriptor.nodes
-            let specialNodeNames = Set(
-                [descriptor.arguments, descriptor.results]
-                    .compactMap {
-                        $0.builtin?.name ?? $0.constant?.name
-                    }
-            )
-
-            // Convert bridge edges to edges, filtering out edges that reference truly missing nodes
-            let edges = descriptor.edges.compactMap { bridgeEdge -> _Proto_ShaderNodeGraph.Edge? in
-                let outputExists = validNodeNames.contains(bridgeEdge.outputNode) || specialNodeNames.contains(bridgeEdge.outputNode)
-                let inputExists = validNodeNames.contains(bridgeEdge.inputNode) || specialNodeNames.contains(bridgeEdge.inputNode)
-
-                guard outputExists && inputExists else {
+            // Connect edges via the SGGraph API.
+            let insertedNames = Set(sgNodes.map { $0.name })
+                .union([argumentsName, resultsName])
+            for bridgeEdge in descriptor.edges {
+                guard insertedNames.contains(bridgeEdge.outputNode),
+                    insertedNames.contains(bridgeEdge.inputNode)
+                else { continue }
+                let outputNode =
+                    bridgeEdge.outputNode == argumentsName
+                    ? sgGraph.argumentsNode
+                    : bridgeEdge.outputNode == resultsName ? sgGraph.resultsNode : sgGraph.node(named: bridgeEdge.outputNode)
+                let inputNode =
+                    bridgeEdge.inputNode == argumentsName
+                    ? sgGraph.argumentsNode
+                    : bridgeEdge.inputNode == resultsName ? sgGraph.resultsNode : sgGraph.node(named: bridgeEdge.inputNode)
+                guard let output = outputNode?.outputNamed(bridgeEdge.outputPort),
+                    let input = inputNode?.inputNamed(bridgeEdge.inputPort)
+                else { continue }
+                do {
+                    try sgGraph.connect(output, to: input)
+                } catch {
                     logError(
-                        "Skipping edge from '\(bridgeEdge.outputNode).\(bridgeEdge.outputPort)' to '\(bridgeEdge.inputNode).\(bridgeEdge.inputPort)' - one or both nodes not found"
+                        "Failed to connect \(bridgeEdge.outputNode):\(bridgeEdge.outputPort) -> \(bridgeEdge.inputNode):\(bridgeEdge.inputPort): \(error)"
                     )
-                    return nil
                 }
-
-                return _Proto_ShaderNodeGraph.Edge(
-                    outputNode: bridgeEdge.outputNode,
-                    outputPort: bridgeEdge.outputPort,
-                    inputNode: bridgeEdge.inputNode,
-                    inputPort: bridgeEdge.inputPort
-                )
             }
 
-            // Use replace to set nodes and edges
-            try graph.replace(nodes: nodesDictionary, edges: edges)
+            // Restore primvarMappings so ShaderGraph knows how to resolve UV primvar names
+            // (e.g. "UV0") to actual mesh texture coordinates. Without this the ND_geompropvalue
+            // node can't find UV data and all texture sampling breaks.
+            for (primvarName, texcoordName) in zip(descriptor.primvarMappingPrimvarNames, descriptor.primvarMappingTexcoordNames) {
+                if let texcoord = textureCoordinate(from: texcoordName) {
+                    graph.primvarMappings[primvarName] = texcoord
+                }
+            }
+
+            // Restore functionConstantInputs so runtime-driven inputs are declared correctly.
+            graph.functionConstantInputs = descriptor.functionConstantInputNames
 
             return graph
         } catch {
-            logError("Failed to create ShaderNodeGraph: \(error)")
+            logError("Failed to reconstruct ShaderNodeGraph: \(error)")
             return nil
         }
+    }
+}
+
+// Creates an SGNode for a constant directly with the exact SGDataType, bypassing the lossy
+// _Proto_ShaderGraphValue layer. This preserves color4f (44) vs cgColor4 (56) distinctions.
+private func makeConstantSGNode(from constant: WKBridgeConstantContainer) throws -> SGNode {
+    let values = constant.constantValues
+    let name = constant.name
+
+    // Helpers to build NSNumber arrays and CGColors for the SGNode factory methods.
+    func nums(_ n: Int) -> NSArray { values[0..<n].map { $0.number } as NSArray }
+    func extendedColor(_ n: Int) -> CGColor {
+        let comps =
+            (0..<n).map { CGFloat(values[$0].number.floatValue) }
+            + (n == 3 ? [CGFloat(1.0)] : [])
+        let cs = CGColorSpace(name: CGColorSpace.extendedLinearSRGB)
+        return cs.flatMap { unsafe CGColor(colorSpace: $0, components: comps) }
+            ?? CGColor(red: comps[0], green: comps[1], blue: comps[2], alpha: comps.count > 3 ? comps[3] : 1)
+    }
+
+    switch constant.constant {
+    case .bool:
+        return try SGNode.create(values.first?.number.boolValue ?? false, name: name)
+    case .uchar:
+        return try SGNode.create(values.first?.number ?? 0, type: .uchar, name: name)
+    case .int:
+        return try SGNode.create(values.first?.number ?? 0, type: .int, name: name)
+    case .uint:
+        return try SGNode.create(values.first?.number ?? 0, type: .uint, name: name)
+    case .half:
+        return try SGNode.create(values.first?.number ?? 0, type: .half, name: name)
+    case .float:
+        return try SGNode.create(values.first?.number ?? 0, type: .float, name: name)
+    case .timecode:
+        return try SGNode.create(values.first?.number ?? 0, type: .timecode, name: name)
+    case .string:
+        return try SGNode.create(value: values.first?.string ?? "", type: .string, name: name)
+    case .token:
+        return try SGNode.create(value: values.first?.string ?? "", type: .token, name: name)
+    case .asset:
+        return try SGNode.create(value: values.first?.string ?? "", type: .asset, name: name)
+    case .float2:
+        return try SGNode.create(nums(2), type: .float2, name: name)
+    case .texCoord2f:
+        return try SGNode.create(nums(2), type: .texCoord2f, name: name)
+    case .texCoord2h:
+        return try SGNode.create(nums(2), type: .texCoord2h, name: name)
+    case .float3:
+        return try SGNode.create(nums(3), type: .float3, name: name)
+    case .vector3f:
+        return try SGNode.create(nums(3), type: .vector3f, name: name)
+    case .point3f:
+        return try SGNode.create(nums(3), type: .point3f, name: name)
+    case .normal3f:
+        return try SGNode.create(nums(3), type: .normal3f, name: name)
+    case .texCoord3f:
+        return try SGNode.create(nums(3), type: .texCoord3f, name: name)
+    case .vector3h:
+        return try SGNode.create(nums(3), type: .vector3h, name: name)
+    case .point3h:
+        return try SGNode.create(nums(3), type: .point3h, name: name)
+    case .normal3h:
+        return try SGNode.create(nums(3), type: .normal3h, name: name)
+    case .half3:
+        return try SGNode.create(nums(3), type: .half3, name: name)
+    case .texCoord3h:
+        return try SGNode.create(nums(3), type: .texCoord3h, name: name)
+    case .float4, .matrix2f:
+        return try SGNode.create(nums(4), type: .float4, name: name)
+    case .half2:
+        return try SGNode.create(nums(2), type: .half2, name: name)
+    case .half4:
+        return try SGNode.create(nums(4), type: .half4, name: name)
+    case .int2:
+        return try SGNode.create(nums(2), type: .int2, name: name)
+    case .int3:
+        return try SGNode.create(nums(3), type: .int3, name: name)
+    case .int4:
+        return try SGNode.create(nums(4), type: .int4, name: name)
+    case .matrix3f:
+        return try SGNode.create(nums(9), type: .matrix3f, name: name)
+    case .matrix4f:
+        return try SGNode.create(nums(16), type: .matrix4f, name: name)
+    case .quatf, .quath:
+        return try SGNode.create(nums(4), type: .quatf, name: name)
+    case .cgColor3:
+        return try SGNode.createColor3(color: extendedColor(3), name: name)
+    case .cgColor4:
+        return try SGNode.createColor4(color: extendedColor(4), name: name)
+    case .color4f:
+        return try SGNode.create(nums(4), type: .color4f, name: name)
+    case .color4h:
+        return try SGNode.create(nums(4), type: .color4h, name: name)
+    case .color3f:
+        return try SGNode.create(nums(3), type: .color3f, name: name)
+    case .color3h:
+        return try SGNode.create(nums(3), type: .color3h, name: name)
+    @unknown default:
+        fatalError("makeConstantSGNode - Unhandled constant type \(constant.constant) for '\(name)'")
     }
 }
 
@@ -1618,10 +1686,8 @@ private func fromWKBridgeDataType(_ dataType: WKBridgeDataType) -> _Proto_Shader
     case .int3: .int3
     case .int4: .int4
     case .float: .float
-    case .color3f: .cgColor3
-    case .color3h: .cgColor3 // Map to cgColor3, closest match
-    case .color4f: .cgColor4
-    case .color4h: .cgColor4 // Map to cgColor4, closest match
+    case .cgColor3: .cgColor3
+    case .cgColor4: .cgColor4
     case .float2: .float2
     case .float3: .float3
     case .float4: .float4
@@ -1651,30 +1717,33 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
 
     switch constant.constant {
     case .bool:
-        return .bool(values.first?.number.boolValue ?? false)
+        guard let v = values.first else { fatalError("fromWKBridgeConstant: missing value for bool constant '\(constant.name)'") }
+        return .bool(v.number.boolValue)
     case .uchar:
-        return .uchar(values.first?.number.uint8Value ?? 0)
+        guard let v = values.first else { fatalError("fromWKBridgeConstant: missing value for uchar constant '\(constant.name)'") }
+        return .uchar(v.number.uint8Value)
     case .int:
-        return .int(Int32(values.first?.number.intValue ?? 0))
+        guard let v = values.first else { fatalError("fromWKBridgeConstant: missing value for int constant '\(constant.name)'") }
+        return .int(Int32(v.number.intValue))
     case .uint:
-        return .uint(UInt32(values.first?.number.uintValue ?? 0))
+        guard let v = values.first else { fatalError("fromWKBridgeConstant: missing value for uint constant '\(constant.name)'") }
+        return .uint(UInt32(v.number.uintValue))
     case .half:
-        return .half(values.first?.number.uint16Value ?? 0)
+        guard let v = values.first else { fatalError("fromWKBridgeConstant: missing value for half constant '\(constant.name)'") }
+        return .half(v.number.uint16Value)
     case .float:
-        return .float(values.first?.number.floatValue ?? 0)
+        guard let v = values.first else { fatalError("fromWKBridgeConstant: missing value for float constant '\(constant.name)'") }
+        return .float(v.number.floatValue)
     case .string, .token, .asset:
-        let stringValue = values.first?.string ?? ""
-        if stringValue.isEmpty && !values.isEmpty {
-            logInfo(
-                "⚠️ DEBUG: String value is empty for node '\(constant.name)'. values.count=\(values.count), first value=\(String(describing: values.first))"
-            )
-        }
-        return .string(stringValue)
+        guard let v = values.first else { fatalError("fromWKBridgeConstant: missing value for string constant '\(constant.name)'") }
+        return .string(v.string)
     case .timecode:
-        // timecode maps to float
-        return .float(Float(values.first?.number.doubleValue ?? 0))
+        guard let v = values.first else { fatalError("fromWKBridgeConstant: missing value for timecode constant '\(constant.name)'") }
+        return .float(Float(v.number.doubleValue))
     case .float2, .texCoord2f:
-        guard values.count >= 2 else { return .float2(.zero) }
+        guard values.count >= 2 else {
+            fatalError("fromWKBridgeConstant: expected 2 values for float2 constant '\(constant.name)', got \(values.count)")
+        }
         return .float2(
             SIMD2<Float>(
                 values[0].number.floatValue,
@@ -1683,7 +1752,9 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
         )
     case .vector3f, .float3, .point3f, .normal3f, .texCoord3f:
         // All float3-based semantic types map to float3
-        guard values.count >= 3 else { return .float3(.zero) }
+        guard values.count >= 3 else {
+            fatalError("fromWKBridgeConstant: expected 3 values for float3 constant '\(constant.name)', got \(values.count)")
+        }
         return .float3(
             SIMD3<Float>(
                 values[0].number.floatValue,
@@ -1692,7 +1763,9 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
             )
         )
     case .float4, .matrix2f:
-        guard values.count >= 4 else { return .float4(.zero) }
+        guard values.count >= 4 else {
+            fatalError("fromWKBridgeConstant: expected 4 values for float4 constant '\(constant.name)', got \(values.count)")
+        }
         return .float4(
             SIMD4<Float>(
                 values[0].number.floatValue,
@@ -1703,7 +1776,9 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
         )
     case .half2, .texCoord2h:
         // half2-based semantic types map to half2
-        guard values.count >= 2 else { return .half2(.zero) }
+        guard values.count >= 2 else {
+            fatalError("fromWKBridgeConstant: expected 2 values for half2 constant '\(constant.name)', got \(values.count)")
+        }
         return .half2(
             SIMD2<UInt16>(
                 values[0].number.uint16Value,
@@ -1712,7 +1787,9 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
         )
     case .vector3h, .half3, .point3h, .normal3h, .texCoord3h:
         // All half3-based semantic types map to half3
-        guard values.count >= 3 else { return .half3(.zero) }
+        guard values.count >= 3 else {
+            fatalError("fromWKBridgeConstant: expected 3 values for half3 constant '\(constant.name)', got \(values.count)")
+        }
         return .half3(
             SIMD3<UInt16>(
                 values[0].number.uint16Value,
@@ -1721,7 +1798,9 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
             )
         )
     case .half4:
-        guard values.count >= 4 else { return .half4(.zero) }
+        guard values.count >= 4 else {
+            fatalError("fromWKBridgeConstant: expected 4 values for half4 constant '\(constant.name)', got \(values.count)")
+        }
         return .half4(
             SIMD4<UInt16>(
                 values[0].number.uint16Value,
@@ -1731,7 +1810,9 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
             )
         )
     case .int2:
-        guard values.count >= 2 else { return .int2(.zero) }
+        guard values.count >= 2 else {
+            fatalError("fromWKBridgeConstant: expected 2 values for int2 constant '\(constant.name)', got \(values.count)")
+        }
         return .int2(
             SIMD2<Int32>(
                 values[0].number.int32Value,
@@ -1739,7 +1820,9 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
             )
         )
     case .int3:
-        guard values.count >= 3 else { return .int3(.zero) }
+        guard values.count >= 3 else {
+            fatalError("fromWKBridgeConstant: expected 3 values for int3 constant '\(constant.name)', got \(values.count)")
+        }
         return .int3(
             SIMD3<Int32>(
                 values[0].number.int32Value,
@@ -1748,7 +1831,9 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
             )
         )
     case .int4:
-        guard values.count >= 4 else { return .int4(.zero) }
+        guard values.count >= 4 else {
+            fatalError("fromWKBridgeConstant: expected 4 values for int4 constant '\(constant.name)', got \(values.count)")
+        }
         return .int4(
             SIMD4<Int32>(
                 values[0].number.int32Value,
@@ -1760,12 +1845,7 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
     case .matrix3f:
         // matrix3f maps to float3x3 - needs 9 values (3 columns of 3 rows each)
         guard values.count >= 9 else {
-            // Return identity matrix if values are missing
-            return .float3x3(
-                SIMD3<Float>(1, 0, 0),
-                SIMD3<Float>(0, 1, 0),
-                SIMD3<Float>(0, 0, 1)
-            )
+            fatalError("fromWKBridgeConstant: expected 9 values for matrix3f constant '\(constant.name)', got \(values.count)")
         }
         return .float3x3(
             SIMD3<Float>(values[0].number.floatValue, values[1].number.floatValue, values[2].number.floatValue),
@@ -1775,13 +1855,7 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
     case .matrix4f:
         // matrix4f maps to float4x4 - needs 16 values (4 columns of 4 rows each)
         guard values.count >= 16 else {
-            // Return identity matrix if values are missing
-            return .float4x4(
-                SIMD4<Float>(1, 0, 0, 0),
-                SIMD4<Float>(0, 1, 0, 0),
-                SIMD4<Float>(0, 0, 1, 0),
-                SIMD4<Float>(0, 0, 0, 1)
-            )
+            fatalError("fromWKBridgeConstant: expected 16 values for matrix4f constant '\(constant.name)', got \(values.count)")
         }
         return .float4x4(
             SIMD4<Float>(
@@ -1811,7 +1885,9 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
         )
     case .quatf, .quath:
         // quath/quatf don't exist in the enum - map to float4
-        guard values.count >= 4 else { return .float4(.zero) }
+        guard values.count >= 4 else {
+            fatalError("fromWKBridgeConstant: expected 4 values for quat constant '\(constant.name)', got \(values.count)")
+        }
         return .float4(
             SIMD4<Float>(
                 values[0].number.floatValue,
@@ -1820,29 +1896,80 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
                 values[3].number.floatValue
             )
         )
-    case .color3f, .color3h:
-        // color3f/h map to cgColor3
+    case .cgColor3:
         guard values.count >= 3 else {
-            // Return a default black color if values are missing
-            return .cgColor3(CGColor(red: 0, green: 0, blue: 0, alpha: 1))
+            fatalError("fromWKBridgeConstant: expected 3 values for color3 constant '\(constant.name)', got \(values.count)")
         }
-        let red = CGFloat(values[0].number.floatValue)
-        let green = CGFloat(values[1].number.floatValue)
-        let blue = CGFloat(values[2].number.floatValue)
-        return .cgColor3(CGColor(red: red, green: green, blue: blue, alpha: 1))
-    case .color4f, .color4h:
-        // color4f/h map to cgColor4
+        // Use extendedLinearSRGB to preserve values outside [0,1] (e.g. negative bias, scale > 1).
+        // CGColor(red:green:blue:alpha:) clamps to device RGB [0,1] which corrupts shader constants.
+        let components3: [CGFloat] = [
+            CGFloat(values[0].number.floatValue),
+            CGFloat(values[1].number.floatValue),
+            CGFloat(values[2].number.floatValue),
+            1.0,
+        ]
+        if let cs = CGColorSpace(name: CGColorSpace.extendedLinearSRGB),
+            let color = unsafe CGColor(colorSpace: cs, components: components3)
+        {
+            return .cgColor3(color)
+        }
+        return .cgColor3(CGColor(red: components3[0], green: components3[1], blue: components3[2], alpha: 1.0))
+    case .cgColor4:
         guard values.count >= 4 else {
-            // Return a default transparent black color if values are missing
-            return .cgColor4(CGColor(red: 0, green: 0, blue: 0, alpha: 0))
+            fatalError("fromWKBridgeConstant: expected 4 values for color4 constant '\(constant.name)', got \(values.count)")
         }
-        let red = CGFloat(values[0].number.floatValue)
-        let green = CGFloat(values[1].number.floatValue)
-        let blue = CGFloat(values[2].number.floatValue)
-        let alpha = CGFloat(values[3].number.floatValue)
-        return .cgColor4(CGColor(red: red, green: green, blue: blue, alpha: alpha))
+        // Use extendedLinearSRGB to preserve values outside [0,1] (e.g. negative bias, scale > 1).
+        // CGColor(red:green:blue:alpha:) clamps to device RGB [0,1] which corrupts shader constants.
+        let components4: [CGFloat] = [
+            CGFloat(values[0].number.floatValue),
+            CGFloat(values[1].number.floatValue),
+            CGFloat(values[2].number.floatValue),
+            CGFloat(values[3].number.floatValue),
+        ]
+        if let cs = CGColorSpace(name: CGColorSpace.extendedLinearSRGB),
+            let color = unsafe CGColor(colorSpace: cs, components: components4)
+        {
+            return .cgColor4(color)
+        }
+        return .cgColor4(CGColor(red: components4[0], green: components4[1], blue: components4[2], alpha: components4[3]))
+    case .color4f:
+        // USD/MaterialX color4f or color4h — encoded as 4 raw floats without CGColor clamping.
+        // Decoded as cgColor4 via extendedLinearSRGB to preserve color semantics for MaterialX.
+        guard values.count >= 4 else {
+            fatalError("fromWKBridgeConstant: expected 4 values for color4f constant '\(constant.name)', got \(values.count)")
+        }
+        let components4f: [CGFloat] = [
+            CGFloat(values[0].number.floatValue),
+            CGFloat(values[1].number.floatValue),
+            CGFloat(values[2].number.floatValue),
+            CGFloat(values[3].number.floatValue),
+        ]
+        if let cs = CGColorSpace(name: CGColorSpace.extendedLinearSRGB),
+            let color = unsafe CGColor(colorSpace: cs, components: components4f)
+        {
+            return .cgColor4(color)
+        }
+        return .cgColor4(CGColor(red: components4f[0], green: components4f[1], blue: components4f[2], alpha: components4f[3]))
+    case .color3f:
+        // USD/MaterialX color3f or color3h — encoded as 3 raw floats without CGColor clamping.
+        // Decoded as cgColor3 via extendedLinearSRGB to preserve color semantics for MaterialX.
+        guard values.count >= 3 else {
+            fatalError("fromWKBridgeConstant: expected 3 values for color3f constant '\(constant.name)', got \(values.count)")
+        }
+        let components3f: [CGFloat] = [
+            CGFloat(values[0].number.floatValue),
+            CGFloat(values[1].number.floatValue),
+            CGFloat(values[2].number.floatValue),
+            1.0,
+        ]
+        if let cs = CGColorSpace(name: CGColorSpace.extendedLinearSRGB),
+            let color = unsafe CGColor(colorSpace: cs, components: components3f)
+        {
+            return .cgColor3(color)
+        }
+        return .cgColor3(CGColor(red: components3f[0], green: components3f[1], blue: components3f[2], alpha: 1.0))
     @unknown default:
-        return .string("")
+        fatalError("fromWKBridgeConstant: unhandled constant type \(constant.constant) for '\(constant.name)'")
     }
 }
 
@@ -1874,7 +2001,7 @@ final class USDModelLoader {
 
     func loadModel(from url: Foundation.URL) {
         do {
-            let stage = try UsdStage(contentsOf: url)
+            let stage = try UsdStage.open(url)
             self.setupTimes(from: stage)
             self.usdStageSession.loadStage(stage)
         } catch {

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
@@ -690,11 +690,11 @@ static WKBridgeDataType convert(DataType type)
     case DataType::kFloat:
         return WKBridgeDataTypeFloat;
     case DataType::kColor3f:
-        return WKBridgeDataTypeColor3f;
+        return WKBridgeDataTypeCgColor3;
     case DataType::kColor3h:
         return WKBridgeDataTypeColor3h;
     case DataType::kColor4f:
-        return WKBridgeDataTypeColor4f;
+        return WKBridgeDataTypeCgColor4;
     case DataType::kColor4h:
         return WKBridgeDataTypeColor4h;
     case DataType::kFloat2:
@@ -737,6 +737,8 @@ static WKBridgeDataType convert(DataType type)
         return WKBridgeDataTypeToken;
     case DataType::kAsset:
         return WKBridgeDataTypeAsset;
+    default:
+        RELEASE_ASSERT_NOT_REACHED("unknown data type");
     }
 }
 
@@ -763,12 +765,7 @@ static NSArray<WKBridgeInputOutput *> *convert(const Vector<InputOutput>& inputO
 {
     NSMutableArray<WKBridgeInputOutput *> *result = [NSMutableArray array];
     for (const auto& io : inputOutputs) {
-        WKBridgeDataType semanticType = WKBridgeDataTypeAsset;
-        BOOL hasSemanticType = NO;
-        if (io.semanticType) {
-            semanticType = convert(*io.semanticType);
-            hasSemanticType = YES;
-        }
+        NSString *semanticTypeName = io.semanticTypeName ? io.semanticTypeName->createNSString().get() : nil;
 
         WKBridgeConstantContainer *defaultValue = nil;
         if (io.defaultValue)
@@ -776,8 +773,7 @@ static NSArray<WKBridgeInputOutput *> *convert(const Vector<InputOutput>& inputO
 
         [result addObject:[WebKit::allocWKBridgeInputOutputInstance() initWithType:convert(io.type)
             name:io.name.createNSString().get()
-            semanticType:semanticType
-            hasSemanticType:hasSemanticType
+            semanticTypeName:semanticTypeName
             defaultValue:defaultValue]];
     }
 
@@ -829,9 +825,27 @@ static NSArray<WKBridgeNode *> *convert(const Vector<Node>& nodes)
     return result;
 }
 
+static NSArray<NSString *> *convertStrings(const Vector<String>& strings)
+{
+    NSMutableArray<NSString *> *result = [NSMutableArray arrayWithCapacity:strings.size()];
+    for (const auto& s : strings)
+        [result addObject:s.createNSString().get()];
+    return result;
+}
+
 static WKBridgeMaterialGraph *convert(const MaterialGraph& material)
 {
-    return [WebKit::allocWKBridgeMaterialGraphInstance() initWithNodes:convert(material.nodes) edges:convert(material.edges) arguments:convert(material.arguments) results:convert(material.results) inputs:convert(material.inputs) outputs:convert(material.outputs)];
+    return [WebKit::allocWKBridgeMaterialGraphInstance()
+        initWithGraphName:material.graphName.createNSString().get()
+        nodes:convert(material.nodes)
+        edges:convert(material.edges)
+        arguments:convert(material.arguments)
+        results:convert(material.results)
+        inputs:convert(material.inputs)
+        outputs:convert(material.outputs)
+        primvarMappingPrimvarNames:convertStrings(material.primvarMappingPrimvarNames)
+        primvarMappingTexcoordNames:convertStrings(material.primvarMappingTexcoordNames)
+        functionConstantInputNames:convertStrings(material.functionConstantInputNames)];
 }
 
 #endif

--- a/Source/WebKit/Shared/Model.serialization.in
+++ b/Source/WebKit/Shared/Model.serialization.in
@@ -318,7 +318,7 @@ header: <WebKit/ModelTypes.h>
 [AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebModel::InputOutput {
     WebModel::DataType type;
     String name;
-    std::optional<WebModel::DataType> semanticType;
+    std::optional<String> semanticTypeName;
     std::optional<WebModel::ConstantContainer> defaultValue;
 };
 
@@ -337,12 +337,16 @@ header: <WebKit/ModelTypes.h>
 
 header: <WebKit/ModelTypes.h>
 [AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebModel::MaterialGraph {
+    String graphName;
     Vector<WebModel::Node> nodes;
     Vector<WebModel::Edge> edges;
     WebModel::Node arguments;
     WebModel::Node results;
     Vector<WebModel::InputOutput> inputs;
     Vector<WebModel::InputOutput> outputs;
+    Vector<String> primvarMappingPrimvarNames;
+    Vector<String> primvarMappingTexcoordNames;
+    Vector<String> functionConstantInputNames;
 };
 #endif
 

--- a/Source/WebKit/WebProcess/Model/ModelInlineConverters.h
+++ b/Source/WebKit/WebProcess/Model/ModelInlineConverters.h
@@ -156,7 +156,7 @@ static WebCore::WebGPU::VertexFormat toVertexFormat(MTLVertexFormat format)
     case MTLVertexFormatUChar4Normalized_BGRA:
         return WebCore::WebGPU::VertexFormat::Unorm8x4Bgra;
     default:
-        return WebCore::WebGPU::VertexFormat::Float32;
+        RELEASE_ASSERT_NOT_REACHED("%s - USD file is corrupt", __PRETTY_FUNCTION__);
     }
 }
 
@@ -174,7 +174,7 @@ static WebCore::WebGPU::PrimitiveTopology toPrimitiveTopology(MTLPrimitiveType t
     case MTLPrimitiveTypeTriangleStrip:
         return WebCore::WebGPU::PrimitiveTopology::TriangleStrip;
     default:
-        return WebCore::WebGPU::PrimitiveTopology::TriangleList;
+        RELEASE_ASSERT_NOT_REACHED("%s - USD file is corrupt", __PRETTY_FUNCTION__);
     }
 }
 
@@ -186,7 +186,7 @@ static WebModel::IndexType toIndexType(MTLIndexType indexType)
     case MTLIndexTypeUInt32:
         return WebModel::IndexType::UInt32;
     default:
-        return WebModel::IndexType::UInt16;
+        RELEASE_ASSERT_NOT_REACHED("%s - USD file is corrupt", __PRETTY_FUNCTION__);
     }
 }
 
@@ -206,7 +206,7 @@ static WebCore::WebGPU::TextureViewDimension toTextureViewDimension(MTLTextureTy
     case MTLTextureType3D:
         return WebCore::WebGPU::TextureViewDimension::_3d;
     default:
-        return WebCore::WebGPU::TextureViewDimension::_2d;
+        RELEASE_ASSERT_NOT_REACHED("%s - USD file is corrupt", __PRETTY_FUNCTION__);
     }
 }
 
@@ -401,9 +401,15 @@ static WebCore::WebGPU::TextureFormat toTextureFormat(MTLPixelFormat pixelFormat
     case MTLPixelFormatBC7_RGBAUnorm_sRGB:
         return WebCore::WebGPU::TextureFormat::Bc7RgbaUnormSRGB;
 #endif
+    case MTLPixelFormatR16Unorm:   return WebCore::WebGPU::TextureFormat::R16unorm;
+    case MTLPixelFormatR16Snorm:   return WebCore::WebGPU::TextureFormat::R16snorm;
+    case MTLPixelFormatRG16Unorm:  return WebCore::WebGPU::TextureFormat::Rg16unorm;
+    case MTLPixelFormatRG16Snorm:  return WebCore::WebGPU::TextureFormat::Rg16snorm;
+    case MTLPixelFormatRGBA16Unorm: return WebCore::WebGPU::TextureFormat::Rgba16unorm;
+    case MTLPixelFormatRGBA16Snorm: return WebCore::WebGPU::TextureFormat::Rgba16snorm;
     case MTLPixelFormatInvalid:
     default:
-        return WebCore::WebGPU::TextureFormat::R8unorm;
+        RELEASE_ASSERT_NOT_REACHED("%s - USD file is corrupt", __PRETTY_FUNCTION__);
     }
 }
 
@@ -418,7 +424,7 @@ static WebCore::WebGPU::TextureUsageFlags toTextureUsageFlags(MTLTextureUsage te
     if (textureUsage & MTLTextureUsageRenderTarget)
         flags.add(WebCore::WebGPU::TextureUsage::RenderAttachment);
     if (textureUsage & MTLTextureUsagePixelFormatView)
-        flags.add(WebCore::WebGPU::TextureUsage::TextureBinding);
+        flags.add(WebCore::WebGPU::TextureUsage::CopySource);
 
     return flags;
 }
@@ -584,9 +590,10 @@ static WebModel::NodeType convert(WKBridgeNodeType nodeType)
         return WebModel::NodeType::Constant;
     case WKBridgeNodeTypeArguments:
         return WebModel::NodeType::Arguments;
-    default:
     case WKBridgeNodeTypeResults:
         return WebModel::NodeType::Results;
+    default:
+        RELEASE_ASSERT_NOT_REACHED("%s - USD file is corrupt", __PRETTY_FUNCTION__);
     }
 }
 
@@ -662,14 +669,10 @@ static WebModel::Constant convert(WKBridgeConstant constant)
         return WebModel::Constant::kVector3f;
     case WKBridgeConstantVector3h:
         return WebModel::Constant::kVector3h;
-    case WKBridgeConstantColor3f:
+    case WKBridgeConstantCgColor3:
         return WebModel::Constant::kColor3f;
-    case WKBridgeConstantColor3h:
-        return WebModel::Constant::kColor3h;
-    case WKBridgeConstantColor4f:
+    case WKBridgeConstantCgColor4:
         return WebModel::Constant::kColor4f;
-    case WKBridgeConstantColor4h:
-        return WebModel::Constant::kColor4h;
     case WKBridgeConstantTexCoord2h:
         return WebModel::Constant::kTexCoord2h;
     case WKBridgeConstantTexCoord2f:
@@ -678,6 +681,14 @@ static WebModel::Constant convert(WKBridgeConstant constant)
         return WebModel::Constant::kTexCoord3h;
     case WKBridgeConstantTexCoord3f:
         return WebModel::Constant::kTexCoord3f;
+    case WKBridgeConstantColor4f:
+        return WebModel::Constant::kColor4f;
+    case WKBridgeConstantColor4h:
+        return WebModel::Constant::kColor4h;
+    case WKBridgeConstantColor3f:
+        return WebModel::Constant::kColor3f;
+    case WKBridgeConstantColor3h:
+        return WebModel::Constant::kColor3h;
     }
 }
 
@@ -742,11 +753,11 @@ static WebModel::DataType convert(WKBridgeDataType type)
         return WebModel::DataType::kInt4;
     case WKBridgeDataTypeFloat:
         return WebModel::DataType::kFloat;
-    case WKBridgeDataTypeColor3f:
+    case WKBridgeDataTypeCgColor3:
         return WebModel::DataType::kColor3f;
     case WKBridgeDataTypeColor3h:
         return WebModel::DataType::kColor3h;
-    case WKBridgeDataTypeColor4f:
+    case WKBridgeDataTypeCgColor4:
         return WebModel::DataType::kColor4f;
     case WKBridgeDataTypeColor4h:
         return WebModel::DataType::kColor4h;
@@ -790,16 +801,14 @@ static WebModel::DataType convert(WKBridgeDataType type)
         return WebModel::DataType::kToken;
     case WKBridgeDataTypeAsset:
         return WebModel::DataType::kAsset;
-    default:
-        RELEASE_ASSERT_NOT_REACHED("USD file is corrupt");
     }
 }
 
 static WebModel::InputOutput convert(WKBridgeInputOutput *inputOutput)
 {
-    std::optional<WebModel::DataType> semanticType;
-    if (inputOutput.hasSemanticType)
-        semanticType = convert(inputOutput.semanticType);
+    std::optional<String> semanticTypeName;
+    if (inputOutput.semanticTypeName)
+        semanticTypeName = String(inputOutput.semanticTypeName);
 
     std::optional<WebModel::ConstantContainer> defaultValue;
     if (inputOutput.defaultValue)
@@ -808,7 +817,7 @@ static WebModel::InputOutput convert(WKBridgeInputOutput *inputOutput)
     return WebModel::InputOutput {
         .type = convert(inputOutput.type),
         .name = String(inputOutput.name),
-        .semanticType = semanticType,
+        .semanticTypeName = semanticTypeName,
         .defaultValue = defaultValue
     };
 }
@@ -850,13 +859,26 @@ static WebModel::UpdateMeshDescriptor convert(WKBridgeUpdateMesh *update)
 
 static WebModel::MaterialGraph convert(WKBridgeMaterialGraph *materialGraph)
 {
+    Vector<String> primvarPrimvarNames;
+    for (NSString *s in materialGraph.primvarMappingPrimvarNames)
+        primvarPrimvarNames.append(String(s));
+    Vector<String> primvarTexcoordNames;
+    for (NSString *s in materialGraph.primvarMappingTexcoordNames)
+        primvarTexcoordNames.append(String(s));
+    Vector<String> functionConstantInputNames;
+    for (NSString *s in materialGraph.functionConstantInputNames)
+        functionConstantInputNames.append(String(s));
     return WebModel::MaterialGraph {
+        .graphName = String(materialGraph.graphName),
         .nodes = convert<WKBridgeNode, WebModel::Node>(materialGraph.nodes),
         .edges = convert<WKBridgeEdge, WebModel::Edge>(materialGraph.edges),
         .arguments = convert(materialGraph.arguments),
         .results = convert(materialGraph.results),
         .inputs = convert<WKBridgeInputOutput, WebModel::InputOutput>(materialGraph.inputs),
         .outputs = convert<WKBridgeInputOutput, WebModel::InputOutput>(materialGraph.outputs),
+        .primvarMappingPrimvarNames = WTF::move(primvarPrimvarNames),
+        .primvarMappingTexcoordNames = WTF::move(primvarTexcoordNames),
+        .functionConstantInputNames = WTF::move(functionConstantInputNames),
     };
 }
 
@@ -876,7 +898,7 @@ static WebModel::ImageAsset convert(WKBridgeImageAsset *imageAsset)
         .data = makeVector(imageAsset.data),
         .width = imageAsset.width,
         .height = imageAsset.height,
-        .depth = 1,
+        .depth = imageAsset.depth,
         .textureType = toTextureViewDimension(imageAsset.textureType),
         .pixelFormat = toTextureFormat(imageAsset.pixelFormat),
         .mipmapLevelCount = imageAsset.mipmapLevelCount,


### PR DESCRIPTION
#### d3b687ec2dc96a63e9675dabbd592c27b3c32657
<pre>
ShaderGraph does not get correctly reconstructed after passed over IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=311830">https://bugs.webkit.org/show_bug.cgi?id=311830</a>
<a href="https://rdar.apple.com/174185162">rdar://174185162</a>

Reviewed by Dan Glastonbury.

Accurately serialize the ShaderGraph across IPC to avoid
reconstruction issues in the GPU process.

* Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h:
* Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift:
(debugPrintValue(_:indent:)):
(nodeDataTypeString(_:)):
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(constantValues(_:WKBridgeConstant:)):
(toWKBridgeConstantContainer(_:colorOverride:)):
(toWKBridgeDataType(_:)):
(toWKBridgeDataTypeFromSGRawValue(_:fallback:)):
(toWebNode(_:colorOverride:)):
(texcoordName(for:)):
(textureCoordinate(from:)):
(toWebMaterialGraph(_:)):
(shaderGraphValuesEquivalent(_:_:)):
(shaderGraphNodeDataEquivalent(_:_:)):
(shaderGraphsStructurallyEqual(_:_:)):
(ShaderGraph.fromWKDescriptor(_:)):
(makeConstantSGNode(from:)):
(fromWKBridgeDataType(_:)):
(fromWKBridgeConstant(_:)):
(USDModelLoader.loadModel(from:)):
(toWKBridgeConstantContainer(_:)): Deleted.
(toWebNodes(_:)): Deleted.
(toWebNode(_:)): Deleted.
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm:
(WebModel::convert):
* Source/WebKit/Shared/Model.serialization.in:
* Source/WebKit/WebProcess/Model/ModelInlineConverters.h:
(WebKit::toVertexFormat):
(WebKit::toPrimitiveTopology):
(WebKit::toIndexType):
(WebKit::toTextureViewDimension):
(WebKit::toTextureFormat):
(WebKit::toTextureUsageFlags):
(WebKit::toCpp):
(WebKit::convert):

Canonical link: <a href="https://commits.webkit.org/311732@main">https://commits.webkit.org/311732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08e787dc6a68f4c1331a8e6b08f5d6b1856f6f77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157822 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166646 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31161 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122214 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160780 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24492 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/141722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102878 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/23548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/21838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14417 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/133229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169135 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13894 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21154 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/130389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30905 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25907 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130498 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35338 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30843 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141326 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88693 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25241 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18132 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30395 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95225 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29916 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30146 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30043 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->