### PR TITLE
Unable to interact with native PiP on Hulu.com

### DIFF
--- a/LayoutTests/pointerevents/ios/pointerdown-prevent-default-with-active-touch-listener-allows-page-scrolling-expected.txt
+++ b/LayoutTests/pointerevents/ios/pointerdown-prevent-default-with-active-touch-listener-allows-page-scrolling-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Calling preventDefault() on pointerdown does not prevent page scrolling when touch listeners are active (non-passive).
+

--- a/LayoutTests/pointerevents/ios/pointerdown-prevent-default-with-active-touch-listener-allows-page-scrolling.html
+++ b/LayoutTests/pointerevents/ios/pointerdown-prevent-default-with-active-touch-listener-allows-page-scrolling.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset=utf-8>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+body {
+    width: 2000px;
+    height: 2000px;
+}
+</style>
+</head>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../utils.js"></script>
+<script>
+
+'use strict';
+
+target_test({ width: "200px", height: "200px" }, (target, test) => {
+
+    document.addEventListener("touchstart", () => {}, { passive: false });
+    target.addEventListener("pointerdown", event => event.preventDefault());
+
+    ui.swipe({ x: 100, y: 150 }, { x: 100, y: 50 }).then(() => {
+        assert_not_equals(window.pageYOffset, 0, "The page was scrolled in the y-axis.");
+        test.done();
+    });
+}, "Calling preventDefault() on pointerdown does not prevent page scrolling when touch listeners are active (non-passive).");
+
+</script>
+</body>
+</html>

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4050,7 +4050,16 @@ static Expected<bool, WebCore::RemoteFrameGeometryTransformer> handleTouchEvent(
 
     auto result = localFrame->eventHandler().handleTouchEvent(platform(touchEvent));
 
-    if (weakPage && !result.value_or(false) && weakPage->pointerCaptureController().wasPointerDownDefaultPrevented())
+#if ENABLE(IOS_TOUCH_EVENTS)
+    bool canPreventNativeGestures = touchEvent.canPreventNativeGestures();
+#else
+    bool canPreventNativeGestures = false;
+#endif
+
+    // If a page has active (non-passive) touch listeners and calls pointerdown.preventDefault()
+    // but not touchstart.preventDefault(), scrolling will no longer be suppressed on the
+    // preventable path.
+    if (!canPreventNativeGestures && weakPage && !result.value_or(false) && weakPage->pointerCaptureController().wasPointerDownDefaultPrevented())
         return true;
 
     return result;


### PR DESCRIPTION
#### 9496a11100bf43260f5d23380e3a459903628580
<pre>
Unable to interact with native PiP on Hulu.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=311978">https://bugs.webkit.org/show_bug.cgi?id=311978</a>
<a href="https://rdar.apple.com/174187687">rdar://174187687</a>

Reviewed by Abrar Rahman Protyasha.

The problem: PiP controls in separate windows were blocked because
setDefaultPrevented:YES caused the touch gesture recognizer to claim all
touches. This happened because handleTouchEvent returned handled=true for
pointerdown preventDefault() on both the preventable and unpreventable
touch paths indiscriminately.

The fix: By guarding the override with !touchEvent.canPreventNativeGestures(),
only the unpreventable path (passive / React listeners) reports
handled=true and sets panning flags to block scrolling.
The preventable path now returns the original handled=false which preserves PiP touch
delivery through the existing deferring gesture mechanism.

* LayoutTests/pointerevents/ios/pointerdown-prevent-default-with-active-touch-listener-allows-page-scrolling-expected.txt: Added.
* LayoutTests/pointerevents/ios/pointerdown-prevent-default-with-active-touch-listener-allows-page-scrolling.html: Added.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::handleTouchEvent):

Canonical link: <a href="https://commits.webkit.org/311261@main">https://commits.webkit.org/311261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8921e633b992aaf2056461452f1df5e57dc27c6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165192 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110451 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121096 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23313 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101767 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22380 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20555 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12964 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132055 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167674 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11787 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19866 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129223 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24622 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129335 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35052 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29229 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140047 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87025 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24157 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16846 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28939 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92895 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28465 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28693 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28589 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->