### PR TITLE
[Build Speed] Move debug-only code in VMManager out-of-line; causing excess template creation

### DIFF
--- a/Source/JavaScriptCore/runtime/VMManager.cpp
+++ b/Source/JavaScriptCore/runtime/VMManager.cpp
@@ -119,6 +119,15 @@ VMManager::Error VMManager::forEachVMWithTimeoutImpl(Seconds timeout, const Scop
     return Error::None;
 }
 
+void VMManager::Info::dump(PrintStream& out) const
+{
+    out.print("VMManager::Info(numberOfVMs:", numberOfVMs);
+    out.print(", numberOfActiveVMs:", numberOfActiveVMs);
+    out.print(", numberOfStoppedVMs:", numberOfStoppedVMs);
+    out.print(", worldMode:", worldMode);
+    out.print(", targetVM:", RawPointer(targetVM), ")");
+}
+
 auto VMManager::info() -> Info
 {
     Info info;

--- a/Source/JavaScriptCore/runtime/VMManager.h
+++ b/Source/JavaScriptCore/runtime/VMManager.h
@@ -254,14 +254,7 @@ public:
         Mode worldMode;
         VM* targetVM;
 
-        void dump(PrintStream& out) const
-        {
-            out.print("VMManager::Info(numberOfVMs:", numberOfVMs);
-            out.print(", numberOfActiveVMs:", numberOfActiveVMs);
-            out.print(", numberOfStoppedVMs:", numberOfStoppedVMs);
-            out.print(", worldMode:", worldMode);
-            out.print(", targetVM:", RawPointer(targetVM), ")");
-        }
+        void dump(PrintStream& out) const;
     };
 
     JS_EXPORT_PRIVATE static Info info();


### PR DESCRIPTION
#### 203b7fc87e1da7e8acfbf7f551a24052db5f7503
<pre>
[Build Speed] Move debug-only code in VMManager out-of-line; causing excess template creation
<a href="https://rdar.apple.com/174524471">rdar://174524471</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311979">https://bugs.webkit.org/show_bug.cgi?id=311979</a>

Reviewed by Simon Fraser.

VMManager::mode::dump() causes a number of templates to be instantiated, and those
templates are by far the most expensive template instantiations in all of JSC. Also,
the dump() method is entirely unused. This change removes the top 7 most expensive
template instantiations in the JSC build.

* Source/JavaScriptCore/runtime/VMManager.cpp:
(JSC::VMManager::Info::dump const):
* Source/JavaScriptCore/runtime/VMManager.h:
(JSC::VMManager::Info::dump const): Deleted.

Canonical link: <a href="https://commits.webkit.org/311036@main">https://commits.webkit.org/311036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfb6035a52a7f8c6354bca31c6c01375cc77a028

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164429 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109482 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28776 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120481 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84933 "1 flakes 3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22651 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139779 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101170 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1706fa6-8620-4e81-9dd6-8392cde7d9a0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21737 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19877 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12259 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147716 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131406 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17611 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166908 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16498 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11084 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19222 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128598 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23911 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128730 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34918 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139404 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86223 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23543 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16201 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187551 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28088 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92191 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48068 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27665 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27895 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27738 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->