### PR TITLE
[WPE][Qt] Remove apparently dead code writing to offscreen surface

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
@@ -34,7 +34,6 @@
 #include <wtf/glib/RunLoopSourcePriority.h>
 #include <wtf/glib/WTFGType.h>
 
-#include <QOffscreenSurface>
 #include <QOpenGLFunctions>
 #include <QQuickWindow>
 #include <QSGTexture>
@@ -48,9 +47,6 @@ struct _WPEViewQtQuickPrivate {
     GRefPtr<WPEBuffer> committedBuffer;
     bool bufferUpdateRequested;
     GLuint textureId;
-    GLuint textureUniform;
-    GLuint program;
-    QOffscreenSurface surface;
     QOpenGLContext* context;
     WPEQtView* wpeQtView;
 
@@ -115,45 +111,6 @@ gboolean wpe_view_qtquick_initialize_rendering(WPEViewQtQuick* view, WPEQtView* 
     if (!imageTargetTexture2DOES)
         imageTargetTexture2DOES = reinterpret_cast<PFNGLEGLIMAGETARGETTEXTURE2DOESPROC>(eglGetProcAddress("glEGLImageTargetTexture2DOES"));
 
-    static const char* vertexShaderSource =
-        "attribute vec2 pos;\n"
-        "attribute vec2 texture;\n"
-        "varying vec2 v_texture;\n"
-        "void main() {\n"
-        "  v_texture = texture;\n"
-        "  gl_Position = vec4(pos, 0, 1);\n"
-        "}\n";
-
-    static const char* fragmentShaderSource =
-        "precision mediump float;\n"
-        "uniform sampler2D u_texture;\n"
-        "varying vec2 v_texture;\n"
-        "void main() {\n"
-        "  gl_FragColor = texture2D(u_texture, v_texture);\n"
-        "}\n";
-
-    auto* glFunctions = context->functions();
-    auto vertexShader = glFunctions->glCreateShader(GL_VERTEX_SHADER);
-    glFunctions->glShaderSource(vertexShader, 1, &vertexShaderSource, nullptr);
-    glFunctions->glCompileShader(vertexShader);
-
-    auto fragmentShader = glFunctions->glCreateShader(GL_FRAGMENT_SHADER);
-    glFunctions->glShaderSource(fragmentShader, 1, &fragmentShaderSource, nullptr);
-    glFunctions->glCompileShader(fragmentShader);
-
-    priv->program = glFunctions->glCreateProgram();
-    glFunctions->glAttachShader(priv->program, vertexShader);
-    glFunctions->glAttachShader(priv->program, fragmentShader);
-
-    glFunctions->glBindAttribLocation(priv->program, 0, "pos");
-    glFunctions->glBindAttribLocation(priv->program, 1, "texture");
-
-    glFunctions->glLinkProgram(priv->program);
-    priv->textureUniform = glFunctions->glGetUniformLocation(priv->program, "u_texture");
-
-    priv->surface.setFormat(context->format());
-    priv->surface.create();
-
     return TRUE;
 }
 
@@ -171,7 +128,6 @@ void wpe_view_qtquick_invalidate_rendering(WPEViewQtQuick* view)
 QSGTexture* wpe_view_qtquick_render_buffer_to_texture(WPEViewQtQuick* view, QSize size, GError** error)
 {
     auto* priv = WPE_VIEW_QTQUICK(view)->priv;
-    priv->context->makeCurrent(&priv->surface);
 
     auto wrapNativeTexture = [&]() -> QSGTexture* {
         RELEASE_ASSERT(priv->wpeQtView->window());
@@ -214,49 +170,10 @@ QSGTexture* wpe_view_qtquick_render_buffer_to_texture(WPEViewQtQuick* view, QSiz
         glFunctions->glBindTexture(GL_TEXTURE_2D, 0);
     }
 
-    glFunctions->glClearColor(1, 0, 0, 1);
-    glFunctions->glClear(GL_COLOR_BUFFER_BIT);
-
-    glFunctions->glUseProgram(priv->program);
-
-    glFunctions->glActiveTexture(GL_TEXTURE0);
     glFunctions->glBindTexture(GL_TEXTURE_2D, priv->textureId);
     imageTargetTexture2DOES(GL_TEXTURE_2D, eglImage);
-    glFunctions->glUniform1i(priv->textureUniform, 0);
 
-    static const GLfloat vertices[4][2] = {
-        { -1.0, 1.0 },
-        { 1.0, 1.0 },
-        { -1.0, -1.0 },
-        { 1.0, -1.0 },
-    };
-
-    static const GLfloat texturePos[4][2] = {
-        { 0, 0 },
-        { 1, 0 },
-        { 0, 1 },
-        { 1, 1 },
-    };
-
-    glFunctions->glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, vertices);
-    glFunctions->glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0, texturePos);
-
-    glFunctions->glEnableVertexAttribArray(0);
-    glFunctions->glEnableVertexAttribArray(1);
-
-    glFunctions->glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-
-    glFunctions->glDisableVertexAttribArray(0);
-    glFunctions->glDisableVertexAttribArray(1);
-
-    // Wrap in QSGOpenGLTexture for Qt Scene Graph.
-    auto texture = QNativeInterface::QSGOpenGLTexture::fromNative(priv->textureId, priv->wpeQtView->window(), size, QQuickWindow::TextureHasAlphaChannel);
-    if (!texture) {
-        g_set_error_literal(error, WPE_VIEW_ERROR, WPE_VIEW_ERROR_RENDER_FAILED, "Failed to import QSOpenGLTexture from native OpenGL texture");
-        return nullptr;
-    }
-
-    return texture;
+    return wrapNativeTexture();
 }
 
 void wpe_view_qtquick_did_update_scene(WPEViewQtQuick* view)


### PR DESCRIPTION
#### 175fd097bea0b8bf82d187395123edc69d92c586
<pre>
[WPE][Qt] Remove apparently dead code writing to offscreen surface
<a href="https://bugs.webkit.org/show_bug.cgi?id=311981">https://bugs.webkit.org/show_bug.cgi?id=311981</a>

Reviewed by Nikolas Zimmermann.

wpe_view_qtquick_render_buffer_to_texture was previously writing into an
OffscreenSurface that doesn&apos;t seem to be read from at all.
wpe_view_qtquick_initialize_rendering prepares shaders and performs
initializations, and afterwards
wpe_view_qtquick_render_buffer_to_texture draws into the surface, but
what Qt ends up receiving is the bound textureId.

No visual differences can be appreciated when running graphics
benchmarks on laptop.

* Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp:
(wpe_view_qtquick_initialize_rendering):
(wpe_view_qtquick_render_buffer_to_texture):

Canonical link: <a href="https://commits.webkit.org/311029@main">https://commits.webkit.org/311029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37284730bc747489b1d01a049a26acab832dc829

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164414 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109467 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28761 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120463 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/84927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158610 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22635 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139766 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101152 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21721 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19865 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12244 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131390 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166893 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11069 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19209 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128586 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128718 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34915 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28379 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139391 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86208 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23529 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16188 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28073 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92176 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27650 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27880 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27723 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->