### PR TITLE
[AI Experiment, Do Not Review, Opus Generated] Null check globalObject in ViewTransition::callUpdateCallback before creating promises

### DIFF
--- a/LayoutTests/fast/dom/setupviewtransition-callback-with-no-globalobject-expected.txt
+++ b/LayoutTests/fast/dom/setupviewtransition-callback-with-no-globalobject-expected.txt
@@ -1,0 +1,3 @@
+This test passes if WebKit does not crash
+
+PASS

--- a/LayoutTests/fast/dom/setupviewtransition-callback-with-no-globalobject.html
+++ b/LayoutTests/fast/dom/setupviewtransition-callback-with-no-globalobject.html
@@ -1,0 +1,26 @@
+<body>
+    <p>This test passes if WebKit does not crash</p>
+    <div id="result"></div>
+    <script>
+        window.testRunner?.dumpAsText();
+        window.testRunner?.waitUntilDone();
+        async function test() {
+            const head = XMLDocument.parseHTMLUnsafe(document.documentElement.innerHTML).head;
+            document.documentElement.append(head);
+            const li = document.createElement('li');
+            head.append(li);
+            const frame = document.createElement('iframe');
+            li.prepend(frame);
+            const doc = frame.contentDocument;
+            await navigator.storage.persisted();
+            doc.startViewTransition({ update: () => {} });
+            await navigator.storage.getDirectory();
+            head.innerHTML = '';
+            setTimeout(() => {
+                result.textContent = 'PASS';
+                window.testRunner?.notifyDone();
+            }, 100);
+        }
+        test();
+    </script>
+</body>

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -258,7 +258,10 @@ void ViewTransition::callUpdateCallback()
         return;
 
     Ref document = *this->document();
-    Ref callbackPromise = [&] -> Ref<DOMPromise> {
+    if (!document->globalObject())
+        return;
+
+    RefPtr callbackPromise = [&] -> RefPtr<DOMPromise> {
         if (!m_updateCallback) {
             auto promiseAndWrapper = createPromiseAndWrapper(document);
             protect(promiseAndWrapper.second)->resolve();
@@ -266,6 +269,12 @@ void ViewTransition::callUpdateCallback()
         }
 
         auto result = protect(m_updateCallback)->invoke();
+
+        // After invoke(), JavaScript microtasks may have run (e.g., resuming an async function
+        // that removes the iframe), detaching the document's frame and nulling globalObject().
+        if (!document->globalObject())
+            return nullptr;
+
         if (result.type() != CallbackResultType::Success || result.returnValue()->isSuspended()) {
             auto promiseAndWrapper = createPromiseAndWrapper(document);
             // FIXME: First case should reject with `ExceptionCode::ExistingExceptionError`.
@@ -279,6 +288,8 @@ void ViewTransition::callUpdateCallback()
         return result.releaseReturnValue();
     }();
 
+    if (!callbackPromise)
+        return;
     callbackPromise->whenSettledWithResult([weakThis = WeakPtr { *this }](auto*, bool isFulfilled, auto result) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
@@ -337,6 +348,8 @@ void ViewTransition::setupViewTransition()
         if (!protectedThis)
             return;
         if (protectedThis->m_phase == ViewTransitionPhase::Done)
+            return;
+        if (!protect(protectedThis->document())->globalObject())
             return;
 
         protectedThis->callUpdateCallback();


### PR DESCRIPTION
#### 0dc3be5e3f5585b5c1ad699791db77fa4f286955
<pre>
[AI Experiment, Do Not Review, Opus Generated] Null check globalObject in ViewTransition::callUpdateCallback before creating promises
<a href="https://bugs.webkit.org/show_bug.cgi?id=311983">https://bugs.webkit.org/show_bug.cgi?id=311983</a>
<a href="https://rdar.apple.com/174526996">rdar://174526996</a>

Reviewed by NOBODY (OOPS!).

When a ViewTransition is started on an iframe&apos;s document and the iframe is subsequently
removed, the document&apos;s frame detaches and globalObject() returns null. The queued
callUpdateCallback task from setupViewTransition() can then crash in
createPromiseAndWrapper() which unconditionally dereferences globalObject().

The frame can detach either before the task fires, or during m_updateCallback-&gt;invoke()
when JavaScript microtasks drain (e.g., an async continuation that removes the iframe).

This is the same class of bug fixed in 46ebeb960729 for the skipViewTransition() path,
which missed the setupViewTransition() path.

Test: fast/dom/setupviewtransition-callback-with-no-globalobject.html

* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::callUpdateCallback):
(WebCore::ViewTransition::setupViewTransition):
* LayoutTests/fast/dom/setupviewtransition-callback-with-no-globalobject.html: Added.
* LayoutTests/fast/dom/setupviewtransition-callback-with-no-globalobject-expected.txt: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dc3be5e3f5585b5c1ad699791db77fa4f286955

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164416 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109469 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157526 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29060 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28763 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120466 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84928 "2 flakes 3 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a1f0d7f-579a-469d-9454-eb3b2b80bc92) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158612 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22638 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139767 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101155 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6fd827a5-636a-4e1f-adb5-8becf48ef20f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21724 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19864 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12246 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131393 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166895 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11071 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19210 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128585 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28457 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128717 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28381 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139392 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86210 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23531 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16189 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28075 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92178 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27652 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27882 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27725 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->