### PR TITLE
[AI Experiment, Do Not Review, Next Gen Model Generated] Null check globalObject in ViewTransition::callUpdateCallback before creating promises

### DIFF
--- a/LayoutTests/transitions/view-transition-detached-iframe-crash-expected.txt
+++ b/LayoutTests/transitions/view-transition-detached-iframe-crash-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: ReferenceError: Can't find variable: description
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x8
+  RenderBlock {HTML} at (0,0) size 800x8
+    RenderBody {BODY} at (8,8) size 784x0

--- a/LayoutTests/transitions/view-transition-detached-iframe-crash.html
+++ b/LayoutTests/transitions/view-transition-detached-iframe-crash.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Tests that calling startViewTransition on a detached iframe document does not crash (rdar://173407561).");
+jsTestIsAsync = true;
+
+async function runTest() {
+    // Create an iframe.
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+
+    // Wait for iframe to load.
+    await new Promise(resolve => iframe.onload = resolve);
+
+    const iframeDoc = iframe.contentDocument;
+
+    // Start a view transition on the iframe's document.
+    try {
+        iframeDoc.startViewTransition({ update: () => {} });
+    } catch (e) {
+        // startViewTransition may not be available or may throw.
+    }
+
+    // Remove the iframe, detaching its document.
+    iframe.remove();
+
+    // Allow queued tasks to fire. The ViewTransition callback would
+    // try to call createPromiseAndWrapper on the now-detached document
+    // whose globalObject is null. This should not crash.
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    testPassed("No crash when ViewTransition fires on detached iframe document.");
+    finishJSTest();
+}
+
+runTest();
+</script>
+</head>
+<body>
+</body>
+</html>

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -247,6 +247,11 @@ void ViewTransition::callUpdateCallback()
     if (!document())
         return;
 
+    if (!document()->globalObject()) {
+        skipViewTransition(Exception { ExceptionCode::InvalidStateError, "Document is no longer active."_s });
+        return;
+    }
+
     LOG_WITH_STREAM(ViewTransitions, stream << "ViewTransition " << this << " callUpdateCallback");
 
     ASSERT(m_phase < ViewTransitionPhase::UpdateCallbackCalled || m_phase == ViewTransitionPhase::Done);


### PR DESCRIPTION
#### 63deeb6e31ae7440bcf8acbc05c8a75abbace2c4
<pre>
[AI Experiment, Do Not Review, Next Gen Model Generated] Null check globalObject in ViewTransition::callUpdateCallback before creating promises
<a href="https://bugs.webkit.org/show_bug.cgi?id=311984">https://bugs.webkit.org/show_bug.cgi?id=311984</a>
<a href="https://rdar.apple.com/174527587">rdar://174527587</a>

Reviewed by NOBODY (OOPS!).

When a ViewTransition is started on an iframe&apos;s document and the iframe is subsequently
removed, the document&apos;s frame detaches and globalObject() returns null. The queued
callUpdateCallback task from setupViewTransition() can then crash in
createPromiseAndWrapper() which unconditionally dereferences globalObject().

Add a null check for globalObject() at the top of callUpdateCallback(). If the global
object is null, skip the view transition since the document is no longer active.

Test: transitions/view-transition-detached-iframe-crash.html

* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::callUpdateCallback):
* LayoutTests/transitions/view-transition-detached-iframe-crash.html: Added.
* LayoutTests/transitions/view-transition-detached-iframe-crash-expected.txt: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63deeb6e31ae7440bcf8acbc05c8a75abbace2c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164417 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109470 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a0b8f291-a1a1-4a8c-bbd6-1aea6b356d0a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157527 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120467 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84929 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/66134f8f-3b8d-427c-8c4f-31dddc731775) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22644 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139768 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101156 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/94434edf-8f2c-4902-bd6f-a375c40e7ffa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21730 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19866 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12247 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166896 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11072 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19211 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128587 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28458 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128719 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28382 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139393 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86211 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23530 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16190 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28076 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92179 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27653 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27883 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27726 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->