### PR TITLE
[AI Experiment, Do Not Review, Next Gen Model Generated] RELEASE_ASSERT in GridTrackSizingAlgorithm::copyUsedTrackSizesForSubgrid when subgrid repeat() exceeds parent span

### DIFF
--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -2087,7 +2087,14 @@ bool GridTrackSizingAlgorithm::copyUsedTrackSizesForSubgrid()
     auto span = outer->gridSpanForGridItem(*m_renderGrid, direction);
     auto& allTracks = tracks(m_direction);
     int numTracks = allTracks.size();
-    RELEASE_ASSERT((parentTracks.size()  - 1) >= (numTracks - 1 + span.startLine()));
+
+    // The subgrid's track count must fit within the parent's available tracks
+    // starting from the span's start line. If it doesn't (e.g., due to complex
+    // subgrid repeat() declarations producing more tracks than the parent span
+    // allows), bail out and fall back to normal grid sizing.
+    if (parentTracks.size() < static_cast<unsigned>(numTracks) + span.startLine())
+        return false;
+
     for (int i = 0; i < numTracks; i++)
         allTracks[i].get() = parentTracks[i + span.startLine()].get();
 


### PR DESCRIPTION
#### 65005aeb4abb0950a538c441cc46b7863abbf3b5
<pre>
[AI Experiment, Do Not Review, Next Gen Model Generated] RELEASE_ASSERT in GridTrackSizingAlgorithm::copyUsedTrackSizesForSubgrid when subgrid repeat() exceeds parent span
<a href="https://bugs.webkit.org/show_bug.cgi?id=311987">https://bugs.webkit.org/show_bug.cgi?id=311987</a>
<a href="https://rdar.apple.com/174529007">rdar://174529007</a>

Reviewed by NOBODY (OOPS!).

A complex subgrid repeat() declaration can produce more tracks than the parent grid
span allows, hitting a RELEASE_ASSERT in copyUsedTrackSizesForSubgrid(). Replace the
assertion with a bounds check that returns false, falling back to normal grid sizing
instead of crashing.

* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::copyUsedTrackSizesForSubgrid):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65005aeb4abb0950a538c441cc46b7863abbf3b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164423 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109476 "Failed to checkout and rebase branch from PR 62501") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157533 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120474 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/109476 "Failed to checkout and rebase branch from PR 62501") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158619 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139772 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101163 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21729 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19873 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12253 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131398 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166902 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11078 "Failed to checkout and rebase branch from PR 62501") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19215 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128592 "Passed tests") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28464 "Failed to checkout and rebase branch from PR 62501") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23907 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128724 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28388 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139397 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86217 "Failed to checkout and rebase branch from PR 62501") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23539 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16194 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28082 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92185 "Failed to checkout and rebase branch from PR 62501") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27659 "Failed to checkout and rebase branch from PR 62501") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27889 "Failed to checkout and rebase branch from PR 62501") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27732 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->