### PR TITLE
@scope'd styles don't affect <slot>'d elements, but they should

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-slotted-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-slotted-expected.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>@scope - slotted elements reference</title>
+<style>
+h1 { color: purple; }
+</style>
+<div class="test-scope">
+    <x-card>
+        <h1 slot="heading">Slotted H1</h1>
+    </x-card>
+    <h1>Unslotted H1</h1>
+</div>
+<script>
+customElements.define('x-card', class extends HTMLElement {
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' }).innerHTML = '<slot name="heading"></slot><slot></slot>';
+    }
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-slotted-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-slotted-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>@scope - slotted elements reference</title>
+<style>
+h1 { color: purple; }
+</style>
+<div class="test-scope">
+    <x-card>
+        <h1 slot="heading">Slotted H1</h1>
+    </x-card>
+    <h1>Unslotted H1</h1>
+</div>
+<script>
+customElements.define('x-card', class extends HTMLElement {
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' }).innerHTML = '<slot name="heading"></slot><slot></slot>';
+    }
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-slotted.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-slotted.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>@scope - slotted elements</title>
+<link rel="help" href="https://drafts.csswg.org/css-cascade-6/#scoped-styles">
+<link rel="match" href="scope-slotted-ref.html">
+<meta name="assert" content="@scope rules match elements slotted into shadow DOM">
+<style>
+h1 { color: green; }
+@scope (.test-scope) {
+    h1 { color: purple; }
+}
+</style>
+<div class="test-scope">
+    <x-card>
+        <h1 slot="heading">Slotted H1</h1>
+    </x-card>
+    <h1>Unslotted H1</h1>
+</div>
+<script>
+customElements.define('x-card', class extends HTMLElement {
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' }).innerHTML = '<slot name="heading"></slot><slot></slot>';
+    }
+});
+</script>

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -735,11 +735,17 @@ std::pair<bool, std::optional<Vector<ElementRuleCollector::ScopingRootWithDistan
             unsigned distance = 0;
             RefPtr ancestor = &element();
             bool shadowHostCrossed = false;
+            // Scope root traversal normally stops at shadow boundaries so document-scoped rules don't
+            // leak into shadow trees. However, slotted elements live in the light DOM, so the traversal
+            // must cross the shadow host to find scope roots in the containing document.
+            bool stopsAtShadowBoundary = element().containingShadowRoot() || context.styleScopeOrdinal == Style::ScopeOrdinal::Shadow;
             while (ancestor && !shadowHostCrossed) {
                 auto subContext = context;
-                if (auto* shadowRoot = ancestor->shadowRoot(); shadowRoot && shadowRoot->mode() != ShadowRootMode::UserAgent) {
-                    subContext.styleScopeOrdinal = Style::ScopeOrdinal::Shadow;
-                    shadowHostCrossed = true;
+                if (stopsAtShadowBoundary) {
+                    if (auto* shadowRoot = ancestor->shadowRoot(); shadowRoot && shadowRoot->mode() != ShadowRootMode::UserAgent) {
+                        subContext.styleScopeOrdinal = Style::ScopeOrdinal::Shadow;
+                        shadowHostCrossed = true;
+                    }
                 }
                 for (const auto& selector : selectorList) {
                     auto appendIfMatch = [&] (std::optional<ScopingRootWithDistance> previousScopingRoot = { }) {


### PR DESCRIPTION
#### 00497eb486c0c28266aa0f53c0057cdc548e1a11
<pre>
@scope&apos;d styles don&apos;t affect &lt;slot&gt;&apos;d elements, but they should
<a href="https://bugs.webkit.org/show_bug.cgi?id=308330">https://bugs.webkit.org/show_bug.cgi?id=308330</a>
<a href="https://rdar.apple.com/171383788">rdar://171383788</a>

Reviewed by Antti Koivisto.

When finding scoping roots in scopeRulesMatch(), the ancestor traversal
stops at a non-UA shadow root. This is correct for elements inside a
shadow tree but wrong for slotted elements. The traversal would stop
at the shadow host, never reaching the scope root above it.

Skip the shadow boundary guard when the styled element is not inside
any shadow root and we are not matching shadow-scoped rules.

Test: imported/w3c/web-platform-tests/css/css-cascade/scope-slotted.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-slotted-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-slotted-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-slotted.html: Added.
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::scopeRulesMatch):

Canonical link: <a href="https://commits.webkit.org/311333@main">https://commits.webkit.org/311333@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04c6442bb2baf5519c2bc7da4223dbf90ea5f6e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165511 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30027 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121360 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159646 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/23594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140702 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102028 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13283 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18531 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167994 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/12155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20150 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129474 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129584 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35098 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29549 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140325 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/87350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24407 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17128 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29257 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/93273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/29012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/28908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->