### PR TITLE
Sequential focus navigation stack overflow with many non-focusable shadow hosts

### DIFF
--- a/LayoutTests/fast/shadow-dom/focus-navigation-many-non-focusable-shadow-hosts-expected.txt
+++ b/LayoutTests/fast/shadow-dom/focus-navigation-many-non-focusable-shadow-hosts-expected.txt
@@ -1,0 +1,10 @@
+Tests that sequential focus navigation through many consecutive non-focusable shadow hosts does not cause a stack overflow. See https://bugs.webkit.org/show_bug.cgi?id=311742.
+
+
+
+Focused: before
+After Tab - Focused: after
+PASS forward
+After Shift+Tab - Focused: before
+PASS backward
+

--- a/LayoutTests/fast/shadow-dom/focus-navigation-many-non-focusable-shadow-hosts.html
+++ b/LayoutTests/fast/shadow-dom/focus-navigation-many-non-focusable-shadow-hosts.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Tests that sequential focus navigation through many consecutive non-focusable shadow hosts
+does not cause a stack overflow. See https://bugs.webkit.org/show_bug.cgi?id=311742.</p>
+<input id="before" value="before">
+<div id="container"></div>
+<input id="after" value="after">
+<pre id="output"></pre>
+<script>
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+const count = 8000;
+const container = document.getElementById("container");
+for (let i = 0; i < count; i++) {
+    const host = document.createElement("div");
+    host.attachShadow({ mode: "open" }).innerHTML = "<span>not focusable</span>";
+    container.appendChild(host);
+}
+
+function log(message) {
+    document.getElementById("output").textContent += message + "\n";
+}
+
+window.onload = function() {
+    document.getElementById("before").focus();
+    log("Focused: " + document.activeElement.id);
+
+    if (window.eventSender) {
+        eventSender.keyDown("\t");
+        setTimeout(function() {
+            log("After Tab - Focused: " + document.activeElement.id);
+            log(document.activeElement.id === "after" ? "PASS forward" : "FAIL forward - expected 'after', got '" + document.activeElement.id + "'");
+
+            eventSender.keyDown("\t", ["shiftKey"]);
+            setTimeout(function() {
+                log("After Shift+Tab - Focused: " + document.activeElement.id);
+                log(document.activeElement.id === "before" ? "PASS backward" : "FAIL backward - expected 'before', got '" + document.activeElement.id + "'");
+                testRunner.notifyDone();
+            }, 0);
+        }, 0);
+    }
+};
+
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1068,6 +1068,7 @@ webkit.org/b/116046 fast/events/sequential-focus-navigation-starting-point.html 
 webkit.org/b/159240 fast/events/remove-focus-navigation-starting-point-crash.html [ Skip ]
 webkit.org/b/164888 fast/shadow-dom/focus-navigation-out-of-slot.html [ Skip ]
 webkit.org/b/164888 fast/shadow-dom/focus-navigation-passes-shadow-host.html [ Skip ]
+webkit.org/b/311742 fast/shadow-dom/focus-navigation-many-non-focusable-shadow-hosts.html [ Skip ]
 webkit.org/b/164888 fast/shadow-dom/focus-navigation-passes-svg-use-element.html [ Skip ]
 webkit.org/b/202497 imported/w3c/web-platform-tests/shadow-dom/focus/ [ Skip ]
 imported/w3c/web-platform-tests/shadow-dom/focus/focus-pseudo-matches-on-shadow-host.html [ Pass ]

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -902,37 +902,45 @@ FocusableElementSearchResult FocusController::findFocusableElementWithinScope(Fo
 
 FocusableElementSearchResult FocusController::nextFocusableElementWithinScope(const FocusNavigationScope& scope, Node* start, const FocusEventData& focusEventData)
 {
-    RefPtr found = nextFocusableElementOrScopeOwner(scope, start, focusEventData);
-    if (!found)
-        return { nullptr };
-    if (isNonFocusableScopeOwner(*found, focusEventData)) {
-        auto foundInInnerFocusScope = nextFocusableElementWithinScope(FocusNavigationScope::scopeOwnedByScopeOwner(*found), 0, focusEventData);
-        if (foundInInnerFocusScope.element)
-            return foundInInnerFocusScope;
-        return nextFocusableElementWithinScope(scope, found.get(), focusEventData);
+    RefPtr<Node> current = start;
+    while (true) {
+        RefPtr found = nextFocusableElementOrScopeOwner(scope, current.get(), focusEventData);
+        if (!found)
+            return { nullptr };
+        if (isNonFocusableScopeOwner(*found, focusEventData)) {
+            auto foundInInnerFocusScope = nextFocusableElementWithinScope(FocusNavigationScope::scopeOwnedByScopeOwner(*found), 0, focusEventData);
+            if (foundInInnerFocusScope.element)
+                return foundInInnerFocusScope;
+            current = found;
+            continue;
+        }
+        return { found };
     }
-    return { found };
 }
 
 FocusableElementSearchResult FocusController::previousFocusableElementWithinScope(const FocusNavigationScope& scope, Node* start, const FocusEventData& focusEventData)
 {
-    RefPtr found = previousFocusableElementOrScopeOwner(scope, start, focusEventData);
-    if (!found)
-        return { nullptr };
-    if (isFocusableScopeOwner(*found, focusEventData)) {
-        // Search an inner focusable element in the shadow tree from the end.
-        auto foundInInnerFocusScope = previousFocusableElementWithinScope(FocusNavigationScope::scopeOwnedByScopeOwner(*found), 0, focusEventData);
-        if (foundInInnerFocusScope.element)
-            return foundInInnerFocusScope;
+    RefPtr<Node> current = start;
+    while (true) {
+        RefPtr found = previousFocusableElementOrScopeOwner(scope, current.get(), focusEventData);
+        if (!found)
+            return { nullptr };
+        if (isFocusableScopeOwner(*found, focusEventData)) {
+            // Search an inner focusable element in the shadow tree from the end.
+            auto foundInInnerFocusScope = previousFocusableElementWithinScope(FocusNavigationScope::scopeOwnedByScopeOwner(*found), 0, focusEventData);
+            if (foundInInnerFocusScope.element)
+                return foundInInnerFocusScope;
+            return { found };
+        }
+        if (isNonFocusableScopeOwner(*found, focusEventData)) {
+            auto foundInInnerFocusScope = previousFocusableElementWithinScope(FocusNavigationScope::scopeOwnedByScopeOwner(*found), 0, focusEventData);
+            if (foundInInnerFocusScope.element)
+                return foundInInnerFocusScope;
+            current = found;
+            continue;
+        }
         return { found };
     }
-    if (isNonFocusableScopeOwner(*found, focusEventData)) {
-        auto foundInInnerFocusScope = previousFocusableElementWithinScope(FocusNavigationScope::scopeOwnedByScopeOwner(*found), 0, focusEventData);
-        if (foundInInnerFocusScope.element)
-            return foundInInnerFocusScope;
-        return previousFocusableElementWithinScope(scope, found.get(), focusEventData);
-    }
-    return { found };
 }
 
 Element* FocusController::findFocusableElementOrScopeOwner(FocusDirection direction, const FocusNavigationScope& scope, Node* node, const FocusEventData& focusEventData)


### PR DESCRIPTION
#### 1cb22d29f82443d278401a29606aa4f14f11ec31
<pre>
Sequential focus navigation stack overflow with many non-focusable shadow hosts
<a href="https://bugs.webkit.org/show_bug.cgi?id=311742">https://bugs.webkit.org/show_bug.cgi?id=311742</a>
<a href="https://rdar.apple.com/174359369">rdar://174359369</a>

Reviewed by Ryosuke Niwa and Megan Gardner.

Convert recursive tail calls in nextFocusableElementWithinScope and
previousFocusableElementWithinScope to iterative while loops. When
traversing many consecutive non-focusable shadow hosts (e.g. a large
datalist), the recursive calls could exhaust the stack.

* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::nextFocusableElementWithinScope):
(WebCore::FocusController::previousFocusableElementWithinScope):
* LayoutTests/fast/shadow-dom/focus-navigation-many-non-focusable-shadow-hosts.html: Added.
* LayoutTests/fast/shadow-dom/focus-navigation-many-non-focusable-shadow-hosts-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/311139@main">https://commits.webkit.org/311139@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00a9616a8a0c413a1d07e24b1287b9ee6c7d0bf5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164551 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109603 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157660 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29194 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28897 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120586 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85070 "2 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22772 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139898 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101275 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21858 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20000 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12381 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131527 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167031 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11205 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19341 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128706 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24034 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128838 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34981 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28515 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139523 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86352 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23659 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16321 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187672 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28209 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92312 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/187672 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27786 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28016 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27859 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->