### PR TITLE
[AI Experiment, Do Not Review, Opus Generated] [Grid] RELEASE_ASSERT in copyUsedTrackSizesForSubgrid when contain:paint changes subgrid IFC status

### DIFF
--- a/LayoutTests/fast/css-grid-layout/subgrid-establishes-independent-formatting-context-contain-paint-crash-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/subgrid-establishes-independent-formatting-context-contain-paint-crash-expected.txt
@@ -1,0 +1,1 @@
+PASSES if no crash

--- a/LayoutTests/fast/css-grid-layout/subgrid-establishes-independent-formatting-context-contain-paint-crash.html
+++ b/LayoutTests/fast/css-grid-layout/subgrid-establishes-independent-formatting-context-contain-paint-crash.html
@@ -1,0 +1,31 @@
+<html>
+<head>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<style>
+.grid {
+  display: grid;
+}
+.subgrid-rows {
+  grid-template-rows: subgrid [b] [a] [c];
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div id="outer-subgrid" class="grid subgrid-rows">
+    <div></div>
+    <div id="inner-subgrid" class="grid subgrid-rows">PASSES if no crash</div>
+  </div>
+</div>
+</body>
+
+<script>
+  document.body.offsetHeight;
+  document.getElementById("outer-subgrid").style.contain = "paint";
+  document.getElementById("inner-subgrid").style.border = "1px solid black";
+  document.body.offsetHeight;
+</script>
+

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -218,8 +218,11 @@ void RenderGrid::styleDidChange(Style::Difference diff, const RenderStyle* oldSt
         || style().gridTemplateColumns().autoRepeatSizes.size()
         || style().gridTemplateRows().autoRepeatSizes.size()
         || subgridDidChange == SubgridDidChange::Yes
-        || isSubgridWithIndependentFormattingContextChange())
+        || isSubgridWithIndependentFormattingContextChange()) {
+        if (isSubgridWithIndependentFormattingContextChange() && subgridDidChange == SubgridDidChange::No)
+            subgridDidChange = SubgridDidChange::Yes;
         setNeedsItemPlacement(subgridDidChange);
+    }
 }
 
 SubgridDidChange RenderGrid::subgridDidChange(const RenderStyle& oldStyle) const

--- a/Source/WebCore/style/StyleDifference.cpp
+++ b/Source/WebCore/style/StyleDifference.cpp
@@ -276,7 +276,8 @@ public:
 
         if (a.usedContain().contains(ContainValue::Size) != b.usedContain().contains(ContainValue::Size)
             || a.usedContain().contains(ContainValue::InlineSize) != b.usedContain().contains(ContainValue::InlineSize)
-            || a.usedContain().contains(ContainValue::Layout) != b.usedContain().contains(ContainValue::Layout))
+            || a.usedContain().contains(ContainValue::Layout) != b.usedContain().contains(ContainValue::Layout)
+            || a.usedContain().contains(ContainValue::Paint) != b.usedContain().contains(ContainValue::Paint))
             return true;
 
         // content-visibility:hidden turns on contain:size which requires relayout.


### PR DESCRIPTION
#### fabc6e4d03412d5ead952ef486a3f14d8e109b79
<pre>
[AI Experiment, Do Not Review, Opus Generated] [Grid] RELEASE_ASSERT in copyUsedTrackSizesForSubgrid when contain:paint changes subgrid IFC status
<a href="https://bugs.webkit.org/show_bug.cgi?id=311988">https://bugs.webkit.org/show_bug.cgi?id=311988</a>
<a href="https://rdar.apple.com/174531142">rdar://174531142</a>

Reviewed by NOBODY (OOPS!).

Dynamically applying `contain: paint` to a subgrid element causes a RELEASE_ASSERT crash
in `GridTrackSizingAlgorithm::copyUsedTrackSizesForSubgrid()` due to mismatched track counts.

`ContainValue::Paint` was missing from the containment style diff check in
`StyleDifference.cpp`, so the style change returned `Equal` instead of `Layout`.
This caused `RenderGrid::styleDidChange` to early-return before detecting the
subgrid-to-IFC transition, leaving the parent grid with stale placement data.

This is the `contain: paint` variant of bug 284862 (which fixed `contain: layout`).

The fix adds `ContainValue::Paint` to the layout diff check and upgrades
`subgridDidChange` to `Yes` when the IFC status changes, ensuring
`setNeedsItemPlacement` propagates to the parent grid.

Test: fast/css-grid-layout/subgrid-establishes-independent-formatting-context-contain-paint-crash.html

* Source/WebCore/style/StyleDifference.cpp:
(WebCore::Style::DifferenceFunctions::rareDataChangeRequiresLayout):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::styleDidChange):
* LayoutTests/fast/css-grid-layout/subgrid-establishes-independent-formatting-context-contain-paint-crash-expected.txt: Added.
* LayoutTests/fast/css-grid-layout/subgrid-establishes-independent-formatting-context-contain-paint-crash.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fabc6e4d03412d5ead952ef486a3f14d8e109b79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164431 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109484 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157541 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28778 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120485 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84935 "1 flakes 3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139782 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101174 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4107a9a-d5cb-4911-8806-f1345a4f372c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21742 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19881 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12261 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131411 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166910 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11086 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19225 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128600 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28472 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23915 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128732 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28396 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139407 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86225 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23544 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16204 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28090 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92193 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27667 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27897 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27740 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->