### PR TITLE
[macOS release] inspector/runtime/execution-context-in-scriptless-page.html is a flaky text failure.

### DIFF
--- a/LayoutTests/inspector/runtime/execution-context-in-scriptless-page.html
+++ b/LayoutTests/inspector/runtime/execution-context-in-scriptless-page.html
@@ -25,14 +25,14 @@ function test()
                 contextInfoPromise = (async function () {
                     let { data: { target } } = await WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
                     InspectorTest.assert(target.type === WI.TargetType.Frame);
-                    await target.awaitEvent(WI.FrameTarget.Event.ExecutionContextAdded);
+                    await target.ensureTargetExecutionContext();
                     return { executionContext: target.executionContext, target };
                 })();
             } else {
                 // Without site isolation, execution contexts are reported on Frame objects, not through a target.
                 contextInfoPromise = (async function () {
                     let { data: { childFrame } } = await WI.networkManager.mainFrame.awaitEvent(WI.Frame.Event.ChildFrameWasAdded);
-                    await childFrame.awaitEvent(WI.Frame.Event.ExecutionContextAdded);
+                    await childFrame.ensurePageExecutionContext();
                     return { executionContext: childFrame.pageExecutionContext, target: WI.mainTarget };
                 })();
             }

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2353,8 +2353,6 @@ webkit.org/b/306663 [ Debug arm64 ] webaudio/silent-audio-interrupted-in-backgro
 
 webkit.org/b/310217 imported/w3c/web-platform-tests/pointerevents/pointerevent_pointer_boundary_events_after_removing_last_over_element.html [ Pass Failure ]
 
-webkit.org/b/311958 [ Release ] inspector/runtime/execution-context-in-scriptless-page.html [ Pass Failure ]
-
 webkit.org/b/306670 [ Debug arm64 ] http/tests/webgpu/webgpu/api/validation/render_pipeline/resource_compatibility.html [ Pass Failure Timeout ]
 
 webkit.org/b/310823 [ Release arm64 ] imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub.html [ Pass Failure ]

--- a/Source/WebInspectorUI/UserInterface/Models/Frame.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Frame.js
@@ -219,6 +219,7 @@ WI.Frame = class Frame extends WI.Object
             this._executionContextList.clear();
             this.dispatchEventToListeners(WI.Frame.Event.ExecutionContextsCleared, {committingProvisionalLoad: !!committingProvisionalLoad, contexts});
         }
+        this._executionContextPromise = null;
     }
 
     addExecutionContext(context)
@@ -229,6 +230,14 @@ WI.Frame = class Frame extends WI.Object
 
         if (this._executionContextList.pageExecutionContext === context)
             this.dispatchEventToListeners(WI.Frame.Event.PageExecutionContextChanged);
+    }
+
+    ensurePageExecutionContext()
+    {
+        this._executionContextPromise ||= this.pageExecutionContext 
+            ? Promise.resolve() 
+            : this.awaitEvent(WI.Frame.Event.PageExecutionContextChanged);
+        return this._executionContextPromise;
     }
 
     get mainResource()

--- a/Source/WebInspectorUI/UserInterface/Protocol/FrameTarget.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/FrameTarget.js
@@ -60,10 +60,19 @@ WI.FrameTarget = class FrameTarget extends WI.Target
         this.dispatchEventToListeners(WI.FrameTarget.Event.ExecutionContextAdded, {context});
     }
 
+    ensureTargetExecutionContext()
+    {
+        this._targetExecutionContextPromise ||= this.executionContext 
+            ? Promise.resolve() 
+            : this.awaitEvent(WI.FrameTarget.Event.ExecutionContextAdded);
+        return this._targetExecutionContextPromise;
+    }
+
     clearExecutionContexts()
     {
         this._executionContextList.clear();
         this._executionContext = null;
+        this._targetExecutionContextPromise = null;
     }
 };
 


### PR DESCRIPTION
#### cbc659b870a79cf6317b59fc508e8ad62e364d40
<pre>
[macOS release] inspector/runtime/execution-context-in-scriptless-page.html is a flaky text failure.
<a href="https://rdar.apple.com/174512679">rdar://174512679</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311958">https://bugs.webkit.org/show_bug.cgi?id=311958</a>

Reviewed by Qianlang Chen and BJ Burg.

This test flakily times out on macOS release because awaitEvent(ExecutionContextAdded)
can miss the event and the execution context may already exist on the target by the time
the listener is registered after TargetAdded resolves, causing an indefinite wait.

Files changed (3):
    1. Frame.js - Added ensurePageExecutionContext() that ensures context has been or was
    already added to page. Adjusted clearExecutionContexts() to reset context promise.
    2. TargetFrame.js - Added ensureTargetExecutionContext that ensures context has been
    or was already added to target. Adjusted clearExecutionContexts() to reset context promise.
    3. execution-context-in-scriptless-page.html - instead of doing a forward await on
    context both codepaths now use dedicated helpers to verify context exists.

* LayoutTests/inspector/runtime/execution-context-in-scriptless-page.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebInspectorUI/UserInterface/Models/Frame.js:
(WI.Frame.prototype.clearExecutionContexts):
(WI.Frame.prototype.ensurePageExecutionContext):
* Source/WebInspectorUI/UserInterface/Protocol/FrameTarget.js:
(WI.FrameTarget.prototype.ensureTargetExecutionContext):
(WI.FrameTarget.prototype.clearExecutionContexts):
(WI.FrameTarget):

Canonical link: <a href="https://commits.webkit.org/311360@main">https://commits.webkit.org/311360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69362b42e45f72b95ad2386672d08b59bfadbef8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165508 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110766 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30024 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121358 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85243 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23581 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140710 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102026 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22637 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20836 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13280 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132316 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18539 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167991 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12152 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129472 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24914 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129582 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35115 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29546 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140333 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87347 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24406 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17137 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29254 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93270 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28779 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29009 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28905 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->