### PR TITLE
TextIdicators are offset on iOS.

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WKTextEffectManager.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextEffectManager.mm
@@ -137,7 +137,7 @@ static constexpr WTTextEffectManagerWritingDirection toTextEffectWritingDirectio
     completionHandler(_webView.get());
 }
 
-static RetainPtr<NSArray<_WTTextPreview *>> textPreviewsFromIndicator(const RefPtr<WebCore::TextIndicator>& textIndicator)
+static RetainPtr<NSArray<_WTTextPreview *>> textPreviewsFromIndicator(const RefPtr<WebCore::TextIndicator>& textIndicator, CocoaView *rootView, CocoaView *containerView)
 {
     if (!textIndicator)
         return nil;
@@ -156,12 +156,13 @@ static RetainPtr<NSArray<_WTTextPreview *>> textPreviewsFromIndicator(const RefP
     if (!snapshotPlatformImage)
         return nil;
 
-    CGRect snapshotRectInBoundingRectCoordinates = textIndicator->textBoundingRectInRootViewCoordinates();
+    CGRect boundingRectInRootViewCoordinates = textIndicator->textBoundingRectInRootViewCoordinates();
 
     for (auto textRectInSnapshotCoordinates : textIndicator->textRectsInBoundingRectCoordinates()) {
-        CGRect textLineFrameInBoundingRectCoordinates = CGRectOffset(textRectInSnapshotCoordinates, snapshotRectInBoundingRectCoordinates.origin.x, snapshotRectInBoundingRectCoordinates.origin.y);
+        CGRect frameInRootViewCoordinates = CGRectOffset(textRectInSnapshotCoordinates, boundingRectInRootViewCoordinates.origin.x, boundingRectInRootViewCoordinates.origin.y);
+        CGRect presentationFrame = [rootView convertRect:frameInRootViewCoordinates toView:containerView];
         textRectInSnapshotCoordinates.scale(textIndicator->contentImageScaleFactor());
-        [previews addObject:adoptNS([PAL::alloc_WTTextPreviewInstance() initWithSnapshotImage:adoptCF(CGImageCreateWithImageInRect(snapshotPlatformImage.get(), textRectInSnapshotCoordinates)).get() presentationFrame:textLineFrameInBoundingRectCoordinates]).get()];
+        [previews addObject:adoptNS([PAL::alloc_WTTextPreviewInstance() initWithSnapshotImage:adoptCF(CGImageCreateWithImageInRect(snapshotPlatformImage.get(), textRectInSnapshotCoordinates)).get() presentationFrame:presentationFrame]).get()];
     }
 
     return previews;
@@ -178,20 +179,27 @@ static RetainPtr<NSArray<_WTTextPreview *>> textPreviewsFromIndicator(const RefP
         return completionHandler(nil, nil);
 
     [webView _page]->textIndicatorForTextEffectID(*textEffectUUID, [protectedSelf = retainPtr(self), textEffectUUID = *textEffectUUID, completionHandler = makeBlockPtr(completionHandler)](RefPtr<WebCore::TextIndicator> textIndicator) {
-        RetainPtr textPreviews = textPreviewsFromIndicator(textIndicator);
-        if (!textPreviews) {
-            completionHandler(nil, nil);
-            return;
-        }
-
         RetainPtr webView = protectedSelf->_webView.get();
         if (!webView) {
             completionHandler(nil, nil);
             return;
         }
 
-        [webView _page]->decorationIndicatorForTextEffectID(textEffectUUID, [textPreviews = WTF::move(textPreviews), completionHandler](RefPtr<WebCore::TextIndicator> decorationIndicator) {
-            auto underlinePreviews = textPreviewsFromIndicator(decorationIndicator);
+#if PLATFORM(IOS_FAMILY)
+        CocoaView *rootView = webView->_contentView.get();
+#else
+        CocoaView *rootView = webView.get();
+#endif
+        CocoaView *containerView = webView.get();
+
+        RetainPtr textPreviews = textPreviewsFromIndicator(textIndicator, rootView, containerView);
+        if (!textPreviews) {
+            completionHandler(nil, nil);
+            return;
+        }
+
+        [webView _page]->decorationIndicatorForTextEffectID(textEffectUUID, [textPreviews = WTF::move(textPreviews), rootView = retainPtr(rootView), containerView = retainPtr(containerView), completionHandler](RefPtr<WebCore::TextIndicator> decorationIndicator) {
+            auto underlinePreviews = textPreviewsFromIndicator(decorationIndicator, rootView.get(), containerView.get());
             completionHandler(textPreviews.get(), underlinePreviews.get());
         });
     });


### PR DESCRIPTION
#### 3c48430394352143fe3087da028d0b3eb2b64bfa
<pre>
TextIdicators are offset on iOS.
<a href="https://bugs.webkit.org/show_bug.cgi?id=311990">https://bugs.webkit.org/show_bug.cgi?id=311990</a>
<a href="https://rdar.apple.com/173903530">rdar://173903530</a>

Reviewed by Wenson Hsieh.

On iOS we were giving the location of the textIndicator
in contentView coordinates instead of WebView coordinates.
Update to give them in the right coordinate space.

* Source/WebKit/UIProcess/Cocoa/WKTextEffectManager.mm:
(textPreviewsFromIndicator):
(-[WKTextEffectManager previewsForSuggestionWithUUID:completion:]):

Canonical link: <a href="https://commits.webkit.org/311114@main">https://commits.webkit.org/311114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b574d042512f6d06fb980ce502032ab059aea18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109497 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b56e75c3-3217-4211-9829-133be7f74a8b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157554 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29088 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28791 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120493 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84939 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1311aa14-e1f7-4234-bdbe-0344f740f1eb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139796 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101182 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6bcd766a-7e79-453d-b669-6e08a89f9122) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/155001 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21757 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19896 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12274 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147731 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131426 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166925 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16513 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11099 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128611 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/155081 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128743 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34964 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28409 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139421 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86238 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23559 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16218 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187566 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28103 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92206 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48074 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27680 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27910 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27753 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->