### PR TITLE
Update `auto` to `RetainPtr` in Cocoa API tests

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/DaemonTestUtilities.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/DaemonTestUtilities.mm
@@ -71,7 +71,7 @@ static RetainPtr<NSURL> currentExecutableLocation()
     buffer.resize(size + 1);
     _NSGetExecutablePath(buffer.mutableSpan().data(), &size);
     buffer[size] = '\0';
-    auto pathString = adoptNS([[NSString alloc] initWithUTF8String:buffer.span().data()]);
+    RetainPtr pathString = adoptNS([[NSString alloc] initWithUTF8String:buffer.span().data()]);
     return adoptNS([[NSURL alloc] initFileURLWithPath:pathString.get() isDirectory:NO]);
 }
 
@@ -130,7 +130,7 @@ void registerPlistWithLaunchD(NSDictionary<NSString *, id> *plist, NSURL *tempDi
     auto xpcPlist = convertDictionaryToXPC(plist);
     xpc_dictionary_set_string(xpcPlist.get(), "_ManagedBy", "TestWebKitAPI");
     xpc_dictionary_set_bool(xpcPlist.get(), "RootedSimulatorPath", true);
-    auto launchDJob = adoptNS([[OSLaunchdJob alloc] initWithPlist:xpcPlist.get()]);
+    RetainPtr launchDJob = adoptNS([[OSLaunchdJob alloc] initWithPlist:xpcPlist.get()]);
     [launchDJob submit:&error];
 #else
     NSURL *plistLocation = [tempDir URLByAppendingPathComponent:@"DaemonInfo.plist"];
@@ -147,7 +147,7 @@ void registerPlistWithLaunchD(NSDictionary<NSString *, id> *plist, NSURL *tempDi
 
 static int pidOfFirstDaemonInstance(NSString *daemonExecutableName)
 {
-    auto task = adoptNS([[NSTask alloc] init]);
+    RetainPtr task = adoptNS([[NSTask alloc] init]);
     task.get().launchPath = @"/bin/ps";
     task.get().arguments = @[
         @"-ax",
@@ -155,16 +155,16 @@ static int pidOfFirstDaemonInstance(NSString *daemonExecutableName)
         @"pid,comm"
     ];
 
-    auto taskPipe = adoptNS([[NSPipe alloc] init]);
+    RetainPtr taskPipe = adoptNS([[NSPipe alloc] init]);
     [task setStandardOutput:taskPipe.get()];
     [task launch];
 
-    auto data = adoptNS([[NSMutableData alloc] init]);
+    RetainPtr data = adoptNS([[NSMutableData alloc] init]);
     while ([task isRunning])
         [data appendData:[[taskPipe fileHandleForReading] readDataToEndOfFile]];
     [data appendData:[[taskPipe fileHandleForReading] readDataToEndOfFile]];
 
-    auto psString = adoptNS([[NSString alloc] initWithData:data.get() encoding:NSUTF8StringEncoding]);
+    RetainPtr psString = adoptNS([[NSString alloc] initWithData:data.get() encoding:NSUTF8StringEncoding]);
     NSArray<NSString *> *psEntries = [psString componentsSeparatedByString:@"\n"];
 
     for (NSString* entry in psEntries) {
@@ -184,7 +184,7 @@ void killFirstInstanceOfDaemon(NSString *daemonExecutableName)
     if (!pid)
         return;
 
-    auto task = adoptNS([[NSTask alloc] init]);
+    RetainPtr task = adoptNS([[NSTask alloc] init]);
     task.get().launchPath = @"/bin/kill";
     task.get().arguments = @[
         @"-9",
@@ -208,7 +208,7 @@ BOOL restartService(NSString *, NSString *daemonExecutableName)
 
 BOOL restartService(NSString *serviceName, NSString *)
 {
-    auto task = adoptNS([[NSTask alloc] init]);
+    RetainPtr task = adoptNS([[NSTask alloc] init]);
     [task setLaunchPath:@"/bin/launchctl"];
     [task setArguments:@[@"kickstart", @"-k", @"-p", [NSString stringWithFormat:@"gui/%u/%@", geteuid(), serviceName]]];
     [task launch];

--- a/Tools/TestWebKitAPI/Helpers/cocoa/FindInPageUtilities.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/FindInPageUtilities.mm
@@ -187,7 +187,7 @@ void testPerformTextSearchWithQueryStringInWebView(WKWebView *webView, NSString 
 RetainPtr<NSOrderedSet<UITextRange *>> textRangesForQueryString(WKWebView *webView, NSString *query)
 {
     __block bool finishedSearching = false;
-    auto aggregator = adoptNS([[TestSearchAggregator alloc] initWithCompletionHandler:^{
+    RetainPtr aggregator = adoptNS([[TestSearchAggregator alloc] initWithCompletionHandler:^{
         finishedSearching = true;
     }]);
 

--- a/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.mm
@@ -128,8 +128,8 @@ RetainPtr<nw_parameters_t> HTTPServer::listenerParameters(Protocol protocol, Cer
         customTestIdentity = testIdentity();
 
     auto configureTLS = [protocol, verifier = WTF::move(verifier), testIdentity = WTF::move(customTestIdentity)] (nw_protocol_options_t protocolOptions) mutable {
-        auto options = adoptNS(nw_tls_copy_sec_protocol_options(protocolOptions));
-        auto identity = adoptNS(sec_identity_create(testIdentity.get()));
+        RetainPtr options = adoptNS(nw_tls_copy_sec_protocol_options(protocolOptions));
+        RetainPtr identity = adoptNS(sec_identity_create(testIdentity.get()));
         sec_protocol_options_set_local_identity(options.get(), identity.get());
         if (protocol == Protocol::HttpsWithLegacyTLS) {
 #if ENABLE(TLS_1_2_DEFAULT_MINIMUM)
@@ -148,16 +148,16 @@ RetainPtr<nw_parameters_t> HTTPServer::listenerParameters(Protocol protocol, Cer
     };
 
     auto configureTLSBlock = shouldDisableTLS(protocol) ? makeBlockPtr(NW_PARAMETERS_DISABLE_PROTOCOL) : makeBlockPtr(WTF::move(configureTLS));
-    auto parameters = adoptNS(nw_parameters_create_secure_tcp(configureTLSBlock.get(), NW_PARAMETERS_DEFAULT_CONFIGURATION));
+    RetainPtr parameters = adoptNS(nw_parameters_create_secure_tcp(configureTLSBlock.get(), NW_PARAMETERS_DEFAULT_CONFIGURATION));
     if (port)
         nw_parameters_set_local_endpoint(parameters.get(), nw_endpoint_create_host("::", makeString(*port).utf8().data()));
 
     if (protocol == Protocol::HttpsProxy || protocol == Protocol::HttpsProxyWithAuthentication) {
-        auto stack = adoptNS(nw_parameters_copy_default_protocol_stack(parameters.get()));
-        auto options = adoptNS(nw_framer_create_options(proxyDefinition(protocol).get()));
+        RetainPtr stack = adoptNS(nw_parameters_copy_default_protocol_stack(parameters.get()));
+        RetainPtr options = adoptNS(nw_framer_create_options(proxyDefinition(protocol).get()));
         nw_protocol_stack_prepend_application_protocol(stack.get(), options.get());
 
-        auto tlsOptions = adoptNS(nw_tls_create_options());
+        RetainPtr tlsOptions = adoptNS(nw_tls_create_options());
         configureTLS(tlsOptions.get());
         nw_protocol_stack_prepend_application_protocol(stack.get(), tlsOptions.get());
     }
@@ -498,9 +498,9 @@ NSURLRequest *HTTPServer::requestWithLocalhost(StringView path) const
 
 WKWebViewConfiguration *HTTPServer::httpsProxyConfiguration() const
 {
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", port()]]];
-    auto viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [viewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
     return viewConfiguration.autorelease();
 }

--- a/Tools/TestWebKitAPI/Helpers/cocoa/ImageAnalysisTestingUtilities.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/ImageAnalysisTestingUtilities.mm
@@ -277,7 +277,7 @@ RetainPtr<VKImageAnalyzerRequest> createRequest(CGImageRef image, VKImageOrienta
 IMP makeRequestHandler(CGImageRef image, CGRect cropRect)
 {
     return imp_implementationWithBlock([image = RetainPtr { image }, cropRect](VKCRemoveBackgroundRequestHandler *, VKCRemoveBackgroundRequest *, void (^completion)(VKCRemoveBackgroundResult *, NSError *)) {
-        auto result = adoptNS([[FakeRemoveBackgroundResult alloc] initWithImage:image.get() cropRect:cropRect]);
+        RetainPtr result = adoptNS([[FakeRemoveBackgroundResult alloc] initWithImage:image.get() cropRect:cropRect]);
         completion(static_cast<VKCRemoveBackgroundResult *>(result.get()), nil);
     });
 }

--- a/Tools/TestWebKitAPI/Helpers/cocoa/PasteboardUtilities.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/PasteboardUtilities.mm
@@ -42,10 +42,10 @@ RetainPtr<TestWKWebView> createWebViewWithCustomPasteboardDataEnabled(bool color
     TestWebKitAPI::Util::instantiateUIApplicationIfNeeded();
 #endif
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration _setColorFilterEnabled:colorFilterEnabled];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:webViewConfiguration.get()]);
     auto preferences = (__bridge WKPreferencesRef)[[webView configuration] preferences];
     WKPreferencesSetDataTransferItemsEnabled(preferences, true);
     WKPreferencesSetCustomPasteboardDataEnabled(preferences, true);

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestNavigationDelegate.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestNavigationDelegate.mm
@@ -291,7 +291,7 @@
 {
     auto *oldNavigationDelegate = self.navigationDelegate;
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     self.navigationDelegate = navigationDelegate.get();
     [navigationDelegate waitForDidStartProvisionalNavigation];
 
@@ -302,7 +302,7 @@
 {
     auto *oldNavigationDelegate = self.navigationDelegate;
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     self.navigationDelegate = navigationDelegate.get();
     [navigationDelegate waitForDidFailProvisionalNavigation];
 
@@ -313,7 +313,7 @@
 {
     auto *oldNavigationDelegate = self.navigationDelegate;
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     self.navigationDelegate = navigationDelegate.get();
     [navigationDelegate waitForDidFinishNavigation];
 
@@ -324,7 +324,7 @@
 {
     auto *oldNavigationDelegate = self.navigationDelegate;
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     self.navigationDelegate = navigationDelegate.get();
     [navigationDelegate waitForDidFinishNavigationWithPreferences:preferences];
 
@@ -335,7 +335,7 @@
 {
     auto *oldNavigationDelegate = self.navigationDelegate;
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     self.navigationDelegate = navigationDelegate.get();
     [navigationDelegate waitForDidFinishNavigation];
 
@@ -354,7 +354,7 @@
 {
     auto *oldNavigationDelegate = self.navigationDelegate;
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     self.navigationDelegate = navigationDelegate.get();
     [navigationDelegate waitForDidSameDocumentNavigation];
 
@@ -365,7 +365,7 @@
 {
     auto *oldNavigationDelegate = self.navigationDelegate;
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     navigationDelegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
     };
@@ -387,7 +387,7 @@
 {
     auto *oldNavigationDelegate = self.navigationDelegate;
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     self.navigationDelegate = navigationDelegate.get();
     auto result = [navigationDelegate waitForWebContentProcessDidTerminate];
 

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestProtocol.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestProtocol.mm
@@ -119,7 +119,7 @@ static NSString *contentTypeForFileExtension(NSString *fileExtension)
 
     if ([requestURL.host isEqualToString:@"redirect"]) {
         NSData *data = [@"PASS" dataUsingEncoding:NSASCIIStringEncoding];
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:requestURL MIMEType:@"text/html" expectedContentLength:data.length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:requestURL MIMEType:@"text/html" expectedContentLength:data.length textEncodingName:nil]);
         [self.client URLProtocol:self wasRedirectedToRequest:[NSURLRequest requestWithURL:createRedirectURL(requestURL.query)] redirectResponse:response.get()];
         return;
     }
@@ -142,7 +142,7 @@ static NSString *contentTypeForFileExtension(NSString *fileExtension)
     if (auto& headers = additionalResponseHeaders())
         [responseHeaders addEntriesFromDictionary:headers.get()];
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:requestURL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:responseHeaders]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:requestURL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:responseHeaders]);
 
     [self.client URLProtocol:self didReceiveResponse:response.get() cacheStoragePolicy:NSURLCacheStorageNotAllowed];
     [self.client URLProtocol:self didLoadData:data];

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestUIDelegate.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestUIDelegate.mm
@@ -265,7 +265,7 @@
 - (NSString *)_test_waitForAlert
 {
     EXPECT_FALSE(self.UIDelegate);
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     self.UIDelegate = uiDelegate.get();
     NSString *alert = [uiDelegate waitForAlert];
     self.UIDelegate = nil;
@@ -275,7 +275,7 @@
 - (NSString *)_test_waitForConfirm
 {
     EXPECT_FALSE(self.UIDelegate);
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     self.UIDelegate = uiDelegate.get();
     NSString *message = [uiDelegate waitForConfirm];
     self.UIDelegate = nil;
@@ -285,7 +285,7 @@
 - (NSString *)_test_waitForPromptWithReply:(NSString *)reply
 {
     EXPECT_FALSE(self.UIDelegate);
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     self.UIDelegate = uiDelegate.get();
     NSString *prompt = [uiDelegate waitForPromptWithReply:reply];
     self.UIDelegate = nil;
@@ -295,7 +295,7 @@
 - (void)_test_waitForInspectorToShow
 {
     EXPECT_FALSE(self.UIDelegate);
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     self.UIDelegate = uiDelegate.get();
     [uiDelegate waitForInspectorToShow];
     self.UIDelegate = nil;

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm
@@ -429,8 +429,8 @@ static NSString *overrideBundleIdentifier(id, SEL)
     }
 
 #if USE(BROWSERENGINEKIT)
-    auto nsAlternatives = adoptNS([[NSTextAlternatives alloc] initWithPrimaryString:primaryString alternativeStrings:alternativeStrings]);
-    auto alternatives = adoptNS([[BETextAlternatives alloc] _initWithNSTextAlternatives:nsAlternatives.get()]);
+    RetainPtr nsAlternatives = adoptNS([[NSTextAlternatives alloc] initWithPrimaryString:primaryString alternativeStrings:alternativeStrings]);
+    RetainPtr alternatives = adoptNS([[BETextAlternatives alloc] _initWithNSTextAlternatives:nsAlternatives.get()]);
     [self.asyncTextInput insertTextAlternatives:alternatives.get()];
 #else
     [self.textInputContentView insertText:primaryString alternatives:alternativeStrings style:UITextAlternativeStyleNone];
@@ -441,7 +441,7 @@ static NSString *overrideBundleIdentifier(id, SEL)
 
 static RetainPtr<BEKeyEntry> wrap(WebEvent *webEvent)
 {
-    auto uiKeyEvent = adoptNS([allocUIKeyEventInstance() initWithWebEvent:webEvent]);
+    RetainPtr uiKeyEvent = adoptNS([allocUIKeyEventInstance() initWithWebEvent:webEvent]);
     return adoptNS([[BEKeyEntry alloc] _initWithUIKitKeyEvent:uiKeyEvent.get()]);
 }
 
@@ -583,7 +583,7 @@ static WebEvent *unwrap(BEKeyEntry *event)
 
 - (void)expectElementTagsInOrder:(NSArray<NSString *> *)tagNames
 {
-    auto remainingTags = adoptNS([tagNames mutableCopy]);
+    RetainPtr remainingTags = adoptNS([tagNames mutableCopy]);
     NSArray<NSString *> *tagsInBody = self.tagsInBody;
     for (NSString *tag in tagsInBody.reverseObjectEnumerator) {
         if ([tag isEqualToString:[remainingTags lastObject]])
@@ -1056,7 +1056,7 @@ static InputSessionChangeCount nextInputSessionChangeCount()
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
-    auto defaultConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr defaultConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     return [self initWithFrame:frame configuration:defaultConfiguration.get()];
 }
 
@@ -1423,7 +1423,7 @@ static UIWindowScene *windowScene()
     unichar c = character;
     RetainPtr characters = adoptNS([[NSString alloc] initWithCharacters:&c length:1]);
 
-    auto firstWebEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyDown timeStamp:CFAbsoluteTimeGetCurrent() characters:characters.get() charactersIgnoringModifiers:characters.get() modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:NO]);
+    RetainPtr firstWebEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyDown timeStamp:CFAbsoluteTimeGetCurrent() characters:characters.get() charactersIgnoringModifiers:characters.get() modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:NO]);
     [self handleKeyEvent:firstWebEvent.get() completion:[=](WebEvent *event, BOOL) {
         EXPECT_TRUE([event isEqual:firstWebEvent.get()]);
     }];
@@ -1757,7 +1757,7 @@ static WKContentView *recursiveFindWKContentView(UIView *view)
     RetainPtr pipe = [NSPipe pipe];
     // FIXME: This is currently reliant on `NSTask`, which is absent on iOS. We should find a way to
     // make this helper work on both platforms.
-    auto task = adoptNS([NSTask new]);
+    RetainPtr task = adoptNS([NSTask new]);
     [task setLaunchPath:@"/usr/bin/log"];
     [task setArguments:@[ @"show", @"--last", @"2m", @"--style", @"json", @"--predicate", predicate ]];
     [task setStandardOutput:pipe.get()];

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebViewConfiguration.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebViewConfiguration.mm
@@ -32,31 +32,31 @@
 TEST(WKWebViewConfiguration, FlagsThroughWKWebView)
 {
     {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-        auto view = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr view = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         BOOL defaultRespectsImageOrientation = [configuration _respectsImageOrientation];
         EXPECT_EQ([[view configuration] _respectsImageOrientation], defaultRespectsImageOrientation);
     }
 
     {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         BOOL defaultRespectsImageOrientation = [configuration _respectsImageOrientation];
-        auto view = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr view = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         EXPECT_EQ([[view configuration] _respectsImageOrientation], defaultRespectsImageOrientation);
     }
 
     {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         BOOL defaultRespectsImageOrientation = [configuration _respectsImageOrientation];
         [configuration _setRespectsImageOrientation:!defaultRespectsImageOrientation];
-        auto view = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr view = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         EXPECT_EQ([[view configuration] _respectsImageOrientation], !defaultRespectsImageOrientation);
     }
 
     {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         BOOL defaultRespectsImageOrientation = [configuration _respectsImageOrientation];
-        auto view = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr view = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         EXPECT_EQ([[view configuration] _respectsImageOrientation], defaultRespectsImageOrientation);
         // Spooky action at a distance, due to API::PageConfiguration::copy() doing a shallow copy and keeping a reference to the same WebPreferences.
         [configuration _setRespectsImageOrientation:!defaultRespectsImageOrientation];

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWebExtensionsDelegate.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWebExtensionsDelegate.mm
@@ -73,7 +73,7 @@
     }
 
     TestWebExtensionWindow *window = openWindows.firstObject;
-    auto newTab = adoptNS([[TestWebExtensionTab alloc] initWithWindow:window extensionController:controller]);
+    RetainPtr newTab = adoptNS([[TestWebExtensionTab alloc] initWithWindow:window extensionController:controller]);
 
     window.tabs = [window.tabs arrayByAddingObject:newTab.get()];
 

--- a/Tools/TestWebKitAPI/Helpers/cocoa/UserMediaCaptureUIDelegate.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/UserMediaCaptureUIDelegate.mm
@@ -146,7 +146,7 @@
 #if PLATFORM(IOS_FAMILY)
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction preferences:(WKWebpagePreferences *)preferences decisionHandler:(void (^)(WKNavigationActionPolicy, WKWebpagePreferences *))decisionHandler
 {
-    auto websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
+    RetainPtr websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
     [websitePolicies _setPopUpPolicy:_WKWebsitePopUpPolicyAllow];
     decisionHandler(WKNavigationActionPolicyAllow, websitePolicies.get());
 }

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WKWebViewConfigurationExtras.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WKWebViewConfigurationExtras.mm
@@ -40,14 +40,14 @@
 
 + (instancetype)_test_configurationWithTestPlugInClassName:(NSString *)className configureJSCForTesting:(BOOL)value
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     [processPoolConfiguration setInjectedBundleURL:[[NSBundle mainBundle] URLForResource:@"TestWebKitAPI" withExtension:@"wkbundle"]];
     [processPoolConfiguration setConfigureJSCForTesting:value];
     
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
     [processPool _setObject:className forBundleParameter:TestWebKitAPI::Util::TestPlugInClassNameParameter];
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
 
     return webViewConfiguration.autorelease();

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm
@@ -1002,7 +1002,7 @@ namespace Util {
 
 RetainPtr<TestWebExtensionManager> parseExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration *configuration, BOOL usesEnhancedSecurity)
 {
-    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources]);
+    RetainPtr extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources]);
     return adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get() extensionControllerConfiguration:configuration usesEnhancedSecurity:usesEnhancedSecurity]);
 }
 
@@ -1021,7 +1021,7 @@ void loadAndRunExtension(NSDictionary *manifest, NSDictionary *resources, WKWebE
 NSData *makePNGData(CGSize size, SEL colorSelector)
 {
 #if USE(APPKIT)
-    auto image = adoptNS([[NSImage alloc] initWithSize:size]);
+    RetainPtr image = adoptNS([[NSImage alloc] initWithSize:size]);
 
     [image lockFocus];
 
@@ -1031,7 +1031,7 @@ NSData *makePNGData(CGSize size, SEL colorSelector)
     [image unlockFocus];
 
     auto cgImageRef = [image CGImageForProposedRect:NULL context:nil hints:nil];
-    auto newImageRep = adoptNS([[NSBitmapImageRep alloc] initWithCGImage:cgImageRef]);
+    RetainPtr newImageRep = adoptNS([[NSBitmapImageRep alloc] initWithCGImage:cgImageRef]);
     newImageRep.get().size = size;
 
     return [newImageRep representationUsingType:NSBitmapImageFileTypePNG properties:@{ }];

--- a/Tools/TestWebKitAPI/Helpers/ios/DragAndDropSimulatorIOS.mm
+++ b/Tools/TestWebKitAPI/Helpers/ios/DragAndDropSimulatorIOS.mm
@@ -194,7 +194,7 @@ InteractionType *findInteractionOfType(UIView *view)
 
 - (instancetype)initWithProviders:(NSArray<NSItemProvider *> *)providers location:(CGPoint)locationInWindow window:(UIWindow *)window allowMove:(BOOL)allowMove
 {
-    auto items = adoptNS([[NSMutableArray alloc] init]);
+    RetainPtr items = adoptNS([[NSMutableArray alloc] init]);
     for (NSItemProvider *itemProvider in providers)
         [items addObject:adoptNS([[UIDragItem alloc] initWithItemProvider:itemProvider]).get()];
 

--- a/Tools/TestWebKitAPI/Helpers/ios/PreferredContentMode.mm
+++ b/Tools/TestWebKitAPI/Helpers/ios/PreferredContentMode.mm
@@ -68,7 +68,7 @@
 
 + (instancetype)preferencesWithContentMode:(WKContentMode)mode
 {
-    auto preferences = adoptNS([[self alloc] init]);
+    RetainPtr preferences = adoptNS([[self alloc] init]);
     [preferences setPreferredContentMode:mode];
     return preferences.autorelease();
 }
@@ -171,12 +171,12 @@ namespace TestWebKitAPI {
 template <typename ViewClass>
 RetainPtr<ViewClass> setUpWebViewForPreferredContentModeTestingWithoutNavigationDelegate(std::optional<WKContentMode> defaultContentMode = { }, std::optional<String> applicationNameForUserAgent = { "TestWebKitAPI"_s }, CGSize size = CGSizeMake(1024, 768))
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     if (defaultContentMode)
         [configuration setDefaultWebpagePreferences:[WKWebpagePreferences preferencesWithContentMode:defaultContentMode.value()]];
     if (applicationNameForUserAgent)
         [configuration setApplicationNameForUserAgent:applicationNameForUserAgent->isNull() ? nil : applicationNameForUserAgent.value().createNSString().get()];
-    auto webView = adoptNS([[ViewClass alloc] initWithFrame:CGRectMake(0, 0, size.width, size.height) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[ViewClass alloc] initWithFrame:CGRectMake(0, 0, size.width, size.height) configuration:configuration.get()]);
     EXPECT_TRUE([webView isKindOfClass:WKWebView.class]);
     return webView;
 }
@@ -185,7 +185,7 @@ template <typename ViewClass>
 std::pair<RetainPtr<ViewClass>, RetainPtr<ContentModeNavigationDelegate>> setUpWebViewForPreferredContentModeTesting(std::optional<WKContentMode> defaultContentMode = { }, std::optional<String> applicationNameForUserAgent = { "TestWebKitAPI"_s }, CGSize size = CGSizeMake(1024, 768))
 {
     auto webView = setUpWebViewForPreferredContentModeTestingWithoutNavigationDelegate<ViewClass>(defaultContentMode, applicationNameForUserAgent, size);
-    auto navigationDelegate = adoptNS([[ContentModeNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[ContentModeNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     return { webView, navigationDelegate };
 }

--- a/Tools/TestWebKitAPI/Helpers/mac/DragAndDropSimulatorMac.mm
+++ b/Tools/TestWebKitAPI/Helpers/mac/DragAndDropSimulatorMac.mm
@@ -465,7 +465,7 @@ static BOOL getFilePathsAndTypeIdentifiers(NSArray<NSURL *> *fileURLs, NSArray<N
 
 - (NSArray<NSURL *> *)receivePromisedFiles
 {
-    auto destinationURLs = adoptNS([NSMutableArray new]);
+    RetainPtr destinationURLs = adoptNS([NSMutableArray new]);
     for (NSFilePromiseProvider *provider in _filePromiseProviders.get()) {
         if (!provider.delegate)
             continue;

--- a/Tools/TestWebKitAPI/Helpers/mac/GamepadMappings/GoogleStadia.mm
+++ b/Tools/TestWebKitAPI/Helpers/mac/GamepadMappings/GoogleStadia.mm
@@ -186,7 +186,7 @@ static void publishReportCallback(Vector<float>& buttonValues, Vector<float>& ax
     // Final byte has 5 padding bits, 3 button bits in it, but no way to actuate them
     reportData[reportIndex++] = 0x00;
 
-    auto nsReportData = adoptNS([[NSData alloc] initWithBytes:reportData length:StadiaReportSize]);
+    RetainPtr nsReportData = adoptNS([[NSData alloc] initWithBytes:reportData length:StadiaReportSize]);
     [userDevice handleReport:nsReportData.get() error:nil];
 }
 

--- a/Tools/TestWebKitAPI/Helpers/mac/GamepadMappings/LogitechF310.mm
+++ b/Tools/TestWebKitAPI/Helpers/mac/GamepadMappings/LogitechF310.mm
@@ -125,7 +125,7 @@ static void publishReportCallback(Vector<float>& buttonValues, Vector<float>& ax
     reportData[6] = 0x00;
     reportData[7] = 0xff;
 
-    auto nsReportData = adoptNS([[NSData alloc] initWithBytes:reportData length:F310ReportSize]);
+    RetainPtr nsReportData = adoptNS([[NSData alloc] initWithBytes:reportData length:F310ReportSize]);
     [userDevice handleReport:nsReportData.get() error:nil];
 }
 

--- a/Tools/TestWebKitAPI/Helpers/mac/GamepadMappings/LogitechF710.mm
+++ b/Tools/TestWebKitAPI/Helpers/mac/GamepadMappings/LogitechF710.mm
@@ -136,7 +136,7 @@ static void publishReportCallback(Vector<float>& buttonValues, Vector<float>& ax
     // Final is vendor specific (changes with vibration mode, I know, but not relevant to the gamepad spec at this time)
     reportData[7] = 0x5f;
 
-    auto nsReportData = adoptNS([[NSData alloc] initWithBytes:reportData length:F710ReportSize]);
+    RetainPtr nsReportData = adoptNS([[NSData alloc] initWithBytes:reportData length:F710ReportSize]);
     [userDevice handleReport:nsReportData.get() error:nil];
 }
 

--- a/Tools/TestWebKitAPI/Helpers/mac/GamepadMappings/MicrosoftXboxOne.mm
+++ b/Tools/TestWebKitAPI/Helpers/mac/GamepadMappings/MicrosoftXboxOne.mm
@@ -269,7 +269,7 @@ static void publishReportCallback(Vector<float>& buttonValues, Vector<float>& ax
     // The final byte is the final standalone AC back button
     reportData[reportIndex++] = lround(buttonValues[17]) & 0x01;
 
-    auto nsReportData = adoptNS([[NSData alloc] initWithBytes:reportData length:XboxOneReportSize]);
+    RetainPtr nsReportData = adoptNS([[NSData alloc] initWithBytes:reportData length:XboxOneReportSize]);
     [userDevice handleReport:nsReportData.get() error:nil];
 }
 

--- a/Tools/TestWebKitAPI/Helpers/mac/GamepadMappings/ShenzhenLongshengweiTechnologyGamepad.mm
+++ b/Tools/TestWebKitAPI/Helpers/mac/GamepadMappings/ShenzhenLongshengweiTechnologyGamepad.mm
@@ -134,7 +134,7 @@ static void publishReportCallback(Vector<float>& buttonValues, Vector<float>& ax
 
     reportData[7] = 0x00;
 
-    auto nsReportData = adoptNS([[NSData alloc] initWithBytes:reportData length:SLTGamepadReportSize]);
+    RetainPtr nsReportData = adoptNS([[NSData alloc] initWithBytes:reportData length:SLTGamepadReportSize]);
     [userDevice handleReport:nsReportData.get() error:nil];
 }
 

--- a/Tools/TestWebKitAPI/Helpers/mac/GamepadMappings/SonyDualShock3.mm
+++ b/Tools/TestWebKitAPI/Helpers/mac/GamepadMappings/SonyDualShock3.mm
@@ -181,7 +181,7 @@ static void publishReportCallback(Vector<float>& buttonValues, Vector<float>& ax
     for (size_t i = 4; i < 16; ++i)
         reportData[reportIndex++] = (uint8_t)(buttonValues[i] * 255);
 
-    auto nsReportData = adoptNS([[NSData alloc] initWithBytes:reportData length:Dualshock3ReportSize]);
+    RetainPtr nsReportData = adoptNS([[NSData alloc] initWithBytes:reportData length:Dualshock3ReportSize]);
     [userDevice handleReport:nsReportData.get() error:nil];
 }
 

--- a/Tools/TestWebKitAPI/Helpers/mac/GamepadMappings/SonyDualShock4.mm
+++ b/Tools/TestWebKitAPI/Helpers/mac/GamepadMappings/SonyDualShock4.mm
@@ -308,7 +308,7 @@ static void publishReportCallback(Vector<float>& buttonValues, Vector<float>& ax
     for (size_t i = 4; i < 5; ++i)
         reportData[reportIndex++] = (uint8_t)(axisValues[i] * 255);
 
-    auto nsReportData = adoptNS([[NSData alloc] initWithBytes:reportData length:Dualshock4ReportSize]);
+    RetainPtr nsReportData = adoptNS([[NSData alloc] initWithBytes:reportData length:Dualshock4ReportSize]);
     [userDevice handleReport:nsReportData.get() error:nil];
 }
 

--- a/Tools/TestWebKitAPI/Helpers/mac/GamepadMappings/SteelSeriesNimbus.mm
+++ b/Tools/TestWebKitAPI/Helpers/mac/GamepadMappings/SteelSeriesNimbus.mm
@@ -124,7 +124,7 @@ static void publishReportCallback(Vector<float>& buttonValues, Vector<float>& ax
     for (size_t i = 13; i < 17; ++i)
         reportData[i] = (uint8_t)((int8_t)(axisValues[i - 13] * 127));
 
-    auto nsReportData = adoptNS([[NSData alloc] initWithBytes:reportData length:NimbusInputReportSize]);
+    RetainPtr nsReportData = adoptNS([[NSData alloc] initWithBytes:reportData length:NimbusInputReportSize]);
     [userDevice handleReport:nsReportData.get() error:nil];
 }
 

--- a/Tools/TestWebKitAPI/Helpers/mac/GamepadMappings/SunLightApplicationGenericNES.mm
+++ b/Tools/TestWebKitAPI/Helpers/mac/GamepadMappings/SunLightApplicationGenericNES.mm
@@ -121,7 +121,7 @@ static void publishReportCallback(Vector<float>& buttonValues, Vector<float>& ax
     reportData[6] = 0x00;
     reportData[7] = 0x00;
 
-    auto nsReportData = adoptNS([[NSData alloc] initWithBytes:reportData length:SLAGenericNESReportSize]);
+    RetainPtr nsReportData = adoptNS([[NSData alloc] initWithBytes:reportData length:SLAGenericNESReportSize]);
     [userDevice handleReport:nsReportData.get() error:nil];
 }
 

--- a/Tools/TestWebKitAPI/Helpers/mac/TestFilePromiseReceiver.mm
+++ b/Tools/TestWebKitAPI/Helpers/mac/TestFilePromiseReceiver.mm
@@ -88,7 +88,7 @@ static NSString *fileNameWithNumericSuffix(NSString *fileName, NSUInteger suffix
 
 static NSURL *writeToWebLoc(NSURL *webURL, NSURL *destinationDirectory, NSError **outError)
 {
-    auto components = adoptNS([webURL.absoluteString componentsSeparatedByCharactersInSet:NSCharacterSet.letterCharacterSet.invertedSet].mutableCopy);
+    RetainPtr components = adoptNS([webURL.absoluteString componentsSeparatedByCharactersInSet:NSCharacterSet.letterCharacterSet.invertedSet].mutableCopy);
     [components removeObject:@""];
     NSString *fileName = [[components componentsJoinedByString:@"-"] stringByAppendingPathExtension:@"webloc"];
     NSURL *destinationURL = [NSURL fileURLWithPath:fileName relativeToURL:destinationDirectory];

--- a/Tools/TestWebKitAPI/Helpers/mac/TestFontOptions.mm
+++ b/Tools/TestWebKitAPI/Helpers/mac/TestFontOptions.mm
@@ -182,11 +182,11 @@ static TestFontOptions *sharedFontOptionsForTesting()
 
 - (NSDictionary *)convertAttributes:(NSDictionary *)attributes
 {
-    auto convertedAttributes = adoptNS([attributes mutableCopy]);
+    RetainPtr convertedAttributes = adoptNS([attributes mutableCopy]);
 
     if (_hasPendingShadowChanges) {
         if (_hasShadow) {
-            auto shadow = adoptNS([[NSShadow alloc] init]);
+            RetainPtr shadow = adoptNS([[NSShadow alloc] init]);
             [shadow setShadowBlurRadius:_shadowBlurRadius];
             [shadow setShadowOffset:_shadowOffset];
             [convertedAttributes setObject:shadow.get() forKey:NSShadowAttributeName];

--- a/Tools/TestWebKitAPI/Helpers/mac/VirtualGamepad.mm
+++ b/Tools/TestWebKitAPI/Helpers/mac/VirtualGamepad.mm
@@ -49,8 +49,8 @@ VirtualGamepad::VirtualGamepad(const GamepadMapping& gamepadMapping)
     m_buttonValues = Vector<float>(FillWith { }, m_gamepadMapping.buttonCount, 0.0);
     m_axisValues = Vector<float>(FillWith { }, m_gamepadMapping.axisCount, 0.0);
 
-    auto descriptor = adoptNS([[NSData alloc] initWithBytes:m_gamepadMapping.descriptorData length:m_gamepadMapping.descriptorDataSize]);
-    auto properties = adoptNS([[NSMutableDictionary alloc] init]);
+    RetainPtr descriptor = adoptNS([[NSData alloc] initWithBytes:m_gamepadMapping.descriptorData length:m_gamepadMapping.descriptorDataSize]);
+    RetainPtr properties = adoptNS([[NSMutableDictionary alloc] init]);
 
     properties.get()[@kIOHIDReportDescriptorKey] = descriptor.get();
     properties.get()[@kIOHIDVendorIDKey] = @((uint16_t)m_gamepadMapping.vendorID);

--- a/Tools/TestWebKitAPI/InjectedBundle/mac/InjectedBundleControllerMac.mm
+++ b/Tools/TestWebKitAPI/InjectedBundle/mac/InjectedBundleControllerMac.mm
@@ -34,7 +34,7 @@ namespace TestWebKitAPI {
 void InjectedBundleController::platformInitialize()
 {
     // Set up user defaults.
-    auto argumentDomain = adoptNS([[[NSUserDefaults standardUserDefaults] volatileDomainForName:NSArgumentDomain] mutableCopy]);
+    RetainPtr argumentDomain = adoptNS([[[NSUserDefaults standardUserDefaults] volatileDomainForName:NSArgumentDomain] mutableCopy]);
     if (!argumentDomain)
         argumentDomain = adoptNS([[NSMutableDictionary alloc] init]);
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -174,6 +174,7 @@
 			script = (
 				"\"${SCRIPT_INPUT_FILE_0}\"",
 				"",
+				"",
 			);
 		};
 /* End PBXBuildRule section */

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -844,14 +844,14 @@ static RetainPtr<SecKeyRef> createPrivateKey()
 
 static RetainPtr<NSPersonNameComponents> personNameComponentsForTesting()
 {
-    auto phoneticComponents = adoptNS([[NSPersonNameComponents alloc] init]);
+    RetainPtr phoneticComponents = adoptNS([[NSPersonNameComponents alloc] init]);
     phoneticComponents.get().familyName = @"Family";
     phoneticComponents.get().middleName = @"Middle";
     phoneticComponents.get().namePrefix = @"Doctor";
     phoneticComponents.get().givenName = @"Given";
     phoneticComponents.get().nickname = @"Buddy";
 
-    auto components = adoptNS([[NSPersonNameComponents alloc] init]);
+    RetainPtr components = adoptNS([[NSPersonNameComponents alloc] init]);
     components.get().familyName = @"Familia";
     components.get().middleName = @"Median";
     components.get().namePrefix = @"Physician";
@@ -2010,7 +2010,7 @@ TEST(IPCSerialization, DataDetectors)
     runTestNS({ scannerResult.get() });
 
     // DDActionContext/DDSecureActionContext
-    auto actionContext = adoptNS([PAL::allocWKDDActionContextInstance() init]);
+    RetainPtr actionContext = adoptNS([PAL::allocWKDDActionContextInstance() init]);
     [actionContext setAllResults:@[ (__bridge id)scannerResult.get().coreResult ]];
     [actionContext setMainResult:scannerResult.get().coreResult];
     auto components = personNameComponentsForTesting();

--- a/Tools/TestWebKitAPI/Tests/JavaScriptCore/JSRunLoopTimer.mm
+++ b/Tools/TestWebKitAPI/Tests/JavaScriptCore/JSRunLoopTimer.mm
@@ -87,7 +87,7 @@ TEST(JavaScriptCore, DISABLED_IncrementalSweeperMainThread)
 TEST(JavaScriptCore, IncrementalSweeperMainThread)
 #endif
 {
-    auto context = adoptNS([JSContext new]);
+    RetainPtr context = adoptNS([JSContext new]);
     s_expectedRunLoop = &RunLoop::currentSingleton();
 
     while (!s_done) {
@@ -103,7 +103,7 @@ TEST(JavaScriptCore, DISABLED_IncrementalSweeperSecondaryThread)
 TEST(JavaScriptCore, IncrementalSweeperSecondaryThread)
 #endif
 {
-    auto context = adoptNS([JSContext new]);
+    RetainPtr context = adoptNS([JSContext new]);
     s_expectedRunLoop = &RunLoop::currentSingleton();
 
     while (!s_done) {

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/ContextualizedNSString.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/ContextualizedNSString.mm
@@ -32,7 +32,7 @@ TEST(WTF_ContextualizedNSString, Basic)
 {
     auto context = "abc"_str;
     auto contents = "def"_str;
-    auto contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext:context contents:contents]);
+    RetainPtr contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext:context contents:contents]);
     EXPECT_TRUE([contextualizedString isEqualToString:@"abcdef"]);
     EXPECT_TRUE([@"abcdef" isEqualToString:contextualizedString.get()]);
     EXPECT_EQ(contextualizedString.get().length, 6UL);
@@ -47,7 +47,7 @@ TEST(WTF_ContextualizedNSString, Basic)
 TEST(WTF_ContextualizedNSString, BasicNoContext)
 {
     auto contents = "abc"_str;
-    auto contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext: { } contents:contents]);
+    RetainPtr contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext: { } contents:contents]);
     EXPECT_TRUE([contextualizedString isEqualToString:@"abc"]);
     EXPECT_TRUE([@"abc" isEqualToString:contextualizedString.get()]);
     EXPECT_EQ(contextualizedString.get().length, 3UL);
@@ -60,7 +60,7 @@ TEST(WTF_ContextualizedNSString, getCharacters)
 {
     auto context = "abc"_str;
     auto contents = "def"_str;
-    auto contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext:context contents:contents]);
+    RetainPtr contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext:context contents:contents]);
 
     unichar buffer[7];
     std::ranges::fill(buffer, '\0');
@@ -203,7 +203,7 @@ TEST(WTF_ContextualizedNSString, nonPrimitive)
 {
     auto context = "abc"_str;
     auto contents = "def"_str;
-    auto contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext:context contents:contents]);
+    RetainPtr contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext:context contents:contents]);
 
     EXPECT_TRUE([contextualizedString hasPrefix:@"ab"]);
     EXPECT_TRUE([contextualizedString hasPrefix:@"abcd"]);
@@ -218,10 +218,10 @@ TEST(WTF_ContextualizedNSString, nonPrimitive)
     EXPECT_TRUE([contextualizedString containsString:@"e"]);
     EXPECT_FALSE([contextualizedString containsString:@"cb"]);
 
-    auto copy = adoptNS([contextualizedString copy]);
+    RetainPtr copy = adoptNS([contextualizedString copy]);
     EXPECT_TRUE([copy isEqualToString:@"abcdef"]);
 
-    auto mutableCopy = adoptNS([contextualizedString mutableCopy]);
+    RetainPtr mutableCopy = adoptNS([contextualizedString mutableCopy]);
     EXPECT_TRUE([mutableCopy isEqualToString:@"abcdef"]);
 }
 
@@ -229,7 +229,7 @@ TEST(WTF_ContextualizedNSString, cfString)
 {
     auto context = "abc"_str;
     auto contents = "def"_str;
-    auto contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext:context contents:contents]);
+    RetainPtr contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext:context contents:contents]);
     auto contextualizedCFString = bridge_cast(static_cast<NSString *>(contextualizedString.get()));
 
     EXPECT_EQ(CFStringGetCharacterAtIndex(contextualizedCFString, 0), 'a');
@@ -252,7 +252,7 @@ TEST(WTF_ContextualizedNSString, tokenizer)
 {
     auto context = "th"_str;
     auto contents = "is is some text"_str;
-    auto contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext:context contents:contents]);
+    RetainPtr contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext:context contents:contents]);
     auto contextualizedCFString = bridge_cast(static_cast<NSString *>(contextualizedString.get()));
 
     auto locale = adoptCF(CFLocaleCreate(kCFAllocatorDefault, CFSTR("en_US")));

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm
@@ -204,7 +204,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast)
     }
 
     @autoreleasepool {
-        auto objectNS = adoptNS([[NSString alloc] initWithFormat:@"%s", helloWorldCString]);
+        RetainPtr objectNS = adoptNS([[NSString alloc] initWithFormat:@"%s", helloWorldCString]);
         uintptr_t objectNSPtr;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
             objectNSPtr = reinterpret_cast<uintptr_t>(objectNS.get());
@@ -226,7 +226,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast)
     }
 
     @autoreleasepool {
-        auto objectNS = adoptNS([[NSObject alloc] init]);
+        RetainPtr objectNS = adoptNS([[NSObject alloc] init]);
         uintptr_t objectNSPtr;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
             objectNSPtr = reinterpret_cast<uintptr_t>(objectNS.get());
@@ -297,7 +297,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
     }
 
     @autoreleasepool {
-        auto object = adoptNS([[NSString alloc] initWithFormat:@"%s", helloWorldCString]);
+        RetainPtr object = adoptNS([[NSString alloc] initWithFormat:@"%s", helloWorldCString]);
         uintptr_t objectPtr;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
             objectPtr = reinterpret_cast<uintptr_t>(object.get());

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CoreMediaUtilities.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CoreMediaUtilities.mm
@@ -53,7 +53,7 @@ TEST(PAL, MediaTime)
 static RetainPtr<CMFormatDescriptionRef> makeFormatDescriptionWithTencData(std::span<const uint8_t> tencData)
 {
     auto data = adoptCF(CFDataCreate(kCFAllocatorDefault, tencData.data(), tencData.size()));
-    auto extensions = adoptNS([[NSDictionary alloc] initWithObjectsAndKeys:(__bridge NSData *)data.get(), @"CommonEncryptionTrackEncryptionBox", nil]);
+    RetainPtr extensions = adoptNS([[NSDictionary alloc] initWithObjectsAndKeys:(__bridge NSData *)data.get(), @"CommonEncryptionTrackEncryptionBox", nil]);
     CMFormatDescriptionRef desc = nullptr;
     PAL::CMVideoFormatDescriptionCreate(kCFAllocatorDefault, kCMVideoCodecType_H264, 1920, 1080, (__bridge CFDictionaryRef)extensions.get(), &desc);
     return adoptCF(desc);

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/GraphicsContextCGTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/GraphicsContextCGTests.mm
@@ -121,7 +121,7 @@ TEST(GraphicsContextTests, IOSurfaceRenderingModeIsAccelerated)
 
 TEST(GraphicsContextTests, SmallLayerRenderingModeIsUnaccelerated)
 {
-    auto device = adoptNS(MTLCreateSystemDefaultDevice());
+    RetainPtr device = adoptNS(MTLCreateSystemDefaultDevice());
     if (!device)
         return;
 #if !PLATFORM(IOS_FAMILY)
@@ -158,7 +158,7 @@ TEST(GraphicsContextTests, LargeLayerRenderingModeIsExpected)
 #if PLATFORM(IOS_FAMILY_SIMULATOR)
     expected = WebCore::RenderingMode::Unaccelerated;
 #endif
-    auto device = adoptNS(MTLCreateSystemDefaultDevice());
+    RetainPtr device = adoptNS(MTLCreateSystemDefaultDevice());
     if (!device)
         return;
 #if !PLATFORM(IOS_FAMILY)

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/ScrollbarWidthCrash.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/ScrollbarWidthCrash.mm
@@ -63,7 +63,7 @@ TEST(ScrollbarWidthCrash, DynamicallyChangeScrollbarWidth)
 {
     UISideCompositingScope scope { UISideCompositingState::Disabled };
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
 
     RetainPtr delegate = adoptNS([[CrashNavigationDelegate alloc] init]);
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/WebCoreNSURLSession.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/WebCoreNSURLSession.mm
@@ -138,7 +138,7 @@ public:
 
 TEST_F(WebCoreNSURLSessionTest, BasicOperation)
 {
-    auto session = adoptNS([[WebCoreNSURLSession alloc] initWithResourceLoader:*loader delegate:delegate.get() delegateQueue:[NSOperationQueue mainQueue]]);
+    RetainPtr session = adoptNS([[WebCoreNSURLSession alloc] initWithResourceLoader:*loader delegate:delegate.get() delegateQueue:[NSOperationQueue mainQueue]]);
     didRecieveResponse = false;
     didRecieveData = false;
     didComplete = false;
@@ -166,7 +166,7 @@ TEST_F(WebCoreNSURLSessionTest, DISABLED_InvalidateEmpty)
 TEST_F(WebCoreNSURLSessionTest, InvalidateEmpty)
 #endif
 {
-    auto session = adoptNS([[WebCoreNSURLSession alloc] initWithResourceLoader:*loader delegate:delegate.get() delegateQueue:[NSOperationQueue mainQueue]]);
+    RetainPtr session = adoptNS([[WebCoreNSURLSession alloc] initWithResourceLoader:*loader delegate:delegate.get() delegateQueue:[NSOperationQueue mainQueue]]);
     didInvalidate = false;
     [session finishTasksAndInvalidate];
     TestWebKitAPI::Util::run(&didInvalidate);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/AccessibilityIncreaseContrast.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/AccessibilityIncreaseContrast.mm
@@ -68,11 +68,11 @@ static bool receivedPreferenceNotification = false;
 TEST(WebKit, AccessibilityIncreaseContrast)
 {
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration addToWindow:YES]);
 
     CFPreferencesSetAppValue(INCREASE_CONTRAST_PREFERENCE, kCFBooleanFalse, ACCESSIBILITY_DOMAIN);
 
-    auto observer = adoptNS([[WKPreferenceObserverForTestingIncreaseContrast alloc] init]);
+    RetainPtr observer = adoptNS([[WKPreferenceObserverForTestingIncreaseContrast alloc] init]);
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/AccessibilityReduceMotion.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/AccessibilityReduceMotion.mm
@@ -74,11 +74,11 @@ static bool receivedPreferenceNotification = false;
 TEST(WebKit, AccessibilityReduceMotion)
 {
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration addToWindow:YES]);
 
     CFPreferencesSetAppValue(REDUCED_MOTION_PREFERENCE, kCFBooleanFalse, ACCESSIBILITY_DOMAIN);
 
-    auto observer = adoptNS([[WKPreferenceObserverForTesting alloc] init]);
+    RetainPtr observer = adoptNS([[WKPreferenceObserverForTesting alloc] init]);
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/AccessibilityRemoteUIApp.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/AccessibilityRemoteUIApp.mm
@@ -34,10 +34,10 @@
 
 TEST(WebKit, IsRemoteUIAppForAccessibility)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     auto isRemoteUIApp = [&] {
         return [webView stringByEvaluatingJavaScript:@"window.internals.isRemoteUIAppForAccessibility()"].boolValue;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/Battery.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/Battery.mm
@@ -33,10 +33,10 @@
 
 TEST(WebKit, SystemHasBattery)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     auto hasBattery = [&] {
         return [webView stringByEvaluatingJavaScript:@"window.internals.systemHasBattery()"].boolValue;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/ContextMenuImgWithVideo.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/ContextMenuImgWithVideo.mm
@@ -56,8 +56,8 @@ namespace TestWebKitAPI {
 
 TEST(WebKit, ContextMenuImgWithVideo)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
-    auto uiDelegate = adoptNS([[ContextMenuImgWithVideoDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr uiDelegate = adoptNS([[ContextMenuImgWithVideoDelegate alloc] init]);
     webView.get().UIDelegate = uiDelegate.get();
     [webView synchronouslyLoadTestPageNamed:@"ContextMenuImgWithVideo"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/CustomBundleParameter.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/CustomBundleParameter.mm
@@ -60,7 +60,7 @@ static void didReceiveMessageFromInjectedBundle(WKContextRef context, WKStringRe
     // Attempt to set a parameter using the Objective C API:
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto customObject = adoptNS([[CustomBundleObject alloc] initWithValue:1234]);
+    RetainPtr customObject = adoptNS([[CustomBundleObject alloc] initWithValue:1234]);
     [[configuration processPool] _setObject:customObject.get() forBundleParameter:@"TestParameter1"];
 
     if (loadDone)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/EnableAccessibility.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/EnableAccessibility.mm
@@ -44,9 +44,9 @@ SOFT_LINK_CONSTANT(libAccessibility, kAXSApplicationAccessibilityEnabledNotifica
 TEST(WebKit, EnableAccessibilityCrash)
 {
     {
-        auto poolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
-        auto pool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:poolConfiguration.get()]);
-        auto viewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr poolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+        RetainPtr pool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:poolConfiguration.get()]);
+        RetainPtr viewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
         [viewConfiguration setProcessPool:pool.get()];
     }
 
@@ -57,10 +57,10 @@ TEST(WebKit, EnableAccessibilityCrash)
 
 TEST(WebKit, AccessibilityHasPreferencesServiceAccess)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
@@ -84,10 +84,10 @@ TEST(WebKit, AccessibilityHasPreferencesServiceAccess)
 #if ENABLE(CFPREFS_DIRECT_MODE)
 TEST(WebKit, AccessibilityHasNoPreferencesServiceAccessWhenPostingNotification)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
@@ -106,10 +106,10 @@ TEST(WebKit, AccessibilityHasNoPreferencesServiceAccessWhenPostingNotification)
 #if PLATFORM(IOS_FAMILY)
 TEST(WebKit, AccessibilityHasFrontboardServiceAccess)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
@@ -129,8 +129,8 @@ TEST(WebKit, AccessibilityHasFrontboardServiceAccess)
 
 TEST(WebKit, AccessibilityChildrenPreventsProcessSuspensionOnFrontmostTab)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/FontRegistrySandboxCheck.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/FontRegistrySandboxCheck.mm
@@ -35,11 +35,11 @@
 
 TEST(WebKit, FontdSandboxCheck)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().preferences._shouldAllowUserInstalledFonts = NO;
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     auto sandboxAccess = [&] {
         return [webView stringByEvaluatingJavaScript:@"window.internals.hasSandboxMachLookupAccessToXPCServiceName('com.apple.WebKit.WebContent', 'com.apple.fonts')"].boolValue;
@@ -63,11 +63,11 @@ TEST(WebKit, UserInstalledFontsWork)
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     WKContextSetUsesSingleWebProcess(context.get(), true);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().processPool = (WKProcessPool *)context.get();
     [configuration.get().processPool _warmInitialProcess];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 500) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 500) configuration:configuration.get() addToWindow:YES]);
     [webView synchronouslyLoadTestPageNamed:@"UserInstalledAhem"];
     auto result = [webView stringByEvaluatingJavaScript:@"document.getElementById('target').offsetWidth"].intValue;
     ASSERT_EQ(result, 12 * 48);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/GetBackingScaleFactor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/GetBackingScaleFactor.mm
@@ -71,10 +71,10 @@ TEST(WebKit, GetBackingScaleFactor)
     WKRetainPtr<WKContextRef> context = adoptWK(Util::createContextForInjectedBundleTest("GetBackingScaleFactorTest"));
     setInjectedBundleClient(context.get());
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     configuration.get().processPool = (WKProcessPool *)context.get();
 
-    auto view = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr view = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [view loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
 
     RetainPtr<SyntheticBackingScaleFactorWindow> window1 = createWindow();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/LocalizedDeviceModel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/LocalizedDeviceModel.mm
@@ -35,10 +35,10 @@
 
 TEST(WebKit, LocalizedDeviceModel)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     auto localizedDeviceModel = [&] {
         return [webView stringByEvaluatingJavaScript:@"window.internals.localizedDeviceModel()"].boolValue;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/LogForwarding.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/LogForwarding.mm
@@ -35,11 +35,11 @@
 
 TEST(WebKit, LogForwarding)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
     [webView2 synchronouslyLoadTestPageNamed:@"simple"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/MediaSessionCoordinatorTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/MediaSessionCoordinatorTest.mm
@@ -189,7 +189,7 @@ class MediaSessionCoordinatorTest : public testing::Test {
 public:
     void SetUp() final
     {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         auto preferences = [configuration preferences];
 
         for (_WKFeature *feature in [WKPreferences _features]) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/MobileAssetSandboxCheck.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/MobileAssetSandboxCheck.mm
@@ -35,10 +35,10 @@
 #if !PLATFORM(MAC) || __MAC_OS_X_VERSION_MIN_REQUIRED < 260000
 TEST(WebKit, DISABLED_MobileAssetSandboxCheck)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     auto sandboxAccess = [&] {
         return [webView stringByEvaluatingJavaScript:@"window.internals.hasSandboxMachLookupAccessToXPCServiceName('com.apple.WebKit.WebContent', 'com.apple.mobileassetd.v2')"].boolValue;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/NetworkProcessCrashWithPendingConnection.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/NetworkProcessCrashWithPendingConnection.mm
@@ -108,7 +108,7 @@ TEST(WebKit, NetworkProcessCrashWithPendingConnection)
     kill(relaunchedNetworkProcessIdentifier, SIGKILL);
     Util::run(&networkProcessCrashed);
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     loadedOrCrashed = false;
     [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
         loadedOrCrashed = true;
@@ -126,8 +126,8 @@ TEST(WebKit, NetworkProcessCrashWithPendingConnection)
 
 TEST(WebKit, NetworkProcessRelaunchOnLaunchFailure)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPool = adoptNS([[WKProcessPool alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] init]);
 
     [configuration setProcessPool:processPool.get()];
 
@@ -142,7 +142,7 @@ TEST(WebKit, NetworkProcessRelaunchOnLaunchFailure)
     };
     WKContextSetClient(static_cast<WKContextRef>(processPool.get()), &client.base);
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     testView = webView.get();
 
     // Constucting a WebView starts a network process so terminate this one. The page load below will then request a network process and we
@@ -150,7 +150,7 @@ TEST(WebKit, NetworkProcessRelaunchOnLaunchFailure)
     [WKWebsiteDataStore _makeNextNetworkProcessLaunchFailForTesting];
     [configuration.get().websiteDataStore _terminateNetworkProcess];
 
-    auto delegate = adoptNS([[MonitorWebContentCrashNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[MonitorWebContentCrashNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/OverrideAppleLanguagesPreference.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/OverrideAppleLanguagesPreference.mm
@@ -43,10 +43,10 @@ TEST(WebKit, OverrideAppleLanguagesPreference)
 
     [[NSUserDefaults standardUserDefaults] setVolatileDomain:dict forName:NSArgumentDomain];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     auto preferredLanguage = [&] {
         return [webView stringByEvaluatingJavaScript:@"window.internals.userPreferredLanguages()[0]"];
@@ -64,8 +64,8 @@ TEST(WebKit, OverrideAppleLanguagesPreferenceAffectsNavigatorLanguage)
     };
     [[NSUserDefaults standardUserDefaults] setVolatileDomain:dict forName:NSArgumentDomain];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     EXPECT_WK_STREQ("en-GB", [webView stringByEvaluatingJavaScript:@"window.navigator.language"]);
 }
@@ -78,10 +78,10 @@ public:
     AppleLanguagesTest()
     {
         // Save current system language to restore it later.
-        auto task = adoptNS([[NSTask alloc] init]);
+        RetainPtr task = adoptNS([[NSTask alloc] init]);
         [task setLaunchPath:@"/usr/bin/defaults"];
         [task setArguments:@[@"read", @"NSGlobalDomain", @"AppleLanguages"]];
-        auto pipe = adoptNS([[NSPipe alloc] init]);
+        RetainPtr pipe = adoptNS([[NSPipe alloc] init]);
         [task setStandardOutput:pipe.get()];
         auto fileHandle = [pipe fileHandleForReading];
         [task launch];
@@ -147,8 +147,8 @@ TEST_F(AppleLanguagesTest, DISABLED_UpdateAppleLanguages)
         TestWebKitAPI::Util::runFor(0.1_s);
     EXPECT_WK_STREQ(@"en-GB", getLanguageFromNSUserDefaults());
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
     // We only listen for preference changes when the application is active.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/PictureInPictureSupport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/PictureInPictureSupport.mm
@@ -33,10 +33,10 @@
 
 TEST(WebKit, PictureInPictureSupport)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     auto supportsPictureInPicture = [&] {
         return [webView stringByEvaluatingJavaScript:@"window.internals.supportsPictureInPicture()"].boolValue;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/PreferenceChanges.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/PreferenceChanges.mm
@@ -84,7 +84,7 @@ TEST(WebKit, PreferenceObserver)
 
     CFPreferencesSetAppValue(TEST_KEY(), CFSTR("1"), testDomain);
 
-    auto observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
+    RetainPtr observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
 
     CFPreferencesSetAppValue(TEST_KEY(), CFSTR("2"), testDomain);
 
@@ -101,10 +101,10 @@ TEST(WebKit, PreferenceObserverArray)
 
     NSArray *array = @[@1, @2, @3];
 
-    auto userDefaults = adoptNS([[NSUserDefaults alloc] initWithSuiteName:(NSString *)testDomain]);
+    RetainPtr userDefaults = adoptNS([[NSUserDefaults alloc] initWithSuiteName:(NSString *)testDomain]);
     [userDefaults setObject:array forKey:(NSString *)TEST_KEY()];
 
-    auto observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
+    RetainPtr observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
 
     NSArray *changedArray = @[@3, @2, @1];
     [userDefaults setObject:changedArray forKey:(NSString *)TEST_KEY()];
@@ -125,12 +125,12 @@ TEST(WebKit, PreferenceChanges)
 
     CFPreferencesSetAppValue(TEST_KEY(), CFSTR("0"), testDomain);
 
-    auto observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
+    RetainPtr observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
     
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     [configuration setProcessPool:(WKProcessPool *)context.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
     receivedPreferenceNotification = false;
@@ -166,15 +166,15 @@ TEST(WebKit, PreferenceChangesWithSuspendedProcess)
 
     CFPreferencesSetAppValue(TEST_KEY(), CFSTR("0"), testDomain);
 
-    auto observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
+    RetainPtr observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     [configuration setProcessPool:(WKProcessPool *)context.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:NO]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:NO]);
     [webView2 synchronouslyLoadTestPageNamed:@"simple"];
 
     unsigned attempts = 0;
@@ -209,12 +209,12 @@ TEST(WebKit, GlobalPreferenceChangesUsingDefaultsWrite)
 
     system([NSString stringWithFormat:@"defaults write %@ %@ 0", (__bridge id)globalDomain, (__bridge id)TEST_KEY()].UTF8String);
     
-    auto observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
+    RetainPtr observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
     
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     [configuration setProcessPool:(WKProcessPool *)context.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
     receivedPreferenceNotification = false;
@@ -256,15 +256,15 @@ TEST(WebKit, GlobalPreferenceChangesUsingDefaultsWriteWithSuspendedProcess)
 
     system([NSString stringWithFormat:@"defaults write %@ %@ 0", (__bridge id)globalDomain, (__bridge id)TEST_KEY()].UTF8String);
 
-    auto observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
+    RetainPtr observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     [configuration setProcessPool:(WKProcessPool *)context.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:NO]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:NO]);
     [webView2 synchronouslyLoadTestPageNamed:@"simple"];
     unsigned attempts = 0;
     while (![webView2 _isSuspended] && ++attempts < 5)
@@ -306,17 +306,17 @@ TEST(WebKit, PreferenceChangesArray)
 {
     CLEAR_DEFAULTS();
 
-    auto observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
+    RetainPtr observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
 
     NSArray *array = @[@1, @2, @3];
 
-    auto userDefaults = adoptNS([[NSUserDefaults alloc] initWithSuiteName:(NSString *)testDomain]);
+    RetainPtr userDefaults = adoptNS([[NSUserDefaults alloc] initWithSuiteName:(NSString *)testDomain]);
     [userDefaults setObject:array forKey:(NSString *)TEST_KEY()];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     [configuration setProcessPool:(WKProcessPool *)context.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     auto preferenceValue = [&] {
         waitForPreferenceSynchronization();
@@ -332,7 +332,7 @@ TEST(WebKit, PreferenceChangesArray)
     RetainPtr<NSObject> object;
     for (unsigned i = 0; i < preferenceQueryMaxCount && ![object isEqual:changedArray]; i++) {
         RetainPtr encodedString = preferenceValue();
-        auto encodedData = adoptNS([[NSData alloc] initWithBase64EncodedString:encodedString.get() options:0]);
+        RetainPtr encodedData = adoptNS([[NSData alloc] initWithBase64EncodedString:encodedString.get() options:0]);
         ASSERT_TRUE(encodedData);
         NSError *err = nil;
         object = retainPtr([NSKeyedUnarchiver unarchivedObjectOfClass:[NSObject class] fromData:encodedData.get() error:&err]);
@@ -349,20 +349,20 @@ TEST(WebKit, PreferenceChangesDictionary)
 {
     CLEAR_DEFAULTS();
 
-    auto observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
+    RetainPtr observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
 
     NSDictionary *dict = @{
         @"a" : @1,
         @"b" : @2,
     };
 
-    auto userDefaults = adoptNS([[NSUserDefaults alloc] initWithSuiteName:(NSString *)testDomain]);
+    RetainPtr userDefaults = adoptNS([[NSUserDefaults alloc] initWithSuiteName:(NSString *)testDomain]);
     [userDefaults setObject:dict forKey:(NSString *)TEST_KEY()];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     [configuration setProcessPool:(WKProcessPool *)context.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     auto preferenceValue = [&] {
         waitForPreferenceSynchronization();
@@ -382,7 +382,7 @@ TEST(WebKit, PreferenceChangesDictionary)
     RetainPtr<NSObject> object;
     for (unsigned i = 0; i < preferenceQueryMaxCount && ![object isEqual:changedDict]; i++) {
         RetainPtr encodedString = preferenceValue();
-        auto encodedData = adoptNS([[NSData alloc] initWithBase64EncodedString:encodedString.get() options:0]);
+        RetainPtr encodedData = adoptNS([[NSData alloc] initWithBase64EncodedString:encodedString.get() options:0]);
         ASSERT_TRUE(encodedData);
         NSError *err = nil;
         object = retainPtr([NSKeyedUnarchiver unarchivedObjectOfClass:[NSObject class] fromData:encodedData.get() error:&err]);
@@ -399,17 +399,17 @@ TEST(WebKit, PreferenceChangesData)
 {
     CLEAR_DEFAULTS();
 
-    auto observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
+    RetainPtr observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
 
     NSData *data = [NSData dataWithBytes:"abc" length:3];
 
-    auto userDefaults = adoptNS([[NSUserDefaults alloc] initWithSuiteName:(NSString *)testDomain]);
+    RetainPtr userDefaults = adoptNS([[NSUserDefaults alloc] initWithSuiteName:(NSString *)testDomain]);
     [userDefaults setObject:data forKey:(NSString *)TEST_KEY()];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     [configuration setProcessPool:(WKProcessPool *)context.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     auto preferenceValue = [&] {
         waitForPreferenceSynchronization();
@@ -425,7 +425,7 @@ TEST(WebKit, PreferenceChangesData)
     RetainPtr<NSObject> object;
     for (unsigned i = 0; i < preferenceQueryMaxCount && ![object isEqual:changedData]; i++) {
         RetainPtr encodedString = preferenceValue();
-        auto encodedData = adoptNS([[NSData alloc] initWithBase64EncodedString:encodedString.get() options:0]);
+        RetainPtr encodedData = adoptNS([[NSData alloc] initWithBase64EncodedString:encodedString.get() options:0]);
         ASSERT_TRUE(encodedData);
         NSError *err = nil;
         object = retainPtr([NSKeyedUnarchiver unarchivedObjectOfClass:[NSObject class] fromData:encodedData.get() error:&err]);
@@ -442,17 +442,17 @@ TEST(WebKit, PreferenceChangesDate)
 {
     CLEAR_DEFAULTS();
 
-    auto observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
+    RetainPtr observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
 
     NSDate *date = [NSDate dateWithTimeIntervalSinceNow:0];
 
-    auto userDefaults = adoptNS([[NSUserDefaults alloc] initWithSuiteName:(NSString *)testDomain]);
+    RetainPtr userDefaults = adoptNS([[NSUserDefaults alloc] initWithSuiteName:(NSString *)testDomain]);
     [userDefaults setObject:date forKey:(NSString *)TEST_KEY()];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     [configuration setProcessPool:(WKProcessPool *)context.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     auto preferenceValue = [&] {
         waitForPreferenceSynchronization();
@@ -468,7 +468,7 @@ TEST(WebKit, PreferenceChangesDate)
     RetainPtr<NSObject> object;
     for (unsigned i = 0; i < preferenceQueryMaxCount && ![object isEqual:changedDate]; i++) {
         RetainPtr encodedString = preferenceValue();
-        auto encodedData = adoptNS([[NSData alloc] initWithBase64EncodedString:encodedString.get() options:0]);
+        RetainPtr encodedData = adoptNS([[NSData alloc] initWithBase64EncodedString:encodedString.get() options:0]);
         ASSERT_TRUE(encodedData);
         NSError *err = nil;
         object = retainPtr([NSKeyedUnarchiver unarchivedObjectOfClass:[NSObject class] fromData:encodedData.get() error:&err]);
@@ -485,15 +485,15 @@ TEST(WebKit, PreferenceChangesNil)
 {
     CLEAR_DEFAULTS();
 
-    auto observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
+    RetainPtr observer = adoptNS([[WKTestPreferenceObserver alloc] init]);
 
-    auto userDefaults = adoptNS([[NSUserDefaults alloc] initWithSuiteName:(NSString *)testDomain]);
+    RetainPtr userDefaults = adoptNS([[NSUserDefaults alloc] initWithSuiteName:(NSString *)testDomain]);
     [userDefaults setObject:@1 forKey:(NSString *)TEST_KEY()];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     [configuration setProcessPool:(WKProcessPool *)context.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
     auto preferenceValue = [&] {
@@ -535,10 +535,10 @@ TEST(WebKit, PreferenceObserverStartedOnActivation)
     sharedInstanceMethodOriginal = method_setImplementation(sharedInstanceMethod, (IMP)sharedInstanceMethodOverride);
     ASSERT(sharedInstanceMethodOriginal);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     [configuration setProcessPool:(WKProcessPool *)context.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/SleepDisabler.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/SleepDisabler.mm
@@ -35,10 +35,10 @@
 
 TEST(WebKit, SleepDisabler)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     ASSERT_FALSE([webView _hasSleepDisabler]);
 
@@ -70,7 +70,7 @@ public:
 
     void SetUp() final
     {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         configuration.get()._mediaDataLoadsAutomatically = YES;
         configuration.get().mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
         webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 240) configuration:configuration.get() addToWindow:YES]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/SyscallUnixSandboxCheck.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/SyscallUnixSandboxCheck.mm
@@ -34,10 +34,10 @@
 
 TEST(WebKit, SyscallUnixSandboxCheck)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     auto sandboxAccess = [&](unsigned syscall) {
         auto jsString = [NSString stringWithFormat:@"window.internals.hasSandboxUnixSyscallAccess('com.apple.WebKit.WebContent', %d)", syscall];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/SystemBeep.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/SystemBeep.mm
@@ -35,10 +35,10 @@
 
 TEST(WebKit, SystemBeep)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     [webView stringByEvaluatingJavaScript:@"window.internals.systemBeep()"];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/WebFilter.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/WebFilter.mm
@@ -52,10 +52,10 @@ TEST(WebKit, WebFilterFeatureHasFrontboardServiceAccess)
     isManagedSessionMethodOriginal = method_setImplementation(isManagedSessionMethod, (IMP)isManagedSessionMethodOverride);
     ASSERT(isManagedSessionMethodOriginal);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/mac/CustomProtocolsSyncXHRTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/mac/CustomProtocolsSyncXHRTest.mm
@@ -48,7 +48,7 @@ TEST(WebKit2CustomProtocolsTest, SyncXHR)
     [TestProtocol registerWithScheme:@"http"];
 
     // Allow file URLs to load non-file resources
-    auto wkView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr wkView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     wkView.get().configuration.preferences._universalAccessFromFileURLsAllowed = YES;
     RetainPtr<TestBrowsingContextLoadDelegate> delegate = adoptNS([[TestBrowsingContextLoadDelegate alloc] initWithBlockToRunOnLoad:^(WKWebView *sender) {
         EXPECT_JS_EQ(wkView.get()._pageRefForTransitionToWKWebView, "window._testResult", "PASS");

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/mac/WKThumbnailView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/mac/WKThumbnailView.mm
@@ -55,7 +55,7 @@ static void *snapshotSizeChangeKVOContext = &snapshotSizeChangeKVOContext;
 - (CGImageRef)_test_cgImage
 {
     auto bounds = self.bounds;
-    auto image = adoptNS([[NSImage alloc] initWithSize:bounds.size]);
+    RetainPtr image = adoptNS([[NSImage alloc] initWithSize:bounds.size]);
     [image lockFocus];
     [self.layer renderInContext:NSGraphicsContext.currentContext.CGContext];
     [image unlockFocus];
@@ -208,7 +208,7 @@ TEST(WebKit, WKThumbnailViewMaximumSnapshotSize)
 
 TEST(WebKit, WKThumbnailViewKeepSnapshotWhenRemovedFromSuperviewWKWebView)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     WKPageSetCustomBackingScaleFactor([webView _pageForTesting], 1);
     [webView synchronouslyLoadTestPageNamed:@"lots-of-text"];
 
@@ -247,13 +247,13 @@ TEST(WebKit, WKThumbnailViewKeepSnapshotWhenRemovedFromSuperviewWKWebView)
 
 TEST(WebKit, WKThumbnailViewMaximumSnapshotSizeWKWebView)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     WKPageSetCustomBackingScaleFactor([webView _pageForTesting], 1);
     [webView synchronouslyLoadTestPageNamed:@"lots-of-text"];
 
-    auto thumbnailView = adoptNS([[_WKThumbnailView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) fromWKWebView:webView.get()]);
+    RetainPtr thumbnailView = adoptNS([[_WKThumbnailView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) fromWKWebView:webView.get()]);
 
-    auto observer = adoptNS([[SnapshotSizeObserver alloc] init]);
+    RetainPtr observer = adoptNS([[SnapshotSizeObserver alloc] init]);
     
     [thumbnailView addObserver:observer.get() forKeyPath:@"snapshotSize" options:NSKeyValueObservingOptionNew context:snapshotSizeChangeKVOContext];
     
@@ -293,13 +293,13 @@ TEST(WebKit, WKThumbnailViewMaximumSnapshotSizeWKWebView)
 TEST(WebKit, WKThumbnailViewResetsViewStateWhenUnparented)
 {
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
     [webView removeFromSuperview];
     [webView synchronouslyLoadTestPageNamed:@"lots-of-text"];
 
-    auto thumbnailView = adoptNS([[_WKThumbnailView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) fromWKWebView:webView.get()]);
+    RetainPtr thumbnailView = adoptNS([[_WKThumbnailView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) fromWKWebView:webView.get()]);
 
-    auto observer = adoptNS([[SnapshotSizeObserver alloc] init]);
+    RetainPtr observer = adoptNS([[SnapshotSizeObserver alloc] init]);
 
     [thumbnailView addObserver:observer.get() forKeyPath:@"snapshotSize" options:NSKeyValueObservingOptionNew context:snapshotSizeChangeKVOContext];
 
@@ -342,7 +342,7 @@ static std::pair<WebCore::Color, WebCore::Color> leftCornerColorsForThumbnailVie
 
 void checkThumbnailViewSnapshotConsistency(TestWKWebView *webView)
 {
-    auto thumbnail = adoptNS([[_WKThumbnailView alloc] initWithFrame:webView.frame fromWKWebView:webView]);
+    RetainPtr thumbnail = adoptNS([[_WKThumbnailView alloc] initWithFrame:webView.frame fromWKWebView:webView]);
     [webView.window.contentView addSubview:thumbnail.get()];
 
     auto [topLeftBeforeSnapshot, bottomLeftBeforeSnapshot] = leftCornerColorsForThumbnailView(thumbnail.get());
@@ -357,7 +357,7 @@ TEST(WebKit, WKThumbnailViewLayerReparentingWithUISideCompositing)
 {
     UISideCompositingScope scope { UISideCompositingState::Enabled };
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView synchronouslyLoadTestPageNamed:@"fixed-nav-bar"];
     [webView waitForNextPresentationUpdate];
 
@@ -368,7 +368,7 @@ TEST(WebKit, WKThumbnailViewLayerReparentingWithUISideCompositingAndTopContentIn
 {
     UISideCompositingScope scope { UISideCompositingState::Enabled };
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView _setAutomaticallyAdjustsContentInsets:NO];
     [webView _setTopContentInset:100];
     [webView synchronouslyLoadTestPageNamed:@"fixed-nav-bar"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AVFoundationPreference.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AVFoundationPreference.mm
@@ -56,7 +56,7 @@ public:
     {
         m_configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-        auto handler = adoptNS([[PreferenceTestMessageHandler alloc] init]);
+        RetainPtr handler = adoptNS([[PreferenceTestMessageHandler alloc] init]);
         [[m_configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     }
 
@@ -73,7 +73,7 @@ public:
         m_configuration.get()._inlineMediaPlaybackRequiresPlaysInlineAttribute = NO;
 #endif
 
-        auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:m_configuration.get()]);
+        RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:m_configuration.get()]);
         [webView synchronouslyLoadTestPageNamed:@"video"];
 
         [webView stringByEvaluatingJavaScript:[NSString stringWithFormat:@"test('%s')", elementType == ElementType::Audio ? "audio" : "video"]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdaptiveImageGlyph.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdaptiveImageGlyph.mm
@@ -193,7 +193,7 @@ namespace TestWebKitAPI {
 
 TEST(AdaptiveImageGlyph, SupportsAdaptiveImageGlyphNotEditing)
 {
-    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView _setEditable:YES];
 
     EXPECT_FALSE([webView canInsertAdaptiveImageGlyphs]);
@@ -201,7 +201,7 @@ TEST(AdaptiveImageGlyph, SupportsAdaptiveImageGlyphNotEditing)
 
 TEST(AdaptiveImageGlyph, SupportsAdaptiveImageGlyphEditableView)
 {
-    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView _setEditable:YES];
 
     [webView synchronouslyLoadHTMLString:@"<body></body>"];
@@ -212,7 +212,7 @@ TEST(AdaptiveImageGlyph, SupportsAdaptiveImageGlyphEditableView)
 
 TEST(AdaptiveImageGlyph, SupportsAdaptiveImageGlyphContenteditable)
 {
-    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
 
     [webView synchronouslyLoadHTMLString:@"<body contenteditable></body>"];
     [webView focusElementAndEnsureEditorStateUpdate:@"document.body"];
@@ -222,7 +222,7 @@ TEST(AdaptiveImageGlyph, SupportsAdaptiveImageGlyphContenteditable)
 
 TEST(AdaptiveImageGlyph, SupportsAdaptiveImageGlyphContenteditablePlaintextOnly)
 {
-    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
 
     [webView synchronouslyLoadHTMLString:@"<body contenteditable=\"plaintext-only\"></body>"];
     [webView focusElementAndEnsureEditorStateUpdate:@"document.body"];
@@ -232,7 +232,7 @@ TEST(AdaptiveImageGlyph, SupportsAdaptiveImageGlyphContenteditablePlaintextOnly)
 
 TEST(AdaptiveImageGlyph, SupportsAdaptiveImageGlyphInputElement)
 {
-    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
 
     [webView synchronouslyLoadHTMLString:@"<body><input id=\"input\"></body>"];
     [webView focusElementAndEnsureEditorStateUpdate:@"input"];
@@ -242,14 +242,14 @@ TEST(AdaptiveImageGlyph, SupportsAdaptiveImageGlyphInputElement)
 
 TEST(AdaptiveImageGlyph, SupportsAdaptiveImageGlyphNotEditingWithConfiguration)
 {
-    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configurationForAdaptiveImageGlyphWebView().get()]);
+    RetainPtr webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configurationForAdaptiveImageGlyphWebView().get()]);
 
     EXPECT_FALSE([webView canInsertAdaptiveImageGlyphs]);
 }
 
 TEST(AdaptiveImageGlyph, SupportsAdaptiveImageGlyphEditableViewWithConfiguration)
 {
-    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configurationForAdaptiveImageGlyphWebView().get()]);
+    RetainPtr webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configurationForAdaptiveImageGlyphWebView().get()]);
     [webView _setEditable:YES];
 
     [webView synchronouslyLoadHTMLString:@"<body></body>"];
@@ -260,7 +260,7 @@ TEST(AdaptiveImageGlyph, SupportsAdaptiveImageGlyphEditableViewWithConfiguration
 
 TEST(AdaptiveImageGlyph, SupportsAdaptiveImageGlyphContenteditableWithConfiguration)
 {
-    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configurationForAdaptiveImageGlyphWebView().get()]);
+    RetainPtr webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configurationForAdaptiveImageGlyphWebView().get()]);
 
     [webView synchronouslyLoadHTMLString:@"<body contenteditable></body>"];
     [webView focusElementAndEnsureEditorStateUpdate:@"document.body"];
@@ -270,7 +270,7 @@ TEST(AdaptiveImageGlyph, SupportsAdaptiveImageGlyphContenteditableWithConfigurat
 
 TEST(AdaptiveImageGlyph, SupportsAdaptiveImageGlyphContenteditablePlaintextOnlyWithConfiguration)
 {
-    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configurationForAdaptiveImageGlyphWebView().get()]);
+    RetainPtr webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configurationForAdaptiveImageGlyphWebView().get()]);
 
     [webView synchronouslyLoadHTMLString:@"<body contenteditable=\"plaintext-only\"></body>"];
     [webView focusElementAndEnsureEditorStateUpdate:@"document.body"];
@@ -280,7 +280,7 @@ TEST(AdaptiveImageGlyph, SupportsAdaptiveImageGlyphContenteditablePlaintextOnlyW
 
 TEST(AdaptiveImageGlyph, SupportsAdaptiveImageGlyphInputElementWithConfiguration)
 {
-    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configurationForAdaptiveImageGlyphWebView().get()]);
+    RetainPtr webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configurationForAdaptiveImageGlyphWebView().get()]);
 
     [webView synchronouslyLoadHTMLString:@"<body><input id=\"input\"></body>"];
     [webView focusElementAndEnsureEditorStateUpdate:@"input"];
@@ -290,7 +290,7 @@ TEST(AdaptiveImageGlyph, SupportsAdaptiveImageGlyphInputElementWithConfiguration
 
 TEST(AdaptiveImageGlyph, InsertAdaptiveImageGlyphAsPictureElement)
 {
-    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView _setEditable:YES];
 
     [webView synchronouslyLoadHTMLString:@"<body></body>"];
@@ -331,7 +331,7 @@ TEST(AdaptiveImageGlyph, InsertAdaptiveImageGlyphAsPictureElement)
 
 TEST(AdaptiveImageGlyph, InsertAdaptiveImageGlyphAtLargerFontSize)
 {
-    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView _setEditable:YES];
 
     [webView synchronouslyLoadHTMLString:@"<body style='font-size: 64px;'></body>"];
@@ -376,10 +376,10 @@ TEST(AdaptiveImageGlyph, InsertAdaptiveImageGlyphMatchStyle)
 
 TEST(AdaptiveImageGlyph, InsertAndRemoveWKAttachments)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAttachmentElementEnabled:YES];
 
-    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
     [webView _setEditable:YES];
 
     [webView synchronouslyLoadHTMLString:@"<body></body>"];
@@ -451,15 +451,15 @@ TEST(AdaptiveImageGlyph, InsertWKAttachmentsOnPaste)
     RetainPtr stringData = [attributedString dataFromRange:NSMakeRange(0, [attributedString length]) documentAttributes:@{ } error:nil];
     [[UIPasteboard generalPasteboard] setData:stringData.get() forPasteboardType:UTTypeFlatRTFD.identifier];
 #else
-    auto item = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr item = adoptNS([[NSItemProvider alloc] init]);
     [item registerObject:attributedString.get() visibility:NSItemProviderRepresentationVisibilityAll];
     [UIPasteboard generalPasteboard].itemProviders = @[ item.get() ];
 #endif
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAttachmentElementEnabled:YES];
 
-    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
     [webView _setEditable:YES];
 
     [webView synchronouslyLoadHTMLString:@"<body></body>"];
@@ -496,10 +496,10 @@ TEST(AdaptiveImageGlyph, InsertWKAttachmentsOnPaste)
 
 TEST(AdaptiveImageGlyph, InsertWKAttachmentsCopyFromWebViewPasteToWebView)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAttachmentElementEnabled:YES];
 
-    auto copyWebView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr copyWebView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
     [copyWebView _setEditable:YES];
 
     [copyWebView synchronouslyLoadHTMLString:@"<body></body>"];
@@ -513,7 +513,7 @@ TEST(AdaptiveImageGlyph, InsertWKAttachmentsCopyFromWebViewPasteToWebView)
     [copyWebView selectAll:nil];
     [copyWebView _synchronouslyExecuteEditCommand:@"Copy" argument:nil];
 
-    auto pasteWebView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr pasteWebView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
     [pasteWebView _setEditable:YES];
 
     [pasteWebView synchronouslyLoadHTMLString:@"<body></body>"];
@@ -548,10 +548,10 @@ TEST(AdaptiveImageGlyph, InsertWKAttachmentsCopyFromWebViewPasteToWebView)
 
 TEST(AdaptiveImageGlyph, InsertWKAttachmentsMovingParagraphs)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAttachmentElementEnabled:YES];
 
-    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
     [webView _setEditable:YES];
 
     [webView synchronouslyLoadHTMLString:@"<body dir='auto' role='textbox' aria-label='Message Body'><br><div id='AppleMailSignature' dir='ltr'><!-- signature open -->Sent from my iPhone <!-- signature close --></div></body>"];
@@ -603,7 +603,7 @@ TEST(AdaptiveImageGlyph, InsertWKAttachmentsMovingParagraphs)
 
 TEST(AdaptiveImageGlyph, InsertMultiple)
 {
-    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 800)]);
+    RetainPtr webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 800)]);
     [webView _setEditable:YES];
 
     [webView synchronouslyLoadHTMLString:@"<body dir='auto' role='textbox' aria-label='Message Body'><div><br></div><div><br></div><div><br></div><div id='start'><br></div><div><br></div><div><br></div><div><br></div><div><br></div><br id='lineBreakAtBeginningOfSignature'><div id='AppleMailSignature' dir='ltr'><!-- signature open -->Sent from my iPhone<!-- signature close --></div></body>"];
@@ -701,7 +701,7 @@ TEST(AdaptiveImageGlyph, InsertTextAfterAdaptiveImageGlyph)
 
 TEST(AdaptiveImageGlyph, CopyRTF)
 {
-    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
 
 #if PLATFORM(IOS_FAMILY)
     auto preferences = (__bridge WKPreferencesRef)[[webView configuration] preferences];
@@ -744,7 +744,7 @@ TEST(AdaptiveImageGlyph, CopyRTF)
 
 TEST(AdaptiveImageGlyph, ContentsAsAttributedString)
 {
-    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView _setEditable:YES];
 
     [webView synchronouslyLoadHTMLString:@"<body></body>"];
@@ -790,7 +790,7 @@ TEST(AdaptiveImageGlyph, ContentsAsAttributedString)
 
 TEST(AdaptiveImageGlyph, DragAdaptiveImageGlyphFromContentEditable)
 {
-    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configurationForAdaptiveImageGlyphWebView().get()]);
+    RetainPtr webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configurationForAdaptiveImageGlyphWebView().get()]);
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
         "<head>"
@@ -821,7 +821,7 @@ TEST(AdaptiveImageGlyph, DragAdaptiveImageGlyphFromContentEditable)
     [webView insertAdaptiveImageGlyph:adaptiveImageGlyph.get()];
     [webView waitForNextPresentationUpdate];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(100, 100) to:CGPointMake(100, 300)];
 
     EXPECT_WK_STREQ("", [webView stringByEvaluatingJavaScript:@"target.textContent"]);
@@ -902,7 +902,7 @@ TEST(AdaptiveImageGlyph, DropAdaptiveImageGlyphAsSticker)
 
 TEST(AdaptiveImageGlyph, AttributedStringDocumentEditingContext)
 {
-    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView _setEditable:YES];
 
     [webView synchronouslyLoadHTMLString:@"<body style='font-family: Arial; font-size: 20px;'></body>"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdditionalReadAccessAllowedURLs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdditionalReadAccessAllowedURLs.mm
@@ -82,7 +82,7 @@ TEST(WebKit, AdditionalReadAccessAllowedURLs)
 
     processPoolConfiguration.additionalReadAccessAllowedURLs = @[ readableDirectoryURL.get() ];
 
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration]);
     [processPool _setObject:@"AdditionalReadAccessAllowedURLsPlugIn" forBundleParameter:TestWebKitAPI::Util::TestPlugInClassNameParameter];
     [configuration setProcessPool:processPool.get()];
 
@@ -131,7 +131,7 @@ TEST(WebKit, NSAttributedStringWithReadOnlyPaths)
         EXPECT_TRUE(error.code == NSFileWriteFileExistsError);
 
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
-    auto options = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:@[ readableDirectoryURL.get() ], _WKReadAccessFileURLsOption, nil]);
+    RetainPtr options = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:@[ readableDirectoryURL.get() ], _WKReadAccessFileURLsOption, nil]);
 ALLOW_NEW_API_WITHOUT_GUARDS_END
 
     NSString *testString = [NSString stringWithFormat:@"<p>Hello<img src='%@'></p><p>World<img src='%@'></p>", [readableFileURL absoluteString], [unreadableFileURL absoluteString]];
@@ -182,7 +182,7 @@ TEST(WebKit, NSAttributedStringWithAndWithoutReadOnlyPaths)
         EXPECT_TRUE(error.code == NSFileWriteFileExistsError);
     
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
-    auto options = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:@[ readableDirectoryURL.get() ], _WKReadAccessFileURLsOption, nil]);
+    RetainPtr options = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:@[ readableDirectoryURL.get() ], _WKReadAccessFileURLsOption, nil]);
 ALLOW_NEW_API_WITHOUT_GUARDS_END
 
     NSString *testString = [NSString stringWithFormat:@"<p>Hello<img src='%@'></p><p>World<img src='%@'></p>", [readableFileURL absoluteString], [unreadableFileURL absoluteString]];
@@ -255,7 +255,7 @@ TEST(WebKit, NSAttributedStringWithTooManyReadOnlyPaths)
     NSURL *bundlePathURL = [NSURL fileURLWithPath:[[NSBundle mainBundle] bundlePath]];
 
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
-    auto options = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:@[ readableDirectoryURL.get(), unreadableDirectoryURL.get(), bundlePathURL ], _WKReadAccessFileURLsOption, nil]);
+    RetainPtr options = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:@[ readableDirectoryURL.get(), unreadableDirectoryURL.get(), bundlePathURL ], _WKReadAccessFileURLsOption, nil]);
 ALLOW_NEW_API_WITHOUT_GUARDS_END
 
     bool exceptionRaised = false;
@@ -276,7 +276,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 TEST(WebKit, NSAttributedStringWithInvalidReadOnlyPaths)
 {
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
-    auto options = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:@[ @"/some/random/path" ], _WKReadAccessFileURLsOption, nil]);
+    RetainPtr options = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:@[ @"/some/random/path" ], _WKReadAccessFileURLsOption, nil]);
 ALLOW_NEW_API_WITHOUT_GUARDS_END
 
     bool exceptionRaised = false;
@@ -297,7 +297,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     NSURL* testURL = [NSURL URLWithString:@"https://example.com"];
-    auto options2 = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:@[ testURL ], _WKReadAccessFileURLsOption, nil]);
+    RetainPtr options2 = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:@[ testURL ], _WKReadAccessFileURLsOption, nil]);
 ALLOW_NEW_API_WITHOUT_GUARDS_END
     exceptionRaised = false;
     @try {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdvancedPrivacyProtections.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdvancedPrivacyProtections.mm
@@ -109,7 +109,7 @@ static IMP makeQueryParameterRequestHandler(NSArray<NSString *> *parameters, NSA
 {
     return imp_implementationWithBlock([&didHandleRequest, parameters = RetainPtr { parameters }, domains = RetainPtr { domains }, paths = RetainPtr { paths }](WPResources *, WPResourceRequestOptions *, void(^completion)(WPLinkFilteringData *, NSError *)) mutable {
         RunLoop::mainSingleton().dispatch([&didHandleRequest, parameters = WTF::move(parameters), domains = WTF::move(domains), paths = WTF::move(paths), completion = makeBlockPtr(completion)]() mutable {
-            auto data = adoptNS([PAL::allocWPLinkFilteringDataInstance() initWithQueryParameters:parameters.get()
+            RetainPtr data = adoptNS([PAL::allocWPLinkFilteringDataInstance() initWithQueryParameters:parameters.get()
 #if defined(HAS_WEB_PRIVACY_LINK_FILTERING_RULE_PATH)
                 domains:domains.get() paths:paths.get()
 #endif
@@ -124,7 +124,7 @@ static IMP makeAllowedLinkFilteringDataRequestHandler(NSArray<NSString *> *param
 {
     return imp_implementationWithBlock([parameters = RetainPtr { parameters }](WPResources *, WPResourceRequestOptions *, void(^completion)(WPLinkFilteringData *, NSError *)) mutable {
         RunLoop::mainSingleton().dispatch([parameters = WTF::move(parameters), completion = makeBlockPtr(completion)]() mutable {
-            auto data = adoptNS([PAL::allocWPLinkFilteringDataInstance() initWithQueryParameters:parameters.get()]);
+            RetainPtr data = adoptNS([PAL::allocWPLinkFilteringDataInstance() initWithQueryParameters:parameters.get()]);
             completion(data.get(), nil);
         });
     });
@@ -188,7 +188,7 @@ static RetainPtr<TestWKWebView> createWebViewWithAdvancedPrivacyProtections(BOOL
     preferences = preferences ?: adoptNS([WKWebpagePreferences new]);
     [preferences _setNetworkConnectionIntegrityPolicy:policies];
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:store];
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
     [configuration setDefaultWebpagePreferences:preferences.get()];
@@ -315,7 +315,7 @@ TEST(AdvancedPrivacyProtections, RemoveTrackingQueryParametersWhenNavigatingWith
     [TestProtocol registerWithScheme:@"https"];
     QueryParameterRequestSwizzler swizzler { @[ @"foo", @"bar", @"baz" ], @[ @"", @"", @"" ], @[ @"", @"", @"" ] };
 
-    auto preferences = adoptNS([WKWebpagePreferences new]);
+    RetainPtr preferences = adoptNS([WKWebpagePreferences new]);
     [preferences _setContentBlockersEnabled:NO];
     auto webView = createWebViewWithAdvancedPrivacyProtections(YES, preferences.get());
     auto url = [NSURL URLWithString:@"https://bundle-file/simple.html?foo=10&garply=20&bar=30&baz=40"];
@@ -476,7 +476,7 @@ TEST(AdvancedPrivacyProtections, RemoveTrackingQueryParametersWhenDecidingNaviga
     auto webView = createWebViewWithAdvancedPrivacyProtections();
     [webView synchronouslyLoadHTMLString:@"<body><a href='https://bundle-file/simple.html?foo=10&garply=20&bar=30&baz=40'>Link</a></body>"];
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     bool didCallDecisionHandler = false;
@@ -499,7 +499,7 @@ TEST(AdvancedPrivacyProtections, RemoveTrackingQueryParametersForMainResourcesOn
     QueryParameterRequestSwizzler blockListSwizzler { @[ @"blockThis" ], @[ @"" ], @[ @"" ] };
 
     auto webView = createWebViewWithAdvancedPrivacyProtections();
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
 
     __block Vector<std::pair<String, String>> adjustedURLStrings;
     [navigationDelegate setDidChangeLookalikeCharactersFromURL:^(WKWebView *, NSURL *originalURL, NSURL *adjustedURL) {
@@ -582,7 +582,7 @@ TEST(AdvancedPrivacyProtections, ApplyNavigationalProtectionsAfterMultiplePSON)
     __block bool finishedSuccessfully { false };
     __block RetainPtr<NSURL> targetURL;
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     navigationDelegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         if ([action.request.URL.host isEqualToString:@"127.0.0.1"])
             didCallDecisionHandler = true;
@@ -652,14 +652,14 @@ static RetainPtr<TestWKWebView> setUpWebViewForTestingQueryParameterHiding(NSStr
     auto *store = WKWebsiteDataStore.nonPersistentDataStore;
     store._resourceLoadStatisticsEnabled = YES;
 
-    auto preferences = adoptNS([WKWebpagePreferences new]);
+    RetainPtr preferences = adoptNS([WKWebpagePreferences new]);
     [preferences _setNetworkConnectionIntegrityPolicy:_WKWebsiteNetworkConnectionIntegrityPolicyEnabled];
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:store];
     [configuration setDefaultWebpagePreferences:preferences.get()];
 
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSString *path = task.request.URL.path;
         NSString *type = nil;
@@ -684,7 +684,7 @@ static RetainPtr<TestWKWebView> setUpWebViewForTestingQueryParameterHiding(NSStr
             return;
         }
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:type expectedContentLength:[result length] textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:type expectedContentLength:[result length] textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[result dataUsingEncoding:NSUTF8StringEncoding]];
         [task didFinish];
@@ -799,18 +799,18 @@ static RetainPtr<TestWKWebView> setUpWebViewForTestingTrackerDomainBlocking(Stri
         { "/initialize"_s, { { }, "initialize"_s } },
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto store = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);;
+    RetainPtr store = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
     store.get()._resourceLoadStatisticsEnabled = YES;
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:store.get()];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
 
     RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
@@ -1006,15 +1006,15 @@ TEST(AdvancedPrivacyProtections, LinkPreconnectUsesEnhancedPrivacy)
 
 static RetainPtr<TestWKWebView> webViewAfterCrossSiteNavigationWithReducedPrivacy(NSString *initialURLString, bool withRedirect = false)
 {
-    auto preferences = adoptNS([WKWebpagePreferences new]);
+    RetainPtr preferences = adoptNS([WKWebpagePreferences new]);
     [preferences _setNetworkConnectionIntegrityPolicy:_WKWebsiteNetworkConnectionIntegrityPolicyNone];
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setDefaultWebpagePreferences:preferences.get()];
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     [webView loadRequest:adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:initialURLString]).get()]).get()];
@@ -1089,17 +1089,17 @@ TEST(AdvancedPrivacyProtections, ConsistentlyFilterQueryParametersOnSource)
         { "/destination.html"_s, { "<script>window.result = location.href;</script>"_s } },
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(server.port())
     }];
 
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
 
     RetainPtr webView = createWebViewLinkDecorationFiltering(YES, dataStore.get());
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [navigationDelegate allowAnyTLSCertificate];
 
@@ -1160,17 +1160,17 @@ TEST(AdvancedPrivacyProtections, ConsistentlyFilterQueryParametersOnDestination)
         { "/destination.html"_s, { "<script>window.result = location.href;</script>"_s } },
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(server.port())
     }];
 
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
 
     RetainPtr webView = createWebViewLinkDecorationFiltering(YES, dataStore.get());
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [navigationDelegate allowAnyTLSCertificate];
 
@@ -1194,7 +1194,7 @@ TEST(AdvancedPrivacyProtections, HideScreenMetricsFromBindings)
 
     [TestProtocol registerWithScheme:@"https"];
 
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
 #if PLATFORM(MAC)
     [uiDelegate setGetWindowFrameWithCompletionHandler:^(WKWebView *view, void(^completionHandler)(CGRect)) {
         auto viewBounds = view.bounds;
@@ -1336,7 +1336,7 @@ TEST(AdvancedPrivacyProtections, AddNoiseToWebAudioAPIsAfterMultiplePSON)
     __block bool didCallDecisionHandler { false };
     __block bool finishedSuccessfully { false };
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     navigationDelegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         if ([action.request.URL.host isEqualToString:@"bundle-file"])
             didCallDecisionHandler = true;
@@ -1378,7 +1378,7 @@ TEST(AdvancedPrivacyProtections, AddNoiseToWebAudioAPIsAfterReducingPrivacyProte
 
     server.addResponse("/index1.html"_s, { makeString("<a href='http://127.0.0.1:"_s, server.port(), "/index2.html'>Link</a>"_s) });
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate setDecidePolicyForNavigationActionWithPreferences:[&](WKNavigationAction *action, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         [preferences _setNetworkConnectionIntegrityPolicy:_WKWebsiteNetworkConnectionIntegrityPolicyEnabled | _WKWebsiteNetworkConnectionIntegrityPolicySanitizeLookalikeCharacters | _WKWebsiteNetworkConnectionIntegrityPolicyEnhancedTelemetry];
         decisionHandler(WKNavigationActionPolicyAllow, preferences);
@@ -1605,16 +1605,16 @@ TEST(AdvancedPrivacyProtections, Canvas2DQuirks)
         { "/"_s, { { }, "index"_s } },
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
     auto webView = createWebViewWithAdvancedPrivacyProtections(YES, { }, dataStore.get());
 
     __block bool finishedSuccessfully { false };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
     };

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AlwaysRevalidatedURLSchemes.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AlwaysRevalidatedURLSchemes.mm
@@ -59,8 +59,8 @@ static size_t loadsStarted;
 {
     ++loadsStarted;
 
-    auto data = adoptNS([[NSData alloc] initWithBase64EncodedString:@"iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAFZJREFUeF59z4EJADEIQ1F36k7u5E7ZKXeUQPACJ3wK7UNokVxVk9kHnQH7bY9hbDyDhNXgjpRLqFlo4M2GgfyJHhjq8V4agfrgPQX3JtJQGbofmCHgA/nAKks+JAjFAAAAAElFTkSuQmCC" options:0]);
-    auto response = adoptNS([[NSURLResponse alloc] initWithURL:self.request.URL MIMEType:@"image/png" expectedContentLength:[data length] textEncodingName:nil]);
+    RetainPtr data = adoptNS([[NSData alloc] initWithBase64EncodedString:@"iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAFZJREFUeF59z4EJADEIQ1F36k7u5E7ZKXeUQPACJ3wK7UNokVxVk9kHnQH7bY9hbDyDhNXgjpRLqFlo4M2GgfyJHhjq8V4agfrgPQX3JtJQGbofmCHgA/nAKks+JAjFAAAAAElFTkSuQmCC" options:0]);
+    RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:self.request.URL MIMEType:@"image/png" expectedContentLength:[data length] textEncodingName:nil]);
     [self.client URLProtocol:self didReceiveResponse:response.get() cacheStoragePolicy:NSURLCacheStorageNotAllowed];
     [self.client URLProtocol:self didLoadData:data.get()];
     [self.client URLProtocolDidFinishLoading:self];
@@ -78,14 +78,14 @@ TEST(WebKit, AlwaysRevalidatedURLSchemes)
         [NSURLProtocol registerClass:[AlwaysRevalidatedURLSchemeProtocol class]];
         [WKBrowsingContextController registerSchemeForCustomProtocol:customScheme];
 
-        auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+        RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
         [processPoolConfiguration setAlwaysRevalidatedURLSchemes:@[customScheme]];
 
-        auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
-        auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+        RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
         [webViewConfiguration setProcessPool:processPool.get()];
 
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:webViewConfiguration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:webViewConfiguration.get()]);
 
         NSString *htmlString = [NSString stringWithFormat:@"<!DOCTYPE html><body><img src='%@://image'>", customScheme];
         [webView loadHTMLString:htmlString baseURL:nil];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AnimatedResize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AnimatedResize.mm
@@ -75,21 +75,21 @@ static bool didChangeSafeAreaShouldAffectObscuredInsets;
 
 static RetainPtr<AnimatedResizeWebView> createAnimatedResizeWebView()
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     [processPoolConfiguration setIgnoreSynchronousMessagingTimeoutsForTesting:YES];
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
 
-    auto webView = adoptNS([[AnimatedResizeWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[AnimatedResizeWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
     return webView;
 }
 
 static RetainPtr<TestNavigationDelegate> createFirstVisuallyNonEmptyWatchingNavigationDelegate()
 {
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [navigationDelegate setRenderingProgressDidChange:^(WKWebView *, _WKRenderingProgressEvents progressEvents) {
         if (progressEvents & _WKRenderingProgressEventFirstVisuallyNonEmptyLayout)
             didLayout = true;
@@ -104,7 +104,7 @@ TEST(AnimatedResize, DISABLED_ResizeWithHiddenContentDoesNotHang)
 
     auto navigationDelegate = createFirstVisuallyNonEmptyWatchingNavigationDelegate();
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [window addSubview:webView.get()];
     [window setHidden:NO];
 
@@ -128,7 +128,7 @@ TEST(AnimatedResize, AnimatedResizeDoesNotHang)
 
     auto navigationDelegate = createFirstVisuallyNonEmptyWatchingNavigationDelegate();
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [window addSubview:webView.get()];
     [window setHidden:NO];
 
@@ -159,7 +159,7 @@ TEST(AnimatedResize, AnimatedResizeBlocksViewportFitChanges)
     [webView loadHTMLString:@"<head></head>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
 
-    auto window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [window addSubview:webView.get()];
     [window setHidden:NO];
 
@@ -205,11 +205,11 @@ TEST(AnimatedResize, OverrideLayoutSizeChangesDuringAnimatedResizeSucceed)
     [webView _overrideLayoutParametersWithMinimumLayoutSize:layoutSize minimumUnobscuredSizeOverride:layoutSize maximumUnobscuredSizeOverride:layoutSize];
 
     [webView loadHTMLString:@"<head><meta name='viewport' content='initial-scale=1'></head>" baseURL:nil];
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     webView.get().navigationDelegate = navigationDelegate.get();
     [navigationDelegate waitForDidFinishNavigation];
 
-    auto window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [window addSubview:webView.get()];
     [window setHidden:NO];
 
@@ -249,7 +249,7 @@ TEST(AnimatedResize, OverrideLayoutSizeIsRestoredAfterProcessRelaunch)
     [webView loadHTMLString:@"<head><meta name='viewport' content='initial-scale=1'></head>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
 
-    auto window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [window addSubview:webView.get()];
     [window setHidden:NO];
 
@@ -281,7 +281,7 @@ TEST(AnimatedResize, OverrideLayoutSizeIsRestoredAfterChangingDuringProcessRelau
     [webView loadHTMLString:@"<head><meta name='viewport' content='initial-scale=1'></head>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
 
-    auto window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [window addSubview:webView.get()];
     [window setHidden:NO];
 
@@ -312,11 +312,11 @@ TEST(AnimatedResize, ChangeFrameAndMinimumEffectiveDeviceWidthDuringAnimatedResi
     [webView setUIDelegate:webView.get()];
     [webView loadHTMLString:@"<body>Hello world</body>" baseURL:nil];
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [navigationDelegate waitForDidFinishNavigation];
 
-    auto window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [window addSubview:webView.get()];
     [window setHidden:NO];
 
@@ -366,11 +366,11 @@ TEST(AnimatedResize, ResizeWithContentHiddenCompletes)
     [webView setUIDelegate:webView.get()];
     
     [webView loadHTMLString:@"<head><meta name='viewport' content='initial-scale=1'></head>" baseURL:nil];
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     webView.get().navigationDelegate = navigationDelegate.get();
     [navigationDelegate waitForDidFinishNavigation];
     
-    auto window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [window addSubview:webView.get()];
     [window setHidden:NO];
     
@@ -407,11 +407,11 @@ TEST(AnimatedResize, ResizeWithContentHiddenWithSubsequentNoOpResizeCompletes)
     [webView setUIDelegate:webView.get()];
 
     [webView loadHTMLString:@"<head><meta name='viewport' content='initial-scale=1'></head>" baseURL:nil];
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     webView.get().navigationDelegate = navigationDelegate.get();
     [navigationDelegate waitForDidFinishNavigation];
 
-    auto window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [window addSubview:webView.get()];
     [window setHidden:NO];
 
@@ -458,7 +458,7 @@ TEST(AnimatedResize, AnimatedResizeBlocksDoAfterNextPresentationUpdate)
     [webView loadHTMLString:@"<head></head>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
 
-    auto window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [window addSubview:webView.get()];
     [window setHidden:NO];
 
@@ -490,11 +490,11 @@ TEST(AnimatedResize, ResizeWithContentHiddenWhileScrolling)
     [webView setUIDelegate:webView.get()];
 
     [webView loadHTMLString:@"<head><meta name='viewport' content='initial-scale=1'></head>" baseURL:nil];
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     webView.get().navigationDelegate = navigationDelegate.get();
     [navigationDelegate waitForDidFinishNavigation];
 
-    auto window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [window addSubview:webView.get()];
     [window setHidden:NO];
 
@@ -524,7 +524,7 @@ TEST(AnimatedResize, ResizeWithContentHiddenWhileScrolling)
 
 TEST(AnimatedResize, CreateWebPageAfterAnimatedResize)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 1024, 768)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 1024, 768)]);
     [webView synchronouslyLoadTestPageNamed:@"large-red-square-image"];
 
     [webView _beginAnimatedResizeWithUpdates:^{
@@ -554,7 +554,7 @@ TEST(AnimatedResize, CreateWebPageAfterAnimatedResize)
 
 TEST(AnimatedResize, MinimumEffectiveDeviceWidthChangeIsDeferredDuringLiveResize)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='initial-scale=1' />"];
 
     EXPECT_EQ([webView scrollView].zoomScale, 1);
@@ -690,7 +690,7 @@ TEST(AnimatedResize, ChangingWebViewGeometryDuringAnimatedResizeDoesNotHang)
 
 TEST(AnimatedResize, ResizeWithWithSubsequentNoOpResizeIsNotCancelled)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 1024, 768)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 1024, 768)]);
     [webView synchronouslyLoadHTMLString:@"<head><meta name='viewport' content='initial-scale=1'></head>"];
 
     UIView *scrollView = immediateSubviewOfClass(webView.get(), NSClassFromString(@"WKScrollView"));
@@ -720,7 +720,7 @@ TEST(AnimatedResize, ResizeWithWithSubsequentNoOpResizeIsNotCancelled)
 
 TEST(AnimatedResize, ScaleDuringAnimatedResizeDoesNotMoveContentViewFrameOrigin)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 1024, 768)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 1024, 768)]);
     [webView synchronouslyLoadTestPageNamed:@"large-red-square-image"];
 
     [webView _beginAnimatedResizeWithUpdates:^{
@@ -750,7 +750,7 @@ TEST(AnimatedResize, AnimatedResizeDoesNotFreezeFixedElements)
     [[webView scrollView] setContentOffset:CGPointMake(0, 5000)];
     [webView waitForNextPresentationUpdate];
 
-    auto window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 500, 500)]);
+    RetainPtr window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 500, 500)]);
     [window addSubview:webView.get()];
     [window setHidden:NO];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AnimationControl.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AnimationControl.mm
@@ -47,7 +47,7 @@ static bool isAnimating(NSString *domID, RetainPtr<TestWKWebView> webView)
 TEST(WebKit, PlayAllPauseAllAnimationSupport)
 {
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
 
     [webView synchronouslyLoadHTMLString:@"<img id='imgOne' src='test-mse.mp4'><img id='imgTwo' src='test-without-audio-track.mp4'>"];
 
@@ -72,7 +72,7 @@ TEST(WebKit, PlayAllPauseAllAnimationSupport)
 TEST(WebKit, IsAnyAnimationAllowedToPlayBehaviorWithIndividualAnimationControl)
 {
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
 
     [webView synchronouslyLoadHTMLString:@"<img id='imgOne' src='test-mse.mp4'><img id='imgTwo' src='test-without-audio-track.mp4'>"];
     [webView stringByEvaluatingJavaScript:@"window.internals.setImageAnimationEnabled(false)"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AppPrivacyReport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AppPrivacyReport.mm
@@ -46,9 +46,9 @@ TEST(AppPrivacyReport, DefaultRequestIsAppInitiated)
 {
     TestWebKitAPI::HTTPServer server(TestWebKitAPI::HTTPServer::respondWithChallengeThenOK);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
     NSString *url = [NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()];
 
     __block bool isDone = false;
@@ -76,9 +76,9 @@ TEST(AppPrivacyReport, DefaultRequestIsAppInitiated)
 TEST(AppPrivacyReport, AppInitiatedRequest)
 {
     TestWebKitAPI::HTTPServer server(TestWebKitAPI::HTTPServer::respondWithChallengeThenOK);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
     NSString *url = [NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()];
 
     __block bool isDone = false;
@@ -109,9 +109,9 @@ TEST(AppPrivacyReport, NonAppInitiatedRequest)
 {
     TestWebKitAPI::HTTPServer server(TestWebKitAPI::HTTPServer::respondWithChallengeThenOK);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
     NSString *url = [NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()];
 
     __block bool isDone = false;
@@ -142,9 +142,9 @@ TEST(AppPrivacyReport, AppInitiatedRequestWithNavigation)
 {
     TestWebKitAPI::HTTPServer server(TestWebKitAPI::HTTPServer::respondWithChallengeThenOK);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
     NSString *appInitiatedURL = [NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()];
     NSString *nonAppInitiatedURL = [NSString stringWithFormat:@"http://localhost:%d/", server.port()];
 
@@ -205,11 +205,11 @@ TEST(AppPrivacyReport, AppInitiatedRequestWithNavigation)
 
 TEST(AppPrivacyReport, AppInitiatedRequestWithSubFrame)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setOverrideContentSecurityPolicy:@"script-src 'nonce-b'"];
 
     __block bool isDone = false;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     NSMutableURLRequest *appInitiatedRequest = [NSMutableURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"page-with-csp" withExtension:@"html"]];
     appInitiatedRequest.attribution = NSURLRequestAttributionDeveloper;
 
@@ -228,11 +228,11 @@ TEST(AppPrivacyReport, AppInitiatedRequestWithSubFrame)
 
 TEST(AppPrivacyReport, NonAppInitiatedRequestWithSubFrame)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setOverrideContentSecurityPolicy:@"script-src 'nonce-b'"];
 
     __block bool isDone = false;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     NSMutableURLRequest *nonAppInitiatedRequest = [NSMutableURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"page-with-csp" withExtension:@"html"]];
     nonAppInitiatedRequest.attribution = NSURLRequestAttributionUser;
 
@@ -301,9 +301,9 @@ static void runTest(ResponseType responseType, IsAppInitiated isAppInitiated)
         { "/fetched.html"_s, { "<script>alert('fetched from server')</script>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Https);
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate setDidReceiveAuthenticationChallenge:^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^callback)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
         callback(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
@@ -383,10 +383,10 @@ TEST(AppPrivacyReport, MultipleWebViewsWithSharedServiceWorker)
         { "/fetched.html"_s, { "<script>alert('fetched from server')</script>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Https);
 
-    auto webView1 = adoptNS([WKWebView new]);
-    auto webView2 = adoptNS([WKWebView new]);
+    RetainPtr webView1 = adoptNS([WKWebView new]);
+    RetainPtr webView2 = adoptNS([WKWebView new]);
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate setDidReceiveAuthenticationChallenge:^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^callback)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
         callback(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
@@ -443,15 +443,15 @@ static void softUpdateTest(IsAppInitiated isAppInitiated)
     }];
     TestWebKitAPI::Util::run(&isDone);
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate setDidReceiveAuthenticationChallenge:^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^callback)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
         callback(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
     }];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     webView1.get().navigationDelegate = delegate.get();
     webView2.get().navigationDelegate = delegate.get();
@@ -530,7 +530,7 @@ static void runWebProcessPlugInTest(IsAppInitiated isAppInitiated)
     TestWebKitAPI::HTTPServer server(TestWebKitAPI::HTTPServer::respondWithChallengeThenOK);
 
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"AppPrivacyReportPlugIn"];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration]);
 
     NSString *url = [NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()];
 
@@ -660,10 +660,10 @@ TEST(AppPrivacyReport, RegisterServiceWorkerClientUpdatesAppInitiatedValue)
     RetainPtr<SWAppInitiatedRequestMessageHandler> messageHandler = adoptNS([[SWAppInitiatedRequestMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate setDidReceiveAuthenticationChallenge:^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^callback)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
         callback(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
@@ -706,9 +706,9 @@ TEST(AppPrivacyReport, RegisterServiceWorkerClientUpdatesAppInitiatedValue)
 
 static void loadSimulatedRequestTest(IsAppInitiated isAppInitiated)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSMutableURLRequest *loadRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]];
@@ -742,7 +742,7 @@ TEST(AppPrivacyReport, LoadSimulatedRequestIsNonAppInitiated)
 
 static void restoreFromSessionStateTest(IsAppInitiated isAppInitiated)
 {
-    auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
 
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://www.apple.com/"]];
     request.attribution = isAppInitiated == IsAppInitiated::Yes ? NSURLRequestAttributionDeveloper : NSURLRequestAttributionUser;
@@ -759,7 +759,7 @@ static void restoreFromSessionStateTest(IsAppInitiated isAppInitiated)
     }];
     TestWebKitAPI::Util::run(&isDone);
 
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView2 _restoreSessionState:sessionState.get() andNavigate:YES];
     [webView2 _test_waitForDidFinishNavigation];
 
@@ -789,7 +789,7 @@ TEST(AppPrivacyReport, DISABLED_RestoreFromSessionStateIsNonAppInitiated)
 
 static void restoreFromInteractionStateTest(IsAppInitiated isAppInitiated)
 {
-    auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
 
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://www.apple.com/"]];
     request.attribution = isAppInitiated == IsAppInitiated::Yes ? NSURLRequestAttributionDeveloper : NSURLRequestAttributionUser;
@@ -806,7 +806,7 @@ static void restoreFromInteractionStateTest(IsAppInitiated isAppInitiated)
     }];
     TestWebKitAPI::Util::run(&isDone);
 
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView2 setInteractionState:interactionState];
     [webView2 _test_waitForDidFinishNavigation];
 
@@ -836,7 +836,7 @@ TEST(AppPrivacyReport, DISABLED_RestoreFromInteractionStateIsNonAppInitiated)
 
 static void loadFileTest(IsAppInitiated isAppInitiated)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
 
     NSURL *file = [NSBundle.test_resourcesBundle URLForResource:@"file-with-iframe" withExtension:@"html"];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:file];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ApplePay.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ApplePay.mm
@@ -92,12 +92,12 @@ TEST(ApplePay, ApplePayAvailableByDefault)
 {
     [TestProtocol registerWithScheme:@"https"];
 
-    auto messageHandler = adoptNS([[TestApplePayAvailableScriptMessageHandler alloc] initWithAPIsAvailableExpectation:YES canMakePaymentsExpectation:YES]);
+    RetainPtr messageHandler = adoptNS([[TestApplePayAvailableScriptMessageHandler alloc] initWithAPIsAvailableExpectation:YES canMakePaymentsExpectation:YES]);
 
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration.userContentController addScriptMessageHandler:messageHandler.get() name:@"testApplePay"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://bundle-file/apple-pay-availability.html"]]];
 
     Util::run(&isDone);
@@ -109,14 +109,14 @@ TEST(ApplePay, ApplePayAvailableInFrame)
 {
     [TestProtocol registerWithScheme:@"https"];
 
-    auto messageHandler = adoptNS([[TestApplePayAvailableScriptMessageHandler alloc] initWithAPIsAvailableExpectation:YES canMakePaymentsExpectation:YES]);
-    auto userScript = adoptNS([[WKUserScript alloc] initWithSource:userScriptSource injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
+    RetainPtr messageHandler = adoptNS([[TestApplePayAvailableScriptMessageHandler alloc] initWithAPIsAvailableExpectation:YES canMakePaymentsExpectation:YES]);
+    RetainPtr userScript = adoptNS([[WKUserScript alloc] initWithSource:userScriptSource injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
 
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration.userContentController addUserScript:userScript.get()];
     [configuration.userContentController addScriptMessageHandler:messageHandler.get() name:@"testApplePay"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://bundle-file/apple-pay-availability-in-iframe.html"]]];
     [webView _test_waitForDidFinishNavigation];
     [webView evaluateJavaScript:@"loadApplePayFrame();" completionHandler:nil];
@@ -132,14 +132,14 @@ TEST(ApplePay, UserScriptAtDocumentStartDoesNotDisableApplePay)
 {
     [TestProtocol registerWithScheme:@"https"];
 
-    auto messageHandler = adoptNS([[TestApplePayAvailableScriptMessageHandler alloc] initWithAPIsAvailableExpectation:YES canMakePaymentsExpectation:YES]);
-    auto userScript = adoptNS([[WKUserScript alloc] initWithSource:userScriptSource injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
+    RetainPtr messageHandler = adoptNS([[TestApplePayAvailableScriptMessageHandler alloc] initWithAPIsAvailableExpectation:YES canMakePaymentsExpectation:YES]);
+    RetainPtr userScript = adoptNS([[WKUserScript alloc] initWithSource:userScriptSource injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
 
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration.userContentController addUserScript:userScript.get()];
     [configuration.userContentController addScriptMessageHandler:messageHandler.get() name:@"testApplePay"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://bundle-file/apple-pay-availability.html"]]];
 
     Util::run(&isDone);
@@ -153,14 +153,14 @@ TEST(ApplePay, UserScriptAtDocumentEndDoesNotDisableApplePay)
 {
     [TestProtocol registerWithScheme:@"https"];
     
-    auto messageHandler = adoptNS([[TestApplePayAvailableScriptMessageHandler alloc] initWithAPIsAvailableExpectation:YES canMakePaymentsExpectation:YES]);
-    auto userScript = adoptNS([[WKUserScript alloc] initWithSource:userScriptSource injectionTime:WKUserScriptInjectionTimeAtDocumentEnd forMainFrameOnly:YES]);
+    RetainPtr messageHandler = adoptNS([[TestApplePayAvailableScriptMessageHandler alloc] initWithAPIsAvailableExpectation:YES canMakePaymentsExpectation:YES]);
+    RetainPtr userScript = adoptNS([[WKUserScript alloc] initWithSource:userScriptSource injectionTime:WKUserScriptInjectionTimeAtDocumentEnd forMainFrameOnly:YES]);
     
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration.userContentController addUserScript:userScript.get()];
     [configuration.userContentController addScriptMessageHandler:messageHandler.get() name:@"testApplePay"];
     
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://bundle-file/apple-pay-availability.html"]]];
     
     Util::run(&isDone);
@@ -174,12 +174,12 @@ TEST(ApplePay, UserAgentScriptEvaluationDoesNotDisableApplePay)
 {
     [TestProtocol registerWithScheme:@"https"];
 
-    auto messageHandler = adoptNS([[TestApplePayAvailableScriptMessageHandler alloc] initWithAPIsAvailableExpectation:YES canMakePaymentsExpectation:YES]);
+    RetainPtr messageHandler = adoptNS([[TestApplePayAvailableScriptMessageHandler alloc] initWithAPIsAvailableExpectation:YES canMakePaymentsExpectation:YES]);
 
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration.userContentController addScriptMessageHandler:messageHandler.get() name:@"testApplePay"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://bundle-file/apple-pay-availability-in-iframe.html"]]];
     [webView _test_waitForDidFinishNavigation];
     [webView evaluateJavaScript:@"window.wkScriptEvaluated = true; loadApplePayFrame();" completionHandler:nil];
@@ -195,12 +195,12 @@ TEST(ApplePay, UserAgentScriptEvaluationDoesNotDisableApplePayInExistingObjects)
 {
     [TestProtocol registerWithScheme:@"https"];
 
-    auto messageHandler = adoptNS([[TestApplePayAvailableScriptMessageHandler alloc] initWithAPIsAvailableExpectation:YES canMakePaymentsExpectation:YES]);
+    RetainPtr messageHandler = adoptNS([[TestApplePayAvailableScriptMessageHandler alloc] initWithAPIsAvailableExpectation:YES canMakePaymentsExpectation:YES]);
 
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration.userContentController addScriptMessageHandler:messageHandler.get() name:@"testApplePay"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://bundle-file/apple-pay-availability-existing-object.html"]]];
 
     Util::run(&isDone);
@@ -218,13 +218,13 @@ static void runActiveSessionTest(NSURL *url, BOOL shouldBlockScripts)
 {
     [TestProtocol registerWithScheme:@"https"];
 
-    auto messageHandler = adoptNS([[TestApplePayActiveSessionScriptMessageHandler alloc] init]);
-    auto userScript = adoptNS([[WKUserScript alloc] initWithSource:userScriptSource injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
+    RetainPtr messageHandler = adoptNS([[TestApplePayActiveSessionScriptMessageHandler alloc] init]);
+    RetainPtr userScript = adoptNS([[WKUserScript alloc] initWithSource:userScriptSource injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
 
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration.userContentController addScriptMessageHandler:messageHandler.get() name:@"testApplePay"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     Util::run(&isDone);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ApplicationManifest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ApplicationManifest.mm
@@ -63,7 +63,7 @@ TEST(ApplicationManifest, Basic)
 {
     static bool done = false;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
     [webView synchronouslyLoadHTMLString:@""];
     [webView.get() _getApplicationManifestWithCompletionHandler:^(_WKApplicationManifest *manifest) {
         EXPECT_NULL(manifest);
@@ -135,9 +135,9 @@ TEST(ApplicationManifest, DisplayMode)
         @autoreleasepool {
             NSString *m2 = displayMode.length ? [NSString stringWithFormat:@"{\"display\": \"%@\"}", displayMode] : @"{}";
             RetainPtr<_WKApplicationManifest> manifest = [_WKApplicationManifest applicationManifestFromJSON:m2 manifestURL:[baseURL URLByAppendingPathComponent:@"manifest.json"] documentURL:baseURL];
-            auto config = adoptNS([[WKWebViewConfiguration alloc] init]);
+            RetainPtr config = adoptNS([[WKWebViewConfiguration alloc] init]);
             config.get()._applicationManifest = manifest.get();
-            auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:config.get()]);
+            RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:config.get()]);
             [webView synchronouslyLoadTestPageNamed:@"display-mode"];
             
             done = false;
@@ -153,7 +153,7 @@ TEST(ApplicationManifest, DisplayMode)
 
 TEST(ApplicationManifest, AlwaysFetchData)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
 
     NSDictionary *manifestObject = @{ @"theme_color": @"red" };
     NSString *json = [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0];
@@ -179,7 +179,7 @@ TEST(ApplicationManifest, AlwaysFetchData)
 
 TEST(ApplicationManifest, OnlyFirstManifest)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
 
     NSDictionary *manifestObject1 = @{ @"theme_color": @"red" };
     NSString *json1 = [[NSJSONSerialization dataWithJSONObject:manifestObject1 options:0 error:nil] base64EncodedStringWithOptions:0];
@@ -207,7 +207,7 @@ TEST(ApplicationManifest, OnlyFirstManifest)
 
 TEST(ApplicationManifest, NoManifest)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
 
     [webView synchronouslyLoadHTMLString:@"Hello World"];
 
@@ -224,7 +224,7 @@ TEST(ApplicationManifest, NoManifest)
 
 TEST(ApplicationManifest, MediaAttriute)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
 
     NSDictionary *manifestObject1 = @{ @"theme_color": @"blue" };
     NSString *json1 = [[NSJSONSerialization dataWithJSONObject:manifestObject1 options:0 error:nil] base64EncodedStringWithOptions:0];
@@ -252,7 +252,7 @@ TEST(ApplicationManifest, MediaAttriute)
 
 TEST(ApplicationManifest, DoesNotExist)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
 
     [webView synchronouslyLoadHTMLString:@"<link rel=\"manifest\" href=\"does not exist\">"];
 
@@ -269,7 +269,7 @@ TEST(ApplicationManifest, DoesNotExist)
 
 TEST(ApplicationManifest, Blocked)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
 
     NSDictionary *manifestObject = @{ @"theme_color": @"red" };
     NSString *json = [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0];
@@ -306,7 +306,7 @@ TEST(ApplicationManifest, Icons)
         @"purpose": @"monochrome"
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
     NSDictionary *manifestObject = @{
         @"name": @"A Web Application",
         @"short_name": @"WebApp",
@@ -377,7 +377,7 @@ TEST(ApplicationManifest, IconCoding)
     WebCore::ApplicationManifest::Icon icon = { URL { testURL }, makeVector<String>(@[@"96x96", @"128x128"]), "image/jpg"_s, { WebCore::ApplicationManifest::Icon::Purpose::Monochrome, WebCore::ApplicationManifest::Icon::Purpose::Maskable } };
 
     IGNORE_WARNINGS_BEGIN("objc-method-access")
-    auto manifestIcon = adoptNS([[_WKApplicationManifestIcon alloc] initWithCoreIcon:&icon]);
+    RetainPtr manifestIcon = adoptNS([[_WKApplicationManifestIcon alloc] initWithCoreIcon:&icon]);
     IGNORE_WARNINGS_END
 
     NSError *error = nil;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AsyncFunction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AsyncFunction.mm
@@ -39,7 +39,7 @@ namespace TestWebKitAPI {
 
 TEST(AsyncFunction, Basic)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     NSError *error;
 
     // Function with no return value.
@@ -86,7 +86,7 @@ TEST(AsyncFunction, Basic)
 
 TEST(AsyncFunction, InvalidArguments)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     NSError *error;
 
     // Values can only be NSString, NSNumber, NSDate, NSNull, NS(Mutable)Array, NS(Mutable)Dictionary, NSNull, and may only contain those 6 types.
@@ -106,7 +106,7 @@ TEST(AsyncFunction, InvalidArguments)
 
 TEST(AsyncFunction, RoundTrip)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     NSError *error;
 
     // Tests round tripping a whole bunch of argument inputs and verifying the result.
@@ -140,8 +140,9 @@ TEST(AsyncFunction, RoundTrip)
     result = [webView objectByCallingAsyncFunction:@"return a" withArguments:arguments error:&error];
     EXPECT_NULL(error);
     EXPECT_TRUE([value isEqual:result]);
+    
+    RetainPtr mutableArray = adoptNS([[NSMutableArray alloc] init]);
 
-    auto mutableArray = adoptNS([[NSMutableArray alloc] init]);
     [mutableArray addObject:value];
     arguments = @{ @"a" : mutableArray.get() };
     result = [webView objectByCallingAsyncFunction:@"return a" withArguments:arguments error:&error];
@@ -160,7 +161,7 @@ TEST(AsyncFunction, RoundTrip)
     EXPECT_NULL(error);
     EXPECT_TRUE([value isEqual:result]);
 
-    auto mutableDictionary = adoptNS((NSMutableDictionary<NSString *, id> *)[[NSMutableDictionary alloc] init]);
+    RetainPtr mutableDictionary = adoptNS((NSMutableDictionary<NSString *, id> *)[[NSMutableDictionary alloc] init]);
     mutableDictionary.get()[@"foo"] = value;
     arguments = @{ @"a" : mutableDictionary.get() };
     result = [webView objectByCallingAsyncFunction:@"return a" withArguments:arguments error:&error];
@@ -182,7 +183,7 @@ TEST(AsyncFunction, RoundTrip)
 
 TEST(AsyncFunction, Promise)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     [webView callAsyncJavaScript:@"shouldn't crash" arguments:@{ @"invalidparameter" : webView.get() } inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:nil];
 
@@ -285,8 +286,8 @@ TEST(AsyncFunction, Promise)
 
 TEST(AsyncFunction, PromiseDetachedFrame)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    auto uiDelegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr uiDelegate = adoptNS([[TestUIDelegate alloc] init]);
     [webView setUIDelegate:uiDelegate.get()];
 
     __block RetainPtr<WKFrameInfo> subframe;
@@ -323,12 +324,12 @@ TEST(AsyncFunction, PromiseDetachedFrame)
 
 TEST(AsyncFunction, CircularArgumentReference)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     NSError *error;
 
     // Test circular references in dictionaries and arrays.
     // Before cycle detection, these would blow out the stack and crash.
-    auto circularDictionary = adoptNS([[NSMutableDictionary alloc] init]);
+    RetainPtr circularDictionary = adoptNS([[NSMutableDictionary alloc] init]);
     [circularDictionary setObject:@"value" forKey:@"key"];
     [circularDictionary setObject:circularDictionary.get() forKey:@"self"];
 
@@ -336,7 +337,7 @@ TEST(AsyncFunction, CircularArgumentReference)
     EXPECT_NULL(error);
     EXPECT_TRUE([result isEqualToString:@"value"]);
 
-    auto circularArray = adoptNS([[NSMutableArray alloc] init]);
+    RetainPtr circularArray = adoptNS([[NSMutableArray alloc] init]);
     [circularArray addObject:@"value"];
     [circularArray addObject:circularArray.get()];
 
@@ -347,7 +348,7 @@ TEST(AsyncFunction, CircularArgumentReference)
 
 TEST(AsyncFunction, StructuralSharingPerformance)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     NSError *error;
 
     // Build an object graph with 51 unique objects but 2^50 paths through the tree.
@@ -364,7 +365,7 @@ TEST(AsyncFunction, StructuralSharingPerformance)
 TEST(AsyncFunction, TransientActivation)
 {
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:NO]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:NO]);
 
     [webView synchronouslyLoadHTMLString:@"Hello"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AsyncPolicyForNavigationResponse.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AsyncPolicyForNavigationResponse.mm
@@ -80,8 +80,8 @@ TEST(WebKit, RespondToPolicyForNavigationResponseAsynchronously)
 {
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[WKWebView alloc] init]);
-    auto delegate = adoptNS([[TestAsyncNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr delegate = adoptNS([[TestAsyncNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
 
@@ -98,8 +98,8 @@ TEST(WebKit, PolicyForNavigationResponseCancelAsynchronously)
 {
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[WKWebView alloc] init]);
-    auto delegate = adoptNS([[TestAsyncNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr delegate = adoptNS([[TestAsyncNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AttrStyle.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AttrStyle.mm
@@ -33,13 +33,13 @@
 
 TEST(WebKit, AttrStyle)
 {
-    auto poolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr poolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     [poolConfiguration setAttrStyleEnabled:YES];
-    auto pool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:poolConfiguration.get()]);
-    auto viewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr pool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:poolConfiguration.get()]);
+    RetainPtr viewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [viewConfiguration setProcessPool:pool.get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:viewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:viewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"AttrStyle" withExtension:@"html"]]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AudioBufferSize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AudioBufferSize.mm
@@ -58,7 +58,7 @@ double waitForBufferSizeChange(WKWebView* webView, double oldSize)
 
 TEST(WebKit, AudioBufferSize)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
 
 #if PLATFORM(IOS) || PLATFORM(VISION)
@@ -74,8 +74,8 @@ TEST(WebKit, AudioBufferSize)
     preferences._mockCaptureDevicesEnabled = YES;
     preferences._getUserMediaRequiresFocus = NO;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     webView.get().UIDelegate = delegate.get();
 
     [webView synchronouslyLoadTestPageNamed:@"audio-buffer-size"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AudioRoutingArbitration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AudioRoutingArbitration.mm
@@ -42,7 +42,7 @@ public:
 
     void SetUp() final
     {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
         configuration.get().processPool = (WKProcessPool *)context.get();
         configuration.get()._mediaDataLoadsAutomatically = YES;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AutoLayoutIntegration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AutoLayoutIntegration.mm
@@ -212,7 +212,7 @@ TEST(WebKit, AutoLayoutRenderingProgressRelativeOrdering)
 {
     RetainPtr<AutoLayoutWKWebView> webView = adoptNS([[AutoLayoutWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 1000, 1000)]);
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
 
     __block bool didFinishNavigation = false;
     [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
@@ -240,10 +240,10 @@ TEST(WebKit, AutoLayoutRenderingProgressRelativeOrdering)
 
 TEST(WebKit, AutoLayoutBatchesUpdatesWhenInvalidatingIntrinsicContentSize)
 {
-    auto webView = adoptNS([[AutoLayoutWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 1000, 1000)]);
+    RetainPtr webView = adoptNS([[AutoLayoutWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 1000, 1000)]);
     [webView _setMinimumLayoutWidth:100];
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     __block bool didFinishNavigation = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Badging.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Badging.mm
@@ -132,13 +132,13 @@ TEST(Badging, APIWindow)
         { "/"_s, { simpleMainBytes } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     static bool messagesDone = false;
     static int messageCount = 0;
     static const int expectedMessages = 2;
 
-    auto testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
+    RetainPtr testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:testMessageHandler.get() name:@"sw"];
     [testMessageHandler addMessage:@"SUCCEEDED" withHandler:^{
         EXPECT_TRUE(false);
@@ -151,8 +151,8 @@ TEST(Badging, APIWindow)
             messagesDone = true;
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
-    auto badgeDelegate = adoptNS([BadgeDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr badgeDelegate = adoptNS([BadgeDelegate new]);
     badgeDelegate.get().serverURL = server.request("/"_s).URL;
     badgeDelegate.get().expectedAppBadgeSequence = @[@0, @1, @9007199254740991, [NSNull null], @0];
 
@@ -247,13 +247,13 @@ TEST(Badging, DedicatedWorker)
         { "/worker.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, workerBytes } }
     });
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     static bool workerRunning = false;
     static bool badgingDone = false;
     static bool javascriptDone = false;
 
-    auto testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
+    RetainPtr testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:testMessageHandler.get() name:@"testHandler"];
     [testMessageHandler addMessage:@"RUNNING" withHandler:^{
         workerRunning = true;
@@ -263,8 +263,8 @@ TEST(Badging, DedicatedWorker)
     }];
 
     configuration.get().preferences._appBadgeEnabled = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
-    auto badgeDelegate = adoptNS([BadgeDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr badgeDelegate = adoptNS([BadgeDelegate new]);
     badgeDelegate.get().serverURL = server.request("/"_s).URL;
     badgeDelegate.get().expectedAppBadgeSequence = @[@10, @0];
     configuration.get().websiteDataStore._delegate = badgeDelegate.get();
@@ -317,13 +317,13 @@ TEST(Badging, SharedWorker)
         { "/sharedworker.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, sharedWorkerBytes } }
     });
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     static bool workerRunning = false;
     static bool badgingDone = false;
     static bool javascriptDone = false;
 
-    auto testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
+    RetainPtr testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:testMessageHandler.get() name:@"testHandler"];
     [testMessageHandler addMessage:@"RUNNING" withHandler:^{
         workerRunning = true;
@@ -333,8 +333,8 @@ TEST(Badging, SharedWorker)
     }];
 
     configuration.get().preferences._appBadgeEnabled = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
-    auto badgeDelegate = adoptNS([BadgeDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr badgeDelegate = adoptNS([BadgeDelegate new]);
     badgeDelegate.get().serverURL = server.request("/"_s).URL;
     badgeDelegate.get().expectedAppBadgeSequence = @[@10, @0];
     configuration.get().websiteDataStore._delegate = badgeDelegate.get();
@@ -402,13 +402,13 @@ TEST(Badging, ServiceWorker)
         { "/sw.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, serviceWorkerScriptBytes } }
     });
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     static bool workerRunning = false;
     static bool badgingDone = false;
     static bool javascriptDone = false;
 
-    auto testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
+    RetainPtr testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:testMessageHandler.get() name:@"testHandler"];
     [testMessageHandler addMessage:@"RUNNING" withHandler:^{
         workerRunning = true;
@@ -418,8 +418,8 @@ TEST(Badging, ServiceWorker)
     }];
 
     configuration.get().preferences._appBadgeEnabled = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
-    auto badgeDelegate = adoptNS([BadgeDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr badgeDelegate = adoptNS([BadgeDelegate new]);
     badgeDelegate.get().serverURL = server.request("/"_s).URL;
     badgeDelegate.get().expectedAppBadgeSequence = @[@10, @0];
     configuration.get().websiteDataStore._delegate = badgeDelegate.get();
@@ -450,9 +450,9 @@ window.navigator.setAppBadge(10);
 
 TEST(Badging, Origin)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto handler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr handler = adoptNS([[TestURLSchemeHandler alloc] init]);
     handler.get().startURLSchemeTaskHandler = ^(WKWebView *, id<WKURLSchemeTask> task) {
         if ([task.request.URL.scheme isEqualToString:@"origintest1"])
             return respond(task, originMainFrameBytes);
@@ -465,8 +465,8 @@ TEST(Badging, Origin)
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"origintest2"];
     configuration.get().preferences._appBadgeEnabled = YES;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
-    auto badgeDelegate = adoptNS([BadgeDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr badgeDelegate = adoptNS([BadgeDelegate new]);
 
     NSURL *url = [NSURL URLWithString:@"origintest1://webkit.org/index.html"];
     badgeDelegate.get().serverURL = url;
@@ -487,13 +487,13 @@ TEST(Badging, ServiceWorkerOverride)
         { "/sw.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, serviceWorkerScriptBytes } }
     });
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     static bool workerRunning = false;
     static bool badgingDone = false;
     static bool javascriptDone = false;
 
-    auto testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
+    RetainPtr testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:testMessageHandler.get() name:@"testHandler"];
     [testMessageHandler addMessage:@"RUNNING" withHandler:^{
         workerRunning = true;
@@ -509,8 +509,8 @@ TEST(Badging, ServiceWorkerOverride)
     serviceWorkerOverride._appBadgeEnabled = YES;
     [configuration.get().websiteDataStore _setServiceWorkerOverridePreferences:serviceWorkerOverride];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
-    auto badgeDelegate = adoptNS([BadgeDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr badgeDelegate = adoptNS([BadgeDelegate new]);
     badgeDelegate.get().expectedAppBadgeSequence = @[@10, @0];
     configuration.get().websiteDataStore._delegate = badgeDelegate.get();
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/BundleCSSStyleDeclarationHandle.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/BundleCSSStyleDeclarationHandle.mm
@@ -56,9 +56,9 @@ static bool didVerifyStyle;
 TEST(WebKit, WKWebProcessPlugInCSSStyleDeclarationHandle)
 {
     auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"BundleCSSStyleDeclarationHandlePlugIn"]);
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto object = adoptNS([[BundleCSSStyleDeclarationHandleRemoteObject alloc] init]);
+    RetainPtr object = adoptNS([[BundleCSSStyleDeclarationHandleRemoteObject alloc] init]);
     auto interface = retainPtr([_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(BundleCSSStyleDeclarationHandleProtocol)]);
     [[webView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface.get()];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/BundleEditingDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/BundleEditingDelegate.mm
@@ -120,11 +120,11 @@ TEST(WebKit, WKWebProcessPlugInDoNotCrashWhenCopyingEmptyClientData)
     auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"BundleEditingDelegatePlugIn"]);
     [[configuration processPool] _setObject:@YES forBundleParameter:@"EditingDelegateShouldWriteEmptyData"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadHTMLString:@"<body style='-webkit-user-modify: read-write-plaintext-only'>Just something to copy <script> var textNode = document.body.firstChild; document.getSelection().setBaseAndExtent(textNode, 5, textNode, 14) </script>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
 
-    auto object = adoptNS([[BundleEditingDelegateRemoteObject alloc] init]);
+    RetainPtr object = adoptNS([[BundleEditingDelegateRemoteObject alloc] init]);
     _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(BundleEditingDelegateProtocol)];
     [[webView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/BundleFormDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/BundleFormDelegate.mm
@@ -76,17 +76,17 @@ static id userObject;
 
 TEST(WebKit, WKWebProcessPlugInWithoutRegisteredCustomClass)
 {
-    auto delegate = adoptNS([[FormInputDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[FormInputDelegate alloc] init]);
 
     auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"BundleFormDelegatePlugIn"]);
     [[configuration processPool] _setObject:@YES forBundleParameter:@"FormDelegateShouldAddCustomClass"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView _setInputDelegate:delegate.get()];
     [webView loadHTMLString:@"<input></input><select><option selected>foo</option><option>bar</option></select>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
 
-    auto object = adoptNS([[BundleFormDelegateRemoteObject alloc] init]);
+    RetainPtr object = adoptNS([[BundleFormDelegateRemoteObject alloc] init]);
     _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(BundleFormDelegateProtocol)];
     [[webView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface];
 
@@ -105,18 +105,18 @@ TEST(WebKit, WKWebProcessPlugInWithoutRegisteredCustomClass)
 
 TEST(WebKit, WKWebProcessPlugInWithRegisteredCustomClass)
 {
-    auto delegate = adoptNS([[FormInputDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[FormInputDelegate alloc] init]);
 
     auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"BundleFormDelegatePlugIn"
         configureJSCForTesting:NO]);
     [[configuration processPool] _setObject:@YES forBundleParameter:@"FormDelegateShouldAddCustomClass"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView _setInputDelegate:delegate.get()];
     [webView loadHTMLString:@"<input></input><select><option selected>foo</option><option>bar</option></select>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
 
-    auto object = adoptNS([[BundleFormDelegateRemoteObject alloc] init]);
+    RetainPtr object = adoptNS([[BundleFormDelegateRemoteObject alloc] init]);
     _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(BundleFormDelegateProtocol)];
     [[webView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface];
 
@@ -133,18 +133,18 @@ TEST(WebKit, WKWebProcessPlugInWithRegisteredCustomClass)
 
 TEST(WebKit, WKWebProcessPlugInWithUnregisteredCustomClass)
 {
-    auto delegate = adoptNS([[FormInputDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[FormInputDelegate alloc] init]);
 
     auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"BundleFormDelegatePlugIn"
         configureJSCForTesting:NO]);
     [[configuration processPool] _setObject:@YES forBundleParameter:@"FormDelegateShouldAddCustomClass"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView _setInputDelegate:delegate.get()];
     [webView loadHTMLString:@"<input></input><select><option selected>foo</option><option>bar</option></select>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
 
-    auto object = adoptNS([[BundleFormDelegateRemoteObject alloc] init]);
+    RetainPtr object = adoptNS([[BundleFormDelegateRemoteObject alloc] init]);
     _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(BundleFormDelegateProtocol)];
     [[webView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/BundleParameters.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/BundleParameters.mm
@@ -39,7 +39,7 @@ TEST(WebKit, BundleParameters)
     @autoreleasepool {
         NSString * const testPlugInClassName = @"BundleParametersPlugIn";
         auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:testPlugInClassName]);
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
         [webView evaluateJavaScript:TestWebKitAPI::Util::TestPlugInClassNameParameter completionHandler:^(id result, NSError *error) {
             EXPECT_TRUE([result isKindOfClass:[NSString class]]);
@@ -117,7 +117,7 @@ TEST(WebKit, LoadDataWithUserData)
 {
     NSString * const testPlugInClassName = @"BundleParametersPlugIn";
     auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:testPlugInClassName]);
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
     [webView _loadData:NSData.data MIMEType:@"text/html" characterEncodingName:@"utf-8" baseURL:[NSURL URLWithString:@"https://webkit.org/"] userData:NSData.data];
     [webView _test_waitForDidFinishNavigation];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CSSViewportUnits.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CSSViewportUnits.mm
@@ -76,7 +76,7 @@ static float scrollbarSize()
 
 TEST(CSSViewportUnits, AllSame)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
     [webView waitForNextPresentationUpdate];
 
@@ -235,7 +235,7 @@ TEST(CSSViewportUnits, AllSame)
 
 TEST(CSSViewportUnits, NegativeMinimumViewportInset)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
 
     bool didThrow = false;
     @try {
@@ -248,7 +248,7 @@ TEST(CSSViewportUnits, NegativeMinimumViewportInset)
 
 TEST(CSSViewportUnits, NegativeMaximumViewportInset)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
 
     bool didThrow = false;
     @try {
@@ -261,7 +261,7 @@ TEST(CSSViewportUnits, NegativeMaximumViewportInset)
 
 TEST(CSSViewportUnits, MinimumViewportInsetLargerThanMaximumViewportInset)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
 
     bool didThrow = false;
     @try {
@@ -274,7 +274,7 @@ TEST(CSSViewportUnits, MinimumViewportInsetLargerThanMaximumViewportInset)
 
 TEST(CSSViewportUnits, MinimumViewportInsetThanLargerFrame)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
 
     bool didThrow = false;
     @try {
@@ -287,7 +287,7 @@ TEST(CSSViewportUnits, MinimumViewportInsetThanLargerFrame)
 
 TEST(CSSViewportUnits, MaximumViewportInsetThanLargerFrame)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
 
     bool didThrow = false;
     @try {
@@ -300,7 +300,7 @@ TEST(CSSViewportUnits, MaximumViewportInsetThanLargerFrame)
 
 TEST(CSSViewportUnits, MinimumViewportInset)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView setMinimumViewportInset:CocoaEdgeInsetsMake(11, 21, 31, 41) maximumViewportInset:CocoaEdgeInsetsMake(12, 22, 32, 42)];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
 
@@ -341,7 +341,7 @@ TEST(CSSViewportUnits, MinimumViewportInset)
 
 TEST(CSSViewportUnits, MaximumViewportInset)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView setMinimumViewportInset:CocoaEdgeInsetsZero maximumViewportInset:CocoaEdgeInsetsMake(12, 22, 32, 42)];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
 
@@ -382,7 +382,7 @@ TEST(CSSViewportUnits, MaximumViewportInset)
 
 TEST(CSSViewportUnits, MinimumViewportInsetWithZoom)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView setMinimumViewportInset:CocoaEdgeInsetsMake(11, 21, 31, 41) maximumViewportInset:CocoaEdgeInsetsMake(12, 22, 32, 42)];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
 
@@ -430,7 +430,7 @@ TEST(CSSViewportUnits, MinimumViewportInsetWithZoom)
 
 TEST(CSSViewportUnits, MaximumViewportInsetWithZoom)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView setMinimumViewportInset:CocoaEdgeInsetsZero maximumViewportInset:CocoaEdgeInsetsMake(12, 22, 32, 42)];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
 
@@ -478,7 +478,7 @@ TEST(CSSViewportUnits, MaximumViewportInsetWithZoom)
 
 TEST(CSSViewportUnits, MinimumViewportInsetWithWritingMode)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView setMinimumViewportInset:CocoaEdgeInsetsMake(11, 21, 31, 41) maximumViewportInset:CocoaEdgeInsetsMake(12, 22, 32, 42)];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
 
@@ -555,7 +555,7 @@ TEST(CSSViewportUnits, MinimumViewportInsetWithWritingMode)
 
 TEST(CSSViewportUnits, MaximumViewportInsetWithWritingMode)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView setMinimumViewportInset:CocoaEdgeInsetsZero maximumViewportInset:CocoaEdgeInsetsMake(12, 22, 32, 42)];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
 
@@ -632,7 +632,7 @@ TEST(CSSViewportUnits, MaximumViewportInsetWithWritingMode)
 
 TEST(CSSViewportUnits, MinimumViewportInsetWithFrame)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView setMinimumViewportInset:CocoaEdgeInsetsMake(11, 21, 31, 41) maximumViewportInset:CocoaEdgeInsetsMake(12, 22, 32, 42)];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
 
@@ -675,7 +675,7 @@ TEST(CSSViewportUnits, MinimumViewportInsetWithFrame)
 
 TEST(CSSViewportUnits, MaximumViewportInsetWithFrame)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView setMinimumViewportInset:CocoaEdgeInsetsZero maximumViewportInset:CocoaEdgeInsetsMake(12, 22, 32, 42)];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
 
@@ -718,7 +718,7 @@ TEST(CSSViewportUnits, MaximumViewportInsetWithFrame)
 
 TEST(CSSViewportUnits, MinimumViewportInsetWithBounds)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView setMinimumViewportInset:CocoaEdgeInsetsMake(11, 21, 31, 41) maximumViewportInset:CocoaEdgeInsetsMake(12, 22, 32, 42)];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
 
@@ -761,7 +761,7 @@ TEST(CSSViewportUnits, MinimumViewportInsetWithBounds)
 
 TEST(CSSViewportUnits, MaximumViewportInsetWithBounds)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView setMinimumViewportInset:CocoaEdgeInsetsZero maximumViewportInset:CocoaEdgeInsetsMake(12, 22, 32, 42)];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
 
@@ -811,9 +811,9 @@ TEST(CSSViewportUnits, DISABLED_TopContentInset)
 TEST(CSSViewportUnits, TopContentInset)
 #endif
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
 
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:CGRectMake(0, 0, 320, 500) styleMask:(NSWindowStyleMaskTitled | NSWindowStyleMaskFullSizeContentView) backing:NSBackingStoreBuffered defer:NO]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:CGRectMake(0, 0, 320, 500) styleMask:(NSWindowStyleMaskTitled | NSWindowStyleMaskFullSizeContentView) backing:NSBackingStoreBuffered defer:NO]);
     [[window contentView] addSubview:webView.get()];
     [window makeKeyAndOrderFront:nil];
 
@@ -859,9 +859,9 @@ TEST(CSSViewportUnits, TopContentInset)
 
 TEST(CSSViewportUnits, MinimumViewportInsetWithTopContentInset)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
 
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:CGRectMake(0, 0, 320, 500) styleMask:(NSWindowStyleMaskTitled | NSWindowStyleMaskFullSizeContentView) backing:NSBackingStoreBuffered defer:NO]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:CGRectMake(0, 0, 320, 500) styleMask:(NSWindowStyleMaskTitled | NSWindowStyleMaskFullSizeContentView) backing:NSBackingStoreBuffered defer:NO]);
     [[window contentView] addSubview:webView.get()];
     [window makeKeyAndOrderFront:nil];
 
@@ -913,9 +913,9 @@ TEST(CSSViewportUnits, DISABLED_MaximumViewportInsetWithTopContentInset)
 TEST(CSSViewportUnits, MaximumViewportInsetWithTopContentInset)
 #endif
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
 
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:CGRectMake(0, 0, 320, 500) styleMask:(NSWindowStyleMaskTitled | NSWindowStyleMaskFullSizeContentView) backing:NSBackingStoreBuffered defer:NO]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:CGRectMake(0, 0, 320, 500) styleMask:(NSWindowStyleMaskTitled | NSWindowStyleMaskFullSizeContentView) backing:NSBackingStoreBuffered defer:NO]);
     [[window contentView] addSubview:webView.get()];
     [window makeKeyAndOrderFront:nil];
 
@@ -966,7 +966,7 @@ TEST(CSSViewportUnits, MaximumViewportInsetWithTopContentInset)
 
 TEST(CSSViewportUnits, MinimumViewportInsetWithContentInset)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView setMinimumViewportInset:CocoaEdgeInsetsMake(11, 21, 31, 41) maximumViewportInset:CocoaEdgeInsetsMake(12, 22, 32, 42)];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
 
@@ -1009,7 +1009,7 @@ TEST(CSSViewportUnits, MinimumViewportInsetWithContentInset)
 
 TEST(CSSViewportUnits, MaximumViewportInsetWithContentInset)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView setMinimumViewportInset:CocoaEdgeInsetsZero maximumViewportInset:CocoaEdgeInsetsMake(12, 22, 32, 42)];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
 
@@ -1052,11 +1052,11 @@ TEST(CSSViewportUnits, MaximumViewportInsetWithContentInset)
 
 TEST(CSSViewportUnits, MinimumViewportInsetWithSafeAreaInsets)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView setMinimumViewportInset:CocoaEdgeInsetsMake(11, 21, 31, 41) maximumViewportInset:CocoaEdgeInsetsMake(12, 22, 32, 42)];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
 
-    auto viewController = adoptNS([[UIViewController alloc] init]);
+    RetainPtr viewController = adoptNS([[UIViewController alloc] init]);
     [viewController setAdditionalSafeAreaInsets:CocoaEdgeInsetsMake(50, 60, 70, 80)];
     [viewController setView:webView.get()];
 
@@ -1097,11 +1097,11 @@ TEST(CSSViewportUnits, MinimumViewportInsetWithSafeAreaInsets)
 
 TEST(CSSViewportUnits, MaximumViewportInsetWithSafeAreaInsets)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView setMinimumViewportInset:CocoaEdgeInsetsZero maximumViewportInset:CocoaEdgeInsetsMake(12, 22, 32, 42)];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
 
-    auto viewController = adoptNS([[UIViewController alloc] init]);
+    RetainPtr viewController = adoptNS([[UIViewController alloc] init]);
     [viewController setAdditionalSafeAreaInsets:CocoaEdgeInsetsMake(50, 60, 70, 80)];
     [viewController setView:webView.get()];
 
@@ -1142,7 +1142,7 @@ TEST(CSSViewportUnits, MaximumViewportInsetWithSafeAreaInsets)
 
 TEST(CSSViewportUnits, UnobscuredSizeOverridesIgnoreMinimumViewportInset)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView setMinimumViewportInset:CocoaEdgeInsetsMake(11, 21, 31, 41) maximumViewportInset:CocoaEdgeInsetsMake(12, 22, 32, 42)];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
 
@@ -1185,7 +1185,7 @@ TEST(CSSViewportUnits, UnobscuredSizeOverridesIgnoreMinimumViewportInset)
 
 TEST(CSSViewportUnits, UnobscuredSizeOverridesIgnoreMaximumViewportInset)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView setMinimumViewportInset:CocoaEdgeInsetsZero maximumViewportInset:CocoaEdgeInsetsMake(12, 22, 32, 42)];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
 
@@ -1228,7 +1228,7 @@ TEST(CSSViewportUnits, UnobscuredSizeOverridesIgnoreMaximumViewportInset)
 
 TEST(CSSViewportUnits, EmptyUnobscuredSizeOverrides)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(10.5, 20.5) minimumUnobscuredSizeOverride:CGSizeZero maximumUnobscuredSizeOverride:CGSizeZero];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
     [webView waitForNextPresentationUpdate];
@@ -1373,7 +1373,7 @@ TEST(CSSViewportUnits, EmptyUnobscuredSizeOverrides)
 
 TEST(CSSViewportUnits, SameUnobscuredSizeOverrides)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto unobscuredSizeOverride = CGSizeMake(10.5, 20.5);
     [webView _overrideLayoutParametersWithMinimumLayoutSize:unobscuredSizeOverride minimumUnobscuredSizeOverride:unobscuredSizeOverride maximumUnobscuredSizeOverride:unobscuredSizeOverride];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
@@ -1519,7 +1519,7 @@ TEST(CSSViewportUnits, SameUnobscuredSizeOverrides)
 
 TEST(CSSViewportUnits, DifferentUnobscuredSizeOverrides)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(10.5, 20.5) minimumUnobscuredSizeOverride:CGSizeMake(10.5, 30.5) maximumUnobscuredSizeOverride:CGSizeMake(30.5, 40.5)];
     [webView synchronouslyLoadTestPageNamed:@"CSSViewportUnits"];
     [webView waitForNextPresentationUpdate];
@@ -1666,7 +1666,7 @@ TEST(CSSViewportUnits, DifferentUnobscuredSizeOverrides)
 
 TEST(CSSViewportUnits, SVGDocument)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"CSSViewportUnits" withExtension:@"svg"]]];
     [webView _test_waitForDidFinishNavigation];
     [webView waitForNextPresentationUpdate];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Challenge.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Challenge.mm
@@ -226,12 +226,12 @@ TEST(Challenge, SecIdentity)
     using namespace TestWebKitAPI;
     HTTPServer server(HTTPServer::respondWithChallengeThenOK);
 
-    auto webView = adoptNS([WKWebView new]);
-    auto delegate = adoptNS([ChallengeDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([ChallengeDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     // Make sure no credential left by previous tests.
-    auto protectionSpace = adoptNS([[NSURLProtectionSpace alloc] initWithHost:@"127.0.0.1" port:server.port() protocol:NSURLProtectionSpaceHTTP realm:@"testrealm" authenticationMethod:NSURLAuthenticationMethodHTTPBasic]);
+    RetainPtr protectionSpace = adoptNS([[NSURLProtectionSpace alloc] initWithHost:@"127.0.0.1" port:server.port() protocol:NSURLProtectionSpaceHTTP realm:@"testrealm" authenticationMethod:NSURLAuthenticationMethodHTTPBasic]);
     [[webView configuration].processPool _clearPermanentCredentialsForProtectionSpace:protectionSpace.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
@@ -244,7 +244,7 @@ TEST(Challenge, DeallocateDuringChallenge)
     using namespace TestWebKitAPI;
     HTTPServer server({{ "/"_s, { "hi"_s }}}, HTTPServer::Protocol::Https);
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
     };
@@ -301,8 +301,8 @@ TEST(Challenge, ClientCertificate)
         complete(true);
     });
 
-    auto webView = adoptNS([WKWebView new]);
-    auto delegate = adoptNS([ClientCertificateDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([ClientCertificateDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:server.request()];
     
@@ -347,12 +347,12 @@ TEST(Challenge, BasicProposedCredential)
     using namespace TestWebKitAPI;
     HTTPServer server(HTTPServer::respondWithChallengeThenOK);
     auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"BasicProposedCredentialPlugIn"]);
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto delegate = adoptNS([ProposedCredentialDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([ProposedCredentialDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     // Make sure no credential left by previous tests.
-    auto protectionSpace = adoptNS([[NSURLProtectionSpace alloc] initWithHost:@"127.0.0.1" port:server.port() protocol:NSURLProtectionSpaceHTTP realm:@"testrealm" authenticationMethod:NSURLAuthenticationMethodHTTPBasic]);
+    RetainPtr protectionSpace = adoptNS([[NSURLProtectionSpace alloc] initWithHost:@"127.0.0.1" port:server.port() protocol:NSURLProtectionSpaceHTTP realm:@"testrealm" authenticationMethod:NSURLAuthenticationMethodHTTPBasic]);
     [[webView configuration].processPool _clearPermanentCredentialsForProtectionSpace:protectionSpace.get()];
 
     RetainPtr<NSURLRequest> request = server.request();
@@ -371,7 +371,7 @@ TEST(Challenge, BasicPersistentCredential)
 {
     using namespace TestWebKitAPI;
     HTTPServer server(HTTPServer::respondWithChallengeThenOK);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     __block RetainPtr<NSURLProtectionSpace> protectionSpace;
     auto credentialStorage = [NSURLCredentialStorage sharedCredentialStorage];
     delegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
@@ -381,7 +381,7 @@ TEST(Challenge, BasicPersistentCredential)
         EXPECT_WK_STREQ(protectionSpace.get().authenticationMethod, NSURLAuthenticationMethodHTTPBasic);
         completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialWithUser:@"testuser" password:@"testpassword" persistence:NSURLCredentialPersistencePermanent]);
     };
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     webView.get().navigationDelegate = delegate.get();
     [webView loadRequest:server.request()];
     [delegate waitForDidFinishNavigation];
@@ -604,8 +604,8 @@ TEST(WebKit, ServerTrust)
 {
     HTTPServer server(HTTPServer::respondWithOK, HTTPServer::Protocol::Https);
 
-    auto webView = adoptNS([WKWebView new]);
-    auto delegate = adoptNS([ServerTrustDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([ServerTrustDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"https://localhost:%d/", server.port()]]]];
@@ -618,12 +618,12 @@ TEST(WebKit, ServerTrust)
 TEST(WebKit, FastServerTrust)
 {
     HTTPServer server(HTTPServer::respondWithOK, HTTPServer::Protocol::Https);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [dataStoreConfiguration setFastServerTrustEvaluationEnabled:YES];
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]).get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto delegate = adoptNS([ServerTrustDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([ServerTrustDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"https://localhost:%d/", server.port()]]]];
     [delegate waitForDidFinishNavigation];
@@ -640,10 +640,10 @@ TEST(WebKit, ErrorSecureCoding)
     NSError *error = [delegate waitForDidFailProvisionalNavigation];
 
     EXPECT_WK_STREQ(NSStringFromClass([error.userInfo[_WKRecoveryAttempterErrorKey] class]), @"WKReloadFrameErrorRecoveryAttempter");
-    auto archiver = adoptNS([[NSKeyedArchiver alloc] initRequiringSecureCoding:YES]);
+    RetainPtr archiver = adoptNS([[NSKeyedArchiver alloc] initRequiringSecureCoding:YES]);
     [archiver encodeObject:error forKey:NSKeyedArchiveRootObjectKey];
     [archiver finishEncoding];
-    auto unarchiver = adoptNS([[NSKeyedUnarchiver alloc] initForReadingFromData:archiver.get().encodedData error:nullptr]);
+    RetainPtr unarchiver = adoptNS([[NSKeyedUnarchiver alloc] initForReadingFromData:archiver.get().encodedData error:nullptr]);
     NSError *decodedError = [unarchiver decodeObjectOfClasses:[NSSet setWithObjects:[NSDictionary class], [NSString class], [NSError class], NSClassFromString(@"WKReloadFrameErrorRecoveryAttempter"), nil] forKey:NSKeyedArchiveRootObjectKey];
     EXPECT_EQ(decodedError.code, NSURLErrorNetworkConnectionLost);
     EXPECT_WK_STREQ(decodedError.domain, NSURLErrorDomain);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Coding.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Coding.mm
@@ -52,7 +52,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 TEST(Coding, WKPreferences)
 {
-    auto a = adoptNS([[WKPreferences alloc] init]);
+    RetainPtr a = adoptNS([[WKPreferences alloc] init]);
 
     // Change all defaults to something else.
     [a setMinimumFontSize:10];
@@ -100,7 +100,7 @@ TEST(Coding, WKWebsiteDataStore_NonPersistent)
 
 TEST(Coding, WKWebViewConfiguration)
 {
-    auto a = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr a = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     // Change all defaults to something else.
     [a setSuppressesIncrementalRendering:YES];
@@ -132,7 +132,7 @@ TEST(Coding, WKWebViewConfiguration)
 
 TEST(Coding, WKWebView)
 {
-    auto a = adoptNS([[WKWebView alloc] init]);
+    RetainPtr a = adoptNS([[WKWebView alloc] init]);
 
     // Change all defaults to something else.
     [a setAllowsBackForwardNavigationGestures:YES];
@@ -170,10 +170,10 @@ TEST(Coding, WKWebView_SameConfiguration)
     // First, encode two WKWebViews sharing the same configuration.
     RetainPtr<NSData> data;
     {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-        auto a = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-        auto b = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+        RetainPtr a = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+        RetainPtr b = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
         data = [NSKeyedArchiver archivedDataWithRootObject:@[a.get(), b.get()] requiringSecureCoding:YES error:nullptr];
     }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Configuration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Configuration.mm
@@ -34,28 +34,28 @@
 
 TEST(WebKit, ConfigurationCPULimit)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     EXPECT_EQ([configuration _cpuLimit], 0);
     [configuration _setCPULimit:0.75];
     EXPECT_EQ([configuration _cpuLimit], 0.75);
-    auto other = adoptNS([configuration copy]);
+    RetainPtr other = adoptNS([configuration copy]);
     EXPECT_EQ([other _cpuLimit], 0.75);
 }
 
 TEST(WebKit, ConfigurationDrawsBackground)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     EXPECT_EQ([configuration _drawsBackground], YES);
     [configuration _setDrawsBackground:NO];
     EXPECT_EQ([configuration _drawsBackground], NO);
 
-    auto other = adoptNS([configuration copy]);
+    RetainPtr other = adoptNS([configuration copy]);
     EXPECT_EQ([other _drawsBackground], NO);
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect]);
     EXPECT_EQ([webView _drawsBackground], YES);
 
-    auto configedWebView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
+    RetainPtr configedWebView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
     EXPECT_EQ([configedWebView _drawsBackground], NO);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ContentFiltering.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ContentFiltering.mm
@@ -104,7 +104,7 @@ using DecisionPoint = WebCore::MockContentFilterSettings::DecisionPoint;
 static RetainPtr<WKWebViewConfiguration> configurationWithContentFilterSettings(Decision decision, DecisionPoint decisionPoint)
 {
     auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"ContentFilteringPlugIn"]);
-    auto contentFilterEnabler = adoptNS([[MockContentFilterEnabler alloc] initWithDecision:decision decisionPoint:decisionPoint]);
+    RetainPtr contentFilterEnabler = adoptNS([[MockContentFilterEnabler alloc] initWithDecision:decision decisionPoint:decisionPoint]);
     [[configuration processPool] _setObject:contentFilterEnabler.get() forBundleParameter:NSStringFromClass([MockContentFilterEnabler class])];
     return configuration;
 }
@@ -137,8 +137,8 @@ TEST(ContentFiltering, URLAfterServerRedirect)
         [TestProtocol registerWithScheme:@"https"];
 
         auto configuration = configurationWithContentFilterSettings(Decision::Allow, DecisionPoint::AfterAddData);
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-        auto navigationDelegate = adoptNS([[ServerRedirectNavigationDelegate alloc] init]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+        RetainPtr navigationDelegate = adoptNS([[ServerRedirectNavigationDelegate alloc] init]);
         [webView setNavigationDelegate:navigationDelegate.get()];
         [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://redirect?pass"]]];
         TestWebKitAPI::Util::run(&isDone);
@@ -189,10 +189,10 @@ static void downloadTest(Decision decision, DecisionPoint decisionPoint)
         [TestProtocol registerWithScheme:@"https"];
 
         auto configuration = configurationWithContentFilterSettings(decision, decisionPoint);
-        auto downloadDelegate = adoptNS([[ContentFilteringDownloadDelegate alloc] init]);
+        RetainPtr downloadDelegate = adoptNS([[ContentFilteringDownloadDelegate alloc] init]);
         [[configuration processPool] _setDownloadDelegate:downloadDelegate.get()];
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-        auto navigationDelegate = adoptNS([[BecomeDownloadDelegate alloc] init]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+        RetainPtr navigationDelegate = adoptNS([[BecomeDownloadDelegate alloc] init]);
         [webView setNavigationDelegate:navigationDelegate.get()];
         [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://redirect/?download"]]];
 
@@ -304,8 +304,8 @@ static void loadAlternateTest(Decision decision, DecisionPoint decisionPoint)
         [TestProtocol registerWithScheme:@"https"];
 
         auto configuration = configurationWithContentFilterSettings(decision, decisionPoint);
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-        auto navigationDelegate = adoptNS([[LoadAlternateNavigationDelegate alloc] init]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+        RetainPtr navigationDelegate = adoptNS([[LoadAlternateNavigationDelegate alloc] init]);
         [webView setNavigationDelegate:navigationDelegate.get()];
         [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://redirect/?result"]]];
 
@@ -343,7 +343,7 @@ TEST(ContentFiltering, LoadAlternateAfterFinishedAddingDataWK2)
 
 TEST(ContentFiltering, CookieAccessFromReplacementData)
 {
-    auto networkProcessStarter = adoptNS([WKWebView new]);
+    RetainPtr networkProcessStarter = adoptNS([WKWebView new]);
     [networkProcessStarter synchronouslyLoadHTMLString:@"hi"];
     auto pidBefore = networkProcessStarter.get().configuration.websiteDataStore._networkProcessIdentifier;
     loadAlternateTest(Decision::Block, DecisionPoint::AfterWillSendRequest);
@@ -422,7 +422,7 @@ TEST(ContentFiltering, LazilyLoadPlatformFrameworks)
     method_setImplementation(method, reinterpret_cast<IMP>(isManagedSession));
 
     @autoreleasepool {
-        auto controller = adoptNS([[LazilyLoadPlatformFrameworksController alloc] init]);
+        RetainPtr controller = adoptNS([[LazilyLoadPlatformFrameworksController alloc] init]);
         [controller expectParentalControlsLoaded:NO];
 
         isDone = false;
@@ -529,8 +529,8 @@ TEST(ContentFiltering, URLAfterServerRedirectBlocked)
         });
 
         auto configuration = configurationWithContentFilterSettings(Decision::Block, DecisionPoint::AfterAddData);
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-        auto navigationDelegate = adoptNS([[LoadAlternateNavigationDelegate alloc] init]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+        RetainPtr navigationDelegate = adoptNS([[LoadAlternateNavigationDelegate alloc] init]);
         [webView setNavigationDelegate:navigationDelegate.get()];
         [webView loadRequest:server.request()];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ContentRuleListNotification.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ContentRuleListNotification.mm
@@ -129,11 +129,11 @@ static RetainPtr<WKContentRuleList> makeContentRuleList(NSString *source, NSStri
 
 TEST(ContentRuleList, NotificationMainResource)
 {
-    auto delegate = adoptNS([[ContentRuleListNotificationDelegate alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr delegate = adoptNS([[ContentRuleListNotificationDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addContentRuleList:makeContentRuleList(notificationSource).get()];
     [configuration setURLSchemeHandler:delegate.get() forURLScheme:@"apitest"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"apitest:///match"]]];
     TestWebKitAPI::Util::run(&receivedNotification);
@@ -143,11 +143,11 @@ TEST(ContentRuleList, NotificationMainResource)
 
 TEST(ContentRuleList, NotificationSubresource)
 {
-    auto delegate = adoptNS([[ContentRuleListNotificationDelegate alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr delegate = adoptNS([[ContentRuleListNotificationDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addContentRuleList:makeContentRuleList(notificationSource).get()];
     [configuration setURLSchemeHandler:delegate.get() forURLScheme:@"apitest"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
     [webView loadHTMLString:@"<script>fetch('match').then(function(response){alert('fetch complete')})</script>" baseURL:[NSURL URLWithString:@"apitest:///"]];
@@ -169,9 +169,9 @@ TEST(ContentRuleList, LoadHTMLStringDisplayNone)
         "{ \"action\": { \"type\" : \"ignore-previous-rules\" }, \"trigger\": { \"url-filter\": \"example.com\" }}"
     "]");
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [[configuration userContentController] addContentRuleList:list.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView synchronouslyLoadHTMLString:html];
     EXPECT_WK_STREQ([webView objectByEvaluatingJavaScript:getLinkDisplay], "none");
@@ -185,9 +185,9 @@ TEST(ContentRuleList, LoadHTMLStringDisplayNone)
     auto list2 = makeContentRuleList(@"["
         "{ \"action\": { \"type\" : \"css-display-none\", \"selector\": \"a[href*='apple.com']\" }, \"trigger\": { \"url-filter\": \"webkit.org\" }}"
     "]", @"other extension");
-    auto configuration2 = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration2 = adoptNS([WKWebViewConfiguration new]);
     [[configuration2 userContentController] addContentRuleList:list2.get()];
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration2.get()]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration2.get()]);
 
     [webView2 synchronouslyLoadHTMLString:html baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
     EXPECT_WK_STREQ([webView2 objectByEvaluatingJavaScript:getLinkDisplay], "none");
@@ -204,9 +204,9 @@ TEST(ContentRuleList, DisplayNoneInSrcDocIFrame)
         "{ \"action\": { \"type\" : \"css-display-none\", \"selector\": \".header\" }, \"trigger\": { \"url-filter\": \".*\" }}"
     "]");
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [[configuration userContentController] addContentRuleList:list.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView synchronouslyLoadHTMLString:html];
 
@@ -234,9 +234,9 @@ TEST(ContentRuleList, DisplayNoneInAboutBlankIFrame)
         "{ \"action\": { \"type\" : \"css-display-none\", \"selector\": \"h1\" }, \"trigger\": { \"url-filter\": \".*\" }}"
     "]");
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [[configuration userContentController] addContentRuleList:list.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView synchronouslyLoadHTMLString:html];
 
@@ -271,9 +271,9 @@ TEST(ContentRuleList, DisplayNoneAfterIgnoreFollowingRules)
         "{ \"action\": { \"type\" : \"css-display-none\", \"selector\": \"h1[id*='B']\" }, \"trigger\": { \"url-filter\": \".*\" }}"
     "]");
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [[configuration userContentController] addContentRuleList:list.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView synchronouslyLoadHTMLString:html];
     EXPECT_WK_STREQ([webView objectByEvaluatingJavaScript:headerADisplay], "none");
@@ -288,12 +288,12 @@ TEST(ContentRuleList, PerformedActionForURL)
 {
     NSString *firstList = @"[{\"action\":{\"type\":\"notify\",\"notification\":\"testnotification\"},\"trigger\":{\"url-filter\":\"notify\"}}]";
     NSString *secondList = @"[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"block\"}}]";
-    auto delegate = adoptNS([[ContentRuleListNotificationDelegate alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr delegate = adoptNS([[ContentRuleListNotificationDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addContentRuleList:makeContentRuleList(firstList, @"firstList").get()];
     [[configuration userContentController] addContentRuleList:makeContentRuleList(secondList, @"secondList").get()];
     [configuration setURLSchemeHandler:delegate.get() forURLScheme:@"apitest"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
     [webView loadHTMLString:@"<script>fetch('notify').then(function(){fetch('block').then().catch(function(){alert('test complete')})})</script>" baseURL:[NSURL URLWithString:@"apitest:///"]];
@@ -383,11 +383,11 @@ TEST(ContentRuleList, RequestMethods)
         return makeContentRuleList([NSString stringWithFormat:@"[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\", \"request-method\": \"%@\"}}]", method]);
     };
 
-    auto delegate = adoptNS([[ContentRuleListNotificationDelegate alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr delegate = adoptNS([[ContentRuleListNotificationDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:delegate.get() forURLScheme:@"apitest"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
 
@@ -593,10 +593,10 @@ TEST(ContentRuleList, CSPReport)
         { "Content-Security-Policy"_s, "frame-src 'none'; report-uri resources/save-report.py"_s }
     }, "<iframe src=\"https://webkit.org/\"></iframe>"_s } } });
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [[configuration userContentController] addContentRuleList:makeContentRuleList(@"[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\",\"resource-type\":[\"csp-report\"]}}]").get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
-    auto delegate = adoptNS([ContentRuleListNotificationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([ContentRuleListNotificationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:server.request()];
     while (notificationList.isEmpty())
@@ -613,14 +613,14 @@ TEST(WebKit, RedirectToPlaintextHTTPSUpgrade)
     HTTPServer plaintextServer({ { "http://download/redirectTarget"_s, { "<script>alert('success!')</script>"_s } } });
     HTTPServer secureServer({ { "/originalRequest"_s, { 302, { { "Location"_s, "http://download/redirectTarget"_s } }, emptyString() } } }, HTTPServer::Protocol::HttpsProxy);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setHTTPProxy:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", plaintextServer.port()]]];
     [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", secureServer.port()]]];
     [storeConfiguration setAllowsServerPreconnect:NO];
-    auto viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [viewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:viewConfiguration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:viewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
     };
@@ -639,11 +639,11 @@ TEST(ContentRuleList, RedirectBeforeBlock)
 
     NSString *rules = [NSString stringWithFormat:@"[{\"action\":{\"type\":\"redirect\",\"redirect\":{\"url\":\"%@\"}},\"trigger\":{\"url-filter\":\".*\"}},{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\"}}]", server.request("/redirected"_s).URL.absoluteString];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addContentRuleList:makeContentRuleList(rules).get()];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         preferences._activeContentRuleListActionPatterns = @{
             @"testidentifier": [NSSet setWithObject:@"*://*/*"]

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ContentSecurityPolicy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ContentSecurityPolicy.mm
@@ -77,8 +77,8 @@ TEST(WKWebView, SetOverrideContentSecurityPolicyForPageWithoutCSP)
 TEST(WKWebView, CheckViolationReportDocumentURIForFileProtocol)
 {
     @autoreleasepool {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-        auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"csp-document-uri-report" withExtension:@"html"]];
         [webView loadRequest:request];
 
@@ -89,14 +89,14 @@ TEST(WKWebView, CheckViolationReportDocumentURIForFileProtocol)
 TEST(WKWebView, CheckViolationReportDocumentURIForDataProtocol)
 {
     @autoreleasepool {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-        auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         NSString *path = [NSBundle.test_resourcesBundle pathForResource:@"csp-document-uri-report" ofType:@"html"];
         NSString* content = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:NULL];
 
         NSURLRequest *loadRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"data:text/html"]];
         NSData *data = [content dataUsingEncoding:NSUTF8StringEncoding];
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:[NSURL URLWithString:@"data:text/html"] MIMEType:@"text/HTML" expectedContentLength:[data length] textEncodingName:@"UTF-8"]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:[NSURL URLWithString:@"data:text/html"] MIMEType:@"text/HTML" expectedContentLength:[data length] textEncodingName:@"UTF-8"]);
 
         [webView loadSimulatedRequest:loadRequest response:response.get() responseData:data];
         [webView waitForMessage:@"document-uri: data"];
@@ -106,8 +106,8 @@ TEST(WKWebView, CheckViolationReportDocumentURIForDataProtocol)
 TEST(WKWebView, CheckViolationReportDocumentURIForAboutProtocol)
 {
     @autoreleasepool {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-        auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         NSString *path = [NSBundle.test_resourcesBundle pathForResource:@"csp-document-uri-report" ofType:@"html"];
         NSString* content = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:NULL];
 
@@ -122,7 +122,7 @@ TEST(ContentSecurityPolicy, InvalidRequireTrustedTypesFor)
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "content-security-policy"_s, "require-trusted-types-for 'script html'"_s } }, "hi"_s } }
     });
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView loadRequest:server.request()];
     [webView _test_waitForDidFinishNavigation];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CookieAcceptPolicy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CookieAcceptPolicy.mm
@@ -60,12 +60,12 @@ TEST(WebKit, CookieAcceptPolicy)
 {
     auto originalCookieAcceptPolicy = [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookieAcceptPolicy];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto handler = adoptNS([[CookieAcceptPolicyMessageHandler alloc] init]);
+    RetainPtr handler = adoptNS([[CookieAcceptPolicyMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"CookieMessage" withExtension:@"html"]];
     __block bool setPolicy = false;
@@ -89,11 +89,11 @@ TEST(WKHTTPCookieStore, CookiePolicy)
     using namespace TestWebKitAPI;
 
     __block bool done { false };
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     auto dataStore = [WKWebsiteDataStore nonPersistentDataStore];
     auto cookieStore = dataStore.httpCookieStore;
     configuration.get().websiteDataStore = dataStore;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     [cookieStore getCookiePolicy:^(WKCookiePolicy policy) {
         EXPECT_EQ(policy, WKCookiePolicyAllow);
@@ -178,13 +178,13 @@ TEST(WKHTTPCookieStore, CookiePolicyAllowIsOnlyFromMainDocumentDomain)
         });
     });
 
-    auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [dataStoreConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(server.port())
     }];
     [dataStoreConfiguration setAllowsServerPreconnect:NO];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
     auto cookieStore = dataStore.get().httpCookieStore;
     [cookieStore setCookiePolicy:WKCookiePolicyAllow completionHandler:^{
         done = true;
@@ -192,12 +192,12 @@ TEST(WKHTTPCookieStore, CookiePolicyAllowIsOnlyFromMainDocumentDomain)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:dataStore.get()];
     // Relax WebKit's third-party cookies blocking policy so the WebKit will use cookie storage's policy
     // to decide whether third-party cookeis can be stored.
     [configuration _setShouldRelaxThirdPartyCookieBlocking:true];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.webkit.org/"]]];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "fetched");
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CookiePrivateBrowsing.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CookiePrivateBrowsing.mm
@@ -58,15 +58,15 @@ static bool didRunJavaScriptAlertForCookiePrivateBrowsing;
 
 TEST(WebKit, CookiePrivateBrowsing)
 {
-    auto delegate = adoptNS([[CookiePrivateBrowsingDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[CookiePrivateBrowsingDelegate alloc] init]);
 
-    auto configuration1 = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto configuration2 = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration1 = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration2 = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration2 setProcessPool:[configuration1 processPool]];
     [configuration1 setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
     [configuration2 setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
-    auto view1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration1.get()]);
-    auto view2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration2.get()]);
+    RetainPtr view1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration1.get()]);
+    RetainPtr view2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration2.get()]);
     [view1 setUIDelegate:delegate.get()];
     [view2 setUIDelegate:delegate.get()];
     NSString *alertOldCookie = @"<script>var oldCookie = document.cookie; document.cookie = 'key=value'; alert('old cookie: <' + oldCookie + '>');</script>";
@@ -85,10 +85,10 @@ TEST(WebKit, CookieCacheSyncAcrossProcess)
     }];
     TestWebKitAPI::Util::run(&setDefaultCookieAcceptPolicy);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
-    auto view1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto view2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr view1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr view2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [view1 synchronouslyLoadHTMLString:@"foo" baseURL:[NSURL URLWithString:@"http://example.com/"]];
     [view2 synchronouslyLoadHTMLString:@"bar" baseURL:[NSURL URLWithString:@"http://example.com/"]];
 
@@ -142,8 +142,8 @@ TEST(WebKit, CookieCacheSyncAcrossProcess)
 
 TEST(WebKit, CookieCachePruning)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto view = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr view = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     for (unsigned i = 0; i < 100; ++i) {
         [view synchronouslyLoadHTMLString:@"foo" baseURL:adoptNS([[NSURL alloc] initWithString:makeString("http://foo"_s, i, ".example.com/"_s).createNSString().get()]).get()];
@@ -166,18 +166,18 @@ TEST(WebKit, DISABLED_CookieAccessFromPDFInAboutBlank)
 TEST(WebKit, CookieAccessFromPDFInAboutBlank)
 #endif
 {
-    auto delegate = adoptNS([TestUIDelegate new]);
+    RetainPtr delegate = adoptNS([TestUIDelegate new]);
     __block RetainPtr<WKWebView> openedWebView;
     delegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *, WKWindowFeatures *) {
         openedWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
         return openedWebView.get();
     };
 
-    auto webProcessStarter = adoptNS([TestWKWebView new]);
+    RetainPtr webProcessStarter = adoptNS([TestWKWebView new]);
     [webProcessStarter synchronouslyLoadHTMLString:@"start network process so the creation of the second web view doesn't send NetworkProcessCreationParameters" baseURL:nil];
 
     TestWebKitAPI::HTTPServer server({ { "/"_s, { "hi"_s } } });
-    auto webView = adoptNS([TestWKWebView new]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
     webView.get().UIDelegate = delegate.get();
     NSString *html = [NSString stringWithFormat:@"<script>"
         "var w = window.open();"

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyHTML.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyHTML.mm
@@ -119,7 +119,7 @@ TEST(CopyHTML, SanitizationPreservesCharacterSetInSelectedText)
     EXPECT_TRUE([copiedMarkup containsString:@"我叫謝文昇"]);
     EXPECT_TRUE([copiedMarkup containsString:@"</span>"]);
 
-    auto attributedString = adoptNS([[NSAttributedString alloc] initWithData:readHTMLDataFromPasteboard() options:@{ NSDocumentTypeDocumentOption: NSHTMLTextDocumentType } documentAttributes:nil error:nil]);
+    RetainPtr attributedString = adoptNS([[NSAttributedString alloc] initWithData:readHTMLDataFromPasteboard() options:@{ NSDocumentTypeDocumentOption: NSHTMLTextDocumentType } documentAttributes:nil error:nil]);
     EXPECT_WK_STREQ("我叫謝文昇", [attributedString string]);
 }
 
@@ -159,7 +159,7 @@ TEST(CopyHTML, SanitizationPreservesCharacterSet)
 
         NSError *attributedStringConversionError = nil;
 
-        auto attributedString = adoptNS([[NSAttributedString alloc] initWithData:copiedData.get() options:@{ NSDocumentTypeDocumentOption: NSHTMLTextDocumentType } documentAttributes:nil error:&attributedStringConversionError]);
+        RetainPtr attributedString = adoptNS([[NSAttributedString alloc] initWithData:copiedData.get() options:@{ NSDocumentTypeDocumentOption: NSHTMLTextDocumentType } documentAttributes:nil error:&attributedStringConversionError]);
         EXPECT_WK_STREQ("我叫謝文昇", [attributedString string]);
 
         __block BOOL foundColorAttribute = NO;
@@ -215,7 +215,7 @@ TEST(CopyHTML, SanitizationPreservesRelativeURLInAttributedString)
     [webView stringByEvaluatingJavaScript:@"getSelection().selectAllChildren(document.body)"];
 
     auto [resultString, resultError] = copyAndLoadAttributedStringUsingWebArchive(webView.get());
-    auto links = adoptNS([NSMutableArray<NSURL *> new]);
+    RetainPtr links = adoptNS([NSMutableArray<NSURL *> new]);
     [resultString enumerateAttribute:NSLinkAttributeName inRange:NSMakeRange(0, 5) options:0 usingBlock:^(NSURL *url, NSRange, BOOL*) {
         [links addObject:url];
     }];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyRTF.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CopyRTF.mm
@@ -62,7 +62,7 @@ static NSData *readRTFDataFromPasteboard()
 
 static RetainPtr<NSAttributedString> copyAttributedStringFromHTML(NSString *htmlString, bool forceDarkMode)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
 
     auto preferences = (__bridge WKPreferencesRef)[[webView configuration] preferences];
     WKPreferencesSetWriteRichTextDataWhenCopyingOrDragging(preferences, true);
@@ -78,7 +78,7 @@ static RetainPtr<NSAttributedString> copyAttributedStringFromHTML(NSString *html
     NSData *rtfData = readRTFDataFromPasteboard();
     EXPECT_NOT_NULL(rtfData);
 
-    auto attributedString = adoptNS([[NSAttributedString alloc] initWithData:rtfData options:@{ } documentAttributes:nil error:nullptr]);
+    RetainPtr attributedString = adoptNS([[NSAttributedString alloc] initWithData:rtfData options:@{ } documentAttributes:nil error:nullptr]);
     EXPECT_NOT_NULL(attributedString.get());
 
     return attributedString;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CreateWebArchive.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CreateWebArchive.mm
@@ -56,8 +56,8 @@ window.webkit.messageHandlers.testHandler.postMessage("done");
 
 TEST(WebArchive, CreateCustomScheme)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
 
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
@@ -69,13 +69,13 @@ TEST(WebArchive, CreateCustomScheme)
         else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[NSData dataWithBytes:bytes length:strlen(bytes)]];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     static bool done = false;
     [webView createWebArchiveDataWithCompletionHandler:^(NSData *result, NSError *error) {
@@ -123,8 +123,8 @@ TEST(WebArchive, CreateCustomScheme)
 static RetainPtr<NSData> webArchiveAccessingCookies()
 {
     HTTPServer server({ { "/"_s, { "<script>document.cookie</script>"_s } } }, HTTPServer::Protocol::HttpsProxy);
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:server.httpsProxyConfiguration()]);
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:server.httpsProxyConfiguration()]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     webView.get().navigationDelegate = navigationDelegate.get();
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org/"]]];
@@ -148,7 +148,7 @@ TEST(WebArchive, CookieAccessAfterLoadRequest)
     BOOL success = [webArchive writeToFile:path atomically:YES];
     EXPECT_TRUE(success);
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL fileURLWithPath:path isDirectory:NO]]];
     [webView _test_waitForDidFinishNavigation];
     [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
@@ -157,7 +157,7 @@ TEST(WebArchive, CookieAccessAfterLoadRequest)
 TEST(WebArchive, CookieAccessAfterLoadData)
 {
     auto webArchive = webArchiveAccessingCookies();
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView loadData:webArchive.get() MIMEType:@"application/x-webarchive" characterEncodingName:@"utf-8" baseURL:[NSURL URLWithString:@"http://example.com/"]];
     [webView _test_waitForDidFinishNavigation];
 }
@@ -166,7 +166,7 @@ TEST(WebArchive, ApplicationXWebarchiveMIMETypeDoesNotLoadHTML)
 {
     HTTPServer server({ { "/"_s, { { { "Content-Type"_s, "application/x-webarchive"_s } }, "Not web archive content, should not load"_s } } });
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView loadRequest:server.request()];
     [webView _test_waitForDidFailProvisionalNavigation];
 }
@@ -177,8 +177,8 @@ TEST(WebArchive, SaveResourcesBasic)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [@"<head><script src=\"script.js\"></script></head><img src=\"image.png\" onload=\"onImageLoad()\"><script>function onImageLoad() { notifyTestRunner(); }</script>" dataUsingEncoding:NSUTF8StringEncoding];
     NSData *scriptData = [@"function notifyTestRunner() { window.webkit.messageHandlers.testHandler.postMessage(\"done\"); }" dataUsingEncoding:NSUTF8StringEncoding];
@@ -198,13 +198,13 @@ TEST(WebArchive, SaveResourcesBasic)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"done" action:[&] {
         messageReceived = true;
@@ -268,8 +268,8 @@ TEST(WebArchive, SaveResourcesIframe)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForIframe length:strlen(htmlDataBytesForIframe)];
     NSData *iframeHTMLData = [NSData dataWithBytes:iframeHTMLDataBytes length:strlen(iframeHTMLDataBytes)];
@@ -293,13 +293,13 @@ TEST(WebArchive, SaveResourcesIframe)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"done" action:[&] {
         messageReceived = true;
@@ -378,8 +378,8 @@ TEST(WebArchive, SaveResourcesFrame)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForFrame length:strlen(htmlDataBytesForFrame)];
     NSData *frameHTMLData = [NSData dataWithBytes:frameHTMLDataBytes length:strlen(frameHTMLDataBytes)];
@@ -399,13 +399,13 @@ TEST(WebArchive, SaveResourcesFrame)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"done" action:[&] {
         messageReceived = true;
@@ -459,8 +459,8 @@ TEST(WebArchive, SaveResourcesValidFileName)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
 
     NSMutableString *mutableFileName = [NSMutableString stringWithCapacity:256];
@@ -491,13 +491,13 @@ TEST(WebArchive, SaveResourcesValidFileName)
             mimeType = @"image/png";
             data = imageData;
         }
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"done" action:[&] {
         messageReceived = true;
@@ -560,8 +560,8 @@ TEST(WebArchive, SaveResourcesBlobURL)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
 
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForBlobURL length:strlen(htmlDataBytesForBlobURL)];
@@ -578,13 +578,13 @@ TEST(WebArchive, SaveResourcesBlobURL)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"done" action:[&] {
         messageReceived = true;
@@ -671,8 +671,8 @@ TEST(WebArchive, SaveResourcesResponsiveImages)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForResponsiveImages length:strlen(htmlDataBytesForResponsiveImages)];
     NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
@@ -688,13 +688,13 @@ TEST(WebArchive, SaveResourcesResponsiveImages)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"done" action:[&] {
         messageReceived = true;
@@ -743,8 +743,8 @@ TEST(WebArchive, SaveResourcesDataURL)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
 
     NSData *htmlData = [NSData dataWithBytes:hTMLDataBytesForDataURL length:strlen(hTMLDataBytesForDataURL)];
@@ -761,13 +761,13 @@ TEST(WebArchive, SaveResourcesDataURL)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"done" action:[&] {
         messageReceived = true;
@@ -844,8 +844,8 @@ TEST(WebArchive, SaveResourcesIframeInIframe)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForIframeInIframe length:strlen(htmlDataBytesForIframeInIframe)];
     NSData *iframe1HTMLData = [NSData dataWithBytes:iframe1HTMLDataBytes length:strlen(iframe1HTMLDataBytes)];
@@ -865,13 +865,13 @@ TEST(WebArchive, SaveResourcesIframeInIframe)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"done" action:[&] {
         messageReceived = true;
@@ -949,8 +949,8 @@ TEST(WebArchive, SaveResourcesIframesWithSameURL)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForIframesWithSameURL length:strlen(htmlDataBytesForIframesWithSameURL)];
     NSData *iframeHTMLData = [NSData dataWithBytes:iframeHTMLDataBytesForIframesWithSameURL length:strlen(iframeHTMLDataBytesForIframesWithSameURL)];
@@ -966,13 +966,13 @@ TEST(WebArchive, SaveResourcesIframesWithSameURL)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"done" action:[&] {
         messageReceived = true;
@@ -1040,8 +1040,8 @@ TEST(WebArchive, SaveResourcesShadowDOM)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForShadowDOM length:strlen(htmlDataBytesForShadowDOM)];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
@@ -1053,13 +1053,13 @@ TEST(WebArchive, SaveResourcesShadowDOM)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"start" action:[&] {
         messageReceived = true;
@@ -1105,8 +1105,8 @@ TEST(WebArchive, SaveResourcesDeclarativeShadowDOM)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForDeclarativeShadowDOM length:strlen(htmlDataBytesForDeclarativeShadowDOM)];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
@@ -1118,13 +1118,13 @@ TEST(WebArchive, SaveResourcesDeclarativeShadowDOM)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"done" action:[&] {
         messageReceived = true;
@@ -1172,8 +1172,8 @@ TEST(WebArchive, SaveResourcesStyle)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForStyle length:strlen(htmlDataBytesForStyle)];
     NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
@@ -1193,13 +1193,13 @@ TEST(WebArchive, SaveResourcesStyle)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"done" action:[&] {
         messageReceived = true;
@@ -1245,8 +1245,8 @@ TEST(WebArchive, SaveResourcesInlineStyle)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForInlineStyle length:strlen(htmlDataBytesForInlineStyle)];
     NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
@@ -1262,13 +1262,13 @@ TEST(WebArchive, SaveResourcesInlineStyle)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"done" action:[&] {
         messageReceived = true;
@@ -1342,8 +1342,8 @@ TEST(WebArchive, SaveResourcesLink)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForLink length:strlen(htmlDataBytesForLink)];
     NSData *cssData = [NSData dataWithBytes:cssDataBytesForLink length:strlen(cssDataBytesForLink)];
@@ -1370,13 +1370,13 @@ TEST(WebArchive, SaveResourcesLink)
             data = fontData;
         }
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"done" action:[&] {
         messageReceived = true;
@@ -1510,8 +1510,8 @@ TEST(WebArchive, SaveResourcesLinksWithSameURL)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForLinksWithSameURL length:strlen(htmlDataBytesForLinksWithSameURL)];
     NSData *cssData = [NSData dataWithBytes:cssDataBytesForLinksWithSameURL length:strlen(cssDataBytesForLinksWithSameURL)];
@@ -1526,13 +1526,13 @@ TEST(WebArchive, SaveResourcesLinksWithSameURL)
             data = cssData;
         }
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"done" action:[&] {
         messageReceived = true;
@@ -1598,8 +1598,8 @@ TEST(WebArchive, SaveResourcesCSSImportRule)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForCSSImportRule length:strlen(htmlDataBytesForCSSImportRule)];
     NSData *cssData = [NSData dataWithBytes:cssDataBytesForLink length:strlen(cssDataBytesForLink)];
@@ -1618,13 +1618,13 @@ TEST(WebArchive, SaveResourcesCSSImportRule)
             data = cssData;
         }
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"done" action:[&] {
         messageReceived = true;
@@ -1687,8 +1687,8 @@ TEST(WebArchive, SaveResourcesCSSSupportsRule)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForCSSSupportsRule length:strlen(htmlDataBytesForCSSSupportsRule)];
     NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
@@ -1703,13 +1703,13 @@ TEST(WebArchive, SaveResourcesCSSSupportsRule)
             data = imageData;
         }
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"done" action:[&] {
         messageReceived = true;
@@ -1782,7 +1782,7 @@ TEST(WebArchive, SaveResourcesCSSMediaRule)
             data = imageData.get();
         }
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data];
         [task didFinish];
@@ -1840,8 +1840,8 @@ TEST(WebArchive, SaveResourcesCrossOriginLink)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForCrossOriginLink length:strlen(htmlDataBytesForCrossOriginLink)];
     NSData *cssData = [NSData dataWithBytes:cssDataBytesForCrossOriginLink length:strlen(cssDataBytesForCrossOriginLink)];
@@ -1856,13 +1856,13 @@ TEST(WebArchive, SaveResourcesCrossOriginLink)
             data = cssData;
         }
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"done" action:[&] {
         messageReceived = true;
@@ -1909,8 +1909,8 @@ TEST(WebArchive, SaveResourcesExcludeBaseElement)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForExcludeBaseElement length:strlen(htmlDataBytesForExcludeBaseElement)];
     NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
@@ -1925,13 +1925,13 @@ TEST(WebArchive, SaveResourcesExcludeBaseElement)
             data = imageData;
         }
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"done" action:[&] {
         messageReceived = true;
@@ -1978,8 +1978,8 @@ TEST(WebArchive, SaveResourcesExclusionRules)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForExclusionRules length:strlen(htmlDataBytesForExclusionRules)];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
@@ -1991,13 +1991,13 @@ TEST(WebArchive, SaveResourcesExclusionRules)
         }
 
         EXPECT_TRUE(data.get());
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"done" action:[&] {
         messageReceived = true;
@@ -2050,8 +2050,8 @@ TEST(WebArchive, SaveResourcesExcludeCrossOriginAttribute)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForExcludeCrossOriginAttribute length:strlen(htmlDataBytesForExcludeCrossOriginAttribute)];
     NSData *scriptData = [NSData dataWithBytes:scriptDataBytesForExcludeCrossOriginAttribute length:strlen(scriptDataBytesForExcludeCrossOriginAttribute)];
@@ -2081,13 +2081,13 @@ TEST(WebArchive, SaveResourcesExcludeCrossOriginAttribute)
         if (shouldAddAccessControlHeader)
             [headerFields setObject:@"*" forKey:@"Access-Control-Allow-Origin"];
 
-        auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:task.request.URL statusCode:200 HTTPVersion:nil headerFields:headerFields.get()]);
+        RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:task.request.URL statusCode:200 HTTPVersion:nil headerFields:headerFields.get()]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"done" action:[&] {
         messageReceived = true;
@@ -2150,8 +2150,8 @@ TEST(WebArchive, SaveResourcesStyleWithUnloadedResources)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     RetainPtr htmlData = [NSData dataWithBytes:htmlDataBytesForUnsavedSubresources length:strlen(htmlDataBytesForUnsavedSubresources)];
     RetainPtr fontData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"Ahem-10000A" withExtension:@"ttf"]];
@@ -2215,8 +2215,8 @@ TEST(WebArchive, SaveResourcesWithUTF8Encoding)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:directoryURL.get() error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForUTF8Encoding length:strlen(htmlDataBytesForUTF8Encoding)];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
@@ -2234,7 +2234,7 @@ TEST(WebArchive, SaveResourcesWithUTF8Encoding)
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     static bool messageReceived = false;
     [webView performAfterReceivingMessage:@"done" action:[&] {
         messageReceived = true;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CustomUserAgent.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CustomUserAgent.mm
@@ -33,7 +33,7 @@
 
 TEST(CustomUserAgent, UpdateCachedNavigatorUserAgent)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
 
     [webView _test_waitForDidFinishNavigation];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DataDetection.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DataDetection.mm
@@ -131,7 +131,7 @@ TEST(WebKit, DISABLED_DataDetectionReferenceDate)
 
 TEST(WebKit, AddAndRemoveDataDetectors)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"data-detectors"];
     [webView expectElementCount:0 querySelector:@"a[x-apple-data-detectors=true]"];
     EXPECT_EQ(0U, [webView _dataDetectionResults].count);
@@ -167,7 +167,7 @@ TEST(WebKit, AddAndRemoveDataDetectors)
 
 TEST(WebKit, DoNotCrashWhenDetectingDataAfterWebProcessTerminates)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"data-detectors"];
     [webView _killWebContentProcessAndResetState];
     [webView synchronouslyDetectDataWithTypes:WKDataDetectorTypeAll];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DecidePolicyForNavigationAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DecidePolicyForNavigationAction.mm
@@ -105,12 +105,12 @@ static NSString *thirdURL = @"data:text/html,Third";
 
 TEST(WebKit, DecidePolicyForNavigationActionReload)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
     [[window contentView] addSubview:webView.get()];
 
-    auto controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
+    RetainPtr controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
@@ -135,12 +135,12 @@ TEST(WebKit, DecidePolicyForNavigationActionReload)
 
 TEST(WebKit, DecidePolicyForNavigationActionReloadFromOrigin)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
     [[window contentView] addSubview:webView.get()];
 
-    auto controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
+    RetainPtr controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
@@ -165,12 +165,12 @@ TEST(WebKit, DecidePolicyForNavigationActionReloadFromOrigin)
 
 TEST(WebKit, DecidePolicyForNavigationActionGoBack)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
     [[window contentView] addSubview:webView.get()];
 
-    auto controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
+    RetainPtr controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
@@ -199,12 +199,12 @@ TEST(WebKit, DecidePolicyForNavigationActionGoBack)
 
 TEST(WebKit, DecidePolicyForNavigationActionGoForward)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
     [[window contentView] addSubview:webView.get()];
 
-    auto controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
+    RetainPtr controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
@@ -349,12 +349,12 @@ TEST(WebKit, DecidePolicyForNavigationActionCancelAfterDiscardingForwardItemsWit
 
 TEST(WebKit, DecidePolicyForNavigationActionOpenNewWindowAndDeallocSourceWebView)
 {
-    auto controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
+    RetainPtr controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
 
     @autoreleasepool {
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-        auto window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
+        RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
         [[window contentView] addSubview:webView.get()];
 
         [webView setNavigationDelegate:controller.get()];
@@ -403,12 +403,12 @@ TEST(WebKit, DecidePolicyForNewWindowAction)
 
 TEST(WebKit, DecidePolicyForNavigationActionForTargetedHyperlink)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
     [[window contentView] addSubview:webView.get()];
 
-    auto controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
+    RetainPtr controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
@@ -459,12 +459,12 @@ TEST(WebKit, DecidePolicyForNavigationActionForTargetedHyperlink)
 
 TEST(WebKit, DecidePolicyForNavigationActionForLoadHTMLStringAllow)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
     [[window contentView] addSubview:webView.get()];
 
-    auto controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
+    RetainPtr controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
@@ -477,12 +477,12 @@ TEST(WebKit, DecidePolicyForNavigationActionForLoadHTMLStringAllow)
 
 TEST(WebKit, DecidePolicyForNavigationActionForLoadHTMLStringDeny)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
     [[window contentView] addSubview:webView.get()];
 
-    auto controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
+    RetainPtr controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
@@ -497,12 +497,12 @@ TEST(WebKit, DecidePolicyForNavigationActionForLoadHTMLStringDeny)
 
 TEST(WebKit, DecidePolicyForNavigationActionForTargetedWindowOpen)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
     [[window contentView] addSubview:webView.get()];
 
-    auto controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
+    RetainPtr controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
@@ -548,12 +548,12 @@ TEST(WebKit, DecidePolicyForNavigationActionForTargetedWindowOpen)
 
 TEST(WebKit, DecidePolicyForNavigationActionForTargetedFormSubmission)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
     [[window contentView] addSubview:webView.get()];
 
-    auto controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
+    RetainPtr controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
@@ -604,19 +604,19 @@ TEST(WebKit, DecidePolicyForNavigationActionForTargetedFormSubmission)
 enum class ShouldEnableProcessSwap : bool { No, Yes };
 static void runDecidePolicyForNavigationActionForHyperlinkThatRedirects(ShouldEnableProcessSwap shouldEnableProcessSwap)
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().processSwapsOnNavigation = shouldEnableProcessSwap == ShouldEnableProcessSwap::Yes ? YES : NO;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
     [[window contentView] addSubview:webView.get()];
 
-    auto controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
+    RetainPtr controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
@@ -677,12 +677,12 @@ TEST(WebKit, DecidePolicyForNavigationActionForHyperlinkThatRedirectsWithPSON)
 
 TEST(WebKit, DecidePolicyForNavigationActionForPOSTFormSubmissionThatRedirectsToGET)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
     [[window contentView] addSubview:webView.get()];
 
-    auto controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
+    RetainPtr controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
@@ -724,12 +724,12 @@ TEST(WebKit, DecidePolicyForNavigationActionForPOSTFormSubmissionThatRedirectsTo
 
 TEST(WebKit, DecidePolicyForNavigationActionForPOSTFormSubmissionThatRedirectsToPOST)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
     [[window contentView] addSubview:webView.get()];
 
-    auto controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
+    RetainPtr controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
@@ -773,8 +773,8 @@ TEST(WebKit, DelayDecidePolicyForNavigationAction)
 {
     shouldDelayDecision = true;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    auto controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr controller = adoptNS([[DecidePolicyForNavigationActionController alloc] init]);
     [webView setNavigationDelegate:controller.get()];
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
@@ -815,8 +815,8 @@ static size_t calls;
 
 TEST(WebKit, DecidePolicyForNavigationActionFragment)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
-    auto delegate = adoptNS([[DecidePolicyForNavigationActionFragmentDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr delegate = adoptNS([[DecidePolicyForNavigationActionFragmentDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView loadHTMLString:@"<script>window.location.href='#fragment';</script>" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     TestWebKitAPI::Util::run(&done);
@@ -825,8 +825,8 @@ TEST(WebKit, DecidePolicyForNavigationActionFragment)
 TEST(WebKit, NavigationActionFrames)
 {
     TestWebKitAPI::HTTPServer server({ { "/"_s, { "hi"_s } } });
-    auto webView = adoptNS([WKWebView new]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         EXPECT_NOT_NULL(action.sourceFrame.request);
         EXPECT_NOT_NULL(action.targetFrame.request);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DeviceOrientation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DeviceOrientation.mm
@@ -87,12 +87,12 @@ Function<bool()> _decisionHandler;
 enum class DeviceOrientationPermission { GrantedByClient, DeniedByClient, GrantedByUser, DeniedByUser };
 static void runDeviceOrientationTest(DeviceOrientationPermission deviceOrientationPermission)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto messageHandler = adoptNS([[DeviceOrientationMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[DeviceOrientationMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     RetainPtr<DeviceOrientationPermissionUIDelegate> uiDelegate;
     switch (deviceOrientationPermission) {
@@ -174,13 +174,13 @@ TEST(DeviceOrientation, PermissionDeniedByClient)
 
 TEST(DeviceOrientation, RememberPermissionForSession)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = [WKWebsiteDataStore defaultDataStore];
 
-    auto messageHandler = adoptNS([[DeviceOrientationMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[DeviceOrientationMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     RetainPtr<DeviceOrientationPermissionUIDelegate> uiDelegate = adoptNS([[DeviceOrientationPermissionUIDelegate alloc] initWithHandler:[] { return true; }]);
     [webView setUIDelegate:uiDelegate.get()];
 
@@ -269,13 +269,13 @@ TEST(DeviceOrientation, RememberPermissionForSession)
 
 TEST(DeviceOrientation, FireOrientationEventsRightAwayIfPermissionAlreadyGranted)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = [WKWebsiteDataStore defaultDataStore];
 
-    auto messageHandler = adoptNS([[DeviceOrientationMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[DeviceOrientationMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     RetainPtr<DeviceOrientationPermissionUIDelegate> uiDelegate = adoptNS([[DeviceOrientationPermissionUIDelegate alloc] initWithHandler:[] { return true; }]);
     [webView setUIDelegate:uiDelegate.get()];
 
@@ -339,13 +339,13 @@ TEST(DeviceOrientation, PermissionSecureContextCheck)
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { mainBytes } }
     });
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = [WKWebsiteDataStore defaultDataStore];
     
-    auto messageHandler = adoptNS([[DeviceOrientationMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[DeviceOrientationMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
     
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     RetainPtr<DeviceOrientationPermissionUIDelegate> uiDelegate = adoptNS([[DeviceOrientationPermissionUIDelegate alloc] initWithHandler:[] { return true; }]);
     [webView setUIDelegate:uiDelegate.get()];
     
@@ -414,13 +414,13 @@ TEST(WebKit, DeviceOrientationPermissionInIFrame)
         { "/frame"_s, { frameText } },
     }, TestWebKitAPI::HTTPServer::Protocol::Https, nullptr, nullptr, 9091);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto permissionDelegate = adoptNS([[DeviceOrientationPermissionValidationDelegate alloc] init]);
+    RetainPtr permissionDelegate = adoptNS([[DeviceOrientationPermissionValidationDelegate alloc] init]);
     [webView setUIDelegate:permissionDelegate.get()];
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate setDidReceiveAuthenticationChallenge:^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^callback)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
         callback(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DisableSpellcheck.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DisableSpellcheck.mm
@@ -32,7 +32,7 @@
 TEST(WebKit, DisableSpellcheck)
 {
     auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"DisableSpellcheckPlugIn" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
     BOOL isSpellcheckDisabled = [[webView objectByEvaluatingJavaScript:@"internals.isSpellcheckDisabledExceptTextReplacement(document.getElementById('disabled'))"] boolValue];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DisplayName.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DisplayName.mm
@@ -57,10 +57,10 @@ static void checkUntilDisplayNameIs(WKWebView *webView, NSString *expectedName, 
 #if !ENABLE(SET_WEBCONTENT_PROCESS_INFORMATION_IN_NETWORK_PROCESS) || USE(APPLE_INTERNAL_SDK)
 TEST(WebKit, CustomDisplayName)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     NSString *displayNameToSet = @"test display name";
     configuration.get()._processDisplayName = displayNameToSet;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:@"start web process"];
 
     bool done = false;
@@ -70,7 +70,7 @@ TEST(WebKit, CustomDisplayName)
 
 TEST(WebKit, DefaultDisplayName)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"start web process"];
 
     __block bool done = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DocumentEditingContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DocumentEditingContext.mm
@@ -61,7 +61,7 @@ static constexpr auto longTextString = "Here's to the crazy ones. The misfits. T
 
 static UIWKDocumentRequest *makeRequest(UIWKDocumentRequestFlags flags, UITextGranularity granularity, NSInteger granularityCount, CGRect documentRect = CGRectZero, id<NSCopying> inputElementIdentifier = nil)
 {
-    auto request = adoptNS([[UIWKDocumentRequest alloc] init]);
+    RetainPtr request = adoptNS([[UIWKDocumentRequest alloc] init]);
     [request setFlags:flags];
     [request setSurroundingGranularity:granularity];
     [request setGranularityCount:granularityCount];
@@ -136,7 +136,7 @@ static UIWKDocumentRequest *makeRequest(UIWKDocumentRequestFlags flags, UITextGr
         return a.first.location < b.first.location;
     });
 
-    auto result = adoptNS([[NSMutableArray alloc] initWithCapacity:rangesAndRects.size()]);
+    RetainPtr result = adoptNS([[NSMutableArray alloc] initWithCapacity:rangesAndRects.size()]);
     for (auto& rangeAndRect : rangesAndRects)
         [result addObject:[NSValue valueWithCGRect:rangeAndRect.second]];
     return result.autorelease();
@@ -348,7 +348,7 @@ TEST(DocumentEditingContext, Simple)
 
 TEST(DocumentEditingContext, RequestMarkedText)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     auto *contentView = [webView textInputContentView];
 
     [webView synchronouslyLoadHTMLString:@"<body style='-webkit-text-size-adjust: none;' contenteditable>"];
@@ -450,7 +450,7 @@ TEST(DocumentEditingContext, DISABLED_RequestMarkedTextRectsAndTextOnly)
 TEST(DocumentEditingContext, RequestMarkedTextRectsAndTextOnly)
 #endif
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(@"<input />")];
     [webView stringByEvaluatingJavaScript:@"document.querySelector('input').focus()"];
     [webView _synchronouslyExecuteEditCommand:@"InsertText" argument:@"Hello world"];
@@ -460,7 +460,7 @@ TEST(DocumentEditingContext, RequestMarkedTextRectsAndTextOnly)
     [contentView setMarkedText:@"world" selectedRange:NSMakeRange(0, 5)];
     [webView collapseToEnd];
 
-    auto request = adoptNS([[UIWKDocumentRequest alloc] init]);
+    RetainPtr request = adoptNS([[UIWKDocumentRequest alloc] init]);
     [request setFlags:UIWKDocumentRequestMarkedTextRects | UIWKDocumentRequestText];
 
     auto context = retainPtr([webView synchronouslyRequestDocumentContext:request.get()]);
@@ -486,7 +486,7 @@ TEST(DocumentEditingContext, DISABLED_SpatialRequestInTextField)
 TEST(DocumentEditingContext, SpatialRequestInTextField)
 #endif
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     [webView synchronouslyLoadHTMLString:@"<span style='-webkit-text-size-adjust: none;'>Hello<input type='text' value='foo bar' />world</span>"];
     [webView stringByEvaluatingJavaScript:@"document.querySelector('input').focus()"];
@@ -519,7 +519,7 @@ static CGRect CGRectFromJSONEncodedDOMRectJSValue(id jsValue)
 
 TEST(DocumentEditingContext, RectsRequestInContentEditable)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(@"<p id='text' contenteditable>Test<br><br><br><br></p>")];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(text.lastChild, text.lastChild.length, text.lastChild, text.lastChild.length)"]; // Will focus <p>.
@@ -544,7 +544,7 @@ TEST(DocumentEditingContext, RectsRequestInContentEditable)
 
 TEST(DocumentEditingContext, RectsRequestInContentEditableWithDivBreaks)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(@"<div id='text' contenteditable>Test<div><br></div><div><br></div><div><br></div></div>")];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(text.lastChild, text.lastChild.length, text.lastChild, text.lastChild.length)"]; // Will focus <p>.
@@ -569,7 +569,7 @@ TEST(DocumentEditingContext, RectsRequestInContentEditableWithDivBreaks)
 
 TEST(DocumentEditingContext, PasswordFieldRequest)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(@"<input id='passwordField' type='password' value='testPassword'>")];
     [webView stringByEvaluatingJavaScript:@"passwordField.focus(); passwordField.select();"];
@@ -583,7 +583,7 @@ TEST(DocumentEditingContext, PasswordFieldRequest)
 
 TEST(DocumentEditingContext, SpatialRequest_RectEncompassingInput)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
 
     // Use "padding: 0" as the default user-agent stylesheet can effect text wrapping.
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(@"before <textarea id='test' style='width: 26em; margin: 200px 0 0 200px; padding: 0;'>The quick brown fox jumps over the lazy dog.</textarea> after")]; // Word wraps "over" onto next line
@@ -599,7 +599,7 @@ TEST(DocumentEditingContext, SpatialRequest_RectEncompassingInput)
 
 TEST(DocumentEditingContext, SpatialRequest_RectBeforeInput)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
 
     // Use "padding: 0" as the default user-agent stylesheet can effect text wrapping.
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(@"before <textarea id='test' style='width: 26em; margin: 200px 0 0 200px; padding: 0;'>The quick brown fox jumps over the lazy dog.</textarea> after")]; // Word wraps "over" onto next line
@@ -621,7 +621,7 @@ TEST(DocumentEditingContext, SpatialRequest_RectBeforeInput)
 
 TEST(DocumentEditingContext, SpatialRequest_RectInsideInput)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
 
     // Use "padding: 0" as the default user-agent stylesheet can effect text wrapping.
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(@"before <textarea id='test' style='width: 26em; margin: 200px 0 0 200px; padding: 0;'>The quick brown fox jumps over the lazy dog.</textarea> after")]; // Word wraps "over" onto next line
@@ -643,7 +643,7 @@ TEST(DocumentEditingContext, SpatialRequest_RectInsideInput)
 
 TEST(DocumentEditingContext, SpatialRequest_RectAfterInput)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
 
     // Use "padding: 0" as the default user-agent stylesheet can effect text wrapping.
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(@"before <textarea id='test' style='width: 26em; margin: 200px 0 0 200px; padding: 0;'>The quick brown fox jumps over the lazy dog.</textarea> after")]; // Word wraps "over" onto next line
@@ -665,7 +665,7 @@ TEST(DocumentEditingContext, SpatialRequest_RectAfterInput)
 
 TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_RectBeforeRangeSelection)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:DocumentEditingContextTestHelpers::applyAhemStyle(@"<span id='spatialBox'>The</span> quick brown fox <span id='jumps'>jumps</span> over the dog.")];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(jumps, 0, jumps, 1)"];
 
@@ -684,7 +684,7 @@ TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_RectBeforeRangeSe
 
 TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_RectAfterRangeSelection)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:DocumentEditingContextTestHelpers::applyAhemStyle(@"The quick brown fox <span id='jumps'>jumps</span> over the dog.<span id='spatialBox'></span>")];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(jumps, 0, jumps, 1)"];
 
@@ -703,7 +703,7 @@ TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_RectAfterRangeSel
 
 TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_RectAroundRangeSelection)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:DocumentEditingContextTestHelpers::applyAhemStyle(@"The quick brown <span id='spatialBox'>fox <span id='jumps'>jumps</span> </span>over the dog.")];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(jumps, 0, jumps, 1)"];
 
@@ -722,7 +722,7 @@ TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_RectAroundRangeSe
 
 TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_RectBeforeCaretSelection)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:DocumentEditingContextTestHelpers::applyAhemStyle(@"<body contenteditable='true'><span id='spatialBox'>The</span> quick brown fox <span id='jumps'>jumps</span> over the dog.</body>")];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(jumps, 0, jumps, 0)"];
 
@@ -741,7 +741,7 @@ TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_RectBeforeCaretSe
 
 TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_RectAfterCaretSelection)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:DocumentEditingContextTestHelpers::applyAhemStyle(@"<body contenteditable='true'>The quick brown fox <span id='jumps'>jumps</span> over the dog.<span id='spatialBox'></span></body>")];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(jumps, 0, jumps, 0)"];
 
@@ -760,7 +760,7 @@ TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_RectAfterCaretSel
 
 TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_RectAroundCaretSelection)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:DocumentEditingContextTestHelpers::applyAhemStyle(@"<body contenteditable='true'>The quick brown <span id='spatialBox'>fox <span id='jumps'>jumps</span> </span>over the dog.</body>")];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(jumps, 0, jumps, 0)"];
 
@@ -779,7 +779,7 @@ TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_RectAroundCaretSe
 
 TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_RectEncompassingInputWithSelection)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
 
     // Use "padding: 0" as the default user-agent stylesheet can effect text wrapping.
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(@"before <span contenteditable id='test' style='display: inline-block; width: 26em; margin: 200px 0 0 200px;'>The quick brown <span id='fox_jumps_over'>fox jumps over</span> the lazy dog.</span> after")]; // Word wraps "over" onto next line
@@ -796,7 +796,7 @@ TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_RectEncompassingI
 
 TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_RectBeforeInputWithSelection)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
 
     // Use "padding: 0" as the default user-agent stylesheet can effect text wrapping.
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(@"before <span contenteditable id='test' style='display: inline-block; width: 26em; margin: 200px 0 0 200px;'>The quick brown <span id='fox_jumps_over'>fox jumps over</span> the lazy dog.</span> after")]; // Word wraps "over" onto next line
@@ -819,7 +819,7 @@ TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_RectBeforeInputWi
 
 TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_RectBeforeSelectionInInput)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
 
     // Use "padding: 0" as the default user-agent stylesheet can effect text wrapping.
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(@"before <span contenteditable id='test' style='display: inline-block; width: 26em; margin: 200px 0 0 200px;'>The quick brown <span id='fox_jumps_over'>fox jumps over</span> the lazy dog.</span> after")]; // Word wraps "over" onto next line
@@ -844,7 +844,7 @@ TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_RectBeforeSelecti
 
 TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_RectAfterSelectionInInput)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
 
     // Use "padding: 0" as the default user-agent stylesheet can effect text wrapping.
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(@"before <span contenteditable id='test' style='display: inline-block; width: 26em; margin: 200px 0 0 200px;'>The quick brown <span id='fox_jumps_over'>fox jumps over</span> the lazy dog.</span> after")]; // Word wraps "over" onto next line
@@ -869,7 +869,7 @@ TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_RectAfterSelectio
 
 TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_RectAfterInputWithSelection)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 980, 600)]);
 
     // Use "padding: 0" as the default user-agent stylesheet can effect text wrapping.
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(@"before <span contenteditable id='test' style='display: inline-block; width: 26em; margin: 200px 0 0 200px;'>The quick brown <span id='fox_jumps_over'>fox jumps over</span> the lazy dog.</span> after")]; // Word wraps "over" onto next line
@@ -963,7 +963,7 @@ TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_LimitContextToVis
 
 TEST(DocumentEditingContext, RequestRectsInTextAreaAcrossWordWrappedLine)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     // Use "padding: 0" as the default user-agent stylesheet can effect text wrapping.
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(@"<textarea id='test' style='width: 26em; padding: 0'>The quick brown fox jumps over the lazy dog.</textarea>")]; // Word wraps "over" onto next line
     [webView stringByEvaluatingJavaScript:@"test.focus(); test.setSelectionRange(25, 25)"]; // Place caret after 's' in "jumps".
@@ -1010,7 +1010,7 @@ TEST(DocumentEditingContext, RequestRectsInTextAreaAcrossWordWrappedLine)
 
 TEST(DocumentEditingContext, RequestRectsInTextAreaInsideIFrame)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     // Use "padding: 0" for the <textarea> as the default user-agent stylesheet can effect text wrapping.
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle([NSString stringWithFormat:@"<iframe srcdoc=\"%@\" style='position: absolute; left: 1em; top: 1em; border: none'></iframe>", DocumentEditingContextTestHelpers::applyAhemStyle(@"<textarea id='test' style='padding: 0'>The quick brown fox jumps over the lazy dog.</textarea><script>let textarea = document.getElementById('test'); textarea.focus(); textarea.setSelectionRange(0, 0); /* Place caret at the beginning of the field. */</script>")])];
 
@@ -1040,7 +1040,7 @@ TEST(DocumentEditingContext, RequestRectsInTextAreaInsideIFrame)
 // FIXME when rdar://107850452 is resolved
 TEST(DocumentEditingContext, RequestRectsInTextAreaInsideScrolledIFrame)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     // Use "padding: 0" for the <textarea> as the default user-agent stylesheet can effect text wrapping.
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle([NSString stringWithFormat:@"<iframe srcdoc=\"%@\" style='position: absolute; left: 1em; top: 1em; border: none' height='200'></iframe>",
         DocumentEditingContextTestHelpers::applyAhemStyle(@"<body style='height: 1000px'><div style='width: 200px; height: 200px'></div><textarea id='test' style='padding: 0'>The quick brown fox jumps over the lazy dog.</textarea>"
@@ -1073,7 +1073,7 @@ TEST(DocumentEditingContext, RequestRectsInTextAreaInsideScrolledIFrame)
 
 TEST(DocumentEditingContext, RequestFirstTwoWords)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(@"<p id='text' contenteditable>The quick brown fox jumps over the lazy dog.</p>")];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(text.firstChild, 0, text.firstChild, 0)"]; // Will focus <p>.
 
@@ -1110,7 +1110,7 @@ TEST(DocumentEditingContext, RequestFirstTwoWords)
 
 TEST(DocumentEditingContext, RequestFirstTwoWordWithLeadingNonBreakableSpace)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(@"<p id='text' contenteditable>&nbsp;The quick brown fox jumps over the lazy dog.</p>")];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(text.firstChild, 0, text.firstChild, 0)"]; // Will focus <p>.
 
@@ -1137,7 +1137,7 @@ TEST(DocumentEditingContext, RequestFirstTwoWordWithLeadingNonBreakableSpace)
 
 TEST(DocumentEditingContext, RequestLastWord)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(@"<p id='text' contenteditable>The quick brown fox jumps over the lazy dog.</p>")];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(text.firstChild, text.firstChild.length, text.firstChild, text.firstChild.length)"]; // Will focus <p>.
 
@@ -1164,7 +1164,7 @@ TEST(DocumentEditingContext, RequestLastWord)
 
 TEST(DocumentEditingContext, RequestLastWordWithTrailingNonBreakableSpace)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(@"<p id='text' contenteditable>The quick brown fox jumps over the lazy dog.&nbsp;</p>")];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(text.firstChild, text.firstChild.length, text.firstChild, text.firstChild.length)"]; // Will focus <p>.
 
@@ -1193,7 +1193,7 @@ TEST(DocumentEditingContext, RequestLastWordWithTrailingNonBreakableSpace)
 
 TEST(DocumentEditingContext, RequestTwoWordsAroundSelection)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyStyle(@"<span id='the'>The</span> quick brown fox <span id='jumps'>jumps</span> over the lazy <span id='dog'>dog.</span>")];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(jumps, 0, jumps, 1)"];
 
@@ -1206,7 +1206,7 @@ TEST(DocumentEditingContext, RequestTwoWordsAroundSelection)
 
 TEST(DocumentEditingContext, RequestThreeWordsAroundSelection)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyStyle(@"<span id='the'>The</span> quick brown fox <span id='jumps'>jumps</span> over the lazy <span id='dog'>dog.</span>")];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(jumps, 0, jumps, 1)"];
 
@@ -1219,7 +1219,7 @@ TEST(DocumentEditingContext, RequestThreeWordsAroundSelection)
 
 TEST(DocumentEditingContext, RequestBeforeInlinePlaceholder)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyStyle(@"<span id='wrapper' contenteditable>hello world</span>")];
     [webView stringByEvaluatingJavaScript:@"getSelection().setPosition(wrapper.firstChild, 5)"]; // Place cursor after "hello".
 
@@ -1236,7 +1236,7 @@ TEST(DocumentEditingContext, RequestBeforeInlinePlaceholder)
 
 TEST(DocumentEditingContext, RequestAfterInlinePlaceholder)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyStyle(@"<span id='wrapper' contenteditable>hello world</span>")];
     [webView stringByEvaluatingJavaScript:@"getSelection().setPosition(wrapper.firstChild, 6)"]; // Place cursor before "world".
 
@@ -1253,7 +1253,7 @@ TEST(DocumentEditingContext, RequestAfterInlinePlaceholder)
 
 TEST(DocumentEditingContext, RequestBeforeBlockPlaceholder)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyStyle(@"<span id='wrapper' contenteditable>hello world</span>")];
     [webView stringByEvaluatingJavaScript:@"getSelection().setPosition(wrapper.firstChild, 5)"]; // Place cursor after "hello".
 
@@ -1270,7 +1270,7 @@ TEST(DocumentEditingContext, RequestBeforeBlockPlaceholder)
 
 TEST(DocumentEditingContext, RequestAfterBlockPlaceholder)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyStyle(@"<span id='wrapper' contenteditable>hello world</span>")];
     [webView stringByEvaluatingJavaScript:@"getSelection().setPosition(wrapper.firstChild, 6)"]; // Place cursor before "world".
 
@@ -1291,7 +1291,7 @@ constexpr NSString * const threeSentencesExample = @"<p id='text' contenteditabl
 
 TEST(DocumentEditingContext, RequestFirstTwoSentences)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyStyle(threeSentencesExample)];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(text.firstChild, 0, text.firstChild, 0)"]; // Will focus <p>.
 
@@ -1304,7 +1304,7 @@ TEST(DocumentEditingContext, RequestFirstTwoSentences)
 
 TEST(DocumentEditingContext, RequestFirstTwoSentencesNoSpaces)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyStyle(@"<p id='text' contenteditable>The first sentence.The second sentence.The third sentence.</p>")];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(text.firstChild, 0, text.firstChild, 0)"]; // Will focus <p>.
 
@@ -1317,7 +1317,7 @@ TEST(DocumentEditingContext, RequestFirstTwoSentencesNoSpaces)
 
 TEST(DocumentEditingContext, RequestLastSentence)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyStyle(threeSentencesExample)];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(text.firstChild, text.firstChild.length, text.firstChild, text.firstChild.length)"]; // Will focus <p>.
 
@@ -1330,7 +1330,7 @@ TEST(DocumentEditingContext, RequestLastSentence)
 
 TEST(DocumentEditingContext, RequestLastTwoSentences)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyStyle(threeSentencesExample)];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(text.firstChild, text.firstChild.length, text.firstChild, text.firstChild.length)"]; // Will focus <p>.
 
@@ -1347,7 +1347,7 @@ constexpr NSString * const threeParagraphsExample = @"<p id='text' style='width:
 
 TEST(DocumentEditingContext, RequestFirstParagraph)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyStyle(threeParagraphsExample)];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(text.firstChild, 0, text.firstChild, 0)"]; // Will focus <p>.
 
@@ -1360,7 +1360,7 @@ TEST(DocumentEditingContext, RequestFirstParagraph)
 
 TEST(DocumentEditingContext, RequestFirstTwoParagraphs)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyStyle(threeParagraphsExample)];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(text.firstChild, 0, text.firstChild, 0)"]; // Will focus <p>.
 
@@ -1373,7 +1373,7 @@ TEST(DocumentEditingContext, RequestFirstTwoParagraphs)
 
 TEST(DocumentEditingContext, RequestLastParagraph)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyStyle(threeParagraphsExample)];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(text.firstChild, text.firstChild.length, text.firstChild, text.firstChild.length)"]; // Will focus <p>.
 
@@ -1386,7 +1386,7 @@ TEST(DocumentEditingContext, RequestLastParagraph)
 
 TEST(DocumentEditingContext, RequestLastTwoParagraphs)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyStyle(threeParagraphsExample)];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(text.firstChild, text.firstChild.length, text.firstChild, text.firstChild.length)"]; // Will focus <p>.
 
@@ -1399,7 +1399,7 @@ TEST(DocumentEditingContext, RequestLastTwoParagraphs)
 
 TEST(DocumentEditingContext, RequestLastTwoParagraphsWithSelectiontWithinParagraph)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(@"<span id='the'>The</span> quick brown fox <span id='jumps'>jumps</span> over the lazy <span id='dog'>dog.</span>")];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(jumps, 0, jumps, 1)"]; // Will focus <p>.
 
@@ -1415,7 +1415,7 @@ TEST(DocumentEditingContext, RequestLastTwoParagraphsWithSelectiontWithinParagra
 
 TEST(DocumentEditingContext, RequestFirstCharacter)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyStyle(threeParagraphsExample)];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(text.firstChild, 0, text.firstChild, 0)"]; // Will focus <p>.
 
@@ -1428,7 +1428,7 @@ TEST(DocumentEditingContext, RequestFirstCharacter)
 
 TEST(DocumentEditingContext, RequestFirstWordUsingCharacterGranularity)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyStyle(threeParagraphsExample)];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(text.firstChild, 0, text.firstChild, 0)"]; // Will focus <p>.
 
@@ -1441,7 +1441,7 @@ TEST(DocumentEditingContext, RequestFirstWordUsingCharacterGranularity)
 
 TEST(DocumentEditingContext, RequestFirstWordPlusTrailingSpaceUsingCharacterGranularity)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyStyle(threeParagraphsExample)];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(text.firstChild, 0, text.firstChild, 0)"]; // Will focus <p>.
 
@@ -1456,7 +1456,7 @@ TEST(DocumentEditingContext, RequestFirstWordPlusTrailingSpaceUsingCharacterGran
 
 TEST(DocumentEditingContext, RequestFirstLine)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(threeParagraphsExample)];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(text.firstChild, 0, text.firstChild, 0)"]; // Will focus <p>.
 
@@ -1469,7 +1469,7 @@ TEST(DocumentEditingContext, RequestFirstLine)
 
 TEST(DocumentEditingContext, RequestFirstTwoLines)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(threeParagraphsExample)];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(text.firstChild, 0, text.firstChild, 0)"]; // Will focus <p>.
 
@@ -1482,7 +1482,7 @@ TEST(DocumentEditingContext, RequestFirstTwoLines)
 
 TEST(DocumentEditingContext, RequestLastLine)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(threeParagraphsExample)];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(text.firstChild, text.firstChild.length, text.firstChild, text.firstChild.length)"]; // Will focus <p>.
 
@@ -1495,7 +1495,7 @@ TEST(DocumentEditingContext, RequestLastLine)
 
 TEST(DocumentEditingContext, RequestLastTwoLines)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:DocumentEditingContextTestHelpers::applyAhemStyle(threeParagraphsExample)];
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(text.firstChild, text.firstChild.length, text.firstChild, text.firstChild.length)"]; // Will focus <p>.
 
@@ -1508,7 +1508,7 @@ TEST(DocumentEditingContext, RequestLastTwoLines)
 
 TEST(DocumentEditingContext, RequestSentencesAfterTextInsertion)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadTestPageNamed:@"simple-editor"];
 
     auto *context = [webView synchronouslyRequestDocumentContext:makeRequest(UIWKDocumentRequestText, UITextGranularitySentence, 1)];
@@ -1547,7 +1547,7 @@ static void checkThatAllCharacterRectsAreConsistentWithSelectionRects(TestWKWebV
 
 TEST(DocumentEditingContext, CharacterRectConsistency)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 300)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 300)]);
     [webView synchronouslyLoadTestPageNamed:@"editable-body-mixed-text"];
 
     checkThatAllCharacterRectsAreConsistentWithSelectionRects(webView.get());
@@ -1555,7 +1555,7 @@ TEST(DocumentEditingContext, CharacterRectConsistency)
 
 TEST(DocumentEditingContext, CharacterRectConsistencyWithRTL)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 300)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 300)]);
     [webView synchronouslyLoadTestPageNamed:@"editable-body-mixed-text"];
     [webView stringByEvaluatingJavaScript:@"document.body.style = 'direction: rtl;'"];
 
@@ -1564,7 +1564,7 @@ TEST(DocumentEditingContext, CharacterRectConsistencyWithRTL)
 
 TEST(DocumentEditingContext, CharacterRectConsistencyWithVerticalText)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 300)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 300)]);
     [webView synchronouslyLoadTestPageNamed:@"editable-body-mixed-text"];
     [webView stringByEvaluatingJavaScript:@"document.body.style = 'writing-mode: vertical-rl;'"];
 
@@ -1573,7 +1573,7 @@ TEST(DocumentEditingContext, CharacterRectConsistencyWithVerticalText)
 
 TEST(DocumentEditingContext, CharacterRectConsistencyWithRTLAndVerticalText)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 300)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 300)]);
     [webView synchronouslyLoadTestPageNamed:@"editable-body-mixed-text"];
     [webView stringByEvaluatingJavaScript:@"document.body.style = 'writing-mode: vertical-rl; direction: rtl;'"];
 
@@ -1582,7 +1582,7 @@ TEST(DocumentEditingContext, CharacterRectConsistencyWithRTLAndVerticalText)
 
 TEST(DocumentEditingContext, CharacterRectsInEditableWebView)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 320, 568)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 320, 568)]);
     [webView _setEditable:YES];
     [webView synchronouslyLoadHTMLString:makeString("<meta name='viewport' content='width=device-width, initial-scale=1'><body>"_s, longTextString, "</body>"_s).createNSString().get()];
     [webView objectByEvaluatingJavaScript:@"getSelection().setPosition(document.body, 0)"];
@@ -1608,9 +1608,9 @@ TEST(DocumentEditingContext, RequestAutocorrectedRanges)
     if (![UIWKDocumentContext instancesRespondToSelector:@selector(autocorrectedRanges)])
         return;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id<_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         return _WKFocusStartsInputSessionPolicyAllow;
     }];
@@ -1675,7 +1675,7 @@ TEST(DocumentEditingContext, RequestAutocorrectedRanges)
 
 TEST(DocumentEditingContext, RequestAnnotationsForTextChecking)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     auto loadWebViewAndGetContext = [&] {
         [webView synchronouslyLoadHTMLString:makeString("<body>"_s, longTextString, "</body>"_s).createNSString().get()];
         [webView objectByEvaluatingJavaScript:@"(() => {"

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Download.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Download.mm
@@ -140,7 +140,7 @@ IGNORE_WARNINGS_END
 TEST(_WKDownload, DownloadDelegate)
 {
     RetainPtr<WKProcessPool> processPool = adoptNS([[WKProcessPool alloc] init]);
-    auto downloadDelegate = adoptNS([[DownloadDelegate alloc] init]);
+    RetainPtr downloadDelegate = adoptNS([[DownloadDelegate alloc] init]);
     [processPool _setDownloadDelegate:downloadDelegate.get()];
 
     @autoreleasepool {
@@ -364,10 +364,10 @@ TEST(_WKDownload, DownloadRequestOriginalURLDirectDownload)
 
 TEST(_WKDownload, DownloadRequestOriginalURLDirectDownloadWithLoadedContent)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    auto navigationDelegate = adoptNS([[DownloadRequestOriginalURLNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr navigationDelegate = adoptNS([[DownloadRequestOriginalURLNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto downloadDelegate = adoptNS([[DownloadRequestOriginalURLDelegate alloc] initWithExpectedOriginalURL:sourceURL]);
+    RetainPtr downloadDelegate = adoptNS([[DownloadRequestOriginalURLDelegate alloc] initWithExpectedOriginalURL:sourceURL]);
     [[[webView configuration] processPool] _setDownloadDelegate:downloadDelegate.get()];
 
     expectedUserInitiatedState = false;
@@ -521,9 +521,9 @@ TEST(_WKDownload, RedirectedDownload)
     redirectCount = 0;
     isDone = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
-    auto downloadDelegate = adoptNS([[RedirectedDownloadDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr downloadDelegate = adoptNS([[RedirectedDownloadDelegate alloc] init]);
     [[[webView configuration] processPool] _setDownloadDelegate:downloadDelegate.get()];
 
     // Do 2 loads in the same view to make sure the redirect chain is properly cleared between loads.
@@ -533,7 +533,7 @@ TEST(_WKDownload, RedirectedDownload)
     expectedOriginatingWebView = webView.get();
     expectedUserInitiatedState = true;
 
-    auto navigationDelegate = adoptNS([[DownloadNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[DownloadNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [webView objectByEvaluatingJavaScriptWithUserGesture:@"document.getElementById('link').click();"];
 
@@ -548,10 +548,10 @@ TEST(_WKDownload, RedirectedLoadConvertedToDownload)
 {
     [TestProtocol registerWithScheme:@"http"];
 
-    auto navigationDelegate = adoptNS([[ConvertResponseToDownloadNavigationDelegate alloc] init]);
-    auto downloadDelegate = adoptNS([[RedirectedDownloadDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[ConvertResponseToDownloadNavigationDelegate alloc] init]);
+    RetainPtr downloadDelegate = adoptNS([[RedirectedDownloadDelegate alloc] init]);
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [[[webView configuration] processPool] _setDownloadDelegate:downloadDelegate.get()];
 
@@ -571,10 +571,10 @@ TEST(_WKDownload, RedirectedSubframeLoadConvertedToDownload)
 {
     [TestProtocol registerWithScheme:@"http"];
 
-    auto navigationDelegate = adoptNS([[ConvertResponseToDownloadNavigationDelegate alloc] init]);
-    auto downloadDelegate = adoptNS([[RedirectedDownloadDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[ConvertResponseToDownloadNavigationDelegate alloc] init]);
+    RetainPtr downloadDelegate = adoptNS([[RedirectedDownloadDelegate alloc] init]);
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [[[webView configuration] processPool] _setDownloadDelegate:downloadDelegate.get()];
 
@@ -626,10 +626,10 @@ TEST(_WKDownload, DownloadCanceledWhileDecidingDestination)
 {
     [TestProtocol registerWithScheme:@"http"];
 
-    auto navigationDelegate = adoptNS([[DownloadNavigationDelegate alloc] init]);
-    auto downloadDelegate = adoptNS([[CancelDownloadWhileDecidingDestinationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[DownloadNavigationDelegate alloc] init]);
+    RetainPtr downloadDelegate = adoptNS([[CancelDownloadWhileDecidingDestinationDelegate alloc] init]);
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [[[webView configuration] processPool] _setDownloadDelegate:downloadDelegate.get()];
 
@@ -726,11 +726,11 @@ TEST(_WKDownload, SystemPreviewUSDZBlobNaming)
 
 TEST(_WKDownload, DownloadAttributeDoesNotStartDownloads)
 {
-    auto delegate = adoptNS([[DownloadAttributeTestDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[DownloadAttributeTestDelegate alloc] init]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get()._allowTopNavigationToDataURLs = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView setNavigationDelegate:delegate.get()];
     [webView configuration].processPool._downloadDelegate = delegate.get();
@@ -745,11 +745,11 @@ TEST(_WKDownload, DownloadAttributeDoesNotStartDownloads)
 
 TEST(_WKDownload, StartDownloadWithDownloadAttribute)
 {
-    auto delegate = adoptNS([[DownloadAttributeTestDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[DownloadAttributeTestDelegate alloc] init]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get()._allowTopNavigationToDataURLs = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView setNavigationDelegate:delegate.get()];
     [webView configuration].processPool._downloadDelegate = delegate.get();
@@ -787,8 +787,8 @@ static bool didDownloadStart;
 
 TEST(_WKDownload, CrashAfterDownloadDidFinishWhenDownloadProxyHoldsTheLastRefOnWebProcessPool)
 {
-    auto navigationDelegate = adoptNS([[DownloadNavigationDelegate alloc] init]);
-    auto downloadDelegate = adoptNS([[WaitUntilDownloadCanceledDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[DownloadNavigationDelegate alloc] init]);
+    RetainPtr downloadDelegate = adoptNS([[WaitUntilDownloadCanceledDelegate alloc] init]);
     WeakObjCPtr<WKProcessPool> processPool;
     @autoreleasepool {
         RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
@@ -877,20 +877,20 @@ void respondSlowly(const Connection& connection, double kbps)
 
 static RetainPtr<DownloadMonitorTestDelegate> monitorDelegate()
 {
-    static auto delegate = adoptNS([DownloadMonitorTestDelegate new]);
+    static RetainPtr delegate = adoptNS([DownloadMonitorTestDelegate new]);
     return delegate;
 }
 
 RetainPtr<WKWebView> webViewWithDownloadMonitorSpeedMultiplier(size_t multiplier)
 {
-    static auto navigationDelegate = adoptNS([DownloadNavigationDelegate new]);
-    auto processPoolConfiguration = adoptNS([_WKProcessPoolConfiguration new]);
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
-    auto dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    static RetainPtr navigationDelegate = adoptNS([DownloadNavigationDelegate new]);
+    RetainPtr processPoolConfiguration = adoptNS([_WKProcessPoolConfiguration new]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     [dataStoreConfiguration setTestSpeedMultiplier:multiplier];
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [webViewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]).get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [webView configuration].processPool._downloadDelegate = monitorDelegate().get();
     return webView;
@@ -1015,8 +1015,8 @@ TEST(WebKit, DownloadNavigationResponseFromMemoryCache)
     [TestProtocol registerWithScheme:@"http"];
     TestProtocol.additionalResponseHeaders = @{ @"Cache-Control" : @"max-age=3600" };
 
-    auto delegate = adoptNS([[TestDownloadNavigationResponseFromMemoryCacheDelegate alloc] init]);
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr delegate = adoptNS([[TestDownloadNavigationResponseFromMemoryCacheDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView configuration].processPool._downloadDelegate = delegate.get();
 
@@ -1183,8 +1183,8 @@ TEST(WKDownload, ResumedDownloadCanHandleAuthenticationChallenge)
         });
     });
 
-    auto webView = adoptNS([WKWebView new]);
-    auto delegate1 = adoptNS([DownloadCancelingDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr delegate1 = adoptNS([DownloadCancelingDelegate new]);
 
     isDone = false;
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]];
@@ -1194,7 +1194,7 @@ TEST(WKDownload, ResumedDownloadCanHandleAuthenticationChallenge)
 
     Util::run(&isDone);
     isDone = false;
-    auto delegate2 = adoptNS([AuthenticationChallengeHandlingDelegate new]);
+    RetainPtr delegate2 = adoptNS([AuthenticationChallengeHandlingDelegate new]);
     [webView resumeDownloadFromResumeData:[delegate1 resumeData].get() completionHandler:^(WKDownload *download) {
         download.delegate = delegate2.get();
     }];
@@ -1319,7 +1319,7 @@ TEST(WKDownload, Resume)
 
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     navigationDelegate.get().decidePolicyForNavigationResponse = ^(WKNavigationResponse *, void (^completionHandler)(WKNavigationResponsePolicy)) {
         completionHandler(WKNavigationResponsePolicyDownload);
     };
@@ -1332,8 +1332,8 @@ TEST(WKDownload, Resume)
     __block RetainPtr<WKDownload> download;
     __block RetainPtr<NSData> resumeData;
 
-    auto downloadDelegate = adoptNS([TestDownloadDelegate new]);
-    auto observer = adoptNS([DownloadObserver new]);
+    RetainPtr downloadDelegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr observer = adoptNS([DownloadObserver new]);
 
     navigationDelegate.get().navigationResponseDidBecomeDownload = ^(WKNavigationResponse *, WKDownload *downloadFromDelegate) {
         callbacks.append(Callback::Start);
@@ -1360,7 +1360,7 @@ TEST(WKDownload, Resume)
         didFinish = true;
     };
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [webView loadRequest:server.request()];
     Util::run(&receivedData);
@@ -1445,10 +1445,10 @@ function loaded()
 
 TEST(_WKDownload, SubframeSecurityOrigin)
 {
-    auto navigationDelegate = adoptNS([[DownloadTestSchemeDelegate alloc] init]);
-    auto downloadDelegate = adoptNS([[DownloadSecurityOriginDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[DownloadTestSchemeDelegate alloc] init]);
+    RetainPtr downloadDelegate = adoptNS([[DownloadSecurityOriginDelegate alloc] init]);
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [[[webView configuration] processPool] _setDownloadDelegate:downloadDelegate.get()];
 
@@ -1500,8 +1500,8 @@ TEST(WKDownload, FinishSuccessfully)
 {
     auto server = simpleDownloadTestServer();
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
-    auto delegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
     delegate.get().navigationResponseDidBecomeDownload = ^(WKWebView *, WKNavigationResponse *, WKDownload *download) {
@@ -1537,8 +1537,8 @@ static void resumeAndFinishDownload(NSData *resumeData, NSURL *destination)
     @autoreleasepool {
         checkFileContents(destination, longString<5000>('a'));
 
-        auto delegate = adoptNS([TestDownloadDelegate new]);
-        auto webView = adoptNS([WKWebView new]);
+        RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+        RetainPtr webView = adoptNS([WKWebView new]);
 
         [webView resumeDownloadFromResumeData:resumeData completionHandler:^(WKDownload *download) {
             retainedDownload = download;
@@ -1554,7 +1554,7 @@ static void resumeAndFinishDownload(NSData *resumeData, NSURL *destination)
             ASSERT_NOT_REACHED();
         };
 
-        auto observer = adoptNS([DownloadObserver new]);
+        RetainPtr observer = adoptNS([DownloadObserver new]);
         observer.get().progressChangeCallback = ^(int64_t bytesWritten, int64_t totalByteCount) {
             if (bytesWritten == 10000) {
                 EXPECT_EQ(totalByteCount, 10000);
@@ -1589,7 +1589,7 @@ static void waitForFirst5k(RetainPtr<WKDownload>& download)
 {
     __block bool downloadedFirst5k = false;
     
-    auto observer = adoptNS([DownloadObserver new]);
+    RetainPtr observer = adoptNS([DownloadObserver new]);
     observer.get().progressChangeCallback = ^(int64_t bytesWritten, int64_t totalByteCount) {
         if (bytesWritten == 5000) {
             EXPECT_EQ(totalByteCount, 10000);
@@ -1607,8 +1607,8 @@ TEST(WKDownload, CancelAndResume)
 {
     auto server = downloadTestServer();
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
-    auto delegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block RetainPtr<WKDownload> retainedDownload;
@@ -1646,14 +1646,14 @@ TEST(WKDownload, CancelAndResume)
 
 TEST(WKDownload, FailAndResume)
 {
-    auto delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
     RetainPtr<WKDownload> retainedDownload;
     auto server = downloadTestServer(IncludeETag::Yes, [&] (TestWebKitAPI::Connection connection) {
         waitForFirst5k(retainedDownload);
         connection.terminate();
     });
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
     RetainPtr<NSData> retainedResumeData;
@@ -1692,8 +1692,8 @@ TEST(WKDownload, CancelNoResumeData)
 {
     auto server = downloadTestServer(IncludeETag::No);
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
-    auto delegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block RetainPtr<WKDownload> retainedDownload;
@@ -1727,14 +1727,14 @@ TEST(WKDownload, CancelNoResumeData)
 
 TEST(WKDownload, FailNoResumeData)
 {
-    auto delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
     RetainPtr<WKDownload> retainedDownload;
     auto server = downloadTestServer(IncludeETag::No, [&] (TestWebKitAPI::Connection connection) {
         waitForFirst5k(retainedDownload);
         connection.terminate();
     });
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
     bool done = false;
@@ -1802,8 +1802,8 @@ TEST(WKDownload, ResumeAfterZeroBytesReceived)
     });
 
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
-    auto delegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     webView.navigationDelegate = delegate.get();
 
     delegate.get().navigationResponseDidBecomeDownload = ^(WKWebView *, WKNavigationResponse *, WKDownload *download) {
@@ -1850,8 +1850,8 @@ TEST(WKDownload, ResumeAfterZeroBytesReceived)
 
 void testResumeAfterMutatingDisk(NSURLRequest *serverRequest, NSURL *expectedDownloadFile, void(^mutateFile)(void))
 {
-    auto delegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block RetainPtr<WKDownload> retainedDownload;
@@ -1990,7 +1990,7 @@ TEST(WKDownload, ResumeWithInvalidResumeData)
 {
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
     EXPECT_TRUE([[@"initial data on disk" dataUsingEncoding:NSUTF8StringEncoding] writeToURL:expectedDownloadFile.get() atomically:YES]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     bool caughtException = false;
     @try {
         [webView resumeDownloadFromResumeData:[@"invalid resume data" dataUsingEncoding:NSUTF8StringEncoding] completionHandler:^(WKDownload *download) {
@@ -2007,8 +2007,8 @@ TEST(WKDownload, ResumeCantReconnect)
 {
     auto server = downloadTestServer();
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
-    auto delegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block RetainPtr<WKDownload> retainedDownload;
@@ -2070,12 +2070,12 @@ TEST(WKDownload, UnknownContentLength)
         });
     });
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
-    auto delegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool done = false;
-    auto observer = adoptNS([DownloadObserver new]);
+    RetainPtr observer = adoptNS([DownloadObserver new]);
     observer.get().progressChangeCallback = ^(int64_t bytesWritten, int64_t totalByteCount) {
         EXPECT_EQ(totalByteCount, -1);
         if (bytesWritten == 5000)
@@ -2109,10 +2109,10 @@ TEST(WKDownload, UnknownContentLength)
 
 TEST(WKDownload, InvalidArguments)
 {
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     __block bool caughtException = false;
     auto server = downloadTestServer();
-    auto delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
     [webView startDownloadUsingRequest:server.request() completionHandler:^(WKDownload *download) {
         download.delegate = delegate.get();
         delegate.get().decideDestinationUsingResponse = ^(WKDownload *, NSURLResponse *, NSString *, void (^completionHandler)(NSURL *)) {
@@ -2145,11 +2145,11 @@ TEST(WKDownload, RedirectAllow)
 {
     auto server = redirectServer();
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
-    auto delegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
-    auto serverRequest = adoptNS([server.request() mutableCopy]);
+    RetainPtr serverRequest = adoptNS([server.request() mutableCopy]);
     [serverRequest setHTTPBody:[@"body" dataUsingEncoding:NSUTF8StringEncoding]];
 
     __block bool finishedDownload = false;
@@ -2194,8 +2194,8 @@ TEST(WKDownload, RedirectCancel)
 {
     auto server = redirectServer();
     RetainPtr serverRequest = server.request();
-    auto delegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool cancelled = false;
@@ -2229,8 +2229,8 @@ TEST(WKDownload, DownloadRequestFailure)
         connection.terminate();
     });
     RetainPtr serverRequest = server.request();
-    auto delegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool failed = false;
@@ -2270,8 +2270,8 @@ TEST(WKDownload, DownloadRequest404)
         { "/"_s, { 404, { }, "http body"_s } }
     });
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
-    auto delegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool didFinish = false;
@@ -2304,8 +2304,8 @@ TEST(WKDownload, DecidePlaceholderPolicy)
         { "/"_s, { 404, { }, "http body"_s } }
     });
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
-    auto delegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool didFinish = false;
@@ -2335,8 +2335,8 @@ TEST(WKDownload, PlaceholderPolicyEnable)
         { "/"_s, { 404, { }, "http body"_s } }
     });
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
-    auto delegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool didFinish = false;
@@ -2373,8 +2373,8 @@ TEST(WKDownload, PlaceholderPolicyDisable)
         { "/"_s, { 404, { }, "http body"_s } }
     });
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
-    auto delegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
     // manually create a placeholder file
@@ -2415,8 +2415,8 @@ TEST(WKDownload, PlaceholderPolicyDisableWithNonExistentPlaceholderURL)
         { "/"_s, { 404, { }, "http body"_s } }
     });
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
-    auto delegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
     // Pass a non-existent file URL as the placeholder. This should not cause
@@ -2453,8 +2453,8 @@ TEST(WKDownload, NetworkProcessCrash)
 {
     auto server = downloadTestServer();
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
-    auto delegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block RetainPtr<WKDownload> retainedDownload;
@@ -2494,8 +2494,8 @@ TEST(WKDownload, SuggestedFilenameFromHost)
         { "/"_s, { "download content"_s } }
     });
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
-    auto delegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
     delegate.get().navigationResponseDidBecomeDownload = ^(WKWebView *, WKNavigationResponse *, WKDownload *download) {
@@ -2525,9 +2525,9 @@ TEST(WKDownload, SuggestedFilenameFromHost)
 TEST(WKDownload, RequestHTTPBody)
 {
     auto server = downloadTestServer();
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     __block bool done = false;
-    auto request = adoptNS([server.request() mutableCopy]);
+    RetainPtr request = adoptNS([server.request() mutableCopy]);
     [request setHTTPBody:[@"body" dataUsingEncoding:NSUTF8StringEncoding]];
     [webView startDownloadUsingRequest:request.get() completionHandler:^(WKDownload *download) {
         EXPECT_NULL(download.originalRequest.HTTPBody); // FIXME: We probably want to make this non-null.
@@ -2543,8 +2543,8 @@ TEST(WKDownload, PathMustExist)
     NSURL *expectedDownloadFile = [tempDir URLByAppendingPathComponent:@"example.txt"];
 
     auto server = downloadTestServer();
-    auto delegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool failed = false;
@@ -2577,8 +2577,8 @@ TEST(WKDownload, FileMustNotExist)
 {
     auto server = downloadTestServer();
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
-    __block auto retainedDelegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    __block RetainPtr retainedDelegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:retainedDelegate.get()];
 
     EXPECT_TRUE([[@"initial data on disk" dataUsingEncoding:NSUTF8StringEncoding] writeToURL:expectedDownloadFile.get() atomically:YES]);
@@ -2614,8 +2614,8 @@ TEST(WKDownload, FileMustNotExist)
 TEST(WKDownload, DestinationNullString)
 {
     auto server = downloadTestServer();
-    auto delegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool failed = false;
@@ -2647,8 +2647,8 @@ TEST(WKDownload, DestinationNullString)
 TEST(WKDownload, ChallengeSuccess)
 {
     HTTPServer server({{ "/"_s, { "download content"_s }}}, HTTPServer::Protocol::Https);
-    auto delegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
     __block bool finished = false;
     delegate.get().downloadDidFinish = ^(WKDownload *download) {
@@ -2682,8 +2682,8 @@ TEST(WKDownload, ChallengeSuccess)
 TEST(WKDownload, ChallengeFailure)
 {
     HTTPServer server({ }, HTTPServer::Protocol::Https);
-    auto delegate = adoptNS([TestDownloadDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     __block bool failed = false;
     delegate.get().didFailWithError = ^(WKDownload *download, NSError *error, NSData *resumeData) {
         EXPECT_WK_STREQ(error.domain, NSURLErrorDomain);
@@ -2719,9 +2719,9 @@ void blobTest(bool downloadFromNavigationAction, std::initializer_list<DownloadC
     "}"
     "</script><body onload='downloadBlob()'></body>";
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView loadHTMLString:html baseURL:nil];
-    auto delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         if ([action.request.URL.absoluteString isEqualToString:@"about:blank"])
@@ -2797,9 +2797,9 @@ TEST(WKDownload, BlobResponseNoFilename)
     "    a.click();"
     "}"
     "</script><body onload='downloadBlob()'></body>";
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
-    auto delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         EXPECT_FALSE(action.shouldPerformDownload);
@@ -2841,9 +2841,9 @@ TEST(WKDownload, BlobDownload)
     auto *script = @"createBlob()";
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
 
-    auto webView = adoptNS([TestWKWebView new]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
 
-    auto delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
 
     [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
     [webView _test_waitForDidFinishNavigation];
@@ -2906,10 +2906,10 @@ TEST(WKDownload, SubframeOriginator)
 
     NSString *mainHTML = [NSString stringWithFormat:@"<iframe src='http://127.0.0.1:%d/'></iframe>", childFrameServer.port()];
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView loadHTMLString:mainHTML baseURL:[NSURL URLWithString:@"http://webkit.org/"]];
 
-    auto delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     delegate.get().decidePolicyForNavigationResponse = ^(WKNavigationResponse *response, void (^completionHandler)(WKNavigationResponsePolicy)) {
         if ([response.response.URL.absoluteString isEqualToString:@"http://webkit.org/"]
@@ -2966,10 +2966,10 @@ static TestWebKitAPI::HTTPServer simplePDFTestServer()
 
 TEST(WKDownload, LockdownModePDF)
 {
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     auto server = simplePDFTestServer();
     RetainPtr expectedDownloadFile = tempPDFThatDoesNotExist();
@@ -3021,10 +3021,10 @@ static TestWebKitAPI::HTTPServer simpleUSDZTestServer()
 
 TEST(WKDownload, LockdownModeUSDZ)
 {
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestDownloadDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     auto server = simpleUSDZTestServer();
     RetainPtr expectedDownloadFile = tempUSDZThatDoesNotExist();
@@ -3064,9 +3064,9 @@ TEST(WKDownload, DecideAfterRedirect)
     } };
     RetainPtr request = server.request();
     RetainPtr redirectedRequest = server.request("/redirectTarget"_s);
-    auto webView = adoptNS([WKWebView new]);
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
-    auto downloadDelegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr downloadDelegate = adoptNS([TestDownloadDelegate new]);
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
 
     downloadDelegate.get().decideDestinationUsingResponse = ^(WKDownload *, NSURLResponse *, NSString *, void (^completionHandler)(NSURL *)) {
@@ -3100,11 +3100,11 @@ TEST(WKDownload, DecideAfterRedirectLegacyDownloadSPI)
     } };
     RetainPtr request = server.request();
     RetainPtr redirectedRequest = server.request("/redirectTarget"_s);
-    auto webView = adoptNS([WKWebView new]);
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
 
-    auto downloadDelegate = adoptNS([TestLegacyDownloadDelegate new]);
+    RetainPtr downloadDelegate = adoptNS([TestLegacyDownloadDelegate new]);
     downloadDelegate.get().decideDestinationWithSuggestedFilename = ^(_WKDownload *, NSString *suggestedFilename, void (^completionHandler)(BOOL, NSString *)) {
         completionHandler(YES, expectedDownloadFile.get().path);
     };
@@ -3141,8 +3141,8 @@ TEST(WKDownload, OriginatingFrameAndUserGesture)
     }, HTTPServer::Protocol::HttpsProxy };
 
     RetainPtr configuration = server.httpsProxyConfiguration();
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:navigationDelegate.get()];
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]];
@@ -3185,7 +3185,7 @@ TEST(WKDownload, OriginatingFrameAndUserGesture)
     userGesture = YES;
     check();
 
-    auto emptyWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr emptyWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
     checkedDownload = false;
     [emptyWebView startDownloadUsingRequest:request completionHandler:^(WKDownload *download) {
         EXPECT_NOT_NULL(download.originatingFrame.securityOrigin);
@@ -3201,9 +3201,9 @@ TEST(WKDownload, OriginatingFrameAndUserGesture)
 TEST(WKDownload, DestinationFileAlreadyExists)
 {
     HTTPServer server { { { "/"_s, { "hi"_s } } } };
-    auto webView = adoptNS([WKWebView new]);
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
-    auto downloadDelegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr downloadDelegate = adoptNS([TestDownloadDelegate new]);
     RetainPtr expectedDownloadFile = tempFileThatDoesNotExist();
     [[NSData data] writeToURL:expectedDownloadFile.get() atomically:YES];
 
@@ -3245,8 +3245,8 @@ TEST(WKDownload, OriginatingFrameWhenConvertingNavigationInNewWindow)
     }, HTTPServer::Protocol::HttpsProxy };
 
     RetainPtr configuration = server.httpsProxyConfiguration();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:navigationDelegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
@@ -3254,7 +3254,7 @@ TEST(WKDownload, OriginatingFrameWhenConvertingNavigationInNewWindow)
 
     RetainPtr<WKFrameInfo> openerMainFrame = [webView mainFrame].info;
 
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     [webView setUIDelegate:uiDelegate.get()];
     __block RetainPtr<WKWebView> openedWebView;
     uiDelegate.get().createWebViewWithConfiguration = ^WKWebView *(WKWebViewConfiguration *configuration, WKNavigationAction *, WKWindowFeatures *) {
@@ -3325,8 +3325,8 @@ TEST(WKDownload, OriginatingFrameWhenNavigatingToNewDomainWithRedirect)
     }, HTTPServer::Protocol::HttpsProxy);
 
     RetainPtr configuration = server.httpsProxyConfiguration();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:navigationDelegate.get()];
     auto request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/original_page"]];
@@ -3472,8 +3472,8 @@ TEST(WKDownload, SuggestedFilenameCorrectedByContentType)
         });
     });
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
-    auto downloadDelegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr downloadDelegate = adoptNS([TestDownloadDelegate new]);
 
     __block bool downloadDestinationDecided = false;
     __block RetainPtr<NSString> receivedSuggestedFilename;
@@ -3493,7 +3493,7 @@ TEST(WKDownload, SuggestedFilenameCorrectedByContentType)
     };
 
     auto requestURL = makeString("http://127.0.0.1:"_s, server.port(), "/video.gif"_s);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:requestURL.createNSString().get()]]];
     Util::run(&downloadDestinationDecided);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DownloadProgress.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DownloadProgress.mm
@@ -168,7 +168,7 @@ static void* progressObservingContext = &progressObservingContext;
 {
     m_protocol = protocol;
 
-    auto response = adoptNS([[NSURLResponse alloc] initWithURL:protocol.request.URL MIMEType:@"application/x-test-file" expectedContentLength:m_expectedLength textEncodingName:nullptr]);
+    RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:protocol.request.URL MIMEType:@"application/x-test-file" expectedContentLength:m_expectedLength textEncodingName:nullptr]);
     [m_protocol.get().client URLProtocol:m_protocol.get() didReceiveResponse:response.get() cacheStoragePolicy:NSURLCacheStorageNotAllowed];
 }
 
@@ -243,12 +243,12 @@ static void* progressObservingContext = &progressObservingContext;
     m_startType = startType;
     m_expectedLength = expectedLength;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     m_webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
     m_webView.get().navigationDelegate = self;
     m_webView.get().configuration.processPool._downloadDelegate = self;
 
-    auto request = adoptNS([[NSURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://file"]]);
+    RetainPtr request = adoptNS([[NSURLRequest alloc] initWithURL:[NSURL URLWithString:@"http://file"]]);
 
     switch (startType) {
     case DownloadStartType::ConvertLoadToDownload:
@@ -269,7 +269,7 @@ static void* progressObservingContext = &progressObservingContext;
 
 - (void)receiveData:(NSInteger)length
 {
-    auto data = adoptNS([[NSMutableData alloc] init]);
+    RetainPtr data = adoptNS([[NSMutableData alloc] init]);
     while (length-- > 0) {
         const char byte = 'A';
         [data.get() appendBytes:static_cast<const void*>(&byte) length:1];
@@ -401,7 +401,7 @@ static void* progressObservingContext = &progressObservingContext;
 // progress, and the NSProgress should be unpublished when the download finishes.
 TEST(DownloadProgress, BasicSubscriptionAndProgressUpdates)
 {
-    auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
+    RetainPtr testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
     [testRunner.get() startDownload:DownloadStartType::ConvertLoadToDownload expectedLength:100];
     [testRunner.get() publishProgress];
@@ -425,7 +425,7 @@ TEST(DownloadProgress, BasicSubscriptionAndProgressUpdates)
 // Similar test as before, but initiating the download before receiving its response.
 TEST(DownloadProgress, StartDownloadFromNavigationAction)
 {
-    auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
+    RetainPtr testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
     [testRunner.get() startDownload:DownloadStartType::StartFromNavigationAction expectedLength:100];
     [testRunner.get() publishProgress];
@@ -441,7 +441,7 @@ TEST(DownloadProgress, StartDownloadFromNavigationAction)
 // If the download is canceled, the progress should be unpublished.
 TEST(DownloadProgress, LoseProgressWhenDownloadIsCanceled)
 {
-    auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
+    RetainPtr testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
     [testRunner.get() startDownload:DownloadStartType::ConvertLoadToDownload expectedLength:100];
     [testRunner.get() publishProgress];
@@ -457,7 +457,7 @@ TEST(DownloadProgress, LoseProgressWhenDownloadIsCanceled)
 // If the download fails, the progress should be unpublished.
 TEST(DownloadProgress, LoseProgressWhenDownloadFails)
 {
-    auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
+    RetainPtr testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
     [testRunner.get() startDownload:DownloadStartType::ConvertLoadToDownload expectedLength:100];
     [testRunner.get() publishProgress];
@@ -473,7 +473,7 @@ TEST(DownloadProgress, LoseProgressWhenDownloadFails)
 // Canceling the progress should cancel the download.
 TEST(DownloadProgress, CancelDownloadWhenProgressIsCanceled)
 {
-    auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
+    RetainPtr testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
     [testRunner.get() startDownload:DownloadStartType::ConvertLoadToDownload expectedLength:100];
     [testRunner.get() publishProgress];
@@ -489,7 +489,7 @@ TEST(DownloadProgress, CancelDownloadWhenProgressIsCanceled)
 // Publishing progress on a download after it has finished should be a safe no-op.
 TEST(DownloadProgress, PublishProgressAfterDownloadFinished)
 {
-    auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
+    RetainPtr testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
     [testRunner.get() startDownload:DownloadStartType::ConvertLoadToDownload expectedLength:100];
     [testRunner.get() receiveData:100];
@@ -503,7 +503,7 @@ TEST(DownloadProgress, PublishProgressAfterDownloadFinished)
 // Test the behavior of a download of unknown length.
 TEST(DownloadProgress, IndeterminateDownloadSize)
 {
-    auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
+    RetainPtr testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
     [testRunner.get() startDownload:DownloadStartType::ConvertLoadToDownload expectedLength:NSURLResponseUnknownLength];
     [testRunner.get() publishProgress];
@@ -525,7 +525,7 @@ TEST(DownloadProgress, IndeterminateDownloadSize)
 // Test the behavior when a download continues returning data beyond its expected length.
 TEST(DownloadProgress, ExtraData)
 {
-    auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
+    RetainPtr testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
     [testRunner.get() startDownload:DownloadStartType::ConvertLoadToDownload expectedLength:100];
     [testRunner.get() publishProgress];
@@ -545,7 +545,7 @@ TEST(DownloadProgress, ExtraData)
 // Clients should be able to publish progress on a download that has already started.
 TEST(DownloadProgress, PublishProgressOnPartialDownload)
 {
-    auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
+    RetainPtr testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
     [testRunner.get() startDownload:DownloadStartType::ConvertLoadToDownload expectedLength:100];
     [testRunner.get() receiveData:50];
@@ -570,7 +570,7 @@ TEST(DownloadProgress, PublishProgressOnPartialDownload)
 
 TEST(DownloadProgress, ProgressExtendedAttributeSetAfterPartialDownloadStops)
 {
-    auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
+    RetainPtr testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
     [testRunner.get() startDownload:DownloadStartType::ConvertLoadToDownload expectedLength:100];
     [testRunner.get() publishProgress];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DragAndDropTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DragAndDropTests.mm
@@ -71,11 +71,11 @@
 TEST(DragAndDropTests, ModernWebArchiveType)
 {
     NSData *markupData = [@"<strong><i>Hello world</i></strong>" dataUsingEncoding:NSUTF8StringEncoding];
-    auto mainResource = adoptNS([[WebResource alloc] initWithData:markupData URL:[NSURL URLWithString:@"foo.html"] MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
-    auto archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:@[ ] subframeArchives:@[ ]]);
+    RetainPtr mainResource = adoptNS([[WebResource alloc] initWithData:markupData URL:[NSURL URLWithString:@"foo.html"] MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
+    RetainPtr archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:@[ ] subframeArchives:@[ ]]);
     NSString *webArchiveType = UTTypeWebArchive.identifier;
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500)]);
     auto webView = [simulator webView];
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width'><body style='width: 100%; height: 100%;' contenteditable>"];
 #if PLATFORM(MAC)
@@ -85,7 +85,7 @@ TEST(DragAndDropTests, ModernWebArchiveType)
     [pasteboard setData:[@"Hello world" dataUsingEncoding:NSUTF8StringEncoding] forType:UTTypeUTF8PlainText.identifier];
     [simulator setExternalDragPasteboard:pasteboard];
 #else
-    auto item = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr item = adoptNS([[NSItemProvider alloc] init]);
     [item registerDataRepresentationForTypeIdentifier:webArchiveType visibility:NSItemProviderRepresentationVisibilityAll loadHandler:[&] (void (^completionHandler)(NSData *, NSError *)) -> NSProgress * {
         completionHandler([archive data], nil);
         return nil;
@@ -105,7 +105,7 @@ TEST(DragAndDropTests, ModernWebArchiveType)
 
 TEST(DragAndDropTests, DragImageLocationForLinkInSubframe)
 {
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 400, 400)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 400, 400)]);
     [[simulator webView] synchronouslyLoadTestPageNamed:@"link-in-iframe-and-input"];
     [simulator runFrom:CGPointMake(200, 375) to:CGPointMake(200, 125)];
 
@@ -118,7 +118,7 @@ TEST(DragAndDropTests, DragImageLocationForLinkInSubframe)
 
 TEST(DragAndDropTests, ExposeMultipleURLsInDataTransfer)
 {
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500)]);
     auto webView = [simulator webView];
     WKPreferencesSetCustomPasteboardDataEnabled((__bridge WKPreferencesRef)[webView configuration].preferences, true);
     [webView synchronouslyLoadTestPageNamed:@"DataTransfer"];
@@ -132,9 +132,9 @@ TEST(DragAndDropTests, ExposeMultipleURLsInDataTransfer)
     [pasteboard writeObjects:@[ stringData, firstURL, secondURL ]];
     [simulator setExternalDragPasteboard:pasteboard];
 #else
-    auto stringItem = adoptNS([[NSItemProvider alloc] initWithObject:stringData]);
-    auto firstURLItem = adoptNS([[NSItemProvider alloc] initWithObject:firstURL]);
-    auto secondURLItem = adoptNS([[NSItemProvider alloc] initWithObject:secondURL]);
+    RetainPtr stringItem = adoptNS([[NSItemProvider alloc] initWithObject:stringData]);
+    RetainPtr firstURLItem = adoptNS([[NSItemProvider alloc] initWithObject:firstURL]);
+    RetainPtr secondURLItem = adoptNS([[NSItemProvider alloc] initWithObject:secondURL]);
     for (NSItemProvider *item in @[ stringItem.get(), firstURLItem.get(), secondURLItem.get() ])
         item.preferredPresentationStyle = UIPreferredPresentationStyleInline;
     [simulator setExternalItemProviders:@[ stringItem.get(), firstURLItem.get(), secondURLItem.get() ]];
@@ -151,7 +151,7 @@ TEST(DragAndDropTests, ExposeMultipleURLsInDataTransfer)
 #if PLATFORM(MAC)
 TEST(DragAndDropTests, DragAndDropOnEmptyView)
 {
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500)]);
     simulator.get().dragDestinationAction = WKDragDestinationActionAny;
     auto webView = [simulator webView];
 
@@ -176,7 +176,7 @@ TEST(DragAndDropTests, DragAndDropOnEmptyView)
 
 TEST(DragAndDropTests, PreventingMouseDownShouldPreventDragStart)
 {
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500)]);
     auto webView = [simulator webView];
     WKPreferencesSetCustomPasteboardDataEnabled((__bridge WKPreferencesRef)[webView configuration].preferences, true);
     [webView synchronouslyLoadTestPageNamed:@"link-and-target-div"];
@@ -226,7 +226,7 @@ static DragStartData runDragStartDataTestCase(DragAndDropSimulator *simulator, N
 
 TEST(DragAndDropTests, DataTransferTypesOnDragStartForTextSelection)
 {
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 500, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 500, 500)]);
     [[simulator webView] synchronouslyLoadTestPageNamed:@"dragstart-data"];
 
     auto result = runDragStartDataTestCase(simulator.get(), @"regular");
@@ -267,7 +267,7 @@ TEST(DragAndDropTests, DataTransferTypesOnDragStartForTextSelection)
 
 TEST(DragAndDropTests, DataTransferTypesOnDragStartForImage)
 {
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 500, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 500, 500)]);
     [[simulator webView] synchronouslyLoadTestPageNamed:@"dragstart-data"];
 
     auto result = runDragStartDataTestCase(simulator.get(), @"image");
@@ -296,7 +296,7 @@ TEST(DragAndDropTests, DataTransferTypesOnDragStartForImage)
 
 TEST(DragAndDropTests, DataTransferTypesOnDragStartForLink)
 {
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 500, 800)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 500, 800)]);
     [[simulator webView] synchronouslyLoadTestPageNamed:@"dragstart-data"];
 
     auto result = runDragStartDataTestCase(simulator.get(), @"link");
@@ -316,7 +316,7 @@ TEST(DragAndDropTests, DataTransferTypesOnDragStartForLink)
 
 TEST(DragAndDropTests, DoNotCrashWhenRemovingNodeOnDrop)
 {
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500)]);
     auto webView = [simulator webView];
     [webView synchronouslyLoadTestPageNamed:@"remove-node-on-drop"];
     [simulator runFrom:CGPointMake(150, 50) to:CGPointMake(150, 150)];
@@ -325,7 +325,7 @@ TEST(DragAndDropTests, DoNotCrashWhenRemovingNodeOnDrop)
 
 TEST(DragAndDropTests, ColorInputToColorInput)
 {
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500)]);
     auto webView = [simulator webView];
 
     [webView synchronouslyLoadTestPageNamed:@"color-drop"];
@@ -336,7 +336,7 @@ TEST(DragAndDropTests, ColorInputToColorInput)
 
 TEST(DragAndDropTests, ColorInputToDisabledColorInput)
 {
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500)]);
     auto webView = [simulator webView];
 
     [webView synchronouslyLoadTestPageNamed:@"color-drop"];
@@ -348,7 +348,7 @@ TEST(DragAndDropTests, ColorInputToDisabledColorInput)
 
 TEST(DragAndDropTests, DisabledColorInputToColorInput)
 {
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500)]);
     auto webView = [simulator webView];
 
     [webView synchronouslyLoadTestPageNamed:@"color-drop"];
@@ -360,7 +360,7 @@ TEST(DragAndDropTests, DisabledColorInputToColorInput)
 
 TEST(DragAndDropTests, ReadOnlyColorInputToReadOnlyColorInput)
 {
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500)]);
     auto webView = [simulator webView];
 
     [webView synchronouslyLoadTestPageNamed:@"color-drop"];
@@ -373,7 +373,7 @@ TEST(DragAndDropTests, ReadOnlyColorInputToReadOnlyColorInput)
 
 TEST(DragAndDropTests, ColorInputEvents)
 {
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500)]);
     auto webView = [simulator webView];
 
     [webView synchronouslyLoadTestPageNamed:@"color-drop"];
@@ -400,7 +400,7 @@ TEST(DragAndDropTests, DragElementWithImageOverlay)
     auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES]);
     [[configuration preferences] _setLargeImageAsyncDecodingEnabled:NO];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     [[simulator webView] synchronouslyLoadTestPageNamed:@"simple-image-overlay"];
 
     [simulator runFrom:NSMakePoint(150, 40) to:NSMakePoint(300, 40)];
@@ -415,7 +415,7 @@ TEST(DragAndDropTests, DragSelectedTextInImageOverlay)
     auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES]);
     [[configuration preferences] _setLargeImageAsyncDecodingEnabled:NO];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     [[simulator webView] synchronouslyLoadTestPageNamed:@"simple-image-overlay"];
     [[simulator webView] stringByEvaluatingJavaScript:@"selectImageOverlay()"];
     [[simulator webView] waitForNextPresentationUpdate];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DuplicateCompletionHandlerCalls.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DuplicateCompletionHandlerCalls.mm
@@ -124,11 +124,11 @@ static void expectException(void (^completionHandler)())
 
 TEST(WebKit, DuplicateCompletionHandlerCalls)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     auto preferences = (__bridge WKPreferencesRef)[[webView configuration] preferences];
     WKPreferencesSetWebSQLDisabled(preferences, false);
 
-    auto delegate = adoptNS([[DuplicateCompletionHandlerCallsDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[DuplicateCompletionHandlerCallsDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
     [webView _setInputDelegate:delegate.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EditorStateTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EditorStateTests.mm
@@ -94,8 +94,8 @@ namespace TestWebKitAPI {
 
 static RetainPtr<EditingTestHarness> setUpEditorStateTestHarness()
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
-    auto testHarness = adoptNS([[EditingTestHarness alloc] initWithWebView:webView.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr testHarness = adoptNS([[EditingTestHarness alloc] initWithWebView:webView.get()]);
     [webView synchronouslyLoadTestPageNamed:@"editor-state-test-harness"];
     return testHarness;
 }
@@ -328,8 +328,8 @@ TEST(EditorStateTests, ContentViewHasTextInContentEditableElement)
 
 TEST(EditorStateTests, ContentViewHasTextInTextarea)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
-    auto testHarness = adoptNS([[EditingTestHarness alloc] initWithWebView:webView.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr testHarness = adoptNS([[EditingTestHarness alloc] initWithWebView:webView.get()]);
     [webView synchronouslyLoadHTMLString:@"<textarea id='textarea'></textarea>"];
     [webView stringByEvaluatingJavaScript:@"textarea.focus()"];
     [webView waitForNextPresentationUpdate];
@@ -354,7 +354,7 @@ TEST(EditorStateTests, ContentViewHasTextInTextarea)
 
 TEST(EditorStateTests, CaretColorInContentEditable)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<body style=\"caret-color: red;\" contenteditable=\"true\"></body>"];
     [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
     [webView waitForNextPresentationUpdate];
@@ -369,12 +369,12 @@ TEST(EditorStateTests, CaretColorInContentEditable)
 
 TEST(EditorStateTests, ObserveSelectionAttributeChanges)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto editor = adoptNS([[EditingTestHarness alloc] initWithWebView:webView.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr editor = adoptNS([[EditingTestHarness alloc] initWithWebView:webView.get()]);
     [webView _setEditable:YES];
     [webView synchronouslyLoadHTMLString:@"<body></body>"];
 
-    auto observer = adoptNS([[SelectionChangeObserver alloc] initWithWebView:webView.get()]);
+    RetainPtr observer = adoptNS([[SelectionChangeObserver alloc] initWithWebView:webView.get()]);
 
     [webView evaluateJavaScript:@"document.body.focus()" completionHandler:nil];
     [webView waitForNextPresentationUpdate];
@@ -408,13 +408,13 @@ TEST(EditorStateTests, ObserveSelectionAttributeChanges)
 
 TEST(EditorStateTests, ParagraphBoundary)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<body contenteditable><p>Hello world.</p></body>"];
     [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
     [webView waitForNextPresentationUpdate];
 
     auto textInput = [webView textInputContentView];
-    auto editor = adoptNS([[EditingTestHarness alloc] initWithWebView:webView.get()]);
+    RetainPtr editor = adoptNS([[EditingTestHarness alloc] initWithWebView:webView.get()]);
     [editor selectAll];
 
     EXPECT_TRUE([textInput isPosition:textInput.selectedTextRange.start atBoundary:UITextGranularityParagraph inDirection:UITextStorageDirectionBackward]);
@@ -430,7 +430,7 @@ TEST(EditorStateTests, ParagraphBoundary)
 
 TEST(EditorStateTests, SelectedText)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"lots-of-text"];
     [webView _synchronouslyExecuteEditCommand:@"SelectAll" argument:nil];
     [webView waitForNextPresentationUpdate];
@@ -490,7 +490,7 @@ TEST(EditorStateTests, MarkedTextRange_HorizontalCaretSelection)
 {
     IPhoneUserInterfaceSwizzler userInterfaceSwizzler;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:EditorStateTests::applyAhemStyle(@"<body contenteditable='true'>.</body>")]; // . is dummy to force Ahem to load
     [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
 
@@ -511,7 +511,7 @@ TEST(EditorStateTests, MarkedTextRange_HorizontalRangeSelection)
 {
     IPhoneUserInterfaceSwizzler userInterfaceSwizzler;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:EditorStateTests::applyAhemStyle(@"<body contenteditable='true'>.</body>")]; // . is dummy to force Ahem to load
     [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
     [webView _synchronouslyExecuteEditCommand:@"InsertText" argument:@"Hello world"];
@@ -534,7 +534,7 @@ TEST(EditorStateTests, MarkedTextRange_VerticalCaretSelection)
 {
     IPhoneUserInterfaceSwizzler userInterfaceSwizzler;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:EditorStateTests::applyAhemStyle(@"<body style='writing-mode: vertical-lr' contenteditable='true'>.</body>")]; // . is dummy to force Ahem to load
     [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
 
@@ -555,7 +555,7 @@ TEST(EditorStateTests, MarkedTextRange_VerticalRangeSelection)
 {
     IPhoneUserInterfaceSwizzler userInterfaceSwizzler;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:EditorStateTests::applyAhemStyle(@"<body style='writing-mode: vertical-lr' contenteditable='true'>.</body>")]; // . is dummy to force Ahem to load
     [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
     [webView _synchronouslyExecuteEditCommand:@"InsertText" argument:@"Hello world"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ElementTargetingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ElementTargetingTests.mm
@@ -91,19 +91,19 @@
 
 - (NSArray<_WKTargetedElementInfo *> *)targetedElementInfoAt:(CGPoint)point
 {
-    auto request = adoptNS([[_WKTargetedElementRequest alloc] initWithPoint:point]);
+    RetainPtr request = adoptNS([[_WKTargetedElementRequest alloc] initWithPoint:point]);
     return [self targetedElementInfo:request.get()];
 }
 
 - (NSArray<_WKTargetedElementInfo *> *)targetedElementInfoWithText:(NSString *)searchText
 {
-    auto request = adoptNS([[_WKTargetedElementRequest alloc] initWithSearchText:searchText]);
+    RetainPtr request = adoptNS([[_WKTargetedElementRequest alloc] initWithSearchText:searchText]);
     return [self targetedElementInfo:request.get()];
 }
 
 - (NSArray<_WKTargetedElementInfo *> *)targetedElementInfoWithSelectors:(NSArray<NSSet<NSString *> *> *)selectors
 {
-    auto request = adoptNS([[_WKTargetedElementRequest alloc] initWithSelectors:selectors]);
+    RetainPtr request = adoptNS([[_WKTargetedElementRequest alloc] initWithSelectors:selectors]);
     return [self targetedElementInfo:request.get()];
 }
 
@@ -191,7 +191,7 @@ namespace TestWebKitAPI {
 
 TEST(ElementTargeting, BasicElementTargeting)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView synchronouslyLoadTestPageNamed:@"element-targeting-1"];
 
     Util::waitForConditionWithLogging([&] {
@@ -246,7 +246,7 @@ TEST(ElementTargeting, BasicElementTargeting)
 
 TEST(ElementTargeting, DoNotIgnorePointerEventsNone)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView synchronouslyLoadTestPageNamed:@"element-targeting-1"];
 
     Util::waitForConditionWithLogging([&] {
@@ -264,7 +264,7 @@ TEST(ElementTargeting, DoNotIgnorePointerEventsNone)
 
 TEST(ElementTargeting, NearbyOutOfFlowElements)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView synchronouslyLoadTestPageNamed:@"element-targeting-2"];
 
     RetainPtr elements = [webView targetedElementInfoAt:CGPointMake(100, 100)];
@@ -296,7 +296,7 @@ TEST(ElementTargeting, NearbyOutOfFlowElements)
 static std::pair<RetainPtr<TestWKWebView>, RetainPtr<Util::PlatformWindow>> setUpWebViewForSnapshotting(CGRect frame)
 {
 #if PLATFORM(IOS_FAMILY)
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:frame configuration:configuration.get() addToWindow:NO]);
     RetainPtr window = adoptNS([[UIWindow alloc] initWithFrame:frame]);
     [window addSubview:webView.get()];
@@ -394,7 +394,7 @@ TEST(ElementTargeting, AdjustVisibilityFromSelectors)
 
 TEST(ElementTargeting, RequestElementsFromSelectors)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 480)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 480)]);
 
     RetainPtr preferences = adoptNS([WKWebpagePreferences new]);
     [preferences _setVisibilityAdjustmentSelectors:[NSSet setWithObjects:
@@ -573,7 +573,7 @@ TEST(ElementTargeting, AdjustVisibilityForTargetsInShadowRoot)
 
 TEST(ElementTargeting, TargetContainsShadowRoot)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView synchronouslyLoadTestPageNamed:@"element-targeting-4"];
 
     RetainPtr elements = [webView targetedElementInfoAt:CGPointMake(100, 150)];
@@ -583,7 +583,7 @@ TEST(ElementTargeting, TargetContainsShadowRoot)
 
 TEST(ElementTargeting, ParentRelativeSelectors)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView synchronouslyLoadTestPageNamed:@"element-targeting-5"];
     [webView expectSingleTargetedSelector:@"BODY > DIV:first-of-type" at:CGPointMake(100, 50)];
     [webView expectSingleTargetedSelector:@"BODY > DIV:nth-child(3)" at:CGPointMake(100, 150)];
@@ -594,7 +594,7 @@ TEST(ElementTargeting, ParentRelativeSelectors)
 TEST(ElementTargeting, TargetInFlowElements)
 {
     auto center = CGPointMake(200, 200);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"element-targeting-6"];
     [webView expectSingleTargetedSelector:@"MAIN > P:first-of-type" at:center];
 
@@ -609,7 +609,7 @@ TEST(ElementTargeting, TargetInFlowElements)
 
 TEST(ElementTargeting, ReplacedRendererSizeIgnoresPageScaleAndZoom)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView synchronouslyLoadTestPageNamed:@"element-targeting-7"];
     RetainPtr targetBeforeScaling = [[webView targetedElementInfoAt:CGPointMake(100, 100)] firstObject];
 #if PLATFORM(MAC)
@@ -631,7 +631,7 @@ TEST(ElementTargeting, ReplacedRendererSizeIgnoresPageScaleAndZoom)
 
 TEST(ElementTargeting, RequestTargetedElementsBySearchableText)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView synchronouslyLoadTestPageNamed:@"element-targeting-7"];
 
     RetainPtr targetFromHitTest = [[webView targetedElementInfoAt:CGPointMake(100, 100)] firstObject];
@@ -658,7 +658,7 @@ TEST(ElementTargeting, TargetedElementWithInvalidURLShouldNotCrash)
 
 TEST(ElementTargeting, AdjustVisibilityAfterRecreatingElement)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
 
     RetainPtr delegate = adoptNS([TestUIDelegate new]);
     [webView setUIDelegate:delegate.get()];
@@ -679,7 +679,7 @@ TEST(ElementTargeting, AdjustVisibilityAfterRecreatingElement)
 
 TEST(ElementTargeting, TargetedElementWithLargeImage)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 480, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 480, 600)]);
     [webView synchronouslyLoadTestPageNamed:@"element-targeting-9"];
     RetainPtr element = [[webView targetedElementInfoAt:CGPointMake(80, 80)] firstObject];
 
@@ -690,7 +690,7 @@ TEST(ElementTargeting, TargetedElementWithLargeImage)
 
 TEST(ElementTargeting, CountVisibilityAdjustmentsAfterNavigatingBack)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView synchronouslyLoadTestPageNamed:@"element-targeting-1"];
 
     Util::waitForConditionWithLogging([&] {
@@ -733,7 +733,7 @@ TEST(ElementTargeting, DoNotBeginRepeatedVisibilityAdjustmentIfTargetIsAlreadyHi
 #if PLATFORM(VISION)
 TEST(ElementTargeting, RequestAllVisibleElements)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView synchronouslyLoadTestPageNamed:@"element-targeting-11"];
 
     RetainPtr elements = [webView allTargetableElementsWithHitTestInterval:CGFloat(40.0)];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EnhancedSecurity.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EnhancedSecurity.mm
@@ -74,9 +74,9 @@ static bool isJITEnabled(WKWebView *webView)
 
 TEST(EnhancedSecurity, EnhancedSecurityEnablesTrue)
 {
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     [webView _test_waitForDidFinishNavigation];
@@ -87,9 +87,9 @@ TEST(EnhancedSecurity, EnhancedSecurityEnablesTrue)
 
 TEST(EnhancedSecurity, EnhancedSecurityEnableFalse)
 {
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     [webView _test_waitForDidFinishNavigation];
@@ -100,9 +100,9 @@ TEST(EnhancedSecurity, EnhancedSecurityEnableFalse)
 
 TEST(EnhancedSecurity, EnhancedSecurityDisablesJIT)
 {
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     [webView _test_waitForDidFinishNavigation];
@@ -111,10 +111,10 @@ TEST(EnhancedSecurity, EnhancedSecurityDisablesJIT)
 
 TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterNavigation)
 {
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool finishedNavigation = false;
@@ -137,10 +137,10 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterNavigation)
 
 TEST(EnhancedSecurity, PSONToEnhancedSecurity)
 {
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool finishedNavigation = false;
@@ -183,10 +183,10 @@ TEST(EnhancedSecurity, PSONToEnhancedSecurity)
 
 TEST(EnhancedSecurity, PSONToEnhancedSecuritySamePage)
 {
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool finishedNavigation = false;
@@ -229,7 +229,7 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySamePage)
 
 static RetainPtr<_WKProcessPoolConfiguration> psonProcessPoolConfiguration()
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().processSwapsOnNavigation = YES;
     processPoolConfiguration.get().usesWebProcessCache = YES;
     processPoolConfiguration.get().prewarmsProcessesAutomatically = YES;
@@ -240,15 +240,15 @@ static RetainPtr<_WKProcessPoolConfiguration> psonProcessPoolConfiguration()
 TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPool)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [webViewConfiguration setProcessPool:processPool.get()];
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool finishedNavigation = false;
@@ -265,7 +265,7 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPool)
     EXPECT_NE(pid1, 0);
 
     finishedNavigation = false;
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     [webView2 setNavigationDelegate:delegate.get()];
 
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
@@ -286,15 +286,15 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPool)
 TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPoolReverse)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [webViewConfiguration setProcessPool:processPool.get()];
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool finishedNavigation = false;
@@ -311,7 +311,7 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPoolReverse)
     EXPECT_NE(pid1, 0);
 
     finishedNavigation = false;
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     [webView2 setNavigationDelegate:delegate.get()];
 
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
@@ -331,13 +331,13 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPoolReverse)
 
 TEST(EnhancedSecurity, ProcessVariantMatchesConfiguration)
 {
-    auto webViewConfiguration1 = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration1 = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration1.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration1.get()]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration1.get()]);
 
-    auto webViewConfiguration2 = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration2 = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration2.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration2.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration2.get()]);
 
     NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
@@ -354,17 +354,17 @@ TEST(EnhancedSecurity, ProcessVariantMatchesConfiguration)
 
 TEST(EnhancedSecurity, ProcessCanLaunch)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
     configuration.get().processPool = adoptNS([[WKProcessPool alloc] init]).get();
     configuration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadHTMLString:@"<html><body>test</body></html>" baseURL:nil];
 
     // Wait with explicit timeout instead of _test_waitForDidFinishNavigation
     __block bool navigationFinished = false;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().didFinishNavigation = ^(WKWebView *, WKNavigation *) {
         navigationFinished = true;
     };
@@ -391,16 +391,16 @@ TEST(EnhancedSecurity, CaptivePortalProcessCanLaunch)
     [WKProcessPool _setCaptivePortalModeEnabledGloballyForTesting:YES];
 
     // Create configuration AFTER setting global mode
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
     configuration.get().processPool = adoptNS([[WKProcessPool alloc] init]).get();
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadHTMLString:@"<html><body>test</body></html>" baseURL:nil];
 
     // Wait with explicit timeout instead of _test_waitForDidFinishNavigation
     __block bool navigationFinished = false;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().didFinishNavigation = ^(WKWebView *, WKNavigation *) {
         navigationFinished = true;
     };
@@ -434,8 +434,8 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNaviga
     [webViewConfiguration.get().processPool _setObject:@"WebProcessPlugInWithInternals" forBundleParameter:TestWebKitAPI::Util::TestPlugInClassNameParameter];
     webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
 
     [webView setNavigationDelegate:delegate.get()];
@@ -480,8 +480,8 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNaviga
     [webViewConfiguration.get().processPool _setObject:@"WebProcessPlugInWithInternals" forBundleParameter:TestWebKitAPI::Util::TestPlugInClassNameParameter];
     webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
 
     [webView setNavigationDelegate:delegate.get()];
@@ -530,8 +530,8 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavig
     [webViewConfiguration.get().processPool _setObject:@"WebProcessPlugInWithInternals" forBundleParameter:TestWebKitAPI::Util::TestPlugInClassNameParameter];
     webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = NO;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
 
     [webView setNavigationDelegate:delegate.get()];
@@ -575,8 +575,8 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavig
     [webViewConfiguration.get().processPool _setObject:@"WebProcessPlugInWithInternals" forBundleParameter:TestWebKitAPI::Util::TestPlugInClassNameParameter];
     webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = NO;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
 
     [webView setNavigationDelegate:delegate.get()];
@@ -622,16 +622,16 @@ TEST(EnhancedSecurity, WindowOpenWithNoopenerFromEnhancedSecurityPage)
     webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
     webViewConfiguration.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto openerDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr openerDelegate = adoptNS([TestNavigationDelegate new]);
     [openerDelegate allowAnyTLSCertificate];
     [openerWebView setNavigationDelegate:openerDelegate.get()];
 
     __block RetainPtr<WKWebView> openedWebView;
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *, WKWindowFeatures *) {
         openedWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
-        auto openedDelegate = adoptNS([TestNavigationDelegate new]);
+        RetainPtr openedDelegate = adoptNS([TestNavigationDelegate new]);
         [openedDelegate allowAnyTLSCertificate];
         [openedWebView setNavigationDelegate:openedDelegate.get()];
         return openedWebView.get();
@@ -662,16 +662,16 @@ TEST(EnhancedSecurity, WindowOpenWithOpenerFromEnhancedSecurityPage)
     webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
     webViewConfiguration.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto openerDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr openerDelegate = adoptNS([TestNavigationDelegate new]);
     [openerDelegate allowAnyTLSCertificate];
     [openerWebView setNavigationDelegate:openerDelegate.get()];
 
     __block RetainPtr<WKWebView> openedWebView;
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *, WKWindowFeatures *) {
         openedWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
-        auto openedDelegate = adoptNS([TestNavigationDelegate new]);
+        RetainPtr openedDelegate = adoptNS([TestNavigationDelegate new]);
         [openedDelegate allowAnyTLSCertificate];
         [openedWebView setNavigationDelegate:openedDelegate.get()];
         return openedWebView.get();
@@ -697,15 +697,15 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSec
     }, HTTPServer::Protocol::HttpsProxy);
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
     RetainPtr standardConfig = server.httpsProxyConfiguration();
     [standardConfig.get() setProcessPool:processPool.get()];
     standardConfig.get().defaultWebpagePreferences._enhancedSecurityEnabled = NO;
     standardConfig.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    auto standardWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:standardConfig.get()]);
-    auto standardDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr standardWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:standardConfig.get()]);
+    RetainPtr standardDelegate = adoptNS([TestNavigationDelegate new]);
     [standardDelegate allowAnyTLSCertificate];
     [standardWebView setNavigationDelegate:standardDelegate.get()];
 
@@ -722,16 +722,16 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSec
     enhancedConfig.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
     enhancedConfig.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 1, 1) configuration:enhancedConfig.get()]);
-    auto openerDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 1, 1) configuration:enhancedConfig.get()]);
+    RetainPtr openerDelegate = adoptNS([TestNavigationDelegate new]);
     [openerDelegate allowAnyTLSCertificate];
     [openerWebView setNavigationDelegate:openerDelegate.get()];
 
     __block RetainPtr<WKWebView> openedWebView;
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *, WKWindowFeatures *) {
         openedWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 1, 1) configuration:configuration]);
-        auto openedDelegate = adoptNS([TestNavigationDelegate new]);
+        RetainPtr openedDelegate = adoptNS([TestNavigationDelegate new]);
         [openedDelegate allowAnyTLSCertificate];
         [openedWebView setNavigationDelegate:openedDelegate.get()];
         return openedWebView.get();
@@ -761,21 +761,21 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromStandardWithEnhancedSecurityViaDele
     }, HTTPServer::Protocol::HttpsProxy);
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
     RetainPtr standardConfig = server.httpsProxyConfiguration();
     [standardConfig.get() setProcessPool:processPool.get()];
     standardConfig.get().defaultWebpagePreferences._enhancedSecurityEnabled = NO;
     standardConfig.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:standardConfig.get()]);
-    auto openerDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:standardConfig.get()]);
+    RetainPtr openerDelegate = adoptNS([TestNavigationDelegate new]);
     [openerDelegate allowAnyTLSCertificate];
     [openerWebView setNavigationDelegate:openerDelegate.get()];
 
     __block RetainPtr<WKWebView> openedWebView;
     __block RetainPtr<TestNavigationDelegate> openedDelegate;
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *, WKWindowFeatures *) {
         configuration.defaultWebpagePreferences._enhancedSecurityEnabled = YES;
         openedWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
@@ -822,21 +822,21 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityWithStandardViaDele
     }, HTTPServer::Protocol::HttpsProxy);
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
     RetainPtr enhancedConfig = server.httpsProxyConfiguration();
     [enhancedConfig.get() setProcessPool:processPool.get()];
     enhancedConfig.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
     enhancedConfig.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:enhancedConfig.get()]);
-    auto openerDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:enhancedConfig.get()]);
+    RetainPtr openerDelegate = adoptNS([TestNavigationDelegate new]);
     [openerDelegate allowAnyTLSCertificate];
     [openerWebView setNavigationDelegate:openerDelegate.get()];
 
     __block RetainPtr<WKWebView> openedWebView;
     __block RetainPtr<TestNavigationDelegate> openedDelegate;
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *, WKWindowFeatures *) {
         configuration.defaultWebpagePreferences._enhancedSecurityEnabled = NO;
         openedWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
@@ -871,11 +871,11 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityWithStandardViaDele
 
 TEST(EnhancedSecurity, LockdownModeTakesPrecedenceOverEnhancedSecurity)
 {
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
     webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 1, 1) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 1, 1) configuration:webViewConfiguration.get()]);
     NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     [webView _test_waitForDidFinishNavigation];
@@ -887,11 +887,11 @@ TEST(EnhancedSecurity, LockdownModeTakesPrecedenceOverEnhancedSecurity)
 
 TEST(EnhancedSecurity, EnhancedSecurityRequestedWhenLockdownModeActive)
 {
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool finishedNavigation = false;
@@ -926,10 +926,10 @@ TEST(EnhancedSecurity, SystemLockdownModeEnablesEnhancedSecurityWhenLockdownOpts
 {
     [WKProcessPool _setCaptivePortalModeEnabledGloballyForTesting:YES];
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = NO;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     [webView _test_waitForDidFinishNavigation];
@@ -945,10 +945,10 @@ TEST(EnhancedSecurity, SystemLockdownModeEnablesEnhancedSecurityWhenSecurityRest
 {
     [WKProcessPool _setCaptivePortalModeEnabledGloballyForTesting:YES];
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     [webView _test_waitForDidFinishNavigation];
@@ -964,11 +964,11 @@ TEST(EnhancedSecurity, SystemLockdownModeEnablesEnhancedSecurityWhenBothAPIOptsO
 {
     [WKProcessPool _setCaptivePortalModeEnabledGloballyForTesting:YES];
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
     webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = NO;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     [webView _test_waitForDidFinishNavigation];
@@ -984,10 +984,10 @@ TEST(EnhancedSecurity, SystemLockdownModeEnablesEnhancedSecurityWhenMaximizeComp
 {
     [WKProcessPool _setCaptivePortalModeEnabledGloballyForTesting:YES];
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     [webView _test_waitForDidFinishNavigation];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EnhancedSecurityPolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EnhancedSecurityPolicies.mm
@@ -104,7 +104,7 @@ using namespace TestWebKitAPI;
 - (NSArray *)_test_waitForAlertWithEnhancedSecurity
 {
     EXPECT_FALSE(self.UIDelegate);
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     self.UIDelegate = uiDelegate.get();
     NSArray *result = [uiDelegate waitForAlertWithEnhancedSecurity];
     self.UIDelegate = nil;
@@ -200,7 +200,7 @@ static RetainPtr<TestWKWebView> enhancedSecurityTestConfiguration(
 
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 1, 1) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 1, 1) configuration:configuration]);
 
     if (secureServer) {
         auto navigationDelegate = [TestNavigationDelegate new];
@@ -220,7 +220,7 @@ static void runActionAndCheckEnhancedSecurityAlerts(
 {
     RELEASE_ASSERT(!webView.get().UIDelegate);
 
-    __block auto uiDelegate = adoptNS([TestUIDelegate new]);
+    __block RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     [webView setUIDelegate:uiDelegate.get()];
 
     __block auto navigationDelegate = [webView navigationDelegate];
@@ -1224,7 +1224,7 @@ enum class SeenOutsideEnhancedSecurity : bool { Seen, NotSeen };
 
 static NSURL *enhancedSecuritySitesPath()
 {
-    auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     NSURL *rootStorage = [dataStoreConfiguration.get().generalStorageDirectory URLByDeletingLastPathComponent];
     NSURL *enhancedSecurityDirectory = [rootStorage URLByAppendingPathComponent:@"EnhancedSecurity"];
     NSURL *enhancedSecurityFile = [enhancedSecurityDirectory URLByAppendingPathComponent:@"EnhancedSecuritySites.db"];
@@ -1348,7 +1348,7 @@ TEST(EnhancedSecurityPolicies, NonPersistentDataStoreCookieNotification)
 
     auto webView = enhancedSecurityTestConfiguration(&plaintextServer, nullptr, /* useSiteIsolation */ false, /* useNonPersistentStore */ true);
 
-    auto observer = adoptNS([EnhancedSecurityCookieObserver new]);
+    RetainPtr observer = adoptNS([EnhancedSecurityCookieObserver new]);
     globalCookieStore = webView.get().configuration.websiteDataStore.httpCookieStore;
     [globalCookieStore addObserver:observer.get()];
 
@@ -1433,7 +1433,7 @@ static void runContentRuleListCallbackOccurs(bool useSiteIsolation)
 
     [[webView.get().configuration userContentController] addContentRuleList:contentRuleList.get()];
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
 
     __block bool receivedActionNotification { false };
     navigationDelegate.get().contentRuleListPerformedAction = ^(WKWebView *, NSString *identifier, _WKContentRuleListAction *action, NSURL *url) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EventAttribution.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EventAttribution.mm
@@ -109,7 +109,7 @@ static RetainPtr<SecTrustRef> secTrustFromCertificateChain(NSArray *chain)
 static TestNavigationDelegate *delegateAllowingAllTLS()
 {
     static RetainPtr<TestNavigationDelegate> delegate = [] {
-        auto delegate = adoptNS([TestNavigationDelegate new]);
+        RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
         delegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
             completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
         };
@@ -125,9 +125,9 @@ static NSURL *exampleURL()
 
 static RetainPtr<WKWebViewConfiguration> configurationWithoutUsingDaemon()
 {
-    auto dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     dataStoreConfiguration.get().pcmMachServiceName = nil;
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     configuration.get().websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]).get();
     return configuration;
 }
@@ -296,7 +296,7 @@ static void signUnlinkableTokenAndSendSecretToken(TokenSigningParty signingParty
     size_t modulusNBytes = cc_ceiling(ccrsa_pubkeylength(rsaPublicKey), 8);
 
     size_t exportSize = ccder_encode_rsa_pub_size(rsaPublicKey);
-    auto publicKey = adoptNS([[NSMutableData alloc] initWithLength:exportSize]);
+    RetainPtr publicKey = adoptNS([[NSMutableData alloc] initWithLength:exportSize]);
     ccder_encode_rsa_pub(rsaPublicKey, static_cast<uint8_t*>([publicKey mutableBytes]), static_cast<uint8_t*>([publicKey mutableBytes]) + [publicKey length]);
 
     auto secKey = adoptCF(SecKeyCreateWithData((__bridge CFDataRef)publicKey.get(), (__bridge CFDictionaryRef)@{
@@ -336,7 +336,7 @@ static void signUnlinkableTokenAndSendSecretToken(TokenSigningParty signingParty
                         auto blindedMessage = base64URLDecode(token);
 
                         const struct ccrsabssa_ciphersuite *ciphersuite = &ccrsabssa_ciphersuite_rsa4096_sha384;
-                        auto blindedSignature = adoptNS([[NSMutableData alloc] initWithLength:modulusNBytes]);
+                        RetainPtr blindedSignature = adoptNS([[NSMutableData alloc] initWithLength:modulusNBytes]);
                         ccrsabssa_sign_blinded_message(ciphersuite, rsaPrivateKey, blindedMessage->span().data(), blindedMessage->size(), static_cast<uint8_t *>([blindedSignature mutableBytes]), [blindedSignature length], rng);
                         auto unlinkableToken = base64URLEncodeToString(span(blindedSignature.get()));
 
@@ -455,16 +455,16 @@ TEST(PrivateClickMeasurement, DatabaseLocation)
     if ([fileManager fileExistsAtPath:tempDir.path])
         [fileManager removeItemAtURL:tempDir error:nil];
 
-    auto webViewToKeepNetworkProcessAlive = adoptNS([TestWKWebView new]);
+    RetainPtr webViewToKeepNetworkProcessAlive = adoptNS([TestWKWebView new]);
     [webViewToKeepNetworkProcessAlive synchronouslyLoadHTMLString:@"start network process"];
 
     pid_t originalNetworkProcessPid = 0;
     @autoreleasepool {
-        auto dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+        RetainPtr dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
         dataStoreConfiguration.get()._resourceLoadStatisticsDirectory = tempDir;
         dataStoreConfiguration.get().pcmMachServiceName = nil;
         auto viewConfiguration = configurationWithoutUsingDaemon();
-        auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+        RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
         viewConfiguration.get().websiteDataStore = dataStore.get();
         runBasicPCMTest(viewConfiguration.get(), [](WKWebView *webView, const HTTPServer& server) {
             [webView _addEventAttributionWithSourceID:42 destinationURL:exampleURL() sourceDescription:@"test source description" purchaser:@"test purchaser" reportEndpoint:server.request().URL optionalNonce:nil applicationBundleID:@"test.bundle.id" ephemeral:NO];
@@ -533,7 +533,7 @@ static std::pair<NSURL *, WKWebViewConfiguration *> setUpDaemon(WKWebViewConfigu
 
     registerPlistWithLaunchD(testDaemonPList(tempDir), tempDir);
 
-    auto dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     dataStoreConfiguration.get().pcmMachServiceName = @"org.webkit.pcmtestdaemon.service";
     viewConfiguration.websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]).get();
 
@@ -587,7 +587,7 @@ TEST(PrivateClickMeasurement, DaemonBasicFunctionality)
 static RetainPtr<TestWKWebView> webViewWithOpenInspector(WKWebViewConfiguration *configuration, id<WKUIDelegate> uiDelegate)
 {
     configuration.preferences._developerExtrasEnabled = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
     [webView synchronouslyLoadHTMLString:@"start processes"];
     [[webView _inspector] show];
     [webView _test_waitForInspectorToShow];
@@ -600,7 +600,7 @@ TEST(PrivateClickMeasurement, DaemonDebugMode)
     auto [tempDir, configuration] = setUpDaemon(adoptNS([WKWebViewConfiguration new]).autorelease());
     configuration._shouldSendConsoleLogsToUIProcessForTesting = YES;
     __block Vector<String> consoleMessages;
-    auto delegate = adoptNS([TestUIDelegate new]);
+    RetainPtr delegate = adoptNS([TestUIDelegate new]);
     delegate.get().didReceiveConsoleLogForTesting = ^(NSString *log) {
         consoleMessages.append(log);
     };
@@ -621,13 +621,13 @@ static void setupSKAdNetworkTest(Vector<String>& consoleMessages, id<WKNavigatio
 {
     HTTPServer server({ { "/app/id1234567890"_s, { "hello"_s } } }, HTTPServer::Protocol::HttpsProxy);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(server.port())
     }];
 
-    auto viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
     viewConfiguration.get().websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get();
     viewConfiguration.get()._shouldSendConsoleLogsToUIProcessForTesting = YES;
     auto webView = webViewWithOpenInspector(viewConfiguration.get(), uiDelegate);
@@ -659,12 +659,12 @@ static NSString *linkToAppStoreHTML = @"<body><a href='https://apps.apple.com/ap
 TEST(PrivateClickMeasurement, SKAdNetwork)
 {
     __block Vector<String> consoleMessages;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *navigationAction, void (^decisionHandler)(WKNavigationActionPolicy)) {
         decisionHandler(_WKNavigationActionPolicyAllowWithoutTryingAppLink);
     };
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().didReceiveConsoleLogForTesting = ^(NSString *log) {
         consoleMessages.append(log);
     };
@@ -677,8 +677,8 @@ TEST(PrivateClickMeasurement, SKAdNetwork)
 TEST(PrivateClickMeasurement, SKAdNetworkAboutBlank)
 {
     __block Vector<String> consoleMessages;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     __block RetainPtr<TestWKWebView> openedWebView;
     uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *, WKWindowFeatures *) {
         openedWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
@@ -704,7 +704,7 @@ TEST(PrivateClickMeasurement, SKAdNetworkAboutBlank)
 TEST(PrivateClickMeasurement, SKAdNetworkWithoutNavigatingToAppStoreLink)
 {
     __block Vector<String> consoleMessages;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *navigationAction, void (^decisionHandler)(WKNavigationActionPolicy)) {
         decisionHandler(WKNavigationActionPolicyCancel);
@@ -712,7 +712,7 @@ TEST(PrivateClickMeasurement, SKAdNetworkWithoutNavigatingToAppStoreLink)
         EXPECT_EQ(0u, consoleMessages.size());
         [navigationAction _storeSKAdNetworkAttribution];
     };
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().didReceiveConsoleLogForTesting = ^(NSString *log) {
         consoleMessages.append(log);
     };
@@ -725,10 +725,10 @@ TEST(PrivateClickMeasurement, SKAdNetworkWithoutNavigatingToAppStoreLink)
 
 TEST(PrivateClickMeasurement, NetworkProcessDebugMode)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     configuration.get()._shouldSendConsoleLogsToUIProcessForTesting = YES;
     __block Vector<String> consoleMessages;
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().didReceiveConsoleLogForTesting = ^(NSString *log) {
         consoleMessages.append(log);
     };
@@ -751,7 +751,7 @@ TEST(PrivateClickMeasurement, NetworkProcessDebugMode)
 TEST(PrivateClickMeasurement, BasicWithIOSSPI)
 {
     runBasicPCMTest(nil, [](WKWebView *webView, const HTTPServer& server) {
-        auto attribution = adoptNS([[MockEventAttribution alloc] initWithReportEndpoint:server.request().URL destinationURL:exampleURL()]);
+        RetainPtr attribution = adoptNS([[MockEventAttribution alloc] initWithReportEndpoint:server.request().URL destinationURL:exampleURL()]);
         webView._uiEventAttribution = (UIEventAttribution *)attribution.get();
         EXPECT_WK_STREQ(webView._uiEventAttribution.sourceDescription, "test source description");
         EXPECT_WK_STREQ(webView._uiEventAttribution.purchaser, "test purchaser");
@@ -761,7 +761,7 @@ TEST(PrivateClickMeasurement, BasicWithIOSSPI)
 TEST(PrivateClickMeasurement, BasicWithEphemeralIOSSPI)
 {
     runBasicPCMTest(nil, [](WKWebView *webView, const HTTPServer& server) {
-        auto attribution = adoptNS([[MockEventAttribution alloc] initWithReportEndpoint:server.request().URL destinationURL:exampleURL()]);
+        RetainPtr attribution = adoptNS([[MockEventAttribution alloc] initWithReportEndpoint:server.request().URL destinationURL:exampleURL()]);
         webView._ephemeralUIEventAttribution = (UIEventAttribution *)attribution.get();
     });
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FTP.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FTP.mm
@@ -46,12 +46,12 @@ namespace TestWebKitAPI {
 
 TEST(WKWebView, FTPMainResource)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     configuration.get()._shouldSendConsoleLogsToUIProcessForTesting = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     
     RetainPtr consoleMessages = [NSMutableArray arrayWithCapacity:2];
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().didReceiveConsoleLogForTesting = ^(NSString *log) {
         [consoleMessages addObject:log];
     };
@@ -70,12 +70,12 @@ TEST(WKWebView, FTPMainResourceRedirect)
         { "/ftp_redirect"_s, { 301, {{ "Location"_s, "ftp://example.com/"_s }} } },
     });
     
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     configuration.get()._shouldSendConsoleLogsToUIProcessForTesting = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     
     RetainPtr consoleMessages = [NSMutableArray arrayWithCapacity:2];
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().didReceiveConsoleLogForTesting = ^(NSString *log) {
         [consoleMessages addObject:log];
     };
@@ -97,12 +97,12 @@ Goodbye
 
 TEST(WKWebView, FTPSubresource)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     configuration.get()._shouldSendConsoleLogsToUIProcessForTesting = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
 
     RetainPtr consoleMessages = [NSMutableArray arrayWithCapacity:2];
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().didReceiveConsoleLogForTesting = ^(NSString *log) {
         [consoleMessages addObject:log];
     };
@@ -122,16 +122,16 @@ TEST(WKWebView, FTPSubresourceRedirect)
         { "/webkitten.png"_s, { 301, {{ "Location"_s, "ftp://example.com/webkitten.png"_s }} } },
     });
         
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     configuration.get()._shouldSendConsoleLogsToUIProcessForTesting = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     
     // Allow HTTP to redirect away from HTTP for subresources for the purposes of this test
     auto preferences = (__bridge WKPreferencesRef)[[webView configuration] preferences];
     WKPreferencesSetRestrictedHTTPResponseAccess(preferences, false);
     
     RetainPtr consoleMessages = [NSMutableArray arrayWithCapacity:2];
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().didReceiveConsoleLogForTesting = ^(NSString *log) {
         [consoleMessages addObject:log];
     };

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FileSystemAccess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FileSystemAccess.mm
@@ -99,14 +99,14 @@ test();
 
 TEST(FileSystemAccess, WebProcessCrashDuringWrite)
 {
-    auto handler = adoptNS([[FileSystemAccessMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[FileSystemAccessMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     auto preferences = [configuration preferences];
     preferences._fileSystemAccessEnabled = YES;
     preferences._accessHandleEnabled = YES;
     preferences._storageAPIEnabled = YES;
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         RetainPtr<NSURLResponse> response;
         RetainPtr<NSData> data;
@@ -120,7 +120,7 @@ TEST(FileSystemAccess, WebProcessCrashDuringWrite)
     }];
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webkit"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadHTMLString:workerFrameString baseURL:[NSURL URLWithString:@"webkit://webkit.org"]];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
     receivedScriptMessage = false;
@@ -131,7 +131,7 @@ TEST(FileSystemAccess, WebProcessCrashDuringWrite)
     receivedScriptMessage = false;
     EXPECT_WK_STREQ(@"success: write 10 bytes", [lastScriptMessage body]);
 
-    auto secondWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr secondWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [secondWebView loadHTMLString:workerFrameString baseURL:[NSURL URLWithString:@"webkit://webkit.org"]];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
     receivedScriptMessage = false;
@@ -153,19 +153,19 @@ TEST(FileSystemAccess, WebProcessCrashDuringWrite)
 
 TEST(FileSystemAccess, NetworkProcessCrashDuringWrite)
 {
-    auto handler = adoptNS([[FileSystemAccessMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[FileSystemAccessMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     auto preferences = [configuration preferences];
     preferences._fileSystemAccessEnabled = YES;
     preferences._accessHandleEnabled = YES;
     preferences._storageAPIEnabled = YES;
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         RetainPtr<NSData> data;
         NSURL *requestURL = task.request.URL;
         EXPECT_WK_STREQ("webkit://webkit.org/worker.js", requestURL.absoluteString);
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:requestURL MIMEType:@"text/javascript" expectedContentLength:0 textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:requestURL MIMEType:@"text/javascript" expectedContentLength:0 textEncodingName:nil]);
         data = [NSData dataWithBytes:workerBytes length:strlen(workerBytes)];
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
@@ -173,7 +173,7 @@ TEST(FileSystemAccess, NetworkProcessCrashDuringWrite)
     }];
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webkit"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadHTMLString:workerFrameString baseURL:[NSURL URLWithString:@"webkit://webkit.org"]];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
     receivedScriptMessage = false;
@@ -200,18 +200,18 @@ TEST(FileSystemAccess, NetworkProcessCrashDuringWrite)
 
 TEST(FileSystemAccess, DeleteDataDuringWrite)
 {
-    auto handler = adoptNS([[FileSystemAccessMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[FileSystemAccessMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     auto preferences = [configuration preferences];
     preferences._fileSystemAccessEnabled = YES;
     preferences._accessHandleEnabled = YES;
     preferences._storageAPIEnabled = YES;
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSURL *requestURL = task.request.URL;
         EXPECT_WK_STREQ("webkit://webkit.org/worker.js", requestURL.absoluteString);
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:requestURL MIMEType:@"text/javascript" expectedContentLength:0 textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:requestURL MIMEType:@"text/javascript" expectedContentLength:0 textEncodingName:nil]);
         RetainPtr<NSData> data = [NSData dataWithBytes:workerBytes length:strlen(workerBytes)];
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data.get()];
@@ -219,7 +219,7 @@ TEST(FileSystemAccess, DeleteDataDuringWrite)
     }];
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webkit"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadHTMLString:workerFrameString baseURL:[NSURL URLWithString:@"webkit://webkit.org"]];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
     receivedScriptMessage = false;
@@ -297,14 +297,14 @@ TEST(FileSystemAccess, MigrateToNewStorageDirectory)
     EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:newFilePath]);
 
     // Ensure file can be opened after migration: test page only opens the file if it exists.
-    auto handler = adoptNS([[FileSystemAccessMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[FileSystemAccessMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     auto preferences = [configuration preferences];
     preferences._fileSystemAccessEnabled = YES;
     preferences._storageAPIEnabled = YES;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadHTMLString:basicString baseURL:[NSURL URLWithString:@"https://webkit.org"]];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
     receivedScriptMessage = false;
@@ -327,8 +327,8 @@ static NSString *testString = @"<script> \
 
 TEST(FileSystemAccess, FetchAndRemoveData)
 {
-    auto handler = adoptNS([[FileSystemAccessMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[FileSystemAccessMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     auto websiteDataStore = [configuration websiteDataStore];
     auto types = [NSSet setWithObject:WKWebsiteDataTypeFileSystem];
@@ -343,7 +343,7 @@ TEST(FileSystemAccess, FetchAndRemoveData)
     auto preferences = [configuration preferences];
     preferences._fileSystemAccessEnabled = YES;
     preferences._storageAPIEnabled = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadHTMLString:testString baseURL:[NSURL URLWithString:@"https://webkit.org"]];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
     receivedScriptMessage = false;
@@ -379,13 +379,13 @@ TEST(FileSystemAccess, FetchAndRemoveData)
 
 TEST(FileSystemAccess, RemoveDataByModificationTime)
 {
-    auto handler = adoptNS([[FileSystemAccessMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[FileSystemAccessMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     auto preferences = [configuration preferences];
     preferences._fileSystemAccessEnabled = YES;
     preferences._storageAPIEnabled = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadHTMLString:testString baseURL:[NSURL URLWithString:@"https://webkit.org"]];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
     receivedScriptMessage = false;
@@ -457,8 +457,8 @@ TEST(FileSystemAccess, FetchDataForThirdParty)
         { "/"_s, { frameBytes } },
     }, TestWebKitAPI::HTTPServer::Protocol::Https, nullptr, nullptr, 9091);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([[FileSystemAccessMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[FileSystemAccessMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     auto preferences = [configuration preferences];
     preferences._fileSystemAccessEnabled = YES;
@@ -472,8 +472,8 @@ TEST(FileSystemAccess, FetchDataForThirdParty)
     }];
     TestWebKitAPI::Util::run(&done);
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate setDidReceiveAuthenticationChallenge:^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^callback)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
         callback(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FindInPage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FindInPage.mm
@@ -157,7 +157,7 @@ TEST(WebKit, FindInPage)
 
 TEST(WebKit, FindInPageSelectMatch)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 200, 200)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 200, 200)]);
     auto request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
     [webView _setUsePlatformFindUI:NO];
     [webView loadRequest:request];
@@ -299,7 +299,7 @@ TEST(WebKit, FindInPageWrappingSubframe)
 
 TEST(WebKit, FindAndReplace)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"<body contenteditable><input id='first' value='hello'>hello world<input id='second' value='world'></body>"];
 
     auto result = findMatches(webView.get(), @"hello");
@@ -329,7 +329,7 @@ TEST(WebKit, FindAndReplace)
 TEST(WebKit, FindTextInImageOverlay)
 {
     auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"simple-image-overlay"];
     {
         auto [matches, didWrap] = findMatches(webView.get(), @"foobar");
@@ -406,7 +406,7 @@ static size_t overlayCount(WKWebView *webView)
 
 TEST(WebKit, FindInPage)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
     [webView loadRequest:request];
@@ -418,7 +418,7 @@ TEST(WebKit, FindInPage)
 
 TEST(WebKit, FindInPageCaseInsensitive)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
     [webView loadRequest:request];
@@ -433,7 +433,7 @@ TEST(WebKit, FindInPageCaseInsensitive)
 
 TEST(WebKit, FindInPageStartsWith)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
     [webView loadRequest:request];
@@ -452,7 +452,7 @@ TEST(WebKit, FindInPageStartsWith)
 
 TEST(WebKit, FindInPageFullWord)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
     [webView loadRequest:request];
@@ -470,7 +470,7 @@ TEST(WebKit, FindInPageFullWord)
 
 TEST(WebKit, FindInPageDoNotCrashWhenUsingMutableString)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
     [webView loadRequest:request];
@@ -500,7 +500,7 @@ TEST(WebKit, FindAndReplace)
     NSString *replacementString = @"colour";
     NSString *replacedContent = [originalContent stringByReplacingOccurrencesOfString:searchString withString:replacementString];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView _setFindInteractionEnabled:YES];
     [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<p>%@</p>", originalContent]];
 
@@ -525,7 +525,7 @@ TEST(WebKit, FindAndReplace)
 
 TEST(WebKit, FindInteraction)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
 
     EXPECT_NULL([webView _findInteraction]);
 
@@ -547,7 +547,7 @@ TEST(WebKit, FindInteraction)
 TEST(WebKit, FindAndHighlightDifferentWebViews)
 {
     auto createAndSetUpWebView = []() {
-        auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+        RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
         [webView setFindInteractionEnabled:YES];
         [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<p>Test</p><iframe src='data:text/html,<p>Test</p>'></iframe>"]];
         return webView;
@@ -575,7 +575,7 @@ TEST(WebKit, FindAndHighlightDifferentWebViews)
 
 TEST(WebKit, RequestRectForFoundTextRange)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:@"<iframe srcdoc='<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Tellus in metus vulputate eu scelerisque felis imperdiet. Mi quis hendrerit dolor magna eget est lorem ipsum dolor. In cursus turpis massa tincidunt dui ut ornare. Sapien et ligula ullamcorper malesuada. Maecenas volutpat blandit aliquam etiam erat. Turpis egestas integer eget aliquet nibh praesent tristique. Ipsum dolor sit amet consectetur adipiscing. Tellus cras adipiscing enim eu turpis egestas pretium aenean pharetra. Sem fringilla ut morbi tincidunt augue interdum velit euismod. Habitant morbi tristique senectus et netus. Aenean euismod elementum nisi quis. Facilisi nullam vehicula ipsum a. Elementum facilisis leo vel fringilla. Molestie nunc non blandit massa enim. Orci ac auctor augue mauris. Pellentesque pulvinar pellentesque habitant morbi tristique senectus et. Magnis dis parturient montes nascetur ridiculus mus mauris vitae. Id leo in vitae turpis massa sed. Netus et malesuada fames ac turpis egestas sed tempus. Morbi quis commodo odio aenean sed adipiscing diam donec. Sit amet purus gravida quis blandit turpis. Odio euismod lacinia at quis risus sed vulputate. Varius duis at consectetur lorem donec massa. Sit amet consectetur adipiscing elit pellentesque habitant. Feugiat in fermentum posuere urna nec tincidunt praesent.</p>'></iframe>"];
 
     auto ranges = textRangesForQueryString(webView.get(), @"Sapien");
@@ -607,11 +607,11 @@ TEST(WebKit, RequestRectForFoundTextRange)
 
 TEST(WebKit, ScrollToFoundRangeWithExistingSelection)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width,initial-scale=1'><div contenteditable><p>Top</p><p style='margin-top: 800px'>Bottom</p></div>"];
     [webView objectByEvaluatingJavaScript:@"let p = document.querySelector('p'); document.getSelection().setBaseAndExtent(p, 0, p, 1)"];
 
-    auto scrollViewDelegate = adoptNS([[TestScrollViewDelegate alloc] init]);
+    RetainPtr scrollViewDelegate = adoptNS([[TestScrollViewDelegate alloc] init]);
     [webView scrollView].delegate = scrollViewDelegate.get();
 
     auto ranges = textRangesForQueryString(webView.get(), @"Bottom");
@@ -623,15 +623,15 @@ TEST(WebKit, ScrollToFoundRangeWithExistingSelection)
 
 TEST(WebKit, ScrollToFoundRangeDoesNotFocusElement)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width,initial-scale=1'><input id='input'><div id='editor' contenteditable><p>Top</p><p style='margin-top: 800px'>Bottom</p></div>"];
 
-    auto scrollViewDelegate = adoptNS([[TestScrollViewDelegate alloc] init]);
+    RetainPtr scrollViewDelegate = adoptNS([[TestScrollViewDelegate alloc] init]);
     [webView scrollView].delegate = scrollViewDelegate.get();
 
     bool inputFocused = false;
 
-    auto inputDelegate = adoptNS([TestInputDelegate new]);
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&inputFocused] (WKWebView *, id<_WKFocusedElementInfo> focusedElementInfo) -> _WKFocusStartsInputSessionPolicy {
         switch (focusedElementInfo.type) {
         case WKInputTypeText:
@@ -657,11 +657,11 @@ TEST(WebKit, ScrollToFoundRangeDoesNotFocusElement)
 
 TEST(WebKit, ScrollToFoundRangeRepeated)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width,initial-scale=1'><div contenteditable><p>Top</p><p style='margin-top: 800px'>Bottom</p></div>"];
     [webView objectByEvaluatingJavaScript:@"let p = document.querySelector('p'); document.getSelection().setBaseAndExtent(p, 0, p, 1)"];
 
-    auto scrollViewDelegate = adoptNS([[TestScrollViewDelegate alloc] init]);
+    RetainPtr scrollViewDelegate = adoptNS([[TestScrollViewDelegate alloc] init]);
     [webView scrollView].delegate = scrollViewDelegate.get();
 
     auto ranges = textRangesForQueryString(webView.get(), @"Bottom");
@@ -680,7 +680,7 @@ TEST(WebKit, ScrollToFoundRangeRepeated)
 
 TEST(WebKit, ScrollToFoundRangeAtTopWithContentInsets)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
     [webView scrollView].contentInset = UIEdgeInsetsMake(30, 0, 0, 0);
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width,initial-scale=1'><div contenteditable><p>Top</p><p style='margin-top: 800px'>Bottom</p></div>"];
     [webView objectByEvaluatingJavaScript:@"let p = document.querySelector('p'); document.getSelection().setBaseAndExtent(p, 0, p, 1)"];
@@ -696,7 +696,7 @@ TEST(WebKit, ScrollToFoundRangeAtTopWithObscuredContentInsets)
 {
     UIEdgeInsets obscuredInsets = UIEdgeInsetsMake(30, 0, 0, 0);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
     [webView scrollView].contentInset = obscuredInsets;
     [webView _setObscuredInsets:obscuredInsets];
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width,initial-scale=1'><div contenteditable><p>Top</p><p style='margin-top: 800px'>Bottom</p></div>"];
@@ -739,7 +739,7 @@ TEST(WebKit, ScrollToUserSelectNoneFoundRange)
     "<p style='-webkit-user-select: none; height:500px'>findme</p>"
     ];
 
-    auto scrollViewDelegate = adoptNS([[TestScrollViewDelegate alloc] init]);
+    RetainPtr scrollViewDelegate = adoptNS([[TestScrollViewDelegate alloc] init]);
     [webView scrollView].delegate = scrollViewDelegate.get();
 
     EXPECT_TRUE(CGPointEqualToPoint([webView scrollView].contentOffset, CGPointMake(0, 0)));
@@ -754,7 +754,7 @@ TEST(WebKit, ScrollToUserSelectNoneFoundRange)
 
 TEST(WebKit, CannotHaveMultipleFindOverlays)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
     [webView loadRequest:request];
@@ -782,7 +782,7 @@ TEST(WebKit, CannotHaveMultipleFindOverlays)
 
 TEST(WebKit, FindOverlayCloseWebViewCrash)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
     [webView setFindInteractionEnabled:YES];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
@@ -805,9 +805,9 @@ TEST(WebKit, FindOverlayCloseWebViewCrash)
 
 TEST(WebKit, FindOverlaySPI)
 {
-    auto findDelegate = adoptNS([[TestFindDelegate alloc] init]);
+    RetainPtr findDelegate = adoptNS([[TestFindDelegate alloc] init]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
     [webView _setFindDelegate:findDelegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"lots-of-text" withExtension:@"html"]];
@@ -916,7 +916,7 @@ TEST(WebKit, FindInUnifiedPDFAfterFindInPage)
 
 TEST(WebKit, FindInteractionSupportsTextReplacement)
 {
-    auto webView = adoptNS([[FindInPageTestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
+    RetainPtr webView = adoptNS([[FindInPageTestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
     [webView synchronouslyLoadTestPageNamed:@"lots-of-text"];
 
     auto findSessionSupportsReplacement = [&] {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FindInPageAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FindInPageAPI.mm
@@ -45,11 +45,11 @@
 
 TEST(WKWebView, FindAPIForwardsNoMatch)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"word word" baseURL:nil];
 
     // The default find configuration is "forwards, case insensitive, wrapping"
-    auto configuration = adoptNS([[WKFindConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKFindConfiguration alloc] init]);
 
     EXPECT_TRUE([webView selectionRangeHasStartOffset:0 endOffset:0]);
 
@@ -66,11 +66,11 @@ TEST(WKWebView, FindAPIForwardsNoMatch)
 
 TEST(WKWebView, FindAPIForwardsWrap)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"word word" baseURL:nil];
 
     // The default find configuration is "forwards, case insensitive, wrapping"
-    auto configuration = adoptNS([[WKFindConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKFindConfiguration alloc] init]);
 
     static bool done;
     [webView findString:@"word" withConfiguration:configuration.get() completionHandler:^(WKFindResult *result) {
@@ -103,11 +103,11 @@ TEST(WKWebView, FindAPIForwardsWrap)
 
 TEST(WKWebView, FindAPIForwardsNoWrap)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"word word" baseURL:nil];
 
     // The default find configuration is "forwards, case insensitive, wrapping"
-    auto configuration = adoptNS([[WKFindConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKFindConfiguration alloc] init]);
     configuration.get().wraps = NO;
 
     static bool done;
@@ -141,11 +141,11 @@ TEST(WKWebView, FindAPIForwardsNoWrap)
 
 TEST(WKWebView, FindAPIBackwardsWrap)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"word word" baseURL:nil];
 
     // The default find configuration is "forwards, case insensitive, wrapping"
-    auto configuration = adoptNS([[WKFindConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKFindConfiguration alloc] init]);
     configuration.get().backwards = YES;
 
     EXPECT_TRUE([webView selectionRangeHasStartOffset:0 endOffset:0]);
@@ -181,11 +181,11 @@ TEST(WKWebView, FindAPIBackwardsWrap)
 
 TEST(WKWebView, FindAPIBackwardsNoWrap)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"word word" baseURL:nil];
 
     // The default find configuration is "forwards, case insensitive, wrapping"
-    auto configuration = adoptNS([[WKFindConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKFindConfiguration alloc] init]);
     configuration.get().backwards = YES;
     configuration.get().wraps = NO;
 
@@ -222,11 +222,11 @@ TEST(WKWebView, FindAPIBackwardsNoWrap)
 
 TEST(WKWebView, FindAPIForwardsCaseSensitive)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"word Word word" baseURL:nil];
 
     // The default find configuration is "forwards, case insensitive, wrapping"
-    auto configuration = adoptNS([[WKFindConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKFindConfiguration alloc] init]);
     configuration.get().caseSensitive = YES;
 
     static bool done;
@@ -322,7 +322,7 @@ TEST(WKWebView, FindAPITextInImage)
     auto webView = createWebViewWithImageAnalysisDuringFindInPageEnabled();
     [webView synchronouslyLoadTestPageNamed:@"image-with-text"];
 
-    auto findDelegate = adoptNS([[FindDelegate alloc] init]);
+    RetainPtr findDelegate = adoptNS([[FindDelegate alloc] init]);
     [webView _setFindDelegate:findDelegate.get()];
 
     __block bool done;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FirstVisuallyNonEmptyMilestone.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FirstVisuallyNonEmptyMilestone.mm
@@ -61,11 +61,11 @@ static bool receivedMessage;
 
 TEST(WebKit, FirstVisuallyNonEmptyMilestoneWithDeferredScript)
 {
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[FirstPaintMessageHandler alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[FirstPaintMessageHandler alloc] init]);
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"firstpaint"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
     RetainPtr<RenderingProgressNavigationDelegate> delegate = adoptNS([[RenderingProgressNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
@@ -107,7 +107,7 @@ static NSString *contentTypeForFileExtension(NSString *fileExtension)
     NSData *responseData = [NSData dataWithContentsOfURL:bundleURL];
     NSUInteger responseLength = responseData.length;
 
-    auto response = adoptNS([[NSURLResponse alloc] initWithURL:requestURL MIMEType:contentTypeForFileExtension(fileExtension) expectedContentLength:responseLength textEncodingName:nil]);
+    RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:requestURL MIMEType:contentTypeForFileExtension(fileExtension) expectedContentLength:responseLength textEncodingName:nil]);
     [task didReceiveResponse:response.get()];
 
     [task didReceiveData:[responseData subdataWithRange:NSMakeRange(0, responseLength - 1024)]];
@@ -121,17 +121,17 @@ static NSString *contentTypeForFileExtension(NSString *fileExtension)
 
 TEST(WebKit, FirstVisuallyNonEmptyMilestoneWithMediaDocument)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 #if PLATFORM(IOS_FAMILY)
     [configuration setAllowsInlineMediaPlayback:YES];
     [configuration _setInlineMediaPlaybackRequiresPlaysInlineAttribute:NO];
 #endif
 
-    auto schemeHandler = adoptNS([[NeverFinishLoadingSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[NeverFinishLoadingSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:NeverFinishLoadingSchemeHandler.URLScheme];
 
-    auto navigationDelegate = adoptNS([[RenderingProgressNavigationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr navigationDelegate = adoptNS([[RenderingProgressNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [webView _setAllowsMediaDocumentInlinePlayback:YES];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FixedLayoutSize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FixedLayoutSize.mm
@@ -36,7 +36,7 @@
 
 TEST(WebKit, OverrideMinimumLayoutSizeWithNegativeHeight)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView _overrideLayoutParametersWithMinimumLayoutSize:CGSizeMake(320, -1000) minimumUnobscuredSizeOverride:CGSizeZero maximumUnobscuredSizeOverride:CGSizeZero];
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width, initial-scale=1'><body>Hello</body>"];
     EXPECT_GE([webView _fixedLayoutSize].height, 0);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FocusWebView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FocusWebView.mm
@@ -293,10 +293,10 @@ TEST(FocusWebView, FocusNavigationIntoFrameWithNestedRemoteFrameSiteIsolation)
 TEST(FocusWebView, DoNotFocusWebViewWhenUnparented)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration]);
     [webView synchronouslyLoadTestPageNamed:@"open-in-new-tab"];
 
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     [webView setUIDelegate:uiDelegate.get()];
 
     __block bool calledFocusWebView = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FontAttributes.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FontAttributes.mm
@@ -218,7 +218,7 @@ static void checkParagraphStyles(NSParagraphStyle *style, ParagraphStyleExpectat
 
 static RetainPtr<TestWKWebView> webViewForTestingFontAttributes(NSString *testPageName)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:testPageName];
     [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
 #if PLATFORM(MAC)
@@ -231,7 +231,7 @@ static RetainPtr<TestWKWebView> webViewForTestingFontAttributes(NSString *testPa
 
 TEST(FontAttributes, FontAttributesAfterChangingSelection)
 {
-    auto delegate = adoptNS([FontAttributesListener new]);
+    RetainPtr delegate = adoptNS([FontAttributesListener new]);
     auto webView = webViewForTestingFontAttributes(@"rich-text-attributes");
     [webView setUIDelegate:delegate.get()];
 
@@ -412,7 +412,7 @@ TEST(FontAttributes, FontAttributesAfterChangingSelection)
 
 TEST(FontAttributes, NestedTextListsWithHorizontalAlignment)
 {
-    auto delegate = adoptNS([FontAttributesListener new]);
+    RetainPtr delegate = adoptNS([FontAttributesListener new]);
     auto webView = webViewForTestingFontAttributes(@"nested-lists");
     [webView setUIDelegate:delegate.get()];
 
@@ -461,8 +461,8 @@ TEST(FontAttributes, NestedTextListsWithHorizontalAlignment)
 
 TEST(FontAttributes, FontTextStyle)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
-    auto uiDelegate = adoptNS([[FontTextStyleUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr uiDelegate = adoptNS([[FontTextStyleUIDelegate alloc] init]);
     [webView setUIDelegate:uiDelegate.get()];
     [webView synchronouslyLoadHTMLString:@"<body contenteditable>"
         "<span id='foo'>foo</span> <span id='bar'>bar</span> <span id='baz'>baz</span>"
@@ -492,7 +492,7 @@ TEST(FontAttributes, FontTextStyle)
 TEST(FontAttributes, SelectTextStyle)
 {
     __block bool done = false;
-    auto menu = adoptNS([NSMenu new]);
+    RetainPtr menu = adoptNS([NSMenu new]);
     InstanceMethodSwizzler swizzler { [[menu _menuImpl] class],
         NSSelectorFromString(@"popUpMenu:atLocation:width:forView:withSelectedItem:withFont:withFlags:withOptions:"),
         imp_implementationWithBlock(^(id, NSMenu *menu, NSPoint, CGFloat, NSView *, NSInteger, NSFont* font, NSUInteger, NSDictionary *) {
@@ -501,8 +501,8 @@ TEST(FontAttributes, SelectTextStyle)
             done = true;
     }) };
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
-    auto uiDelegate = adoptNS([[FontTextStyleUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr uiDelegate = adoptNS([[FontTextStyleUIDelegate alloc] init]);
     [webView setUIDelegate:uiDelegate.get()];
     [webView synchronouslyLoadHTMLString:@"<body>"
         "<select style='font-family: Helvetica; font-size: 32px; background-color: white;'>"

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenAlert.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenAlert.mm
@@ -40,9 +40,9 @@ static bool isOutOfFullscreen = false;
 
 TEST(Fullscreen, DISABLED_Alert)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration preferences].elementFullscreenEnabled = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
 
     auto checkFullscreen = [&] {
         isInFullscreen = [webView _isInFullscreen];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenLayoutConstraints.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenLayoutConstraints.mm
@@ -55,7 +55,7 @@ TEST(Fullscreen, LayoutConstraints)
 {
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration preferences].elementFullscreenEnabled = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
     RetainPtr<FullscreenStateChangeMessageHandler> handler = adoptNS([[FullscreenStateChangeMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"fullscreenStateChangeHandler"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenLifecycle.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenLifecycle.mm
@@ -58,15 +58,15 @@ static bool fullscreenStateChanged;
 
 TEST(Fullscreen, AudioLifecycle)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
     [configuration preferences].elementFullscreenEnabled = YES;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
     ASSERT_FALSE([webView _canEnterFullscreen]);
     ASSERT_EQ([webView fullscreenState], WKFullscreenStateNotInFullscreen);
 
-    auto observer = adoptNS([[FullscreenLifecycleObserver alloc] init]);
+    RetainPtr observer = adoptNS([[FullscreenLifecycleObserver alloc] init]);
     [webView addObserver:observer.get() forKeyPath:canEnterFullscreenKeyPath options:NSKeyValueObservingOptionNew context:nil];
     [webView addObserver:observer.get() forKeyPath:fullscreenStateKeyPath options:NSKeyValueObservingOptionNew context:nil];
 
@@ -82,11 +82,11 @@ TEST(Fullscreen, AudioLifecycle)
 
 static void runTest(WKWebViewConfiguration *configuration)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration]);
     ASSERT_FALSE([webView _canEnterFullscreen]);
     ASSERT_EQ([webView fullscreenState], WKFullscreenStateNotInFullscreen);
 
-    auto observer = adoptNS([[FullscreenLifecycleObserver alloc] init]);
+    RetainPtr observer = adoptNS([[FullscreenLifecycleObserver alloc] init]);
     [webView addObserver:observer.get() forKeyPath:canEnterFullscreenKeyPath options:NSKeyValueObservingOptionNew context:nil];
     [webView addObserver:observer.get() forKeyPath:fullscreenStateKeyPath options:NSKeyValueObservingOptionNew context:nil];
 
@@ -131,7 +131,7 @@ static void runTest(WKWebViewConfiguration *configuration)
 
 TEST(Fullscreen, VideoLifecycle)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
     [configuration preferences].elementFullscreenEnabled = YES;
 
@@ -145,7 +145,7 @@ TEST(Fullscreen, DISABLED_VideoLifecycleElementFullscreenDisabled)
 TEST(Fullscreen, VideoLifecycleElementFullscreenDisabled)
 #endif
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
     [configuration preferences]._videoFullscreenRequiresElementFullscreen = YES;
 
@@ -158,15 +158,15 @@ TEST(Fullscreen, VideoLifecycleElementFullscreenDisabled)
 
 TEST(Fullscreen, VideoPausesAfterExitingFullscreen)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
     [configuration preferences]._videoFullscreenRequiresElementFullscreen = YES;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
     ASSERT_FALSE([webView _canEnterFullscreen]);
     ASSERT_EQ([webView fullscreenState], WKFullscreenStateNotInFullscreen);
 
-    auto observer = adoptNS([[FullscreenLifecycleObserver alloc] init]);
+    RetainPtr observer = adoptNS([[FullscreenLifecycleObserver alloc] init]);
     [webView addObserver:observer.get() forKeyPath:fullscreenStateKeyPath options:NSKeyValueObservingOptionNew context:nil];
 
     [webView loadTestPageNamed:@"large-video-test-now-playing"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenRemoveNodeBeforeEnter.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenRemoveNodeBeforeEnter.mm
@@ -39,9 +39,9 @@ namespace TestWebKitAPI {
 
 TEST(Fullscreen, RemoveNodeBeforeEnter)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration preferences].elementFullscreenEnabled = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
 
     [webView synchronouslyLoadHTMLString:
         @"<html><head><script>"

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenScrollAndResize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenScrollAndResize.mm
@@ -39,9 +39,9 @@ namespace TestWebKitAPI {
 
 TEST(Fullscreen, ScrollAndResize)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration preferences].elementFullscreenEnabled = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
 
     [webView synchronouslyLoadHTMLString:
         @"<html><head><style>"

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenVideoTextRecognition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FullscreenVideoTextRecognition.mm
@@ -85,7 +85,7 @@ static void swizzledSetAnalysis(VKCImageAnalysisInteraction *, SEL, VKCImageAnal
 {
     auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     configuration.preferences.elementFullscreenEnabled = YES;
-    auto webView = adoptNS([[FullscreenVideoTextRecognitionWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration]);
+    RetainPtr webView = adoptNS([[FullscreenVideoTextRecognitionWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration]);
     [webView synchronouslyLoadTestPageNamed:@"element-fullscreen"];
     return webView;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GPUProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GPUProcess.mm
@@ -51,10 +51,10 @@ static NSInteger getPixelIndex(NSInteger x, NSInteger y, NSInteger width)
 
 TEST(GPUProcess, RelaunchOnCrash)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("UseGPUProcessForMediaEnabled"));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"audio-context-playing"];
 
     // evaluateJavaScript gives us the user gesture we need to reliably start audio playback on all platforms.
@@ -102,10 +102,10 @@ TEST(GPUProcess, RelaunchOnCrash)
 
 TEST(GPUProcess, WebProcessTerminationAfterTooManyGPUProcessCrashes)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("UseGPUProcessForMediaEnabled"));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"audio-context-playing"];
 
     // evaluateJavaScript gives us the user gesture we need to reliably start audio playback on all platforms.
@@ -208,13 +208,13 @@ TEST(GPUProcess, OnlyLaunchesGPUProcessWhenNecessary)
     if ([[[NSUserDefaults standardUserDefaults] objectForKey:@"WebKit2GPUProcessForDOMRendering"] boolValue])
         return;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("UseGPUProcessForMediaEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("CaptureVideoInGPUProcessEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("UseGPUProcessForCanvasRenderingEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], false, WKStringCreateWithUTF8CString("UseGPUProcessForDOMRenderingEnabled"));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
     TestWebKitAPI::Util::spinRunLoop(10);
@@ -241,7 +241,7 @@ TEST(GPUProcess, GPUProcessForDOMRenderingCarriesOverFromRelatedPage)
 
     RetainPtr<TestWKWebView> newWebView;
     {
-        auto newPreferences = adoptNS([[configuration preferences] copy]);
+        RetainPtr newPreferences = adoptNS([[configuration preferences] copy]);
         WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)newPreferences.get(), false, WKStringCreateWithUTF8CString("UseGPUProcessForDOMRenderingEnabled"));
         [configuration setPreferences:newPreferences.get()];
         ALLOW_DEPRECATED_DECLARATIONS_BEGIN
@@ -264,13 +264,13 @@ TEST(GPUProcess, OnlyLaunchesGPUProcessWhenNecessarySVG)
     if ([[[NSUserDefaults standardUserDefaults] objectForKey:@"WebKit2GPUProcessForDOMRendering"] boolValue])
         return;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("UseGPUProcessForMediaEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("CaptureVideoInGPUProcessEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("UseGPUProcessForCanvasRenderingEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], false, WKStringCreateWithUTF8CString("UseGPUProcessForDOMRenderingEnabled"));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:@"<img src='enormous.svg'></img>"];
 
     TestWebKitAPI::Util::spinRunLoop(10);
@@ -283,13 +283,13 @@ TEST(GPUProcess, OnlyLaunchesGPUProcessWhenNecessaryMediaFeatureDetection)
     if ([[[NSUserDefaults standardUserDefaults] objectForKey:@"WebKit2GPUProcessForDOMRendering"] boolValue])
         return;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("UseGPUProcessForMediaEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("CaptureVideoInGPUProcessEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("UseGPUProcessForCanvasRenderingEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], false, WKStringCreateWithUTF8CString("UseGPUProcessForDOMRenderingEnabled"));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
     __block bool done = false;
@@ -316,11 +316,11 @@ TEST(GPUProcess, OnlyLaunchesGPUProcessWhenNecessaryMediaFeatureDetection)
 
 TEST(GPUProcess, DoNotLeakConnectionAfterClosingWebPage)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("UseGPUProcessForCanvasRenderingEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], false, WKStringCreateWithUTF8CString("UseGPUProcessForDOMRenderingEnabled"));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"canvas-image-data"];
     EXPECT_EQ(1U, [webView gpuToWebProcessConnectionCount]);
     [webView _close];
@@ -332,13 +332,13 @@ TEST(GPUProcess, DoNotLeakConnectionAfterClosingWebPage)
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
 TEST(GPUProcess, LegacyCDM)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("UseGPUProcessForMediaEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("CaptureVideoInGPUProcessEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("UseGPUProcessForCanvasRenderingEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], false, WKStringCreateWithUTF8CString("UseGPUProcessForDOMRenderingEnabled"));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
     __block bool done = false;
@@ -357,10 +357,10 @@ TEST(GPUProcess, LegacyCDM)
 
 TEST(GPUProcess, CrashWhilePlayingVideo)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("UseGPUProcessForMediaEnabled"));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"large-video-with-audio"];
 
     [webView objectByEvaluatingJavaScript:@"document.getElementsByTagName('video')[0].loop = true;"];
@@ -417,10 +417,10 @@ TEST(GPUProcess, CrashWhilePlayingVideo)
 
 TEST(GPUProcess, CrashWhilePlayingAudioViaCreateMediaElementSource)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("UseGPUProcessForMediaEnabled"));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"webaudio-createMediaElementSource"];
 
     __block bool done = false;
@@ -485,12 +485,12 @@ static NSString *testCanvasPage = @"<body> \n"
 
 TEST(GPUProcess, CanvasBasicCrashHandling)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("UseGPUProcessForCanvasRenderingEnabled"));
 
     NSInteger viewWidth = 400;
     NSInteger viewHeight = 400;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, viewWidth, viewHeight) configuration:configuration.get() addToWindow:NO]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, viewWidth, viewHeight) configuration:configuration.get() addToWindow:NO]);
 
     RetainPtr<Util::PlatformWindow> window;
     CGFloat backingScaleFactor;
@@ -527,7 +527,7 @@ TEST(GPUProcess, CanvasBasicCrashHandling)
     auto gpuProcessPID = [processPool _gpuProcessIdentifier];
     EXPECT_NE(0, gpuProcessPID);
 
-    auto snapshotConfiguration = adoptNS([[WKSnapshotConfiguration alloc] init]);
+    RetainPtr snapshotConfiguration = adoptNS([[WKSnapshotConfiguration alloc] init]);
     [snapshotConfiguration setRect:NSMakeRect(0, 0, 150, 150)];
     [snapshotConfiguration setSnapshotWidth:@(150)];
     [snapshotConfiguration setAfterScreenUpdates:YES];
@@ -624,7 +624,7 @@ static void runMemoryPressureExitTest(Function<void(WKWebView *)>&& loadTestPage
     if ([[[NSUserDefaults standardUserDefaults] objectForKey:@"WebKit2GPUProcessForDOMRendering"] boolValue])
         return;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("UseGPUProcessForMediaEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("CaptureVideoInGPUProcessEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("CaptureAudioInGPUProcessEnabled"));
@@ -634,7 +634,7 @@ static void runMemoryPressureExitTest(Function<void(WKWebView *)>&& loadTestPage
 
     updateConfiguration(configuration.get());
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
     loadTestPageSynchronously(webView.get());
 
     // A GPUProcess should get launched.
@@ -726,7 +726,7 @@ static bool waitUntilCaptureState(WKWebView *webView, _WKMediaCaptureStateDeprec
 TEST(GPUProcess, ExitsUnderMemoryPressureGetUserMediaAudioCase)
 {
     runMemoryPressureExitTest([](WKWebView *webView) {
-        auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+        RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
         webView.UIDelegate = delegate.get();
 
         [webView loadTestPageNamed:@"getUserMedia"];
@@ -750,7 +750,7 @@ TEST(GPUProcess, ExitsUnderMemoryPressureGetUserMediaVideoCase)
 #endif
 {
     runMemoryPressureExitTest([](WKWebView *webView) {
-        auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+        RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
         webView.UIDelegate = delegate.get();
 
         [webView loadTestPageNamed:@"getUserMedia"];
@@ -773,7 +773,7 @@ TEST(GPUProcess, ExitsUnderMemoryPressureWebRTCCase)
 #endif
 {
     runMemoryPressureExitTest([](WKWebView *webView) {
-        auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+        RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
         webView.UIDelegate = delegate.get();
 
         [webView loadTestPageNamed:@"getUserMedia"];
@@ -815,13 +815,13 @@ TEST(GPUProcess, ExitsUnderMemoryPressureWebAudioNonRenderingAudioContext)
     if ([[[NSUserDefaults standardUserDefaults] objectForKey:@"WebKit2GPUProcessForDOMRendering"] boolValue])
         return;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("UseGPUProcessForMediaEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("CaptureVideoInGPUProcessEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("UseGPUProcessForCanvasRenderingEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], false, WKStringCreateWithUTF8CString("UseGPUProcessForDOMRenderingEnabled"));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"audio-context-playing"];
 
     // evaluateJavaScript gives us the user gesture we need to reliably start audio playback on all platforms.
@@ -864,10 +864,10 @@ TEST(GPUProcess, ExitsUnderMemoryPressureWebAudioNonRenderingAudioContext)
 
 TEST(GPUProcess, ValidateWebAudioMediaProcessingAssertion)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("UseGPUProcessForMediaEnabled"));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"audio-context-playing"];
 
     // evaluateJavaScript gives us the user gesture we need to reliably start audio playback on all platforms.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Geolocation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Geolocation.mm
@@ -89,7 +89,7 @@ static bool didShowGeolocationPrompt = false;
     ASSERT(_shouldAuthorizeGeolocation);
     WTF::callOnMainThread([listener = _listener, simulateError = _simulateError] {
         if (!simulateError) {
-            auto location = adoptNS([[CLLocation alloc] initWithLatitude:37.3348 longitude:-122.009]);
+            RetainPtr location = adoptNS([[CLLocation alloc] initWithLatitude:37.3348 longitude:-122.009]);
             [listener positionChanged:[_WKGeolocationPosition positionWithLocation:location.get()]];
         } else
             [listener errorOccurred:@"Error Message"];
@@ -158,13 +158,13 @@ namespace TestWebKitAPI {
 
 TEST(Geolocation, DeniedByLocationProvider)
 {
-    auto uiDelegate = adoptNS([[GeolocationTestUIDelegate alloc] init]);
-    auto coreLocationProvider = adoptNS([[TestCoreLocationProvider alloc] init]);
-    auto processPool = adoptNS([[WKProcessPool alloc] init]);
+    RetainPtr uiDelegate = adoptNS([[GeolocationTestUIDelegate alloc] init]);
+    RetainPtr coreLocationProvider = adoptNS([[TestCoreLocationProvider alloc] init]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] init]);
     processPool.get()._coreLocationProvider = coreLocationProvider.get();
-    auto config = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr config = adoptNS([[WKWebViewConfiguration alloc] init]);
     config.get().processPool = processPool.get();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:config.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:config.get()]);
     webView.get().UIDelegate = uiDelegate.get();
 
     coreLocationProvider.get().shouldAuthorizeGeolocation = NO;
@@ -182,13 +182,13 @@ TEST(Geolocation, DeniedByLocationProvider)
 
 TEST(Geolocation, DeniedByAPI)
 {
-    auto uiDelegate = adoptNS([[GeolocationTestUIDelegate alloc] init]);
-    auto coreLocationProvider = adoptNS([[TestCoreLocationProvider alloc] init]);
-    auto processPool = adoptNS([[WKProcessPool alloc] init]);
+    RetainPtr uiDelegate = adoptNS([[GeolocationTestUIDelegate alloc] init]);
+    RetainPtr coreLocationProvider = adoptNS([[TestCoreLocationProvider alloc] init]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] init]);
     processPool.get()._coreLocationProvider = coreLocationProvider.get();
-    auto config = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr config = adoptNS([[WKWebViewConfiguration alloc] init]);
     config.get().processPool = processPool.get();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:config.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:config.get()]);
     webView.get().UIDelegate = uiDelegate.get();
 
     coreLocationProvider.get().shouldAuthorizeGeolocation = YES;
@@ -206,13 +206,13 @@ TEST(Geolocation, DeniedByAPI)
 
 TEST(Geolocation, AllowedByAPI)
 {
-    auto uiDelegate = adoptNS([[GeolocationTestUIDelegate alloc] init]);
-    auto coreLocationProvider = adoptNS([[TestCoreLocationProvider alloc] init]);
-    auto processPool = adoptNS([[WKProcessPool alloc] init]);
+    RetainPtr uiDelegate = adoptNS([[GeolocationTestUIDelegate alloc] init]);
+    RetainPtr coreLocationProvider = adoptNS([[TestCoreLocationProvider alloc] init]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] init]);
     processPool.get()._coreLocationProvider = coreLocationProvider.get();
-    auto config = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr config = adoptNS([[WKWebViewConfiguration alloc] init]);
     config.get().processPool = processPool.get();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:config.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:config.get()]);
     webView.get().UIDelegate = uiDelegate.get();
 
     coreLocationProvider.get().shouldAuthorizeGeolocation = YES;
@@ -230,13 +230,13 @@ TEST(Geolocation, AllowedByAPI)
 
 TEST(Geolocation, Error)
 {
-    auto uiDelegate = adoptNS([[GeolocationTestUIDelegate alloc] init]);
-    auto coreLocationProvider = adoptNS([[TestCoreLocationProvider alloc] init]);
-    auto processPool = adoptNS([[WKProcessPool alloc] init]);
+    RetainPtr uiDelegate = adoptNS([[GeolocationTestUIDelegate alloc] init]);
+    RetainPtr coreLocationProvider = adoptNS([[TestCoreLocationProvider alloc] init]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] init]);
     processPool.get()._coreLocationProvider = coreLocationProvider.get();
-    auto config = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr config = adoptNS([[WKWebViewConfiguration alloc] init]);
     config.get().processPool = processPool.get();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:config.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:config.get()]);
     webView.get().UIDelegate = uiDelegate.get();
 
     coreLocationProvider.get().shouldAuthorizeGeolocation = YES;
@@ -255,13 +255,13 @@ TEST(Geolocation, Error)
 
 TEST(Geolocation, DuplicateAuthorizationCallbackCalls)
 {
-    auto uiDelegate = adoptNS([[GeolocationTestUIDelegate alloc] init]);
-    auto coreLocationProvider = adoptNS([[TestCoreLocationProvider alloc] init]);
-    auto processPool = adoptNS([[WKProcessPool alloc] init]);
+    RetainPtr uiDelegate = adoptNS([[GeolocationTestUIDelegate alloc] init]);
+    RetainPtr coreLocationProvider = adoptNS([[TestCoreLocationProvider alloc] init]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] init]);
     processPool.get()._coreLocationProvider = coreLocationProvider.get();
-    auto config = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr config = adoptNS([[WKWebViewConfiguration alloc] init]);
     config.get().processPool = processPool.get();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:config.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:config.get()]);
     webView.get().UIDelegate = uiDelegate.get();
 
     coreLocationProvider.get().shouldAuthorizeGeolocation = YES;
@@ -280,13 +280,13 @@ TEST(Geolocation, DuplicateAuthorizationCallbackCalls)
 
 TEST(Geolocation, DelegateNotImplemented)
 {
-    auto coreLocationProvider = adoptNS([TestCoreLocationProvider new]);
+    RetainPtr coreLocationProvider = adoptNS([TestCoreLocationProvider new]);
     coreLocationProvider.get().shouldAuthorizeGeolocation = YES;
-    auto processPool = adoptNS([WKProcessPool new]);
+    RetainPtr processPool = adoptNS([WKProcessPool new]);
     processPool.get()._coreLocationProvider = coreLocationProvider.get();
-    auto config = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr config = adoptNS([WKWebViewConfiguration new]);
     config.get().processPool = processPool.get();
-    auto webView = adoptNS([[TestWKWebViewForGeolocation alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:config.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebViewForGeolocation alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:config.get()]);
     EXPECT_FALSE(didShowGeolocationPrompt);
     [webView loadTestPageNamed:@"GeolocationGetCurrentPositionResult"];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "SUCCESS");

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetDisplayMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetDisplayMedia.mm
@@ -151,7 +151,7 @@ protected:
         auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
         m_configuration.get().processPool = (WKProcessPool *)context.get();
 
-        auto handler = adoptNS([[GetDisplayMediaMessageHandler alloc] init]);
+        RetainPtr handler = adoptNS([[GetDisplayMediaMessageHandler alloc] init]);
         [[m_configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
 
         auto preferences = [m_configuration preferences];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetDisplayMediaWindowAndScreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetDisplayMediaWindowAndScreen.mm
@@ -135,7 +135,7 @@ namespace TestWebKitAPI {
 
 TEST(WebKit2, GetDisplayMediaWindowAndScreenPrompt)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
 
     configuration.get().processPool = (WKProcessPool *)context.get();
@@ -145,11 +145,11 @@ TEST(WebKit2, GetDisplayMediaWindowAndScreenPrompt)
     preferences._mediaCaptureRequiresSecureConnection = NO;
     preferences._mockCaptureDevicesEnabled = YES;
 
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
-    auto webView = adoptNS([[WindowAndScreenCaptureTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WindowAndScreenCaptureTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
     [webView setUIDelegate:delegate.get()];
 
-    auto observer = adoptNS([[DisplayCaptureObserver alloc] init]);
+    RetainPtr observer = adoptNS([[DisplayCaptureObserver alloc] init]);
     [webView addObserver:observer.get() forKeyPath:@"_displayCaptureSurfaces" options:NSKeyValueObservingOptionNew context:nil];
     [webView addObserver:observer.get() forKeyPath:@"_displayCaptureState" options:NSKeyValueObservingOptionNew context:nil];
 
@@ -278,7 +278,7 @@ TEST(WebKit2, GetDisplayMediaWindowAndScreenPrompt)
 
 TEST(WebKit2, ToggleScreenshare)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("MediaSessionCaptureToggleAPIEnabled"));
 
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
@@ -289,16 +289,16 @@ TEST(WebKit2, ToggleScreenshare)
     preferences._mediaCaptureRequiresSecureConnection = NO;
     preferences._mockCaptureDevicesEnabled = YES;
 
-    auto messageHandler = adoptNS([[DisplayGUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[DisplayGUMMessageHandler alloc] init]);
     [[configuration.get() userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView _setMediaCaptureReportingDelayForTesting:0];
 
-    auto observer = adoptNS([[DisplayCaptureObserver alloc] init]);
+    RetainPtr observer = adoptNS([[DisplayCaptureObserver alloc] init]);
     [webView addObserver:observer.get() forKeyPath:@"_displayCaptureState" options:NSKeyValueObservingOptionNew context:nil];
 
     messageReceived = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetResourceData.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetResourceData.mm
@@ -37,8 +37,8 @@
 
 TEST(WebKit, GetPDFResourceData)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
 
     __block bool isDone;
     [webView _getMainResourceDataWithCompletionHandler:^(NSData *data, NSError *error) {
@@ -63,8 +63,8 @@ TEST(WebKit, GetPDFResourceData)
 
 TEST(WebKit, GetPDFResourceDataInUnparentedWebView)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:NO]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:NO]);
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]];
     [webView loadRequest:request];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetUserMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetUserMedia.mm
@@ -173,11 +173,11 @@ static void initializeMediaCaptureConfiguration(WKWebViewConfiguration* configur
 
 void doCaptureMuteTest(NOESCAPE const Function<void(TestWKWebView*, _WKMediaMutedState)>& setPageMuted)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     [webView _setMediaCaptureReportingDelayForTesting:0];
@@ -264,16 +264,16 @@ TEST(WebKit2, DISABLED_CaptureMuteAPI)
 TEST(WebKit2, CaptureMuteAPI)
 #endif
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     [webView _setMediaCaptureReportingDelayForTesting:0];
 
-    auto observer = adoptNS([[MediaCaptureObserver alloc] init]);
+    RetainPtr observer = adoptNS([[MediaCaptureObserver alloc] init]);
     [webView addObserver:observer.get() forKeyPath:@"microphoneCaptureState" options:NSKeyValueObservingOptionNew context:nil];
     [webView addObserver:observer.get() forKeyPath:@"cameraCaptureState" options:NSKeyValueObservingOptionNew context:nil];
 
@@ -366,15 +366,15 @@ TEST(WebKit2, CaptureMuteAPI)
 
 TEST(WebKit2, CaptureStop)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration.get() userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     [webView loadTestPageNamed:@"getUserMedia"];
@@ -401,15 +401,15 @@ TEST(WebKit2, CaptureStop)
 
 TEST(WebKit2, CloseWKWebViewShortlyAfterStartingToCapture)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration.get() userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     [webView loadTestPageNamed:@"getUserMedia"];
@@ -426,17 +426,17 @@ TEST(WebKit2, CloseWKWebViewShortlyAfterStartingToCapture)
 
 TEST(WebKit2, CaptureIndicatorDelay)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration.get() userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
     [webView _setMediaCaptureReportingDelayForTesting:2];
 
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     [webView loadTestPageNamed:@"getUserMedia"];
@@ -459,17 +459,17 @@ TEST(WebKit2, CaptureIndicatorDelay)
 
 TEST(WebKit2, CaptureIndicatorDelayWhenClosed)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration.get() userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
     [webView _setMediaCaptureReportingDelayForTesting:2];
 
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     [webView loadTestPageNamed:@"getUserMedia"];
@@ -484,15 +484,15 @@ TEST(WebKit2, CaptureIndicatorDelayWhenClosed)
 
 TEST(WebKit2, GetCapabilities)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration.get() userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     [webView loadTestPageNamed:@"getUserMedia"];
@@ -508,7 +508,7 @@ TEST(WebKit2, GetCapabilities)
 
 TEST(WebKit, InterruptionBetweenSameProcessPages)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
 #if PLATFORM(IOS_FAMILY)
     [configuration setAllowsInlineMediaPlayback:YES];
@@ -516,12 +516,12 @@ TEST(WebKit, InterruptionBetweenSameProcessPages)
 
     initializeMediaCaptureConfiguration(configuration.get());
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
     done = false;
-    auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     webView1.get().UIDelegate = delegate.get();
     [webView1 loadTestPageNamed:@"getUserMedia2"];
     TestWebKitAPI::Util::run(&done);
@@ -531,7 +531,7 @@ TEST(WebKit, InterruptionBetweenSameProcessPages)
     ALLOW_DEPRECATED_DECLARATIONS_END
 
     done = false;
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     webView2.get().UIDelegate = delegate.get();
     [webView2 loadTestPageNamed:@"getUserMedia2"];
     TestWebKitAPI::Util::run(&done);
@@ -591,17 +591,17 @@ TEST(WebKit, TransferTrackBetweenSameProcessPages)
         { "/?no-open"_s, { transferTrackBetweenSameProcessPagesText } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http, nullptr, nullptr, 9090);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     __block RetainPtr<TestWKWebView> webView2;
-    auto observer = adoptNS([[MediaCaptureObserver alloc] init]);
+    RetainPtr observer = adoptNS([[MediaCaptureObserver alloc] init]);
 
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     delegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *, WKWindowFeatures *) {
         webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration addToWindow:YES]);
         [webView2 addObserver:observer.get() forKeyPath:@"microphoneCaptureState" options:NSKeyValueObservingOptionNew context:nil];
@@ -680,16 +680,16 @@ TEST(WebKit, KeepPermissionForWebAppSameOriginNavigations)
         { "/1"_s, { KeepPermissionForWebAppSameOriginNavigationsText } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http, nullptr, nullptr, 9090);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
-    auto observer = adoptNS([[MediaCaptureObserver alloc] init]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr observer = adoptNS([[MediaCaptureObserver alloc] init]);
 
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     webView1.get().UIDelegate = delegate.get();
 
     done = false;
@@ -766,21 +766,21 @@ TEST(WebKit, KeepPermissionForWebAppSameOriginNavigations)
 #if PLATFORM(MAC)
 TEST(WebKit, InterruptionBetweenGetDisplayMediaAndGetUserMedia)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
 
     configuration.get().processPool = (WKProcessPool *)context.get();
 
     initializeMediaCaptureConfiguration(configuration.get());
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     webView1.get().UIDelegate = delegate.get();
 
-    auto observer = adoptNS([[MediaCaptureObserver alloc] init]);
+    RetainPtr observer = adoptNS([[MediaCaptureObserver alloc] init]);
     [webView1 addObserver:observer.get() forKeyPath:@"microphoneCaptureState" options:NSKeyValueObservingOptionNew context:nil];
     [webView1 addObserver:observer.get() forKeyPath:@"cameraCaptureState" options:NSKeyValueObservingOptionNew context:nil];
 
@@ -789,7 +789,7 @@ TEST(WebKit, InterruptionBetweenGetDisplayMediaAndGetUserMedia)
 
     EXPECT_TRUE(waitUntilCameraState(webView1.get(), WKMediaCaptureStateActive));
 
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     webView2.get().UIDelegate = delegate.get();
 
     [delegate setGetDisplayMediaDecision:WKDisplayCapturePermissionDecisionScreenPrompt];
@@ -825,7 +825,7 @@ TEST(WebKit, PermissionDelegateParameters)
         { "/frame"_s, { frameText } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http, nullptr, nullptr, 9091);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
 #if PLATFORM(IOS_FAMILY)
     [configuration setAllowsInlineMediaPlayback:YES];
@@ -834,8 +834,8 @@ TEST(WebKit, PermissionDelegateParameters)
     initializeMediaCaptureConfiguration(configuration.get());
 
     done = false;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegateForParameters alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegateForParameters alloc] init]);
     webView.get().UIDelegate = delegate.get();
     [webView loadRequest:server1.request()];
     TestWebKitAPI::Util::run(&done);
@@ -846,19 +846,19 @@ TEST(WebKit, WebAudioAndGetUserMedia)
 {
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
     configuration.get().processPool._configuration.shouldCaptureAudioInUIProcess = NO;
 
     initializeMediaCaptureConfiguration(configuration.get());
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration.get() userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     auto url = adoptWK(Util::createURLForResource("getUserMedia-webaudio", "html"));
@@ -872,7 +872,7 @@ TEST(WebKit, WebAudioAndGetUserMedia)
 #if ENABLE(GPU_PROCESS)
 TEST(WebKit2, CrashGPUProcessWhileCapturing)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto preferences = [configuration preferences];
 
     for (_WKFeature *feature in [WKPreferences _features]) {
@@ -884,12 +884,12 @@ TEST(WebKit2, CrashGPUProcessWhileCapturing)
 
     initializeMediaCaptureConfiguration(configuration.get());
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     webView.get().UIDelegate = delegate.get();
 
     [webView loadTestPageNamed:@"getUserMedia"];
@@ -944,7 +944,7 @@ TEST(WebKit2, CrashGPUProcessWhileCapturing)
 
 TEST(WebKit2, CrashGPUProcessAfterApplyingConstraints)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto preferences = [configuration preferences];
 
     for (_WKFeature *feature in [WKPreferences _features]) {
@@ -959,12 +959,12 @@ TEST(WebKit2, CrashGPUProcessAfterApplyingConstraints)
     [configuration setAllowsInlineMediaPlayback:YES];
 #endif
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     webView.get().UIDelegate = delegate.get();
 
     [webView loadTestPageNamed:@"getUserMedia"];
@@ -1019,7 +1019,7 @@ TEST(WebKit2, CrashGPUProcessAfterApplyingConstraints)
 
 TEST(WebKit2, CrashGPUProcessWhileCapturingAndCalling)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto preferences = [configuration preferences];
 
     for (_WKFeature *feature in [WKPreferences _features]) {
@@ -1033,12 +1033,12 @@ TEST(WebKit2, CrashGPUProcessWhileCapturingAndCalling)
 
     initializeMediaCaptureConfiguration(configuration.get());
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     webView.get().UIDelegate = delegate.get();
 
     [webView loadTestPageNamed:@"getUserMedia"];
@@ -1165,20 +1165,20 @@ TEST(WebKit, AutoplayOnVisibilityChange)
         { "/"_s, { visibilityTestText } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http, nullptr, nullptr, 9090);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
     initializeMediaCaptureConfiguration(configuration.get());
 
     done = false;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     webView.get().UIDelegate = delegate.get();
 
     NSLog(@"AutoplayOnVisibilityChange 1\n");
@@ -1244,12 +1244,12 @@ TEST(WebKit, GetUserMediaFocus)
         { "/"_s, { getUserMediaFocusText } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http, nullptr, nullptr, 9090);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
     initializeMediaCaptureConfiguration(configuration.get());
@@ -1257,9 +1257,9 @@ TEST(WebKit, GetUserMediaFocus)
     preferences._getUserMediaRequiresFocus = YES;
 
     done = false;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     webView.get().UIDelegate = delegate.get();
 
     // Load page.
@@ -1304,14 +1304,14 @@ TEST(WebKit, InvalidDeviceIdHashSalts)
         Util::spinRunLoop();
 
     // Prepare web view to use the invalid data
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [websiteDataStoreConfiguration setDeviceIdHashSaltsStorageDirectory:tempDir];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
     initializeMediaCaptureConfiguration(configuration.get());
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     // Wait for invalid data to be loaded.
@@ -1338,16 +1338,16 @@ static _WKFeature *permissionsAPIEnabledExperimentalFeature()
 
 TEST(WebKit2, CapturePermission)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
     [[configuration preferences] _setEnabled:YES forFeature:permissionsAPIEnabledExperimentalFeature()];
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration.get() userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -1428,15 +1428,15 @@ TEST(WebKit2, CapturePermissionChangedFromGrantToDeny)
         { "/"_s, { capturePermissionChangedWebPage } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration.get() userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     [delegate setAudioDecision:WKPermissionDecisionGrant];
@@ -1476,15 +1476,15 @@ TEST(WebKit2, CapturePermissionChangedFromDenyToGrant)
         { "/"_s, { capturePermissionChangedWebPage } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration.get() userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     [delegate setAudioDecision:WKPermissionDecisionDeny];
@@ -1520,7 +1520,7 @@ TEST(WebKit2, CapturePermissionChangedFromDenyToGrant)
 
 TEST(WebKit2, EnumerateDevicesAfterMuting)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration preferences]._inactiveMediaCaptureStreamRepromptIntervalInMinutes = .5 / 60;
 
     initializeMediaCaptureConfiguration(configuration.get());
@@ -1529,12 +1529,12 @@ TEST(WebKit2, EnumerateDevicesAfterMuting)
     [configuration setAllowsInlineMediaPlayback:YES];
 #endif
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     webView.get().UIDelegate = delegate.get();
 
     [webView loadTestPageNamed:@"getUserMedia"];
@@ -1555,7 +1555,7 @@ TEST(WebKit2, EnumerateDevicesAfterMuting)
 #if PLATFORM(IOS_FAMILY)
 TEST(WebKit2, CapturePermissionWithSystemBlocking)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get()._mediaCaptureEnabled = YES;
 
     auto preferences = [configuration preferences];
@@ -1564,12 +1564,12 @@ TEST(WebKit2, CapturePermissionWithSystemBlocking)
     preferences._getUserMediaRequiresFocus = NO;
     [preferences _setEnabled:YES forFeature:permissionsAPIEnabledExperimentalFeature()];
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration.get() userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -1610,15 +1610,15 @@ TEST(WebKit2, CapturePermissionWithSystemBlocking)
 #if PLATFORM(MAC)
 TEST(WebKit2, ConnectedToHardwareConsole)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView _setMediaCaptureReportingDelayForTesting:0];
 
-    auto observer = adoptNS([[MediaCaptureObserver alloc] init]);
+    RetainPtr observer = adoptNS([[MediaCaptureObserver alloc] init]);
     [webView addObserver:observer.get() forKeyPath:@"microphoneCaptureState" options:NSKeyValueObservingOptionNew context:nil];
     [webView addObserver:observer.get() forKeyPath:@"cameraCaptureState" options:NSKeyValueObservingOptionNew context:nil];
 
@@ -1666,15 +1666,15 @@ TEST(WebKit2, ConnectedToHardwareConsole)
 
 TEST(WebKit2, DoNotUnmuteWhenTakingAThumbnail)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView _setMediaCaptureReportingDelayForTesting:0];
 
-    auto observer = adoptNS([[MediaCaptureObserver alloc] init]);
+    RetainPtr observer = adoptNS([[MediaCaptureObserver alloc] init]);
     [webView addObserver:observer.get() forKeyPath:@"microphoneCaptureState" options:NSKeyValueObservingOptionNew context:nil];
     [webView addObserver:observer.get() forKeyPath:@"cameraCaptureState" options:NSKeyValueObservingOptionNew context:nil];
 
@@ -1703,23 +1703,23 @@ TEST(WebKit2, WebRTCAndRemoteCommands)
 {
     [TestProtocol registerWithScheme:@"https"];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
     configuration.get().processPool._configuration.shouldCaptureAudioInUIProcess = NO;
 
     initializeMediaCaptureConfiguration(configuration.get());
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration.get() userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView _setMediaCaptureReportingDelayForTesting:0];
 
-    auto observer = adoptNS([[MediaCaptureObserver alloc] init]);
+    RetainPtr observer = adoptNS([[MediaCaptureObserver alloc] init]);
     [webView addObserver:observer.get() forKeyPath:@"microphoneCaptureState" options:NSKeyValueObservingOptionNew context:nil];
     [webView addObserver:observer.get() forKeyPath:@"cameraCaptureState" options:NSKeyValueObservingOptionNew context:nil];
 
@@ -1786,7 +1786,7 @@ TEST(WebKit2, ToggleCameraCaptureWhenRestarting)
 {
     [TestProtocol registerWithScheme:@"https"];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("MediaSessionCaptureToggleAPIEnabled"));
 
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
@@ -1795,16 +1795,16 @@ TEST(WebKit2, ToggleCameraCaptureWhenRestarting)
 
     initializeMediaCaptureConfiguration(configuration.get());
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration.get() userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView _setMediaCaptureReportingDelayForTesting:0];
 
-    auto observer = adoptNS([[MediaCaptureObserver alloc] init]);
+    RetainPtr observer = adoptNS([[MediaCaptureObserver alloc] init]);
     [webView addObserver:observer.get() forKeyPath:@"microphoneCaptureState" options:NSKeyValueObservingOptionNew context:nil];
     [webView addObserver:observer.get() forKeyPath:@"cameraCaptureState" options:NSKeyValueObservingOptionNew context:nil];
 
@@ -1852,7 +1852,7 @@ TEST(WebKit2, ToggleMicrophoneCaptureWhenRestarting)
 {
     [TestProtocol registerWithScheme:@"https"];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("MediaSessionCaptureToggleAPIEnabled"));
 
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
@@ -1861,16 +1861,16 @@ TEST(WebKit2, ToggleMicrophoneCaptureWhenRestarting)
 
     initializeMediaCaptureConfiguration(configuration.get());
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration.get() userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView _setMediaCaptureReportingDelayForTesting:0];
 
-    auto observer = adoptNS([[MediaCaptureObserver alloc] init]);
+    RetainPtr observer = adoptNS([[MediaCaptureObserver alloc] init]);
     [webView addObserver:observer.get() forKeyPath:@"microphoneCaptureState" options:NSKeyValueObservingOptionNew context:nil];
     [webView addObserver:observer.get() forKeyPath:@"cameraCaptureState" options:NSKeyValueObservingOptionNew context:nil];
 
@@ -1926,15 +1926,15 @@ TEST(WebKit2, OrientationNotAffectedByCSSOrientation)
     auto runTestForOrientation = ^(UIInterfaceOrientation orientation) {
         done = false;
 
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-        auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
         initializeMediaCaptureConfiguration(configuration.get());
 
-        auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+        RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
         [[configuration.get() userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-        auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-        auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+        RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+        RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
         [webView setUIDelegate:delegate.get()];
 
         [webView _setInterfaceOrientationOverride:orientation];
@@ -1970,7 +1970,7 @@ TEST(GetUserMedia, DISABLED_ClearRemoteVideoFrameObjectHeapPixelConformerUnderMe
 TEST(GetUserMedia, ClearRemoteVideoFrameObjectHeapPixelConformerUnderMemoryPressure)
 #endif
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("CaptureAudioInGPUProcessEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("CaptureVideoInGPUProcessEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("UseGPUProcessForMediaEnabled"));
@@ -1983,11 +1983,11 @@ TEST(GetUserMedia, ClearRemoteVideoFrameObjectHeapPixelConformerUnderMemoryPress
     preferences._mockCaptureDevicesEnabled = YES;
     preferences._getUserMediaRequiresFocus = NO;
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration.get() userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -2047,15 +2047,15 @@ TEST(WebKit2, getUserMediaWithDeviceChangeWebPage)
         { "/"_s, { getUserMediaWithDeviceChangeWebPage } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
 
-    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
     [[configuration.get() userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegateWithDeviceChange alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegateWithDeviceChange alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -2083,20 +2083,20 @@ TEST(WebKit2, GetUserMediaAfterMuting)
 {
     [TestProtocol registerWithScheme:@"https"];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get()._mediaCaptureEnabled = YES;
     auto preferences = [configuration preferences];
     preferences._mediaCaptureRequiresSecureConnection = NO;
     preferences._mockCaptureDevicesEnabled = YES;
     preferences._getUserMediaRequiresFocus = NO;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
 
-    auto observer = adoptNS([[MediaCaptureObserver alloc] init]);
+    RetainPtr observer = adoptNS([[MediaCaptureObserver alloc] init]);
     [webView addObserver:observer.get() forKeyPath:@"microphoneCaptureState" options:NSKeyValueObservingOptionNew context:nil];
     [webView addObserver:observer.get() forKeyPath:@"cameraCaptureState" options:NSKeyValueObservingOptionNew context:nil];
 
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView _setMediaCaptureReportingDelayForTesting:0];
 
@@ -2143,11 +2143,11 @@ TEST(WebKit, GetUserMediaWithWebThread)
     [WebView enableWebThread];
 #endif
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     [webView _setMediaCaptureReportingDelayForTesting:0];
@@ -2170,23 +2170,23 @@ TEST(GetUserMedia, OriginAndWebArchivePermission)
         { "/"_s, { "body"_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(server.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
     [configuration setWebsiteDataStore:dataStore.get()];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
 
     RetainPtr navDelegate = adoptNS([TestNavigationDelegate new]);
 
-    auto observer = adoptNS([[MediaCaptureObserver alloc] init]);
+    RetainPtr observer = adoptNS([[MediaCaptureObserver alloc] init]);
     [webView addObserver:observer.get() forKeyPath:@"microphoneCaptureState" options:NSKeyValueObservingOptionNew context:nil];
     [webView addObserver:observer.get() forKeyPath:@"cameraCaptureState" options:NSKeyValueObservingOptionNew context:nil];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetUserMediaNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetUserMediaNavigation.mm
@@ -97,14 +97,14 @@ static void initializeMediaCaptureConfiguration(WKWebViewConfiguration* configur
 
 TEST(WebKit, NavigateDuringGetUserMediaPrompt)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     auto preferences = [configuration preferences];
     preferences._mediaCaptureRequiresSecureConnection = NO;
     configuration.get()._mediaCaptureEnabled = YES;
     preferences._mockCaptureDevicesEnabled = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[NavigationWhileGetUserMediaPromptDisplayedUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[NavigationWhileGetUserMediaPromptDisplayedUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     okToProceed = false;
@@ -114,11 +114,11 @@ TEST(WebKit, NavigateDuringGetUserMediaPrompt)
 
 TEST(WebKit, NavigateDuringDeviceEnumeration)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
     WKWebView *webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]).leakRef();
-    auto delegate = adoptNS([[NavigationWhileGetUserMediaPromptDisplayedUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[NavigationWhileGetUserMediaPromptDisplayedUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     okToProceed = false;
@@ -130,7 +130,7 @@ TEST(WebKit, DefaultDeviceIdHashSaltsDirectory)
 {
     NSFileManager *fileManager = [NSFileManager defaultManager];
 
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     auto *path = [websiteDataStoreConfiguration deviceIdHashSaltsStorageDirectory].path;
 
     if ([fileManager fileExistsAtPath:path]) {
@@ -139,12 +139,12 @@ TEST(WebKit, DefaultDeviceIdHashSaltsDirectory)
         EXPECT_FALSE(error);
     }
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[NavigationWhileGetUserMediaPromptDisplayedUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[NavigationWhileGetUserMediaPromptDisplayedUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     [webView loadTestPageNamed:@"enumerateMediaDevices"];
@@ -163,15 +163,15 @@ TEST(WebKit, DeviceIdHashSaltsDirectory)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     EXPECT_FALSE([fileManager fileExistsAtPath:hashSaltLocation.path]);
     
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [websiteDataStoreConfiguration setDeviceIdHashSaltsStorageDirectory:tempDir];
     
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[NavigationWhileGetUserMediaPromptDisplayedUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[NavigationWhileGetUserMediaPromptDisplayedUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     
     [webView loadTestPageNamed:@"enumerateMediaDevices"];
@@ -185,18 +185,18 @@ TEST(WebKit, DeviceIdHashSaltsDirectory)
 
 TEST(WebKit, DeviceIdHashSaltsRemoval)
 {
-    auto dataTypeHashSalt = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeHashSalt]]);
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr dataTypeHashSalt = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeHashSalt]]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     @autoreleasepool {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-        auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
         [configuration setWebsiteDataStore:websiteDataStore.get()];
-        auto messageHandler = adoptNS([[GetUserMeidaNavigationMessageHandler alloc] init]);
+        RetainPtr messageHandler = adoptNS([[GetUserMeidaNavigationMessageHandler alloc] init]);
         [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
-        auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+        RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
         initializeMediaCaptureConfiguration(configuration.get());
-        auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-        auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+        RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+        RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
         [webView setUIDelegate:delegate.get()];
 
         NSString *htmlString = @"<script> \
@@ -218,7 +218,7 @@ TEST(WebKit, DeviceIdHashSaltsRemoval)
     }
 
     // Create a new WebsiteDataStore to ensure DeviceHashSaltStorage receives delete task before storage is loaded from disk.
-    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
     done = false;
     [websiteDataStore removeDataOfTypes:dataTypeHashSalt.get() modifiedSince:[NSDate distantPast] completionHandler:^() {
         done = true;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetUserMediaReprompt.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GetUserMediaReprompt.mm
@@ -76,12 +76,12 @@ static void initializeMediaCaptureConfiguration(WKWebViewConfiguration* configur
 
 TEST(WebKit2, GetUserMediaReprompt)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     auto preferences = [configuration preferences];
     initializeMediaCaptureConfiguration(configuration.get());
-    auto webView = adoptNS([[GetUserMediaRepromptTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[GetUserMediaRepromptTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     [webView loadTestPageNamed:@"getUserMedia"];
@@ -110,14 +110,14 @@ TEST(WebKit2, GetUserMediaReprompt)
 
 TEST(WebKit2, GetUserMediaRepromptWithoutUserGesture)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     auto preferences = [configuration preferences];
     preferences._inactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes = 0.5 / 60;
 
     initializeMediaCaptureConfiguration(configuration.get());
-    auto webView = adoptNS([[GetUserMediaRepromptTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[GetUserMediaRepromptTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     [webView loadTestPageNamed:@"getUserMedia"];
@@ -149,11 +149,11 @@ TEST(WebKit2, GetUserMediaRepromptWithoutUserGesture)
 
 TEST(WebKit2, GetUserMediaRepromptAfterAudioVideoBeingDenied)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
-    auto webView = adoptNS([[GetUserMediaRepromptTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[GetUserMediaRepromptTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [delegate setAudioDecision:WKPermissionDecisionGrant];
     [delegate setVideoDecision:WKPermissionDecisionDeny];
     [webView setUIDelegate:delegate.get()];
@@ -169,11 +169,11 @@ TEST(WebKit2, GetUserMediaRepromptAfterAudioVideoBeingDenied)
 
 TEST(WebKit2, MultipleGetUserMediaSynchronously)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
-    auto webView = adoptNS([[GetUserMediaRepromptTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[GetUserMediaRepromptTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     [webView loadTestPageNamed:@"getUserMedia"];
@@ -187,12 +187,12 @@ TEST(WebKit2, MultipleGetUserMediaSynchronously)
 
 TEST(WebKit2, GetUserMediaDefaultInactiveCaptureRepromptInterval)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     auto preferences = [configuration preferences];
     initializeMediaCaptureConfiguration(configuration.get());
-    auto webView = adoptNS([[GetUserMediaRepromptTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[GetUserMediaRepromptTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     [webView loadTestPageNamed:@"getUserMedia"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HSTS.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HSTS.mm
@@ -40,16 +40,16 @@ namespace TestWebKitAPI {
 
 std::pair<RetainPtr<WKWebView>, RetainPtr<TestNavigationDelegate>> hstsWebViewAndDelegate(const HTTPServer& httpsServer, const HTTPServer& httpServer)
 {
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", httpsServer.port()]]];
     [storeConfiguration setHTTPProxy:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", httpServer.port()]]];
     [storeConfiguration setAllowsServerPreconnect:NO];
     [storeConfiguration setAllowsHSTSWithUntrustedRootCertificate:YES];
-    auto viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [viewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
     [[viewConfiguration websiteDataStore] _setResourceLoadStatisticsEnabled:YES];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:viewConfiguration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:viewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     delegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
@@ -197,13 +197,13 @@ TEST(HSTS, Preconnect)
         preconnectSuccessful = true;
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
     [storeConfiguration setAllowsHSTSWithUntrustedRootCertificate:YES];
-    auto viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [viewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     delegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IPCSharedMemoryFallback.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IPCSharedMemoryFallback.mm
@@ -32,7 +32,7 @@ TEST(IPC, SharedMemoryFallback)
 {
     [WKProcessPool _forceUseSharedMemoryForSendingForTesting:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
     RetainPtr innerHTML = [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IPCTestingAPI.mm
@@ -88,9 +88,9 @@ static RetainPtr<NSString> promptResult;
 
 TEST(IPCTestingAPI, IsDisabledByDefault)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -152,7 +152,7 @@ TEST(IPCTestingAPI, CanDetectNilReplyBlocks)
 {
     auto webView = createWebViewWithIPCTestingAPI();
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     _WKRemoteObjectInterface *interface = remoteObjectInterface();
@@ -204,7 +204,7 @@ TEST(IPCTestingAPI, CanSendAlert)
 {
     auto webView = createWebViewWithIPCTestingAPI();
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -219,7 +219,7 @@ TEST(IPCTestingAPI, AlertIsSyncMessage)
 {
     auto webView = createWebViewWithIPCTestingAPI();
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -233,7 +233,7 @@ TEST(IPCTestingAPI, CanSendInvalidAsyncMessageToUIProcessWithoutTermination)
 {
     auto webView = createWebViewWithIPCTestingAPI();
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -249,7 +249,7 @@ TEST(IPCTestingAPI, CanSendInvalidSyncMessageToUIProcessWithoutTermination)
 {
     auto webView = createWebViewWithIPCTestingAPI();
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -267,7 +267,7 @@ TEST(IPCTestingAPI, CanSendSyncMessageToGPUProcess)
 {
     auto webView = createWebViewWithIPCTestingAPI();
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -283,7 +283,7 @@ TEST(IPCTestingAPI, CanSendAsyncMessageToGPUProcess)
 {
     auto webView = createWebViewWithIPCTestingAPI();
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -303,7 +303,7 @@ TEST(IPCTestingAPI, CanSendInvalidAsyncMessageToGPUProcessWithoutTermination)
 {
     auto webView = createWebViewWithIPCTestingAPI();
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -326,7 +326,7 @@ TEST(IPCTestingAPI, CanCreateSharedMemory)
 {
     auto webView = createWebViewWithIPCTestingAPI();
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -346,7 +346,7 @@ TEST(IPCTestingAPI, CanSendSharedMemory)
 {
     auto webView = createWebViewWithIPCTestingAPI();
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     auto* html = @R"HTML(<!DOCTYPE html>
@@ -375,7 +375,7 @@ TEST(IPCTestingAPI, DecodesReplyArgumentsForPrompt)
 {
     auto webView = createWebViewWithIPCTestingAPI();
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -392,7 +392,7 @@ TEST(IPCTestingAPI, DecodesReplyArgumentsForAsyncMessage)
 {
     auto webView = createWebViewWithIPCTestingAPI();
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -411,7 +411,7 @@ TEST(IPCTestingAPI, EmptyParametersDeleteCookie)
 {
     auto webView = createWebViewWithIPCTestingAPI();
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -455,7 +455,7 @@ TEST(IPCTestingAPI, InvalidURLsDeleteCookie)
 {
     auto webView = createWebViewWithIPCTestingAPI();
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -537,7 +537,7 @@ TEST(IPCTestingAPI, DescribesArguments)
 {
     auto webView = createWebViewWithIPCTestingAPI();
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -555,7 +555,7 @@ TEST(IPCTestingAPI, CanInterceptAlert)
 {
     auto webView = createWebViewWithIPCTestingAPI();
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -580,7 +580,7 @@ TEST(IPCTestingAPI, CanInterceptHasStorageAccess)
 {
     auto webView = createWebViewWithIPCTestingAPI();
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -612,13 +612,13 @@ TEST(IPCTestingAPI, CanInterceptFindString)
 {
     auto webView = createWebViewWithIPCTestingAPI();
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><body><p>hello</p><script>messages = []; IPC.addIncomingMessageListener('UI', (message) => messages.push(message));</script>"];
 
     done = false;
-    auto findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
+    RetainPtr findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
     [webView findString:@"hello" withConfiguration:findConfiguration.get() completionHandler:^(WKFindResult *result) {
         EXPECT_TRUE(result.matchFound);
         EXPECT_TRUE([webView selectionRangeHasStartOffset:0 endOffset:5]);
@@ -682,7 +682,7 @@ TEST(IPCTestingAPI, LockdownModeDisablesWebGL)
 {
     auto webView = createWebViewWithIPCTestingAPIAndLockdownMode(true);
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -702,7 +702,7 @@ TEST(IPCTestingAPI, LockdownModeDisabledAllowsWebGL)
 {
     auto webView = createWebViewWithIPCTestingAPIAndLockdownMode(false);
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     done = false;
@@ -721,7 +721,7 @@ TEST(IPCTestingAPI, LockdownModeDetection)
     // Test with lockdown mode enabled
     {
         auto webViewLockdown = createWebViewWithIPCTestingAPIAndLockdownMode(true);
-        auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+        RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
         [webViewLockdown setUIDelegate:delegate.get()];
 
         [webViewLockdown synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body>Test</body></html>"];
@@ -752,7 +752,7 @@ TEST(IPCTestingAPI, LockdownModeDetection)
     // Test with lockdown mode disabled
     {
         auto webViewNormal = createWebViewWithIPCTestingAPIAndLockdownMode(false);
-        auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+        RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
         [webViewNormal setUIDelegate:delegate.get()];
 
         [webViewNormal synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body>Test</body></html>"];
@@ -789,16 +789,16 @@ TEST(IPCTestingAPI, SpeechSynthesisWithFeatureFlag)
 {
     // Test 1: Feature flag enabled - message should succeed
     {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         for (_WKFeature *feature in [WKPreferences _features]) {
             if ([feature.key isEqualToString:@"IPCTestingAPIEnabled"])
                 [[configuration preferences] _setEnabled:YES forFeature:feature];
             if ([feature.key isEqualToString:@"SpeechSynthesisAPIEnabled"])
                 [[configuration preferences] _setEnabled:YES forFeature:feature];
         }
-        auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-        auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+        RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
         [webView setUIDelegate:delegate.get()];
 
         NSURL *htmlURL = [NSBundle.test_resourcesBundle URLForResource:@"speechsynthesis_feature_test" withExtension:@"html"];
@@ -815,16 +815,16 @@ TEST(IPCTestingAPI, SpeechSynthesisWithFeatureFlag)
 
     // Test 2: Feature flag disabled - message should fail with cancel error
     {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         for (_WKFeature *feature in [WKPreferences _features]) {
             if ([feature.key isEqualToString:@"IPCTestingAPIEnabled"])
                 [[configuration preferences] _setEnabled:YES forFeature:feature];
             if ([feature.key isEqualToString:@"SpeechSynthesisAPIEnabled"])
                 [[configuration preferences] _setEnabled:NO forFeature:feature];
         }
-        auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-        auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+        RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
         [webView setUIDelegate:delegate.get()];
 
         NSURL *htmlURL = [NSBundle.test_resourcesBundle URLForResource:@"speechsynthesis_feature_test" withExtension:@"html"];
@@ -845,7 +845,7 @@ TEST(IPCTestingAPI, SpeechSynthesisWithLockdownMode)
 {
     [WKProcessPool _setCaptivePortalModeEnabledGloballyForTesting:YES];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"IPCTestingAPIEnabled"])
             [[configuration preferences] _setEnabled:YES forFeature:feature];
@@ -859,9 +859,9 @@ TEST(IPCTestingAPI, SpeechSynthesisWithLockdownMode)
     [webpagePreferences setLockdownModeEnabled:YES];
     [configuration setDefaultWebpagePreferences:webpagePreferences.get()];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[IPCTestingAPIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     NSURL *htmlURL = [NSBundle.test_resourcesBundle URLForResource:@"speechsynthesis_lockdown_test" withExtension:@"html"];
@@ -884,7 +884,7 @@ TEST(IPCTestingAPI, SpeechSynthesisWithLockdownMode)
 #if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
 TEST(IPCTestingAPI, CGColorInNSSecureCoding)
 {
-    auto archiver = adoptNS([[NSKeyedArchiver alloc] initRequiringSecureCoding:YES]);
+    RetainPtr archiver = adoptNS([[NSKeyedArchiver alloc] initRequiringSecureCoding:YES]);
 
     RetainPtr<id<NSKeyedArchiverDelegate, NSKeyedUnarchiverDelegate>> delegate = adoptNS([[NSClassFromString(@"WKSecureCodingArchivingDelegate") alloc] init]);
     archiver.get().delegate = delegate.get();
@@ -898,11 +898,11 @@ TEST(IPCTestingAPI, CGColorInNSSecureCoding)
 
     auto data = [archiver encodedData];
 
-    auto unarchiver = adoptNS([[NSKeyedUnarchiver alloc] initForReadingFromData:data error:nullptr]);
+    RetainPtr unarchiver = adoptNS([[NSKeyedUnarchiver alloc] initForReadingFromData:data error:nullptr]);
     unarchiver.get().decodingFailurePolicy = NSDecodingFailurePolicyRaiseException;
     unarchiver.get().delegate = delegate.get();
 
-    auto allowedClassSet = adoptNS([NSMutableSet new]);
+    RetainPtr allowedClassSet = adoptNS([NSMutableSet new]);
     [allowedClassSet addObject:NSDictionary.class];
     [allowedClassSet addObject:NSString.class];
     [allowedClassSet addObject:NSClassFromString(@"WKSecureCodingCGColorWrapper")];
@@ -926,7 +926,7 @@ TEST(IPCTestingAPI, CGColorInNSSecureCoding)
 
 TEST(IPCTestingAPI, NSURLWithBaseURLInNSSecureCoding)
 {
-    auto archiver = adoptNS([[NSKeyedArchiver alloc] initRequiringSecureCoding:YES]);
+    RetainPtr archiver = adoptNS([[NSKeyedArchiver alloc] initRequiringSecureCoding:YES]);
 
     RetainPtr<id<NSKeyedArchiverDelegate, NSKeyedUnarchiverDelegate>> delegate = adoptNS([[NSClassFromString(@"WKSecureCodingArchivingDelegate") alloc] init]);
     archiver.get().delegate = delegate.get();
@@ -944,11 +944,11 @@ TEST(IPCTestingAPI, NSURLWithBaseURLInNSSecureCoding)
 
     auto data = [archiver encodedData];
 
-    auto unarchiver = adoptNS([[NSKeyedUnarchiver alloc] initForReadingFromData:data error:nullptr]);
+    RetainPtr unarchiver = adoptNS([[NSKeyedUnarchiver alloc] initForReadingFromData:data error:nullptr]);
     unarchiver.get().decodingFailurePolicy = NSDecodingFailurePolicyRaiseException;
     unarchiver.get().delegate = delegate.get();
 
-    auto allowedClassSet = adoptNS([NSMutableSet new]);
+    RetainPtr allowedClassSet = adoptNS([NSMutableSet new]);
     [allowedClassSet addObject:NSDictionary.class];
     [allowedClassSet addObject:NSString.class];
     [allowedClassSet addObject:NSClassFromString(@"WKSecureCodingURLWrapper")];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ImageAnalysisTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ImageAnalysisTests.mm
@@ -160,7 +160,7 @@ TEST(ImageAnalysisTests, DoNotAnalyzeImagesInEditableContent)
 {
     auto requestSwizzler = makeImageAnalysisRequestSwizzler(processRequestWithError);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
     [webView _setEditable:YES];
     [webView synchronouslyLoadTestPageNamed:@"image"];
     EXPECT_EQ([webView simulateImageAnalysisGesture:CGPointMake(100, 100)], 0U);
@@ -170,7 +170,7 @@ TEST(ImageAnalysisTests, HandleImageAnalyzerErrors)
 {
     auto requestSwizzler = makeImageAnalysisRequestSwizzler(processRequestWithError);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"image"];
 
     EXPECT_EQ([webView simulateImageAnalysisGesture:CGPointMake(100, 100)], 2U);
@@ -180,7 +180,7 @@ TEST(ImageAnalysisTests, DoNotCrashWhenHitTestingOutsideOfWebView)
 {
     auto requestSwizzler = makeImageAnalysisRequestSwizzler(processRequestWithError);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"image"];
 
     EXPECT_EQ([webView simulateImageAnalysisGesture:CGPointMake(500, 500)], 0U);
@@ -326,7 +326,7 @@ static RetainPtr<CGImageRef> iconImage()
 #if PLATFORM(IOS_FAMILY)
     return [UIImage imageWithContentsOfFile:iconPath].CGImage;
 #else
-    auto image = adoptNS([[NSImage alloc] initWithContentsOfFile:iconPath]);
+    RetainPtr image = adoptNS([[NSImage alloc] initWithContentsOfFile:iconPath]);
     return [image CGImageForProposedRect:nil context:nil hints:nil];
 #endif
 }
@@ -360,7 +360,7 @@ static void invokeRemoveBackgroundAction(TestWKWebView *webView)
 {
     simulateEditMenuAppearance(webView);
 
-    auto menuBuilder = adoptNS([[TestUIMenuBuilder alloc] init]);
+    RetainPtr menuBuilder = adoptNS([[TestUIMenuBuilder alloc] init]);
     [webView buildMenuWithBuilder:menuBuilder.get()];
     [[menuBuilder actionWithTitle:WebCore::contextMenuItemTitleRemoveBackground().createNSString().get()] performWithSender:nil target:nil];
     [webView waitForNextPresentationUpdate];
@@ -377,7 +377,7 @@ TEST(ImageAnalysisTests, RemoveBackgroundUsingContextMenu)
 
     EXPECT_TRUE(simulateEditContextMenuAppearance(webView.get(), CGPointMake(100, 100)));
 
-    auto menuBuilder = adoptNS([[TestUIMenuBuilder alloc] init]);
+    RetainPtr menuBuilder = adoptNS([[TestUIMenuBuilder alloc] init]);
     [webView buildMenuWithBuilder:menuBuilder.get()];
     EXPECT_NOT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTitleRemoveBackground().createNSString().get()]);
 }
@@ -387,7 +387,7 @@ TEST(ImageAnalysisTests, MenuControllerItems)
     RemoveBackgroundSwizzler swizzler { iconImage().autorelease(), CGRectMake(10, 10, 215, 174) };
 
     auto webView = createWebViewWithTextRecognitionEnhancements();
-    auto inputDelegate = adoptNS([TestInputDelegate new]);
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[](WKWebView *, id <_WKFocusedElementInfo>) {
         return _WKFocusStartsInputSessionPolicyAllow;
     }];
@@ -400,7 +400,7 @@ TEST(ImageAnalysisTests, MenuControllerItems)
     [webView waitForNextPresentationUpdate];
     simulateEditMenuAppearance(webView.get());
 
-    auto menuBuilder = adoptNS([[TestUIMenuBuilder alloc] init]);
+    RetainPtr menuBuilder = adoptNS([[TestUIMenuBuilder alloc] init]);
     [webView buildMenuWithBuilder:menuBuilder.get()];
     EXPECT_NOT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTitleRemoveBackground().createNSString().get()]);
 
@@ -426,7 +426,7 @@ static RetainPtr<TestWKWebView> runMarkupTest(NSString *testPage, NSString *scri
     RemoveBackgroundSwizzler swizzler { iconImage().autorelease(), CGRectMake(10, 10, 215, 174) };
 
     auto webView = createWebViewWithTextRecognitionEnhancements();
-    auto inputDelegate = adoptNS([TestInputDelegate new]);
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[](WKWebView *, id <_WKFocusedElementInfo>) {
         return _WKFocusStartsInputSessionPolicyAllow;
     }];
@@ -480,7 +480,7 @@ TEST(ImageAnalysisTests, AllowRemoveBackgroundOnce)
     [webView waitForNextPresentationUpdate];
     simulateEditMenuAppearance(webView.get());
 
-    auto menuBuilder = adoptNS([TestUIMenuBuilder new]);
+    RetainPtr menuBuilder = adoptNS([TestUIMenuBuilder new]);
     [webView buildMenuWithBuilder:menuBuilder.get()];
 
     EXPECT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTitleRemoveBackground().createNSString().get()]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/InAppBrowserPrivacy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/InAppBrowserPrivacy.mm
@@ -146,14 +146,14 @@ TEST(InAppBrowserPrivacy, NonAppBoundDomainFailedUserScriptAtStart)
 {
     isDone = false;
     initializeInAppBrowserPrivacyTestSettings();
-    auto userScript = adoptNS([[WKUserScript alloc] initWithSource:userScriptSource injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
+    RetainPtr userScript = adoptNS([[WKUserScript alloc] initWithSource:userScriptSource injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
 
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
     [configuration.userContentController addUserScript:userScript.get()];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"in-app-browser:///in-app-browser-privacy-test-user-script"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
@@ -186,14 +186,14 @@ TEST(InAppBrowserPrivacy, NonAppBoundDomainFailedUserScriptAtEnd)
 {
     isDone = false;
     initializeInAppBrowserPrivacyTestSettings();
-    auto userScript = adoptNS([[WKUserScript alloc] initWithSource:userScriptSource injectionTime:WKUserScriptInjectionTimeAtDocumentEnd forMainFrameOnly:YES]);
+    RetainPtr userScript = adoptNS([[WKUserScript alloc] initWithSource:userScriptSource injectionTime:WKUserScriptInjectionTimeAtDocumentEnd forMainFrameOnly:YES]);
     
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
     [configuration.userContentController addUserScript:userScript.get()];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"in-app-browser:///in-app-browser-privacy-test-user-script"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
@@ -230,10 +230,10 @@ TEST(InAppBrowserPrivacy, NonAppBoundDomainFailedUserAgentScripts)
     // Disable blocking of restricted APIs for test setup.
     [[configuration preferences] _setNeedsInAppBrowserPrivacyQuirks:YES];
 
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
     
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"in-app-browser:///in-app-browser-privacy-test-user-agent-script"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
@@ -249,7 +249,7 @@ TEST(InAppBrowserPrivacy, NonAppBoundDomainFailedUserAgentScripts)
     // Enable blocking of restricted APIs.
     [[configuration preferences] _setNeedsInAppBrowserPrivacyQuirks:NO];
 
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
     isDone = false;
     [webView2 loadRequest:request];
     [webView2 _test_waitForDidFinishNavigation];
@@ -309,9 +309,9 @@ TEST(InAppBrowserPrivacy, AppBoundSchemes)
 TEST(InAppBrowserPrivacy, LocalFilesAreAppBound)
 {
     initializeInAppBrowserPrivacyTestSettings();
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"in-app-browser-privacy-local-file" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
@@ -328,9 +328,9 @@ TEST(InAppBrowserPrivacy, LocalFilesAreAppBound)
 TEST(InAppBrowserPrivacy, DataProtocolIsAppBound)
 {
     initializeInAppBrowserPrivacyTestSettings();
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"data:text/html,start"]]];
     [webView _test_waitForDidFinishNavigation];
 
@@ -346,9 +346,9 @@ TEST(InAppBrowserPrivacy, DataProtocolIsAppBound)
 TEST(InAppBrowserPrivacy, AboutProtocolIsAppBound)
 {
     initializeInAppBrowserPrivacyTestSettings();
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
     [webView _test_waitForDidFinishNavigation];
 
@@ -366,12 +366,12 @@ TEST(InAppBrowserPrivacy, LocalHostIsAppBound)
     initializeInAppBrowserPrivacyTestSettings();
     isDone = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([AppBoundDomainDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([AppBoundDomainDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"in-app-browser://localhost/app-bound-domain-load"]];
@@ -392,12 +392,12 @@ TEST(InAppBrowserPrivacy, LoopbackIPAddressIsAppBound)
     initializeInAppBrowserPrivacyTestSettings();
     isDone = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([AppBoundDomainDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([AppBoundDomainDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"in-app-browser://127.0.0.1/app-bound-domain-load"]];
@@ -438,16 +438,16 @@ TEST(InAppBrowserPrivacy, NonAppBoundUserStyleSheetForSpecificWebViewFails)
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
     RetainPtr<WKContentWorld> world = [WKContentWorld worldWithName:@"TestWorld"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
     RetainPtr<_WKUserStyleSheet> styleSheet = adoptNS([[_WKUserStyleSheet alloc] initWithSource:styleSheetSource forWKWebView:webView.get() forMainFrameOnly:YES includeMatchPatternStrings:nil excludeMatchPatternStrings:nil baseURL:nil level:_WKUserStyleUserLevel contentWorld:world.get()]);
 
     [[configuration userContentController] _addUserStyleSheet:styleSheet.get()];
 
-    auto delegate = adoptNS([AppBoundDomainDelegate new]);
+    RetainPtr delegate = adoptNS([AppBoundDomainDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"in-app-browser:///in-app-browser-privacy-test-user-style-sheets"]];
@@ -463,14 +463,14 @@ TEST(InAppBrowserPrivacy, NonAppBoundUserStyleSheetForAllWebViewsFails)
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
     
     RetainPtr<_WKUserStyleSheet> styleSheet = adoptNS([[_WKUserStyleSheet alloc] initWithSource:styleSheetSource forMainFrameOnly:YES]);
     [[configuration userContentController] _addUserStyleSheet:styleSheet.get()];
     
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto delegate = adoptNS([AppBoundDomainDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([AppBoundDomainDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"in-app-browser:///in-app-browser-privacy-test-user-style-sheets"]];
@@ -486,13 +486,13 @@ TEST(InAppBrowserPrivacy, NonAppBoundUserStyleSheetAffectingAllFramesFails)
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
     RetainPtr<_WKUserStyleSheet> styleSheet = adoptNS([[_WKUserStyleSheet alloc] initWithSource:styleSheetSource forMainFrameOnly:NO]);
     [[configuration userContentController] _addUserStyleSheet:styleSheet.get()];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto delegate = adoptNS([AppBoundDomainDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([AppBoundDomainDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"in-app-browser:///in-app-browser-privacy-test-user-style-sheets-iframe"]];
@@ -509,10 +509,10 @@ TEST(InAppBrowserPrivacy, NonAppBoundDomainCannotAccessMessageHandlers)
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     [webView performAfterReceivingMessage:@"Failed" action:^() {
         FAIL();
@@ -539,11 +539,11 @@ TEST(InAppBrowserPrivacy, AppBoundDomainCanAccessMessageHandlers)
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
     [configuration setLimitsNavigationsToAppBoundDomains:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     [webView performAfterReceivingMessage:@"Passed" action:^() {
         isDone = true;
@@ -613,7 +613,7 @@ TEST(InAppBrowserPrivacy, SetCookieForNonAppBoundDomainFails)
     initializeInAppBrowserPrivacyTestSettings();
 
     auto dataStore = [WKWebsiteDataStore defaultDataStore];
-    auto webView = adoptNS([TestWKWebView new]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
     [webView loadHTMLString:@"Oh hello" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     [webView _test_waitForDidFinishNavigation];
 
@@ -705,7 +705,7 @@ TEST(InAppBrowserPrivacy, GetCookieForNonAppBoundDomainFails)
     }];
 
     gotFlag = false;
-    auto webView = adoptNS([TestWKWebView new]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
     [webView synchronouslyLoadHTMLString:@"start network process"];
 
     // This should successfully set a cookie because protections are off.
@@ -787,7 +787,7 @@ TEST(InAppBrowserPrivacy, GetCookieForURLFails)
     }];
 
     __block bool done = false;
-    auto webView = adoptNS([TestWKWebView new]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
     [webView synchronouslyLoadHTMLString:@"start network process"];
     [globalCookieStore setCookie:nonAppBoundCookie completionHandler:^{
         [globalCookieStore setCookie:appBoundCookie completionHandler:^{
@@ -914,14 +914,14 @@ static RetainPtr<WKWebView> setUpSWTest(WKWebsiteDataStore *dataStore)
 {
     isDone = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[SWInAppBrowserPrivacyMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWInAppBrowserPrivacyMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
     [configuration preferences]._serviceWorkerEntitlementDisabledForTesting = YES;
     [configuration setLimitsNavigationsToAppBoundDomains:YES];
     [configuration setWebsiteDataStore:dataStore];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
     // Start with a clean slate data store
@@ -1010,9 +1010,9 @@ TEST(InAppBrowserPrivacy, UnregisterServiceWorker)
 TEST(InAppBrowserPrivacy, UnregisterServiceWorkerMaxRegistrationCount)
 {
     initializeInAppBrowserPrivacyTestSettings();
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [websiteDataStoreConfiguration setOverrideServiceWorkerRegistrationCountTestingValue:1];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
     auto webView = setUpSWTest(dataStore.get());
 
     TestWebKitAPI::HTTPServer server({
@@ -1038,9 +1038,9 @@ TEST(InAppBrowserPrivacy, UnregisterServiceWorkerMaxRegistrationCount)
 TEST(InAppBrowserPrivacy, ReregisterServiceWorkerMaxRegistrationCount)
 {
     initializeInAppBrowserPrivacyTestSettings();
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [websiteDataStoreConfiguration setOverrideServiceWorkerRegistrationCountTestingValue:1];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
     auto webView = setUpSWTest(dataStore.get());
 
     TestWebKitAPI::HTTPServer server({
@@ -1069,13 +1069,13 @@ TEST(InAppBrowserPrivacy, NonAppBoundDomainDoesNotAllowServiceWorkers)
     initializeInAppBrowserPrivacyTestSettings();
     isDone = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
     // Disable entitlement which allows service workers.
     [configuration preferences]._serviceWorkerEntitlementDisabledForTesting = YES;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     // Load a non-app bound domain.
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"in-app-browser:///in-app-browser-privacy-test-user-style-sheets"]];
@@ -1104,13 +1104,13 @@ TEST(InAppBrowserPrivacy, AppBoundFlagForNonAppBoundDomainFails)
     initializeInAppBrowserPrivacyTestSettings();
     isDone = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
     [configuration setLimitsNavigationsToAppBoundDomains:YES];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([AppBoundDomainDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([AppBoundDomainDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     // Load a non-app bound domain.
@@ -1130,13 +1130,13 @@ TEST(InAppBrowserPrivacy, NavigateAwayFromAppBoundDomainWithAppBoundFlagFails)
     initializeInAppBrowserPrivacyTestSettings();
     isDone = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
     [configuration setLimitsNavigationsToAppBoundDomains:YES];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([AppBoundDomainDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([AppBoundDomainDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     
     // Navigate to an app-bound domain and expect a successful load.
@@ -1161,12 +1161,12 @@ TEST(InAppBrowserPrivacy, AppBoundDomainWithoutFlagTreatedAsNonAppBound)
     initializeInAppBrowserPrivacyTestSettings();
     isDone = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([AppBoundDomainDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([AppBoundDomainDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     
     // Navigate to an app-bound domain and expect a successful load.
@@ -1190,12 +1190,12 @@ TEST(InAppBrowserPrivacy, WebViewWithoutAppBoundFlagCanFreelyNavigate)
     initializeInAppBrowserPrivacyTestSettings();
     isDone = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([AppBoundDomainDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([AppBoundDomainDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     
     // Navigate to an app-bound domain and expect a successful load.
@@ -1240,13 +1240,13 @@ TEST(InAppBrowserPrivacy, WebViewCannotUpdateAppBoundFlagOnceSet)
     initializeInAppBrowserPrivacyTestSettings();
     isDone = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
     [configuration setLimitsNavigationsToAppBoundDomains:YES];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([AppBoundDomainDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([AppBoundDomainDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     
     // Navigate to an app-bound domain and expect a successful load.
@@ -1275,16 +1275,16 @@ TEST(InAppBrowserPrivacy, InjectScriptThenNavigateToNonAppBoundDomainFails)
 {
     isDone = false;
     initializeInAppBrowserPrivacyTestSettings();
-    auto userScript = adoptNS([[WKUserScript alloc] initWithSource:userScriptSource injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
+    RetainPtr userScript = adoptNS([[WKUserScript alloc] initWithSource:userScriptSource injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
 
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
     [configuration.userContentController addUserScript:userScript.get()];
     [[configuration preferences] _setNeedsInAppBrowserPrivacyQuirks:NO];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
-    auto delegate = adoptNS([AppBoundDomainDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr delegate = adoptNS([AppBoundDomainDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     isDone = false;
@@ -1308,17 +1308,17 @@ TEST(InAppBrowserPrivacy, InjectScriptInNonAppBoundSubframeAppBoundMainframeFail
     isDone = false;
     initializeInAppBrowserPrivacyTestSettings();
 
-    auto userScript = adoptNS([[WKUserScript alloc] initWithSource:@"var img = document.createElement('img'); img.src = 'in-app-browser:///should-load-for-main-frame-only'; document.getElementById('body').appendChild(img);" injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:NO]);
+    RetainPtr userScript = adoptNS([[WKUserScript alloc] initWithSource:@"var img = document.createElement('img'); img.src = 'in-app-browser:///should-load-for-main-frame-only'; document.getElementById('body').appendChild(img);" injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:NO]);
 
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
     [[configuration preferences] _setNeedsInAppBrowserPrivacyQuirks:NO];
     [configuration setLimitsNavigationsToAppBoundDomains:YES];
     [[configuration userContentController] addUserScript:userScript.get()];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
-    auto delegate = adoptNS([AppBoundDomainDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr delegate = adoptNS([AppBoundDomainDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     // Load an app-bound domain with an iframe that is not app-bound.
@@ -1340,17 +1340,17 @@ TEST(InAppBrowserPrivacy, JavaScriptInNonAppBoundFrameFails)
     isDone = false;
     initializeInAppBrowserPrivacyTestSettings();
 
-    auto userScript = adoptNS([[WKUserScript alloc] initWithSource:@"var img = document.createElement('img'); img.src = 'in-app-browser:///should-load-for-main-frame-only'; document.getElementById('body').appendChild(img);" injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:NO]);
+    RetainPtr userScript = adoptNS([[WKUserScript alloc] initWithSource:@"var img = document.createElement('img'); img.src = 'in-app-browser:///should-load-for-main-frame-only'; document.getElementById('body').appendChild(img);" injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:NO]);
 
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
     [[configuration preferences] _setNeedsInAppBrowserPrivacyQuirks:NO];
     [configuration setLimitsNavigationsToAppBoundDomains:YES];
     [[configuration userContentController] addUserScript:userScript.get()];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
 
     __block bool didFinishNavigation = false;
     [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
@@ -1418,14 +1418,14 @@ TEST(InAppBrowserPrivacy, LoadFromHTMLStringsSucceedsIfAppBound)
     initializeInAppBrowserPrivacyTestSettings();
     isDone = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
 
-    auto delegate = adoptNS([AppBoundDomainDelegate new]);
+    RetainPtr delegate = adoptNS([AppBoundDomainDelegate new]);
 
     NSString *HTML = @"<html><head></head><body><img src='in-app-browser:///in-app-browser-privacy-test-user-style-sheets/'></img></body></html>";
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:delegate.get()];
 
     [webView loadHTMLString:HTML baseURL:[NSURL URLWithString:@"in-app-browser://apple.com/"]];
@@ -1439,14 +1439,14 @@ TEST(InAppBrowserPrivacy, LoadFromHTMLStringNoBaseURLIsAppBound)
     initializeInAppBrowserPrivacyTestSettings();
     isDone = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
 
-    auto delegate = adoptNS([AppBoundDomainDelegate new]);
+    RetainPtr delegate = adoptNS([AppBoundDomainDelegate new]);
 
     NSString *HTML = @"<html><head></head><body><img src='in-app-browser:///in-app-browser-privacy-test-user-style-sheets/'></img></body></html>";
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:delegate.get()];
 
     [webView loadHTMLString:HTML baseURL:nil];
@@ -1466,14 +1466,14 @@ TEST(InAppBrowserPrivacy, LoadFromHTMLStringsFailsIfNotAppBound)
     initializeInAppBrowserPrivacyTestSettings();
     isDone = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
 
-    auto delegate = adoptNS([AppBoundDomainDelegate new]);
+    RetainPtr delegate = adoptNS([AppBoundDomainDelegate new]);
 
     NSString *HTML = @"<html><head></head><body><img src='in-app-browser:///in-app-browser-privacy-test-user-style-sheets/'></img></body></html>";
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:delegate.get()];
 
     [webView loadHTMLString:HTML baseURL:[NSURL URLWithString:@"in-app-browser:///in-app-browser-privacy-test-user-agent-script"]];
@@ -1494,19 +1494,19 @@ TEST(InAppBrowserPrivacy, AppBoundCustomScheme)
     initializeInAppBrowserPrivacyTestSettings();
     isDone = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"test"];
     [configuration setLimitsNavigationsToAppBoundDomains:YES];
 
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[NSData dataWithBytes:mainBytes length:strlen(mainBytes)]];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"test://host/main.html"]];
 
@@ -1536,7 +1536,7 @@ TEST(InAppBrowserPrivacy, AppBoundCustomScheme)
 
 static void loadRequest(RetainPtr<TestWKWebView> webView, NSString *url)
 {
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
 
     __block bool didFinishNavigation = false;
     [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
@@ -1565,11 +1565,11 @@ TEST(InAppBrowserPrivacy, AboutBlankSubFrameMatchesTopFrameAppBound)
     initializeInAppBrowserPrivacyTestSettings();
 
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
     [configuration setLimitsNavigationsToAppBoundDomains:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
     NSString *url = @"in-app-browser://apple.com/in-app-browser-privacy-test-about-blank-subframe";
     loadRequest(webView, url);
     
@@ -1604,10 +1604,10 @@ TEST(InAppBrowserPrivacy, AboutBlankSubFrameMatchesTopFrameNonAppBound)
     initializeInAppBrowserPrivacyTestSettings();
 
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[InAppBrowserSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"in-app-browser"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
     NSString *url = @"in-app-browser://apple.com/in-app-browser-privacy-test-about-blank-subframe";
     loadRequest(webView, url);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBDatabaseProcessKill.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBDatabaseProcessKill.mm
@@ -79,8 +79,8 @@ static bool databaseErrorReceived;
 
 TEST(IndexedDB, DatabaseProcessKill)
 {
-    auto handler = adoptNS([[DatabaseProcessKillMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[DatabaseProcessKillMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
@@ -114,8 +114,8 @@ TEST(IndexedDB, OneVMPerThread)
     configuration.get().websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
 
     
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
-    auto secondWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr secondWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     
     NSString *htmlString = @"<script> \
         function openDatabase() { \

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBFileName.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBFileName.mm
@@ -49,16 +49,16 @@
 
 static void runTest()
 {
-    auto handler = adoptNS([[IndexedDBFileNameMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[IndexedDBFileNameMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     // We need to create custom WebsiteDataStore that uses custom IndexedDB paths to test old migration code.
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelNone;
     // Custom WebsiteDataStore must have a different general storage directory than default WebsiteDataStore.
     websiteDataStoreConfiguration.get().generalStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/Default" stringByExpandingTildeInPath] isDirectory:YES];
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     
     // Open a database which does not have a database file on disk yet.
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBFileName-1" withExtension:@"html"]];
@@ -110,7 +110,7 @@ static void runTest()
 static void createDirectories(StringView testName)
 {
     auto defaultFileManager = [NSFileManager defaultManager];
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     RetainPtr idbRootURL = [websiteDataStoreConfiguration _indexedDBDatabaseDirectory];
     NSError *error = nil;
     [defaultFileManager removeItemAtURL:idbRootURL.get() error:&error];
@@ -219,11 +219,11 @@ TEST(IndexedDB, IndexedDBFileNameAPI)
 {
     createDirectories("API"_s);
     
-    auto types = adoptNS([[NSSet alloc] initWithObjects:WKWebsiteDataTypeIndexedDBDatabases, nil]);
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr types = adoptNS([[NSSet alloc] initWithObjects:WKWebsiteDataTypeIndexedDBDatabases, nil]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelNone;
     websiteDataStoreConfiguration.get().generalStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/Default" stringByExpandingTildeInPath] isDirectory:YES];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
 
     [dataStore fetchDataRecordsOfTypes:types.get() completionHandler:^(NSArray<WKWebsiteDataRecord *> * records) {
         EXPECT_EQ(3U, [records count]);
@@ -253,7 +253,7 @@ TEST(IndexedDB, IndexedDBFileHashCollision)
 {
     createDirectories("collision"_s);
     
-    auto handler = adoptNS([[IndexedDBFileNameMessageHandler alloc] init]);
+    RetainPtr handler = adoptNS([[IndexedDBFileNameMessageHandler alloc] init]);
     RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelNone;
     websiteDataStoreConfiguration.get().generalStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/Default" stringByExpandingTildeInPath] isDirectory:YES];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBInPageCache.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBInPageCache.mm
@@ -54,11 +54,11 @@
 
 TEST(IndexedDB, IndexedDBInPageCache)
 {
-    auto handler = adoptNS([[IndexedDBInPageCacheMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[IndexedDBInPageCacheMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     // Load page that holds open database connection.
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBInPageCache" withExtension:@"html"]];
     [webView loadRequest:request];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBPersistence.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBPersistence.mm
@@ -121,7 +121,7 @@ TEST(IndexedDB, IndexedDBPersistencePrivate)
     auto ephemeralStore = [WKWebsiteDataStore nonPersistentDataStore];
     configuration.get().websiteDataStore = ephemeralStore;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBPersistence-1" withExtension:@"html"]];
     [webView loadRequest:request];
@@ -150,7 +150,7 @@ TEST(IndexedDB, IndexedDBPersistencePrivate)
 
 TEST(IndexedDB, IndexedDBDataRemoval)
 {
-    auto websiteDataTypes = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeIndexedDBDatabases]]);
+    RetainPtr websiteDataTypes = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeIndexedDBDatabases]]);
 
     readyToContinue = false;
     [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:websiteDataTypes.get() modifiedSince:[NSDate distantPast] completionHandler:^() {
@@ -166,10 +166,10 @@ TEST(IndexedDB, IndexedDBDataRemoval)
     TestWebKitAPI::Util::run(&readyToContinue);
 
     receivedScriptMessage = false;
-    auto handler = adoptNS([[IndexedDBMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[IndexedDBMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBPersistence-1" withExtension:@"html"]];
     [webView loadRequest:request];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
@@ -255,22 +255,22 @@ static void loadThirdPartyPageInWebView(WKWebView *webView, NSString *expectedRe
 
 TEST(IndexedDB, IndexedDBThirdPartyFrameHasAccess)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([[IndexedDBMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[IndexedDBMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[NSData dataWithBytes:iframeBytesPersistence length:strlen(iframeBytesPersistence)]];
         [task didFinish];
     }];
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"iframe"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     loadThirdPartyPageInWebView(webView.get(), @"database is created - put item success");
 
-    auto secondWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr secondWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     loadThirdPartyPageInWebView(secondWebView.get(), @"database exists - get item success: TestValue");
 
     webView = nil;
@@ -278,13 +278,13 @@ TEST(IndexedDB, IndexedDBThirdPartyFrameHasAccess)
     [configuration.get().websiteDataStore _terminateNetworkProcess];
 
     // Third-party IDB storage is stored in the memory of network process.
-    auto thirdWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr thirdWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     loadThirdPartyPageInWebView(thirdWebView.get(), @"database is created - put item success");
 }
 
 TEST(IndexedDB, IndexedDBThirdPartyDataRemoval)
 {
-    auto websiteDataTypes = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeIndexedDBDatabases]]);
+    RetainPtr websiteDataTypes = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeIndexedDBDatabases]]);
     readyToContinue = false;
     [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:websiteDataTypes.get() modifiedSince:[NSDate distantPast] completionHandler:^() {
         readyToContinue = true;
@@ -293,22 +293,22 @@ TEST(IndexedDB, IndexedDBThirdPartyDataRemoval)
 
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([[IndexedDBMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[IndexedDBMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[NSData dataWithBytes:iframeBytesPersistence length:strlen(iframeBytesPersistence)]];
         [task didFinish];
     }];
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"iframe"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     loadThirdPartyPageInWebView(webView.get(), @"database is created - put item success");
 
-    auto secondWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr secondWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [secondWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"iframe://"]]];
     EXPECT_WK_STREQ( @"database is created - put item success", (NSString *)[getNextMessage() body]);
 
@@ -326,7 +326,7 @@ TEST(IndexedDB, IndexedDBThirdPartyDataRemoval)
     }];
     TestWebKitAPI::Util::run(&readyToContinue);
 
-    auto thirdWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr thirdWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     loadThirdPartyPageInWebView(thirdWebView.get(), @"database is created - put item success");
 }
 
@@ -404,25 +404,25 @@ TEST(IndexedDB, MigrateThirdPartyDataToGeneralStorageDirectory)
     [fileManager createDirectoryAtURL:oldWebkitIframeDatabaseDirectory withIntermediateDirectories:YES attributes:nil error:nil];
     [fileManager copyItemAtURL:resourceDatabase toURL:oldWebkitIframeDatabaseFile error:nil];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([[IndexedDBMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[IndexedDBMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[NSData dataWithBytes:iframeBytesPersistence length:strlen(iframeBytesPersistence)]];
         [task didFinish];
     }];
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"iframe"];
     [[configuration preferences] _setStorageBlockingPolicy:_WKStorageBlockingPolicyAllowAll];
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get()._indexedDBDatabaseDirectory = idbDirectory;
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelBasic;
-    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
     [configuration setWebsiteDataStore:websiteDataStore.get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     // Ensure opening first-party database does not migrate third-party data.
     NSString *firstPartyHTMLString = @"<script> \
@@ -479,10 +479,10 @@ static const char* workerFrameBytes = R"TESTRESOURCE(
 
 TEST(IndexedDB, IndexedDBThirdPartyWorkerHasAccess)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([[IndexedDBMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[IndexedDBMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         RetainPtr<NSURLResponse> response;
         RetainPtr<NSData> data;
@@ -501,17 +501,17 @@ TEST(IndexedDB, IndexedDBThirdPartyWorkerHasAccess)
     }];
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"iframe"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     loadThirdPartyPageInWebView(webView.get(), @"database is created");
 
-    auto secondWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr secondWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     loadThirdPartyPageInWebView(webView.get(), @"database exists");
 
     webView = nil;
     secondWebView = nil;
     [configuration.get().websiteDataStore _terminateNetworkProcess];
 
-    auto thirdWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr thirdWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     loadThirdPartyPageInWebView(thirdWebView.get(), @"database is created");
 }
 
@@ -708,7 +708,7 @@ TEST(IndexedDB, GetFileByIndex)
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
-    auto uiDelegate = adoptNS([[IndexedDBOpenPanelUIDelegate alloc] init]);
+    RetainPtr uiDelegate = adoptNS([[IndexedDBOpenPanelUIDelegate alloc] init]);
     [webView setUIDelegate:uiDelegate.get()];
     [webView loadHTMLString:openFileHTMLString baseURL:[NSURL URLWithString:@"https://webkit.org"]];
     EXPECT_WK_STREQ(@"Opened", [getNextMessage() body]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBStructuredCloneBackwardCompatibility.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBStructuredCloneBackwardCompatibility.mm
@@ -91,7 +91,7 @@ TEST(IndexedDB, StructuredCloneBackwardCompatibility)
 
     // Run the test
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([[StructuredCloneBackwardCompatibilityNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[StructuredCloneBackwardCompatibilityNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBStructuredCloneBackwardCompatibilityRead" withExtension:@"html"]];
     [webView loadRequest:request];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBSuspendImminently.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBSuspendImminently.mm
@@ -55,10 +55,10 @@ TEST(IndexedDB, IndexedDBSuspendImminently)
     }];
     TestWebKitAPI::Util::run(&readyToContinue);
 
-    auto handler = adoptNS([TestScriptMessageHandler new]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([TestScriptMessageHandler new]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBSuspendImminently" withExtension:@"html"]];
     [webView loadRequest:request];
     EXPECT_WK_STREQ([handler waitForMessage].body, @"Continue");
@@ -131,19 +131,19 @@ TEST(IndexedDB, SuspendImminentlyForThirdPartyDatabases)
     </script>
     )TESTRESOURCE";
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([TestScriptMessageHandler new]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([TestScriptMessageHandler new]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[NSData dataWithBytes:iframeBytes length:strlen(iframeBytes)]];
         [task didFinish];
     }];
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"iframe"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadHTMLString:mainFrameString baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     EXPECT_WK_STREQ([handler waitForMessage].body, @"database is created");
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBUserDelete.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBUserDelete.mm
@@ -53,11 +53,11 @@
 
 TEST(IndexedDB, IndexedDBUserDelete)
 {
-    auto handler = adoptNS([[IndexedDBUserDeleteMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[IndexedDBUserDeleteMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBUserDelete" withExtension:@"html"]];
     [webView loadRequest:request];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/InitializeWebViewWhenChangingUserDefaults.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/InitializeWebViewWhenChangingUserDefaults.mm
@@ -53,8 +53,8 @@ namespace TestWebKitAPI {
 
 TEST(WebKit2, NoCrashWhenInitializeWebViewWhenChangingUserDefaults)
 {
-    auto observer = adoptNS([UserDefaultChangeObserver new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr observer = adoptNS([UserDefaultChangeObserver new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/InjectedBundleHitTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/InjectedBundleHitTest.mm
@@ -61,7 +61,7 @@ namespace TestWebKitAPI {
 static RetainPtr<WKWebViewWithHitTester> createWebViewWithHitTester()
 {
     auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"InjectedBundleHitTestPlugIn" configureJSCForTesting:YES];
-    auto webView = adoptNS([[WKWebViewWithHitTester alloc] initWithFrame:CGRectMake(0, 0, 500, 500) configuration:configuration]);
+    RetainPtr webView = adoptNS([[WKWebViewWithHitTester alloc] initWithFrame:CGRectMake(0, 0, 500, 500) configuration:configuration]);
 
     auto interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(InjectedBundleHitTestProtocol)];
     [webView setHitTester:[[webView _remoteObjectRegistry] remoteObjectProxyWithInterface:interface]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/InsertTextAlternatives.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/InsertTextAlternatives.mm
@@ -40,8 +40,8 @@ namespace TestWebKitAPI {
 TEST(InsertTextAlternatives, Simple)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
@@ -73,8 +73,8 @@ TEST(InsertTextAlternatives, Simple)
 TEST(InsertTextAlternatives, InsertLeadingSpace)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
@@ -95,8 +95,8 @@ TEST(InsertTextAlternatives, InsertLeadingSpace)
 TEST(InsertTextAlternatives, InsertLeadingNewline)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
@@ -124,8 +124,8 @@ static inline NSString *makeNSStringWithCharacter(unichar c)
 TEST(InsertTextAlternatives, InsertLeadingNoBreakSpace_ExpectedFailure)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
@@ -148,8 +148,8 @@ TEST(InsertTextAlternatives, InsertLeadingNoBreakSpace_ExpectedFailure)
 TEST(InsertTextAlternatives, InsertTrailingSpace)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
@@ -168,8 +168,8 @@ TEST(InsertTextAlternatives, InsertTrailingSpace)
 TEST(InsertTextAlternatives, InsertTrailingSpaceWhitespaceRebalance)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
@@ -185,8 +185,8 @@ TEST(InsertTextAlternatives, InsertTrailingSpaceWhitespaceRebalance)
 TEST(InsertTextAlternatives, InsertTrailingNewline)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
@@ -208,8 +208,8 @@ TEST(InsertTextAlternatives, InsertTrailingNewline)
 TEST(InsertTextAlternatives, InsertTrailingNoBreakSpace_ExpectedFailure)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
@@ -229,8 +229,8 @@ TEST(InsertTextAlternatives, InsertTrailingNoBreakSpace_ExpectedFailure)
 TEST(InsertTextAlternatives, InsertSpaceInMiddle)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
@@ -252,8 +252,8 @@ TEST(InsertTextAlternatives, InsertSpaceInMiddle)
 TEST(InsertTextAlternatives, InsertNewlineInMiddle_ExpectedFailure)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
@@ -279,8 +279,8 @@ TEST(InsertTextAlternatives, InsertNewlineInMiddle_ExpectedFailure)
 TEST(InsertTextAlternatives, InsertNoBreakSpaceInMiddle)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
@@ -304,8 +304,8 @@ TEST(InsertTextAlternatives, InsertNoBreakSpaceInMiddle)
 TEST(InsertTextAlternatives, InsertLeadingNonWhitespaceCharacter)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
@@ -326,8 +326,8 @@ TEST(InsertTextAlternatives, InsertLeadingNonWhitespaceCharacter)
 TEST(InsertTextAlternatives, InsertTrailingNonWhitespaceCharacter)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
@@ -345,8 +345,8 @@ TEST(InsertTextAlternatives, InsertTrailingNonWhitespaceCharacter)
 TEST(InsertTextAlternatives, InsertNonWhitespaceCharacterInMiddle)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
@@ -368,8 +368,8 @@ TEST(InsertTextAlternatives, InsertNonWhitespaceCharacterInMiddle)
 TEST(InsertTextAlternatives, InsertMultipleWordsWithAlternatives)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/JITEnabled.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/JITEnabled.mm
@@ -46,11 +46,11 @@ TEST(WebKit, JITEnabled)
         TestWebKitAPI::Util::run(&done);
     };
 
-    auto processPoolConfiguration = adoptNS([_WKProcessPoolConfiguration new]);
+    RetainPtr processPoolConfiguration = adoptNS([_WKProcessPoolConfiguration new]);
     [processPoolConfiguration setJITEnabled:NO];
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setProcessPool:adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]).get()];
-    auto webViewNoJIT = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webViewNoJIT = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     checkJITEnabled(WTF::move(webViewNoJIT), NO);
     checkJITEnabled(adoptNS([WKWebView new]), YES);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/JavaScriptDuringNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/JavaScriptDuringNavigation.mm
@@ -81,8 +81,8 @@ TEST(WebKit, JavaScriptDuringNavigation)
     firstURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     secondURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     
-    auto webView = adoptNS([[WKWebView alloc] init]);
-    auto delegate = adoptNS([[JSNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr delegate = adoptNS([[JSNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LegacyPDFPluginTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LegacyPDFPluginTests.mm
@@ -69,7 +69,7 @@ TEST(LegacyPDF, PrintSize)
             mimeType = @"application/pdf";
             data = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"test_print" withExtension:@"pdf"]];
         }
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:url MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:url MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data];
         [task didFinish];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadAlternateHTMLString.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadAlternateHTMLString.mm
@@ -68,8 +68,8 @@ static NSString *loadableURL = @"data:text/html,no%20error";
 
 TEST(WKWebView, LoadAlternateHTMLStringFromProvisionalLoadError)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
-    auto controller = adoptNS([[LoadAlternateHTMLStringFromProvisionalLoadErrorController alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr controller = adoptNS([[LoadAlternateHTMLStringFromProvisionalLoadErrorController alloc] init]);
     [webView setNavigationDelegate:controller.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:unloadableURL]]];
@@ -126,14 +126,14 @@ TEST(WKWebView, LoadAlternateHTMLStringFromProvisionalLoadErrorBackToBack)
 
 TEST(WKWebView, LoadAlternateHTMLStringNoFileSystemPath)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
     [webView loadHTMLString:@"<html>hi</html>" baseURL:[NSURL URLWithString:@"file:///.file/id="]];
 }
 
 TEST(WKWebView, LoadNilAlternateHTMLStringDoesNotCrash)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
-    auto controller = adoptNS([LoadAlternateHTMLStringFromProvisionalLoadErrorController new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr controller = adoptNS([LoadAlternateHTMLStringFromProvisionalLoadErrorController new]);
     [webView setNavigationDelegate:controller.get()];
 
     IGNORE_NULL_CHECK_WARNINGS_BEGIN
@@ -145,8 +145,8 @@ TEST(WKWebView, LoadNilAlternateHTMLStringDoesNotCrash)
 
 TEST(WKWebView, LoadAlternateHTMLStringFromProvisionalLoadErrorReload)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    auto controller = adoptNS([[LoadAlternateHTMLStringFromProvisionalLoadErrorController alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr controller = adoptNS([[LoadAlternateHTMLStringFromProvisionalLoadErrorController alloc] init]);
     [webView setNavigationDelegate:controller.get()];
 
     NSURL *invalidURL = [NSURL URLWithString:@"https://www.example.com%3C%3E/"];
@@ -180,8 +180,8 @@ TEST(WKWebView, LoadHTMLStringOrigin)
             done = true;
         });
     });
-    auto webView = adoptNS([WKWebView new]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *, void (^completionHandler)(WKNavigationActionPolicy)) {
         completionHandler(WKNavigationActionPolicyAllow);
     };
@@ -193,9 +193,9 @@ TEST(WKWebView, LoadHTMLStringOrigin)
 
 TEST(WebKit, LoadHTMLStringWithInvalidBaseURL)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect]);
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     __block bool didCrash = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadAndDecodeImage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadAndDecodeImage.mm
@@ -72,7 +72,7 @@ TEST(WebKit, LoadAndDecodeImage)
         { "/redirect"_s, { 302, { { "Location"_s, "/test_png"_s } }, "redirecting..."_s } },
         { "/not_image"_s, { "this is not an image"_s } }
     };
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
 
     auto imageOrError = [&] (auto requestPath, CGSize size = CGSizeZero) -> Expected<RetainPtr<Util::PlatformImage>, RetainPtr<NSError>> {
         __block RetainPtr<Util::PlatformImage> image;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadDataWithNilMIMEType.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadDataWithNilMIMEType.mm
@@ -31,7 +31,7 @@
 
 TEST(WebKit, LoadDataWithNilMIMEType)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect]);
     NSString *mimeType = nil;
     [webView loadData:[@"test" dataUsingEncoding:NSUTF8StringEncoding] MIMEType:mimeType characterEncodingName:@"UTF-8" baseURL:[NSURL URLWithString:@"about:blank"]];
     [webView _test_waitForDidFinishNavigation];
@@ -39,7 +39,7 @@ TEST(WebKit, LoadDataWithNilMIMEType)
 
 TEST(WebKit, LoadHTMLStringWithFragmentInBaseURL)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect]);
 
     [webView loadHTMLString:@"<body>first</body>" baseURL:[NSURL URLWithString:@"http://example.test/#test"]];
     [webView _test_waitForDidFinishNavigation];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadFileThenReload.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadFileThenReload.mm
@@ -55,9 +55,9 @@
 
 TEST(WKWebView, LoadFileThenReload)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto delegate = adoptNS([[LoadFileThenReloadDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[LoadFileThenReloadDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURL *file = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadFileURL.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadFileURL.mm
@@ -36,9 +36,9 @@
 
 TEST(WKWebView, LoadFileWithLoadRequest)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
@@ -48,9 +48,9 @@ TEST(WKWebView, LoadFileWithLoadRequest)
 
 TEST(WKWebView, LoadTwoFiles)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURL *file = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
@@ -82,9 +82,9 @@ TEST(WKWebView, LoadTwoFiles)
 
 TEST(WKWebView, LoadRelativeFileURL)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     
-    auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     
     NSString *path = [NSBundle.test_resourcesBundle pathForResource:@"simple" ofType:@"html"];
@@ -97,16 +97,16 @@ TEST(WKWebView, LoadRelativeFileURL)
 
 TEST(WKWebView, RepeatLoadFileURL)
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().processSwapsOnNavigation = NO;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
-    auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     
     NSString *path = [NSBundle.test_resourcesBundle pathForResource:@"simple" ofType:@"html"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadInvalidURLRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadInvalidURLRequest.mm
@@ -106,7 +106,7 @@ TEST(WebKit, LoadInvalidURLRequest)
 TEST(WebKit, LoadInvalidURLRequestNonASCII)
 {
     __block bool done = false;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().webContentProcessDidTerminate = ^(WKWebView *, _WKProcessTerminationReason) {
         ASSERT_NOT_REACHED();
     };
@@ -116,7 +116,7 @@ TEST(WebKit, LoadInvalidURLRequestNonASCII)
         EXPECT_WK_STREQ([error.userInfo[NSURLErrorFailingURLErrorKey] absoluteString], "");
         done = true;
     };
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
     const UInt8 bytes[10] = { 'h', 't', 't', 'p', ':', '/', '/', 0xE2, 0x80, 0x80 };
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:bridge_cast(adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, bytes, 10, kCFStringEncodingUTF8, nullptr, true))).get()];
@@ -127,14 +127,14 @@ TEST(WebKit, LoadInvalidURLRequestNonASCII)
 
 TEST(WebKit, LoadNSURLRequestSubclass)
 {
-    auto request = adoptNS([[TestURLRequest alloc] initWithURL:[NSURL URLWithString:@"test:///"]]);
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr request = adoptNS([[TestURLRequest alloc] initWithURL:[NSURL URLWithString:@"test:///"]]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     handler.get().startURLSchemeTaskHandler = ^(WKWebView *, id<WKURLSchemeTask> task) {
         respond(task, "hi");
     };
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"test"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
     [webView loadRequest:request.get()];
     [webView _test_waitForDidFinishNavigation];
 }
@@ -146,16 +146,16 @@ TEST(WebKit, LoadNSURLRequestWithMutablePropertiesAndKeys)
     [NSURLProtocol setProperty:[NSMutableArray array] forKey:@"key1" inRequest:request];
     [NSURLProtocol setProperty:[NSMutableDictionary dictionary] forKey:@"key2" inRequest:request];
     [NSURLProtocol setProperty:[NSMutableString string] forKey:@"key3" inRequest:request];
-    auto webView = adoptNS([WKWebView new]);
-    auto response = adoptNS([[NSURLResponse alloc] initWithURL:request.URL MIMEType:nil expectedContentLength:0 textEncodingName:nil]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:request.URL MIMEType:nil expectedContentLength:0 textEncodingName:nil]);
     [webView loadSimulatedRequest:request response:response.get() responseData:[NSData data]];
     [webView _test_waitForDidFinishNavigation];
 }
 
 TEST(WebKit, NavigateToInvalidURL)
 {
-    auto webView = adoptNS([WKWebView new]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     webView.get().navigationDelegate = delegate.get();
     __block bool finished { false };
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^decisionHandler)(WKNavigationActionPolicy)) {
@@ -172,14 +172,14 @@ TEST(WebKit, NavigateToInvalidURL)
 TEST(WebKit, LoadInvalidURLWithSpaceCharacter)
 {
     __block bool done = false;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().didFailProvisionalNavigation = ^(WKWebView *, WKNavigation *, NSError *error) {
         EXPECT_WK_STREQ(error.domain, @"WebKitErrorDomain");
         EXPECT_EQ(error.code, WebKitErrorCannotShowURL);
         EXPECT_WK_STREQ([error.userInfo[NSURLErrorFailingURLErrorKey] absoluteString], "");
         done = true;
     };
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://%20.example.com/"]]];
     Util::run(&done);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Loading.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Loading.mm
@@ -68,11 +68,11 @@ TEST(WebKit, LoadRequestWithSecPurposePrefetch)
         { "/"_s, { main } },
     }, HTTPServer::Protocol::Http);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[LoadingMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[LoadingMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"loading"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
 
     [messageHandler setMessageHandler:[](WKScriptMessage *message) {
         EXPECT_WK_STREQ(@"PASS", [message body]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LocalStorageDatabaseTracker.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LocalStorageDatabaseTracker.mm
@@ -64,9 +64,9 @@ TEST(WKWebView, LocalStorageFetchDataRecords)
     TestWebKitAPI::Util::run(&readyToContinue);
 
     readyToContinue = false;
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto uiDelegate = adoptNS([[LocalStorageUIDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr uiDelegate = adoptNS([[LocalStorageUIDelegate alloc] init]);
     webView.get().UIDelegate = uiDelegate.get();
     [uiDelegate.get() setExpectedMessage:@"testValue"];
     [webView loadHTMLString:@"<script>localStorage.setItem('testKey', 'testValue');alert(localStorage.getItem('testKey'));</script>" baseURL:[NSURL URLWithString:@"http://localhost"]];
@@ -91,9 +91,9 @@ TEST(WKWebView, LocalStorageNoRecordAfterGetItem)
     }];
     TestWebKitAPI::Util::run(&readyToContinue);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto uiDelegate = adoptNS([[LocalStorageUIDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr uiDelegate = adoptNS([[LocalStorageUIDelegate alloc] init]);
     webView.get().UIDelegate = uiDelegate.get();
     readyToContinue = false;
     [uiDelegate.get() setExpectedMessage:@"null"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LocalStoragePersistence.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LocalStoragePersistence.mm
@@ -244,13 +244,13 @@ TEST(WKWebView, LocalStorageEmptyString)
 
 TEST(WKWebView, LocalStorageOpenWindowPrivate)
 {
-    auto handler = adoptNS([[LocalStorageMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[LocalStorageMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     [configuration _setAllowUniversalAccessFromFileURLs:YES];
     [configuration setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
-    auto delegate = adoptNS([[LocalStorageNavigationDelegate alloc] init]);
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[LocalStorageNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
     [webView configuration].preferences.javaScriptCanOpenWindowsAutomatically = YES;
@@ -265,12 +265,12 @@ TEST(WKWebView, LocalStorageOpenWindowPrivate)
 
 TEST(WKWebView, PrivateBrowsingAffectsLocalStorage)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAllowUniversalAccessFromFileURLs:YES];
     [configuration setWebsiteDataStore:[WKWebsiteDataStore defaultDataStore]];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     
-    auto delegate = adoptNS([[LocalStorageNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[LocalStorageNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
@@ -360,12 +360,12 @@ TEST(WKWebView, PrivateBrowsingAffectsLocalStorage)
 
 TEST(WKWebView, AuxiliaryWindowsShareLocalStorage)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAllowUniversalAccessFromFileURLs:YES];
     [configuration setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     
-    auto delegate = adoptNS([[LocalStorageNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[LocalStorageNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
     
@@ -428,11 +428,11 @@ TEST(WKWebView, AuxiliaryWindowsShareLocalStorage)
 TEST(WKWebView, LocalStorageGroup)
 {
     auto runTest = [] (bool setGroupIdentifier) {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         [configuration setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
         if (setGroupIdentifier)
             [configuration _setGroupIdentifier:@"testgroupidentifier"];
-        auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         NSString *html1 = @""
         "<script>"
         "localStorage.setItem('testkey', 'testvalue1');"
@@ -441,7 +441,7 @@ TEST(WKWebView, LocalStorageGroup)
         [webView1 loadHTMLString:html1 baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
         [webView1 _test_waitForDidFinishNavigation];
 
-        auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         NSString *html2 = @""
         "<script>"
         "alert('second web view got value ' + localStorage.getItem('testkey'));"
@@ -458,10 +458,10 @@ TEST(WKWebView, LocalStorageGroup)
 
 TEST(WKWebView, LocalStorageDifferentPageGroupSameProcess)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
     [configuration _setGroupIdentifier:@"testgroupidentifier1"];
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     NSString *htmlString = @"<script>localStorage.setItem('key', 'value')</script>";
     [webView1 synchronouslyLoadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
 
@@ -470,7 +470,7 @@ TEST(WKWebView, LocalStorageDifferentPageGroupSameProcess)
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     [configuration _setRelatedWebView:webView1.get()];
     ALLOW_DEPRECATED_DECLARATIONS_END
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     // Network process would crash if the second page creates a new StorageArea.
     [webView2 synchronouslyLoadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
 }
@@ -492,11 +492,11 @@ TEST(WKWebView, LocalStorageNoSizeOverflow)
         window.addEventListener('storage', onStorage);\
         window.webkit.messageHandlers.testHandler.postMessage(getItem()); \
         </script>";
-    auto handler = adoptNS([[LocalStorageMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[LocalStorageMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
     EXPECT_WK_STREQ(@"[null]", [lastScriptMessage body]);
@@ -508,7 +508,7 @@ TEST(WKWebView, LocalStorageNoSizeOverflow)
     TestWebKitAPI::Util::run(&receivedScriptMessage);
     receivedScriptMessage = false;
     
-    auto secondWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr secondWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [secondWebView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
     EXPECT_WK_STREQ(@"value", [lastScriptMessage body]);
@@ -553,13 +553,13 @@ TEST(WebKit, LocalStorageCorruptedDatabase)
             result = '[null]'; \
         window.webkit.messageHandlers.testHandler.postMessage(result); \
         </script>";
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
-    auto messageHandler = adoptNS([[LocalStorageMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[LocalStorageMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     receivedScriptMessage = false;
     [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
@@ -573,7 +573,7 @@ TEST(WebKit, LocalStorageCorruptedDatabase)
     TestWebKitAPI::Util::run(&done);
 
     // Ensure item is stored by getting it in another WKWebView.
-    auto secondWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr secondWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     receivedScriptMessage = false;
     [secondWebView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
@@ -585,10 +585,10 @@ TEST(WebKit, LocalStorageCorruptedDatabase)
 
 TEST(WKWebView, LocalStorageDirectoryExcludedFromBackup)
 {
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelNone;
     RetainPtr<NSURL> webStorageDirectory = [websiteDataStoreConfiguration _webStorageDirectory];
-    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
     
     // Create WebStorage directory and make it not excluded.
     [[NSFileManager defaultManager] createDirectoryAtURL:webStorageDirectory.get() withIntermediateDirectories:YES attributes:nil error:nullptr];
@@ -597,10 +597,10 @@ TEST(WKWebView, LocalStorageDirectoryExcludedFromBackup)
     EXPECT_TRUE([webStorageDirectory.get() getResourceValue:&isDirectoryExcluded forKey:NSURLIsExcludedFromBackupKey error:nil]);
     EXPECT_FALSE(isDirectoryExcluded.boolValue);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:websiteDataStore.get()];
-    auto delegate = adoptNS([[LocalStorageNavigationDelegate alloc] init]);
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[LocalStorageNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:delegate.get()];
     didFinishNavigationBoolean = false;
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LockdownModeFonts.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LockdownModeFonts.mm
@@ -79,9 +79,9 @@ TEST(LockdownMode, DISABLED_SVGFonts)
 TEST(LockdownMode, SVGFonts)
 #endif
 {
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"SVGFont" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     [webView _test_waitForDidFinishNavigation];
@@ -96,9 +96,9 @@ TEST(LockdownMode, SVGFonts)
 TEST(LockdownMode, NotAllowedFontLoadingAPI)
 {
     @autoreleasepool {
-        auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+        RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
         webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
         NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"ImmediateFont" withExtension:@"html"];
         [webView loadRequest:[NSURLRequest requestWithURL:url]];
         [webView _test_waitForDidFinishNavigation];
@@ -129,9 +129,9 @@ TEST(LockdownMode, NotAllowedFontLoadingAPI)
 TEST(LockdownMode, AllowedFontLoadingAPI)
 {
     @autoreleasepool {
-        auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+        RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
         webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
         NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"ImmediateFont" withExtension:@"html"];
         [webView loadRequest:[NSURLRequest requestWithURL:url]];
         [webView _test_waitForDidFinishNavigation];
@@ -157,9 +157,9 @@ TEST(LockdownMode, AllowedFontLoadingAPI)
 TEST(LockdownMode, NotSupportedFontLoadingAPI)
 {
     @autoreleasepool {
-        auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+        RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
         webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
         NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"ImmediateFont" withExtension:@"html"];
         [webView loadRequest:[NSURLRequest requestWithURL:url]];
         [webView _test_waitForDidFinishNavigation];
@@ -185,9 +185,9 @@ TEST(LockdownMode, NotSupportedFontLoadingAPI)
 TEST(LockdownMode, AllowedFont)
 {
     @autoreleasepool {
-        auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+        RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
         webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
         NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"LockdownModeFonts" withExtension:@"html"];
         [webView loadRequest:[NSURLRequest requestWithURL:url]];
         [webView _test_waitForDidFinishNavigation];
@@ -205,9 +205,9 @@ TEST(LockdownMode, AllowedFont)
 TEST(LockdownMode, NotAllowedFont)
 {
     @autoreleasepool {
-        auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+        RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
         webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
         NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"LockdownModeFonts" withExtension:@"html"];
         [webView loadRequest:[NSURLRequest requestWithURL:url]];
         [webView _test_waitForDidFinishNavigation];
@@ -234,9 +234,9 @@ TEST(LockdownMode, DISABLED_ImmediateParsedViaSafeFontParser)
 #endif
 {
     @autoreleasepool {
-        auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+        RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
         webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
         NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"ImmediateFont" withExtension:@"html"];
         [webView loadRequest:[NSURLRequest requestWithURL:url]];
         [webView _test_waitForDidFinishNavigation];
@@ -293,8 +293,8 @@ TEST(LockdownMode, DISABLED_CanaryFontSucceedsInFontParser)
 #endif
 {
     @autoreleasepool {
-        auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+        RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
         NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"ImmediateFont" withExtension:@"html"];
         [webView loadRequest:[NSURLRequest requestWithURL:url]];
         [webView _test_waitForDidFinishNavigation];
@@ -341,10 +341,10 @@ TEST(LockdownMode, DISABLED_WorkerFontParsedViaSafeFontParser)
         server.addResponse("/Ahem.ttf"_s, { ahemFontData });
         server.addResponse("/SafeFontParser-invalid.ttf"_s, { canaryFontData });
 
-        auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+        RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
         webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
 
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
         auto workerTestPageURL = [NSURL URLWithString:[[NSString alloc] initWithFormat:@"http://localhost:%u/SafeFontParserWorker.html", server.port()]];
         [webView loadRequest:[NSURLRequest requestWithURL:workerTestPageURL]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MSEIsTypeSupportedCaching.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MSEIsTypeSupportedCaching.mm
@@ -50,7 +50,7 @@ static WKProcessPool *sharedProcessPool()
     static NeverDestroyed<RetainPtr<WKProcessPool>> pool;
     static dispatch_once_t once;
     dispatch_once(&once, ^{
-        auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+        RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
         pool.get() = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
     });
     return pool.get().get();
@@ -58,13 +58,13 @@ static WKProcessPool *sharedProcessPool()
 
 static RetainPtr<TestWKWebView> createWebViewWithSeparateProcess()
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setProcessPool:sharedProcessPool()];
     [configuration setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
     [[configuration preferences] _setManagedMediaSourceEnabled:YES];
     [[configuration preferences] _setMediaSourceEnabled:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"is-type-supported-perf"];
     return webView;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaBufferingPolicy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaBufferingPolicy.mm
@@ -74,12 +74,12 @@ TEST(WebKit, DISABLED_MediaBufferingPolicy)
 TEST(WebKit, MediaBufferingPolicy)
 #endif
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
     configuration.get()._mediaDataLoadsAutomatically = YES;
     configuration.get().mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     __block bool isPlaying = false;
     [webView performAfterReceivingMessage:@"playing" action:^() { isPlaying = true; }];
@@ -116,12 +116,12 @@ TEST(WebKit, DISABLED_MediaBufferingPolicyWhenSuspendedOrHidden)
 TEST(WebKit, MediaBufferingPolicyWhenSuspendedOrHidden)
 #endif
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
     configuration.get()._mediaDataLoadsAutomatically = YES;
     configuration.get().mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     bool isPlaying = false;
     [webView performAfterReceivingMessage:@"playing" action:[&] { isPlaying = true; }];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaDocument.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaDocument.mm
@@ -37,8 +37,8 @@ namespace TestWebKitAPI {
 
 TEST(MediaDocument, WirelessPlaybackEnabled)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     NSURL *videoURL = [NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"mp4"];
     [webView loadFileURL:videoURL allowingReadAccessToURL:videoURL];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaLoading.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaLoading.mm
@@ -49,9 +49,9 @@ static String parseUserAgent(const Vector<char>& request)
 
 TEST(MediaLoading, UserAgentStringCRABS)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     webView.get().customUserAgent = @"TestWebKitAPI";
 
     bool receivedMediaRequest = false;
@@ -72,9 +72,9 @@ TEST(MediaLoading, UserAgentStringCRABS)
 
 TEST(MediaLoading, UserAgentStringHLS)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     webView.get().customUserAgent = @"TestWebKitAPI";
 
     bool receivedManifestRequest = false;
@@ -139,9 +139,9 @@ static Vector<uint8_t> testVideoBytes()
 
 static void runVideoTest(NSURLRequest *request, const char* expectedMessage)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     [webView loadRequest:request];
     EXPECT_WK_STREQ([webView _test_waitForAlert], expectedMessage);
 }
@@ -231,10 +231,10 @@ TEST(MediaLoading, LockdownModeHLS)
     );
     server.addResponse("/video.m3u8"_s, { m3u8Source });
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
     configuration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     [webView loadRequest:server.request()];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "playing");
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaMutedState.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaMutedState.mm
@@ -97,9 +97,9 @@ namespace TestWebKitAPI {
 
 TEST(WKWebView, MediaMuted)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[AudioStateTestView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
-    auto observer = adoptNS([[AudioStateObserver alloc] initWithWebView:webView.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[AudioStateTestView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr observer = adoptNS([[AudioStateObserver alloc] initWithWebView:webView.get()]);
 
     [webView synchronouslyLoadHTMLString:@"<video src=\"video-with-audio.mp4\" webkit-playsinline loop></video>"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaStreamTrackDetached.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaStreamTrackDetached.mm
@@ -55,15 +55,15 @@ namespace TestWebKitAPI {
 
 TEST(WebKit, MediaStreamTrackDetached)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     auto preferences = [configuration preferences];
     preferences._mediaCaptureRequiresSecureConnection = NO;
     configuration.get()._mediaCaptureEnabled = YES;
     preferences._mockCaptureDevicesEnabled = YES;
     preferences._getUserMediaRequiresFocus = NO;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
-    auto delegate = adoptNS([[MediaStreamTrackDetachedUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr delegate = adoptNS([[MediaStreamTrackDetachedUIDelegate alloc] init]);
     webView.get().UIDelegate = delegate.get();
 
     hasReceivedCorrectCaptureState = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaType.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaType.mm
@@ -65,7 +65,7 @@ NSString *testPage = @"<style>\n"
 
 TEST(WKWebView, MediaType)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:testPage baseURL:nil];
 
     EXPECT_TRUE(webView.get().mediaType == nil);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MessagePortProviders.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MessagePortProviders.mm
@@ -51,8 +51,8 @@ namespace TestWebKitAPI {
 TEST(MessagePort, Providers)
 {
     // Loading a WebView that uses message ports guarantees that the default MessagePortChannelProviderImpl is set.
-    auto wk1View = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) frameName:nil groupName:nil]);
-    auto delegate = adoptNS([[MessagePortFrameLoadDelegate alloc] init]);
+    RetainPtr wk1View = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) frameName:nil groupName:nil]);
+    RetainPtr delegate = adoptNS([[MessagePortFrameLoadDelegate alloc] init]);
     [wk1View.get() setFrameLoadDelegate:delegate.get()];
     [[wk1View mainFrame] loadHTMLString:@"<script>new MessageChannel;</script>" baseURL:nil];
 
@@ -61,7 +61,7 @@ TEST(MessagePort, Providers)
     // Now using a WKWebView to load content that uses message ports will use the WK2-style message ports.
     // This should not conflict with WK1-style message ports.
     // The conflict is caught by a RELEASE_ASSERT so, if this doesn't crash, it passes.
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"<script>new MessageChannel;</script>"];
 }
 
@@ -85,7 +85,7 @@ setInterval(() => {
 
 TEST(MessagePort, MessageToClosedPort)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:[NSString stringWithUTF8String:portMessageMemoryBomb]];
 
     RetainPtr networkProcessInfo = [WKProcessPool _networkingProcessInfo];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ModalAlerts.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ModalAlerts.mm
@@ -171,7 +171,7 @@ static bool didRespondToPrompt = false;
 
 TEST(WebKit, SlowBeforeUnloadPromptReject)
 {
-    auto slowBeforeUnloadPromptUIDelegate = adoptNS([[SlowBeforeUnloadPromptUIDelegate alloc] init]);
+    RetainPtr slowBeforeUnloadPromptUIDelegate = adoptNS([[SlowBeforeUnloadPromptUIDelegate alloc] init]);
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
     [webView setUIDelegate:slowBeforeUnloadPromptUIDelegate.get()];
@@ -194,7 +194,7 @@ TEST(WebKit, SlowBeforeUnloadPromptReject)
 
 TEST(WebKit, SlowBeforeUnloadPromptAllow)
 {
-    auto slowBeforeUnloadPromptUIDelegate = adoptNS([[SlowBeforeUnloadPromptUIDelegate alloc] init]);
+    RetainPtr slowBeforeUnloadPromptUIDelegate = adoptNS([[SlowBeforeUnloadPromptUIDelegate alloc] init]);
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
     [webView setUIDelegate:slowBeforeUnloadPromptUIDelegate.get()];
@@ -216,8 +216,8 @@ TEST(WebKit, SlowBeforeUnloadPromptAllow)
 
 TEST(WebKit, BeforeUnloadPromptRejectOnReload)
 {
-    auto slowBeforeUnloadPromptUIDelegate = adoptNS([[SlowBeforeUnloadPromptUIDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr slowBeforeUnloadPromptUIDelegate = adoptNS([[SlowBeforeUnloadPromptUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView setUIDelegate:slowBeforeUnloadPromptUIDelegate.get()];
     [webView synchronouslyLoadTestPageNamed:@"beforeunload"];
 
@@ -241,8 +241,8 @@ TEST(WebKit, BeforeUnloadPromptRejectOnReload)
 
 TEST(WebKit, BeforeUnloadPromptAllowOnReload)
 {
-    auto slowBeforeUnloadPromptUIDelegate = adoptNS([[SlowBeforeUnloadPromptUIDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr slowBeforeUnloadPromptUIDelegate = adoptNS([[SlowBeforeUnloadPromptUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView setUIDelegate:slowBeforeUnloadPromptUIDelegate.get()];
     [webView synchronouslyLoadTestPageNamed:@"beforeunload"];
 
@@ -287,8 +287,8 @@ static unsigned viewDidCloseCallCount = 0;
 
 TEST(WebKit, SlowBeforeUnloadHandlerSingleClosePageCall)
 {
-    auto slowBeforeUnloadHandlerUIDelegate = adoptNS([[SlowBeforeUnloadHandlerUIDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr slowBeforeUnloadHandlerUIDelegate = adoptNS([[SlowBeforeUnloadHandlerUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView setUIDelegate:slowBeforeUnloadHandlerUIDelegate.get()];
     [webView synchronouslyLoadTestPageNamed:@"beforeunload-slow"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ModelProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ModelProcess.mm
@@ -46,7 +46,7 @@ namespace TestWebKitAPI {
 
 TEST(ModelProcess, CleanUpOnReload)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAllowTestOnlyIPC:YES];
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("ModelElementEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("ModelProcessEnabled"));
@@ -54,7 +54,7 @@ TEST(ModelProcess, CleanUpOnReload)
     RetainPtr messageHandler = adoptNS([[ModelLoadingMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"modelLoading"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"simple-model-page"];
 
     while (![messageHandler modelIsReady])
@@ -73,7 +73,7 @@ TEST(ModelProcess, CleanUpOnReload)
 
 TEST(ModelProcess, CleanUpOnNavigate)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAllowTestOnlyIPC:YES];
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("ModelElementEnabled"));
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("ModelProcessEnabled"));
@@ -81,7 +81,7 @@ TEST(ModelProcess, CleanUpOnNavigate)
     RetainPtr messageHandler = adoptNS([[ModelLoadingMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"modelLoading"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"simple-model-page"];
 
     while (![messageHandler modelIsReady])
@@ -105,7 +105,7 @@ TEST(ModelProcess, CleanUpOnHide)
     RetainPtr messageHandler = adoptNS([[ModelLoadingMessageHandler alloc] init]);
     [configuration.userContentController addScriptMessageHandler:messageHandler.get() name:@"modelLoading"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration]);
     [webView synchronouslyLoadTestPageNamed:@"simple-model-page"];
 
     bool isHidden = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NSAttributedStringWebKitAdditions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NSAttributedStringWebKitAdditions.mm
@@ -93,7 +93,7 @@ TEST(NSAttributedStringWebKitAdditions, DirectoriesNotCreated)
     };
     EXPECT_FALSE(cookieDirectoryExists());
 
-    auto webView = adoptNS([TestWKWebView new]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
     [webView synchronouslyLoadHTMLString:@"hi"];
     EXPECT_TRUE(cookieDirectoryExists());
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Navigation.mm
@@ -116,7 +116,7 @@ TEST(WKNavigation, NavigationDelegate)
 {
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto delegate = adoptNS([[NavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[NavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     @autoreleasepool {
@@ -147,14 +147,14 @@ TEST(WKNavigation, LoadRequest)
 TEST(WKNavigation, HTTPBody)
 {
     __block bool done = false;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     NSData *testData = [@"testhttpbody" dataUsingEncoding:NSUTF8StringEncoding];
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^decisionHandler)(WKNavigationActionPolicy)) {
         EXPECT_TRUE([action.request.HTTPBody isEqualToData:testData]);
         decisionHandler(WKNavigationActionPolicyCancel);
         done = true;
     };
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"test:///willNotActuallyLoad"]];
     [request setHTTPBody:testData];
@@ -167,14 +167,14 @@ TEST(WKNavigation, UserAgentAndAccept)
     using namespace TestWebKitAPI;
     HTTPServer server([](Connection) { });
     __block bool done = false;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^decisionHandler)(WKNavigationActionPolicy)) {
         EXPECT_WK_STREQ(action.request.allHTTPHeaderFields[@"User-Agent"], "testUserAgent");
         EXPECT_WK_STREQ(action.request.allHTTPHeaderFields[@"Accept"], "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
         decisionHandler(WKNavigationActionPolicyCancel);
         done = true;
     };
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     webView.get().customUserAgent = @"testUserAgent";
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:server.request()];
@@ -310,8 +310,8 @@ struct ExpectedStrings {
 
 TEST(WKNavigation, Frames)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSString *responseString = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"frame://host1/"])
@@ -325,15 +325,15 @@ TEST(WKNavigation, Frames)
             responseString = @"<p>Hello World</p>";
 
         ASSERT(responseString);
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:responseString.length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:responseString.length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[responseString dataUsingEncoding:NSUTF8StringEncoding]];
         [task didFinish];
     }];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"frame"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([FrameNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([FrameNavigationDelegate new]);
     webView.get().navigationDelegate = delegate.get();
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"frame://host1/"]]];
     [delegate waitForNavigations:3];
@@ -601,9 +601,9 @@ TEST(WKNavigation, DidFailProvisionalNavigation)
 
 TEST(WKNavigation, CrashReason)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     
-    auto delegate = adoptNS([[CrashReasonDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[CrashReasonDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     
     [webView loadHTMLString:@"<html>start the web process</html>" baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
@@ -718,11 +718,11 @@ TEST(WKNavigation, NavigationActionHasNavigation)
 
 TEST(WKNavigation, WebViewWillPerformClientRedirect)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get()._allowTopNavigationToDataURLs = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[ClientRedirectNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[ClientRedirectNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     auto request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"data:text/html,%3Cmeta%20http-equiv=%22refresh%22%20content=%22123;URL=data:text/html,Page1%22%3E"]];
@@ -749,11 +749,11 @@ TEST(WKNavigation, WebViewWillPerformClientRedirect)
 
 TEST(WKNavigation, WebViewDidCancelClientRedirect)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get()._allowTopNavigationToDataURLs = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[ClientRedirectNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[ClientRedirectNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     // Test 1: During a navigation that is not a client redirect, -_webViewDidCancelClientRedirect: should not be called.
@@ -831,8 +831,8 @@ TEST(WKNavigation, WebViewDidCancelClientRedirect)
 
 TEST(WKNavigation, NavigationActionSPI)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    auto delegate = adoptNS([[NavigationActionSPIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr delegate = adoptNS([[NavigationActionSPIDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"data:text/html,1"]]];
     TestWebKitAPI::Util::run(&isDone);
@@ -862,8 +862,8 @@ static bool navigationComplete;
 
 TEST(WKNavigation, WillGoToBackForwardListItem)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
-    auto delegate = adoptNS([[BackForwardDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr delegate = adoptNS([[BackForwardDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
     TestWebKitAPI::Util::run(&navigationComplete);
@@ -940,9 +940,9 @@ static bool didRejectNavigation = false;
 
 TEST(WKNavigation, ShouldGoToBackForwardListItem)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
     navigationComplete = false;
-    auto delegate = adoptNS([[BackForwardDelegateWithShouldGo alloc] init]);
+    RetainPtr delegate = adoptNS([[BackForwardDelegateWithShouldGo alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
     TestWebKitAPI::Util::run(&navigationComplete);
@@ -970,7 +970,7 @@ TEST(WKNavigation, ShouldGoToBackForwardListItem)
     navigationComplete = false;
     didRejectNavigation = false;
 
-    auto delegate2 = adoptNS([[BackForwardDelegateWithShouldGoSPI alloc] init]);
+    RetainPtr delegate2 = adoptNS([[BackForwardDelegateWithShouldGoSPI alloc] init]);
     [webView setNavigationDelegate:delegate2.get()];
     delegate2.get().targetItem = webView.get().backForwardList.backItem;
     delegate2.get().allowNavigation = YES;
@@ -1032,8 +1032,8 @@ RetainPtr<WKBackForwardListItem> secondItem;
 
 TEST(WKNavigation, ListItemAddedRemoved)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
-    auto delegate = adoptNS([[ListItemDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr delegate = adoptNS([[ListItemDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
     TestWebKitAPI::Util::run(&navigationComplete);
@@ -1075,9 +1075,9 @@ TEST(WKNavigation, FrameBackLoading)
         { "/frame1.html"_s, { "<a href='frame2.html'>link</a>"_s } },
         { "/frame2.html"_s, { "<script>alert('frame2 loaded')</script>"_s } },
     });
-    auto webView = adoptNS([WKWebView new]);
-    auto delegate = adoptNS([TestUIDelegate new]);
-    auto observer = adoptNS([LoadingObserver new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestUIDelegate new]);
+    RetainPtr observer = adoptNS([LoadingObserver new]);
     [webView setUIDelegate:delegate.get()];
     [webView addObserver:observer.get() forKeyPath:@"loading" options:NSKeyValueObservingOptionNew context:nil];
     EXPECT_FALSE([webView isLoading]);
@@ -1136,8 +1136,8 @@ TEST(WKNavigation, SimultaneousNavigationWithFontsFinishes)
         { "/iframesrc.html"_s, { "frame content"_s } },
     });
 
-    auto webView = adoptNS([WKWebView new]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
@@ -1167,8 +1167,8 @@ TEST(WKNavigation, LoadRadarURLFromSandboxedFrameAllowPopups)
         { "/frame.html"_s, { frameHTML } },
     });
 
-    auto webView = adoptNS([WKWebView new]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool didTryToLoadRadarURL = false;
@@ -1202,8 +1202,8 @@ TEST(WKNavigation, LoadRadarURLFromSandboxedFrameAllowTopNavigation)
         { "/frame.html"_s, { frameHTML } },
     });
 
-    auto webView = adoptNS([WKWebView new]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool didTryToLoadRadarURL = false;
@@ -1237,8 +1237,8 @@ TEST(WKNavigation, LoadRadarURLFromSandboxedFrameAllowCustomProtocolsNavigation)
         { "/frame.html"_s, { frameHTML } },
     });
 
-    auto webView = adoptNS([WKWebView new]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool didTryToLoadRadarURL = false;
@@ -1272,8 +1272,8 @@ TEST(WKNavigation, LoadRadarURLFromSandboxedFrameWithUserGesture)
         { "/frame.html"_s, { frameHTML } },
     });
 
-    auto webView = adoptNS([WKWebView new]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block RetainPtr<WKFrameInfo> iframe;
@@ -1315,8 +1315,8 @@ TEST(WKNavigation, LoadRadarURLFromSandboxedFrame)
         { "/frame.html"_s, { frameHTML } },
     });
 
-    auto webView = adoptNS([WKWebView new]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool didTryToLoadRadarURL = false;
@@ -1352,8 +1352,8 @@ TEST(WKNavigation, LoadRadarURLFromSandboxedFrameMissingUserGesture)
         { "/frame.html"_s, { frameHTML } },
     });
 
-    auto webView = adoptNS([WKWebView new]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool didTryToLoadRadarURL = false;
@@ -1387,21 +1387,21 @@ TEST(WKNavigation, CrossOriginCOOPCancelResponseFailProvisionalNavigationCallbac
         { "/path3"_s, { { { "Cross-Origin-Opener-Policy"_s, "same-origin"_s } }, "hi"_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(server.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block Vector<bool> finishedSuccessfullyCallbacks;
     auto loadWithResponsePolicy = ^(WKWebView *webView, NSString *url, WKNavigationResponsePolicy responsePolicy) {
         auto callbacksSizeBefore = finishedSuccessfullyCallbacks.size();
 
-        auto delegate = adoptNS([TestNavigationDelegate new]);
+        RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
         delegate.get().decidePolicyForNavigationResponse = ^(WKNavigationResponse *response, void (^decisionHandler)(WKNavigationResponsePolicy)) {
             decisionHandler(responsePolicy);
         };
@@ -1439,15 +1439,15 @@ TEST(WKNavigation, HTTPSFirstHTTPDowngrade)
         { "http://site.example/secure"_s, { "Welcome"_s } }
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences._networkConnectionIntegrityPolicy = _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSFirst;
     for (_WKFeature *feature in [WKPreferences _features]) {
@@ -1456,12 +1456,12 @@ TEST(WKNavigation, HTTPSFirstHTTPDowngrade)
             break;
         }
     }
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block int loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -1540,15 +1540,15 @@ TEST(WKNavigation, HTTPSFirstHTTPDowngradeAfterPSON)
         { "http://site2.example/secure"_s, { "body"_s } }
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"HTTPSByDefaultEnabled"]) {
@@ -1556,14 +1556,14 @@ TEST(WKNavigation, HTTPSFirstHTTPDowngradeAfterPSON)
             break;
         }
     }
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block bool didFailNavigation { false };
     __block bool didFailLoad { false };
     __block unsigned loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -1669,15 +1669,15 @@ TEST(WKNavigation, HTTPSFirstHTTPDowngradeAndSameSiteNavigation)
         { "http://site2.example/secure2"_s, { "<body>Done</body>"_s } },
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences._networkConnectionIntegrityPolicy = _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSFirst;
     for (_WKFeature *feature in [WKPreferences _features]) {
@@ -1686,12 +1686,12 @@ TEST(WKNavigation, HTTPSFirstHTTPDowngradeAndSameSiteNavigation)
             break;
         }
     }
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block unsigned loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -1803,24 +1803,24 @@ TEST(WKNavigation, HTTPSFirstHTTPDowngradeRedirect)
         { "http://site.example/secure"_s, { 302, {{ "Location"_s, "https://site.example/secure"_s }}, "redirecting..."_s } }
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences._networkConnectionIntegrityPolicy = _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSFirst;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block bool didFailNavigation { false };
     __block int loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -1855,23 +1855,23 @@ TEST(WKNavigation, HTTPSFirstRedirectNoHTTPDowngradeRedirect)
         { "http://site.example/redirect"_s, { 302, {{ "Location"_s, "https://site.example"_s }}, "redirecting..."_s } }
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences._networkConnectionIntegrityPolicy = _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSFirst;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block int loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
 
     delegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         if (!loadCount)
@@ -1909,15 +1909,15 @@ TEST(WKNavigation, HTTPSFirstLocalHostIPAddress)
         { "/notsecure"_s, { { }, "not secure page"_s } },
     }, HTTPServer::Protocol::Http);
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     configuration.get().defaultWebpagePreferences._networkConnectionIntegrityPolicy = _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSFirst;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block int loadCount { 0 };
     __block bool didReceiveAuthenticationChallenge { false };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -1972,25 +1972,25 @@ TEST(WKNavigation, HTTPSOnlyInitialLoad)
         { "http://site.example/notsecure"_s, { { }, "not secure page"_s } },
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences._networkConnectionIntegrityPolicy = _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSOnly;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block bool didFailNavigation { false };
     __block int loadCount { 0 };
     __block bool didReceiveAuthenticationChallenge { false };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -2034,11 +2034,11 @@ TEST(WKNavigation, HTTPSOnlyNonHTTPSSecureSchemes)
 
     [TestProtocol registerWithScheme:secureScheme];
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     configuration.get().defaultWebpagePreferences._networkConnectionIntegrityPolicy = _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSOnly;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         completionHandler(WKNavigationActionPolicyAllow);
     };
@@ -2109,22 +2109,22 @@ TEST(WKNavigation, HTTPSOnlyHTTPFallbackGoBack)
         { "/secure"_s, { { }, "hi"_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences._networkConnectionIntegrityPolicy = _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSOnly;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block bool failedNavigation { false };
     __block int loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -2186,24 +2186,24 @@ TEST(WKNavigation, HTTPSOnlyHTTPFallbackContinue)
         { "http://site.example/page2"_s, { } }
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences._networkConnectionIntegrityPolicy = _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSOnly;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block bool failedNavigation { false };
     __block int loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -2326,21 +2326,21 @@ TEST(WKNavigation, HTTPSOnlyHTTPFallbackBypassEnabledCertificateError)
         { "/secure"_s, { { }, "hi"_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences._networkConnectionIntegrityPolicy = _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSOnly | _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSOnlyExplicitlyBypassedForDomain;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block int loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -2391,25 +2391,25 @@ TEST(WKNavigation, HTTPSOnlyWithSameSiteBypass)
         { "http://site2.example/secure"_s, { { }, "hi: not secure"_s } }
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences._networkConnectionIntegrityPolicy = _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSOnly;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     // Step 1: Attempt https load without implementing didReceiveAuthenticationChallenge
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block bool didFailNavigation { false };
     __block int loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -2565,24 +2565,24 @@ TEST(WKNavigation, HTTPSOnlyWithHTTPRedirect)
         { "http://site2.example/secure3"_s, { { }, "hi: not secure"_s } },
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences._networkConnectionIntegrityPolicy = _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSOnly;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block bool didFailNavigation { false };
     __block int loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -2738,24 +2738,24 @@ TEST(WKNavigation, HTTPSFirstWithHTTPRedirect)
         { "http://site2.example/secure3"_s, { { }, "hi: not secure"_s } },
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences._networkConnectionIntegrityPolicy = _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSFirst;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block bool didFailNavigation { false };
     __block int loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -2879,23 +2879,23 @@ TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackHTTPDowngrade)
         { "http://site.example/secure"_s, { "Welcome"_s } }
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences.preferredHTTPSNavigationPolicy = WKWebpagePreferencesUpgradeToHTTPSPolicyAutomaticFallbackToHTTP;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block int loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -2974,24 +2974,24 @@ TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackHTTPDowngradeAfterPS
         { "http://site2.example/secure"_s, { "body"_s } }
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block bool didFailNavigation { false };
     __block bool didFailLoad { false };
     __block unsigned loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -3097,23 +3097,23 @@ TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackHTTPDowngradeAndSame
         { "http://site2.example/secure2"_s, { "<body>Done</body>"_s } },
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences.preferredHTTPSNavigationPolicy = WKWebpagePreferencesUpgradeToHTTPSPolicyAutomaticFallbackToHTTP;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block unsigned loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -3225,24 +3225,24 @@ TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackHTTPDowngradeRedirec
         { "http://site.example/secure"_s, { 302, {{ "Location"_s, "https://site.example/secure"_s }}, "redirecting..."_s } }
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences.preferredHTTPSNavigationPolicy = WKWebpagePreferencesUpgradeToHTTPSPolicyAutomaticFallbackToHTTP;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block bool didFailNavigation { false };
     __block int loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -3277,23 +3277,23 @@ TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackRedirectNoHTTPDowngr
         { "http://site.example/redirect"_s, { 302, {{ "Location"_s, "https://site.example"_s }}, "redirecting..."_s } }
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences.preferredHTTPSNavigationPolicy = WKWebpagePreferencesUpgradeToHTTPSPolicyAutomaticFallbackToHTTP;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block int loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
 
     delegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         if (!loadCount)
@@ -3331,15 +3331,15 @@ TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackLocalHostIPAddress)
         { "/notsecure"_s, { { }, "not secure page"_s } },
     }, HTTPServer::Protocol::Http);
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     configuration.get().defaultWebpagePreferences.preferredHTTPSNavigationPolicy = WKWebpagePreferencesUpgradeToHTTPSPolicyAutomaticFallbackToHTTP;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block int loadCount { 0 };
     __block bool didReceiveAuthenticationChallenge { false };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -3393,23 +3393,23 @@ TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackAfterTerminateProces
         { "http://site.example/secure"_s, { "Welcome"_s } }
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences.preferredHTTPSNavigationPolicy = WKWebpagePreferencesUpgradeToHTTPSPolicyAutomaticFallbackToHTTP;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block int loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -3547,23 +3547,23 @@ TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackAfterSessionRestore)
         { "http://site.example/secure"_s, { "Welcome"_s } }
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences.preferredHTTPSNavigationPolicy = WKWebpagePreferencesUpgradeToHTTPSPolicyAutomaticFallbackToHTTP;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block int loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -3706,25 +3706,25 @@ TEST(WKNavigation, PreferredHTTPSPolicyUserMediatedHTTPFallbackInitialLoad)
         { "http://site.example/notsecure"_s, { { }, "not secure page"_s } },
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences.preferredHTTPSNavigationPolicy = WKWebpagePreferencesUpgradeToHTTPSPolicyUserMediatedFallbackToHTTP;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block bool didFailNavigation { false };
     __block int loadCount { 0 };
     __block bool didReceiveAuthenticationChallenge { false };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -3763,22 +3763,22 @@ TEST(WKNavigation, PreferredHTTPSPolicyUserMediatedHTTPFallbackHTTPFallbackGoBac
         { "/secure"_s, { { }, "hi"_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences.preferredHTTPSNavigationPolicy = WKWebpagePreferencesUpgradeToHTTPSPolicyUserMediatedFallbackToHTTP;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block bool failedNavigation { false };
     __block int loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -3840,24 +3840,24 @@ TEST(WKNavigation, PreferredHTTPSPolicyUserMediatedHTTPFallbackHTTPFallbackConti
         { "http://site.example/page2"_s, { } }
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences.preferredHTTPSNavigationPolicy = WKWebpagePreferencesUpgradeToHTTPSPolicyUserMediatedFallbackToHTTP;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block bool failedNavigation { false };
     __block int loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -3987,24 +3987,24 @@ TEST(WKNavigation, PreferredHTTPSPolicyUserMediatedHTTPFallbackWithHTTPRedirect)
         { "http://site2.example/secure3"_s, { { }, "hi: not secure"_s } },
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences.preferredHTTPSNavigationPolicy = WKWebpagePreferencesUpgradeToHTTPSPolicyUserMediatedFallbackToHTTP;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block bool didFailNavigation { false };
     __block int loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -4113,24 +4113,24 @@ TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackWithHTTPRedirect)
         { "http://site2.example/secure3"_s, { { }, "hi: not secure"_s } },
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences.preferredHTTPSNavigationPolicy = WKWebpagePreferencesUpgradeToHTTPSPolicyAutomaticFallbackToHTTP;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block bool didFailNavigation { false };
     __block int loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -4183,23 +4183,23 @@ TEST(WKNavigation, PreferredHTTPSPolicyNoFallbackRedirectNoHTTPDowngradeRedirect
         { "http://site.example/redirect"_s, { 302, {{ "Location"_s, "https://site.example"_s }}, "redirecting..."_s } }
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences.preferredHTTPSNavigationPolicy = WKWebpagePreferencesUpgradeToHTTPSPolicyErrorOnFailure;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block int loadCount { 0 };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
 
     delegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         if (!loadCount)
@@ -4241,25 +4241,25 @@ TEST(WKNavigation, PreferredHTTPSPolicyNoFallbackInitialLoad)
         { "http://site.example/notsecure"_s, { { }, "not secure page"_s } },
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences.preferredHTTPSNavigationPolicy = WKWebpagePreferencesUpgradeToHTTPSPolicyErrorOnFailure;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block bool didFailNavigation { false };
     __block int loadCount { 0 };
     __block bool didReceiveAuthenticationChallenge { false };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -4302,25 +4302,25 @@ TEST(WKNavigation, PreferredHTTPSPolicyNoFallbackOnCertificateError)
         { "http://site.example/notsecure"_s, { { }, "not secure page"_s } },
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     configuration.get().defaultWebpagePreferences.preferredHTTPSNavigationPolicy = WKWebpagePreferencesUpgradeToHTTPSPolicyErrorOnFailure;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block int errorCode { 0 };
     __block bool finishedSuccessfully { false };
     __block bool didFailNavigation { false };
     __block int loadCount { 0 };
     __block bool didReceiveAuthenticationChallenge { false };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         ++loadCount;
         completionHandler(WKNavigationActionPolicyAllow);
@@ -4425,20 +4425,20 @@ TEST(WKNavigation, Multiple303Redirects)
         { "http://site.example/page3"_s, { "Done."_s  } },
     });
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port())
     }];
 
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     __block bool finishedSuccessfully { false };
     __block bool reachedPage3 { false };
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
         if ([action.request.URL.path isEqual:@"/page1"]) {
             EXPECT_WK_STREQ(action.request.URL.path, @"/page1");
@@ -4475,9 +4475,9 @@ TEST(WKNavigation, Multiple303Redirects)
 
 TEST(WKNavigation, NavigationToUnknownBlankURL)
 {
-    auto viewConfiguration = adoptNS([WKWebViewConfiguration new]);
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool navigationFailed = false;
@@ -4550,7 +4550,7 @@ TEST(WKNavigation, GeneratePageLoadTiming)
     RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 400, 400) styleMask:0 backing:NSBackingStoreBuffered defer:NO]);
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     [window.get().contentView addSubview:webView.get()];
 
@@ -4591,7 +4591,7 @@ TEST(WKNavigation, GeneratePageLoadTimingWithNoSubresources)
     RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 400, 400) styleMask:0 backing:NSBackingStoreBuffered defer:NO]);
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:viewConfiguration.get()]);
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:delegate.get()];
     [window.get().contentView addSubview:webView.get()];
@@ -4696,23 +4696,23 @@ PrivateTokenTestSetupState setupWebViewForPrivateTokenTests(bool& didDecideServi
         }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(server->port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
     [dataStore _setPrivateTokenIPCForTesting:true];
 
     RetainPtr<NavigationDelegate> websiteDataStoreDelegate = adoptNS([[NavigationDelegate alloc] init]);
     dataStore.get()._delegate = websiteDataStoreDelegate.get();
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     navigationDelegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
     };
@@ -5148,8 +5148,8 @@ TEST(WKNavigation, AllowResourceLoadFromBlockedPortWithCustomScheme)
         { "/page1"_s, { 302, {{ "Location"_s, "custom://site.example:0/"_s } }, "redirecting..."_s } },
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     __block unsigned requestsSchemeHandled = 0;
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSString *responseString = nil;
@@ -5159,26 +5159,26 @@ TEST(WKNavigation, AllowResourceLoadFromBlockedPortWithCustomScheme)
             responseString = @"alert('This resource was loaded');";
         ASSERT(responseString);
         requestsSchemeHandled++;
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:responseString.length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:responseString.length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[responseString dataUsingEncoding:NSUTF8StringEncoding]];
         [task didFinish];
     }];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"custom"];
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
     [configuration setWebsiteDataStore:dataStore.get()];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto navDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr navDelegate = adoptNS([TestNavigationDelegate new]);
     [navDelegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:navDelegate.get()];
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     [webView setUIDelegate:uiDelegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://site.example/page1"]]];
     EXPECT_WK_STREQ([uiDelegate waitForAlert], "This resource was loaded");
@@ -5235,17 +5235,17 @@ TEST(Navigation, FormResubmited)
         }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
     [configuration setWebsiteDataStore:dataStore.get()];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto navDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr navDelegate = adoptNS([TestNavigationDelegate new]);
     [navDelegate allowAnyTLSCertificate];
 
     __block bool didCommitNavigation = false;
@@ -5254,7 +5254,7 @@ TEST(Navigation, FormResubmited)
     };
 
     [webView setNavigationDelegate:navDelegate.get()];
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     [webView setUIDelegate:uiDelegate.get()];
 
     // Load main page from same origin as form submission

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NavigationAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NavigationAction.mm
@@ -93,8 +93,8 @@
 
 TEST(WKNavigationAction, ShouldPerformDownload_NoDownloadAttribute)
 {
-    auto navigationDelegate = adoptNS([[NavigationActionTestDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr navigationDelegate = adoptNS([[NavigationActionTestDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     auto baseURL = retainPtr([NSURL URLWithString:@"https://example.com/index.html"]);
@@ -111,8 +111,8 @@ TEST(WKNavigationAction, ShouldPerformDownload_NoDownloadAttribute)
 
 TEST(WKNavigationAction, ShouldPerformDownload_BlankDownloadAttribute_SameOrigin)
 {
-    auto navigationDelegate = adoptNS([[NavigationActionTestDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr navigationDelegate = adoptNS([[NavigationActionTestDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     auto baseURL = retainPtr([NSURL URLWithString:@"https://example.com/index.html"]);
@@ -129,8 +129,8 @@ TEST(WKNavigationAction, ShouldPerformDownload_BlankDownloadAttribute_SameOrigin
 
 TEST(WKNavigationAction, ShouldPerformDownload_BlankDownloadAttribute_CrossOrigin)
 {
-    auto navigationDelegate = adoptNS([[NavigationActionTestDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr navigationDelegate = adoptNS([[NavigationActionTestDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     auto baseURL = retainPtr([NSURL URLWithString:@"https://example.com/index.html"]);
@@ -147,8 +147,8 @@ TEST(WKNavigationAction, ShouldPerformDownload_BlankDownloadAttribute_CrossOrigi
 
 TEST(WKNavigationAction, ShouldPerformDownload_DownloadAttribute_SameOrigin)
 {
-    auto navigationDelegate = adoptNS([[NavigationActionTestDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr navigationDelegate = adoptNS([[NavigationActionTestDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     auto baseURL = retainPtr([NSURL URLWithString:@"https://example.com/index.html"]);
@@ -165,8 +165,8 @@ TEST(WKNavigationAction, ShouldPerformDownload_DownloadAttribute_SameOrigin)
 
 TEST(WKNavigationAction, ShouldPerformDownload_DownloadAttribute_CrossOrigin)
 {
-    auto navigationDelegate = adoptNS([[NavigationActionTestDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr navigationDelegate = adoptNS([[NavigationActionTestDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     auto baseURL = retainPtr([NSURL URLWithString:@"https://example.com/index.html"]);
@@ -201,8 +201,8 @@ TEST(WKNavigationAction, BlobRequestBody)
             "}"
         "</script>"
         "<body onload='bodyLoaded()'>";
-    auto delegate = adoptNS([TestNavigationDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
     __block bool done = false;
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
@@ -225,8 +225,8 @@ TEST(WKNavigationAction, NonMainThread)
         { "/"_s, { "hi"_s } },
     });
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
     __block bool done = false;
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
@@ -249,9 +249,9 @@ TEST(WKNavigationAction, NonMainThread)
 
 TEST(WKNavigationAction, TargetFrameName)
 {
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     webView.get().configuration.preferences.javaScriptCanOpenWindowsAutomatically = YES;
     webView.get().navigationDelegate = navigationDelegate.get();
     webView.get().UIDelegate = uiDelegate.get();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NavigationSwipeTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NavigationSwipeTests.mm
@@ -69,7 +69,7 @@ TEST(NavigationSwipeTests, RestoreFirstResponderAfterNavigationSwipe)
 {
     poseAsClass("TestNavigationInteractiveTransition", "_UINavigationInteractiveTransitionBase");
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView setAllowsBackForwardNavigationGestures:YES];
     [webView becomeFirstResponder];
 
@@ -84,7 +84,7 @@ TEST(NavigationSwipeTests, DoNotBecomeFirstResponderAfterNavigationSwipeIfWebVie
 {
     poseAsClass("TestNavigationInteractiveTransition", "_UINavigationInteractiveTransitionBase");
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView setAllowsBackForwardNavigationGestures:YES];
     [webView becomeFirstResponder];
 
@@ -102,7 +102,7 @@ TEST(NavigationSwipeTests, DoNotAssertWhenSnapshottingZeroSizeView)
 {
     poseAsClass("TestNavigationInteractiveTransition", "_UINavigationInteractiveTransitionBase");
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero]);
     [webView setAllowsBackForwardNavigationGestures:YES];
     [webView becomeFirstResponder];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NetworkActivityTrackerTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NetworkActivityTrackerTests.mm
@@ -41,8 +41,8 @@ static constexpr uint8_t completionCodeCancel = 4;
 
 TEST(NetworkActivityTracker, PageLoadCompletedReportsSuccess)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     HTTPServer server({ { "/"_s, { "<html><body>Hello</body></html>"_s } } });
@@ -63,8 +63,8 @@ TEST(NetworkActivityTracker, PageLoadCompletedReportsSuccess)
 
 TEST(NetworkActivityTracker, NavigationCancelReportsCancel)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     // Load a first page successfully to establish root activity tracking for this page.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NetworkProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NetworkProcess.mm
@@ -57,7 +57,7 @@
 
 TEST(NetworkProcess, Entitlements)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:adoptNS([[WKWebViewConfiguration alloc] init]).get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:adoptNS([[WKWebViewConfiguration alloc] init]).get()]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
     WKWebsiteDataStore *store = [webView configuration].websiteDataStore;
     bool hasEntitlement = [store _networkProcessHasEntitlementForTesting:@"com.apple.rootless.storage.WebKitNetworkingSandbox"];
@@ -84,7 +84,7 @@ TEST(WebKit, HTTPReferer)
                 done = true;
             });
         });
-        auto webView = adoptNS([WKWebView new]);
+        RetainPtr webView = adoptNS([WKWebView new]);
         [webView loadHTMLString:[NSString stringWithFormat:@"<meta name='referrer' content='unsafe-url'><body onload='document.getElementById(\"formID\").submit()'><form id='formID' method='post' action='http://127.0.0.1:%d/'></form></body>", server.port()] baseURL:baseURL];
         Util::run(&done);
     };
@@ -108,7 +108,7 @@ TEST(NetworkProcess, LaunchOnlyWhenNecessary)
     RetainPtr<WKWebsiteDataStore> websiteDataStore;
 
     @autoreleasepool {
-        auto webView = adoptNS([WKWebView new]);
+        RetainPtr webView = adoptNS([WKWebView new]);
         websiteDataStore = [webView configuration].websiteDataStore;
         [websiteDataStore _setResourceLoadStatisticsEnabled:YES];
         [[webView configuration].processPool _registerURLSchemeAsSecure:@"test"];
@@ -123,11 +123,11 @@ TEST(NetworkProcess, CrashWhenNotAssociatedWithDataStore)
 {
     pid_t networkProcessPID = 0;
     @autoreleasepool {
-        auto viewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
-        auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
-        auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+        RetainPtr viewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+        RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
         [viewConfiguration setWebsiteDataStore:dataStore.get()];
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:viewConfiguration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:viewConfiguration.get()]);
         [webView loadHTMLString:@"foo" baseURL:[NSURL URLWithString:@"about:blank"]];
         while (![dataStore _networkProcessIdentifier])
             TestWebKitAPI::Util::spinRunLoop(10);
@@ -140,11 +140,11 @@ TEST(NetworkProcess, CrashWhenNotAssociatedWithDataStore)
     kill(networkProcessPID, 9);
     TestWebKitAPI::Util::spinRunLoop(10);
 
-    auto viewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr viewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
     [viewConfiguration setWebsiteDataStore:dataStore.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:viewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:viewConfiguration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
     EXPECT_NE(networkProcessPID, [webView configuration].websiteDataStore._networkProcessIdentifier);
 }
@@ -153,10 +153,10 @@ TEST(NetworkProcess, TerminateWhenNoWebsiteDataStore)
 {
     pid_t networkProcessIdentifier = 0;
     @autoreleasepool {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         auto nonPersistentStore = [WKWebsiteDataStore nonPersistentDataStore];
         configuration.get().websiteDataStore = nonPersistentStore;
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 0, 0) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 0, 0) configuration:configuration.get()]);
         [webView synchronouslyLoadTestPageNamed:@"simple"];
         EXPECT_TRUE([WKWebsiteDataStore _defaultNetworkProcessExists]);
 
@@ -174,7 +174,7 @@ TEST(NetworkProcess, TerminateWhenNoDefaultWebsiteDataStore)
 {
     pid_t networkProcessIdentifier = 0;
     @autoreleasepool {
-        auto webView = adoptNS([WKWebView new]);
+        RetainPtr webView = adoptNS([WKWebView new]);
         [webView synchronouslyLoadTestPageNamed:@"simple"];
         EXPECT_TRUE([WKWebsiteDataStore _defaultNetworkProcessExists]);
 
@@ -214,7 +214,7 @@ TEST(NetworkProcess, TerminateWhenNetworkProcessIsSuspended)
 {
     pid_t networkProcessIdentifier = 0;
     @autoreleasepool {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         auto nonPersistentStore = [WKWebsiteDataStore nonPersistentDataStore];
 
         bool networkProcessLaunched = TestWebKitAPI::Util::waitFor([&]() {
@@ -242,13 +242,13 @@ TEST(NetworkProcess, TerminateWhenNetworkProcessIsSuspended)
 
 TEST(NetworkProcess, DoNotLaunchOnDataStoreDestruction)
 {
-    auto storeConfiguration1 = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
-    auto websiteDataStore1 = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration: storeConfiguration1.get()]);
+    RetainPtr storeConfiguration1 = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr websiteDataStore1 = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration: storeConfiguration1.get()]);
 
     EXPECT_FALSE([WKWebsiteDataStore _defaultNetworkProcessExists]);
     @autoreleasepool {
-        auto storeConfiguration2 = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
-        auto websiteDataStore2 = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration: storeConfiguration2.get()]);
+        RetainPtr storeConfiguration2 = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+        RetainPtr websiteDataStore2 = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration: storeConfiguration2.get()]);
     }
 
     TestWebKitAPI::Util::spinRunLoop(10);
@@ -287,14 +287,14 @@ TEST(NetworkProcess, CORSPreflightCachePartitioned)
     });
     NSString *html = [NSString stringWithFormat:@"<script>var xhr = new XMLHttpRequest();xhr.open('DELETE', 'http://localhost:%d/');xhr.send()</script>", server.port()];
     NSURL *baseURL = [NSURL URLWithString:@"http://example.com/"];
-    auto firstWebView = adoptNS([WKWebView new]);
+    RetainPtr firstWebView = adoptNS([WKWebView new]);
     [firstWebView loadHTMLString:html baseURL:baseURL];
     while (preflightRequestsReceived != 1)
         TestWebKitAPI::Util::spinRunLoop();
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     configuration.get().websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
-    auto secondWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr secondWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [secondWebView loadHTMLString:html baseURL:baseURL];
     while (preflightRequestsReceived != 2)
         TestWebKitAPI::Util::spinRunLoop();
@@ -348,12 +348,12 @@ static void waitUntilNetworkProcessIsResponsive(WKWebView *webView1, WKWebView *
 
 TEST(NetworkProcess, BroadcastChannelCrashRecovery)
 {
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[NetworkProcessTestMessageHandler alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[NetworkProcessTestMessageHandler alloc] init]);
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"test"];
 
-    auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
     receivedMessage = false;
     receivedMessagesVector.clear();
@@ -533,7 +533,7 @@ TEST(_WKDataTask, Basic)
             EXPECT_FALSE(true);
         }
     });
-    auto webView = adoptNS([TestWKWebView new]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
     [webView synchronouslyLoadRequest:server.request("/initial_request"_s)];
 
     __block bool done = false;
@@ -543,7 +543,7 @@ TEST(_WKDataTask, Basic)
     auto requestBody = "request body";
     [postRequest setHTTPBody:[NSData dataWithBytes:requestBody length:strlen(requestBody)]];
     [webView _dataTaskWithRequest:postRequest.get() completionHandler:^(_WKDataTask *task) {
-        auto delegate = adoptNS([TestDataTaskDelegate new]);
+        RetainPtr delegate = adoptNS([TestDataTaskDelegate new]);
         task.delegate = delegate.get();
         __block bool receivedResponse = false;
         delegate.get().didReceiveResponse = ^(_WKDataTask *, NSURLResponse *response, void (^decisionHandler)(_WKDataTaskResponsePolicy)) {
@@ -572,7 +572,7 @@ TEST(_WKDataTask, Basic)
     __block RetainPtr<_WKDataTask> retainedTask;
     [webView _dataTaskWithRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"unsupported:blank"]] completionHandler:^(_WKDataTask *task) {
         retainedTask = task;
-        auto delegate = adoptNS([TestDataTaskDelegate new]);
+        RetainPtr delegate = adoptNS([TestDataTaskDelegate new]);
         task.delegate = delegate.get();
         __block bool receivedResponse = false;
         delegate.get().didReceiveResponse = ^(_WKDataTask *, NSURLResponse *response, void (^decisionHandler)(_WKDataTaskResponsePolicy)) {
@@ -598,7 +598,7 @@ TEST(_WKDataTask, Basic)
     done = false;
     [webView _dataTaskWithRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org<>/"]] completionHandler:^(_WKDataTask *task) {
         retainedTask = task;
-        auto delegate = adoptNS([TestDataTaskDelegate new]);
+        RetainPtr delegate = adoptNS([TestDataTaskDelegate new]);
         task.delegate = delegate.get();
         delegate.get().didCompleteWithError = ^(_WKDataTask *task, NSError *error) {
             EXPECT_WK_STREQ(error.domain, WebKitErrorDomain);
@@ -613,11 +613,11 @@ TEST(_WKDataTask, Challenge)
 {
     using namespace TestWebKitAPI;
     HTTPServer server(HTTPServer::respondWithChallengeThenOK, HTTPServer::Protocol::Https);
-    auto webView = adoptNS([TestWKWebView new]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
 
     __block bool done = false;
     [webView _dataTaskWithRequest:server.request() completionHandler:^(_WKDataTask *task) {
-        auto delegate = adoptNS([TestDataTaskDelegate new]);
+        RetainPtr delegate = adoptNS([TestDataTaskDelegate new]);
         task.delegate = delegate.get();
         __block bool receivedServerTrustChallenge = false;
         __block bool receivedBasicAuthChallenge = false;
@@ -677,9 +677,9 @@ TEST(_WKDataTask, Cancel)
         });
     });
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView _dataTaskWithRequest:server.request() completionHandler:^(_WKDataTask *task) {
-        auto delegate = adoptNS([TestDataTaskDelegate new]);
+        RetainPtr delegate = adoptNS([TestDataTaskDelegate new]);
         task.delegate = delegate.get();
         delegate.get().didReceiveResponse = ^(_WKDataTask *task, NSURLResponse *response, void (^decisionHandler)(_WKDataTaskResponsePolicy)) {
             decisionHandler(_WKDataTaskResponsePolicyAllow);
@@ -694,7 +694,7 @@ TEST(_WKDataTask, Cancel)
 
     __block bool completed { false };
     [webView _dataTaskWithRequest:server.request() completionHandler:^(_WKDataTask *task) {
-        auto delegate = adoptNS([TestDataTaskDelegate new]);
+        RetainPtr delegate = adoptNS([TestDataTaskDelegate new]);
         task.delegate = delegate.get();
         delegate.get().didReceiveResponse = ^(_WKDataTask *task, NSURLResponse *response, void (^decisionHandler)(_WKDataTaskResponsePolicy)) {
             decisionHandler(_WKDataTaskResponsePolicyCancel);
@@ -715,11 +715,11 @@ TEST(_WKDataTask, Redirect)
         { "/"_s, { 301, { { "Location"_s, "/redirectTarget"_s }, { "Custom-Name"_s, "Custom-Value"_s } } } },
         { "/redirectTarget"_s, { "hi"_s } },
     } };
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     RetainPtr<NSURLRequest> serverRequest = server.request();
     __block bool receivedData { false };
     [webView _dataTaskWithRequest:serverRequest.get() completionHandler:^(_WKDataTask *task) {
-        auto delegate = adoptNS([TestDataTaskDelegate new]);
+        RetainPtr delegate = adoptNS([TestDataTaskDelegate new]);
         task.delegate = delegate.get();
         delegate.get().willPerformHTTPRedirection = ^(_WKDataTask *task, NSHTTPURLResponse *response, NSURLRequest *request, void(^decisionHandler)(_WKDataTaskRedirectPolicy)) {
             EXPECT_WK_STREQ(serverRequest.get().URL.absoluteString, response.URL.absoluteString);
@@ -738,7 +738,7 @@ TEST(_WKDataTask, Redirect)
     __block bool completed { false };
     __block bool receivedResponse { false };
     [webView _dataTaskWithRequest:serverRequest.get() completionHandler:^(_WKDataTask *task) {
-        auto delegate = adoptNS([TestDataTaskDelegate new]);
+        RetainPtr delegate = adoptNS([TestDataTaskDelegate new]);
         task.delegate = delegate.get();
         delegate.get().willPerformHTTPRedirection = ^(_WKDataTask *task, NSHTTPURLResponse *response, NSURLRequest *request, void(^decisionHandler)(_WKDataTaskRedirectPolicy)) {
             decisionHandler(_WKDataTaskRedirectPolicyCancel);
@@ -762,10 +762,10 @@ TEST(_WKDataTask, CrashDuringCreation)
 {
     using namespace TestWebKitAPI;
     HTTPServer server(HTTPServer::respondWithOK);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     __block bool done = false;
     [webView _dataTaskWithRequest:server.request() completionHandler:^(_WKDataTask *task) {
-        auto delegate = adoptNS([TestDataTaskDelegate new]);
+        RetainPtr delegate = adoptNS([TestDataTaskDelegate new]);
         task.delegate = delegate.get();
         delegate.get().didCompleteWithError = ^(_WKDataTask *, NSError *error) {
             EXPECT_NOT_NULL(error);
@@ -783,11 +783,11 @@ TEST(_WKDataTask, Crash)
 {
     using namespace TestWebKitAPI;
     HTTPServer server(HTTPServer::respondWithOK);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
 
     __block bool done = false;
     [webView _dataTaskWithRequest:server.request() completionHandler:^(_WKDataTask *task) {
-        auto delegate = adoptNS([TestDataTaskDelegate new]);
+        RetainPtr delegate = adoptNS([TestDataTaskDelegate new]);
         task.delegate = delegate.get();
         delegate.get().didReceiveResponse = ^(_WKDataTask *task, NSURLResponse *response, void (^decisionHandler)(_WKDataTaskResponsePolicy)) {
             kill(webView.get().configuration.websiteDataStore._networkProcessIdentifier, SIGKILL);
@@ -805,13 +805,13 @@ TEST(_WKDataTask, Crash)
 TEST(_WKDataTask, Blob)
 {
     __block bool done { false };
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     NSString *html = @"<script>alert(window.URL.createObjectURL(new Blob(['Blob hello'], {type: 'application/octet-stream'})));</script>";
     [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
     NSString *url = [webView _test_waitForAlert];
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:url]];
     [webView _dataTaskWithRequest:request completionHandler:^(_WKDataTask *task) {
-        auto delegate = adoptNS([TestDataTaskDelegate new]);
+        RetainPtr delegate = adoptNS([TestDataTaskDelegate new]);
         task.delegate = delegate.get();
         __block bool receivedResponse = false;
         delegate.get().didReceiveResponse = ^(_WKDataTask *, NSURLResponse *response, void (^decisionHandler)(_WKDataTaskResponsePolicy)) {
@@ -821,7 +821,7 @@ TEST(_WKDataTask, Blob)
         __block bool receivedData = false;
         delegate.get().didReceiveData = ^(_WKDataTask *, NSData *data) {
             EXPECT_TRUE(receivedResponse);
-            auto dataString = adoptNS([[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
+            RetainPtr dataString = adoptNS([[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
             EXPECT_WK_STREQ(dataString.get(), "Blob hello");
             receivedData = true;
         };
@@ -863,19 +863,19 @@ TEST(WKWebView, CrossOriginDoubleRedirectAuthentication)
         }
     });
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(server.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [viewConfiguration setWebsiteDataStore:dataStore.get()];
 
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://example.com/original-target"]];
     [request setValue:@"TestValue" forHTTPHeaderField:@"Authorization"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:viewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:viewConfiguration.get()]);
     [webView loadRequest:request];
     Util::run(&done);
 }
@@ -912,11 +912,11 @@ TEST(NetworkProcess, DoNotLaunchForDOMCacheDestruction)
         { "/"_s, { mainBytes } },
         { "/worker.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, workerBytes } }
     });
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration.get().websiteDataStore _setResourceLoadStatisticsEnabled:NO];
-    auto messageHandler = adoptNS([[NetworkProcessTestMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[NetworkProcessTestMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
     [webView loadRequest:server.request()];
     EXPECT_WK_STREQ(@"cache is opened", (NSString *)[waitAndGetNextMessage() body]);
     EXPECT_TRUE([configuration.get().websiteDataStore _networkProcessExists]);
@@ -941,7 +941,7 @@ TEST(NetworkProcess, CustomSchemeWasPrivateRelayed)
 {
     [TestProtocol registerWithScheme:@"custom"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"custom://test"]]];
 
     EXPECT_EQ(NO, [webView _wasPrivateRelayed]);
@@ -951,21 +951,21 @@ TEST(NetworkProcess, CustomSchemeWasPrivateRelayed)
 
 TEST(NetworkProcess, URLSchemeHandlerWasPrivateRelayed)
 {
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         auto result = @"<html></html>";
         auto type = @"text/html";
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:type expectedContentLength:[result length] textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:type expectedContentLength:[result length] textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[result dataUsingEncoding:NSUTF8StringEncoding]];
         [task didFinish];
     }];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"custom"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"custom://test"]]];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NetworkProcessCrashNonPersistentDataStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NetworkProcessCrashNonPersistentDataStore.mm
@@ -61,10 +61,10 @@ static void checkRecoveryAfterCrash(WKWebsiteDataStore *dataStore)
     NSURL *simple = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     NSURL *simple2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:dataStore];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([[CrashDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[CrashDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:simple]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NoHistoryItemScrollToFragment.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NoHistoryItemScrollToFragment.mm
@@ -71,16 +71,16 @@ namespace TestWebKitAPI {
 
 TEST(WebKit, NoHistoryItemScrollToFragment)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
 
 #if PLATFORM(MAC)
-    auto delegate = adoptNS([[DidScrollToFragmentDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[DidScrollToFragmentDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 #endif
 #if PLATFORM(IOS_FAMILY)
-    auto delegateForScrollView = adoptNS([[DidScrollToFragmentScrollViewDelegate alloc] init]);
+    RetainPtr delegateForScrollView = adoptNS([[DidScrollToFragmentScrollViewDelegate alloc] init]);
     [webView scrollView].delegate = delegateForScrollView.get();
 #endif
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NoPauseWhenSwitchingTabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NoPauseWhenSwitchingTabs.mm
@@ -44,7 +44,7 @@ TEST(WebKit, DISABLED_NoPauseWhenSwitchingTabs)
 TEST(WebKit, NoPauseWhenSwitchingTabs)
 #endif
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 #if PLATFORM(IOS) || PLATFORM(VISION)
     configuration.get().allowsInlineMediaPlayback = YES;
     configuration.get()._inlineMediaPlaybackRequiresPlaysInlineAttribute = NO;
@@ -52,7 +52,7 @@ TEST(WebKit, NoPauseWhenSwitchingTabs)
     configuration.get()._mediaDataLoadsAutomatically = YES;
     configuration.get().mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeAudio;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     [webView synchronouslyLoadTestPageNamed:@"video-with-audio"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NoResumeSoundPlayedToTheEndAfterThePageBecomesVisible.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NoResumeSoundPlayedToTheEndAfterThePageBecomesVisible.mm
@@ -38,8 +38,8 @@
 
 TEST(WebKit, NoResumeSoundPlayedToTheEndAfterThePageBecomesVisible)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 500, 500) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 500, 500) configuration:configuration.get() addToWindow:YES]);
 
     bool isEnded = false;
     [webView performAfterReceivingMessage:@"audioEnded" action:[&] { isEnded = true; }];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NotificationAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NotificationAPI.mm
@@ -80,12 +80,12 @@ namespace TestWebKitAPI {
 enum class ShouldGrantPermission : bool { No, Yes };
 static void runRequestPermissionTest(ShouldGrantPermission shouldGrantPermission)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[NotificationPermissionMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[NotificationPermissionMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto uiDelegate = adoptNS([[NotificationPermissionUIDelegate alloc] initWithHandler:[shouldGrantPermission] { return shouldGrantPermission == ShouldGrantPermission::Yes; }]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr uiDelegate = adoptNS([[NotificationPermissionUIDelegate alloc] initWithHandler:[shouldGrantPermission] { return shouldGrantPermission == ShouldGrantPermission::Yes; }]);
     [webView setUIDelegate:uiDelegate.get()];
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
@@ -128,12 +128,12 @@ TEST(Notification, RequestPermissionGranted)
 
 static void runParallelPermissionRequestsTest(ShouldGrantPermission shouldGrantPermission)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[NotificationPermissionMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[NotificationPermissionMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto uiDelegate = adoptNS([[NotificationPermissionUIDelegate alloc] initWithHandler:[shouldGrantPermission] { return shouldGrantPermission == ShouldGrantPermission::Yes; }]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr uiDelegate = adoptNS([[NotificationPermissionUIDelegate alloc] initWithHandler:[shouldGrantPermission] { return shouldGrantPermission == ShouldGrantPermission::Yes; }]);
     [webView setUIDelegate:uiDelegate.get()];
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
@@ -173,8 +173,8 @@ TEST(Notification, ParallelPermissionRequestsGranted)
 #if ENABLE(WEB_ARCHIVE)
 TEST(Notification, WebArchiveNotificationNotSupported)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[NotificationPermissionMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[NotificationPermissionMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NowPlayingControlsTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NowPlayingControlsTests.mm
@@ -107,9 +107,9 @@ namespace TestWebKitAPI {
 #if PLATFORM(MAC)
 TEST(NowPlayingControlsTests, NowPlayingControlsDoNotShowForForegroundPage)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
-    auto webView = adoptNS([[NowPlayingTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[NowPlayingTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadTestPageNamed:@"large-video-test-now-playing"];
     [webView waitForMessage:@"playing"];
 
@@ -128,9 +128,9 @@ TEST(NowPlayingControlsTests, NowPlayingControlsDoNotShowForForegroundPage)
 
 TEST(NowPlayingControlsTests, NowPlayingControlsShowForBackgroundPage)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
-    auto webView = adoptNS([[NowPlayingTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[NowPlayingTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadTestPageNamed:@"large-video-test-now-playing"];
     [webView waitForMessage:@"playing"];
 
@@ -146,10 +146,10 @@ TEST(NowPlayingControlsTests, NowPlayingControlsShowForBackgroundPage)
 #if ENABLE(REQUIRES_PAGE_VISIBILITY_FOR_NOW_PLAYING)
 TEST(NowPlayingControlsTests, NowPlayingApplicationNotRegisteredForBackgroundPage)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
     [configuration preferences]._requiresPageVisibilityForVideoToBeNowPlayingForTesting = YES;
-    auto webView = adoptNS([[NowPlayingTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[NowPlayingTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadTestPageNamed:@"large-video-test-now-playing"];
     [webView waitForMessage:@"playing"];
 
@@ -171,9 +171,9 @@ TEST(NowPlayingControlsTests, NowPlayingApplicationNotRegisteredForBackgroundPag
 
 TEST(NowPlayingControlsTests, NowPlayingControlsHideAfterShowingKeepsSessionActive)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
-    auto webView = adoptNS([[NowPlayingTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[NowPlayingTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadTestPageNamed:@"large-video-test-now-playing"];
     [webView waitForMessage:@"playing"];
 
@@ -194,9 +194,9 @@ TEST(NowPlayingControlsTests, NowPlayingControlsHideAfterShowingKeepsSessionActi
 
 TEST(NowPlayingControlsTests, NowPlayingControlsClearInfoAfterSessionIsNoLongerValid)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
-    auto webView = adoptNS([[NowPlayingTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[NowPlayingTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
     [webView loadTestPageNamed:@"large-video-test-now-playing"];
     [webView waitForMessage:@"playing"];
 
@@ -235,9 +235,9 @@ TEST(NowPlayingControlsTests, NowPlayingControlsClearInfoAfterSessionIsNoLongerV
 
 TEST(NowPlayingControlsTests, NowPlayingControlsCheckRegistered)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
-    auto webView = adoptNS([[NowPlayingTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[NowPlayingTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadTestPageNamed:@"large-video-test-now-playing"];
     [webView waitForMessage:@"playing"];
     [webView setWindowVisible:NO];
@@ -262,9 +262,9 @@ TEST(NowPlayingControlsTests, NowPlayingControlsCheckRegistered)
 // FIXME: Re-enable this test once <webkit.org/b/175204> is resolved.
 TEST(NowPlayingControlsTests, DISABLED_NowPlayingControlsIOS)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
-    auto webView = adoptNS([[NowPlayingTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[NowPlayingTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
     [webView loadTestPageNamed:@"large-video-test-now-playing"];
     [webView waitForMessage:@"playing"];
 
@@ -278,7 +278,7 @@ TEST(NowPlayingControlsTests, DISABLED_NowPlayingControlsIOS)
 TEST(NowPlayingControlsTests, LazyRegisterAsNowPlayingApplication)
 {
     auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES]);
-    auto webView = adoptNS([[NowPlayingTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[NowPlayingTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:@"<body>Hello world</body>"];
 
     auto haveMediaSessionManager = [&] {
@@ -326,7 +326,7 @@ TEST(NowPlayingControlsTests, DISABLED_NowPlayingUpdatesThrottled)
 
     auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES]);
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
-    auto webView = adoptNS([[NowPlayingTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[NowPlayingTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
 
     constexpr double internalTestTimout = 20;
     auto waitForMessageOrTimeout = [&] (const char* eventName) -> bool {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NowPlayingMetadataObserver.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NowPlayingMetadataObserver.mm
@@ -34,10 +34,10 @@ namespace TestWebKitAPI {
 
 TEST(NowPlayingMetadataObserver, VideoTitle)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
     [webView loadTestPageNamed:@"large-video-test-now-playing"];
     [webView waitForMessage:@"playing"];
 
@@ -58,10 +58,10 @@ TEST(NowPlayingMetadataObserver, VideoTitle)
 
 TEST(NowPlayingMetadataObserver, VideoTitleUpdatedByMediaSession)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
     [webView loadTestPageNamed:@"large-video-test-now-playing"];
     [webView waitForMessage:@"playing"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/OpenAndCloseWindow.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/OpenAndCloseWindow.mm
@@ -240,7 +240,7 @@ TEST(WebKit, OpenWindowFeatures)
 {
     resetToConsistentState();
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     sharedCheckWindowFeaturesUIDelegate = adoptNS([[CheckWindowFeaturesUIDelegate alloc] init]);
     [webView setUIDelegate:sharedCheckWindowFeaturesUIDelegate.get()];
@@ -409,9 +409,9 @@ TEST(WebKit, OpenWindowThenDocumentOpen)
 {
     resetToConsistentState();
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto uiDelegate = adoptNS([[OpenWindowThenDocumentOpenUIDelegate alloc] init]);
+    RetainPtr uiDelegate = adoptNS([[OpenWindowThenDocumentOpenUIDelegate alloc] init]);
     [webView setUIDelegate:uiDelegate.get()];
     [webView configuration].preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
@@ -432,9 +432,9 @@ TEST(WebKit, OpenFileURLWithHost)
 {
     resetToConsistentState();
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto uiDelegate = adoptNS([[OpenWindowThenDocumentOpenUIDelegate alloc] init]);
+    RetainPtr uiDelegate = adoptNS([[OpenWindowThenDocumentOpenUIDelegate alloc] init]);
     [webView setUIDelegate:uiDelegate.get()];
     [webView configuration].preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
@@ -450,7 +450,7 @@ TEST(WebKit, OpenFileURLWithHost)
 
 TEST(WebKit, TryClose)
 {
-    auto webView = adoptNS([TestWKWebView new]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
     [webView synchronouslyLoadHTMLString:@"load something"];
     EXPECT_TRUE([webView _tryClose]);
     [webView synchronouslyLoadHTMLString:@"<body onunload='runScriptThatDoesNotNeedToExist()'/>"];
@@ -464,11 +464,11 @@ TEST(WebKit, TryWindowOpenJavascriptURLInIframeSingleWindowApp)
         { "/subframe"_s, { ""_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
-    auto webView = adoptNS([TestWKWebView new]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
     webView.get().configuration.preferences.javaScriptCanOpenWindowsAutomatically = YES;
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     [webView setUIDelegate:uiDelegate.get()];
     webView.get().navigationDelegate = navigationDelegate.get();
 
@@ -495,7 +495,7 @@ static void runHasOpenerTest(NSString *js, bool expectsOpener)
     __block bool popupHasOpenerInCreateWebView = false;
     __block bool popupHasOpenerInDecidePolicyForNavigationAction = false;
 
-    __block auto popupNavigationDelegate = adoptNS([TestNavigationDelegate new]);
+    __block RetainPtr popupNavigationDelegate = adoptNS([TestNavigationDelegate new]);
     popupNavigationDelegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^decisionHandler)(WKNavigationActionPolicy)) {
         popupHasOpenerInDecidePolicyForNavigationAction = action._hasOpener;
         decisionHandler(WKNavigationActionPolicyCancel);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PDFLinkReferrer.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PDFLinkReferrer.mm
@@ -47,7 +47,7 @@ static void emptyReleaseInfoCallback(void*)
 
 static RetainPtr<NSData> createPDFWithLinkToURL(NSURL *url)
 {
-    auto pdfData = adoptNS([[NSMutableData alloc] init]);
+    RetainPtr pdfData = adoptNS([[NSMutableData alloc] init]);
     
     CGDataConsumerCallbacks callbacks;
     callbacks.putBytes = (CGDataConsumerPutBytesCallback)putPDFBytesCallback;
@@ -93,7 +93,7 @@ TEST(WebKit, PDFLinkReferrer)
 
     RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     webView.get().navigationDelegate = navigationDelegate.get();
 
     auto *linkURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%hu", server.port()]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PageZoom.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PageZoom.mm
@@ -34,7 +34,7 @@ namespace TestWebKitAPI {
 
 TEST(WKWebView, PageZoom)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"<body>TEST</body>" baseURL:nil];
 
     // On macOS this will be 400, per the size of the WKWebView.
@@ -49,7 +49,7 @@ TEST(WKWebView, PageZoom)
 
 TEST(WKWebView, PageZoomAfterPDF)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
@@ -72,7 +72,7 @@ TEST(WKWebView, PageZoomAfterPDF)
 
 TEST(WKWebView, MinimumMagnification)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"<body>TEST</body>" baseURL:nil];
 
     EXPECT_EQ([webView minimumMagnification], 1.00);
@@ -80,7 +80,7 @@ TEST(WKWebView, MinimumMagnification)
 
 TEST(WKWebView, MinimumMagnificationPDF)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
 
     NSURLRequest *pdfRequest = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]];
     [webView loadRequest:pdfRequest];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParserYieldTokenTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParserYieldTokenTests.mm
@@ -49,10 +49,10 @@
 
 + (RetainPtr<ParserYieldTokenTestWebView>)webView
 {
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"ParserYieldTokenPlugIn"];
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"custom"];
-    auto webView = adoptNS([[ParserYieldTokenTestWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200) configuration:configuration]);
+    RetainPtr webView = adoptNS([[ParserYieldTokenTestWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200) configuration:configuration]);
     [[webView _remoteObjectRegistry] registerExportedObject:webView.get() interface:[_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(ParserYieldTokenTestRunner)]];
     webView->_bundle = [[webView _remoteObjectRegistry] remoteObjectProxyWithInterface:[_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(ParserYieldTokenTestBundle)]];
     webView->_schemeHandler = WTF::move(schemeHandler);
@@ -167,7 +167,7 @@ TEST(ParserYieldTokenTests, AsyncScriptRunsWhenFetched)
     auto webView = [ParserYieldTokenTestWebView webView];
     [webView schemeHandler].startURLSchemeTaskHandler = [] (WKWebView *, id <WKURLSchemeTask> task) {
         auto script = retainPtr(@"window.eventMessages.push('Running async script.');");
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/javascript" expectedContentLength:[script length] textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/javascript" expectedContentLength:[script length] textEncodingName:nil]);
         dispatch_async(mainDispatchQueueSingleton(), [task = retainPtr(task), response = WTF::move(response), script = WTF::move(script)] {
             [task didReceiveResponse:response.get()];
             [task didReceiveData:[script dataUsingEncoding:NSUTF8StringEncoding]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PasteHTML.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PasteHTML.mm
@@ -64,10 +64,10 @@ void writeHTMLToPasteboard(NSString *html)
 
 static RetainPtr<TestWKWebView> createWebViewWithCustomPasteboardDataSetting(bool enabled, bool colorFilterEnabled = false)
 {
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration _setColorFilterEnabled:colorFilterEnabled];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:webViewConfiguration.get()]);
     auto preferences = (__bridge WKPreferencesRef)[[webView configuration] preferences];
     WKPreferencesSetDataTransferItemsEnabled(preferences, true);
     WKPreferencesSetCustomPasteboardDataEnabled(preferences, enabled);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PasteImage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PasteImage.mm
@@ -55,9 +55,9 @@ void writeImageDataToPasteboard(NSDictionary <NSString *, NSData *> *typesAndDat
 void writeImageDataToPasteboard(NSArray<NSDictionary <NSString *, NSData *> *> *items)
 {
     [NSPasteboard.generalPasteboard clearContents];
-    auto pasteboardItems = adoptNS([[NSMutableArray alloc] initWithCapacity:items.count]);
+    RetainPtr pasteboardItems = adoptNS([[NSMutableArray alloc] initWithCapacity:items.count]);
     for (NSDictionary<NSString *, NSData *> *typesAndData in items) {
-        auto pasteboardItem = adoptNS([[NSPasteboardItem alloc] init]);
+        RetainPtr pasteboardItem = adoptNS([[NSPasteboardItem alloc] init]);
         for (NSString *type in typesAndData)
             [pasteboardItem setData:typesAndData[type] forType:type];
         [pasteboardItems addObject:pasteboardItem.get()];
@@ -108,7 +108,7 @@ void writeImageDataToPasteboard(NSArray<NSDictionary <NSString *, NSData *> *> *
 
 TEST(PasteImage, PasteGIFImage)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"paste-image"];
 
     auto *data = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-400px" ofType:@"gif"]];
@@ -130,7 +130,7 @@ TEST(PasteImage, PasteGIFImage)
 
 TEST(PasteImage, PasteJPEGImage)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"paste-image"];
 
     auto *data = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-600px" ofType:@"jpg"]];
@@ -152,7 +152,7 @@ TEST(PasteImage, PasteJPEGImage)
 
 TEST(PasteImage, PastePNGImage)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"paste-image"];
 
     auto *data = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-200px" ofType:@"png"]];
@@ -174,7 +174,7 @@ TEST(PasteImage, PastePNGImage)
 
 TEST(PasteImage, PasteImageWithMultipleRepresentations)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"paste-image"];
 
     auto pngData = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-200px" ofType:@"png"]];
@@ -198,7 +198,7 @@ TEST(PasteImage, PasteImageWithMultipleRepresentations)
 
 TEST(PasteImage, RevealSelectionAfterPastingImage)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width, initial-scale=1'><body contenteditable>Hello world</body>"];
     [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
     [webView _synchronouslyExecuteEditCommand:@"InsertText" argument:@"Hello world"];
@@ -220,7 +220,7 @@ void writeBundleFileToPasteboard(id object)
 
 TEST(PasteImage, PasteGIFFile)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"paste-image"];
 
     NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"sunset-in-cupertino-400px" withExtension:@"gif"];
@@ -241,7 +241,7 @@ TEST(PasteImage, PasteGIFFile)
 
 TEST(PasteImage, PasteJPEGFile)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"paste-image"];
 
     NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"sunset-in-cupertino-600px" withExtension:@"jpg"];
@@ -262,7 +262,7 @@ TEST(PasteImage, PasteJPEGFile)
 
 TEST(PasteImage, PastePNGFile)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"paste-image"];
 
     NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"sunset-in-cupertino-200px" withExtension:@"png"];
@@ -283,7 +283,7 @@ TEST(PasteImage, PastePNGFile)
 
 TEST(PasteImage, PasteTIFFFile)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"paste-image"];
 
     NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"sunset-in-cupertino-100px" withExtension:@"tiff"];
@@ -304,7 +304,7 @@ TEST(PasteImage, PasteTIFFFile)
 
 TEST(PasteImage, PasteLegacyTIFFImage)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"paste-image"];
 
     auto *data = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-100px" ofType:@"tiff"]];
@@ -325,7 +325,7 @@ TEST(PasteImage, PasteLegacyTIFFImage)
 
 TEST(PasteImage, PasteTIFFImage)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"paste-image"];
 
     auto *data = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-100px" ofType:@"tiff"]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PasteMixedContent.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PasteMixedContent.mm
@@ -90,7 +90,7 @@ void writeTypesAndDataToPasteboard(id type, ...)
 
 static RetainPtr<TestWKWebView> setUpWebView()
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     WKPreferencesSetCustomPasteboardDataEnabled((__bridge WKPreferencesRef)[webView configuration].preferences, true);
     [webView synchronouslyLoadTestPageNamed:@"DataTransfer"];
     return webView;
@@ -122,8 +122,8 @@ TEST(PasteMixedContent, ImageFileAndWebArchive)
 {
     auto webView = setUpWebView();
     NSURL *mainResourceURL = [NSURL fileURLWithPath:@"/some/nonexistent/file.html"];
-    auto mainResource = adoptNS([[WebResource alloc] initWithData:[markupString() dataUsingEncoding:NSUTF8StringEncoding] URL:mainResourceURL MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
-    auto archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:nil subframeArchives:nil]);
+    RetainPtr mainResource = adoptNS([[WebResource alloc] initWithData:[markupString() dataUsingEncoding:NSUTF8StringEncoding] URL:mainResourceURL MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
+    RetainPtr archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:nil subframeArchives:nil]);
     writeTypesAndDataToPasteboard(NSFilenamesPboardType, @[ imagePath() ], WebArchivePboardType, [archive data], nil);
     [webView paste:nil];
 
@@ -154,7 +154,7 @@ TEST(PasteMixedContent, ImageFileAndHTML)
 TEST(PasteMixedContent, ImageFileAndRTF)
 {
     auto webView = setUpWebView();
-    auto text = adoptNS([[NSMutableAttributedString alloc] init]);
+    RetainPtr text = adoptNS([[NSMutableAttributedString alloc] init]);
     [text appendAttributedString:adoptNS([[NSAttributedString alloc] initWithString:@"link to "]).get()];
     [text appendAttributedString:adoptNS([[NSAttributedString alloc] initWithString:@"apple" attributes:@{ NSLinkAttributeName: [NSURL URLWithString:@"https://www.apple.com/"] }]).get()];
     NSData *rtfData = [text RTFFromRange:NSMakeRange(0, [text length]) documentAttributes:@{ }];
@@ -246,7 +246,7 @@ TEST(PasteMixedContent, PasteURLWrittenToPasteboardUsingWriteObjects)
 {
     NSString *urlToCopy = @"https://www.webkit.org/";
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"<body contenteditable></body><script>document.body.focus()</script>"];
     [[NSPasteboard generalPasteboard] clearContents];
     [[NSPasteboard generalPasteboard] writeObjects:@[ [NSURL URLWithString:urlToCopy] ]];
@@ -354,18 +354,18 @@ TEST(PasteMixedContent, CopyAndPasteWithCustomPasteboardDataOnly)
     NSString *markupForSource = @"<body oncopy=\"event.preventDefault(); event.clipboardData.setData('foo', 'bar')\">hello</body>";
     NSString *markupForDestination = @"<input autofocus onpaste=\"event.preventDefault(); this.value = event.clipboardData.getData('foo')\">";
 
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"same"];
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"different"];
     WKPreferencesSetCustomPasteboardDataEnabled((__bridge WKPreferencesRef)[configuration preferences], true);
 
-    auto source = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr source = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
     [source synchronouslyLoadHTMLString:markupForSource baseURL:[NSURL URLWithString:@"same://"]];
     [source selectAll:nil];
     [source _synchronouslyExecuteEditCommand:@"copy" argument:nil];
 
-    auto destination = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr destination = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
     [destination synchronouslyLoadHTMLString:markupForDestination baseURL:[NSURL URLWithString:@"same://"]];
 #if PLATFORM(IOS_FAMILY)
     {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PasteRTFD.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PasteRTFD.mm
@@ -86,9 +86,9 @@ void writeRTFDToPasteboard(NSData *data)
 
 static RetainPtr<NSAttributedString> createHelloWorldString()
 {
-    auto hello = adoptNS([[NSAttributedString alloc] initWithString:@"hello" attributes:@{ NSUnderlineStyleAttributeName : @(NSUnderlineStyleSingle) }]);
-    auto world = adoptNS([[NSAttributedString alloc] initWithString:@", world" attributes:@{ }]);
-    auto string = adoptNS([[NSMutableAttributedString alloc] init]);
+    RetainPtr hello = adoptNS([[NSAttributedString alloc] initWithString:@"hello" attributes:@{ NSUnderlineStyleAttributeName : @(NSUnderlineStyleSingle) }]);
+    RetainPtr world = adoptNS([[NSAttributedString alloc] initWithString:@", world" attributes:@{ }]);
+    RetainPtr string = adoptNS([[NSMutableAttributedString alloc] init]);
     [string appendAttributedString:hello.get()];
     [string appendAttributedString:world.get()];
     return string;
@@ -144,7 +144,7 @@ TEST(PasteRTFD, ImageElementUsesBlobURL)
     [webView synchronouslyLoadTestPageNamed:@"paste-rtfd"];
 
     auto *pngData = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-200px" ofType:@"png"]];
-    auto attachment = adoptNS([[NSTextAttachment alloc] initWithData:pngData ofType:UTTypePNG.identifier]);
+    RetainPtr attachment = adoptNS([[NSTextAttachment alloc] initWithData:pngData ofType:UTTypePNG.identifier]);
     NSAttributedString *string = [NSAttributedString attributedStringWithAttachment:attachment.get()];
     NSData *RTFDData = [string RTFDFromRange:NSMakeRange(0, [string length]) documentAttributes:@{ }];
 
@@ -162,7 +162,7 @@ TEST(PasteRTFD, ImageElementUsesBlobURLInHTML)
     [webView synchronouslyLoadTestPageNamed:@"paste-rtfd"];
 
     auto *pngData = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-200px" ofType:@"png"]];
-    auto attachment = adoptNS([[NSTextAttachment alloc] initWithData:pngData ofType:UTTypePNG.identifier]);
+    RetainPtr attachment = adoptNS([[NSTextAttachment alloc] initWithData:pngData ofType:UTTypePNG.identifier]);
     NSAttributedString *string = [NSAttributedString attributedStringWithAttachment:attachment.get()];
     NSData *RTFDData = [string RTFDFromRange:NSMakeRange(0, [string length]) documentAttributes:@{ }];
 
@@ -190,9 +190,9 @@ TEST(PasteRTFD, TransformColorsOfDarkContent)
     PlatformColor *textColor = [PlatformColor lightGrayColor];
     PlatformColor *backgroundColor = [PlatformColor darkGrayColor];
 
-    auto hello = adoptNS([[NSAttributedString alloc] initWithString:@"Hello" attributes:@{ NSBackgroundColorAttributeName : backgroundColor, NSForegroundColorAttributeName : textColor }]);
-    auto world = adoptNS([[NSAttributedString alloc] initWithString:@" World" attributes:@{ NSForegroundColorAttributeName : textColor }]);
-    auto string = adoptNS([[NSMutableAttributedString alloc] init]);
+    RetainPtr hello = adoptNS([[NSAttributedString alloc] initWithString:@"Hello" attributes:@{ NSBackgroundColorAttributeName : backgroundColor, NSForegroundColorAttributeName : textColor }]);
+    RetainPtr world = adoptNS([[NSAttributedString alloc] initWithString:@" World" attributes:@{ NSForegroundColorAttributeName : textColor }]);
+    RetainPtr string = adoptNS([[NSMutableAttributedString alloc] init]);
     [string appendAttributedString:hello.get()];
     [string appendAttributedString:world.get()];
 
@@ -220,9 +220,9 @@ TEST(PasteRTFD, DoesNotTransformColorsOfLightContent)
     PlatformColor *textColor = [PlatformColor darkGrayColor];
     PlatformColor *backgroundColor = [PlatformColor lightGrayColor];
 
-    auto hello = adoptNS([[NSAttributedString alloc] initWithString:@"Hello" attributes:@{ NSBackgroundColorAttributeName : backgroundColor, NSForegroundColorAttributeName : textColor }]);
-    auto world = adoptNS([[NSAttributedString alloc] initWithString:@" World" attributes:@{ NSForegroundColorAttributeName : textColor }]);
-    auto string = adoptNS([[NSMutableAttributedString alloc] init]);
+    RetainPtr hello = adoptNS([[NSAttributedString alloc] initWithString:@"Hello" attributes:@{ NSBackgroundColorAttributeName : backgroundColor, NSForegroundColorAttributeName : textColor }]);
+    RetainPtr world = adoptNS([[NSAttributedString alloc] initWithString:@" World" attributes:@{ NSForegroundColorAttributeName : textColor }]);
+    RetainPtr string = adoptNS([[NSMutableAttributedString alloc] init]);
     [string appendAttributedString:hello.get()];
     [string appendAttributedString:world.get()];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PasteWebArchive.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PasteWebArchive.mm
@@ -47,8 +47,8 @@ TEST(PasteWebArchive, ExposesHTMLTypeInDataTransfer)
     auto* url = [NSURL URLWithString:@"file:///some-file.html"];
     auto* markup = [@"<!DOCTYPE html><html><body><meta content=\"secret\"><b onmouseover=\"dangerousCode()\">hello</b>"
         "<!-- secret-->, world<script>dangerousCode()</script></html>" dataUsingEncoding:NSUTF8StringEncoding];
-    auto mainResource = adoptNS([[WebResource alloc] initWithData:markup URL:url MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
-    auto archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:nil subframeArchives:nil]);
+    RetainPtr mainResource = adoptNS([[WebResource alloc] initWithData:markup URL:url MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
+    RetainPtr archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:nil subframeArchives:nil]);
 
     [[NSPasteboard generalPasteboard] declareTypes:@[WebArchivePboardType] owner:nil];
     [[NSPasteboard generalPasteboard] setData:[archive data] forType:WebArchivePboardType];
@@ -76,8 +76,8 @@ TEST(PasteWebArchive, SanitizesHTML)
     auto* url = [NSURL URLWithString:@"file:///some-file.html"];
     auto* markup = [@"<!DOCTYPE html><html><body><meta content=\"secret\"><b onmouseover=\"dangerousCode()\">hello</b>"
         "<!-- secret-->, world<script>dangerousCode()</script></html>" dataUsingEncoding:NSUTF8StringEncoding];
-    auto mainResource = adoptNS([[WebResource alloc] initWithData:markup URL:url MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
-    auto archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:nil subframeArchives:nil]);
+    RetainPtr mainResource = adoptNS([[WebResource alloc] initWithData:markup URL:url MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
+    RetainPtr archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:nil subframeArchives:nil]);
 
     [[NSPasteboard generalPasteboard] declareTypes:@[WebArchivePboardType] owner:nil];
     [[NSPasteboard generalPasteboard] setData:[archive data] forType:WebArchivePboardType];
@@ -99,8 +99,8 @@ TEST(PasteWebArchive, PreservesMSOList)
 {
     auto *url = [NSURL URLWithString:@"file:///some-file.html"];
     auto *markup = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"mso-list" ofType:@"html"]];
-    auto mainResource = adoptNS([[WebResource alloc] initWithData:markup URL:url MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
-    auto archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:nil subframeArchives:nil]);
+    RetainPtr mainResource = adoptNS([[WebResource alloc] initWithData:markup URL:url MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
+    RetainPtr archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:nil subframeArchives:nil]);
 
     [[NSPasteboard generalPasteboard] declareTypes:@[WebArchivePboardType] owner:nil];
     [[NSPasteboard generalPasteboard] setData:[archive data] forType:WebArchivePboardType];
@@ -150,8 +150,8 @@ TEST(PasteWebArchive, PreservesMSOListInCompatibilityMode)
 {
     auto *url = [NSURL URLWithString:@"file:///some-file.html"];
     auto *markup = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"mso-list-compat-mode" ofType:@"html"]];
-    auto mainResource = adoptNS([[WebResource alloc] initWithData:markup URL:url MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
-    auto archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:nil subframeArchives:nil]);
+    RetainPtr mainResource = adoptNS([[WebResource alloc] initWithData:markup URL:url MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
+    RetainPtr archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:nil subframeArchives:nil]);
 
     [[NSPasteboard generalPasteboard] declareTypes:@[WebArchivePboardType] owner:nil];
     [[NSPasteboard generalPasteboard] setData:[archive data] forType:WebArchivePboardType];
@@ -204,8 +204,8 @@ TEST(PasteWebArchive, StripsMSOListWhenMissingMSOHTMLElement)
     auto *url = [NSURL URLWithString:@"file:///some-file.html"];
     auto *markup = msoListMarkupWithoutProperHTMLElement();
 
-    auto mainResource = adoptNS([[WebResource alloc] initWithData:markup URL:url MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
-    auto archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:nil subframeArchives:nil]);
+    RetainPtr mainResource = adoptNS([[WebResource alloc] initWithData:markup URL:url MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
+    RetainPtr archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:nil subframeArchives:nil]);
 
     [[NSPasteboard generalPasteboard] declareTypes:@[WebArchivePboardType] owner:nil];
     [[NSPasteboard generalPasteboard] setData:[archive data] forType:WebArchivePboardType];
@@ -238,15 +238,15 @@ TEST(PasteWebArchive, PreservesPictureInsideSpan)
 {
     NSData *markupData = [@"<span class='s1'><picture><source srcset='1.png' type='image/png'><img src='2.gif'></picture></span>" dataUsingEncoding:NSUTF8StringEncoding];
 
-    auto mainResource = adoptNS([[WebResource alloc] initWithData:markupData URL:[NSURL URLWithString:@"foo.html"] MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
+    RetainPtr mainResource = adoptNS([[WebResource alloc] initWithData:markupData URL:[NSURL URLWithString:@"foo.html"] MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
 
     auto pngData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]];
-    auto pngResource = adoptNS([[WebResource alloc] initWithData:pngData URL:[NSURL URLWithString:@"1.png"] MIMEType:@"image/png" textEncodingName:nil frameName:nil]);
+    RetainPtr pngResource = adoptNS([[WebResource alloc] initWithData:pngData URL:[NSURL URLWithString:@"1.png"] MIMEType:@"image/png" textEncodingName:nil frameName:nil]);
 
     auto gifData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"apple" withExtension:@"gif"]];
-    auto gifResource = adoptNS([[WebResource alloc] initWithData:gifData URL:[NSURL URLWithString:@"2.gif"] MIMEType:@"image/gif" textEncodingName:nil frameName:nil]);
+    RetainPtr gifResource = adoptNS([[WebResource alloc] initWithData:gifData URL:[NSURL URLWithString:@"2.gif"] MIMEType:@"image/gif" textEncodingName:nil frameName:nil]);
 
-    auto archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:@[ pngResource.get(), gifResource.get() ] subframeArchives:@[ ]]);
+    RetainPtr archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:@[ pngResource.get(), gifResource.get() ] subframeArchives:@[ ]]);
 
     [[NSPasteboard generalPasteboard] declareTypes:@[WebArchivePboardType] owner:nil];
     [[NSPasteboard generalPasteboard] setData:[archive data] forType:WebArchivePboardType];
@@ -266,8 +266,8 @@ TEST(PasteWebArchive, WebArchiveTypeIdentifier)
     NSURL *url = [NSURL URLWithString:@"file:///some-file.html"];
     NSString *markup = @"<strong style='color: rgb(255, 0, 0);'>This is some text to copy.</strong>";
 
-    auto mainResource = adoptNS([[WebResource alloc] initWithData:[markup dataUsingEncoding:NSUTF8StringEncoding] URL:url MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
-    auto archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:nil subframeArchives:nil]);
+    RetainPtr mainResource = adoptNS([[WebResource alloc] initWithData:[markup dataUsingEncoding:NSUTF8StringEncoding] URL:url MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
+    RetainPtr archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:nil subframeArchives:nil]);
 
     NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
     [pasteboard declareTypes:@[UTTypeWebArchive.identifier] owner:nil];
@@ -317,8 +317,8 @@ TEST(PasteWebArchive, StripsDataDetectorsLinks)
 {
     auto* url = [NSURL URLWithString:@"file:///some-file.html"];
     auto* markup = [@"<!DOCTYPE html><html><body><span>Meeting <a href=\"x-apple-data-detectors://0\" dir=\"ltr\" x-apple-data-detectors=\"true\" x-apple-data-detectors-type=\"calendar-event\" x-apple-data-detectors-result=\"0\" style=\"color: currentcolor; text-decoration-color: rgba(128, 128, 128, 0.38); font-weight: bold;\">on Friday 11/6 at 4pm</a> at <a href=\"x-apple-data-detectors://1\" dir=\"ltr\" x-apple-data-detectors=\"true\" x-apple-data-detectors-type=\"address\" x-apple-data-detectors-result=\"1\" style=\"color: currentcolor; text-decoration-color: rgba(128, 128, 128, 0.38);\">1 Apple Park Way, Cupertino CA</a></span></body></html>" dataUsingEncoding:NSUTF8StringEncoding];
-    auto mainResource = adoptNS([[WebResource alloc] initWithData:markup URL:url MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
-    auto archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:nil subframeArchives:nil]);
+    RetainPtr mainResource = adoptNS([[WebResource alloc] initWithData:markup URL:url MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
+    RetainPtr archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:nil subframeArchives:nil]);
 
     [[NSPasteboard generalPasteboard] declareTypes:@[WebArchivePboardType] owner:nil];
     [[NSPasteboard generalPasteboard] setData:[archive data] forType:WebArchivePboardType];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Preconnect.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Preconnect.mm
@@ -63,7 +63,7 @@ TEST(Preconnect, HTTP)
             requested = true;
         });
     });
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView _preconnectToServer:server.request().URL];
     Util::run(&connected);
     Util::spinRunLoop(10);
@@ -86,7 +86,7 @@ TEST(Preconnect, ConnectionCount)
             requested = true;
         });
     });
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
 
     [webView _preconnectToServer:server.request().URL];
     Util::run(&anyConnections);
@@ -111,8 +111,8 @@ TEST(Preconnect, HTTPS)
             requested = true;
         });
     }, HTTPServer::Protocol::Https);
-    auto webView = adoptNS([WKWebView new]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     [delegate setDidReceiveAuthenticationChallenge:^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^callback)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         receivedChallenge = true;
@@ -164,7 +164,7 @@ TEST(Preconnect, H2Ping)
         pingPong(H2::Connection::create(tlsConnection), headersCount);
     }, HTTPServer::Protocol::Http2);
     
-    auto delegate = adoptNS([SessionDelegate new]);
+    RetainPtr delegate = adoptNS([SessionDelegate new]);
     NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration] delegate:delegate.get() delegateQueue:[NSOperationQueue mainQueue]];
     NSURLSessionDataTask *task = [session dataTaskWithRequest:server.request()];
     task._preconnect = YES;
@@ -205,9 +205,9 @@ TEST(Preconnect, H2PingFromWebCoreNSURLSession)
     }, HTTPServer::Protocol::Http2);
 
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     __block bool receivedChallenge = false;
     [delegate setDidReceiveAuthenticationChallenge:^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^callback)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
@@ -232,9 +232,9 @@ static void verifyPreconnectDisabled(void(*disabler)(WKWebViewConfiguration *))
     NSString *html = [NSString stringWithFormat:@"<link rel='preconnect' href='http://127.0.0.1:%d'>", server.port()];
 
     {
-        auto configuration = adoptNS([WKWebViewConfiguration new]);
+        RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
         disabler(configuration.get());
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
         [webView loadHTMLString:html baseURL:nil];
         [webView _test_waitForDidFinishNavigation];
         Util::spinRunLoop(10);
@@ -244,7 +244,7 @@ static void verifyPreconnectDisabled(void(*disabler)(WKWebViewConfiguration *))
     }
 
     {
-        auto webView = adoptNS([WKWebView new]);
+        RetainPtr webView = adoptNS([WKWebView new]);
         [webView loadHTMLString:html baseURL:nil];
         [webView _test_waitForDidFinishNavigation];
         while (connectionCount != 1)
@@ -281,11 +281,11 @@ TEST(Preconnect, PrivacyProxyRequestFlags)
         | _WKWebsiteNetworkConnectionIntegrityPolicyFailClosed
         | _WKWebsiteNetworkConnectionIntegrityPolicyRequestValidation;
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration defaultWebpagePreferences]._networkConnectionIntegrityPolicy = policies;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
-    auto request = adoptNS(server.request().mutableCopy);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr request = adoptNS(server.request().mutableCopy);
     [request _setPrivacyProxyFailClosedForUnreachableHosts:YES];
     [request _setUseEnhancedPrivacyMode:YES];
     [webView loadRequest:request.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Preferences.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Preferences.mm
@@ -70,9 +70,9 @@ TEST(WebKit, ExperimentalFeatures)
 TEST(WebKit, WebAudioPreference)
 {
     auto check = [](bool value) {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         [configuration preferences]._webAudioEnabled = value;
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
         __block bool done = false;
         __block RetainPtr<NSString> result;
         [webView evaluateJavaScript:@"new Boolean(window.AudioContext).toString()" completionHandler:^(id resultFromJS, NSError *error) {
@@ -114,16 +114,16 @@ static bool receivedAlert;
 TEST(WebKit, WebGLEnabled)
 {
     NSString *html = @"<script>if(document.createElement('canvas').getContext('webgl')){alert('enabled')}else{alert('disabled')}</script>";
-    auto delegate = adoptNS([[AlertSaver alloc] init]);
+    RetainPtr delegate = adoptNS([[AlertSaver alloc] init]);
 
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView loadHTMLString:html baseURL:nil];
     TestWebKitAPI::Util::run(&receivedAlert);
     EXPECT_STREQ([delegate alert].UTF8String, "enabled");
 
     receivedAlert = false;
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration preferences] _setWebGLEnabled:NO];
     webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setUIDelegate:delegate.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PrepareForMoveToWindow.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PrepareForMoveToWindow.mm
@@ -40,7 +40,7 @@
 
 TEST(WKWebView, PrepareForMoveToWindow)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
@@ -59,7 +59,7 @@ TEST(WKWebView, PrepareForMoveToWindow)
 
 TEST(WKWebView, PrepareToUnparentView)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
     __block bool done = false;
@@ -73,8 +73,8 @@ TEST(WKWebView, PrepareToUnparentView)
 
 TEST(WKWebView, PrepareForMoveToWindowShouldNotCrashWhenRemovingWindowObservers)
 {
-    auto window = adoptNS([NSWindow new]);
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr window = adoptNS([NSWindow new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
     [[window contentView] addSubview:webView.get()];
@@ -90,7 +90,7 @@ TEST(WKWebView, PrepareForMoveToWindowShouldNotCrashWhenRemovingWindowObservers)
 
 TEST(WKWebView, PrepareForMoveToWindowThenClose)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
@@ -110,10 +110,10 @@ TEST(WKWebView, PrepareForMoveToWindowThenClose)
 
 TEST(WKWebView, PrepareForMoveToWindowThenViewDeallocBeforeMoving)
 {
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 200, 200) styleMask:NSBorderlessWindowMask backing:NSBackingStoreBuffered defer:NO]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 200, 200) styleMask:NSBorderlessWindowMask backing:NSBackingStoreBuffered defer:NO]);
 
     @autoreleasepool {
-        auto webView = adoptNS([[WKWebView alloc] init]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] init]);
         [webView _prepareForMoveToWindow:window.get() completionHandler:^{
             isDone = true;
         }];
@@ -134,11 +134,11 @@ TEST(WKWebView, PrepareForMoveToWindowThenViewDeallocBeforeMoving)
 
 TEST(WKWebView, PrepareForMoveToWindowThenWindowDeallocBeforeMoving)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
     static WeakObjCPtr<NSWindow> weakWindow;
 
     @autoreleasepool {
-        auto window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskTitled backing:NSBackingStoreBuffered defer:NO]);
+        RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskTitled backing:NSBackingStoreBuffered defer:NO]);
         weakWindow = window.get();
         [webView _prepareForMoveToWindow:window.get() completionHandler:^{
             isDone = true;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PrivateClickMeasurement.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PrivateClickMeasurement.mm
@@ -41,15 +41,15 @@
 static RetainPtr<WKWebView> webViewWithResourceLoadStatisticsEnabledInNetworkProcess()
 {
     auto *sharedProcessPool = [WKProcessPool _sharedProcessPool];
-    auto dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     dataStoreConfiguration.get().pcmMachServiceName = nil;
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setProcessPool: sharedProcessPool];
     configuration.get().websiteDataStore = dataStore.get();
 
     // We need an active NetworkProcess to perform PCM operations.
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [dataStore _setResourceLoadStatisticsEnabled:YES];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
     return webView;
@@ -294,7 +294,7 @@ static void pollUntilPCMIsMigrated(WKWebView *webView, MigratingFromResourceLoad
 static NSString *emptyObservationsDBPath()
 {
     NSFileManager *defaultFileManager = NSFileManager.defaultManager;
-    auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     NSURL *itpRootURL = dataStoreConfiguration.get()._resourceLoadStatisticsDirectory;
     NSURL *fileURL = [itpRootURL URLByAppendingPathComponent:@"observations.db"];
     [defaultFileManager removeItemAtPath:itpRootURL.path error:nil];
@@ -306,7 +306,7 @@ static NSString *emptyObservationsDBPath()
 static NSString *emptyPcmDBPath()
 {
     NSFileManager *defaultFileManager = NSFileManager.defaultManager;
-    auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     NSURL *itpRootURL = dataStoreConfiguration.get()._resourceLoadStatisticsDirectory;
     NSURL *fileURL = [itpRootURL URLByAppendingPathComponent:@"pcm.db"];
     [defaultFileManager removeItemAtPath:itpRootURL.path error:nil];
@@ -320,7 +320,7 @@ static void cleanUp(RetainPtr<WKWebView> webView)
     static bool isDone = false;
     [[webView.get() configuration].websiteDataStore _closeDatabases:^{
         NSFileManager *defaultFileManager = NSFileManager.defaultManager;
-        auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+        RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
         NSString *itpRoot = dataStoreConfiguration.get()._resourceLoadStatisticsDirectory.path;
         [defaultFileManager removeItemAtPath:itpRoot error:nil];
         while ([defaultFileManager fileExistsAtPath:itpRoot])

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessPreWarming.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessPreWarming.mm
@@ -36,7 +36,7 @@ static NSString *loadableURL = @"data:text/html,no%20error%20A";
 
 TEST(WKProcessPool, WarmInitialProcess)
 {
-    auto pool = adoptNS([[WKProcessPool alloc] init]);
+    RetainPtr pool = adoptNS([[WKProcessPool alloc] init]);
 
     EXPECT_FALSE([pool _hasPrewarmedWebProcess]);
 
@@ -52,21 +52,21 @@ TEST(WKProcessPool, WarmInitialProcess)
 enum class ShouldUseEphemeralStore : bool { No, Yes };
 static void runInitialWarmedProcessUsedTest(ShouldUseEphemeralStore shouldUseEphemeralStore)
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().prewarmsProcessesAutomatically = NO;
 
-    auto pool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr pool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
     [pool _warmInitialProcess];
 
     EXPECT_TRUE([pool _hasPrewarmedWebProcess]);
     EXPECT_EQ(1U, [pool _webPageContentProcessCount]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().processPool = pool.get();
     if (shouldUseEphemeralStore == ShouldUseEphemeralStore::Yes)
         configuration.get().websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL]]];
 
@@ -91,18 +91,18 @@ TEST(WKProcessPool, InitialWarmedProcessUsedForEphemeralSession)
 
 static void runAutomaticProcessWarmingTest(unsigned prewarmedProcessCountLimit)
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().prewarmsProcessesAutomatically = YES;
     processPoolConfiguration.get().prewarmedProcessCountLimitForTesting = prewarmedProcessCountLimit;
-    auto pool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr pool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
     EXPECT_FALSE([pool _hasPrewarmedWebProcess]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().processPool = pool.get();
     configuration.get().websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
 
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     EXPECT_FALSE([pool _hasPrewarmedWebProcess]);
     EXPECT_EQ(1U, [pool _webPageContentProcessCount]);
 
@@ -117,7 +117,7 @@ static void runAutomaticProcessWarmingTest(unsigned prewarmedProcessCountLimit)
     EXPECT_EQ(prewarmedProcessCountLimit, [prewarmedProcessIdentifiers count]);
     EXPECT_EQ(1U + prewarmedProcessCountLimit, [pool _webPageContentProcessCount]);
 
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView2 loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL]]];
     [webView2 _test_waitForDidFinishNavigation];
 
@@ -144,10 +144,10 @@ TEST(WKProcessPool, AutomaticProcessWarmingWithMultipleProcesses)
 
 TEST(WKProcessPool, PrewarmedProcessCrash)
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().prewarmsProcessesAutomatically = NO;
 
-    auto pool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr pool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
     [pool _warmInitialProcess];
 
     EXPECT_TRUE([pool _hasPrewarmedWebProcess]);
@@ -169,7 +169,7 @@ TEST(WKProcessPool, PrewarmedProcessCrash)
 
 TEST(WKProcessPool, TryUsingPrewarmedProcessThatJustCrashed)
 {
-    auto pool = adoptNS([[WKProcessPool alloc] init]);
+    RetainPtr pool = adoptNS([[WKProcessPool alloc] init]);
 
     EXPECT_FALSE([pool _hasPrewarmedWebProcess]);
 
@@ -187,10 +187,10 @@ TEST(WKProcessPool, TryUsingPrewarmedProcessThatJustCrashed)
     kill([pid intValue], 9);
 
     // Try using the prewarmed process right away.
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().processPool = pool.get();
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
     delegate.get().webContentProcessDidTerminate = ^(WKWebView *view, _WKProcessTerminationReason) {
         [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL]]];
     };

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessSuspendMediaBuffering.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessSuspendMediaBuffering.mm
@@ -38,12 +38,12 @@ TEST(WebKit, DISABLED_ProcessSuspendMediaBuffering)
 TEST(WebKit, ProcessSuspendMediaBuffering)
 #endif
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKRetainPtr<WKContextRef> context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     configuration.get().processPool = (WKProcessPool *)context.get();
     configuration.get()._mediaDataLoadsAutomatically = YES;
     configuration.get().mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     __block bool isPlaying = false;
     [webView performAfterReceivingMessage:@"playing" action:^() { isPlaying = true; }];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessSuspension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessSuspension.mm
@@ -36,8 +36,8 @@
 
 TEST(ProcessSuspension, CancelWebProcessSuspension)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
     [webView synchronouslyLoadTestPageNamed:@"large-red-square-image"];
 
     auto pid1 = [webView _webProcessIdentifier];
@@ -57,25 +57,25 @@ TEST(ProcessSuspension, CancelWebProcessSuspension)
 
 TEST(ProcessSuspension, DestroyWebPageDuringWebProcessSuspension)
 {
-    auto configuration1 = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration1.get() addToWindow:YES]);
+    RetainPtr configuration1 = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration1.get() addToWindow:YES]);
     [webView1 synchronouslyLoadTestPageNamed:@"large-red-square-image"];
 
     auto pid1 = [webView1 _webProcessIdentifier];
     EXPECT_NE(pid1, 0);
 
-    auto configuration2 = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration2 = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration2.get().processPool = configuration1.get().processPool;
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     configuration2.get()._relatedWebView = webView1.get();
     ALLOW_DEPRECATED_DECLARATIONS_END
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(100, 0, 100, 100) configuration:configuration2.get() addToWindow:YES]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(100, 0, 100, 100) configuration:configuration2.get() addToWindow:YES]);
     [webView2 synchronouslyLoadTestPageNamed:@"large-red-square-image"];
 
     auto pid2 = [webView2 _webProcessIdentifier];
     EXPECT_EQ(pid1, pid2);
 
-    auto webView3 = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(200, 0, 100, 100) configuration:configuration2.get() addToWindow:YES]);
+    RetainPtr webView3 = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(200, 0, 100, 100) configuration:configuration2.get() addToWindow:YES]);
     [webView3 synchronouslyLoadTestPageNamed:@"large-red-square-image"];
 
     [webView3 _processWillSuspendForTesting:^{ }];
@@ -90,16 +90,16 @@ TEST(ProcessSuspension, DestroyWebPageDuringWebProcessSuspension)
 
 TEST(ProcessSuspension, WKWebViewSuspendPage)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
+    RetainPtr testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:testMessageHandler.get() name:@"testHandler"];
     __block unsigned timerFiredCount = 0;
     [testMessageHandler addMessage:@"timer fired" withHandler:^{
         ++timerFiredCount;
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
     [webView synchronouslyLoadTestPageNamed:@"postMessage-regularly"];
 
     auto pid = [webView _webProcessIdentifier];
@@ -221,7 +221,7 @@ TEST(ProcessSuspension, DeallocateSuspendedView)
 {
     // Deallocating a suspended WebView should not throw or crash.
     @autoreleasepool {
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
         [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
         [webView _test_waitForDidFinishNavigation];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessSwapOnNavigation.mm
@@ -366,7 +366,7 @@ static RetainPtr<WKWebView> createdWebView;
         RetainPtr redirectResponse = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:nil expectedContentLength:0 textEncodingName:nil]);
 
         finalURL = adoptNS([[NSURL alloc] initWithString:target.createNSString().get()]);
-        auto request = adoptNS([[NSURLRequest alloc] initWithURL:finalURL.get()]);
+        RetainPtr request = adoptNS([[NSURLRequest alloc] initWithURL:finalURL.get()]);
 
         [(id<WKURLSchemeTaskPrivate>)task _didPerformRedirection:redirectResponse.get() newRequest:request.get()];
     }
@@ -376,7 +376,7 @@ static RetainPtr<WKWebView> createdWebView;
         [headerDictionary setObject:@"text/html" forKey:@"Content-Type"];
         [headerDictionary setObject:@"1" forKey:@"Content-Length"];
 
-        auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:finalURL.get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:headerDictionary]);
+        RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:finalURL.get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:headerDictionary]);
         [task didReceiveResponse:response.get()];
     }, 0.1);
 
@@ -572,7 +572,7 @@ window.addEventListener('pageshow', function(event) {
 
 static RetainPtr<_WKProcessPoolConfiguration> psonProcessPoolConfiguration()
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().processSwapsOnNavigation = YES;
     processPoolConfiguration.get().usesWebProcessCache = YES;
     processPoolConfiguration.get().prewarmsProcessesAutomatically = YES;
@@ -584,16 +584,16 @@ enum class SchemeHandlerShouldBeAsync : bool { No, Yes };
 static void runBasicTest(SchemeHandlerShouldBeAsync schemeHandlerShouldBeAsync)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler setShouldRespondAsynchronously:(schemeHandlerShouldBeAsync == SchemeHandlerShouldBeAsync::Yes)];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]];
@@ -641,15 +641,15 @@ TEST(ProcessSwap, NoProcessSwappingWithinSameNonHTTPFamilyProtocol)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     processPoolConfiguration.get().processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol = NO;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"CUSTOM"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"custom://abc/main1.html"]];
@@ -698,15 +698,15 @@ TEST(ProcessSwap, NoProcessSwappingWithinSameNonHTTPFamilyProtocol)
 TEST(ProcessSwap, LoadAfterPolicyDecision)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]];
@@ -734,16 +734,16 @@ TEST(ProcessSwap, LoadAfterPolicyDecision)
 TEST(ProcessSwap, KillWebContentProcessAfterServerRedirectPolicyDecision)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addRedirectFromURLString:@"pson://www.webkit.org/main2.html" toURLString:@"pson://www.apple.com/main.html"];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = NO;
@@ -792,13 +792,13 @@ TEST(ProcessSwap, PSONRedirectionToExternal)
     auto popupURL = makeString("https://localhost:"_s, server.port(), "/popup.html"_s);
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = NO;
@@ -825,15 +825,15 @@ TEST(ProcessSwap, PSONRedirectionToExternal)
 TEST(ProcessSwap, KillProvisionalWebContentProcessThenStartNewLoad)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -867,15 +867,15 @@ TEST(ProcessSwap, KillProvisionalWebContentProcessThenStartNewLoad)
 TEST(ProcessSwap, NoSwappingForeTLDPlus2)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www1.webkit.org/main1.html"]];
@@ -902,11 +902,11 @@ TEST(ProcessSwap, NoSwappingForeTLDPlus2)
 TEST(ProcessSwap, Back)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:testBytes];
     [handler addMappingFromURLString:@"pson://www.apple.com/main.html" toData:testBytes];
     [handler addMappingFromURLString:@"pson://www.google.com/main.html" toData:testBytes];
@@ -915,9 +915,9 @@ TEST(ProcessSwap, Back)
     RetainPtr<PSONMessageHandler> messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     EXPECT_GT([processPool _maximumSuspendedPageCount], 0U);
@@ -1019,16 +1019,16 @@ static constexpr auto pageWithFragmentTestBytes = R"PSONRESOURCE(
 TEST(ProcessSwap, HistoryNavigationToFragmentURL)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.apple.com/main.html#foo" toData:pageWithFragmentTestBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -1071,15 +1071,15 @@ TEST(ProcessSwap, HistoryNavigationToFragmentURL)
 TEST(ProcessSwap, SuspendedPageDiesAfterBackForwardListItemIsGone)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     EXPECT_GT([processPool _maximumSuspendedPageCount], 0U);
@@ -1130,11 +1130,11 @@ TEST(ProcessSwap, SuspendedPageDiesAfterBackForwardListItemIsGone)
 TEST(ProcessSwap, SuspendedPagesInActivityMonitor)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:testBytes];
     [handler addMappingFromURLString:@"pson://www.google.com/main.html" toData:testBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
@@ -1142,14 +1142,14 @@ TEST(ProcessSwap, SuspendedPagesInActivityMonitor)
     RetainPtr<PSONMessageHandler> messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
     // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     if (!isUsingBackForwardCache(webView.get())) {
         NSLog(@"ProcessSwap.SuspendedPagesInActivityMonitor: Test is skipped as back-forward cache is disabled");
         return;
     }
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -1224,19 +1224,19 @@ TEST(ProcessSwap, SuspendedPagesInActivityMonitor)
 TEST(ProcessSwap, BackWithoutSuspendedPage)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:testBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
     RetainPtr<PSONMessageHandler> messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView1 setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -1251,7 +1251,7 @@ TEST(ProcessSwap, BackWithoutSuspendedPage)
     RetainPtr<_WKSessionState> sessionState = [webView1 _sessionState];
     webView1 = nullptr;
 
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView2 setNavigationDelegate:delegate.get()];
 
@@ -1281,15 +1281,15 @@ TEST(ProcessSwap, BackWithoutSuspendedPage)
 TEST(ProcessSwap, BackNavigationAfterSessionRestore)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView1 setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -1312,7 +1312,7 @@ TEST(ProcessSwap, BackNavigationAfterSessionRestore)
     RetainPtr<_WKSessionState> sessionState = [webView1 _sessionState];
     webView1 = nullptr;
 
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView2 setNavigationDelegate:delegate.get()];
 
@@ -1335,19 +1335,19 @@ TEST(ProcessSwap, BackNavigationAfterSessionRestore)
 TEST(ProcessSwap, CrossSiteWindowOpenNoOpener)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     [webViewConfiguration preferences].javaScriptCanOpenWindowsAutomatically = YES;
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:windowOpenCrossSiteNoOpenerTestBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView setUIDelegate:uiDelegate.get()];
 
     numberOfDecidePolicyCalls = 0;
@@ -1375,19 +1375,19 @@ TEST(ProcessSwap, CrossSiteWindowOpenNoOpener)
 TEST(ProcessSwap, CrossOriginButSameSiteWindowOpenNoOpener)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     [webViewConfiguration preferences].javaScriptCanOpenWindowsAutomatically = YES;
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:windowOpenCrossOriginButSameSiteNoOpenerTestBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView setUIDelegate:uiDelegate.get()];
 
     numberOfDecidePolicyCalls = 0;
@@ -1427,20 +1427,20 @@ static void enableSiteIsolationForPSONTest(WKWebViewConfiguration *configuration
 TEST(ProcessSwap, CrossSiteWindowOpenWithOpener)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     enableSiteIsolationForPSONTest(webViewConfiguration.get());
     [webViewConfiguration setProcessPool:processPool.get()];
     [webViewConfiguration preferences].javaScriptCanOpenWindowsAutomatically = YES;
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:windowOpenCrossSiteWithOpenerTestBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView setUIDelegate:uiDelegate.get()];
 
     numberOfDecidePolicyCalls = 0;
@@ -1470,22 +1470,22 @@ enum class WindowHasName : bool { No, Yes };
 static void runSameSiteWindowOpenNoOpenerTest(WindowHasName windowHasName)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     [webViewConfiguration preferences].javaScriptCanOpenWindowsAutomatically = YES;
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     if (windowHasName == WindowHasName::Yes)
         [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:windowOpenWithNameSameSiteNoOpenerTestBytes];
     else
         [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:windowOpenSameSiteNoOpenerTestBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView setUIDelegate:uiDelegate.get()];
 
     numberOfDecidePolicyCalls = 0;
@@ -1537,19 +1537,19 @@ TEST(ProcessSwap, SameSiteWindowOpenWithNameNoOpener)
 TEST(ProcessSwap, CrossSiteBlankTargetWithOpener)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     [webViewConfiguration preferences].javaScriptCanOpenWindowsAutomatically = YES;
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:targetBlankCrossSiteWithExplicitOpenerTestBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView setUIDelegate:uiDelegate.get()];
 
     numberOfDecidePolicyCalls = 0;
@@ -1580,19 +1580,19 @@ TEST(ProcessSwap, CrossSiteBlankTargetWithOpener)
 TEST(ProcessSwap, CrossSiteBlankTargetImplicitNoOpener)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     [webViewConfiguration preferences].javaScriptCanOpenWindowsAutomatically = YES;
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:targetBlankCrossSiteWithImplicitNoOpenerTestBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView setUIDelegate:uiDelegate.get()];
 
     numberOfDecidePolicyCalls = 0;
@@ -1620,19 +1620,19 @@ TEST(ProcessSwap, CrossSiteBlankTargetImplicitNoOpener)
 TEST(ProcessSwap, CrossSiteBlankTargetNoOpener)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     [webViewConfiguration preferences].javaScriptCanOpenWindowsAutomatically = YES;
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:targetBlankCrossSiteNoOpenerTestBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView setUIDelegate:uiDelegate.get()];
 
     numberOfDecidePolicyCalls = 0;
@@ -1660,19 +1660,19 @@ TEST(ProcessSwap, CrossSiteBlankTargetNoOpener)
 TEST(ProcessSwap, SameSiteBlankTargetNoOpener)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     [webViewConfiguration preferences].javaScriptCanOpenWindowsAutomatically = YES;
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:targetBlankSameSiteNoOpenerTestBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView setUIDelegate:uiDelegate.get()];
 
     numberOfDecidePolicyCalls = 0;
@@ -1701,16 +1701,16 @@ TEST(ProcessSwap, SameSiteBlankTargetNoOpener)
 TEST(ProcessSwap, ServerRedirectFromNewWebView)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addRedirectFromURLString:@"pson://www.webkit.org/main.html" toURLString:@"pson://www.apple.com/main.html"];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -1734,16 +1734,16 @@ TEST(ProcessSwap, ServerRedirectFromNewWebView)
 TEST(ProcessSwap, ServerRedirect)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addRedirectFromURLString:@"pson://www.webkit.org/main.html" toURLString:@"pson://www.apple.com/main.html"];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.google.com/main1.html"]];
@@ -1784,18 +1784,18 @@ TEST(ProcessSwap, ServerRedirect2)
 {
     // This tests a load that *starts out* to the same origin as the previous load, but then redirects to a new origin.
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler1 = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler1 = adoptNS([[PSONScheme alloc] init]);
     [handler1 addRedirectFromURLString:@"pson://www.webkit.org/main2.html" toURLString:@"pson://www.apple.com/main.html"];
     [webViewConfiguration setURLSchemeHandler:handler1.get() forURLScheme:@"pson"];
-    auto handler2 = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler2 = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler2.get() forURLScheme:@"psonredirected"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]];
@@ -1847,17 +1847,17 @@ static void runSameOriginServerRedirectTest(ShouldCacheProcessFirst shouldCacheP
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     processPoolConfiguration.get().processSwapsOnNavigation = YES;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:crossSiteClientSideRedirectBytes];
     [handler addRedirectFromURLString:@"pson://www.apple.com/main.html" toURLString:@"pson://www.apple.com/main2.html"];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request;
@@ -1926,15 +1926,15 @@ TEST(ProcessSwap, SameOriginServerRedirectFromCachedProcess)
 TEST(ProcessSwap, TerminateProcessRightAfterSwap)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = NO;
@@ -1965,17 +1965,17 @@ static constexpr auto linkToWebKitBytes = R"PSONRESOURCE(
 TEST(ProcessSwap, PolicyCancelAfterServerRedirect)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.google.com/main.html" toData:linkToWebKitBytes];
     [handler addRedirectFromURLString:@"pson://www.webkit.org/main.html" toURLString:@"pson://www.apple.com/ignore.html"];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     navigationDelegate->decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^decisionHandler)(WKNavigationActionPolicy)) {
@@ -2018,17 +2018,17 @@ TEST(ProcessSwap, PolicyCancelAfterServerRedirect)
 TEST(ProcessSwap, CrossSiteDownload)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.google.com/main.html" toData:linkToWebKitBytes];
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:"Hello"];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.google.com/main.html"]];
@@ -2078,11 +2078,11 @@ static constexpr auto systemPreviewCrossOriginTestBytes = R"PSONRESOURCE(
 TEST(ProcessSwap, SameOriginSystemPreview)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:systemPreviewSameOriginTestBytes];
     [handler addMappingFromURLString:@"pson://www.webkit.org/whatever" toData:"Fake USDZ data"];
     [handler addMappingFromURLString:@"pson://www.webkit.org/image" toData:"Fake image data"];
@@ -2090,8 +2090,8 @@ TEST(ProcessSwap, SameOriginSystemPreview)
 
     [webViewConfiguration _setSystemPreviewEnabled:YES];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -2115,11 +2115,11 @@ TEST(ProcessSwap, SameOriginSystemPreview)
 TEST(ProcessSwap, CrossOriginSystemPreview)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:systemPreviewCrossOriginTestBytes];
     [handler addMappingFromURLString:@"pson://www.apple.com/whatever" toData:"Fake USDZ data"];
     [handler addMappingFromURLString:@"pson://www.webkit.org/image" toData:"Fake image data"];
@@ -2127,8 +2127,8 @@ TEST(ProcessSwap, CrossOriginSystemPreview)
 
     [webViewConfiguration _setSystemPreviewEnabled:YES];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -2156,17 +2156,17 @@ static void runClientSideRedirectTest(ShouldEnablePSON shouldEnablePSON)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     processPoolConfiguration.get().processSwapsOnNavigation = shouldEnablePSON == ShouldEnablePSON::Yes ? YES : NO;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:linkToCrossSiteClientSideRedirectBytes];
     [handler addMappingFromURLString:@"pson://www.google.com/clientSideRedirect.html" toData:crossSiteClientSideRedirectBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -2290,15 +2290,15 @@ TEST(ProcessSwap, CrossSiteClientSideRedirectWithPSON)
 TEST(ProcessSwap, CrossSiteClientSideRedirectFromFileURL)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     willPerformClientRedirect = false;
@@ -2326,17 +2326,17 @@ TEST(ProcessSwap, CrossSiteClientSideRedirectFromFileURL)
 TEST(ProcessSwap, NavigateBackAfterClientSideRedirect)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:linkToCrossSiteClientSideRedirectBytes];
     [handler addMappingFromURLString:@"pson://www.google.com/clientSideRedirect.html" toData:crossSiteClientSideRedirectBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -2401,20 +2401,20 @@ static void runNavigationWithLockedHistoryTest(ShouldEnablePSON shouldEnablePSON
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     processPoolConfiguration.get().processSwapsOnNavigation = shouldEnablePSON == ShouldEnablePSON::Yes ? YES : NO;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:navigationWithLockedHistoryBytes];
     [handler addMappingFromURLString:@"pson://www.apple.com/main.html" toData:pageCache1Bytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"pson"];
 
-    auto messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
@@ -2488,15 +2488,15 @@ static void runQuickBackForwardNavigationTest(ShouldEnablePSON shouldEnablePSON)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     processPoolConfiguration.get().processSwapsOnNavigation = shouldEnablePSON == ShouldEnablePSON::Yes ? YES : NO;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = NO;
@@ -2585,19 +2585,19 @@ TEST(ProcessSwap, SessionStorage)
     for (int i = 0; i < 5; ++i) {
         [receivedMessages removeAllObjects];
         auto processPoolConfiguration = psonProcessPoolConfiguration();
-        auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+        RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-        auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
         [webViewConfiguration setProcessPool:processPool.get()];
-        auto handler = adoptNS([[PSONScheme alloc] init]);
+        RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
         [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:sessionStorageTestBytes];
         [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-        auto messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
+        RetainPtr messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
         [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-        auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+        RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
         [webView setNavigationDelegate:delegate.get()];
 
         NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -2643,15 +2643,15 @@ TEST(ProcessSwap, ReuseSuspendedProcess)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     processPoolConfiguration.get().usesWebProcessCache = NO;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]];
@@ -2711,16 +2711,16 @@ var myWorker = new Worker('worker.js');
 TEST(ProcessSwap, ReuseSuspendedProcessEvenIfPageCacheFails)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main1.html" toData:failsToEnterPageCacheTestBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]];
@@ -2763,16 +2763,16 @@ TEST(ProcessSwap, ReuseSuspendedProcessEvenIfPageCacheFails)
 TEST(ProcessSwap, ReuseSuspendedProcessOnBackEvenIfPageCacheFails)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main1.html" toData:failsToEnterPageCacheTestBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]];
@@ -2811,17 +2811,17 @@ static constexpr auto withSubframesTestBytes = R"PSONRESOURCE(
 TEST(ProcessSwap, HistoryItemIDConfusion)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:failsToEnterPageCacheTestBytes];
     [handler addMappingFromURLString:@"pson://www.apple.com/main.html" toData:withSubframesTestBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -2876,18 +2876,18 @@ TEST(ProcessSwap, HistoryItemIDConfusion)
 TEST(ProcessSwap, GoToSecondItemInBackHistory)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main1.html" toData:withSubframesTestBytes];
     [handler addMappingFromURLString:@"pson://www.webkit.org/main2.html" toData:withSubframesTestBytes];
     [handler addMappingFromURLString:@"pson://www.apple.com/main.html" toData:withSubframesTestBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]];
@@ -2933,21 +2933,21 @@ TEST(ProcessSwap, GoToSecondItemInBackHistory)
 TEST(ProcessSwap, PrivateAndRegularSessionsShouldGetDifferentProcesses)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto privateWebViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr privateWebViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [privateWebViewConfiguration setProcessPool:processPool.get()];
     [privateWebViewConfiguration setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [privateWebViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
-    auto regularWebViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr regularWebViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [regularWebViewConfiguration setProcessPool:processPool.get()];
     [regularWebViewConfiguration setWebsiteDataStore:[WKWebsiteDataStore defaultDataStore]];
     [regularWebViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
 
-    auto regularWebView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:regularWebViewConfiguration.get()]);
+    RetainPtr regularWebView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:regularWebViewConfiguration.get()]);
     [regularWebView1 setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.google.com/main.html"]];
@@ -2959,7 +2959,7 @@ TEST(ProcessSwap, PrivateAndRegularSessionsShouldGetDifferentProcesses)
     [regularWebView1 _close];
     regularWebView1 = nil;
 
-    auto privateWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:privateWebViewConfiguration.get()]);
+    RetainPtr privateWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:privateWebViewConfiguration.get()]);
     [privateWebView setNavigationDelegate:delegate.get()];
 
     request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -2982,7 +2982,7 @@ TEST(ProcessSwap, PrivateAndRegularSessionsShouldGetDifferentProcesses)
     [privateWebView _close];
     privateWebView = nil;
 
-    auto regularWebView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:regularWebViewConfiguration.get()]);
+    RetainPtr regularWebView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:regularWebViewConfiguration.get()]);
     [regularWebView2 setNavigationDelegate:delegate.get()];
 
     request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.google.com/main.html"]];
@@ -3038,18 +3038,18 @@ void testReuseSuspendedProcessForRegularNavigation(RetainPageInBundle retainPage
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     if (retainPageInBundle == RetainPageInBundle::Yes)
         [processPoolConfiguration setInjectedBundleURL:[[NSBundle mainBundle] URLForResource:@"TestWebKitAPI" withExtension:@"wkbundle"]];
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
     if (retainPageInBundle == RetainPageInBundle::Yes)
         [processPool _setObject:@"BundleRetainPagePlugIn" forBundleParameter:TestWebKitAPI::Util::TestPlugInClassNameParameter];
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main1.html" toData:keepNavigatingFrameBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]];
@@ -3113,21 +3113,21 @@ static constexpr auto mainFramesOnlySubframe2 = R"PSONRESOURCE(
 TEST(ProcessSwap, MainFramesOnly)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:mainFramesOnlyMainFrame];
     [handler addMappingFromURLString:@"pson://www.webkit.org/iframe" toData:mainFramesOnlySubframe];
     [handler addMappingFromURLString:@"pson://www.apple.com/main.html" toData:mainFramesOnlySubframe2];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -3177,17 +3177,17 @@ static unsigned waitUntilClientWidthIs(WKWebView *webView, unsigned expectedClie
 TEST(ProcessSwap, PageZoomLevelAfterSwap)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:getClientWidthBytes];
     [handler addMappingFromURLString:@"pson://www.apple.com/main.html" toData:getClientWidthBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     delegate->didCommitNavigationHandler = ^ {
@@ -3248,17 +3248,17 @@ static constexpr auto mediaTypeBytes = R"PSONRESOURCE(
 TEST(ProcessSwap, MediaTypeAfterSwap)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:mediaTypeBytes];
     [handler addMappingFromURLString:@"pson://www.apple.com/main.html" toData:mediaTypeBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -3313,17 +3313,17 @@ static constexpr auto navigateBeforePageLoadEndBytes = R"PSONRESOURCE(
 TEST(ProcessSwap, NavigateCrossSiteBeforePageLoadEnd)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:navigateBeforePageLoadEndBytes];
     [handler setShouldRespondAsynchronously:YES];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = NO;
@@ -3343,15 +3343,15 @@ static void runCancelCrossSiteProvisionalLoadTest(ShouldEnablePSON shouldEnableP
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     processPoolConfiguration.get().processSwapsOnNavigation = shouldEnablePSON == ShouldEnablePSON::Yes;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     failed = false;
@@ -3387,15 +3387,15 @@ TEST(ProcessSwap, CancelCrossSiteProvisionalLoadWithPSON)
 TEST(ProcessSwap, DoSameSiteNavigationAfterCrossSiteProvisionalLoadStarted)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = NO;
@@ -3428,15 +3428,15 @@ TEST(ProcessSwap, DoSameSiteNavigationAfterCrossSiteProvisionalLoadStarted)
 TEST(ProcessSwap, SuspendedPageLimit)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     auto maximumSuspendedPageCount = [processPool _maximumSuspendedPageCount];
@@ -3493,19 +3493,19 @@ TEST(ProcessSwap, SuspendedPageLimit)
 TEST(ProcessSwap, PageCache1)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:pageCache1Bytes];
     [handler addMappingFromURLString:@"pson://www.apple.com/main.html" toData:pageCache1Bytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
     // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     if (!isUsingBackForwardCache(webView.get())) {
@@ -3513,7 +3513,7 @@ TEST(ProcessSwap, PageCache1)
         return;
     }
 
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -3574,17 +3574,17 @@ TEST(ProcessSwap, NavigateBackAfterCrossOriginClientRedirect)
 #endif
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://webkit.org/navigated_from" toData:"<a href='pson://apple.com/'>hello</a>"];
     [handler addMappingFromURLString:@"pson://apple.com/" toData:"<script>window.location.href='pson://webkit.org/redirected_to'</script>redirecting..."];
     [handler addMappingFromURLString:@"pson://webkit.org/redirected_to" toData:"<p>hello again</p>"];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://webkit.org/navigated_from"]]];
     [webView _test_waitForDidFinishNavigation];
@@ -3601,20 +3601,20 @@ TEST(ProcessSwap, NavigateBackAfterCrossOriginClientRedirect)
 TEST(ProcessSwap, BackForwardCacheSkipBackForwardListItem)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:pageCache1Bytes];
     [handler addMappingFromURLString:@"pson://www.apple.com/main.html" toData:pageCache1Bytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -3676,21 +3676,21 @@ TEST(ProcessSwap, ClearWebsiteDataWithSuspendedPage)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     processPoolConfiguration.get().usesWebProcessCache = NO;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:pageCache1Bytes];
     [handler addMappingFromURLString:@"pson://www.apple.com/main.html" toData:pageCache1Bytes];
     [handler addMappingFromURLString:@"pson://www.google.com/main.html" toData:pageCache1Bytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -3729,26 +3729,26 @@ TEST(ProcessSwap, ClearWebsiteDataWithSuspendedPage)
 TEST(ProcessSwap, PageCacheAfterProcessSwapByClient)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main1.html" toData:pageCache1Bytes];
     [handler addMappingFromURLString:@"pson://www.webkit.org/main2.html" toData:pageCache1Bytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
     // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     if (!isUsingBackForwardCache(webView.get())) {
         NSLog(@"ProcessSwap.PageCacheAfterProcessSwapByClient: Test is skipped as back-forward cache is disabled");
         return;
     }
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]];
@@ -3811,19 +3811,19 @@ TEST(ProcessSwap, PageCacheAfterProcessSwapByClient)
 TEST(ProcessSwap, PageCacheWhenNavigatingFromJS)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:pageCache1Bytes];
     [handler addMappingFromURLString:@"pson://www.apple.com/main.html" toData:pageCache1Bytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
     // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     if (!isUsingBackForwardCache(webView.get())) {
@@ -3831,7 +3831,7 @@ TEST(ProcessSwap, PageCacheWhenNavigatingFromJS)
         return;
     }
 
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -3889,14 +3889,14 @@ TEST(ProcessSwap, PageCacheWhenNavigatingFromJS)
 TEST(ProcessSwap, UseWebProcessCacheAfterTermination)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
         done = true;
     }];
@@ -3904,7 +3904,7 @@ TEST(ProcessSwap, UseWebProcessCacheAfterTermination)
     int webkitPID = 0;
 
     @autoreleasepool {
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
         [webView setNavigationDelegate:navigationDelegate.get()];
 
         NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -3917,7 +3917,7 @@ TEST(ProcessSwap, UseWebProcessCacheAfterTermination)
 
     EXPECT_EQ(1U, [processPool _webProcessCountIgnoringPrewarmed]);
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.apple.com/main.html"]];
@@ -3953,14 +3953,14 @@ TEST(ProcessSwap, UseWebProcessCacheAfterTermination)
 TEST(ProcessSwap, ProcessCrashedWhileInTheCache)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
         done = true;
     }];
@@ -3968,7 +3968,7 @@ TEST(ProcessSwap, ProcessCrashedWhileInTheCache)
     int webkitPID = 0;
 
     @autoreleasepool {
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
         [webView setNavigationDelegate:navigationDelegate.get()];
 
         NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -3987,7 +3987,7 @@ TEST(ProcessSwap, ProcessCrashedWhileInTheCache)
     while ([processPool _processCacheSize])
         TestWebKitAPI::Util::runFor(0.1_s);
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -4002,14 +4002,14 @@ TEST(ProcessSwap, ProcessCrashedWhileInTheCache)
 TEST(ProcessSwap, ProcessTerminatedWhileInTheCache)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
         done = true;
     }];
@@ -4017,7 +4017,7 @@ TEST(ProcessSwap, ProcessTerminatedWhileInTheCache)
     int webkitPID = 0;
 
     @autoreleasepool {
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
         [webView setNavigationDelegate:navigationDelegate.get()];
 
         NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -4036,7 +4036,7 @@ TEST(ProcessSwap, ProcessTerminatedWhileInTheCache)
 
     EXPECT_EQ(0U, [processPool _processCacheSize]);
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -4051,19 +4051,19 @@ TEST(ProcessSwap, ProcessTerminatedWhileInTheCache)
 TEST(ProcessSwap, UseWebProcessCacheForLoadInNewView)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
 
     int webkitPID = 0;
 
     @autoreleasepool {
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
         [webView setNavigationDelegate:navigationDelegate.get()];
 
         // Process launch should be delayed until a load actually happens.
@@ -4085,7 +4085,7 @@ TEST(ProcessSwap, UseWebProcessCacheForLoadInNewView)
     EXPECT_EQ(1U, [processPool _webProcessCountIgnoringPrewarmed]);
 
     @autoreleasepool {
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
         [webView setNavigationDelegate:navigationDelegate.get()];
 
         NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main2.html"]];
@@ -4103,7 +4103,7 @@ TEST(ProcessSwap, UseWebProcessCacheForLoadInNewView)
     EXPECT_EQ(1U, [processPool _webProcessCountIgnoringPrewarmed]);
 
     @autoreleasepool {
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
         [webView setNavigationDelegate:navigationDelegate.get()];
 
         NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.apple.com/main.html"]];
@@ -4122,15 +4122,15 @@ TEST(ProcessSwap, UseWebProcessCacheForLoadInNewView)
 TEST(ProcessSwap, NumberOfPrewarmedProcesses)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -4162,22 +4162,22 @@ TEST(ProcessSwap, NumberOfCachedProcesses)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     processPoolConfiguration.get().prewarmsProcessesAutomatically = NO;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
     EXPECT_GT([processPool _maximumSuspendedPageCount], 0u);
     EXPECT_GT([processPool _processCacheCapacity], 0u);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
 
     const unsigned maxSuspendedPageCount = [processPool _maximumSuspendedPageCount];
     for (unsigned i = 0; i < maxSuspendedPageCount + 2; i++)
         [handler addMappingFromURLString:makeString("pson://www.domain-"_s, i, ".com"_s).createNSString().get() toData:pageCache1Bytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     for (unsigned i = 0; i < maxSuspendedPageCount + 1; i++) {
@@ -4244,20 +4244,20 @@ window.addEventListener('pagehide', function(event) {
 TEST(ProcessSwap, PageShowHide)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:visibilityBytes];
     [handler addMappingFromURLString:@"pson://www.apple.com/main.html" toData:visibilityBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -4335,21 +4335,21 @@ window.addEventListener('load', function(event) {
 TEST(ProcessSwap, LoadUnload)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:loadUnloadBytes];
     [handler addMappingFromURLString:@"pson://www.apple.com/main.html" toData:loadUnloadBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
     [[webViewConfiguration preferences] _setUsesPageCache:NO];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -4411,17 +4411,17 @@ TEST(ProcessSwap, LoadUnload)
 TEST(ProcessSwap, WebInspector)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     webViewConfiguration.get().preferences._developerExtrasEnabled = YES;
 
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]];
@@ -4460,13 +4460,13 @@ TEST(ProcessSwap, WebInspector)
 TEST(ProcessSwap, WebInspectorDelayedProcessLaunch)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     webViewConfiguration.get().preferences._developerExtrasEnabled = YES;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
     EXPECT_EQ(0, [webView _webProcessIdentifier]);
     TestWebKitAPI::Util::spinRunLoop(100);
@@ -4488,13 +4488,13 @@ TEST(ProcessSwap, WebInspectorDelayedProcessLaunch)
 TEST(ProcessSwap, DelayedProcessLaunchThenLaunchInitialProcessIfNecessary)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     webViewConfiguration.get()._delaysWebProcessLaunchUntilFirstLoad = YES;
     [webViewConfiguration setProcessPool:processPool.get()];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
     EXPECT_EQ(0, [webView _webProcessIdentifier]);
     TestWebKitAPI::Util::runFor(200_ms);
@@ -4510,13 +4510,13 @@ TEST(ProcessSwap, DelayedProcessLaunchThenLaunchInitialProcessIfNecessary)
 TEST(ProcessSwap, DelayedProcessLaunchThenLoad)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     webViewConfiguration.get()._delaysWebProcessLaunchUntilFirstLoad = YES;
     [webViewConfiguration setProcessPool:processPool.get()];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
     EXPECT_EQ(0, [webView _webProcessIdentifier]);
     TestWebKitAPI::Util::runFor(200_ms);
@@ -4531,13 +4531,13 @@ TEST(ProcessSwap, DelayedProcessLaunchThenLoad)
 TEST(ProcessSwap, DelayedProcessLaunchDisabled)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     webViewConfiguration.get()._delaysWebProcessLaunchUntilFirstLoad = NO;
     [webViewConfiguration setProcessPool:processPool.get()];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
     while (![webView _webProcessIdentifier])
         TestWebKitAPI::Util::spinRunLoop();
@@ -4557,17 +4557,17 @@ link.href = URL.createObjectURL(blob);
 TEST(ProcessSwap, SameOriginBlobNavigation)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] initWithBytes:sameOriginBlobNavigationTestBytes]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] initWithBytes:sameOriginBlobNavigationTestBytes]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView setUIDelegate:uiDelegate.get()];
 
     numberOfDecidePolicyCalls = 0;
@@ -4591,17 +4591,17 @@ TEST(ProcessSwap, SameOriginBlobNavigation)
 TEST(ProcessSwap, CrossOriginBlobNavigation)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] initWithBytes:sameOriginBlobNavigationTestBytes]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] initWithBytes:sameOriginBlobNavigationTestBytes]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView setUIDelegate:uiDelegate.get()];
 
     numberOfDecidePolicyCalls = 0;
@@ -4649,17 +4649,17 @@ TEST(ProcessSwap, CrossOriginBlobNavigation)
 TEST(ProcessSwap, NavigateToAboutBlank)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] initWithBytes:sameOriginBlobNavigationTestBytes]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] initWithBytes:sameOriginBlobNavigationTestBytes]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView setUIDelegate:uiDelegate.get()];
 
     numberOfDecidePolicyCalls = 0;
@@ -4682,17 +4682,17 @@ TEST(ProcessSwap, NavigateToAboutBlank)
 TEST(ProcessSwap, NavigateToDataURL)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] initWithBytes:sameOriginBlobNavigationTestBytes]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] initWithBytes:sameOriginBlobNavigationTestBytes]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView setUIDelegate:uiDelegate.get()];
 
     numberOfDecidePolicyCalls = 0;
@@ -4715,15 +4715,15 @@ TEST(ProcessSwap, NavigateToDataURL)
 TEST(ProcessSwap, ProcessReuse)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]];
@@ -4760,15 +4760,15 @@ TEST(ProcessSwap, ProcessReuse)
 TEST(ProcessSwap, ProcessReuseeTLDPlus2)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www1.webkit.org/main1.html"]];
@@ -4805,15 +4805,15 @@ TEST(ProcessSwap, ProcessReuseeTLDPlus2)
 TEST(ProcessSwap, ConcurrentHistoryNavigations)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]]];
@@ -4881,19 +4881,19 @@ TEST(ProcessSwap, CookieAccessAfterMultipleRedirects)
         { "http://site2.example/redirect"_s, { 302, {{ "Location"_s, "http://site1.example/end"_s }}, "redirecting..."_s } }, // Process 1
         { "http://site1.example/end"_s, { "Done."_s  } }, // Process 3
     }, HTTPServer::Protocol::Http);
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
     [configuration setProcessPool:processPool.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
 
     __block bool navigationFailed = false;
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
@@ -4936,17 +4936,17 @@ TEST(ProcessSwap, CookieAccessAfterMultipleRedirects)
 TEST(ProcessSwap, NavigateToInvalidURL)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView setUIDelegate:uiDelegate.get()];
 
     numberOfDecidePolicyCalls = 0;
@@ -4998,16 +4998,16 @@ TEST(ProcessSwap, NavigateToDataURLThenBack)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     processPoolConfiguration.get().pageCacheEnabled = NO;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     webViewConfiguration.get()._allowTopNavigationToDataURLs = YES;
-    auto handler = adoptNS([[PSONScheme alloc] initWithBytes:navigateToDataURLThenBackBytes]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] initWithBytes:navigateToDataURLThenBackBytes]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     numberOfDecidePolicyCalls = 0;
@@ -5034,15 +5034,15 @@ TEST(ProcessSwap, NavigateCrossSiteWithPageCacheDisabled)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     processPoolConfiguration.get().pageCacheEnabled = NO;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]]];
@@ -5066,12 +5066,12 @@ TEST(ProcessSwap, NavigateCrossSiteWithPageCacheDisabled)
 
 TEST(ProcessSwap, APIControlledProcessSwapping)
 {
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([[PSONScheme alloc] initWithBytes:"Hello World!"]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] initWithBytes:"Hello World!"]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     numberOfDecidePolicyCalls = 0;
@@ -5107,12 +5107,12 @@ TEST(ProcessSwap, APIControlledProcessSwapping)
 enum class WithDelay : bool { No, Yes };
 static void runAPIControlledProcessSwappingThenBackTest(WithDelay withDelay)
 {
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([[PSONScheme alloc] initWithBytes:"Hello World!"]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] initWithBytes:"Hello World!"]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
     
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org"]]];
@@ -5162,15 +5162,15 @@ TEST(ProcessSwap, NavigateToCrossSiteThenBackFromJS)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     processPoolConfiguration.get().pageCacheEnabled = NO;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     numberOfDecidePolicyCalls = 0;
@@ -5211,16 +5211,16 @@ Name: <input type="text" name="name" placeholder="Name">
 TEST(ProcessSwap, SwapOnFormSubmission)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:crossSiteFormSubmissionBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]]];
@@ -5269,15 +5269,15 @@ TEST(ProcessSwap, SwapOnFormSubmission)
 TEST(ProcessSwap, ClosePageAfterCrossSiteProvisionalLoad)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = NO;
@@ -5327,15 +5327,15 @@ static unsigned urlChangeCount;
 TEST(ProcessSwap, LoadingStateAfterPolicyDecision)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = NO;
@@ -5344,7 +5344,7 @@ TEST(ProcessSwap, LoadingStateAfterPolicyDecision)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto loadObserver = adoptNS([[PSONLoadingObserver alloc] init]);
+    RetainPtr loadObserver = adoptNS([[PSONLoadingObserver alloc] init]);
     [webView addObserver:loadObserver.get() forKeyPath:@"loading" options:0 context:webView.get()];
     [webView addObserver:loadObserver.get() forKeyPath:@"URL" options:0 context:webView.get()];
 
@@ -5403,19 +5403,19 @@ window.onload = function() {
 
 TEST(ProcessSwap, OpenerLinkAfterAPIControlledProcessSwappingOfOpener)
 {
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration preferences].javaScriptCanOpenWindowsAutomatically = YES;
 
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main1.html" toData:windowOpenSameSiteWithOpenerTestBytes]; // Opens "pson://www.webkit.org/main2.html".
     [handler addMappingFromURLString:@"pson://www.webkit.org/main2.html" toData:saveOpenerTestBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView setUIDelegate:uiDelegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]]];
@@ -5478,18 +5478,18 @@ TEST(ProcessSwap, OpenerLinkAfterAPIControlledProcessSwappingOfOpener)
 
 TEST(ProcessSwap, OpenerLinkAfterAPIControlledProcessSwappingOfOpenee)
 {
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration preferences].javaScriptCanOpenWindowsAutomatically = YES;
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main1.html" toData:windowOpenSameSiteWithOpenerTestBytes]; // Opens "pson://www.webkit.org/main2.html".
     [handler addMappingFromURLString:@"pson://www.webkit.org/main2.html" toData:saveOpenerTestBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView setUIDelegate:uiDelegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]]];
@@ -5538,15 +5538,15 @@ TEST(ProcessSwap, OpenerLinkAfterAPIControlledProcessSwappingOfOpenee)
 static void runProcessSwapDueToRelatedWebViewTest(NSURL* relatedViewURL, NSURL* targetURL, ExpectSwap expectSwap)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webView1Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView1Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webView1Configuration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webView1Configuration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView1Configuration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView1Configuration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView1 setNavigationDelegate:delegate.get()];
 
     numberOfDecidePolicyCalls = 0;
@@ -5558,13 +5558,13 @@ static void runProcessSwapDueToRelatedWebViewTest(NSURL* relatedViewURL, NSURL* 
 
     auto pid1 = [webView1 _webProcessIdentifier];
 
-    auto webView2Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView2Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webView2Configuration setProcessPool:processPool.get()];
     [webView2Configuration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     webView2Configuration.get()._relatedWebView = webView1.get(); // webView2 will be related to webView1 and webView1's URL will be used for process swap decision.
     ALLOW_DEPRECATED_DECLARATIONS_END
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView2Configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView2Configuration.get()]);
     [webView2 setNavigationDelegate:delegate.get()];
 
     request = [NSURLRequest requestWithURL:targetURL];
@@ -5596,24 +5596,24 @@ TEST(ProcessSwap, NoProcessSwapDueToRelatedView)
 TEST(ProcessSwap, RelatedWebViewBeforeWebProcessLaunch)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webView1Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView1Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webView1Configuration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webView1Configuration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView1Configuration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView1Configuration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView1 setNavigationDelegate:delegate.get()];
 
-    auto webView2Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView2Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webView2Configuration setProcessPool:processPool.get()];
     [webView2Configuration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     webView2Configuration.get()._relatedWebView = webView1.get(); // webView2 will be related to webView1 and webView1's URL will be used for process swap decision.
     ALLOW_DEPRECATED_DECLARATIONS_END
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView2Configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView2Configuration.get()]);
     [webView2 setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]];
@@ -5638,15 +5638,15 @@ TEST(ProcessSwap, RelatedWebViewBeforeWebProcessLaunch)
 TEST(ProcessSwap, ReloadRelatedWebViewAfterCrash)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webView1Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView1Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webView1Configuration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webView1Configuration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView1Configuration.get()]);
-    auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView1Configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
     __block bool didCrash = false;
     [delegate setWebContentProcessDidTerminate:^(WKWebView *view, _WKProcessTerminationReason) {
         [view reload];
@@ -5658,13 +5658,13 @@ TEST(ProcessSwap, ReloadRelatedWebViewAfterCrash)
 
     [webView1 setNavigationDelegate:delegate.get()];
 
-    auto webView2Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView2Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webView2Configuration setProcessPool:processPool.get()];
     [webView2Configuration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     webView2Configuration.get()._relatedWebView = webView1.get(); // webView2 will be related to webView1 and webView1's URL will be used for process swap decision.
     ALLOW_DEPRECATED_DECLARATIONS_END
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView2Configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView2Configuration.get()]);
     [webView2 setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]];
@@ -5700,15 +5700,15 @@ TEST(ProcessSwap, ReloadRelatedWebViewAfterCrash)
 TEST(ProcessSwap, TerminatedSuspendedPageProcess)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]];
@@ -5720,12 +5720,12 @@ TEST(ProcessSwap, TerminatedSuspendedPageProcess)
     auto pid1 = [webView _webProcessIdentifier];
 
     @autoreleasepool {
-        auto webViewConfiguration2 = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr webViewConfiguration2 = adoptNS([[WKWebViewConfiguration alloc] init]);
         [webViewConfiguration2 setProcessPool:processPool.get()];
         ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         [webViewConfiguration2 _setRelatedWebView:webView.get()]; // Make sure it uses the same process.
         ALLOW_DEPRECATED_DECLARATIONS_END
-        auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration2.get()]);
+        RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration2.get()]);
         [webView2 setNavigationDelegate:delegate.get()];
 
         request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]];
@@ -5765,15 +5765,15 @@ TEST(ProcessSwap, TerminatedSuspendedPageProcess)
 TEST(ProcessSwap, CommittedProcessCrashDuringCrossSiteNavigation)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     done = false;
@@ -5807,15 +5807,15 @@ TEST(ProcessSwap, CommittedProcessCrashDuringCrossSiteNavigation)
 TEST(ProcessSwap, NavigateBackAndForth)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -5858,15 +5858,15 @@ TEST(ProcessSwap, NavigateBackAndForth)
 TEST(ProcessSwap, SwapOnLoadHTMLString)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     numberOfDecidePolicyCalls = 0;
@@ -5901,17 +5901,17 @@ TEST(ProcessSwap, SwapOnLoadHTMLString)
 TEST(ProcessSwap, EphemeralWebStorage)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
     
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     [webViewConfiguration setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/iframe.html" toData:"<script>window.localStorage.setItem('c','d')</script>"];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"pson"];
     
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://webkit.org/"]]];
@@ -5973,16 +5973,16 @@ TEST(ProcessSwap, EphemeralWebStorage)
 TEST(ProcessSwap, UsePrewarmedProcessAfterTerminatingNetworkProcess)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     webViewConfiguration.get().websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get();
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
@@ -5995,7 +5995,7 @@ TEST(ProcessSwap, UsePrewarmedProcessAfterTerminatingNetworkProcess)
 
     [webViewConfiguration.get().websiteDataStore _terminateNetworkProcess];
 
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     [webView2 setNavigationDelegate:delegate.get()];
     request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"]];
     [webView2 loadRequest:request];
@@ -6009,21 +6009,21 @@ TEST(ProcessSwap, UseSessionCookiesAfterProcessSwapInPrivateBrowsing)
     auto originalCookieAcceptPolicy = [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookieAcceptPolicy];
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
     RetainPtr<WKWebsiteDataStore> ephemeralStore = [WKWebsiteDataStore nonPersistentDataStore];
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     webViewConfiguration.get().websiteDataStore = ephemeralStore.get();
 
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"pson"];
 
-    auto messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool setPolicy = false;
@@ -6084,24 +6084,24 @@ TEST(ProcessSwap, UseSessionCookiesAfterProcessSwapInNonDefaultPersistentSession
     processPoolConfiguration.get().pageCacheEnabled = NO;
     processPoolConfiguration.get().prewarmsProcessesAutomatically = NO;
 
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
-    auto customDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr customDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
 
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     [webViewConfiguration setProcessPool:processPool.get()];
     webViewConfiguration.get().websiteDataStore = customDataStore.get();
 
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"pson"];
 
-    auto messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool setPolicy = false;
@@ -6155,16 +6155,16 @@ TEST(ProcessSwap, UseSessionCookiesAfterProcessSwapInNonDefaultPersistentSession
 TEST(ProcessSwap, ProcessSwapInRelatedView)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webView1Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView1Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webView1Configuration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webView1Configuration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView1Configuration.get()]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView1Configuration.get()]);
 
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView1 setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.apple.com/main.html"]];
@@ -6175,14 +6175,14 @@ TEST(ProcessSwap, ProcessSwapInRelatedView)
 
     auto applePID = [webView1 _webProcessIdentifier];
 
-    auto webView2Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView2Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webView2Configuration setProcessPool:processPool.get()];
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     [webView2Configuration _setRelatedWebView:webView1.get()];
     ALLOW_DEPRECATED_DECLARATIONS_END
     [webView2Configuration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView2Configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView2Configuration.get()]);
     [webView2 _restoreSessionState:webView1.get()._sessionState andNavigate:NO];
 
     [webView2 setNavigationDelegate:delegate.get()];
@@ -6199,17 +6199,17 @@ TEST(ProcessSwap, ProcessSwapInRelatedView)
 TEST(ProcessSwap, TerminateProcessAfterProcessSwap)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     [webView setAllowsBackForwardNavigationGestures:YES];
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     __block bool webProcessTerminated = false;
     [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *, _WKProcessTerminationReason) {
@@ -6273,16 +6273,16 @@ TEST(ProcessSwap, SwapWithGestureController)
 {
     @autoreleasepool {
         auto processPoolConfiguration = psonProcessPoolConfiguration();
-        auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+        RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-        auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
         [webViewConfiguration setProcessPool:processPool.get()];
-        auto handler = adoptNS([[PSONScheme alloc] init]);
+        RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
         [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
-        auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+        RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
         [webView setNavigationDelegate:delegate.get()];
 
         NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.apple.com/main.html"]];
@@ -6318,16 +6318,16 @@ TEST(ProcessSwap, CrashWithGestureController)
 {
     @autoreleasepool {
         auto processPoolConfiguration = psonProcessPoolConfiguration();
-        auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+        RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-        auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
         [webViewConfiguration setProcessPool:processPool.get()];
-        auto handler = adoptNS([[PSONScheme alloc] init]);
+        RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
         [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
-        auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+        RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
         [webView setNavigationDelegate:navigationDelegate.get()];
         __block bool webProcessTerminated = false;
         [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *, _WKProcessTerminationReason) {
@@ -6371,21 +6371,21 @@ TEST(ProcessSwap, CrashWithGestureController)
 TEST(ProcessSwap, NavigateCrossOriginWithOpenee)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main1.html" toData:windowOpenSameSiteWithOpenerTestBytes]; // Opens "pson://www.webkit.org/main2.html".
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView setUIDelegate:uiDelegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]];
@@ -6472,22 +6472,22 @@ static constexpr auto pageWithLinkToAppleBytes = R"PSONRESOURCE(
 TEST(ProcessSwap, NavigateCrossOriginWithOpener)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main1.html" toData:crossSiteLinkWithOpenerTestBytes];
     [handler addMappingFromURLString:@"pson://www.webkit.org/main2.html" toData:pageWithLinkToAppleBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView setUIDelegate:uiDelegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]];
@@ -6605,22 +6605,22 @@ TEST(ProcessSwap, NavigateCrossOriginWithOpener)
 TEST(ProcessSwap, NavigateCrossOriginWithOpenerViaClientInitiatedNavigation)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main1.html" toData:crossSiteLinkWithOpenerTestBytes];
     [handler addMappingFromURLString:@"pson://www.webkit.org/main2.html" toData:pageWithLinkToAppleBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView setUIDelegate:uiDelegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]];
@@ -6823,19 +6823,19 @@ TEST(ProcessSwap, NavigateCrossOriginWithOpenerWithRestrictedOpenerTypeNoOpener)
 TEST(ProcessSwap, GoBackToSuspendedPageWithMainFrameIDThatIsNotOne)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main1.html" toData:targetBlankSameSiteNoOpenerTestBytes];
     [handler addMappingFromURLString:@"pson://www.webkit.org/main2.html" toData:linkToAppleTestBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PSONMessageHandler alloc] init]);
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
     // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     if (!isUsingBackForwardCache(webView1.get())) {
@@ -6843,9 +6843,9 @@ TEST(ProcessSwap, GoBackToSuspendedPageWithMainFrameIDThatIsNotOne)
         return;
     }
 
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView1 setNavigationDelegate:navigationDelegate.get()];
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView1 setUIDelegate:uiDelegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main1.html"]];
@@ -6943,16 +6943,16 @@ static unsigned waitUntilScrollPositionIsRestored(WKWebView *webView)
 TEST(ProcessSwap, ScrollPositionRestoration)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:tallPageBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -7047,9 +7047,9 @@ TEST(ProcessSwap, ContentBlockingAfterProcessSwap)
     done = false;
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
 
     __block bool doneCompiling = false;
@@ -7064,15 +7064,15 @@ TEST(ProcessSwap, ContentBlockingAfterProcessSwap)
     }];
     TestWebKitAPI::Util::run(&doneCompiling);
 
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:contentBlockingAfterProcessSwapTestBytes];
     [handler addMappingFromURLString:@"pson://www.webkit.org/blockme.html" toData:markSubFrameAsLoadedTestBytes];
     [handler addMappingFromURLString:@"pson://www.apple.com/main.html" toData:contentBlockingAfterProcessSwapTestBytes];
     [handler addMappingFromURLString:@"pson://www.apple.com/blockme.html" toData:markSubFrameAsLoadedTestBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -7147,9 +7147,9 @@ TEST(ProcessSwap, ContentExtensionBlocksMainLoadThenReloadWithoutExtensions)
     done = false;
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     webViewConfiguration.get()._allowTopNavigationToDataURLs = YES;
 
@@ -7168,12 +7168,12 @@ TEST(ProcessSwap, ContentExtensionBlocksMainLoadThenReloadWithoutExtensions)
     }];
     TestWebKitAPI::Util::run(&doneCompiling);
 
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.apple.com/blockme.html" toData:notifyLoadedBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -7217,9 +7217,9 @@ TEST(ProcessSwap, LoadAlternativeHTML)
     done = false;
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     webViewConfiguration.get()._allowTopNavigationToDataURLs = YES;
 
@@ -7238,12 +7238,12 @@ TEST(ProcessSwap, LoadAlternativeHTML)
     }];
     TestWebKitAPI::Util::run(&doneCompiling);
 
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.apple.com/blockme.html" toData:notifyLoadedBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -7299,9 +7299,9 @@ TEST(ProcessSwap, GetUserMediaCaptureState)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     processPoolConfiguration.get().pageCacheEnabled = NO;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto preferences = [webViewConfiguration.get() preferences];
     preferences._mediaCaptureRequiresSecureConnection = NO;
     webViewConfiguration.get()._mediaCaptureEnabled = YES;
@@ -7309,18 +7309,18 @@ TEST(ProcessSwap, GetUserMediaCaptureState)
     preferences._getUserMediaRequiresFocus = NO;
 
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/getUserMedia.html" toData:getUserMediaBytes];
     [handler addMappingFromURLString:@"pson://www.apple.org/test.html" toData:""];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     webView.get()._mediaCaptureReportingDelayForTesting = 1;
 
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
-    auto uiDelegate = adoptNS([[GetUserMediaUIDelegate alloc] init]);
+    RetainPtr uiDelegate = adoptNS([[GetUserMediaUIDelegate alloc] init]);
     [webView setUIDelegate: uiDelegate.get()];
 
     auto request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/getUserMedia.html"]];
@@ -7378,20 +7378,20 @@ TEST(ProcessSwap, PageOverlayLayerPersistence)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     [processPoolConfiguration setInjectedBundleURL:[[NSBundle mainBundle] URLForResource:@"TestWebKitAPI" withExtension:@"wkbundle"]];
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
     [processPool _setObject:@"PageOverlayPlugIn" forBundleParameter:TestWebKitAPI::Util::TestPlugInClassNameParameter];
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
 
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/page-overlay" toData:""];
     [handler addMappingFromURLString:@"pson://www.apple.com/page-overlay" toData:""];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     auto request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/page-overlay"]];
@@ -7431,16 +7431,16 @@ TEST(ProcessSwap, PageOverlayLayerPersistence)
 TEST(ProcessSwap, QuickLookRequestsPasswordAfterSwap)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     auto* request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -7484,17 +7484,17 @@ div {
 TEST(ProcessSwap, PassMinimumDeviceWidthOnNewWebView)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:minimumWidthPageBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     auto preferences = [[webView configuration] preferences];
@@ -7521,18 +7521,18 @@ TEST(ProcessSwap, PassMinimumDeviceWidthOnNewWebView)
 TEST(ProcessSwap, SuspendAllMediaPlayback)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
 #if TARGET_OS_IPHONE
     configuration.get().allowsInlineMediaPlayback = YES;
 #endif
     [configuration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     __block bool loaded = false;
     [webView performAfterLoading:^{ loaded = true; }];
@@ -7551,20 +7551,20 @@ TEST(ProcessSwap, SuspendAllMediaPlayback)
 TEST(ProcessSwap, PassSandboxExtension)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
 #if TARGET_OS_IPHONE
     configuration.get().allowsInlineMediaPlayback = YES;
 #endif
     [configuration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]]];
@@ -7593,20 +7593,20 @@ static constexpr auto openedPage = "Hello World"_s;
 TEST(ProcessSwap, SameSiteWindowWithOpenerNavigateToFile)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     enableSiteIsolationForPSONTest(webViewConfiguration.get());
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:pageThatOpensBytes];
     [handler addMappingFromURLString:@"pson://www.webkit.org/window.html" toData:openedPage];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView setUIDelegate:uiDelegate.get()];
 
     numberOfDecidePolicyCalls = 0;
@@ -7680,17 +7680,17 @@ static constexpr auto responsivePageBytes = R"PSONRESOURCE(
 TEST(ProcessSwap, ResizeWebViewDuringCrossSiteProvisionalNavigation)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:responsivePageBytes];
     [handler addMappingFromURLString:@"pson://www.apple.com/main.html" toData:responsivePageBytes];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"pson"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 800) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 800) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = NO;
@@ -7733,21 +7733,21 @@ TEST(ProcessSwap, ResizeWebViewDuringCrossSiteProvisionalNavigation)
 
 TEST(WebProcessCache, ClearWhenEnteringCache)
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().usesWebProcessCache = YES;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
     @autoreleasepool {
-        auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 800) configuration:webViewConfiguration.get()]);
-        auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 800) configuration:webViewConfiguration.get()]);
-        auto webView3 = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 800) configuration:webViewConfiguration.get()]);
+        RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 800) configuration:webViewConfiguration.get()]);
+        RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 800) configuration:webViewConfiguration.get()]);
+        RetainPtr webView3 = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 800) configuration:webViewConfiguration.get()]);
 
-        auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+        RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
         [webView1 setNavigationDelegate:delegate.get()];
         [webView2 setNavigationDelegate:delegate.get()];
         [webView3 setNavigationDelegate:delegate.get()];
@@ -7787,9 +7787,9 @@ TEST(ProcessSwap, ResponsePolicyDownloadAfterCOOPProcessSwap)
     }, HTTPServer::Protocol::Https);
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"CrossOriginOpenerPolicyEnabled"])
@@ -7798,8 +7798,8 @@ TEST(ProcessSwap, ResponsePolicyDownloadAfterCOOPProcessSwap)
             [[webViewConfiguration preferences] _setEnabled:YES forFeature:feature];
     }
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     done = false;
@@ -7845,9 +7845,9 @@ TEST(ProcessSwap, MainFrameURLAfterServerSideRedirectToCOOP)
     }, HTTPServer::Protocol::Https);
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"CrossOriginOpenerPolicyEnabled"])
@@ -7856,10 +7856,10 @@ TEST(ProcessSwap, MainFrameURLAfterServerSideRedirectToCOOP)
             [[webViewConfiguration preferences] _setEnabled:YES forFeature:feature];
     }
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView setUIDelegate:uiDelegate.get()];
 
     done = false;
@@ -7894,9 +7894,9 @@ TEST(ProcessSwap, COOPAndCOEPOn304Response)
     }, HTTPServer::Protocol::Https);
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webView1Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView1Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webView1Configuration setProcessPool:processPool.get()];
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"CrossOriginOpenerPolicyEnabled"])
@@ -7905,8 +7905,8 @@ TEST(ProcessSwap, COOPAndCOEPOn304Response)
             [[webView1Configuration preferences] _setEnabled:YES forFeature:feature];
     }
 
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView1Configuration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView1Configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView1 setNavigationDelegate:navigationDelegate.get()];
 
     done = false;
@@ -7923,7 +7923,7 @@ TEST(ProcessSwap, COOPAndCOEPOn304Response)
     Util::run(&done);
     done = false;
 
-    auto webView2Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView2Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webView2Configuration setProcessPool:processPool.get()];
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"CrossOriginOpenerPolicyEnabled"])
@@ -7934,7 +7934,7 @@ TEST(ProcessSwap, COOPAndCOEPOn304Response)
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     webView2Configuration.get()._relatedWebView = webView1.get(); // webView2 will be related to webView1 and webView1's URL will be used for process swap decision.
     ALLOW_DEPRECATED_DECLARATIONS_END
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView2Configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView2Configuration.get()]);
     [webView2 setNavigationDelegate:navigationDelegate.get()];
 
     done = false;
@@ -7963,9 +7963,9 @@ TEST(ProcessSwap, NavigateBackAfterNavigatingAwayFromCOOP)
     }, HTTPServer::Protocol::Https);
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"CrossOriginOpenerPolicyEnabled"])
@@ -7974,8 +7974,8 @@ TEST(ProcessSwap, NavigateBackAfterNavigatingAwayFromCOOP)
             [[webViewConfiguration preferences] _setEnabled:YES forFeature:feature];
     }
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     done = false;
@@ -8002,9 +8002,9 @@ TEST(ProcessSwap, NavigateBackAfterNavigatingAwayFromCrossOriginOpenerPolicyUsin
     }, HTTPServer::Protocol::Https);
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"CrossOriginOpenerPolicyEnabled"])
@@ -8013,8 +8013,8 @@ TEST(ProcessSwap, NavigateBackAfterNavigatingAwayFromCrossOriginOpenerPolicyUsin
             [[webViewConfiguration preferences] _setEnabled:YES forFeature:feature];
     }
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     navigationDelegate->didSameDocumentNavigationHandler = ^{
         done = true;
     };
@@ -8084,9 +8084,9 @@ TEST(ProcessSwap, MultitabCOOPSwapSameOriginProcessPool)
     }, HTTPServer::Protocol::Https);
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"CrossOriginOpenerPolicyEnabled"])
@@ -8096,8 +8096,8 @@ TEST(ProcessSwap, MultitabCOOPSwapSameOriginProcessPool)
     }
 
     // ORIGINAL TAB
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView1 setNavigationDelegate:navigationDelegate.get()];
 
     // 1: load coopSite
@@ -8121,8 +8121,8 @@ TEST(ProcessSwap, MultitabCOOPSwapSameOriginProcessPool)
     EXPECT_NE(pid2, pid3);
 
     // NEW TAB
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate2 = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate2 = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView2 setNavigationDelegate:navigationDelegate2.get()];
 
     // 4: load coopSite again in new tab => COOP always spawns a fresh process
@@ -8155,16 +8155,16 @@ TEST(ProcessSwap, NavigateBackAfterNavigatingAwayFromCrossOriginOpenerPolicyUsin
     using namespace TestWebKitAPI;
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org" toData:"<script>function navigateToApple() { window.location = 'pson://www.apple.com'; }</script>foo"];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     navigationDelegate->didSameDocumentNavigationHandler = ^{
         done = true;
     };
@@ -8223,9 +8223,9 @@ TEST(ProcessSwap, CommittedURLAfterNavigatingBackToCOOP)
     }, HTTPServer::Protocol::Https);
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"CrossOriginOpenerPolicyEnabled"])
@@ -8234,8 +8234,8 @@ TEST(ProcessSwap, CommittedURLAfterNavigatingBackToCOOP)
             [[webViewConfiguration preferences] _setEnabled:YES forFeature:feature];
     }
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     done = false;
@@ -8312,12 +8312,12 @@ static void runCOOPProcessSwapTest(ASCIILiteral sourceCOOP, ASCIILiteral sourceC
         server.addResponse("/popup.html"_s, WTF::move(destinationResponse));
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
     bool sourceShouldBeCrossOriginIsolated = sourceCOOP == "same-origin"_s && sourceCOEP == "require-corp"_s;
     bool destinationShouldBeCrossOriginIsolated = destinationCOOP == "same-origin"_s && destinationCOEP == "require-corp"_s;
     EXPECT_TRUE(sourceShouldBeCrossOriginIsolated == destinationShouldBeCrossOriginIsolated || expectSwapBrowsingContextGroup == ExpectSwap::Yes);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     [webViewConfiguration preferences].javaScriptCanOpenWindowsAutomatically = YES;
     for (_WKFeature *feature in [WKPreferences _features]) {
@@ -8327,8 +8327,8 @@ static void runCOOPProcessSwapTest(ASCIILiteral sourceCOOP, ASCIILiteral sourceC
             [[webViewConfiguration preferences] _setEnabled:YES forFeature:feature];
     }
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
 
     __block unsigned numberOfProvisionalLoads = 0;
     navigationDelegate->didStartProvisionalNavigationHandler = ^{
@@ -8336,7 +8336,7 @@ static void runCOOPProcessSwapTest(ASCIILiteral sourceCOOP, ASCIILiteral sourceC
     };
 
     [webView setNavigationDelegate:navigationDelegate.get()];
-    auto uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
+    RetainPtr uiDelegate = adoptNS([[PSONUIDelegate alloc] initWithNavigationDelegate:navigationDelegate.get()]);
     [webView setUIDelegate:uiDelegate.get()];
 
     failed = false;
@@ -8597,10 +8597,10 @@ TEST(ProcessSwap, ClientRedirectAfterCOOPIframeIgnored)
 
     RetainPtr configuration = server.httpsProxyConfiguration();
     configuration.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
     __block RetainPtr<WKWebView> opened;
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     uiDelegate.get().createWebViewWithConfiguration = ^WKWebView *(WKWebViewConfiguration *configuration, WKNavigationAction *, WKWindowFeatures *) {
         opened = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
@@ -8882,15 +8882,15 @@ static void configureLockdownWKWebViewConfiguration(WKWebViewConfiguration *conf
 
 TEST(ProcessSwap, NavigatingToLockdownMode)
 {
-    auto messageHandler = adoptNS([[LockdownMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[LockdownMessageHandler alloc] init]);
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     EXPECT_FALSE(webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled);
     configureLockdownWKWebViewConfiguration(webViewConfiguration.get());
     [webViewConfiguration.get().userContentController addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     EXPECT_TRUE(isJITEnabled(webView.get()));
@@ -8948,14 +8948,14 @@ TEST(ProcessSwap, NavigatingToLockdownMode)
 
 TEST(ProcessSwap, LockdownModeSystemSettingChange)
 {
-    auto kvo = adoptNS([LockdownModeKVO new]);
+    RetainPtr kvo = adoptNS([LockdownModeKVO new]);
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     EXPECT_FALSE(webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled);
     [webViewConfiguration.get().defaultWebpagePreferences addObserver:kvo.get() forKeyPath:@"lockdownModeEnabled" options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:nil];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     EXPECT_TRUE(isJITEnabled(webView.get()));
@@ -9013,16 +9013,16 @@ TEST(ProcessSwap, LockdownModeSystemSettingChange)
 TEST(ProcessSwap, DestinationProcessTerminationDuringProcessSwap)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [webViewConfiguration setProcessPool:processPool.get()];
 
-    auto handler = adoptNS([PSONScheme new]);
+    RetainPtr handler = adoptNS([PSONScheme new]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([PSONNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([PSONNavigationDelegate new]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/source.html"]]];
@@ -9054,16 +9054,16 @@ TEST(ProcessSwap, DestinationProcessTerminationDuringProcessSwap)
 TEST(ProcessSwap, MemoryPressureDuringProcessSwap)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [webViewConfiguration setProcessPool:processPool.get()];
 
-    auto handler = adoptNS([PSONScheme new]);
+    RetainPtr handler = adoptNS([PSONScheme new]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([PSONNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([PSONNavigationDelegate new]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/source.html"]]];
@@ -9094,13 +9094,13 @@ TEST(ProcessSwap, MemoryPressureDuringProcessSwap)
 
 TEST(ProcessSwap, CannotDisableLockdownModeWithoutBrowserEntitlement)
 {
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     EXPECT_FALSE(webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled);
     configureLockdownWKWebViewConfiguration(webViewConfiguration.get());
     webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     EXPECT_FALSE(isJITEnabled(webView.get()));
@@ -9138,13 +9138,13 @@ TEST(ProcessSwap, CannotDisableLockdownModeWithoutBrowserEntitlement)
 
 TEST(ProcessSwap, LockdownModeEnabledByDefaultThenOptOut)
 {
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     EXPECT_FALSE(webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled);
     configureLockdownWKWebViewConfiguration(webViewConfiguration.get());
     webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     EXPECT_FALSE(isJITEnabled(webView.get()));
@@ -9195,10 +9195,10 @@ TEST(ProcessSwap, LockdownModeEnabledByDefaultThenOptOut)
     checkSettingsControlledByLockdownMode(webView.get(), ShouldBeEnabled::Yes);
 
     // lockdown mode should be disabled in new WebViews since it is not enabled globally.
-    auto webViewConfiguration2 = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration2 = adoptNS([WKWebViewConfiguration new]);
     configureLockdownWKWebViewConfiguration(webViewConfiguration2.get());
     EXPECT_TRUE(webViewConfiguration2.get().defaultWebpagePreferences.lockdownModeEnabled == NO);
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration2.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration2.get()]);
     [webView2 setNavigationDelegate:delegate.get()];
     EXPECT_TRUE(isJITEnabled(webView2.get()));
     checkSettingsControlledByLockdownMode(webView2.get(), ShouldBeEnabled::Yes, IsShowingInitialEmptyDocument::Yes);
@@ -9219,12 +9219,12 @@ TEST(ProcessSwap, LockdownModeSystemSettingChangeDoesNotReloadViewsWhenModeIsSet
 {
     // Captive portal mode is disabled globally and explicitly opted out via defaultWebpagePreferences.
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     EXPECT_FALSE(webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled);
     webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = NO; // Explicitly opt out via default WKWebpagePreferences.
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     EXPECT_TRUE(isJITEnabled(webView.get()));
@@ -9264,12 +9264,12 @@ TEST(ProcessSwap, LockdownModeSystemSettingChangeDoesNotReloadViewsWhenModeIsSet
     // Captive portal mode is enabled globally but explicitly opted out via defaultWebpagePreferences.
     [WKProcessPool _setCaptivePortalModeEnabledGloballyForTesting:YES];
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     EXPECT_TRUE(webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled);
     webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = NO; // Explicitly opt out via default WKWebpagePreferences.
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     EXPECT_FALSE(isJITEnabled(webView.get()));
@@ -9308,11 +9308,11 @@ TEST(ProcessSwap, LockdownModeSystemSettingChangeDoesNotReloadViewsWhenModeIsSet
 {
     // Captive portal mode is disabled globally and explicitly opted out for the load.
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     EXPECT_FALSE(webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled);
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     EXPECT_TRUE(isJITEnabled(webView.get()));
@@ -9358,11 +9358,11 @@ TEST(ProcessSwap, LockdownModeSystemSettingChangeDoesNotReloadViewsWhenModeIsSet
     // Captive portal mode is enabled globally but explicitly opted out for the load.
     [WKProcessPool _setCaptivePortalModeEnabledGloballyForTesting:YES];
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     EXPECT_TRUE(webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled);
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     EXPECT_FALSE(isJITEnabled(webView.get()));
@@ -9416,17 +9416,17 @@ TEST(ProcessSwap, ContentModeInCaseOfCoopProcessSwap)
     }, HTTPServer::Protocol::Https);
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
 
-    auto webpagePreferences = adoptNS([[WKWebpagePreferences alloc] init]);
+    RetainPtr webpagePreferences = adoptNS([[WKWebpagePreferences alloc] init]);
     [webpagePreferences setPreferredContentMode:WKContentModeDesktop];
     [webViewConfiguration setDefaultWebpagePreferences:webpagePreferences.get()];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 1024, 768) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 1024, 768) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     done = false;
@@ -9491,17 +9491,17 @@ TEST(ProcessSwap, ContentModeInCaseOfPSONThenCoopProcessSwap)
     }, HTTPServer::Protocol::Http);
 
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
 
-    auto webpagePreferences = adoptNS([[WKWebpagePreferences alloc] init]);
+    RetainPtr webpagePreferences = adoptNS([[WKWebpagePreferences alloc] init]);
     [webpagePreferences setPreferredContentMode:WKContentModeDesktop];
     [webViewConfiguration setDefaultWebpagePreferences:webpagePreferences.get()];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 1024, 768) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 1024, 768) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     done = false;
@@ -9556,16 +9556,16 @@ TEST(ProcessSwap, ContentModeInCaseOfPSONThenCoopProcessSwap)
 TEST(ProcessSwap, ChangeViewSizeDuringNavigationActionPolicyDecision)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [webViewConfiguration setProcessPool:processPool.get()];
 
-    auto handler = adoptNS([PSONScheme new]);
+    RetainPtr handler = adoptNS([PSONScheme new]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([PSONNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([PSONNavigationDelegate new]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/source.html"]]];
@@ -9614,7 +9614,7 @@ TEST(ProcessSwap, NewProcessAfterNavigatingToCrossOriginThroughAboutPage)
         { "/destination.html"_s, { ""_s } },
     });
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
 
     [webView synchronouslyLoadRequest:server.request("/source.html"_s)];
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
@@ -9636,7 +9636,7 @@ TEST(ProcessSwap, ReuseProcessAfterNavigatingToSameOriginThroughAboutPage)
         { "/destination.html"_s, { ""_s } },
     });
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
 
     [webView synchronouslyLoadRequest:server.request("/source.html"_s)];
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
@@ -9657,7 +9657,7 @@ TEST(ProcessSwap, ReuseProcessAfterNavigatingFromAboutPage)
         { "/destination.html"_s, { ""_s } },
     });
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
 
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
 
@@ -9674,21 +9674,21 @@ TEST(ProcessSwap, ReuseProcessAfterNavigatingFromAboutPage)
 #if !PLATFORM(IOS_FAMILY)
 TEST(WebProcessCache, ReusedCrashedCachedWebProcess)
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().usesWebProcessCache = YES;
     processPoolConfiguration.get().processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol = YES;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
 
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 800) configuration:webViewConfiguration.get()]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 800) configuration:webViewConfiguration.get()]);
     [webView1 setNavigationDelegate:delegate.get()];
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 800) configuration:webViewConfiguration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 800) configuration:webViewConfiguration.get()]);
     [webView2 setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -9732,16 +9732,16 @@ TEST(WebProcessCache, CachedProcessSuspension)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     processPoolConfiguration.get().pageCacheEnabled = NO;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 800) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 800) configuration:webViewConfiguration.get()]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -9777,19 +9777,19 @@ TEST(WebProcessCache, CachedProcessSuspension)
 
 TEST(WebProcessCache, ReusedCrashedBackForwardSuspendedWebProcess)
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().usesWebProcessCache = YES;
     processPoolConfiguration.get().processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol = YES;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto handler = adoptNS([[PSONScheme alloc] init]);
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 800) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 800) configuration:webViewConfiguration.get()]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
@@ -9833,16 +9833,16 @@ TEST(WebProcessCache, ReusedCrashedBackForwardSuspendedWebProcess)
 TEST(ProcessSwap, MouseEventDuringCrossSiteProvisionalNavigation)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [webViewConfiguration setProcessPool:processPool.get()];
 
-    auto handler = adoptNS([PSONScheme new]);
+    RetainPtr handler = adoptNS([PSONScheme new]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 800) configuration:webViewConfiguration.get()]);
-    auto navigationDelegate = adoptNS([PSONNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 800) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([PSONNavigationDelegate new]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/source.html"]]];
@@ -9871,16 +9871,16 @@ TEST(ProcessSwap, CrossSiteWindowOpenNoOpenerUsesNewProcess)
     RetainPtr configuration = server.httpsProxyConfiguration();
     configuration.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
     __block RetainPtr<WKWebView> openedWebView;
     __block RetainPtr<TestNavigationDelegate> openedNavigationDelegate;
     __block bool openedPageLoaded = false;
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:navigationDelegate.get()];
 
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().createWebViewWithConfiguration = ^WKWebView *(WKWebViewConfiguration *config, WKNavigationAction *, WKWindowFeatures *) {
         openedWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:config]);
         openedNavigationDelegate = adoptNS([TestNavigationDelegate new]);
@@ -9917,16 +9917,16 @@ TEST(ProcessSwap, CrossSiteLinkTargetBlankNoOpenerUsesNewProcess)
     RetainPtr configuration = server.httpsProxyConfiguration();
     configuration.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
     __block RetainPtr<WKWebView> openedWebView;
     __block RetainPtr<TestNavigationDelegate> openedNavigationDelegate;
     __block bool openedPageLoaded = false;
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:navigationDelegate.get()];
 
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().createWebViewWithConfiguration = ^WKWebView *(WKWebViewConfiguration *config, WKNavigationAction *, WKWindowFeatures *) {
         openedWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:config]);
         openedNavigationDelegate = adoptNS([TestNavigationDelegate new]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProvisionalURLNotChange.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProvisionalURLNotChange.mm
@@ -34,9 +34,9 @@
 
 TEST(WKWebView, ProvisionalURLNotChange)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
         isDone = true;
     }];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Proxy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Proxy.mm
@@ -79,13 +79,13 @@ TEST(WebKit, HTTPSProxy)
 {
     HTTPServer server(HTTPServer::respondWithOK, HTTPServer::Protocol::HttpsProxy);
 
-    auto storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
     [storeConfiguration setAllowsServerPreconnect:NO];
-    auto viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [viewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:viewConfiguration.get()]);
-    auto delegate = adoptNS([ProxyDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:viewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([ProxyDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
 
@@ -144,15 +144,15 @@ TEST(WebKit, SOCKS5)
         });
     });
 
-    auto storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     [storeConfiguration setProxyConfiguration:@{
         @"SOCKSProxy": @"127.0.0.1",
         @"SOCKSPort": @(server.port())
     }];
     [storeConfiguration setAllowsServerPreconnect:NO];
-    auto viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [viewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:viewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:viewConfiguration.get()]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://example.com/"]]];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "success!");
 }
@@ -160,8 +160,8 @@ TEST(WebKit, SOCKS5)
 #if HAVE(NW_PROXY_CONFIG)
 TEST(WebKit, HTTPSProxyAPI)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)]);
-    auto delegate = adoptNS([ProxyDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)]);
+    RetainPtr delegate = adoptNS([ProxyDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
 
@@ -179,14 +179,14 @@ TEST(WebKit, HTTPSProxyAPI)
 
     // 127.0.0.1:1 will never be reachable and will immediately timeout, causing
     // us to fallback to 127.0.0.1:<real port>
-    auto endpoint1 = adoptNS(nw_endpoint_create_host("127.0.0.1", "1"));
-    auto proxyConfig1 = adoptNS(nw_proxy_config_create_http_connect(endpoint1.get(), nil));
+    RetainPtr endpoint1 = adoptNS(nw_endpoint_create_host("127.0.0.1", "1"));
+    RetainPtr proxyConfig1 = adoptNS(nw_proxy_config_create_http_connect(endpoint1.get(), nil));
 
-    auto endpoint2 = adoptNS(nw_endpoint_create_host("127.0.0.1", std::to_string(proxyServer1.port()).c_str()));
-    auto proxyConfig2 = adoptNS(nw_proxy_config_create_http_connect(endpoint2.get(), nil));
+    RetainPtr endpoint2 = adoptNS(nw_endpoint_create_host("127.0.0.1", std::to_string(proxyServer1.port()).c_str()));
+    RetainPtr proxyConfig2 = adoptNS(nw_proxy_config_create_http_connect(endpoint2.get(), nil));
 
-    auto endpoint3 = adoptNS(nw_endpoint_create_host("127.0.0.1", std::to_string(proxyServer2.port()).c_str()));
-    auto proxyConfig3 = adoptNS(nw_proxy_config_create_http_connect(endpoint3.get(), nil));
+    RetainPtr endpoint3 = adoptNS(nw_endpoint_create_host("127.0.0.1", std::to_string(proxyServer2.port()).c_str()));
+    RetainPtr proxyConfig3 = adoptNS(nw_proxy_config_create_http_connect(endpoint3.get(), nil));
 
     // Proxy 1 should be ignored as it is unreachable.
     // Proxy 2 should be used.
@@ -221,16 +221,16 @@ TEST(WebKit, ProxyAfterNetworkProcessCrash)
         { "/"_s, { "<script>alert('proxy success!')</script>"_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
 
-    auto endpoint = adoptNS(nw_endpoint_create_host("127.0.0.1", std::to_string(proxyServer1.port()).c_str()));
-    auto proxyConfig = adoptNS(nw_proxy_config_create_http_connect(endpoint.get(), nil));
+    RetainPtr endpoint = adoptNS(nw_endpoint_create_host("127.0.0.1", std::to_string(proxyServer1.port()).c_str()));
+    RetainPtr proxyConfig = adoptNS(nw_proxy_config_create_http_connect(endpoint.get(), nil));
 
     auto dataStore = WKWebsiteDataStore.nonPersistentDataStore;
     dataStore.proxyConfigurations = @[ proxyConfig.get() ];
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
-    auto delegate = adoptNS([ProxyDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([ProxyDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
 
@@ -299,10 +299,10 @@ TEST(WebKit, SOCKS5API)
         });
     });
 
-    auto endpoint = adoptNS(nw_endpoint_create_host("127.0.0.1", std::to_string(server.port()).c_str()));
-    auto proxyConfig = adoptNS(nw_proxy_config_create_socksv5(endpoint.get()));
+    RetainPtr endpoint = adoptNS(nw_endpoint_create_host("127.0.0.1", std::to_string(server.port()).c_str()));
+    RetainPtr proxyConfig = adoptNS(nw_proxy_config_create_socksv5(endpoint.get()));
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)]);
     webView.get().configuration.websiteDataStore.proxyConfigurations = @[ proxyConfig.get() ];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://example.com/"]]];
@@ -317,7 +317,7 @@ static HTTPServer proxyAuthenticationServer()
 
 static std::pair<RetainPtr<WKWebView>, RetainPtr<ProxyDelegate>> webViewAndDelegate(const HTTPServer& server)
 {
-    auto storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(server.port())
@@ -325,10 +325,10 @@ static std::pair<RetainPtr<WKWebView>, RetainPtr<ProxyDelegate>> webViewAndDeleg
     [storeConfiguration setAllowsServerPreconnect:NO];
     [storeConfiguration setPreventsSystemHTTPProxyAuthentication:YES];
 
-    auto viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [viewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:viewConfiguration.get()]);
-    auto delegate = adoptNS([ProxyDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:viewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([ProxyDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
     return { webView, delegate };
@@ -352,13 +352,13 @@ TEST(WebKit, DISABLED_ProxyConfigurationAuthentication)
 #endif
 {
     auto server = proxyAuthenticationServer();
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
 
-    auto endpoint = adoptNS(nw_endpoint_create_host("127.0.0.1", std::to_string(server.port()).c_str()));
-    auto proxyConfiguration = adoptNS(nw_proxy_config_create_http_connect(endpoint.get(), nil));
+    RetainPtr endpoint = adoptNS(nw_endpoint_create_host("127.0.0.1", std::to_string(server.port()).c_str()));
+    RetainPtr proxyConfiguration = adoptNS(nw_proxy_config_create_http_connect(endpoint.get(), nil));
     webView.get().configuration.websiteDataStore.proxyConfigurations = @[ proxyConfiguration.get() ];
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     __block bool challenged { false };
     delegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust])
@@ -409,7 +409,7 @@ TEST(WebKit, SecureProxyConnection)
         });
     });
     
-    auto storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(server.port())
@@ -417,9 +417,9 @@ TEST(WebKit, SecureProxyConnection)
     [storeConfiguration setAllowsServerPreconnect:NO];
     [storeConfiguration setRequiresSecureHTTPSProxyConnection:YES];
 
-    auto viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [viewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:viewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:viewConfiguration.get()]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/"]]];
     TestWebKitAPI::Util::run(&receivedValidClientHello);
 }
@@ -497,18 +497,18 @@ TEST(WebKit, RelaxThirdPartyCookieBlocking)
             });
         });
 
-        auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+        RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
         [storeConfiguration setProxyConfiguration:@{
             (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
             (NSString *)kCFStreamPropertyHTTPProxyPort: @(server.port())
         }];
         [storeConfiguration setAllowsServerPreconnect:NO];
-        auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+        RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
         [dataStore _setResourceLoadStatisticsEnabled:YES];
-        auto viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+        RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
         [viewConfiguration _setShouldRelaxThirdPartyCookieBlocking:shouldRelaxThirdPartyCookieBlocking];
         [viewConfiguration setWebsiteDataStore:dataStore.get()];
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:viewConfiguration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:viewConfiguration.get()]);
 
         [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.webkit.org/path1"]]];
         EXPECT_WK_STREQ([webView _test_waitForAlert], "fetched");

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PushAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PushAPI.mm
@@ -142,7 +142,7 @@ static bool waitUntilEvaluatesToTrue(const Function<bool()>& f)
 
 static RetainPtr<WKWebViewConfiguration> createConfigurationWithNotificationsEnabled()
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration preferences] _setNotificationsEnabled:YES];
     [[configuration preferences] _setNotificationEventEnabled:YES];
     return configuration;
@@ -162,13 +162,13 @@ TEST(PushAPI, firePushEvent)
     auto provider = TestWebKitAPI::TestNotificationProvider({ [[configuration processPool] _notificationManagerForTesting], WKNotificationManagerGetSharedServiceWorkerNotificationManager() });
     provider.setPermission(server.origin(), true);
 
-    auto messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     clearWebsiteDataStore([configuration websiteDataStore]);
 
     expectedMessage = "Ready"_s;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:server.request()];
 
     TestWebKitAPI::Util::run(&done);
@@ -256,7 +256,7 @@ TEST(PushAPI, notificationPermissionsDelegateInvalidResponse)
         @":" : @YES
     };
     [configuration websiteDataStore]._delegate = delegate.get();
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:NO]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:NO]);
 
     // If the WebView completes the page load successfully, the test passes.
     [webView synchronouslyLoadHTMLString:@"Hello"];
@@ -271,7 +271,7 @@ TEST(PushAPI, firePushEventDataStoreDelegate)
 
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
-    auto messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
     auto configuration = createConfigurationWithNotificationsEnabled();
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
@@ -284,7 +284,7 @@ TEST(PushAPI, firePushEventDataStoreDelegate)
     [configuration websiteDataStore]._delegate = delegate.get();
 
     expectedMessage = "Ready"_s;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:server.request()];
 
     TestWebKitAPI::Util::run(&done);
@@ -379,7 +379,7 @@ TEST(PushAPI, testSilentFlag)
 
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
-    auto messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
     auto configuration = createConfigurationWithNotificationsEnabled();
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
@@ -392,7 +392,7 @@ TEST(PushAPI, testSilentFlag)
     [configuration websiteDataStore]._delegate = delegate.get();
 
     expectedMessage = "Ready"_s;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:server.request()];
 
     TestWebKitAPI::Util::run(&done);
@@ -543,11 +543,11 @@ TEST(PushAPI, firePushEventWithNoPagesSuccessful)
     auto provider = TestWebKitAPI::TestNotificationProvider({ [[configuration processPool] _notificationManagerForTesting], WKNotificationManagerGetSharedServiceWorkerNotificationManager() });
     provider.setPermission(server.origin(), true);
 
-    auto messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     expectedMessage = "Ready"_s;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:server.request()];
 
     TestWebKitAPI::Util::run(&done);
@@ -591,11 +591,11 @@ TEST(PushAPI, firePushEventWithNoPagesFail)
     auto provider = TestWebKitAPI::TestNotificationProvider({ [[configuration processPool] _notificationManagerForTesting], WKNotificationManagerGetSharedServiceWorkerNotificationManager() });
     provider.setPermission(server.origin(), true);
 
-    auto messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     expectedMessage = "Ready"_s;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:server.request()];
 
     TestWebKitAPI::Util::run(&done);
@@ -633,9 +633,9 @@ TEST(PushAPI, firePushEventWithNoPagesTimeout)
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
     // Disable service worker delay for the purpose of testing, push event should timeout after 1 second.
-    auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [dataStoreConfiguration setServiceWorkerProcessTerminationDelayEnabled:NO];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
 
     auto configuration = createConfigurationWithNotificationsEnabled();
     configuration.get().websiteDataStore = dataStore.get();
@@ -644,14 +644,14 @@ TEST(PushAPI, firePushEventWithNoPagesTimeout)
     auto provider = TestWebKitAPI::TestNotificationProvider({ [[configuration processPool] _notificationManagerForTesting], WKNotificationManagerGetSharedServiceWorkerNotificationManager() });
     provider.setPermission(server.origin(), true);
 
-    auto messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     expectedMessage = "Ready"_s;
 
     fprintf(stderr, "totot1\n");
     @autoreleasepool {
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         [webView loadRequest:server.request()];
         TestWebKitAPI::Util::run(&done);
     }
@@ -734,11 +734,11 @@ TEST(PushAPI, pushEventsAndInspectedServiceWorker)
     auto provider = TestWebKitAPI::TestNotificationProvider({ [[configuration processPool] _notificationManagerForTesting], WKNotificationManagerGetSharedServiceWorkerNotificationManager() });
     provider.setPermission(server.origin(), true);
 
-    auto messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     expectedMessage = "Ready"_s;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:server.request()];
 
     TestWebKitAPI::Util::run(&done);
@@ -840,9 +840,9 @@ static void testInspectedServiceWorkerWithoutPage(bool enableServiceWorkerInspec
 
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
-    auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [dataStoreConfiguration setServiceWorkerProcessTerminationDelayEnabled:NO];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
 
     auto configuration = createConfigurationWithNotificationsEnabled();
     configuration.get().websiteDataStore = dataStore.get();
@@ -854,11 +854,11 @@ static void testInspectedServiceWorkerWithoutPage(bool enableServiceWorkerInspec
     auto provider = TestWebKitAPI::TestNotificationProvider({ [[configuration processPool] _notificationManagerForTesting], WKNotificationManagerGetSharedServiceWorkerNotificationManager() });
     provider.setPermission(server.origin(), true);
 
-    auto messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     expectedMessage = "Ready"_s;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:server.request()];
 
     TestWebKitAPI::Util::run(&done);
@@ -997,13 +997,13 @@ TEST(PushAPI, fireNotificationClickEvent)
     auto provider = TestWebKitAPI::TestNotificationProvider({ [[configuration processPool] _notificationManagerForTesting], WKNotificationManagerGetSharedServiceWorkerNotificationManager() });
     provider.setPermission(server.origin(), true);
 
-    auto messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     clearWebsiteDataStore([configuration websiteDataStore]);
 
     expectedMessage = "Ready"_s;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:server.request()];
 
     TestWebKitAPI::Util::run(&done);
@@ -1052,13 +1052,13 @@ TEST(PushAPI, fireNotificationCloseEvent)
     auto provider = TestWebKitAPI::TestNotificationProvider({ [[configuration processPool] _notificationManagerForTesting], WKNotificationManagerGetSharedServiceWorkerNotificationManager() });
     provider.setPermission(server.origin(), true);
 
-    auto messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     clearWebsiteDataStore([configuration websiteDataStore]);
 
     expectedMessage = "Ready"_s;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:server.request()];
 
     TestWebKitAPI::Util::run(&done);
@@ -1167,13 +1167,13 @@ TEST(PushAPI, callNotificationClose)
     auto provider = TestWebKitAPI::TestNotificationProvider({ [[configuration processPool] _notificationManagerForTesting], WKNotificationManagerGetSharedServiceWorkerNotificationManager() });
     provider.setPermission(server.origin(), true);
 
-    auto messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     clearWebsiteDataStore([configuration websiteDataStore]);
 
     expectedMessage = "Ready"_s;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:server.request()];
 
     TestWebKitAPI::Util::run(&done);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/QuickLook.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/QuickLook.mm
@@ -293,7 +293,7 @@ static RetainPtr<WKWebView> runTestDecideAfterLoading(QuickLookDelegate *delegat
 
 TEST(QuickLook, AllowResponseBeforeLoadingPreview)
 {
-    auto delegate = adoptNS([[QuickLookDelegate alloc] initWithExpectedFileURL:pagesDocumentURL().get() responsePolicy:WKNavigationResponsePolicyAllow]);
+    RetainPtr delegate = adoptNS([[QuickLookDelegate alloc] initWithExpectedFileURL:pagesDocumentURL().get() responsePolicy:WKNavigationResponsePolicyAllow]);
     runTestDecideBeforeLoading(delegate.get(), [NSURLRequest requestWithURL:pagesDocumentURL().get()]);
     EXPECT_FALSE([delegate didFailNavigation]);
     EXPECT_TRUE([delegate didFinishNavigation]);
@@ -332,7 +332,7 @@ TEST(QuickLook, AllowResponseAfterLoadingPreview)
 #if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(QuickLook, AsyncAllowResponseBeforeLoadingPreview)
 {
-    auto delegate = adoptNS([[QuickLookAsyncDelegate alloc] initWithExpectedFileURL:pagesDocumentURL().get() responsePolicy:WKNavigationResponsePolicyAllow]);
+    RetainPtr delegate = adoptNS([[QuickLookAsyncDelegate alloc] initWithExpectedFileURL:pagesDocumentURL().get() responsePolicy:WKNavigationResponsePolicyAllow]);
     runTestDecideBeforeLoading(delegate.get(), [NSURLRequest requestWithURL:pagesDocumentURL().get()]);
     EXPECT_FALSE([delegate didFailNavigation]);
     EXPECT_TRUE([delegate didFinishNavigation]);
@@ -342,7 +342,7 @@ TEST(QuickLook, AsyncAllowResponseBeforeLoadingPreview)
 
 TEST(QuickLook, AsyncAllowResponseAfterLoadingPreview)
 {
-    auto delegate = adoptNS([[QuickLookAsyncDelegate alloc] initWithExpectedFileURL:pagesDocumentURL().get() previewMIMEType:pagesDocumentPreviewMIMEType responsePolicy:WKNavigationResponsePolicyAllow]);
+    RetainPtr delegate = adoptNS([[QuickLookAsyncDelegate alloc] initWithExpectedFileURL:pagesDocumentURL().get() previewMIMEType:pagesDocumentPreviewMIMEType responsePolicy:WKNavigationResponsePolicyAllow]);
     runTestDecideAfterLoading(delegate.get(), [NSURLRequest requestWithURL:pagesDocumentURL().get()]);
     EXPECT_FALSE([delegate didFailNavigation]);
     EXPECT_TRUE([delegate didFinishNavigation]);
@@ -353,7 +353,7 @@ TEST(QuickLook, AsyncAllowResponseAfterLoadingPreview)
 
 TEST(QuickLook, CancelResponseBeforeLoadingPreview)
 {
-    auto delegate = adoptNS([[QuickLookDelegate alloc] initWithExpectedFileURL:pagesDocumentURL().get() responsePolicy:WKNavigationResponsePolicyCancel]);
+    RetainPtr delegate = adoptNS([[QuickLookDelegate alloc] initWithExpectedFileURL:pagesDocumentURL().get() responsePolicy:WKNavigationResponsePolicyCancel]);
     runTestDecideBeforeLoading(delegate.get(), [NSURLRequest requestWithURL:pagesDocumentURL().get()]);
     EXPECT_EQ(WebKitErrorFrameLoadInterruptedByPolicyChange, [delegate navigationError].code);
     EXPECT_FALSE([delegate didFinishNavigation]);
@@ -377,7 +377,7 @@ TEST(QuickLook, CancelResponseAfterLoadingPreview)
 
 TEST(QuickLook, DownloadResponseBeforeLoadingPreview)
 {
-    auto delegate = adoptNS([[QuickLookDelegate alloc] initWithExpectedFileURL:pagesDocumentURL().get() responsePolicy:WKNavigationResponsePolicyDownload]);
+    RetainPtr delegate = adoptNS([[QuickLookDelegate alloc] initWithExpectedFileURL:pagesDocumentURL().get() responsePolicy:WKNavigationResponsePolicyDownload]);
     runTestDecideBeforeLoading(delegate.get(), [NSURLRequest requestWithURL:pagesDocumentURL().get()]);
     EXPECT_EQ(WebKitErrorFrameLoadInterruptedByPolicyChange, [delegate navigationError].code);
     EXPECT_FALSE([delegate didFinishNavigation]);
@@ -420,7 +420,7 @@ TEST(QuickLook, DownloadResponseAfterLoadingPreview)
 TEST(QuickLook, RequestPasswordBeforeLoadingPreview)
 {
     NSURL *passwordProtectedDocumentURL = [NSBundle.test_resourcesBundle URLForResource:@"password-protected" withExtension:@"pages"];
-    auto delegate = adoptNS([[QuickLookPasswordDelegate alloc] initWithExpectedFileURL:passwordProtectedDocumentURL responsePolicy:WKNavigationResponsePolicyAllow]);
+    RetainPtr delegate = adoptNS([[QuickLookPasswordDelegate alloc] initWithExpectedFileURL:passwordProtectedDocumentURL responsePolicy:WKNavigationResponsePolicyAllow]);
     runTestDecideBeforeLoading(delegate.get(), [NSURLRequest requestWithURL:passwordProtectedDocumentURL]);
     EXPECT_FALSE([delegate didFailNavigation]);
     EXPECT_FALSE([delegate didFinishNavigation]);
@@ -432,7 +432,7 @@ TEST(QuickLook, RequestPasswordBeforeLoadingPreview)
 TEST(QuickLook, RequestPasswordAfterLoadingPreview)
 {
     NSURL *passwordProtectedDocumentURL = [NSBundle.test_resourcesBundle URLForResource:@"password-protected" withExtension:@"pages"];
-    auto delegate = adoptNS([[QuickLookPasswordDelegate alloc] initWithExpectedFileURL:passwordProtectedDocumentURL previewMIMEType:pagesDocumentPreviewMIMEType responsePolicy:WKNavigationResponsePolicyAllow]);
+    RetainPtr delegate = adoptNS([[QuickLookPasswordDelegate alloc] initWithExpectedFileURL:passwordProtectedDocumentURL previewMIMEType:pagesDocumentPreviewMIMEType responsePolicy:WKNavigationResponsePolicyAllow]);
     runTestDecideAfterLoading(delegate.get(), [NSURLRequest requestWithURL:passwordProtectedDocumentURL]);
     EXPECT_FALSE([delegate didFailNavigation]);
     EXPECT_FALSE([delegate didFinishNavigation]);
@@ -443,7 +443,7 @@ TEST(QuickLook, RequestPasswordAfterLoadingPreview)
 
 TEST(QuickLook, ReloadAndSameDocumentNavigation)
 {
-    auto delegate = adoptNS([[QuickLookDelegate alloc] initWithExpectedFileURL:pagesDocumentURL().get() responsePolicy:WKNavigationResponsePolicyAllow]);
+    RetainPtr delegate = adoptNS([[QuickLookDelegate alloc] initWithExpectedFileURL:pagesDocumentURL().get() responsePolicy:WKNavigationResponsePolicyAllow]);
     auto webView = runTestDecideBeforeLoading(delegate.get(), [NSURLRequest requestWithURL:pagesDocumentURL().get()]);
     EXPECT_FALSE([delegate didFailNavigation]);
     EXPECT_TRUE([delegate didFinishNavigation]);
@@ -492,13 +492,13 @@ TEST(QuickLook, LegacyQuickLookContent)
     WebKitInitialize();
     WebThreadLock();
 
-    auto webView = adoptNS([[WebView alloc] init]);
+    RetainPtr webView = adoptNS([[WebView alloc] init]);
 
-    auto delegate = adoptNS([[QuickLookLegacyDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[QuickLookLegacyDelegate alloc] init]);
     [webView setFrameLoadDelegate:delegate.get()];
     [webView setPolicyDelegate:delegate.get()];
 
-    auto webPreferences = adoptNS([[WebPreferences alloc] initWithIdentifier:@"LegacyQuickLookContent"]);
+    RetainPtr webPreferences = adoptNS([[WebPreferences alloc] initWithIdentifier:@"LegacyQuickLookContent"]);
     [webPreferences setQuickLookDocumentSavingEnabled:YES];
     [webView setPreferences:webPreferences.get()];
 
@@ -539,7 +539,7 @@ TEST(QuickLook, LoadFromMemoryCache)
     [TestProtocol registerWithScheme:@"http"];
     TestProtocol.additionalResponseHeaders = @{ @"Cache-Control" : @"max-age=3600" };
 
-    auto webView = adoptNS([[TestWKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] init]);
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://bundle-file/simple.html"]]];
 
     NSString * const contentTypeJavaScript = @"document.contentType";

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ReloadWithDifferingInitialScale.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ReloadWithDifferingInitialScale.mm
@@ -40,9 +40,9 @@ namespace TestWebKitAPI {
 
 TEST(WebKit, ReloadWithDifferingInitialScale)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 375, 375) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 375, 375) configuration:configuration.get()]);
 
     // It is important that we load from a file, not a HTML string, otherwise we don't
     // get a back-forward list item, and thus don't try to restore state.
@@ -64,7 +64,7 @@ TEST(WebKit, ReloadWithDifferingInitialScale)
 
     // Install the user script, so that the next time we load the page,
     // the document lays out very wide, causing the initial scale to be small.
-    auto userScript = adoptNS([[WKUserScript alloc] initWithSource:@"document.body.style.width = '1500px'; setTimeout(function () { window.webkit.messageHandlers.testHandler.postMessage('ranUserScript'); }, 0)" injectionTime:WKUserScriptInjectionTimeAtDocumentEnd forMainFrameOnly:YES]);
+    RetainPtr userScript = adoptNS([[WKUserScript alloc] initWithSource:@"document.body.style.width = '1500px'; setTimeout(function () { window.webkit.messageHandlers.testHandler.postMessage('ranUserScript'); }, 0)" injectionTime:WKUserScriptInjectionTimeAtDocumentEnd forMainFrameOnly:YES]);
     [[webView configuration].userContentController addUserScript:userScript.get()];
 
     // Reload, causing both the user script and the page state restoration code to run.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RemoteObjectRegistry.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RemoteObjectRegistry.mm
@@ -53,7 +53,7 @@ TEST(RemoteObjectRegistry, Basic)
         NSString * const testPlugInClassName = @"RemoteObjectRegistryPlugIn";
         auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:testPlugInClassName]);
         configuration.get()._groupIdentifier = @"testGroupIdentifier";
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
         isDone = false;
 
@@ -93,7 +93,7 @@ TEST(RemoteObjectRegistry, Basic)
         TestWebKitAPI::Util::run(&isDone);
 
         isDone = false;
-        auto initialAwakener = adoptNS([[TestAwakener alloc] initWithValue:42]);
+        RetainPtr initialAwakener = adoptNS([[TestAwakener alloc] initWithValue:42]);
         [object sendAwakener:initialAwakener.get() completionHandler:^(TestAwakener *awakener) {
             EXPECT_EQ(awakener.value, 42);
             isDone = true;
@@ -143,12 +143,12 @@ TEST(RemoteObjectRegistry, Basic)
         isDone = false;
 
         NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org/"]];
-        auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://webkit.org/"] statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"testFieldName" : @"testFieldValue" }]);
+        RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://webkit.org/"] statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"testFieldName" : @"testFieldValue" }]);
         NSError *error = [NSError errorWithDomain:@"testDomain" code:123 userInfo:@{@"a":@"b"}];
-        auto protectionSpace = adoptNS([[NSURLProtectionSpace alloc] initWithHost:@"testHost" port:80 protocol:@"testProtocol" realm:@"testRealm" authenticationMethod:NSURLAuthenticationMethodHTTPDigest]);
+        RetainPtr protectionSpace = adoptNS([[NSURLProtectionSpace alloc] initWithHost:@"testHost" port:80 protocol:@"testProtocol" realm:@"testRealm" authenticationMethod:NSURLAuthenticationMethodHTTPDigest]);
         NSURLCredential *credential = [NSURLCredential credentialWithUser:@"testUser" password:@"testPassword" persistence:NSURLCredentialPersistenceForSession];
         id<NSURLAuthenticationChallengeSender> sender = nil;
-        auto challenge = adoptNS([[NSURLAuthenticationChallenge alloc] initWithProtectionSpace:protectionSpace.get() proposedCredential:credential previousFailureCount:42 failureResponse:response.get() error:error sender:sender]);
+        RetainPtr challenge = adoptNS([[NSURLAuthenticationChallenge alloc] initWithProtectionSpace:protectionSpace.get() proposedCredential:credential previousFailureCount:42 failureResponse:response.get() error:error sender:sender]);
         NSUUID *uuid = [NSUUID UUID];
         [object sendRequest:request response:response.get() challenge:challenge.get() error:error nsNull:[NSNull null] uuid:uuid completionHandler:^(NSURLRequest *deserializedRequest, NSURLResponse *deserializedResponse, NSURLAuthenticationChallenge *deserializedChallenge, NSError *deserializedError, id nsNull, id deserializedUUID) {
             EXPECT_WK_STREQ(deserializedRequest.URL.absoluteString, "https://webkit.org/");
@@ -225,13 +225,13 @@ TEST(RemoteObjectRegistry, Basic)
 
 TEST(RemoteObjectRegistry, CallReplyBlockAfterOriginatingWebViewDeallocates)
 {
-    auto localObject = adoptNS([[LocalObject alloc] init]);
+    RetainPtr localObject = adoptNS([[LocalObject alloc] init]);
     WeakObjCPtr<WKWebView> weakWebViewPtr;
 
     @autoreleasepool {
         NSString * const testPlugInClassName = @"RemoteObjectRegistryPlugIn";
         auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:testPlugInClassName]);
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
         weakWebViewPtr = webView.get();
 
         RetainPtr interface = remoteObjectInterface();
@@ -278,10 +278,10 @@ TEST(RemoteObjectRegistry, CallReplyBlockAfterOriginatingWebViewDeallocates)
 
 TEST(RemoteObjectRegistry, CallReplyBlockWithInvalidTypeSignature)
 {
-    auto completedReplyObject = adoptNS([[LocalObject alloc] init]);
-    auto stringReplyObject = adoptNS([[StringReplyObject alloc] init]);
+    RetainPtr completedReplyObject = adoptNS([[LocalObject alloc] init]);
+    RetainPtr stringReplyObject = adoptNS([[StringReplyObject alloc] init]);
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:[WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"RemoteObjectRegistryPlugIn"]]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:[WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"RemoteObjectRegistryPlugIn"]]);
 
     [[webView _remoteObjectRegistry] registerExportedObject:completedReplyObject.get() interface:localObjectInterface()];
     [[webView _remoteObjectRegistry] registerExportedObject:stringReplyObject.get() interface:stringReplyObjectInterface()];
@@ -300,8 +300,8 @@ TEST(RemoteObjectRegistry, CallReplyBlockWithInvalidTypeSignature)
 TEST(RemoteObjectRegistry, SerializeErrorWithCertificates)
 {
     TestWebKitAPI::HTTPServer server({ }, TestWebKitAPI::HTTPServer::Protocol::Https);
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:[WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"RemoteObjectRegistryPlugIn"]]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:[WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"RemoteObjectRegistryPlugIn"]]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     webView.get().navigationDelegate = delegate.get();
     [webView loadRequest:server.request()];
     NSError *error = [delegate waitForDidFailProvisionalNavigation];
@@ -336,7 +336,7 @@ TEST(RemoteObjectRegistry, CallReplyBlockWithBadInvocation)
         }
     }
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration: configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration: configuration.get()]);
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"RemoteObjectRegistry-BadReplyBlock" withExtension:@"html"]]];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ReparentWebViewTimeout.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ReparentWebViewTimeout.mm
@@ -35,7 +35,7 @@
 
 TEST(WebKit, ReparentWebViewTimeout)
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     [processPoolConfiguration setIgnoreSynchronousMessagingTimeoutsForTesting:YES];
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RequestTextInputContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RequestTextInputContext.mm
@@ -198,8 +198,8 @@ static void webViewLoadHTMLStringAndWaitForAllFramesToPaint(TestWKWebView *webVi
 
 TEST(RequestTextInputContext, Iframe)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     NSArray<_WKTextInputContext *> *contexts;
 
@@ -221,8 +221,8 @@ TEST(RequestTextInputContext, Iframe)
 
 TEST(RequestTextInputContext, ViewIsEditable)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:applyStyle(@"<body></body>")];
     [webView _setEditable:YES];
     EXPECT_GE([webView synchronouslyRequestTextInputContextsInRect:[webView bounds]].count, 1UL);
@@ -275,7 +275,7 @@ TEST(RequestTextInputContext, CompositedOverlap)
 
 TEST(RequestTextInputContext, RectContainsEditableNonRootChild)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:applyStyle(@"<body contenteditable='true' style='width: 500px; height: 500px'><div style='width: 200px; height: 200px; background-color: blue'>Hello World</div></body>")];
     NSArray<_WKTextInputContext *> *contexts = [webView synchronouslyRequestTextInputContextsInRect:CGRectMake(10, 10, 20, 20)];
     EXPECT_EQ(1UL, contexts.count);
@@ -284,7 +284,7 @@ TEST(RequestTextInputContext, RectContainsEditableNonRootChild)
 
 TEST(RequestTextInputContext, RectContainsNestedEditableNonRootChild)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:applyStyle(@"<body contenteditable='true' style='width: 500px; height: 500px'><div style='width: 200px; height: 200px; background-color: blue'><div style='width: 100px; height: 100px; background-color: yellow' contenteditable='true'>Hello World</div></div></body>")];
     NSArray<_WKTextInputContext *> *contexts = [webView synchronouslyRequestTextInputContextsInRect:CGRectMake(10, 10, 20, 20)];
     EXPECT_EQ(1UL, contexts.count);
@@ -293,7 +293,7 @@ TEST(RequestTextInputContext, RectContainsNestedEditableNonRootChild)
 
 TEST(RequestTextInputContext, RectContainsInnerEditableNonRootChild)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:applyStyle(@"<body contenteditable='true' style='width: 500px; height: 500px'><div style='width: 200px; height: 200px; background-color: blue' contenteditable='false'><div style='width: 100px; height: 100px; background-color: yellow' contenteditable='true'>Hello World</div></div><p>Body</p></body>")];
     NSArray<_WKTextInputContext *> *contexts = [webView synchronouslyRequestTextInputContextsInRect:CGRectMake(10, 10, 20, 20)];
     EXPECT_EQ(1UL, contexts.count);
@@ -302,8 +302,8 @@ TEST(RequestTextInputContext, RectContainsInnerEditableNonRootChild)
 
 TEST(RequestTextInputContext, ReadOnlyField)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView synchronouslyLoadHTMLString:applyStyle(@"<input type='text' value='hello world' style='width: 100px; height: 50px;' readonly>")];
     EXPECT_EQ(0UL, [webView synchronouslyRequestTextInputContextsInRect:[webView bounds]].count);
@@ -311,8 +311,8 @@ TEST(RequestTextInputContext, ReadOnlyField)
 
 TEST(RequestTextInputContext, DisabledField)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView synchronouslyLoadHTMLString:applyStyle(@"<input type='text' value='hello world' style='width: 100px; height: 50px;' disabled>")];
     EXPECT_EQ(0UL, [webView synchronouslyRequestTextInputContextsInRect:[webView bounds]].count);
@@ -322,7 +322,7 @@ TEST(RequestTextInputContext, FocusedEditableEmptyLine)
 {
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
@@ -339,7 +339,7 @@ TEST(RequestTextInputContext, FocusedEditableLineWithOnlyLineBreak)
 {
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
@@ -354,8 +354,8 @@ TEST(RequestTextInputContext, FocusedEditableLineWithOnlyLineBreak)
 
 TEST(RequestTextInputContext, FocusAfterNavigation)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     // 1. Load initial page and save off the text input context for the input element on it.
     [webView synchronouslyLoadHTMLString:applyStyle(@"<input type='text' value='hello world' style='width: 100px; height: 50px;'>")];
@@ -372,8 +372,8 @@ TEST(RequestTextInputContext, FocusAfterNavigation)
 
 TEST(RequestTextInputContext, CaretShouldNotMoveInAlreadyFocusedField)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     constexpr char exampleText[] = "hello world";
     constexpr size_t exampleTextLength = sizeof(exampleText) - 1;
@@ -401,9 +401,9 @@ TEST(RequestTextInputContext, CaretShouldNotMoveInAlreadyFocusedField)
 
 TEST(RequestTextInputContext, CaretShouldNotMoveInAlreadyFocusedField2)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
@@ -428,9 +428,9 @@ TEST(RequestTextInputContext, CaretShouldNotMoveInAlreadyFocusedField2)
 
 TEST(RequestTextInputContext, PlaceCaretInNonAssistedFocusedField)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [webView _setInputDelegate:inputDelegate.get()];
 
     [webView synchronouslyLoadHTMLString:applyStyle(@"<input type='text' id='input' value='hello world' style='width: 100px; height: 50px;'>")];
@@ -456,8 +456,8 @@ TEST(RequestTextInputContext, PlaceCaretInNonAssistedFocusedField)
 
 TEST(RequestTextInputContext, FocusTextFieldThenProgrammaticallyReplaceWithTextAreaAndFocusTextArea)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView synchronouslyLoadHTMLString:applyStyle(@"<input type='text' style='width: 50px; height: 50px;'>")];
     NSArray<_WKTextInputContext *> *contexts = [webView synchronouslyRequestTextInputContextsInRect:[webView bounds]];
@@ -479,8 +479,8 @@ TEST(RequestTextInputContext, FocusTextFieldThenProgrammaticallyReplaceWithTextA
 
 TEST(RequestTextInputContext, FocusFieldAndPlaceCaretAtStart)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView synchronouslyLoadHTMLString:applyStyle(@"<input type='text' value='hello world' style='width: 100px; height: 50px;'>")];
     NSArray<_WKTextInputContext *> *contexts = [webView synchronouslyRequestTextInputContextsInRect:[webView bounds]];
@@ -495,8 +495,8 @@ TEST(RequestTextInputContext, FocusFieldAndPlaceCaretAtStart)
 
 TEST(RequestTextInputContext, FocusFieldAndPlaceCaretAtEnd)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     constexpr char exampleText[] = "hello world";
     constexpr size_t exampleTextLength = sizeof(exampleText) - 1;
@@ -515,8 +515,8 @@ TEST(RequestTextInputContext, FocusFieldAndPlaceCaretAtEnd)
 
 TEST(RequestTextInputContext, FocusFieldWithPaddingAndPlaceCaretAtEnd)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     constexpr char exampleText[] = "hello world";
     constexpr size_t exampleTextLength = sizeof(exampleText) - 1;
@@ -535,8 +535,8 @@ TEST(RequestTextInputContext, FocusFieldWithPaddingAndPlaceCaretAtEnd)
 
 TEST(RequestTextInputContext, FocusFieldAndPlaceCaretOutsideField)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     constexpr char exampleText[] = "hello world";
     constexpr size_t exampleTextLength = sizeof(exampleText) - 1;
@@ -567,9 +567,9 @@ TEST(RequestTextInputContext, FocusFieldAndPlaceCaretOutsideField)
 
 TEST(RequestTextInputContext, FocusFieldInFrame)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAllowUniversalAccessFromFileURLs:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     auto testPage = applyStyle([NSString stringWithFormat:@"<input type='text' value='mainFrameField' style='width: 100px; height: 50px;'>%@", applyIframe(@"<input type='text' value='iframeField' style='width: 120px; height: 70px;'>")]);
     webViewLoadHTMLStringAndWaitForAllFramesToPaint(webView.get(), testPage);
@@ -587,9 +587,9 @@ TEST(RequestTextInputContext, FocusFieldInFrame)
 
 TEST(RequestTextInputContext, SwitchFocusBetweenFrames)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAllowUniversalAccessFromFileURLs:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     auto testPage = applyStyle([NSString stringWithFormat:@"<input type='text' value='mainFrameField' style='width: 100px; height: 50px;'>%@", applyIframe(@"<input type='text' value='iframeField' style='width: 100px; height: 50px;'>")]);
     webViewLoadHTMLStringAndWaitForAllFramesToPaint(webView.get(), testPage);
@@ -614,9 +614,9 @@ TEST(RequestTextInputContext, SwitchFocusBetweenFrames)
 
 TEST(RequestTextInputContext, FocusingAssistedElementShouldNotScrollPage)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
     [webView synchronouslyLoadHTMLString:applyStyle(@"<body style='height: 4096px'><div id='editable' style='position: fixed; width: 100%; height: 50px; background-color: blue' contenteditable='true'></div></body>")];
@@ -641,8 +641,8 @@ TEST(RequestTextInputContext, TextInteraction_FocusingReadOnlyElementShouldScrol
 {
     IPhoneUserInterfaceSwizzler userInterfaceSwizzler;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:applyStyle(@"<body style='height: 4096px'><input id='input'></body>")];
 
     NSArray<_WKTextInputContext *> *contexts = [webView synchronouslyRequestTextInputContextsInRect:[webView bounds]];
@@ -653,7 +653,7 @@ TEST(RequestTextInputContext, TextInteraction_FocusingReadOnlyElementShouldScrol
     [webView stringByEvaluatingJavaScript:@"input.readOnly = true"];
 
     didScroll = false;
-    auto scrollDelegate = adoptNS([[TextInteractionScrollDelegate alloc] init]);
+    RetainPtr scrollDelegate = adoptNS([[TextInteractionScrollDelegate alloc] init]);
     [webView scrollView].delegate = scrollDelegate.get();
 
     // Focus the field using -focusTextInputContext; scroll view should scroll to reveal the focused element.
@@ -671,9 +671,9 @@ TEST(RequestTextInputContext, TextInteraction_FocusElementInDetachedDocument)
 {
     IPhoneUserInterfaceSwizzler userInterfaceSwizzler;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAllowUniversalAccessFromFileURLs:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     webViewLoadHTMLStringAndWaitForAllFramesToPaint(webView.get(), applyIframe(@"<input type='text' id='input' style='width: 100px; height: 50px;'>"));
 
     NSArray<_WKTextInputContext *> *contexts = [webView synchronouslyRequestTextInputContextsInRect:[webView bounds]];
@@ -683,7 +683,7 @@ TEST(RequestTextInputContext, TextInteraction_FocusElementInDetachedDocument)
     EXPECT_WK_STREQ("BODY", [webView stringByEvaluatingJavaScript:@"document.querySelector('iframe').contentDocument.activeElement.tagName"]);
 
     didScroll = false;
-    auto scrollDelegate = adoptNS([[TextInteractionScrollDelegate alloc] init]);
+    RetainPtr scrollDelegate = adoptNS([[TextInteractionScrollDelegate alloc] init]);
     [webView scrollView].delegate = scrollDelegate.get();
 
     // Save a reference to the framed document (to prevent its destruction when its frame is removed)
@@ -702,8 +702,8 @@ TEST(RequestTextInputContext, TextInteraction_FocusingElementShouldScrollToRevea
 {
     IPhoneUserInterfaceSwizzler userInterfaceSwizzler;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:applyStyle(@"<body style='height: 4096px'><input id='input'></body>")];
 
     NSArray<_WKTextInputContext *> *contexts = [webView synchronouslyRequestTextInputContextsInRect:[webView bounds]];
@@ -713,7 +713,7 @@ TEST(RequestTextInputContext, TextInteraction_FocusingElementShouldScrollToRevea
     EXPECT_WK_STREQ("BODY", [webView stringByEvaluatingJavaScript:@"document.activeElement.tagName"]);
 
     didScroll = false;
-    auto scrollDelegate = adoptNS([[TextInteractionScrollDelegate alloc] init]);
+    RetainPtr scrollDelegate = adoptNS([[TextInteractionScrollDelegate alloc] init]);
     [webView scrollView].delegate = scrollDelegate.get();
 
     // Scroll view should scroll to reveal the focused element.
@@ -731,8 +731,8 @@ TEST(RequestTextInputContext, TextInteraction_FocusingElementMultipleTimesShould
 {
     IPhoneUserInterfaceSwizzler userInterfaceSwizzler;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:applyStyle(@"<body style='height: 4096px'><input id='input'></body>")];
 
     NSArray<_WKTextInputContext *> *contexts = [webView synchronouslyRequestTextInputContextsInRect:[webView bounds]];
@@ -742,7 +742,7 @@ TEST(RequestTextInputContext, TextInteraction_FocusingElementMultipleTimesShould
     EXPECT_WK_STREQ("BODY", [webView stringByEvaluatingJavaScript:@"document.activeElement.tagName"]);
 
     didScroll = false;
-    auto scrollDelegate = adoptNS([[TextInteractionScrollDelegate alloc] init]);
+    RetainPtr scrollDelegate = adoptNS([[TextInteractionScrollDelegate alloc] init]);
     [webView scrollView].delegate = scrollDelegate.get();
 
     // Scroll view should scroll to reveal the focused element.
@@ -762,8 +762,8 @@ TEST(RequestTextInputContext, TextInteraction_FocusDefocusDisableFocusAgainShoul
 {
     IPhoneUserInterfaceSwizzler userInterfaceSwizzler;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:applyStyle(@"<body style='height: 4096px'><input id='input'></body>")];
 
     NSArray<_WKTextInputContext *> *contexts = [webView synchronouslyRequestTextInputContextsInRect:[webView bounds]];
@@ -773,7 +773,7 @@ TEST(RequestTextInputContext, TextInteraction_FocusDefocusDisableFocusAgainShoul
     EXPECT_WK_STREQ("BODY", [webView stringByEvaluatingJavaScript:@"document.activeElement.tagName"]);
 
     didScroll = false;
-    auto scrollDelegate = adoptNS([[TextInteractionScrollDelegate alloc] init]);
+    RetainPtr scrollDelegate = adoptNS([[TextInteractionScrollDelegate alloc] init]);
     [webView scrollView].delegate = scrollDelegate.get();
 
     {
@@ -801,8 +801,8 @@ TEST(RequestTextInputContext, TextInteraction_FocusDefocusFocusAgainShouldScroll
 {
     IPhoneUserInterfaceSwizzler userInterfaceSwizzler;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:applyStyle(@"<body style='height: 4096px'><input id='input'></body>")];
 
     NSArray<_WKTextInputContext *> *contexts = [webView synchronouslyRequestTextInputContextsInRect:[webView bounds]];
@@ -812,7 +812,7 @@ TEST(RequestTextInputContext, TextInteraction_FocusDefocusFocusAgainShouldScroll
     EXPECT_WK_STREQ("BODY", [webView stringByEvaluatingJavaScript:@"document.activeElement.tagName"]);
 
     didScroll = false;
-    auto scrollDelegate = adoptNS([[TextInteractionScrollDelegate alloc] init]);
+    RetainPtr scrollDelegate = adoptNS([[TextInteractionScrollDelegate alloc] init]);
     [webView scrollView].delegate = scrollDelegate.get();
 
     {
@@ -839,9 +839,9 @@ TEST(RequestTextInputContext, DISABLED_TextInteraction_FocusingAssistedElementSh
 {
     IPhoneUserInterfaceSwizzler userInterfaceSwizzler;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
     [webView synchronouslyLoadHTMLString:applyStyle(@"<body style='height: 4096px'><input id='input'></body>")];
@@ -854,7 +854,7 @@ TEST(RequestTextInputContext, DISABLED_TextInteraction_FocusingAssistedElementSh
     EXPECT_WK_STREQ("INPUT", [webView stringByEvaluatingJavaScript:@"document.activeElement.tagName"]);
 
     didScroll = false;
-    auto scrollDelegate = adoptNS([[TextInteractionScrollDelegate alloc] init]);
+    RetainPtr scrollDelegate = adoptNS([[TextInteractionScrollDelegate alloc] init]);
     [webView scrollView].delegate = scrollDelegate.get();
 
     // Focus the field using -focusTextInputContext; scroll view should not scroll to reveal focused element.
@@ -871,9 +871,9 @@ TEST(RequestTextInputContext, TextInteraction_FocusingNonAssistedFocusedElementS
 {
     IPhoneUserInterfaceSwizzler userInterfaceSwizzler;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [webView _setInputDelegate:inputDelegate.get()];
     [webView synchronouslyLoadHTMLString:applyStyle(@"<body style='height: 4096px'><input id='input'></body>")];
 
@@ -886,7 +886,7 @@ TEST(RequestTextInputContext, TextInteraction_FocusingNonAssistedFocusedElementS
     EXPECT_WK_STREQ("INPUT", [webView stringByEvaluatingJavaScript:@"document.activeElement.tagName"]);
 
     didScroll = false;
-    auto scrollDelegate = adoptNS([[TextInteractionScrollDelegate alloc] init]);
+    RetainPtr scrollDelegate = adoptNS([[TextInteractionScrollDelegate alloc] init]);
     [webView scrollView].delegate = scrollDelegate.get();
 
     // Focus the field using -focusTextInputContext; scroll view should scroll to reveal the focused element.
@@ -904,8 +904,8 @@ TEST(RequestTextInputContext, TextInteraction_FocusingNonAssistedFocusedElementS
 
 TEST(RequestTextInputContext, TextInteraction_HighlightSelectedText)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [webView _setInputDelegate:inputDelegate.get()];
     [webView synchronouslyLoadHTMLString:applyStyle(@"<input id='input' value='hello'>")];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ResourceLoadDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ResourceLoadDelegate.mm
@@ -40,9 +40,9 @@
 
 TEST(ResourceLoadDelegate, Basic)
 {
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     __block bool done = false;
     [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
@@ -50,7 +50,7 @@ TEST(ResourceLoadDelegate, Basic)
     }];
 
     __block RetainPtr<NSURLRequest> requestFromDelegate;
-    auto resourceLoadDelegate = adoptNS([TestResourceLoadDelegate new]);
+    RetainPtr resourceLoadDelegate = adoptNS([TestResourceLoadDelegate new]);
     [webView _setResourceLoadDelegate:resourceLoadDelegate.get()];
     [resourceLoadDelegate setDidSendRequest:^(WKWebView *, _WKResourceLoadInfo *, NSURLRequest *request) {
         requestFromDelegate = request;
@@ -71,12 +71,12 @@ TEST(ResourceLoadDelegate, BeaconAndSyncXHR)
         { "/beaconTarget"_s, { "hi"_s } },
     });
 
-    auto webView = adoptNS([TestWKWebView new]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
     [webView synchronouslyLoadRequest:server.request()];
 
     __block RetainPtr<NSURLRequest> requestFromDelegate;
     __block bool receivedCallback = false;
-    auto resourceLoadDelegate = adoptNS([TestResourceLoadDelegate new]);
+    RetainPtr resourceLoadDelegate = adoptNS([TestResourceLoadDelegate new]);
     [webView _setResourceLoadDelegate:resourceLoadDelegate.get()];
     [resourceLoadDelegate setDidSendRequest:^(WKWebView *, _WKResourceLoadInfo *info, NSURLRequest *request) {
         requestFromDelegate = request;
@@ -86,7 +86,7 @@ TEST(ResourceLoadDelegate, BeaconAndSyncXHR)
     }];
     
     __block bool receivedAlert = false;
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     [webView setUIDelegate:uiDelegate.get()];
     [uiDelegate setRunJavaScriptAlertPanelWithMessage:^(WKWebView *, NSString *, WKFrameInfo *, void (^completionHandler)(void)) {
         receivedAlert = true;
@@ -117,7 +117,7 @@ TEST(ResourceLoadDelegate, Redirect)
     });
 
     __block bool done = false;
-    auto resourceLoadDelegate = adoptNS([TestResourceLoadDelegate new]);
+    RetainPtr resourceLoadDelegate = adoptNS([TestResourceLoadDelegate new]);
     [resourceLoadDelegate setDidPerformHTTPRedirection:^(WKWebView *, _WKResourceLoadInfo *loadInfo, NSURLResponse *response, NSURLRequest *request) {
         EXPECT_WK_STREQ(response.URL.path, "/");
         EXPECT_WK_STREQ(request.URL.path, "/redirectTarget");
@@ -130,7 +130,7 @@ TEST(ResourceLoadDelegate, Redirect)
         done = true;
     }];
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView _setResourceLoadDelegate:resourceLoadDelegate.get()];
     [webView loadRequest:server.request()];
     TestWebKitAPI::Util::run(&done);
@@ -176,13 +176,13 @@ TEST(ResourceLoadDelegate, ResourceType)
     __block Vector<RetainPtr<_WKResourceLoadInfo>> loadInfos;
 
     __block size_t requestCount = 0;
-    auto delegate = adoptNS([TestResourceLoadDelegate new]);
+    RetainPtr delegate = adoptNS([TestResourceLoadDelegate new]);
     [delegate setDidSendRequest:^(WKWebView *webView, _WKResourceLoadInfo *loadInfo, NSURLRequest *request) {
         loadInfos.append(loadInfo);
         requestCount++;
     }];
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView _setResourceLoadDelegate:delegate.get()];
     [webView loadRequest:server.request()];
 
@@ -229,7 +229,7 @@ TEST(ResourceLoadDelegate, LoadInfo)
     __block Vector<RetainPtr<id>> otherParameters;
 
     __block size_t resourceCompletionCount = 0;
-    auto delegate = adoptNS([TestResourceLoadDelegate new]);
+    RetainPtr delegate = adoptNS([TestResourceLoadDelegate new]);
     [delegate setDidSendRequest:^(WKWebView *webView, _WKResourceLoadInfo *loadInfo, NSURLRequest *request) {
         callbacks.append(Callback::DidSendRequest);
         webViews.append(webView);
@@ -251,7 +251,7 @@ TEST(ResourceLoadDelegate, LoadInfo)
         resourceCompletionCount++;
     }];
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView _setResourceLoadDelegate:delegate.get()];
     [webView loadRequest:server.request()];
     while (resourceCompletionCount < 3)
@@ -354,7 +354,7 @@ TEST(ResourceLoadDelegate, Challenge)
     using namespace TestWebKitAPI;
     HTTPServer server(HTTPServer::respondWithChallengeThenOK);
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate setDidReceiveAuthenticationChallenge:^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodHTTPBasic);
         completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialWithUser:@"testuser" password:@"testpassword" persistence:NSURLCredentialPersistenceNone]);
@@ -362,7 +362,7 @@ TEST(ResourceLoadDelegate, Challenge)
 
     __block bool receivedErrorNotification = false;
     __block bool receivedChallengeNotificiation = false;
-    auto resourceLoadDelegate = adoptNS([TestResourceLoadDelegate new]);
+    RetainPtr resourceLoadDelegate = adoptNS([TestResourceLoadDelegate new]);
     [resourceLoadDelegate setDidReceiveChallenge:^(WKWebView *, _WKResourceLoadInfo *, NSURLAuthenticationChallenge *challenge) {
         EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodHTTPBasic);
         receivedChallengeNotificiation = true;
@@ -372,7 +372,7 @@ TEST(ResourceLoadDelegate, Challenge)
         receivedErrorNotification = true;
     }];
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [webView _setResourceLoadDelegate:resourceLoadDelegate.get()];
     [webView loadRequest:server.request()];
@@ -389,7 +389,7 @@ TEST(ResourceLoadDelegate, LoadTopResourceFromCache)
     __block bool loadedFromCache = false;
     __block bool done = false;
 
-    auto delegate = adoptNS([TestResourceLoadDelegate new]);
+    RetainPtr delegate = adoptNS([TestResourceLoadDelegate new]);
     [delegate setDidCompleteWithError:^(WKWebView *, _WKResourceLoadInfo *loadInfo, NSError *, NSURLResponse *) {
         EXPECT_WK_STREQ(loadInfo.originalURL.path, "/hello.html");
         EXPECT_WK_STREQ(loadInfo.originalHTTPMethod, "GET");
@@ -397,7 +397,7 @@ TEST(ResourceLoadDelegate, LoadTopResourceFromCache)
         done = true;
     }];
 
-    auto webView1 = adoptNS([WKWebView new]);
+    RetainPtr webView1 = adoptNS([WKWebView new]);
     [webView1 _setResourceLoadDelegate:delegate.get()];
     [webView1 loadRequest:server.request("/hello.html"_s)];
 
@@ -407,7 +407,7 @@ TEST(ResourceLoadDelegate, LoadTopResourceFromCache)
     loadedFromCache = false;
 
     // Second load of same resource in a separate web view should come from network cache.
-    auto webView2 = adoptNS([WKWebView new]);
+    RetainPtr webView2 = adoptNS([WKWebView new]);
     [webView2 _setResourceLoadDelegate:delegate.get()];
     [webView2 loadRequest:server.request("/hello.html"_s)];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ResourceLoadStatistics.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ResourceLoadStatistics.mm
@@ -85,7 +85,7 @@ static bool finishedNavigation = false;
 static void ensureITPFileIsCreated()
 {
     auto *dataStore = [WKWebsiteDataStore defaultDataStore];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [dataStore _setResourceLoadStatisticsEnabled:YES];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
     [dataStore _setResourceLoadStatisticsEnabled:NO];
@@ -94,9 +94,9 @@ static void ensureITPFileIsCreated()
 // FIXME when rdar://172325390 is resolved
 TEST(ResourceLoadStatistics, DISABLED_GrandfatherCallback)
 {
-    auto dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     dataStoreConfiguration.get().pcmMachServiceName = nil;
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
 
     NSURL *statisticsDirectoryURL = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/WebsiteData/ResourceLoadStatistics" stringByExpandingTildeInPath] isDirectory:YES];
     NSURL *fileURL = [statisticsDirectoryURL URLByAppendingPathComponent:@"observations.db"];
@@ -112,7 +112,7 @@ TEST(ResourceLoadStatistics, DISABLED_GrandfatherCallback)
         grandfatheredFlag = true;
     }];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [dataStore _setResourceLoadStatisticsEnabled:YES];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
 
@@ -164,7 +164,7 @@ TEST(ResourceLoadStatistics, ShouldNotGrandfatherOnStartup)
     }];
 
     // We need an active NetworkProcess to perform ResourceLoadStatistics operations.
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [dataStore _setResourceLoadStatisticsEnabled:YES];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
 
@@ -194,7 +194,7 @@ TEST(ResourceLoadStatistics, ChildProcessesNotLaunched)
     }];
 
     // We need an active NetworkProcess to perform ResourceLoadStatistics operations.
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [dataStore _setResourceLoadStatisticsEnabled:YES];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
 
@@ -211,7 +211,7 @@ TEST(ResourceLoadStatistics, IPCAfterStoreDestruction)
 {
     [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:YES];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     // Test page requires window.internals.
 #if WK_HAVE_C_SPI
@@ -219,9 +219,9 @@ TEST(ResourceLoadStatistics, IPCAfterStoreDestruction)
     configuration.get().processPool = (WKProcessPool *)context.get();
 #endif
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto navigationDelegate = adoptNS([[DisableITPDuringNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[DisableITPDuringNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"notify-resourceLoadObserver" withExtension:@"html"]]];
@@ -267,11 +267,11 @@ TEST(ResourceLoadStatistics, EnableDisableITP)
     auto *sharedProcessPool = [WKProcessPool _sharedProcessPool];
     auto *dataStore = [WKWebsiteDataStore defaultDataStore];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setProcessPool: sharedProcessPool];
     configuration.get().websiteDataStore = dataStore;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     
     [webView loadHTMLString:@"WebKit Test" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     [webView _test_waitForDidFinishNavigation];
@@ -344,11 +344,11 @@ TEST(ResourceLoadStatistics, NetworkProcessRestart)
     auto *sharedProcessPool = [WKProcessPool _sharedProcessPool];
     auto *dataStore = [WKWebsiteDataStore defaultDataStore];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setProcessPool: sharedProcessPool];
     configuration.get().websiteDataStore = dataStore;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView loadHTMLString:@"WebKit Test" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     [webView _test_waitForDidFinishNavigation];
@@ -409,7 +409,7 @@ TEST(ResourceLoadStatistics, NetworkProcessRestart)
 
     [configuration.get().websiteDataStore _terminateNetworkProcess];
 
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView2 loadHTMLString:@"WebKit Test 2" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     [webView2 _test_waitForDidFinishNavigation];
@@ -442,7 +442,7 @@ TEST(ResourceLoadStatistics, NetworkProcessRestart)
 
     [configuration.get().websiteDataStore _terminateNetworkProcess];
 
-    auto webView3 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView3 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView3 loadHTMLString:@"WebKit Test 3" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     [webView3 _test_waitForDidFinishNavigation];
@@ -523,17 +523,17 @@ TEST(ResourceLoadStatistics, DataTaskIdentifierCollision)
         });
     });
 
-    auto storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     storeConfiguration.get().httpsProxy = [NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", httpsServer.port()]];
     storeConfiguration.get().allowsServerPreconnect = NO;
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [viewConfiguration setWebsiteDataStore:dataStore.get()];
 
-    auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:viewConfiguration.get() addToWindow:NO]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:viewConfiguration.get() addToWindow:NO]);
     [webView1 synchronouslyLoadHTMLString:@"start network process and initialize data store"];
-    auto delegate = adoptNS([DataTaskIdentifierCollisionDelegate new]);
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:viewConfiguration.get() addToWindow:NO]);
+    RetainPtr delegate = adoptNS([DataTaskIdentifierCollisionDelegate new]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:viewConfiguration.get() addToWindow:NO]);
     [webView1 setUIDelegate:delegate.get()];
     [webView1 setNavigationDelegate:delegate.get()];
     [webView2 setUIDelegate:delegate.get()];
@@ -569,11 +569,11 @@ TEST(ResourceLoadStatistics, DataTaskIdentifierCollision)
 
 TEST(ResourceLoadStatistics, NoMessagesWhenNotTesting)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]).get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]).get()]);
     [configuration setWebsiteDataStore:dataStore.get()];
     [dataStore _setResourceLoadStatisticsEnabled:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
     EXPECT_FALSE([WKWebsiteDataStore _defaultDataStoreExists]);
 }
@@ -583,11 +583,11 @@ TEST(ResourceLoadStatistics, FlushObserverWhenWebPageIsClosedByJavaScript)
     auto *sharedProcessPool = [WKProcessPool _sharedProcessPool];
     auto *dataStore = [WKWebsiteDataStore defaultDataStore];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setProcessPool: sharedProcessPool];
     configuration.get().websiteDataStore = dataStore;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView loadHTMLString:@"WebKit Test" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     [webView _test_waitForDidFinishNavigation];
@@ -646,13 +646,13 @@ TEST(ResourceLoadStatistics, GetResourceLoadStatisticsDataSummary)
     auto *sharedProcessPool = [WKProcessPool _sharedProcessPool];
     auto *dataStore = [WKWebsiteDataStore defaultDataStore];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setProcessPool: sharedProcessPool];
     configuration.get().websiteDataStore = dataStore;
 
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto webView3 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView3 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView1 loadHTMLString:@"WebKit Test" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     [webView1 _test_waitForDidFinishNavigation];
@@ -907,16 +907,16 @@ TEST(ResourceLoadStatistics, MigrateDataFromIncorrectCreateTableSchema)
     [defaultFileManager copyItemAtPath:newFileURL.path toPath:fileURL.path error:nil];
     EXPECT_TRUE([defaultFileManager fileExistsAtPath:fileURL.path]);
 
-    auto dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     dataStoreConfiguration.get()._resourceLoadStatisticsDirectory = itpRootURL;
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setProcessPool: sharedProcessPool];
     configuration.get().websiteDataStore = dataStore.get();
 
     // We need an active NetworkProcess to perform ResourceLoadStatistics operations.
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [dataStore _setResourceLoadStatisticsEnabled:YES];
     [webView loadHTMLString:@"" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     [webView _test_waitForDidFinishNavigation];
@@ -1001,12 +1001,12 @@ TEST(ResourceLoadStatistics, DISABLED_MigrateDataFromMissingTopFrameUniqueRedire
     [defaultFileManager copyItemAtPath:newFileURL.path toPath:fileURL.path error:nil];
     EXPECT_TRUE([defaultFileManager fileExistsAtPath:fileURL.path]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setProcessPool: sharedProcessPool];
     configuration.get().websiteDataStore = dataStore;
 
     // We need an active NetworkProcess to perform ResourceLoadStatistics operations.
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [dataStore _setResourceLoadStatisticsEnabled:YES];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
 
@@ -1045,9 +1045,9 @@ TEST(ResourceLoadStatistics, CanAccessDataSummaryWithNoProcessPool)
     [defaultFileManager copyItemAtPath:newFileURL.path toPath:fileURL.path error:nil];
     EXPECT_TRUE([defaultFileManager fileExistsAtPath:fileURL.path]);
 
-    auto dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     dataStoreConfiguration.get()._resourceLoadStatisticsDirectory = itpRootURL;
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
     [dataStore _setResourceLoadStatisticsEnabled:YES];
 
     static bool doneFlag = false;
@@ -1073,25 +1073,25 @@ TEST(ResourceLoadStatistics, CanAccessDataSummaryWithNoProcessPool)
 TEST(ResourceLoadStatistics, StoreSuspension)
 {
     auto *sharedProcessPool = [WKProcessPool _sharedProcessPool];
-    auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     auto customGeneralStorageDirectory = [NSURL fileURLWithPath:[NSString stringWithFormat:@"%@%@", dataStoreConfiguration.get().generalStorageDirectory.path, @"_Custom"]];
-    auto dataStore1 = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr dataStore1 = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
     dataStoreConfiguration.get().generalStorageDirectory = customGeneralStorageDirectory;
-    auto dataStore2 = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr dataStore2 = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
 
     [dataStore1 _setResourceLoadStatisticsEnabled:YES];
     [dataStore2 _setResourceLoadStatisticsEnabled:YES];
 
-    auto configuration1 = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration1 = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration1 setProcessPool: sharedProcessPool];
     configuration1.get().websiteDataStore = dataStore1.get();
 
-    auto configuration2 = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration2 = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration2 setProcessPool: sharedProcessPool];
     configuration2.get().websiteDataStore = dataStore2.get();
 
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration1.get()]);
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration2.get()]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration1.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration2.get()]);
 
     [webView1 loadHTMLString:@"WebKit Test" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     [webView1 _test_waitForDidFinishNavigation];
@@ -1137,12 +1137,12 @@ TEST(ResourceLoadStatistics, StoreSuspension)
 #if PLATFORM(MAC)
 TEST(ResourceLoadStatistics, DataSummaryWithCachedProcess)
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().processSwapsOnNavigation = YES;
     processPoolConfiguration.get().usesWebProcessCache = YES;
     processPoolConfiguration.get().processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol = YES;
     processPoolConfiguration.get().prewarmsProcessesAutomatically = NO;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
     EXPECT_GT([processPool _maximumSuspendedPageCount], 0u);
     EXPECT_GT([processPool _processCacheCapacity], 0u);
@@ -1150,17 +1150,17 @@ TEST(ResourceLoadStatistics, DataSummaryWithCachedProcess)
     auto *dataStore = [WKWebsiteDataStore defaultDataStore];
     [WKWebsiteDataStore _setCachedProcessSuspensionDelayForTesting:0];
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
     [webViewConfiguration setWebsiteDataStore:dataStore];
 
-    auto handler = adoptNS([[ResourceLoadStatisticsSchemeHandler alloc] init]);
+    RetainPtr handler = adoptNS([[ResourceLoadStatisticsSchemeHandler alloc] init]);
 
     const unsigned maxSuspendedPageCount = [processPool _maximumSuspendedPageCount];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"resource-load-statistics"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     for (unsigned i = 0; i < maxSuspendedPageCount + 1; i++) {
@@ -1192,19 +1192,19 @@ TEST(ResourceLoadStatistics, DataSummaryWithCachedProcess)
 
 TEST(ResourceLoadStatistics, BackForwardPerPageData)
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol = YES;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
     auto *dataStore = [WKWebsiteDataStore defaultDataStore];
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
 
-    auto schemeHandler = adoptNS([[ResourceLoadStatisticsSchemeHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[ResourceLoadStatisticsSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setProcessPool:processPool.get()];
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"resource-load-statistics"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:delegate.get()];
 
     static bool doneFlag = false;
@@ -1305,12 +1305,12 @@ TEST(ResourceLoadStatistics, DISABLED_MigrateDistinctDataFromTableWithMissingInd
     [defaultFileManager copyItemAtPath:newFileURL.path toPath:fileURL.path error:nil];
     EXPECT_TRUE([defaultFileManager fileExistsAtPath:fileURL.path]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setProcessPool: sharedProcessPool];
     configuration.get().websiteDataStore = dataStore;
 
     // We need an active NetworkProcess to perform ResourceLoadStatistics operations.
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [dataStore _setResourceLoadStatisticsEnabled:YES];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
 
@@ -1349,7 +1349,7 @@ static Vector<String> columnsForTable(WebCore::SQLiteDatabase& database, ASCIILi
 
 TEST(ResourceLoadStatistics, DatabaseSchemeUpdate)
 {
-    auto dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
 
     NSError *error = nil;
     [[NSFileManager defaultManager] removeItemAtURL:dataStoreConfiguration.get()._resourceLoadStatisticsDirectory error:&error];
@@ -1372,7 +1372,7 @@ TEST(ResourceLoadStatistics, DatabaseSchemeUpdate)
     EXPECT_TRUE(database->executeCommand(createObservedDomain));
     database->close();
 
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
     [dataStore _setResourceLoadStatisticsEnabled:YES];
     __block bool done { false };
     [dataStore _setPrevalentDomain:[NSURL URLWithString:@"https://example.com/"] completionHandler:^{
@@ -1394,11 +1394,11 @@ TEST(ResourceLoadStatistics, DISABLED_ClientEvaluatedJavaScriptDoesNotLogUserInt
 TEST(ResourceLoadStatistics, ClientEvaluatedJavaScriptDoesNotLogUserInteraction)
 #endif
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]).get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]).get()]);
     [configuration setWebsiteDataStore:dataStore.get()];
     [dataStore _setResourceLoadStatisticsEnabled:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
     [webView loadHTMLString:@"" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     [webView _test_waitForDidFinishNavigation];
 
@@ -1430,10 +1430,10 @@ TEST(ResourceLoadStatistics, UserGestureLogsUserInteraction)
 #endif
 {
     auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]).get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]).get()]);
     [configuration setWebsiteDataStore:dataStore.get()];
     [dataStore _setResourceLoadStatisticsEnabled:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration]);
     [webView loadHTMLString:@"" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     [webView _test_waitForDidFinishNavigation];
 
@@ -1459,12 +1459,12 @@ TEST(ResourceLoadStatistics, UserGestureLogsUserInteraction)
 
 TEST(ResourceLoadStatistics, UserAgentStringForSite)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]).get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]).get()]);
     [configuration setWebsiteDataStore:dataStore.get()];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     auto userAgent = @"NotARealUserAgent";
 
     __block bool done = false;
@@ -1496,8 +1496,8 @@ TEST(ResourceLoadStatistics, UserAgentStringForSite)
 
 TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithQuirk)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]).get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]).get()]);
     [configuration setWebsiteDataStore:dataStore.get()];
 
     [dataStore _setResourceLoadStatisticsEnabled:YES];
@@ -1515,12 +1515,12 @@ TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithQuirk)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
     [webView loadHTMLString:@"" baseURL:[NSURL URLWithString:@"http://site1.example"]];
     [webView _test_waitForDidFinishNavigation];
 
     __block bool navigationDelegateDone = false;
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate setDidPromptForStorageAccess:^(WKWebView *, NSString *topFrameDomain, NSString *subFrameDomain, BOOL hasQuirk) {
         EXPECT_TRUE(hasQuirk);
         navigationDelegateDone = true;
@@ -1528,7 +1528,7 @@ TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithQuirk)
 
     [webView setNavigationDelegate:navigationDelegate.get()];
 
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     [webView setUIDelegate:uiDelegate.get()];
 
     [webView evaluateJavaScript:@"let iframe = document.createElement(\"iframe\"); iframe.src = \"https://www.site2.example\"; document.body.appendChild(iframe);" completionHandler:^(id value, NSError *error) {
@@ -1551,10 +1551,10 @@ TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithTrigger)
         { "/page1c"_s, { "<body><script>if (window.internals) { internals.withUserGesture(() => { document.requestStorageAccess(); }); document.body.innerText = \"Requesting storage access\"; } else document.body.innerText = \"Internals not present\";</script></body>"_s  } },
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     storeConfiguration.get().httpsProxy = [NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", httpServer.port()]];
 
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
 
     [dataStore _setResourceLoadStatisticsEnabled:YES];
 
@@ -1574,16 +1574,16 @@ TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithTrigger)
     auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration setWebsiteDataStore:dataStore.get()];
 
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     __block bool gotRequestStorageAccessPanelForQuirksForDomain { false };
     uiDelegate.get().requestStorageAccessPanelForQuirksForDomain = ^(WKWebView *, NSString *, NSString *, NSDictionary<NSString *, NSArray<NSString *> *> *, void  (^completionHandler)(BOOL)) {
         gotRequestStorageAccessPanelForQuirksForDomain = true;
         completionHandler(NO);
     };
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration]);
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     __block bool didReceiveStorageAccessPrompt = false;
     [navigationDelegate setDidPromptForStorageAccess:^(WKWebView *webview, NSString *topFrameDomain, NSString *subFrameDomain, BOOL hasQuirk) {
@@ -1661,19 +1661,19 @@ TEST(ResourceLoadStatistics, StorageAccessOnRedirectSitesWithOutQuirk)
         { "http://site3.example/page3"_s, { "<body>Done</body>"_s  } },
     });
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
     }];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
     [configuration setWebsiteDataStore:dataStore.get()];
     [dataStore _setResourceLoadStatisticsEnabled:YES];
 
     __block bool done = false;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^decisionHandler)(WKNavigationActionPolicy)) {
         decisionHandler(WKNavigationActionPolicyAllow);
         done = true;
@@ -1684,7 +1684,7 @@ TEST(ResourceLoadStatistics, StorageAccessOnRedirectSitesWithOutQuirk)
         finishedNavigation = true;
     };
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
     [webView setNavigationDelegate:delegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://site3.example/page1"]]];
@@ -1741,14 +1741,14 @@ TEST(ResourceLoadStatistics, StorageAccessOnRedirectSitesWithQuirk)
         { "http://site4.example/page2"_s, { "<body>Done</body>"_s  } },
     });
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
     }];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
     [configuration setWebsiteDataStore:dataStore.get()];
     [dataStore _setResourceLoadStatisticsEnabled:YES];
 
@@ -1771,7 +1771,7 @@ TEST(ResourceLoadStatistics, StorageAccessOnRedirectSitesWithQuirk)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^decisionHandler)(WKNavigationActionPolicy)) {
         decisionHandler(WKNavigationActionPolicyAllow);
         done = true;
@@ -1782,7 +1782,7 @@ TEST(ResourceLoadStatistics, StorageAccessOnRedirectSitesWithQuirk)
         finishedNavigation = true;
     };
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
     [webView setNavigationDelegate:delegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://site3.example/page1"]]];
@@ -2052,10 +2052,10 @@ TEST(ResourceLoadStatistics, EnableResourceLoadStatisticsAfterNetworkProcessCrea
         TestWebKitAPI::Util::run(&done);
 
         auto *sharedProcessPool = [WKProcessPool _sharedProcessPool];
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         configuration.get().processPool = sharedProcessPool;
         configuration.get().websiteDataStore = websiteDataStore;
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         [webView loadHTMLString:@"" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
         [webView _test_waitForDidFinishNavigation];
 
@@ -2124,11 +2124,11 @@ TEST(ResourceLoadStatistics, StorageAccessSupportMultipleSubFrameDomains)
         }
     }, HTTPServer::Protocol::HttpsProxy };
 
-    auto storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     storeConfiguration.get().httpsProxy = [NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", httpServer.port()]];
 
     auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
     [configuration setWebsiteDataStore:dataStore.get()];
     [dataStore _setResourceLoadStatisticsEnabled:YES];
 
@@ -2159,7 +2159,7 @@ TEST(ResourceLoadStatistics, StorageAccessSupportMultipleSubFrameDomains)
 
     __block bool gotRequestStorageAccessPanelForDomain { false };
     __block bool gotRequestStorageAccessPanelForQuirksForDomain { false };
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().requestStorageAccessPanelForDomain = ^(WKWebView *, NSString *subFrameDomain, NSString *topFrameDomain, void  (^completionHandler)(BOOL)) {
         EXPECT_NOT_NULL(subFrameDomain);
         EXPECT_NOT_NULL(subFrameDomain);
@@ -2181,8 +2181,8 @@ TEST(ResourceLoadStatistics, StorageAccessSupportMultipleSubFrameDomains)
         completionHandler(YES);
     };
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration]);
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:navigationDelegate.get()];
 
@@ -2282,11 +2282,11 @@ TEST(ResourceLoadStatistics, StorageAccessGrantMultipleSubFrameDomains)
         }
     }, HTTPServer::Protocol::HttpsProxy };
 
-    auto storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     storeConfiguration.get().httpsProxy = [NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", httpServer.port()]];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
     [configuration.get() setWebsiteDataStore:dataStore.get()];
     [dataStore _setResourceLoadStatisticsEnabled:YES];
 
@@ -2318,7 +2318,7 @@ TEST(ResourceLoadStatistics, StorageAccessGrantMultipleSubFrameDomains)
     __block bool gotRequestStorageAccessPanelForQuirksForDomain { false };
     __block NSString *expectedTopFrameDomain;
     __block NSString *expectedSubFrameDomain;
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().requestStorageAccessPanelForQuirksForDomain = ^(WKWebView *, NSString *subFrameDomain, NSString *topFrameDomain, NSDictionary<NSString *, NSArray<NSString *> *> *quirkDomains, void  (^completionHandler)(BOOL)) {
         EXPECT_NOT_NULL(expectedSubFrameDomain);
         EXPECT_NOT_NULL(expectedTopFrameDomain);
@@ -2333,8 +2333,8 @@ TEST(ResourceLoadStatistics, StorageAccessGrantMultipleSubFrameDomains)
         completionHandler(YES);
     };
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:navigationDelegate.get()];
 
@@ -2442,11 +2442,11 @@ TEST(ResourceLoadStatistics, HasStorageAccessWithDatabaseError)
         { "/has-access"_s, { "<body><script>document.hasStorageAccess().then((result) => alert(result ? 'true' : 'false'), (error) => alert('error'));</script></body>"_s } },
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     storeConfiguration.get().httpsProxy = [NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", httpServer.port()]];
     storeConfiguration.get()._resourceLoadStatisticsDirectory = itpRootURL;
 
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
     [dataStore _setResourceLoadStatisticsEnabled:YES];
 
     // Wait for the ResourceLoadStatisticsStore to be created on the
@@ -2460,12 +2460,12 @@ TEST(ResourceLoadStatistics, HasStorageAccessWithDatabaseError)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:dataStore.get()];
 
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:navigationDelegate.get()];
     [webView setUIDelegate:uiDelegate.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ResponsivenessTimer.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ResponsivenessTimer.mm
@@ -54,13 +54,13 @@ namespace TestWebKitAPI {
 
 TEST(WebKit, ResponsivenessTimerShouldNotFireAfterTearDown)
 {
-    auto processPoolConfiguration = adoptNS([_WKProcessPoolConfiguration new]);
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
-    auto delegate = adoptNS([ResponsivenessTimerDelegate new]);
+    RetainPtr processPoolConfiguration = adoptNS([_WKProcessPoolConfiguration new]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr delegate = adoptNS([ResponsivenessTimerDelegate new]);
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setProcessPool:processPool.get()];
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView1 setNavigationDelegate:delegate.get()];
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView1 loadRequest:request];
@@ -68,7 +68,7 @@ TEST(WebKit, ResponsivenessTimerShouldNotFireAfterTearDown)
 
     EXPECT_FALSE(didBecomeUnresponsive);
 
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView2 setNavigationDelegate:delegate.get()];
 
     didFinishLoad = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ResponsivenessTimerDoesntFireEarly.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ResponsivenessTimerDoesntFireEarly.mm
@@ -76,10 +76,10 @@ TEST(WebKit, ResponsivenessTimerDoesntFireEarly)
     WKRetainPtr<WKContextRef> context = adoptWK(Util::createContextForInjectedBundleTest("ResponsivenessTimerDoesntFireEarlyTest"));
     setInjectedBundleClient(context.get());
 
-    auto delegate = adoptNS([ResponsivenessDelegate new]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr delegate = adoptNS([ResponsivenessDelegate new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setProcessPool:(WKProcessPool *)context.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:delegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RestoreScrollPosition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RestoreScrollPosition.mm
@@ -40,7 +40,7 @@ TEST(RestoreScrollPositionTests, RestoreScrollPositionWithLargeContentInset)
 {
     auto topInset = 1165;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 375, 1024)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 375, 1024)]);
     [webView setOverrideSafeAreaInset:UIEdgeInsetsMake(141, 0, 0, 0)];
     
     [webView synchronouslyLoadTestPageNamed:@"simple-tall"];
@@ -64,13 +64,13 @@ TEST(RestoreScrollPositionTests, RestoreScrollPositionWithLargeContentInset)
 
 TEST(RestoreScrollPositionTests, RestoreScrollPositionDuringResize)
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().pageCacheEnabled = NO;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:webViewConfiguration.get()]);
 
     [webView synchronouslyLoadTestPageNamed:@"simple-tall"];
     [webView stringByEvaluatingJavaScript:@"scrollTo(0, 1000)"];
@@ -113,7 +113,7 @@ TEST(RestoreScrollPositionTests, RestoreScrollPositionDuringResize)
 
 TEST(RestoreScrollPositionTests, RestoreScrollPositionAfterBack)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 390, 664)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 390, 664)]);
 
     [webView synchronouslyLoadTestPageNamed:@"simple-tall"];
     [webView _setViewScale:1.15]; // Simulate MobileSafari setting view scale on every didCommitNavigation.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RestoreSessionStateWithoutNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RestoreSessionStateWithoutNavigation.mm
@@ -80,8 +80,8 @@ namespace TestWebKitAPI {
 
 static WKRetainPtr<WKDataRef> createSessionStateData()
 {
-    auto delegate = adoptNS([SessionStateDelegate new]);
-    auto view = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([SessionStateDelegate new]);
+    RetainPtr view = adoptNS([WKWebView new]);
     [view setNavigationDelegate:delegate.get()];
     [view loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
     Util::run(&didFinishNavigationForSessionState);
@@ -96,7 +96,7 @@ TEST(WebKit, RestoreSessionStateWithoutNavigation)
     auto data = createSessionStateData();
     EXPECT_NOT_NULL(data);
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     auto sessionState = adoptWK(WKSessionStateCreateFromData(data.get()));
     WKPageRestoreFromSessionStateWithoutNavigation([webView _pageForTesting], sessionState.get());
 
@@ -116,8 +116,8 @@ TEST(WebKit, RestoreSessionStateWithoutNavigation)
 
 TEST(WebKit, RestoreSessionStateWithoutNavigationPreservesWasCreatedByJSWithoutUserInteraction)
 {
-    auto delegate = adoptNS([SessionStateDelegate new]);
-    auto view = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([SessionStateDelegate new]);
+    RetainPtr view = adoptNS([WKWebView new]);
     [view setNavigationDelegate:delegate.get()];
 
     [view loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
@@ -138,8 +138,8 @@ TEST(WebKit, RestoreSessionStateWithoutNavigationPreservesWasCreatedByJSWithoutU
     EXPECT_TRUE([view backForwardList].currentItem._wasCreatedByJSWithoutUserInteraction);
 
     // Restore session state into a new web view.
-    auto restoredView = adoptNS([WKWebView new]);
-    auto sessionState = adoptNS([[_WKSessionState alloc] initWithData:[view _sessionStateData]]);
+    RetainPtr restoredView = adoptNS([WKWebView new]);
+    RetainPtr sessionState = adoptNS([[_WKSessionState alloc] initWithData:[view _sessionStateData]]);
     [restoredView _restoreSessionState:sessionState.get() andNavigate:NO];
 
     EXPECT_EQ([restoredView backForwardList].backList.count, 2U);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RunOpenPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RunOpenPanel.mm
@@ -72,8 +72,8 @@ namespace TestWebKitAPI {
 
 TEST(WebKit, RunOpenPanelNonLatin1)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)]);
-    auto uiDelegate = adoptNS([[RunOpenPanelUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)]);
+    RetainPtr uiDelegate = adoptNS([[RunOpenPanelUIDelegate alloc] init]);
     [webView setUIDelegate:uiDelegate.get()];
     [webView loadHTMLString:@"<!DOCTYPE html><input style='width: 100vw; height: 100vh;' id='file' type='file'>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -92,8 +92,8 @@ TEST(WebKit, RunOpenPanelNonLatin1)
 
 TEST(WebKit, FileInputTypeCancelEvent)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)]);
-    auto uiDelegate = adoptNS([[FileInputTypeCancelEventUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)]);
+    RetainPtr uiDelegate = adoptNS([[FileInputTypeCancelEventUIDelegate alloc] init]);
     [webView setUIDelegate:uiDelegate.get()];
 
     NSString *markup = @""

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RunScriptAfterDocumentLoad.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RunScriptAfterDocumentLoad.mm
@@ -47,15 +47,15 @@ static const char* markup =
 
 TEST(RunScriptAfterDocumentLoad, ExecutionOrderOfScriptsInDocument)
 {
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"custom"];
     [configuration _setShouldDeferAsynchronousScriptsUntilAfterDocumentLoad:YES];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         auto responseBlock = [task = retainPtr(task)] {
             NSURL *requestURL = [task request].URL;
             NSString *script = [NSString stringWithFormat:@"webkit.messageHandlers.testHandler.postMessage('Running %@')", requestURL.absoluteString.lastPathComponent];
-            auto response = adoptNS([[NSURLResponse alloc] initWithURL:requestURL MIMEType:@"text/javascript" expectedContentLength:[script length] textEncodingName:nil]);
+            RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:requestURL MIMEType:@"text/javascript" expectedContentLength:[script length] textEncodingName:nil]);
             [task didReceiveResponse:response.get()];
             [task didReceiveData:[script dataUsingEncoding:NSUTF8StringEncoding]];
             [task didFinish];
@@ -72,8 +72,8 @@ TEST(RunScriptAfterDocumentLoad, ExecutionOrderOfScriptsInDocument)
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (0.25_s).nanoseconds()), mainDispatchQueueSingleton(), responseBlock);
     }];
 
-    auto messages = adoptNS([NSMutableArray new]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200) configuration:configuration.get()]);
+    RetainPtr messages = adoptNS([NSMutableArray new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200) configuration:configuration.get()]);
     for (NSString *message in @[ @"Running async.js", @"Running defer.js", @"Running sync.js", @"DOMContentLoaded", @"async.js loaded", @"defer.js loaded", @"sync.js loaded" ]) {
         [webView performAfterReceivingMessage:message action:[message = adoptNS(message.copy), messages] {
             [messages addObject:message.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm
@@ -389,8 +389,8 @@ using GetAuthorizationHintsCallback = void (^)(SOAuthorizationHints *authorizati
 static void overrideGetAuthorizationHintsWithURL(id, SEL, NSURL *url, NSInteger responseCode, GetAuthorizationHintsCallback completion)
 {
     EXPECT_EQ(responseCode, 0l);
-    auto soAuthorizationHintsCore = adoptNS([PAL::allocSOAuthorizationHintsCoreInstance() initWithLocalizedExtensionBundleDisplayName:@"Test"]);
-    auto soAuthorizationHints = adoptNS([PAL::allocSOAuthorizationHintsInstance() initWithAuthorizationHintsCore:soAuthorizationHintsCore.get()]);
+    RetainPtr soAuthorizationHintsCore = adoptNS([PAL::allocSOAuthorizationHintsCoreInstance() initWithLocalizedExtensionBundleDisplayName:@"Test"]);
+    RetainPtr soAuthorizationHints = adoptNS([PAL::allocSOAuthorizationHintsInstance() initWithAuthorizationHintsCore:soAuthorizationHintsCore.get()]);
     completion(soAuthorizationHints.get(), nullptr);
 }
 
@@ -501,8 +501,8 @@ TEST(SOAuthorizationRedirect, NoInterceptions)
     resetState();
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
@@ -519,14 +519,14 @@ TEST(SOAuthorizationRedirect, DisableSSO)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto preferences = configuration.get().preferences;
     EXPECT_TRUE(preferences._isExtensibleSSOEnabled);
 
     preferences._extensibleSSOEnabled = NO;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
@@ -546,8 +546,8 @@ TEST(SOAuthorizationRedirect, InterceptionError)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
@@ -564,8 +564,8 @@ TEST(SOAuthorizationRedirect, InterceptionDoNotHandle)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
@@ -586,8 +586,8 @@ TEST(SOAuthorizationRedirect, InterceptionCancel)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
@@ -609,8 +609,8 @@ TEST(SOAuthorizationRedirect, InterceptionCompleteWithoutData)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
@@ -631,8 +631,8 @@ TEST(SOAuthorizationRedirect, InterceptionUnexpectedCompletion)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
@@ -654,8 +654,8 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed1)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationBasicDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationBasicDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
@@ -668,7 +668,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed1)
     EXPECT_FALSE(gAuthorization.enableEmbeddedAuthorizationViewController);
 #endif
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
 #if PLATFORM(IOS) || PLATFORM(VISION)
@@ -699,8 +699,8 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed2)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationBasicDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationBasicDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     // Force App Links with a request.URL that has a different host than the current one (empty host) and ShouldOpenExternalURLsPolicy::ShouldAllow.
@@ -720,7 +720,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed2)
     EXPECT_FALSE(policyForAppSSOPerformed); // The delegate isn't registered, so this won't be set.
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
     EXPECT_WK_STREQ(redirectURL.get().absoluteString, finalURL);
@@ -732,8 +732,8 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed3)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     // Force App Links with a request.URL that has a different host than the current one (empty host) and ShouldOpenExternalURLsPolicy::ShouldAllow.
@@ -754,7 +754,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed3)
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
     EXPECT_WK_STREQ(redirectURL.get().absoluteString, finalURL);
@@ -768,9 +768,9 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed4)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     // A separate delegate that implements decidePolicyForNavigationAction.
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
     [delegate setIsDefaultPolicy:false];
 
@@ -780,7 +780,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed4)
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
 #if PLATFORM(IOS) || PLATFORM(VISION)
@@ -797,8 +797,8 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithOtherHttpStatusCode)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
@@ -807,7 +807,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithOtherHttpStatusCode)
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:400 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:400 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
     EXPECT_WK_STREQ(testURL.get().absoluteString, finalURL);
@@ -818,8 +818,8 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWith302POST)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     TestWebKitAPI::HTTPServer server({
@@ -842,7 +842,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWith302POST)
     delegateNavigationAction = nullptr;
 
     auto simple2URLString = [[server.request("/simple2.html"_s) URL] absoluteString];
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:[server.request("/simple.html"_s) URL] statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : simple2URLString }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:[server.request("/simple.html"_s) URL] statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : simple2URLString }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
 
@@ -876,9 +876,9 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWith302AfterRedirection)
 
     navigationCompleted = false;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     // A separate delegate that implements decidePolicyForNavigationAction.
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
     [delegate setIsDefaultPolicy:false];
 
@@ -887,7 +887,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWith302AfterRedirection)
     checkAuthorizationOptions(false, ""_s, 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
     auto simpleURL2String = server.request("/simple2.html"_s).URL.absoluteString;
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:simpleURL statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : simpleURL2String }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:simpleURL statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : simpleURL2String }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
     navigationCompleted = false;
@@ -905,8 +905,8 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWith307Simple)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     TestWebKitAPI::HTTPServer server(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> ConnectionTask {
@@ -938,7 +938,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWith307Simple)
     navigationCompleted = false;
     delegateNavigationAction = nullptr;
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:simpleURL statusCode:307 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : simpleURL2String }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:simpleURL statusCode:307 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : simpleURL2String }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
 
@@ -957,8 +957,8 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWith307CrossOrigin)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     TestWebKitAPI::HTTPServer server1({
@@ -995,7 +995,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWith307CrossOrigin)
     delegateNavigationAction = nullptr;
 
     auto server2Simple2URLString = server2.request("/simple2.html"_s).URL.absoluteString;
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:server1SimpleURL statusCode:307 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : server2Simple2URLString }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:server1SimpleURL statusCode:307 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : server2Simple2URLString }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
 
@@ -1015,8 +1015,8 @@ TEST(SOAuthorizationRedirect, InterceptionFailedWith307PUT)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     TestWebKitAPI::HTTPServer server1({
@@ -1053,7 +1053,7 @@ TEST(SOAuthorizationRedirect, InterceptionFailedWith307PUT)
     delegateNavigationAction = nullptr;
 
     auto server2Simple2URLString = server2.request("/simple2.html"_s).URL.absoluteString;
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:server1SimpleURL statusCode:307 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : server2Simple2URLString }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:server1SimpleURL statusCode:307 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : server2Simple2URLString }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
 
@@ -1071,8 +1071,8 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithCookie)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
@@ -1081,7 +1081,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithCookie)
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;", @"Location" : [redirectURL absoluteString] }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;", @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
 #if PLATFORM(IOS) || PLATFORM(VISION)
@@ -1105,8 +1105,8 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithCookies)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
@@ -1115,7 +1115,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithCookies)
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8, qwerty=219ffwef9w0f, id=a3fWa;", @"Location" : [redirectURL absoluteString] }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8, qwerty=219ffwef9w0f, id=a3fWa;", @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
 #if PLATFORM(IOS) || PLATFORM(VISION)
@@ -1138,8 +1138,8 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithRedirectionAndCookie)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     URL testURL { "https://www.example.com"_str };
@@ -1158,7 +1158,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithRedirectionAndCookie)
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;", @"Location" : [redirectURL absoluteString] }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;", @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
     EXPECT_WK_STREQ(redirectURL.get().absoluteString, finalURL);
@@ -1178,8 +1178,8 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithDifferentOrigin)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
@@ -1201,8 +1201,8 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithWaitingSession)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     // The session will be waiting since the web view is is not in the window.
@@ -1218,7 +1218,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithWaitingSession)
     checkAuthorizationOptions(false, emptyString(), 0);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
 #if PLATFORM(IOS) || PLATFORM(VISION)
@@ -1236,8 +1236,8 @@ TEST(SOAuthorizationRedirect, InterceptionAbortedWithWaitingSession)
     RetainPtr<NSURL> testURL1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     RetainPtr<NSURL> testURL2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     // The session will be waiting since the web view is is not in the window.
@@ -1263,8 +1263,8 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithActiveSessionDidMoveWindow)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
@@ -1276,7 +1276,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithActiveSessionDidMoveWindow)
     [webView addToTestWindow];
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
 #if PLATFORM(IOS) || PLATFORM(VISION)
@@ -1293,8 +1293,8 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedTwice)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     for (int i = 0; i < 2; i++) {
@@ -1307,7 +1307,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedTwice)
 
         navigationCompleted = false;
         RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-        auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
+        RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
         [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
         Util::run(&navigationCompleted);
 #if PLATFORM(IOS) || PLATFORM(VISION)
@@ -1325,8 +1325,8 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressActiveSession)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
@@ -1344,7 +1344,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressActiveSession)
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
 #if PLATFORM(IOS) || PLATFORM(VISION)
@@ -1361,8 +1361,8 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressWaitingSession)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     // The session will be waiting since the web view is is not int the window.
@@ -1385,7 +1385,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressWaitingSession)
     checkAuthorizationOptions(false, emptyString(), 0);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
 #if PLATFORM(IOS) || PLATFORM(VISION)
@@ -1402,12 +1402,12 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSAML)
 
     RetainPtr testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"SAML"]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"SAML"]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     // Add a http body to the request to mimic a SAML request.
@@ -1421,7 +1421,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSAML)
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     // Pass a HTTP 200 response with a html to mimic a SAML response.
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:samlResponse length:strlen(samlResponse)]).get()];
     Util::run(&allMessagesReceived);
 }
@@ -1434,8 +1434,8 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSAMLWithPSON)
     RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple3" withExtension:@"html"];
     URL testURL { "http://www.example.com"_str };
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:baseURL.get()]];
@@ -1448,7 +1448,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSAMLWithPSON)
 
     navigationCompleted = false;
     // Pass a HTTP 200 response with a html to mimic a SAML response.
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:samlResponse length:strlen(samlResponse)]).get()];
     Util::run(&navigationCompleted);
 
@@ -1465,8 +1465,8 @@ TEST(SOAuthorizationRedirect, AuthorizationOptions)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:@"" baseURL:URL { "http://www.webkit.org"_str }.createNSURL().get()];
@@ -1484,8 +1484,8 @@ TEST(SOAuthorizationRedirect, AuthorizationOptionsWithPath)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:@"" baseURL:URL { "http://www.webkit.org/some/path"_str }.createNSURL().get()];
@@ -1503,8 +1503,8 @@ TEST(SOAuthorizationRedirect, AuthorizationOptionsAboutBlank)
     resetState();
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:@"" baseURL:[NSURL URLWithString:@"about:blank"]];
@@ -1524,8 +1524,8 @@ TEST(SOAuthorizationRedirect, InterceptionDidNotHandleTwice)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
@@ -1544,8 +1544,8 @@ TEST(SOAuthorizationRedirect, InterceptionCompleteTwice)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
@@ -1554,7 +1554,7 @@ TEST(SOAuthorizationRedirect, InterceptionCompleteTwice)
 
     // Test passes if no crashes.
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
 }
@@ -1566,8 +1566,8 @@ TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyIgnore)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
     [delegate setAllowSOAuthorizationLoad:false];
 
@@ -1585,8 +1585,8 @@ TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyAllowAsync)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
@@ -1595,7 +1595,7 @@ TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyAllowAsync)
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
 #if PLATFORM(IOS) || PLATFORM(VISION)
@@ -1612,8 +1612,8 @@ TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyIgnoreAsync)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
     [delegate setAllowSOAuthorizationLoad:false];
     [delegate setIsAsyncExecution:true];
@@ -1635,16 +1635,16 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithUI)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto viewController = adoptNS([[TestSOAuthorizationViewController alloc] init]);
-    auto view = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr viewController = adoptNS([[TestSOAuthorizationViewController alloc] init]);
+    RetainPtr view = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
     [viewController setView:view.get()];
 
     [gDelegate authorization:gAuthorization presentViewController:viewController.get() withCompletion:^(BOOL success, NSError *) {
@@ -1653,7 +1653,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithUI)
     Util::run(&uiShowed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
     EXPECT_WK_STREQ(redirectURL.get().absoluteString, finalURL);
@@ -1667,16 +1667,16 @@ TEST(SOAuthorizationRedirect, InterceptionCancelWithUI)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto viewController = adoptNS([[TestSOAuthorizationViewController alloc] init]);
-    auto view = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr viewController = adoptNS([[TestSOAuthorizationViewController alloc] init]);
+    RetainPtr view = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
     [viewController setView:view.get()];
 
     [gDelegate authorization:gAuthorization presentViewController:viewController.get() withCompletion:^(BOOL success, NSError *) {
@@ -1698,16 +1698,16 @@ TEST(SOAuthorizationRedirect, InterceptionErrorWithUI)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto viewController = adoptNS([[TestSOAuthorizationViewController alloc] init]);
-    auto view = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr viewController = adoptNS([[TestSOAuthorizationViewController alloc] init]);
+    RetainPtr view = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
     [viewController setView:view.get()];
 
     [gDelegate authorization:gAuthorization presentViewController:viewController.get() withCompletion:^(BOOL success, NSError *) {
@@ -1728,16 +1728,16 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressActiveSessionWithUI)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto viewController = adoptNS([[TestSOAuthorizationViewController alloc] init]);
-    auto view = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr viewController = adoptNS([[TestSOAuthorizationViewController alloc] init]);
+    RetainPtr view = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
     [viewController setView:view.get()];
 
     [gDelegate authorization:gAuthorization presentViewController:viewController.get() withCompletion:^(BOOL success, NSError *) {
@@ -1754,7 +1754,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressActiveSessionWithUI)
     EXPECT_FALSE(uiShowed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
     EXPECT_WK_STREQ(redirectURL.get().absoluteString, finalURL);
@@ -1767,16 +1767,16 @@ TEST(SOAuthorizationRedirect, ShowUITwice)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto viewController = adoptNS([[TestSOAuthorizationViewController alloc] init]);
-    auto view = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr viewController = adoptNS([[TestSOAuthorizationViewController alloc] init]);
+    RetainPtr view = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
     [viewController setView:view.get()];
 
     [gDelegate authorization:gAuthorization presentViewController:viewController.get() withCompletion:^(BOOL success, NSError *) {
@@ -1803,16 +1803,16 @@ TEST(SOAuthorizationRedirect, NSNotificationCenter)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto viewController = adoptNS([[TestSOAuthorizationViewController alloc] init]);
-    auto view = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr viewController = adoptNS([[TestSOAuthorizationViewController alloc] init]);
+    RetainPtr view = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
     {
         InstanceMethodSwizzler swizzler4([NSNotificationCenter class], @selector(addObserverForName:object:queue:usingBlock:), reinterpret_cast<IMP>(overrideAddObserverForName));
         [viewController setView:view.get()];
@@ -1833,16 +1833,16 @@ TEST(SOAuthorizationRedirect, DismissUIDuringMiniaturization)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto viewController = adoptNS([[TestSOAuthorizationViewController alloc] init]);
-    auto view = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr viewController = adoptNS([[TestSOAuthorizationViewController alloc] init]);
+    RetainPtr view = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
     [viewController setView:view.get()];
 
     [gDelegate authorization:gAuthorization presentViewController:viewController.get() withCompletion:^(BOOL success, NSError *) {
@@ -1877,16 +1877,16 @@ TEST(SOAuthorizationRedirect, DismissUIDuringHiding)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto viewController = adoptNS([[TestSOAuthorizationViewController alloc] init]);
-    auto view = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr viewController = adoptNS([[TestSOAuthorizationViewController alloc] init]);
+    RetainPtr view = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
     [viewController setView:view.get()];
 
     [gDelegate authorization:gAuthorization presentViewController:viewController.get() withCompletion:^(BOOL success, NSError *) {
@@ -1924,16 +1924,16 @@ TEST(SOAuthorizationRedirect, DismissUIDuringMiniaturizationThenAnother)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto viewController1 = adoptNS([[TestSOAuthorizationViewController alloc] init]);
-    auto view1 = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr viewController1 = adoptNS([[TestSOAuthorizationViewController alloc] init]);
+    RetainPtr view1 = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
     [viewController1 setView:view1.get()];
 
     [gDelegate authorization:gAuthorization presentViewController:viewController1.get() withCompletion:^(BOOL success, NSError *) {
@@ -1978,16 +1978,16 @@ TEST(SOAuthorizationRedirect, DismissUIDuringHidingThenAnother)
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto viewController = adoptNS([[TestSOAuthorizationViewController alloc] init]);
-    auto view = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr viewController = adoptNS([[TestSOAuthorizationViewController alloc] init]);
+    RetainPtr view = adoptNS([[NSView alloc] initWithFrame:NSZeroRect]);
     [viewController setView:view.get()];
 
     [gDelegate authorization:gAuthorization presentViewController:viewController.get() withCompletion:^(BOOL success, NSError *) {
@@ -2029,8 +2029,8 @@ TEST(SOAuthorizationPopUp, NoInterceptions)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     auto testHtml = generateOpenerHTML(openerTemplate, testURL.get().absoluteString);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:testURL.get()];
@@ -2061,8 +2061,8 @@ TEST(SOAuthorizationPopUp, NoInterceptionsSubFrame)
     auto iframeTestHtml = generateOpenerHTML(openerTemplate, testURL.get().absoluteString);
     auto testHtml = makeString("<iframe style='width:400px;height:400px' srcdoc=\""_s, iframeTestHtml, "\" />"_s);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
@@ -2082,11 +2082,11 @@ TEST(SOAuthorizationPopUp, NoInterceptionsWithoutUserGesture)
     SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
 
     // The default value of javaScriptCanOpenWindowsAutomatically is NO on iOS, and YES on macOS.
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView _evaluateJavaScriptWithoutUserGesture: @"window.open('http://www.example.com')" completionHandler:nil];
@@ -2104,8 +2104,8 @@ TEST(SOAuthorizationPopUp, InterceptionError)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     auto testHtml = generateOpenerHTML(openerTemplate, testURL.get().absoluteString);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
@@ -2141,12 +2141,12 @@ TEST(SOAuthorizationPopUp, InterceptionCancel)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     auto testHtml = generateOpenerHTML(openerTemplate, testURL.get().absoluteString);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"WindowClosed."]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"WindowClosed."]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
@@ -2193,7 +2193,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByItself)
     checkAuthorizationOptions(true, "file://"_s, 1);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto responseHtmlCString = generateHTML(newWindowResponseTemplate, "window.close();"_s).utf8();
     // The secret WKWebView needs to be destroyed right the way.
     @autoreleasepool {
@@ -2211,12 +2211,12 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByParent)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateOpenerHTML(openerTemplate, testURL.string(), emptyString(), "event.source.close();"_s); // The parent closes the pop up.
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"Hello.", @"WindowClosed."]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"Hello.", @"WindowClosed."]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
@@ -2231,7 +2231,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByParent)
     checkAuthorizationOptions(true, "file://"_s, 1);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto resonseHtmlCString = generateHTML(newWindowResponseTemplate, emptyString()).utf8();
     // The secret WKWebView needs to be destroyed right the way.
     @autoreleasepool {
@@ -2249,12 +2249,12 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByWebKit)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateOpenerHTML(openerTemplate, testURL.string());
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"Hello.", @"WindowClosed."]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"Hello.", @"WindowClosed."]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
@@ -2269,7 +2269,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByWebKit)
     checkAuthorizationOptions(true, "file://"_s, 1);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto resonseHtmlCString = generateHTML(newWindowResponseTemplate, emptyString()).utf8();
     // The secret WKWebView needs to be destroyed right the way.
     @autoreleasepool {
@@ -2287,8 +2287,8 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedWithOtherHttpStatusCode)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     auto testHtml = generateOpenerHTML(openerTemplate, testURL.get().absoluteString);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
@@ -2308,7 +2308,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedWithOtherHttpStatusCode)
     navigationCompleted = false;
     authorizationPerformed = false;
     policyForAppSSOPerformed = false;
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:400 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:400 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto resonseHtmlCString = generateHTML(newWindowResponseTemplate, emptyString()).utf8();
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:resonseHtmlCString.data() length:resonseHtmlCString.length()]).get()];
     Util::run(&newWindowCreated);
@@ -2328,12 +2328,12 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedWithCookie)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateOpenerHTML(openerTemplate, testURL.string());
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"Hello.", @"WindowClosed."]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"Hello.", @"WindowClosed."]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
@@ -2348,7 +2348,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedWithCookie)
     checkAuthorizationOptions(true, "file://"_s, 1);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;" }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;" }]);
     auto resonseHtmlCString = generateHTML(newWindowResponseTemplate, emptyString()).utf8();
     // The secret WKWebView needs to be destroyed right the way.
     @autoreleasepool {
@@ -2366,12 +2366,12 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedTwice)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateOpenerHTML(openerTemplate, testURL.string());
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
@@ -2391,7 +2391,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedTwice)
 
         [messageHandler resetExpectations:@[@"Hello.", @"WindowClosed."]];
 
-        auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+        RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
         auto resonseHtmlCString = generateHTML(newWindowResponseTemplate, emptyString()).utf8();
         // The secret WKWebView needs to be destroyed right the way.
         @autoreleasepool {
@@ -2410,8 +2410,8 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedSuppressActiveSession)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateOpenerHTML(openerTemplate, testURL.string());
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
@@ -2428,11 +2428,11 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedSuppressActiveSession)
 
     // Suppress the last active session.
 
-    auto configuration = adoptNS([webView.get().configuration copy]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"Hello.", @"WindowClosed."]]);
+    RetainPtr configuration = adoptNS([webView.get().configuration copy]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"Hello.", @"WindowClosed."]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto newWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr newWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
     configureSOAuthorizationWebView(newWebView.get(), delegate.get());
 
     navigationCompleted = false;
@@ -2458,7 +2458,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedSuppressActiveSession)
     }];
     Util::run(&navigationCompleted);
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto resonseHtmlCString = generateHTML(newWindowResponseTemplate, emptyString()).utf8();
     // The secret WKWebView needs to be destroyed right the way.
     @autoreleasepool {
@@ -2476,12 +2476,12 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedNewWindowNavigation)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateOpenerHTML(openerTemplate, testURL.string(), makeString("newWindow.location = '"_s, unsafeSpan(baseURL.get().absoluteString.UTF8String), "';"_s)); // Starts a new navigation on the new window.
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"Hello.", @"WindowClosed."]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"Hello.", @"WindowClosed."]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
@@ -2496,7 +2496,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedNewWindowNavigation)
     checkAuthorizationOptions(true, "file://"_s, 1);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto resonseHtmlCString = generateHTML(newWindowResponseTemplate, emptyString()).utf8();
     // The secret WKWebView needs to be destroyed right the way.
     @autoreleasepool {
@@ -2513,8 +2513,8 @@ TEST(SOAuthorizationPopUp, AuthorizationOptions)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateOpenerHTML(openerTemplate, testURL.string());
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:URL { "http://www.webkit.org"_str }.createNSURL().get()];
@@ -2538,8 +2538,8 @@ TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyIgnore)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateOpenerHTML(openerTemplate, testURL.string());
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
     [delegate setAllowSOAuthorizationLoad:false];
 
@@ -2565,12 +2565,12 @@ TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyAllowAsync)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateOpenerHTML(openerTemplate, testURL.string());
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"Hello.", @"WindowClosed."]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"Hello.", @"WindowClosed."]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
     [delegate setIsAsyncExecution:true];
 
@@ -2586,7 +2586,7 @@ TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyAllowAsync)
     checkAuthorizationOptions(true, "file://"_s, 1);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto resonseHtmlCString = generateHTML(newWindowResponseTemplate, "window.close();"_s).utf8(); // The pop up closes itself.
     // The secret WKWebView needs to be destroyed right the way.
     @autoreleasepool {
@@ -2604,8 +2604,8 @@ TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyIgnoreAsync)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateOpenerHTML(openerTemplate, testURL.string());
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
     [delegate setAllowSOAuthorizationLoad:false];
     [delegate setIsAsyncExecution:true];
@@ -2630,12 +2630,12 @@ TEST(SOAuthorizationSubFrame, NoInterceptions)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"GetSessionCookie" withExtension:@"html"];
     auto testHtml = generateHTML(parentTemplate, testURL.get().absoluteString);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@""]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@""]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
@@ -2650,8 +2650,8 @@ TEST(SOAuthorizationSubFrame, NoInterceptionsNonAppleFirstPartyMainFrame)
 
     auto testHtml = generateHTML(parentTemplate, URL { "http://www.example.com"_str }.string());
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:URL { "http://www.webkit.org"_str }.createNSURL().get()];
@@ -2698,12 +2698,12 @@ TEST(SOAuthorizationSubFrame, InterceptionError)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"GetSessionCookie" withExtension:@"html"];
     auto testHtml = generateHTML(parentTemplate, testURL.get().absoluteString);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[[NSNull null], @"SOAuthorizationDidStart"]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[[NSNull null], @"SOAuthorizationDidStart"]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
@@ -2730,12 +2730,12 @@ TEST(SOAuthorizationSubFrame, InterceptionCancel)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"GetSessionCookie" withExtension:@"html"];
     auto testHtml = generateHTML(parentTemplate, testURL.get().absoluteString);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[[NSNull null], @"SOAuthorizationDidStart"]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[[NSNull null], @"SOAuthorizationDidStart"]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
@@ -2761,12 +2761,12 @@ TEST(SOAuthorizationSubFrame, InterceptionSuccess)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateHTML(parentTemplate, testURL.string());
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"http://www.example.com", @"SOAuthorizationDidStart"]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"http://www.example.com", @"SOAuthorizationDidStart"]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:nil];
@@ -2777,7 +2777,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSuccess)
 
     [messageHandler extendExpectations:@[@"http://www.example.com", @"Hello."]];
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto iframeHtmlCString = generateHTML(iframeTemplate, emptyString()).utf8();
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
     Util::run(&allMessagesReceived);
@@ -2830,12 +2830,12 @@ TEST(SOAuthorizationSubFrame, InterceptionSucceedWithOtherHttpStatusCode)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"GetSessionCookie" withExtension:@"html"];
     auto testHtml = generateHTML(parentTemplate, testURL.get().absoluteString);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[[NSNull null], @"SOAuthorizationDidStart"]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[[NSNull null], @"SOAuthorizationDidStart"]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
@@ -2847,7 +2847,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSucceedWithOtherHttpStatusCode)
     [messageHandler extendExpectations:@[@"null", @"SOAuthorizationDidCancel", @""]];
 
     // Will fallback to web path.
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:400 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:400 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto iframeHtmlCString = generateHTML(iframeTemplate, emptyString()).utf8();
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
     Util::run(&allMessagesReceived);
@@ -2865,12 +2865,12 @@ TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookie)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateHTML(parentTemplate, testURL.string());
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"http://www.example.com", @"SOAuthorizationDidStart"]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"http://www.example.com", @"SOAuthorizationDidStart"]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:adoptNS([[NSURL alloc] initWithString:@"http://example.com"]).get()];
@@ -2880,7 +2880,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookie)
     EXPECT_TRUE(policyForAppSSOPerformed);
     [messageHandler extendExpectations:@[@"http://www.example.com", @"Hello.", @"http://www.example.com", @"Cookies: sessionid=38afes7a8"]];
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;" }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;" }]);
     auto iframeHtmlCString = generateHTML(iframeTemplate, "parent.postMessage('Cookies: ' + document.cookie, '*');"_s).utf8();
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
     Util::run(&allMessagesReceived);
@@ -2895,12 +2895,12 @@ TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookieButCSPDeny)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateHTML(parentTemplate, testURL.string());
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"http://www.example.com", @"SOAuthorizationDidStart"]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"http://www.example.com", @"SOAuthorizationDidStart"]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:nil];
@@ -2911,7 +2911,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookieButCSPDeny)
 
     [messageHandler extendExpectations:@[@"http://www.example.com", @"SOAuthorizationDidCancel"]];
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;", @"Content-Security-Policy" : @"frame-ancestors 'none';" }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;", @"Content-Security-Policy" : @"frame-ancestors 'none';" }]);
     auto iframeHtmlCString = generateHTML(iframeTemplate, "parent.postMessage('Cookies: ' + document.cookie, '*');"_s).utf8();
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
     Util::run(&allMessagesReceived);
@@ -2926,12 +2926,12 @@ TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookieButXFrameDeny)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateHTML(parentTemplate, testURL.string());
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"http://www.example.com", @"SOAuthorizationDidStart"]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"http://www.example.com", @"SOAuthorizationDidStart"]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:nil];
@@ -2942,7 +2942,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSucceedWithCookieButXFrameDeny)
 
     [messageHandler extendExpectations:@[@"http://www.example.com", @"SOAuthorizationDidCancel"]];
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;", @"X-Frame-Options" : @"DENY" }]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;", @"X-Frame-Options" : @"DENY" }]);
     auto iframeHtmlCString = generateHTML(iframeTemplate, "parent.postMessage('Cookies: ' + document.cookie, '*');"_s).utf8();
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
     Util::run(&allMessagesReceived);
@@ -2957,12 +2957,12 @@ TEST(SOAuthorizationSubFrame, InterceptionSuccessTwice)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateHTML(parentTemplate, testURL.string());
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     for (int i = 0; i < 2; i++) {
@@ -2980,7 +2980,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSuccessTwice)
 
         [messageHandler extendExpectations:@[@"http://www.example.com", @"Hello."]];
 
-        auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+        RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
         auto iframeHtmlCString = generateHTML(iframeTemplate, emptyString()).utf8();
         [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
         Util::run(&allMessagesReceived);
@@ -2996,12 +2996,12 @@ TEST(SOAuthorizationSubFrame, AuthorizationOptions)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateHTML(parentTemplate, testURL.string());
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"http://www.example.com", @"SOAuthorizationDidStart"]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"http://www.example.com", @"SOAuthorizationDidStart"]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:URL { "http://www.apple.com"_str }.createNSURL().get()];
@@ -3018,8 +3018,8 @@ TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyIgnore)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateHTML(parentTemplate, testURL.string());
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
     [delegate setAllowSOAuthorizationLoad:false];
 
@@ -3044,12 +3044,12 @@ TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyAllowAsync)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateHTML(parentTemplate, testURL.string());
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"http://www.example.com", @"SOAuthorizationDidStart"]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"http://www.example.com", @"SOAuthorizationDidStart"]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
     [delegate setIsAsyncExecution:true];
 
@@ -3061,7 +3061,7 @@ TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyAllowAsync)
 
     [messageHandler extendExpectations:@[@"http://www.example.com", @"Hello."]];
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto iframeHtmlCString = generateHTML(iframeTemplate, emptyString()).utf8();
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
     Util::run(&allMessagesReceived);
@@ -3075,8 +3075,8 @@ TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyIgnoreAsync)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateHTML(parentTemplate, testURL.string());
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
     [delegate setAllowSOAuthorizationLoad:false];
     [delegate setIsAsyncExecution:true];
@@ -3119,14 +3119,14 @@ TEST(SOAuthorizationSubFrame, InterceptionErrorWithReferrer)
             });
         });
     });
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto origin = makeString("http://127.0.0.1:"_s, server.port());
     RetainPtr nsOrigin = origin.createNSString();
 
     RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[nsOrigin.get(), @"SOAuthorizationDidStart", nsOrigin.get(), @"SOAuthorizationDidCancel", nsOrigin.get(), @"Hello.", nsOrigin.get(), makeString("Referrer: "_s, origin, '/').createNSString().get()]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView _loadRequest:adoptNS([[NSURLRequest alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:nsOrigin.get()]).get()]).get() shouldOpenExternalURLs:NO];
@@ -3148,12 +3148,12 @@ TEST(SOAuthorizationSubFrame, InterceptionErrorMessageOrder)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"GetSessionCookie" withExtension:@"html"];
     auto testHtml = generateHTML(parentTemplate, testURL.get().absoluteString);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[[NSNull null], @"SOAuthorizationDidStart", [NSNull null], @"SOAuthorizationDidCancel", @""]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[[NSNull null], @"SOAuthorizationDidStart", [NSNull null], @"SOAuthorizationDidCancel", @""]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:baseURL.get()];
@@ -3172,19 +3172,19 @@ TEST(SOAuthorizationSubFrame, InterceptionSuccessMessageOrder)
     URL testURL { "http://www.example.com"_str };
     auto testHtml = generateHTML(parentTemplate, testURL.string());
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[[NSNull null], @"SOAuthorizationDidStart", [NSNull null], @"Hello."]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[[NSNull null], @"SOAuthorizationDidStart", [NSNull null], @"Hello."]]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
     configureSOAuthorizationWebView(webView.get(), delegate.get());
 
     [webView loadHTMLString:testHtml.createNSString().get() baseURL:nil];
     Util::run(&authorizationPerformed);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto iframeHtmlCString = generateHTML(iframeTemplate, emptyString()).utf8();
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
     Util::run(&allMessagesReceived);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SafeBrowsing.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SafeBrowsing.mm
@@ -145,12 +145,12 @@ TEST(SafeBrowsing, Preference)
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [TestLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
     __block bool done = false;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().didStartProvisionalNavigation = ^(WKWebView *, WKNavigation *) {
         done = true;
     };
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     EXPECT_TRUE([webView configuration].preferences.fraudulentWebsiteWarningEnabled);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
     [webView setNavigationDelegate:delegate.get()];
@@ -169,8 +169,8 @@ static RetainPtr<WKWebView> safeBrowsingView()
 {
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [TestLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    static auto delegate = adoptNS([SafeBrowsingNavigationDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    static RetainPtr delegate = adoptNS([SafeBrowsingNavigationDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
@@ -222,15 +222,15 @@ TEST(SafeBrowsing, GoBack)
 
 TEST(SafeBrowsing, GoBackAfterRestoreFromSessionState)
 {
-    auto webView1 = adoptNS([WKWebView new]);
+    RetainPtr webView1 = adoptNS([WKWebView new]);
     [webView1 loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
     [webView1 _test_waitForDidFinishNavigation];
     _WKSessionState *state = [webView1 _sessionState];
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [TestLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto delegate = adoptNS([SafeBrowsingNavigationDelegate new]);
-    auto webView2 = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([SafeBrowsingNavigationDelegate new]);
+    RetainPtr webView2 = adoptNS([WKWebView new]);
     [webView2 configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
     [webView2 setNavigationDelegate:delegate.get()];
     [webView2 setUIDelegate:delegate.get()];
@@ -281,7 +281,7 @@ TEST(SafeBrowsing, ShowWarningSPI)
 {
     __block bool completionHandlerCalled = false;
     __block BOOL shouldContinueValue = NO;
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     auto showWarning = ^{
         completionHandlerCalled = false;
         [webView _showSafeBrowsingWarningWithURL:nil title:@"test title" warning:@"test warning" details:adoptNS([[NSAttributedString alloc] initWithString:@"test details"]).get() completionHandler:^(BOOL shouldContinue) {
@@ -324,11 +324,11 @@ TEST(SafeBrowsing, URLObservation)
 
     RetainPtr<NSURL> simpleURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     RetainPtr<NSURL> simple2URL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    auto observer = adoptNS([SafeBrowsingObserver new]);
+    RetainPtr observer = adoptNS([SafeBrowsingObserver new]);
 
     auto webViewWithWarning = [&] () -> RetainPtr<WKWebView> {
-        auto webView = adoptNS([WKWebView new]);
-        auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+        RetainPtr webView = adoptNS([WKWebView new]);
+        RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
         navigationDelegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^decisionHandler)(WKNavigationActionPolicy)) {
             TestWebKitAPI::Util::runFor(0.01_s);
             decisionHandler(WKNavigationActionPolicyAllow);
@@ -428,8 +428,8 @@ TEST(SafeBrowsing, WKWebViewGoBack)
     phishingResourceName = @"simple3";
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [SimpleLookupContext methodForSelector:@selector(sharedLookupContext)]);
     
-    auto delegate = adoptNS([WKWebViewGoBackNavigationDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([WKWebViewGoBackNavigationDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:resourceURL(@"simple")]];
@@ -453,8 +453,8 @@ TEST(SafeBrowsing, WKWebViewGoBackIFrame)
     phishingResourceName = @"simple";
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [SimpleLookupContext methodForSelector:@selector(sharedLookupContext)]);
     
-    auto delegate = adoptNS([TestNavigationDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView configuration].preferences._safeBrowsingEnabled = YES;
 
     __block bool navigationFailed = false;
@@ -497,7 +497,7 @@ TEST(SafeBrowsing, WKWebViewGoBackIFrame)
 TEST(SafeBrowsing, MissingFramework)
 {
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [NullLookupContext methodForSelector:@selector(sharedLookupContext)]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 }
 
@@ -511,9 +511,9 @@ TEST(SafeBrowsing, HangTimeout)
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     navigationFinished = false;
     [webView setNavigationDelegate:delegate.get()];
@@ -532,9 +532,9 @@ TEST(SafeBrowsing, PostResponse)
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     navigationFinished = false;
     [webView setNavigationDelegate:delegate.get()];
@@ -549,8 +549,8 @@ TEST(SafeBrowsing, PostResponseIframe)
     DelayedLookupContext.delayDuration = 25_ms;
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView configuration].preferences._safeBrowsingEnabled = YES;
 
     __block bool navigationFailed = false;
@@ -580,18 +580,18 @@ TEST(SafeBrowsing, PreresponseSafeBrowsingWarning)
 {
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [TestLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
-    auto handler = adoptNS([[TestURLSchemeHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"sb"];
     configuration.get().preferences.fraudulentWebsiteWarningEnabled = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:delegate.get()];
 
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         RunLoop::mainSingleton().dispatchAfter(1000_s, [task = retainPtr(task)] {
-            auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.get().request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+            RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.get().request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
             [task didReceiveResponse:response.get()];
             [task didReceiveData:[NSData dataWithBytes:mainResource length:strlen(mainResource)]];
             [task didFinish];
@@ -615,9 +615,9 @@ TEST(SafeBrowsing, PostResponseServerSideRedirect)
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     navigationFinished = false;
     [webView setNavigationDelegate:delegate.get()];
@@ -639,9 +639,9 @@ TEST(SafeBrowsing, MultipleRedirectsFirstPhishing)
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [SimpleLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     navigationFinished = false;
     [webView setNavigationDelegate:delegate.get()];
@@ -663,9 +663,9 @@ TEST(SafeBrowsing, MultipleRedirectsMiddlePhishing)
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [SimpleLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     navigationFinished = false;
     [webView setNavigationDelegate:delegate.get()];
@@ -687,9 +687,9 @@ TEST(SafeBrowsing, MultipleRedirectsLastPhishing)
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [SimpleLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     navigationFinished = false;
     [webView setNavigationDelegate:delegate.get()];
@@ -709,9 +709,9 @@ TEST(SafeBrowsing, PostResponseInjectedBundleSkipsDecidePolicyForResponse)
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     navigationFinished = false;
     [webView setNavigationDelegate:delegate.get()];
@@ -731,9 +731,9 @@ TEST(SafeBrowsing, PostTimeout)
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:delegate.get()];
 
@@ -749,8 +749,8 @@ TEST(SafeBrowsing, PhishingInFrame)
     phishingResourceName = @"simple";
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [SimpleLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     auto configuration = webView.get().configuration;
     auto preferences = configuration.preferences;
     preferences._safeBrowsingEnabled = YES;
@@ -791,8 +791,8 @@ TEST(SafeBrowsing, ModalShownImmediatelyWhenNoCheck)
     phishingResourceName = @"phishing";
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [SimpleLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto delegate = adoptNS([ModalDeferralDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([ModalDeferralDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView configuration].preferences._safeBrowsingEnabled = YES;
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
@@ -818,14 +818,14 @@ TEST(SafeBrowsing, ModalDeferredDuringCheck)
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:delegate.get()];
 
-    auto modalDelegate = adoptNS([ModalDeferralDelegate new]);
+    RetainPtr modalDelegate = adoptNS([ModalDeferralDelegate new]);
     [webView setUIDelegate:modalDelegate.get()];
 
     committedNavigation = false;
@@ -858,10 +858,10 @@ TEST(SafeBrowsing, DeferredModalShownWhenProceedingThroughWarning)
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
 
-    auto modalDelegate = adoptNS([ModalDeferralDelegate new]);
+    RetainPtr modalDelegate = adoptNS([ModalDeferralDelegate new]);
     __block bool alertCalled = false;
     __block RetainPtr<NSString> alertMessage;
     modalDelegate.get().onAlert = ^(NSString *message) {
@@ -870,7 +870,7 @@ TEST(SafeBrowsing, DeferredModalShownWhenProceedingThroughWarning)
     };
     [webView setUIDelegate:modalDelegate.get()];
 
-    auto navDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navDelegate = adoptNS([TestNavigationDelegate new]);
     [navDelegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:navDelegate.get()];
 
@@ -902,17 +902,17 @@ TEST(SafeBrowsing, DeferredModalSuppressedWhenGoingBack)
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
 
-    auto modalDelegate = adoptNS([ModalDeferralDelegate new]);
+    RetainPtr modalDelegate = adoptNS([ModalDeferralDelegate new]);
     __block bool alertCalled = false;
     modalDelegate.get().onAlert = ^(NSString *message) {
         alertCalled = true;
     };
     [webView setUIDelegate:modalDelegate.get()];
 
-    auto navDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navDelegate = adoptNS([TestNavigationDelegate new]);
     [navDelegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:navDelegate.get()];
 
@@ -947,17 +947,17 @@ TEST(SafeBrowsing, MultipleDeferredModalsShownInOrder)
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
 
-    auto modalDelegate = adoptNS([ModalDeferralDelegate new]);
+    RetainPtr modalDelegate = adoptNS([ModalDeferralDelegate new]);
     __block Vector<String> modalMessages;
     modalDelegate.get().onAlert = ^(NSString *message) {
         modalMessages.append(String(message));
     };
     [webView setUIDelegate:modalDelegate.get()];
 
-    auto navDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navDelegate = adoptNS([TestNavigationDelegate new]);
     [navDelegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:navDelegate.get()];
 
@@ -994,17 +994,17 @@ TEST(SafeBrowsing, DeferredModalsClearedOnNavigation)
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
 
-    auto modalDelegate = adoptNS([ModalDeferralDelegate new]);
+    RetainPtr modalDelegate = adoptNS([ModalDeferralDelegate new]);
     __block bool alertCalled = false;
     modalDelegate.get().onAlert = ^(NSString *message) {
         alertCalled = true;
     };
     [webView setUIDelegate:modalDelegate.get()];
 
-    auto navDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navDelegate = adoptNS([TestNavigationDelegate new]);
     [navDelegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:navDelegate.get()];
 
@@ -1033,13 +1033,13 @@ TEST(SafeBrowsing, ModalShownWhenCheckCompletesClean)
     phishingResourceName = @"different-url";
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [SimpleLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto delegate = adoptNS([ModalDeferralDelegate new]);
+    RetainPtr delegate = adoptNS([ModalDeferralDelegate new]);
     __block bool alertCalled = false;
     delegate.get().onAlert = ^(NSString *message) {
         alertCalled = true;
     };
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView configuration].preferences._safeBrowsingEnabled = YES;
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
@@ -1064,10 +1064,10 @@ TEST(SafeBrowsing, AllModalTypesProperlyDeferred)
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
 
-    auto modalDelegate = adoptNS([ModalDeferralDelegate new]);
+    RetainPtr modalDelegate = adoptNS([ModalDeferralDelegate new]);
     __block Vector<String> modalTypes;
     modalDelegate.get().onAlert = ^(NSString *message) {
         modalTypes.append("alert"_s);
@@ -1082,7 +1082,7 @@ TEST(SafeBrowsing, AllModalTypesProperlyDeferred)
     };
     [webView setUIDelegate:modalDelegate.get()];
 
-    auto navDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navDelegate = adoptNS([TestNavigationDelegate new]);
     [navDelegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:navDelegate.get()];
 
@@ -1114,15 +1114,15 @@ TEST(SafeBrowsing, NavigationFromWarningPage)
     phishingResourceName = @"phishing";
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [SimpleLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto delegate = adoptNS([SafeBrowsingNavigationDelegate new]);
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([SafeBrowsingNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
 
-    auto handler = adoptNS([[TestURLSchemeHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"sb"];
     configuration.get().preferences.fraudulentWebsiteWarningEnabled = YES;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [webView setUIDelegate:delegate.get()];
 
@@ -1135,7 +1135,7 @@ TEST(SafeBrowsing, NavigationFromWarningPage)
             html = @"<html><body>Safe page</body></html>";
         else
             html = @"<html><body>Unknown</body></html>";
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:html.length textEncodingName:@"utf-8"]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:html.length textEncodingName:@"utf-8"]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[html dataUsingEncoding:NSUTF8StringEncoding]];
         [task didFinish];
@@ -1162,15 +1162,15 @@ TEST(SafeBrowsing, SetTimeoutNavigationFromWarningPage)
     phishingResourceName = @"phishing";
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [SimpleLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto delegate = adoptNS([SafeBrowsingNavigationDelegate new]);
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([SafeBrowsingNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
 
-    auto handler = adoptNS([[TestURLSchemeHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"sb"];
     configuration.get().preferences.fraudulentWebsiteWarningEnabled = YES;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [webView setUIDelegate:delegate.get()];
 
@@ -1183,7 +1183,7 @@ TEST(SafeBrowsing, SetTimeoutNavigationFromWarningPage)
             html = @"<html><body>Safe page</body></html>";
         else
             html = @"<html><body>Unknown</body></html>";
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:html.length textEncodingName:@"utf-8"]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:html.length textEncodingName:@"utf-8"]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[html dataUsingEncoding:NSUTF8StringEncoding]];
         [task didFinish];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SampledPageTopColor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SampledPageTopColor.mm
@@ -95,7 +95,7 @@ namespace TestWebKitAPI {
 
 static RetainPtr<TestWKWebView> createWebViewWithSampledPageTopColorMaxDifference(double sampledPageTopColorMaxDifference, double sampledPageTopColorMinHeight = 0)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setSampledPageTopColorMaxDifference:sampledPageTopColorMaxDifference];
     [configuration _setSampledPageTopColorMinHeight:sampledPageTopColorMinHeight];
 
@@ -105,7 +105,7 @@ static RetainPtr<TestWKWebView> createWebViewWithSampledPageTopColorMaxDifferenc
 static void waitForSampledPageTopColorToChange(TestWKWebView *webView, Function<void()>&& trigger = nullptr)
 {
     bool done = false;
-    auto sampledPageTopColorObserver = adoptNS([[TestKVOWrapper alloc] initWithObservable:webView keyPath:@"_sampledPageTopColor" callback:[&] {
+    RetainPtr sampledPageTopColorObserver = adoptNS([[TestKVOWrapper alloc] initWithObservable:webView keyPath:@"_sampledPageTopColor" callback:[&] {
         done = true;
     }]);
 
@@ -454,7 +454,7 @@ TEST(SampledPageTopColor, MainDocumentChange)
     EXPECT_NULL([webView _sampledPageTopColor]);
 
     size_t notificationCount = 0;
-    auto sampledPageTopColorObserver = adoptNS([[TestKVOWrapper alloc] initWithObservable:webView.get() keyPath:@"_sampledPageTopColor" callback:[&] {
+    RetainPtr sampledPageTopColorObserver = adoptNS([[TestKVOWrapper alloc] initWithObservable:webView.get() keyPath:@"_sampledPageTopColor" callback:[&] {
         ++notificationCount;
     }]);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SchemeRegistry.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SchemeRegistry.mm
@@ -71,7 +71,7 @@ static RetainPtr<NSURL> lastEchoedURL;
     lastEchoedURL = requestURL;
 
     NSData *data = [requestURL.absoluteString dataUsingEncoding:NSASCIIStringEncoding];
-    auto response = adoptNS([[NSURLResponse alloc] initWithURL:self.request.URL MIMEType:@"text/html" expectedContentLength:[data length] textEncodingName:nil]);
+    RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:self.request.URL MIMEType:@"text/html" expectedContentLength:[data length] textEncodingName:nil]);
     [self.client URLProtocol:self didReceiveResponse:response.get() cacheStoragePolicy:NSURLCacheStorageNotAllowed];
     [self.client URLProtocol:self didLoadData:data];
     [self.client URLProtocolDidFinishLoading:self];
@@ -112,13 +112,13 @@ TEST(WebKit, RegisterAsCanDisplayOnlyIfCanRequest_SameOriginLoad)
         [NSURLProtocol registerClass:[EchoURLProtocol class]];
         [WKBrowsingContextController registerSchemeForCustomProtocol:echoScheme];
 
-        auto processPool = adoptNS([[WKProcessPool alloc] init]);
+        RetainPtr processPool = adoptNS([[WKProcessPool alloc] init]);
         [processPool _registerURLSchemeAsCanDisplayOnlyIfCanRequest:echoScheme];
 
-        auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
         [webViewConfiguration setProcessPool:processPool.get()];
 
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:webViewConfiguration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:webViewConfiguration.get()]);
 
         NSString *htmlString = @"<!DOCTYPE html><body><script src='echo://A/A_1'></script>";
         [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"echo://A"]];
@@ -137,13 +137,13 @@ TEST(WebKit, RegisterAsCanDisplayOnlyIfCanRequest_CrossOriginLoad)
         [NSURLProtocol registerClass:[EchoURLProtocol class]];
         [WKBrowsingContextController registerSchemeForCustomProtocol:echoScheme];
 
-        auto processPool = adoptNS([[WKProcessPool alloc] init]);
+        RetainPtr processPool = adoptNS([[WKProcessPool alloc] init]);
         [processPool _registerURLSchemeAsCanDisplayOnlyIfCanRequest:echoScheme];
 
-        auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
         [webViewConfiguration setProcessPool:processPool.get()];
 
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:webViewConfiguration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:webViewConfiguration.get()]);
 
         NSString *htmlString = @"<!DOCTYPE html><body><script src='echo://A/A_1'></script>";
         [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"echo://B"]];
@@ -162,7 +162,7 @@ TEST(WebKit, LoadAlternateHTMLStringAllowsFirstPartyForCookies)
         [NSURLProtocol registerClass:[EchoURLProtocol class]];
         [WKBrowsingContextController registerSchemeForCustomProtocol:echoScheme];
 
-        auto webView = adoptNS([WKWebView new]);
+        RetainPtr webView = adoptNS([WKWebView new]);
 
         NSString *htmlString = @"<link rel=stylesheet type='text/css' href='echo://base/page-load-errors.css'>";
         [webView _loadAlternateHTMLString:htmlString baseURL:[NSURL URLWithString:@"echo://base/"] forUnreachableURL:[NSURL URLWithString:@"echo://unreachable/"]];
@@ -186,7 +186,7 @@ TEST(WebKit, WKContextRegisterURLSchemeAsCanDisplayOnlyIfCanRequest_SameOriginLo
         WKContextRegisterURLSchemeAsCanDisplayOnlyIfCanRequest(context.get(), Util::toWK(echoScheme.UTF8String).get());
 
         PlatformWebView webView { context.get() };
-        auto loadDelegate = adoptNS([[WKContextRegisterURLSchemeAsCanDisplayOnlyIfCanRequestLoadDelegate alloc] init]);
+        RetainPtr loadDelegate = adoptNS([[WKContextRegisterURLSchemeAsCanDisplayOnlyIfCanRequestLoadDelegate alloc] init]);
         webView.platformView().navigationDelegate = loadDelegate.get();
         [webView.platformView() loadHTMLString:@"<!DOCTYPE html><body><script src='echo://A/A_1'></script>" baseURL:[NSURL URLWithString:@"echo://A"]];
         Util::run(&didFinishLoad);
@@ -210,7 +210,7 @@ TEST(WebKit, WKContextRegisterURLSchemeAsCanDisplayOnlyIfCanRequest_CrossOriginL
         WKContextRegisterURLSchemeAsCanDisplayOnlyIfCanRequest(context.get(), Util::toWK(echoScheme.UTF8String).get());
 
         PlatformWebView webView { context.get() };
-        auto loadDelegate = adoptNS([[WKContextRegisterURLSchemeAsCanDisplayOnlyIfCanRequestLoadDelegate alloc] init]);
+        RetainPtr loadDelegate = adoptNS([[WKContextRegisterURLSchemeAsCanDisplayOnlyIfCanRequestLoadDelegate alloc] init]);
         webView.platformView().navigationDelegate = loadDelegate.get();
         [webView.platformView() loadHTMLString:@"<!DOCTYPE html><body><script src='echo://A/A_1'></script>" baseURL:[NSURL URLWithString:@"echo://B"]];
         Util::run(&didFinishLoad);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ScreenTime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ScreenTime.mm
@@ -321,7 +321,7 @@ TEST(ScreenTime, IsBlockedByScreenTimeKVO)
     __block bool childRestrictionsDone = false;
 
     RetainPtr webView = webViewForScreenTimeTests();
-    auto observer = adoptNS([[BlockedStateObserver alloc] initWithWebView:webView.get()]);
+    RetainPtr observer = adoptNS([[BlockedStateObserver alloc] initWithWebView:webView.get()]);
 
     RetainPtr request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://webkit.org"]];
     auto swizzle = swizzleEnforcesChildRestrictions(childRestrictionsDone);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ScreenWakeLock.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ScreenWakeLock.mm
@@ -172,7 +172,7 @@ void ScreenWakeLockTests::setUpCrossSite()
 
 void ScreenWakeLockTests::setUpSameSite()
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     m_webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
     [m_webView synchronouslyLoadHTMLString:@"<body></body>"];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ScriptTrackingPrivacyTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ScriptTrackingPrivacyTests.mm
@@ -1021,13 +1021,13 @@ TEST(ScriptTrackingPrivacyTests, BlockSubsequentFetch)
         }
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(server.port())
     }];
 
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
 
     RetainPtr webView = setUpWebViewForFingerprintingTests(@"http://top-domain.org/index.html", dataStore.get());
 
@@ -1126,13 +1126,13 @@ TEST(ScriptTrackingPrivacyTests, BlockSubsequentElement)
         }
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(server.port())
     }];
 
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
 
     RetainPtr webView = setUpWebViewForFingerprintingTests(@"http://top-domain.org/index.html", dataStore.get());
 
@@ -1203,13 +1203,13 @@ TEST(ScriptTrackingPrivacyTests, BlockSubsequent2Element)
         }
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(server.port())
     }];
 
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
 
     RetainPtr webView = setUpWebViewForFingerprintingTests(@"http://top-domain.org/index.html", dataStore.get());
 
@@ -1281,13 +1281,13 @@ TEST(ScriptTrackingPrivacyTests, SameSiteFetchNotBlocked)
         }
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(server.port())
     }];
 
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
 
     RetainPtr webView = setUpWebViewForFingerprintingTests(@"http://tainted.example/index.html", dataStore.get());
 
@@ -1333,13 +1333,13 @@ TEST(ScriptTrackingPrivacyTests, MainFrameNavigationNotBlocked)
         }
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(server.port())
     }];
 
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
 
     RetainPtr webView = setUpWebViewForFingerprintingTests(@"http://top-domain.org/index.html", dataStore.get());
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
@@ -534,9 +534,9 @@ enum class ShouldRunServiceWorkersOnMainThread : bool { No, Yes };
 
 static void setViewDataStore(WKWebViewConfiguration* viewConfiguration, ShouldRunServiceWorkersOnMainThread shouldRunServiceWorkersOnMainThread)
 {
-    auto storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     [storeConfiguration setShouldRunServiceWorkersOnMainThreadForTesting:shouldRunServiceWorkersOnMainThread == ShouldRunServiceWorkersOnMainThread::Yes];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
     [viewConfiguration setWebsiteDataStore:dataStore.get()];
 }
 
@@ -549,10 +549,10 @@ static void runBasicSWTest(ShouldRunServiceWorkersOnMainThread shouldRunServiceW
 
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     setViewDataStore(configuration.get(), shouldRunServiceWorkersOnMainThread);
 
-    auto messageHandler = adoptNS([[SWMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     // Start with a clean slate data store
@@ -562,7 +562,7 @@ static void runBasicSWTest(ShouldRunServiceWorkersOnMainThread shouldRunServiceW
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView loadRequest:server.request()];
 
@@ -609,7 +609,7 @@ TEST(ServiceWorkers, BasicWithMainThreadSW)
 
 - (void)_webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction preferences:(WKWebpagePreferences *)preferences userInfo:(id <NSSecureCoding>)userInfo decisionHandler:(void (^)(WKNavigationActionPolicy, WKWebpagePreferences *))decisionHandler
 {
-    auto websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
+    RetainPtr websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
     if (navigationAction.targetFrame.mainFrame)
         [websitePolicies _setCustomUserAgent:_userAgent];
 
@@ -660,9 +660,9 @@ TEST(ServiceWorkers, UserAgentOverride)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto messageHandler = adoptNS([[SWUserAgentMessageHandler alloc] initWithExpectedMessage:@"Message from worker: Foo Custom UserAgent"]);
+    RetainPtr messageHandler = adoptNS([[SWUserAgentMessageHandler alloc] initWithExpectedMessage:@"Message from worker: Foo Custom UserAgent"]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server({
@@ -670,9 +670,9 @@ TEST(ServiceWorkers, UserAgentOverride)
         { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, userAgentSWBytes } },
     });
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[SWCustomUserAgentDelegate alloc] initWithUserAgent:@"Foo Custom UserAgent"]);
+    RetainPtr delegate = adoptNS([[SWCustomUserAgentDelegate alloc] initWithUserAgent:@"Foo Custom UserAgent"]);
     [webView setNavigationDelegate:delegate.get()];
 
     [webView loadRequest:server.request()];
@@ -713,7 +713,7 @@ TEST(ServiceWorkers, RestoreFromDisk)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     RetainPtr<SWMessageHandlerForRestoreFromDiskTest> messageHandler = adoptNS([[SWMessageHandlerForRestoreFromDiskTest alloc] initWithExpectedMessage:@"PASS: Registration was successful and service worker was activated"]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
@@ -774,7 +774,7 @@ TEST(ServiceWorkers, UpdateCheckAfterRestoreFromDisk)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     RetainPtr<SWMessageHandlerForRestoreFromDiskTest> messageHandler = adoptNS([[SWMessageHandlerForRestoreFromDiskTest alloc] initWithExpectedMessage:@"PASS: Registration was successful and service worker was activated"]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
@@ -898,10 +898,10 @@ TEST(ServiceWorkers, ThirdPartyRestoredFromDisk)
 
     // Normally, service workers get terminated several seconds after their clients are gone.
     // Disable this delay for the purpose of testing.
-    auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [dataStoreConfiguration setServiceWorkerProcessTerminationDelayEnabled:NO];
 
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
 
     // Start with a clean slate data store
     [dataStore removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
@@ -910,7 +910,7 @@ TEST(ServiceWorkers, ThirdPartyRestoredFromDisk)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = dataStore.get();
 
     RetainPtr<SWMessageHandlerForRestoreFromDiskTest> messageHandler = adoptNS([[SWMessageHandlerForRestoreFromDiskTest alloc] initWithExpectedMessage:@"LOADED"]);
@@ -999,12 +999,12 @@ TEST(ServiceWorkers, CacheStorageRestoreFromDisk)
         { "/"_s, { mainCacheStorageBytes } }
     });
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[SWMessageHandlerForRestoreFromDiskTest alloc] initWithExpectedMessage:@"No cache storage data"]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWMessageHandlerForRestoreFromDiskTest alloc] initWithExpectedMessage:@"No cache storage data"]);
 
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView loadRequest:server.request()];
 
@@ -1049,7 +1049,7 @@ TEST(ServiceWorkers, FetchAfterRestoreFromDisk)
         { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptHandlingFetchBytes } },
     });
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView loadRequest:server.request()];
 
@@ -1135,7 +1135,7 @@ TEST(ServiceWorkers, MainThreadSWInterceptsLoad)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto messageHandler = adoptNS([[SWMessageHandlerWithExpectedMessage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWMessageHandlerWithExpectedMessage alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server({
@@ -1143,7 +1143,7 @@ TEST(ServiceWorkers, MainThreadSWInterceptsLoad)
         { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptInterceptingFirstLoadBytes } },
     });
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     expectedMessage = "Service Worker activated"_s;
     [webView loadRequest:server.request("/main.html"_s)];
@@ -1219,7 +1219,7 @@ TEST(ServiceWorkers, WaitForPolicyDelegate)
     done = false;
 
     webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestSWAsyncNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestSWAsyncNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
 
@@ -1513,9 +1513,9 @@ TEST(ServiceWorkers, CacheStorageInPrivateBrowsingMode)
 {
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto messageHandler = adoptNS([[SWMessageHandlerForCacheStorage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWMessageHandlerForCacheStorage alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server({
@@ -1525,7 +1525,7 @@ TEST(ServiceWorkers, CacheStorageInPrivateBrowsingMode)
 
     configuration.get().websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:server.request("/first.html"_s)];
     TestWebKitAPI::Util::run(&done);
     done = false;
@@ -1582,7 +1582,7 @@ TEST(ServiceWorkers, ServiceWorkerCacheAccessEphemeralSession)
     TestWebKitAPI::Util::run(&done);
     done = false;
     
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     [configuration setProcessPool:(WKProcessPool *)context.get()];
@@ -1595,7 +1595,7 @@ TEST(ServiceWorkers, ServiceWorkerCacheAccessEphemeralSession)
         { "/serviceworker-private-browsing-worker.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerCacheAccessEphemeralSessionSWBytes } },
     });
 
-    auto defaultWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr defaultWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [defaultWebView synchronouslyLoadHTMLString:@"foo" baseURL:server.request().URL];
 
     bool openedCache = false;
@@ -1606,10 +1606,10 @@ TEST(ServiceWorkers, ServiceWorkerCacheAccessEphemeralSession)
 
     configuration.get().websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
 
-    auto messageHandler = adoptNS([[SWMessageHandlerForCacheStorage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWMessageHandlerForCacheStorage alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
-    auto ephemeralWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr ephemeralWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [ephemeralWebView loadRequest:server.request()];
     TestWebKitAPI::Util::run(&done);
@@ -1665,10 +1665,10 @@ TEST(ServiceWorkers, DifferentSessionsUseDifferentRegistrations)
     TestWebKitAPI::Util::run(&done);
     done = false;
     
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     setConfigurationInjectedBundlePath(configuration.get());
     
-    auto messageHandler = adoptNS([[SWMessageHandlerForCacheStorage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWMessageHandlerForCacheStorage alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
     
     TestWebKitAPI::HTTPServer server({
@@ -1678,7 +1678,7 @@ TEST(ServiceWorkers, DifferentSessionsUseDifferentRegistrations)
         { "/third.html"_s, { privatePageMainBytes } },
     });
 
-    auto defaultWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr defaultWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [defaultWebView synchronouslyLoadRequest:server.request("/first.html"_s)];
 
     TestWebKitAPI::Util::run(&done);
@@ -1690,7 +1690,7 @@ TEST(ServiceWorkers, DifferentSessionsUseDifferentRegistrations)
     done = false;
 
     configuration.get().websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
-    auto ephemeralWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr ephemeralWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [ephemeralWebView synchronouslyLoadRequest:server.request("/third.html"_s)];
 
     TestWebKitAPI::Util::run(&done);
@@ -1723,7 +1723,7 @@ TEST(ServiceWorkers, ServiceWorkerAndCacheStorageDefaultDirectories)
 {
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     setConfigurationInjectedBundlePath(configuration.get());
 
     RetainPtr<DirectoryPageMessageHandler> directoryPageMessageHandler = adoptNS([[DirectoryPageMessageHandler alloc] init]);
@@ -1765,13 +1765,13 @@ TEST(ServiceWorkers, ServiceWorkerAndCacheStorageSpecificDirectories)
 {
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     setConfigurationInjectedBundlePath(configuration.get());
-    auto dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     NSString* tempDirectory = @"/var/tmp";
     [dataStoreConfiguration _setServiceWorkerRegistrationDirectory:[NSURL fileURLWithPath:tempDirectory]];
     [dataStoreConfiguration _setCacheStorageDirectory:[NSURL fileURLWithPath:tempDirectory]];
-    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
     [configuration setWebsiteDataStore:websiteDataStore.get()];
 
     RetainPtr<DirectoryPageMessageHandler> directoryPageMessageHandler = adoptNS([[DirectoryPageMessageHandler alloc] init]);
@@ -1880,10 +1880,10 @@ TEST(ServiceWorkers, ProcessPerSite)
 
     // Normally, service workers get terminated several seconds after their clients are gone.
     // Disable this delay for the purpose of testing.
-    auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [dataStoreConfiguration setServiceWorkerProcessTerminationDelayEnabled:NO];
 
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
     
     // Start with a clean slate data store
     [dataStore removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
@@ -1969,9 +1969,9 @@ TEST(ServiceWorkers, ParallelProcessLaunch)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto messageHandler = adoptNS([[SWMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server1({
@@ -1985,9 +1985,9 @@ TEST(ServiceWorkers, ParallelProcessLaunch)
 
     auto *processPool = configuration.get().processPool;
 
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView1 loadRequest:server1.request()];
     [webView2 loadRequest:server2.requestWithLocalhost()];
@@ -2006,9 +2006,9 @@ static size_t launchServiceWorkerProcess(bool useSeparateServiceWorkerProcess, b
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto messageHandler = adoptNS([[SWMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server({
@@ -2019,9 +2019,9 @@ static size_t launchServiceWorkerProcess(bool useSeparateServiceWorkerProcess, b
     auto *processPool = configuration.get().processPool;
     [processPool _setUseSeparateServiceWorkerProcess: useSeparateServiceWorkerProcess];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
         didFinishNavigationBoolean = true;
     }];
@@ -2204,9 +2204,9 @@ void testSuspendServiceWorkerProcessBasedOnClientProcesses(UseSeparateServiceWor
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto messageHandler = adoptNS([[SWMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server({
@@ -2217,14 +2217,14 @@ void testSuspendServiceWorkerProcessBasedOnClientProcesses(UseSeparateServiceWor
     auto *processPool = configuration.get().processPool;
     [processPool _setUseSeparateServiceWorkerProcess:(useSeparateServiceWorkerProcess == UseSeparateServiceWorkerProcess::Yes)];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView loadRequest:server.request()];
     [webView _test_waitForDidFinishNavigation];
 
     EXPECT_TRUE(waitUntilEvaluatesToTrue([&] { return [processPool _serviceWorkerProcessCount] == 1; }));
 
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView2 loadRequest:server.request()];
     [webView2 _test_waitForDidFinishNavigation];
 
@@ -2327,7 +2327,7 @@ TEST(ServiceWorkers, SuspendAndTerminateWorker)
     });
 
     auto *processPool = configuration.get().processPool;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     expectedMessage = "Message from worker: ServiceWorker received: Hello from the web page"_s;
     [webView loadRequest:server.request()];
@@ -2393,19 +2393,19 @@ TEST(ServiceWorkers, ThrottleCrash)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto messageHandler = adoptNS([[SWMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWMessageHandler alloc] init]);
 
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { mainBytes } },
         { "/sw.js"_s, { {{ "Content-Type"_s, "application/javascript"_s }}, scriptBytes } },
     });
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
         didFinishNavigationBoolean = true;
     }];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 #if PLATFORM(MAC)
     [[configuration preferences] _setAppNapEnabled:YES];
 #endif
@@ -2413,7 +2413,7 @@ TEST(ServiceWorkers, ThrottleCrash)
 
     auto *processPool = configuration.get().processPool;
 
-    auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow: YES]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow: YES]);
     [webView1 setNavigationDelegate:navigationDelegate.get()];
 
     // Let's make it so that webView1 be app nappable after loading is completed.
@@ -2429,7 +2429,7 @@ TEST(ServiceWorkers, ThrottleCrash)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto webView2Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView2Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 #if PLATFORM(MAC)
     [[webView2Configuration preferences] _setAppNapEnabled:NO];
 #endif
@@ -2439,7 +2439,7 @@ TEST(ServiceWorkers, ThrottleCrash)
     webView2Configuration.get()._relatedWebView = webView1.get();
     ALLOW_DEPRECATED_DECLARATIONS_END
 
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView2Configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView2Configuration.get()]);
     [webView2 setNavigationDelegate:navigationDelegate.get()];
 
     [webView2 loadRequest:server.request()];
@@ -2471,7 +2471,7 @@ TEST(ServiceWorkers, LoadData)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[TestSWAsyncNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestSWAsyncNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
 
@@ -2511,17 +2511,17 @@ TEST(ServiceWorkers, RestoreFromDiskNonDefaultStore)
     });
 
     @autoreleasepool {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-        auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+        RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
         websiteDataStoreConfiguration.get()._serviceWorkerRegistrationDirectory = swDBPath;
-        auto nonDefaultDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+        RetainPtr nonDefaultDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
         configuration.get().websiteDataStore = nonDefaultDataStore.get();
 
-        auto messageHandler = adoptNS([[SWMessageHandlerForRestoreFromDiskTest alloc] initWithExpectedMessage:@"PASS: Registration was successful and service worker was activated"]);
+        RetainPtr messageHandler = adoptNS([[SWMessageHandlerForRestoreFromDiskTest alloc] initWithExpectedMessage:@"PASS: Registration was successful and service worker was activated"]);
         [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         protectedProcessPool = webView.get().configuration.processPool;
         protectedWebsiteDataStore = webView.get().configuration.websiteDataStore;
 
@@ -2539,14 +2539,14 @@ TEST(ServiceWorkers, RestoreFromDiskNonDefaultStore)
     TestWebKitAPI::Util::spinRunLoop(10);
 
     @autoreleasepool {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
         configuration.get().websiteDataStore = protectedWebsiteDataStore.get();
 
-        auto messageHandler = adoptNS([[SWMessageHandlerForRestoreFromDiskTest alloc] initWithExpectedMessage:@"PASS: Registration already has an active worker"]);
+        RetainPtr messageHandler = adoptNS([[SWMessageHandlerForRestoreFromDiskTest alloc] initWithExpectedMessage:@"PASS: Registration already has an active worker"]);
         [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
         [webView loadRequest:server.request("/second.html"_s)];
 
@@ -2560,9 +2560,9 @@ TEST(ServiceWorkers, SuspendNetworkProcess)
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
     // Start with a clean slate data store
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelBasic;
-    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
     [websiteDataStore.get() removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
         done = true;
     }];
@@ -2582,7 +2582,7 @@ TEST(ServiceWorkers, SuspendNetworkProcess)
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[TestSWAsyncNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestSWAsyncNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
 
@@ -2631,12 +2631,12 @@ TEST(WebKit, ServiceWorkerDatabaseWithRecordsTableButUnexpectedSchema)
     [[NSFileManager defaultManager] createDirectoryAtURL:swPath withIntermediateDirectories:YES attributes:nil error:nil];
     [[NSFileManager defaultManager] copyItemAtURL:url1 toURL:[swPath URLByAppendingPathComponent:serviceWorkerRegistrationFilename] error:nil];
 
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get()._serviceWorkerRegistrationDirectory = swPath;
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
 
     // Fetch SW records
-    auto websiteDataTypes = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeServiceWorkerRegistrations]]);
+    RetainPtr websiteDataTypes = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeServiceWorkerRegistrations]]);
     static bool readyToContinue;
     [dataStore fetchDataRecordsOfTypes:websiteDataTypes.get() completionHandler:^(NSArray<WKWebsiteDataRecord *> *dataRecords) {
         EXPECT_EQ(0U, dataRecords.count);
@@ -2675,12 +2675,12 @@ TEST(ServiceWorkers, V2DatabaseUpgrade)
     NSURL *scriptPath = [NSURL fileURLWithPath:[@"~/Library/Caches/com.apple.WebKit.TestWebKitAPI/WebKit/ServiceWorkers/Scripts/V1/xPAvXL4WjRQdGV0mpfwak2b5_1GqLUx4U9UZRpYn2Jw/wc4tzUMAvirBHXPD6rEkc5sG5oyRXMuxJl04TscgvKI/bNUYH4V9T2WYLnx37jHP2cE6FjNkL078xwiNeE465Bs" stringByExpandingTildeInPath]];
     [[NSFileManager defaultManager] copyItemAtURL:saltResource toURL:scriptPath error:nil];
 
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get()._serviceWorkerRegistrationDirectory = swPath;
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
 
     // Fetch SW records
-    auto websiteDataTypes = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeServiceWorkerRegistrations]]);
+    RetainPtr websiteDataTypes = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeServiceWorkerRegistrations]]);
     static bool readyToContinue;
     [dataStore fetchDataRecordsOfTypes:websiteDataTypes.get() completionHandler:^(NSArray<WKWebsiteDataRecord *> *dataRecords) {
         EXPECT_EQ(1U, dataRecords.count);
@@ -2701,9 +2701,9 @@ TEST(ServiceWorkers, ProcessPerSession)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto messageHandler = adoptNS([[SWMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server1({
@@ -2713,7 +2713,7 @@ TEST(ServiceWorkers, ProcessPerSession)
 
     WKProcessPool *processPool = configuration.get().processPool;
 
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView1 loadRequest:server1.request()];
     TestWebKitAPI::Util::run(&done);
     done = false;
@@ -2727,7 +2727,7 @@ TEST(ServiceWorkers, ProcessPerSession)
         { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
     });
 
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView2 loadRequest:server2.requestWithLocalhost()];
     TestWebKitAPI::Util::run(&done);
     done = false;
@@ -2769,9 +2769,9 @@ TEST(ServiceWorkers, ContentRuleList)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto messageHandler = adoptNS([[SWMessageHandlerWithExpectedMessage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWMessageHandlerWithExpectedMessage alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
     [[configuration userContentController] addContentRuleList:contentRuleList.get()];
 
@@ -2793,7 +2793,7 @@ TEST(ServiceWorkers, ContentRuleList)
 
     expectedMessage = @"Message from worker: PASS - blocked first request, allowed second";
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
     TestWebKitAPI::Util::run(&done);
     
@@ -2886,9 +2886,9 @@ static void runTest(ResponseType responseType)
         { "/fetched.html"_s, { "<script>alert('fetched from server')</script>"_s } },
     }, HTTPServer::Protocol::Https);
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate setDidReceiveAuthenticationChallenge:^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^callback)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
         callback(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
@@ -2947,15 +2947,15 @@ TEST(ServiceWorkers, ChangeOfServerCertificate)
     "</script>"_s;
     static constexpr auto js = ""_s;
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate setDidReceiveAuthenticationChallenge:^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^callback)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
         callback(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
     }];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     webView1.get().navigationDelegate = delegate.get();
     webView2.get().navigationDelegate = delegate.get();
@@ -3000,9 +3000,9 @@ TEST(ServiceWorkers, ClearDOMCacheAlsoIncludesServiceWorkerRegistrations)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto messageHandler = adoptNS([[SWMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server({
@@ -3010,13 +3010,13 @@ TEST(ServiceWorkers, ClearDOMCacheAlsoIncludesServiceWorkerRegistrations)
         { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
     });
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:server.request()];
     TestWebKitAPI::Util::run(&done);
     done = false;
 
     // Fetch SW records
-    auto websiteDataTypes = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeServiceWorkerRegistrations]]);
+    RetainPtr websiteDataTypes = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeServiceWorkerRegistrations]]);
     static bool readyToContinue;
     [[WKWebsiteDataStore defaultDataStore] fetchDataRecordsOfTypes:websiteDataTypes.get() completionHandler:^(NSArray<WKWebsiteDataRecord *> *dataRecords) {
         EXPECT_EQ(1U, dataRecords.count);
@@ -3026,7 +3026,7 @@ TEST(ServiceWorkers, ClearDOMCacheAlsoIncludesServiceWorkerRegistrations)
     readyToContinue = false;
 
     // Clear DOM Cache
-    auto typesToRemove = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeFetchCache]]);
+    RetainPtr typesToRemove = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeFetchCache]]);
     [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:typesToRemove.get() modifiedSince:[NSDate distantPast] completionHandler:^() {
         done = true;
     }];
@@ -3050,15 +3050,15 @@ TEST(ServiceWorkers, CustomDataStorePathsVersusCompletionHandlers)
 
     [[NSFileManager defaultManager] createDirectoryAtURL:swPath withIntermediateDirectories:YES attributes:nil error:nil];
 
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelBasic;
     websiteDataStoreConfiguration.get()._serviceWorkerRegistrationDirectory = swPath;
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:dataStore.get()];
 
-    auto messageHandler = adoptNS([[SWMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server({
@@ -3066,7 +3066,7 @@ TEST(ServiceWorkers, CustomDataStorePathsVersusCompletionHandlers)
         { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
     });
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:server.request()];
     TestWebKitAPI::Util::run(&done);
     done = false;
@@ -3077,7 +3077,7 @@ TEST(ServiceWorkers, CustomDataStorePathsVersusCompletionHandlers)
     EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:[swPath URLByAppendingPathComponent:serviceWorkerRegistrationFilename].path]);
 
     // Fetch SW records
-    auto websiteDataTypes = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeServiceWorkerRegistrations]]);
+    RetainPtr websiteDataTypes = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeServiceWorkerRegistrations]]);
     static bool readyToContinue;
     [dataStore fetchDataRecordsOfTypes:websiteDataTypes.get() completionHandler:^(NSArray<WKWebsiteDataRecord *> *dataRecords) {
         EXPECT_EQ(1U, dataRecords.count);
@@ -3125,16 +3125,16 @@ TEST(ServiceWorkers, WebProcessCache)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().processSwapsOnNavigation = YES;
     processPoolConfiguration.get().usesWebProcessCache = YES;
     processPoolConfiguration.get().prewarmsProcessesAutomatically = YES;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setProcessPool:processPool.get()];
 
-    auto messageHandler = adoptNS([[SWMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     static constexpr auto main =
@@ -3168,12 +3168,12 @@ TEST(ServiceWorkers, WebProcessCache)
     });
 
     // Create a first web view and load a page
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView1 loadRequest:server.request()];
     EXPECT_WK_STREQ([webView1 _test_waitForAlert], "loaded");
 
     // Create a second web view and load a page
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView2 loadRequest:server.request()];
     EXPECT_WK_STREQ([webView2 _test_waitForAlert], "loaded");
 
@@ -3237,7 +3237,7 @@ static bool didStartURLSchemeTaskForImportedScript = false;
     else
         [headerDictionary setObject:@"text/html" forKey:@"Content-Type"];
     [headerDictionary setObject:@"1" forKey:@"Content-Length"];
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:finalURL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:headerDictionary]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:finalURL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:headerDictionary]);
     [task didReceiveResponse:response.get()];
 
     if (RetainPtr data = _dataMappings.get([finalURL absoluteString]))
@@ -3281,7 +3281,7 @@ TEST(ServiceWorker, ExtensionServiceWorker)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto schemeHandler = adoptNS([ServiceWorkerSchemeHandler new]);
+    RetainPtr schemeHandler = adoptNS([ServiceWorkerSchemeHandler new]);
     [schemeHandler addMappingFromURLString:@"sw-ext://ABC/other.html" toData:"foo"];
     [schemeHandler addMappingFromURLString:@"sw-ext://ABC/sw.js" toData:"importScripts('sw-ext://ABC/importedScript.js');"];
     [schemeHandler addMappingFromURLString:@"sw-ext://ABC/bar.xml" toData:"bar"];
@@ -3289,10 +3289,10 @@ TEST(ServiceWorker, ExtensionServiceWorker)
 
     WKWebViewConfiguration *webViewConfiguration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"ServiceWorkerPagePlugIn"];
 
-    auto otherViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr otherViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     otherViewConfiguration.get().processPool = webViewConfiguration.processPool;
     [otherViewConfiguration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"sw-ext"];
-    auto otherWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:otherViewConfiguration.get()]);
+    RetainPtr otherWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:otherViewConfiguration.get()]);
     [otherWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"sw-ext://ABC/other.html"]]];
     [otherWebView _test_waitForDidFinishNavigation];
 
@@ -3303,9 +3303,9 @@ TEST(ServiceWorker, ExtensionServiceWorker)
     webViewConfiguration._relatedWebView = otherWebView.get();
     ALLOW_DEPRECATED_DECLARATIONS_END
     [webViewConfiguration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"sw-ext"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
 
-    auto object = adoptNS([[ServiceWorkerPageRemoteObject alloc] init]);
+    RetainPtr object = adoptNS([[ServiceWorkerPageRemoteObject alloc] init]);
     _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(ServiceWorkerPageProtocol)];
     [[webView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface];
 
@@ -3388,7 +3388,7 @@ TEST(ServiceWorker, ExtensionServiceWorkerDisableCORS)
 
     auto testJS = makeString("fetch('http://127.0.0.1:"_s, server.port(), "/bar.xml', { headers: { 'Custom-Header': 'CustomHeaderValue' } });"_s);
 
-    auto schemeHandler = adoptNS([ServiceWorkerSchemeHandler new]);
+    RetainPtr schemeHandler = adoptNS([ServiceWorkerSchemeHandler new]);
     [schemeHandler addMappingFromURLString:@"sw-ext://ABC/sw.js" toData:testJS.utf8().data()];
 
     WKWebViewConfiguration *webViewConfiguration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"ServiceWorkerPagePlugIn"];
@@ -3402,7 +3402,7 @@ TEST(ServiceWorker, ExtensionServiceWorkerDisableCORS)
     [[webViewConfiguration userContentController] _addScriptMessageHandler:handler.get() name:@"testHandler" contentWorld:world.get()];
     [[webViewConfiguration userContentController] addUserScript:userScript.get()];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
     // The service worker script should get loaded over the custom scheme handler.
     done = false;
     didStartURLSchemeTask = false;
@@ -3432,7 +3432,7 @@ TEST(ServiceWorker, ExtensionServiceWorkerWithModules)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto schemeHandler = adoptNS([ServiceWorkerSchemeHandler new]);
+    RetainPtr schemeHandler = adoptNS([ServiceWorkerSchemeHandler new]);
 
     [schemeHandler addMappingFromURLString:@"sw-ext://ABC/exports.js" toData:"const x = 805; export { x };"];
     [schemeHandler addMappingFromURLString:@"sw-ext://ABC/sw.js" toData:"import { x } from './exports.js'; x;"];
@@ -3440,9 +3440,9 @@ TEST(ServiceWorker, ExtensionServiceWorkerWithModules)
     WKWebViewConfiguration *webViewConfiguration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"ServiceWorkerPagePlugIn"];
     webViewConfiguration.websiteDataStore = [adoptNS([WKWebViewConfiguration new]) websiteDataStore];
     [webViewConfiguration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"sw-ext"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
 
-    auto object = adoptNS([[ServiceWorkerPageRemoteObject alloc] init]);
+    RetainPtr object = adoptNS([[ServiceWorkerPageRemoteObject alloc] init]);
     _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(ServiceWorkerPageProtocol)];
     [[webView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface];
 
@@ -3468,14 +3468,14 @@ TEST(ServiceWorker, ExtensionServiceWorkerFailureBadScript)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto schemeHandler = adoptNS([ServiceWorkerSchemeHandler new]);
+    RetainPtr schemeHandler = adoptNS([ServiceWorkerSchemeHandler new]);
     [schemeHandler addMappingFromURLString:@"sw-ext://ABC/bad-sw.js" toData:"1 = 1;"];
 
     WKWebViewConfiguration *webViewConfiguration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"ServiceWorkerPagePlugIn"];
     [webViewConfiguration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"sw-ext"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
 
-    auto object = adoptNS([[ServiceWorkerPageRemoteObject alloc] init]);
+    RetainPtr object = adoptNS([[ServiceWorkerPageRemoteObject alloc] init]);
     _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(ServiceWorkerPageProtocol)];
     [[webView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface];
 
@@ -3502,9 +3502,9 @@ TEST(ServiceWorker, ExtensionServiceWorkerFailureBadURL)
     done = false;
 
     WKWebViewConfiguration *webViewConfiguration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"ServiceWorkerPagePlugIn"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
 
-    auto object = adoptNS([[ServiceWorkerPageRemoteObject alloc] init]);
+    RetainPtr object = adoptNS([[ServiceWorkerPageRemoteObject alloc] init]);
     _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(ServiceWorkerPageProtocol)];
     [[webView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface];
 
@@ -3528,9 +3528,9 @@ TEST(ServiceWorker, ExtensionServiceWorkerFailureViewClosed)
     done = false;
 
     WKWebViewConfiguration *webViewConfiguration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"ServiceWorkerPagePlugIn"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
 
-    auto object = adoptNS([[ServiceWorkerPageRemoteObject alloc] init]);
+    RetainPtr object = adoptNS([[ServiceWorkerPageRemoteObject alloc] init]);
     _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(ServiceWorkerPageProtocol)];
     [[webView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface];
 
@@ -3555,9 +3555,9 @@ TEST(ServiceWorker, ExtensionServiceWorkerFailureViewDestroyed)
 
     @autoreleasepool {
         WKWebViewConfiguration *webViewConfiguration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"ServiceWorkerPagePlugIn"];
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
 
-        auto object = adoptNS([[ServiceWorkerPageRemoteObject alloc] init]);
+        RetainPtr object = adoptNS([[ServiceWorkerPageRemoteObject alloc] init]);
         _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(ServiceWorkerPageProtocol)];
         [[webView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface];
 
@@ -3615,12 +3615,12 @@ TEST(ServiceWorker, RemovalOfSameRegistrableDomainButDifferentOrigin)
         { "/sw.js"_s, { {{ "Content-Type"_s, "application/javascript"_s }}, "onfetch = () => { };"_s } }
     });
 
-    auto mainViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr mainViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [mainViewConfiguration.get().processPool _setUseSeparateServiceWorkerProcess: true];
     [mainViewConfiguration.get().preferences _setSecureContextChecksEnabled:NO];
 
     // Load main page which will register the service worker in another process.
-    auto mainWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:mainViewConfiguration.get()]);
+    RetainPtr mainWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:mainViewConfiguration.get()]);
     [mainWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://a.amazon.com:%d/main.html", server.port()]]]];
     EXPECT_WK_STREQ([mainWebView _test_waitForAlert], "successfully registered");
 
@@ -3630,7 +3630,7 @@ TEST(ServiceWorker, RemovalOfSameRegistrableDomainButDifferentOrigin)
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     mainViewConfiguration.get()._relatedWebView = mainWebView.get();
     ALLOW_DEPRECATED_DECLARATIONS_END
-    auto otherWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:mainViewConfiguration.get()]);
+    RetainPtr otherWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:mainViewConfiguration.get()]);
     [otherWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://b.amazon.com:%d/other.html", server.port()]]]];
     EXPECT_WK_STREQ([otherWebView _test_waitForAlert], "loaded");
 
@@ -3715,20 +3715,20 @@ TEST(ServiceWorkers, CacheStorageNetworkProcessCrash)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
 
     auto defaultPreferences = [configuration preferences];
     [defaultPreferences _setSecureContextChecksEnabled:NO];
 
-    auto messageHandler = adoptNS([[SWMessageHandlerForCacheStorage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWMessageHandlerForCacheStorage alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { cacheStorageNetworkProcessCrashMainBytes } }
     });
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     // Create cache1
     [webView loadRequest:server.request()];
@@ -3810,7 +3810,7 @@ TEST(ServiceWorker, ServiceWorkerWindowClientFocus)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto preferences = [configuration preferences];
 
     for (_WKFeature *feature in [WKPreferences _features]) {
@@ -3818,11 +3818,11 @@ TEST(ServiceWorker, ServiceWorkerWindowClientFocus)
             [preferences _setEnabled:NO forFeature:feature];
     }
 
-    auto messageHandler = adoptNS([[SWMessageHandlerWithExpectedMessage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWMessageHandlerWithExpectedMessage alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
-    auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { ServiceWorkerWindowClientFocusMain } },
@@ -3897,7 +3897,7 @@ TEST(ServiceWorker, ServiceWorkerWindowClientFocusRequiresUserGesture)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto preferences = [configuration preferences];
 
     for (_WKFeature *feature in [WKPreferences _features]) {
@@ -3905,10 +3905,10 @@ TEST(ServiceWorker, ServiceWorkerWindowClientFocusRequiresUserGesture)
             [preferences _setEnabled:YES forFeature:feature];
     }
 
-    auto messageHandler = adoptNS([[SWMessageHandlerWithExpectedMessage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWMessageHandlerWithExpectedMessage alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { ServiceWorkerWindowClientFocusMain } },
@@ -3978,7 +3978,7 @@ TEST(ServiceWorker, openWindowWithoutDelegate)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto preferences = [configuration preferences];
 
     for (_WKFeature *feature in [WKPreferences _features]) {
@@ -3986,10 +3986,10 @@ TEST(ServiceWorker, openWindowWithoutDelegate)
             [preferences _setEnabled:NO forFeature:feature];
     }
 
-    auto messageHandler = adoptNS([[SWMessageHandlerWithExpectedMessage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWMessageHandlerWithExpectedMessage alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { ServiceWorkerWindowClientOpenWindowMain } },
@@ -4126,7 +4126,7 @@ TEST(ServiceWorker, WindowClientNavigate)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"CrossOriginOpenerPolicyEnabled"])
             [[configuration preferences] _setEnabled:YES forFeature:feature];
@@ -4134,8 +4134,8 @@ TEST(ServiceWorker, WindowClientNavigate)
             [[configuration preferences] _setEnabled:YES forFeature:feature];
     }
 
-    auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { ServiceWorkerWindowClientNavigateMain } },
@@ -4151,7 +4151,7 @@ TEST(ServiceWorker, WindowClientNavigate)
     [webView2 loadRequest:server.request()];
     EXPECT_WK_STREQ([webView2 _test_waitForAlert], "already active");
 
-    auto navigationDelegate = adoptNS([[ServiceWorkerPSONNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[ServiceWorkerPSONNavigationDelegate alloc] init]);
     [webView2 setNavigationDelegate:navigationDelegate.get()];
 
     auto *baseURL = [[server.request() URL] absoluteString];
@@ -4196,10 +4196,10 @@ TEST(ServiceWorker, WindowClientNavigateCrossOrigin)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     TestWebKitAPI::HTTPServer server1({
         { "/"_s, { ServiceWorkerWindowClientNavigateMain } },
@@ -4260,7 +4260,7 @@ TEST(ServiceWorker, OpenWindowWebsiteDataStoreDelegate)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     auto preferences = [configuration preferences];
     for (_WKFeature *feature in [WKPreferences _features]) {
@@ -4268,10 +4268,10 @@ TEST(ServiceWorker, OpenWindowWebsiteDataStoreDelegate)
             [preferences _setEnabled:NO forFeature:feature];
     }
 
-    auto dataStoreDelegate = adoptNS([[ServiceWorkerOpenWindowWebsiteDataStoreDelegate alloc] initWithConfiguration:configuration.get()]);
+    RetainPtr dataStoreDelegate = adoptNS([[ServiceWorkerOpenWindowWebsiteDataStoreDelegate alloc] initWithConfiguration:configuration.get()]);
     [[configuration websiteDataStore] set_delegate:dataStoreDelegate.get()];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { ServiceWorkerWindowClientNavigateMain } },
@@ -4311,7 +4311,7 @@ TEST(ServiceWorker, OpenWindowCOOP)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     auto preferences = [configuration preferences];
     for (_WKFeature *feature in [WKPreferences _features]) {
@@ -4319,10 +4319,10 @@ TEST(ServiceWorker, OpenWindowCOOP)
             [preferences _setEnabled:NO forFeature:feature];
     }
 
-    auto dataStoreDelegate = adoptNS([[ServiceWorkerOpenWindowWebsiteDataStoreDelegate alloc] initWithConfiguration:configuration.get()]);
+    RetainPtr dataStoreDelegate = adoptNS([[ServiceWorkerOpenWindowWebsiteDataStoreDelegate alloc] initWithConfiguration:configuration.get()]);
     [[configuration websiteDataStore] set_delegate:dataStoreDelegate.get()];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { ServiceWorkerWindowClientNavigateMain } },
@@ -4433,7 +4433,7 @@ TEST(ServiceWorker, FocusNotYetLoadedClient)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     auto preferences = [configuration preferences];
     for (_WKFeature *feature in [WKPreferences _features]) {
@@ -4441,7 +4441,7 @@ TEST(ServiceWorker, FocusNotYetLoadedClient)
             [preferences _setEnabled:NO forFeature:feature];
     }
 
-    auto dataStoreDelegate = adoptNS([[ServiceWorkerOpenWindowWebsiteDataStoreDelegate alloc] initWithConfiguration:configuration.get()]);
+    RetainPtr dataStoreDelegate = adoptNS([[ServiceWorkerOpenWindowWebsiteDataStoreDelegate alloc] initWithConfiguration:configuration.get()]);
     [[configuration websiteDataStore] set_delegate:dataStoreDelegate.get()];
 
     TestWebKitAPI::HTTPServer server(TestWebKitAPI::HTTPServer::UseCoroutines::Yes, [&](auto connection) -> TestWebKitAPI::ConnectionTask {
@@ -4468,11 +4468,11 @@ TEST(ServiceWorker, FocusNotYetLoadedClient)
         }
     });
 
-    auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     [webView1 loadRequest:server.request()];
     EXPECT_WK_STREQ([webView1 _test_waitForAlert], "successfully registered");
 
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     [webView2 loadRequest:server.request("/delayed-client"_s)];
     EXPECT_WK_STREQ([webView2 _test_waitForAlert], "PASS");
 
@@ -4568,20 +4568,20 @@ TEST(ServiceWorkers, ServiceWorkerStorageTiming)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto messageHandler = adoptNS([[SWMessageHandlerWithExpectedMessage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWMessageHandlerWithExpectedMessage alloc] init]);
 
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Cache-Control"_s, "no-cache"_s } }, serviceWorkerStorageTimingMainBytes } },
         { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerStorageTimingScriptBytesV1 } },
     });
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     setConfigurationInjectedBundlePath(configuration.get());
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     done = false;
     expectedMessage = "Message from worker: V1"_s;
-    auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow: YES]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow: YES]);
     [webView1 loadRequest:server.request()];
     TestWebKitAPI::Util::run(&done);
 
@@ -4592,7 +4592,7 @@ TEST(ServiceWorkers, ServiceWorkerStorageTiming)
 
     done = false;
     expectedMessage = "Message from worker: V1"_s;
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView2 loadRequest:server.request()];
     TestWebKitAPI::Util::run(&done);
 
@@ -4608,7 +4608,7 @@ TEST(ServiceWorkers, ServiceWorkerStorageTiming)
 
     done = false;
     expectedMessage = "Message from worker: V2"_s;
-    auto webView3 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView3 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView3 loadRequest:server.request()];
     TestWebKitAPI::Util::run(&done);
 }
@@ -4665,11 +4665,11 @@ TEST(ServiceWorker, ServiceWorkerProcessSwapWithNoDelay)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [dataStoreConfiguration setServiceWorkerProcessTerminationDelayEnabled:NO];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     setConfigurationInjectedBundlePath(configuration.get());
     configuration.get().websiteDataStore = dataStore.get();
 
@@ -4680,11 +4680,11 @@ TEST(ServiceWorker, ServiceWorkerProcessSwapWithNoDelay)
             [[configuration preferences] _setEnabled:YES forFeature:feature];
     }
 
-    auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     size_t responsePolicyCount { 0 };
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     navigationDelegate.get().decidePolicyForNavigationResponse = makeBlockPtr([&](WKNavigationResponse *, void (^completionHandler)(WKNavigationResponsePolicy)) {
         ++responsePolicyCount;
         completionHandler(WKNavigationResponsePolicyAllow);
@@ -4800,7 +4800,7 @@ TEST(ServiceWorkers, ServiceWorkerCacheReference)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     [configuration setProcessPool:(WKProcessPool *)context.get()];
@@ -4814,7 +4814,7 @@ TEST(ServiceWorkers, ServiceWorkerCacheReference)
             [defaultPreferences _setEnabled:NO forFeature:feature];
     }
 
-    auto messageHandler = adoptNS([[SWMessageHandlerForCacheStorage alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SWMessageHandlerForCacheStorage alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     TestWebKitAPI::HTTPServer server({
@@ -4822,7 +4822,7 @@ TEST(ServiceWorkers, ServiceWorkerCacheReference)
         { "/clear"_s, { "<script>webkit.messageHandlers.sw.postMessage('PASS');</script>"_s } },
     });
 
-    auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView1 loadRequest:server.request("#fill"_s)];
     TestWebKitAPI::Util::run(&done);
@@ -4830,7 +4830,7 @@ TEST(ServiceWorkers, ServiceWorkerCacheReference)
 
     [webView1 _close];
 
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView2 loadRequest:server.request("#check"_s)];
     TestWebKitAPI::Util::run(&done);
@@ -4942,15 +4942,15 @@ TEST(ServiceWorker, ServiceWorkerIdleOnMemoryPressure)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [dataStoreConfiguration setServiceWorkerProcessTerminationDelayEnabled:NO];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     setConfigurationInjectedBundlePath(configuration.get());
     configuration.get().websiteDataStore = dataStore.get();
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { ServiceWorkerIdleOnMemoryPressureMain } },
@@ -5082,17 +5082,17 @@ TEST(ServiceWorker, ServiceWorkerReadableStreamDownloadCancel)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [dataStoreConfiguration setServiceWorkerProcessTerminationDelayEnabled:NO];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     setConfigurationInjectedBundlePath(configuration.get());
     configuration.get().websiteDataStore = dataStore.get();
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     TestWebKitAPI::HTTPServer server({
@@ -5103,7 +5103,7 @@ TEST(ServiceWorker, ServiceWorkerReadableStreamDownloadCancel)
     [webView loadRequest:server.request()];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "Ready");
 
-    auto navigationDownloadDelegate = adoptNS([TestDownloadDelegate new]);
+    RetainPtr navigationDownloadDelegate = adoptNS([TestDownloadDelegate new]);
     [webView setNavigationDelegate:navigationDownloadDelegate.get()];
 
     navigationDownloadDelegate.get().navigationResponseDidBecomeDownload = ^(WKWebView *, WKNavigationResponse *, WKDownload *download) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerModuleUnregisterDuringLoad.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerModuleUnregisterDuringLoad.mm
@@ -55,8 +55,8 @@ TEST(ServiceWorkers, ModuleUnregisterDuringLoadNoMainThreadCrash)
 
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
-    auto storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
 
     // Start with a clean slate data store.
     __block bool cleanDone = false;
@@ -65,10 +65,10 @@ TEST(ServiceWorkers, ModuleUnregisterDuringLoadNoMainThreadCrash)
     }];
     TestWebKitAPI::Util::run(&cleanDone);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:dataStore.get()];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     // Use _loadServiceWorker:usingModules: to exercise the production code path
     // (used by Web Extensions / Safari) where the service worker runs on the main

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SessionStorage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SessionStorage.mm
@@ -40,14 +40,14 @@ static void runSessionStorageInNewWindowTest(NSString* createWindowJS, ShouldSes
 {
     __block RetainPtr<TestWKWebView> openedWebView;
 
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
         openedWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
         [openedWebView setUIDelegate:uiDelegate.get()];
         return openedWebView.get();
     };
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView setUIDelegate:uiDelegate.get()];
     [webView configuration].preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
@@ -121,11 +121,11 @@ TEST(SessionStorage, NonBlankLinkTargetRelNoopenerDoesNotCloneSession)
 
 TEST(SessionStorage, ClearByModificationTime)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:@"<script>sessionStorage.setItem('key', 'value')</script>" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
 
-    auto websiteDataTypes = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeSessionStorage]]);
+    RetainPtr websiteDataTypes = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeSessionStorage]]);
     readyToContinue = false;
     [[WKWebsiteDataStore defaultDataStore] fetchDataRecordsOfTypes:websiteDataTypes.get() completionHandler:^(NSArray<WKWebsiteDataRecord *> *dataRecords) {
         EXPECT_EQ(1u, dataRecords.count);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ShouldGoToBackForwardListItem.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ShouldGoToBackForwardListItem.mm
@@ -54,8 +54,8 @@ namespace TestWebKitAPI {
 
 TEST(WebKit, ShouldGoToBackForwardListItem)
 {
-    auto delegate = adoptNS([BackForwardClient new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([BackForwardClient new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ShouldOpenAppLinks.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ShouldOpenAppLinks.mm
@@ -68,8 +68,8 @@ static TestWebKitAPI::HTTPServer shouldOpenAppLinksTestServer()
 
 TEST(ShouldOpenAppLinks, DisallowAppLinksWhenReloadingAfterWebProcessCrash)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    auto delegate = adoptNS([ShouldOpenAppLinksTestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr delegate = adoptNS([ShouldOpenAppLinksTestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     auto server = shouldOpenAppLinksTestServer();
@@ -87,8 +87,8 @@ TEST(ShouldOpenAppLinks, DisallowAppLinksWhenReloadingAfterWebProcessCrash)
 
 TEST(ShouldOpenAppLinks, DisallowAppLinksWhenReloadingAfterWebProcessCrashAfterFollowingLink)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    auto delegate = adoptNS([ShouldOpenAppLinksTestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr delegate = adoptNS([ShouldOpenAppLinksTestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     auto server = shouldOpenAppLinksTestServer();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ShouldOpenExternalURLsInNewWindowActions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ShouldOpenExternalURLsInNewWindowActions.mm
@@ -71,12 +71,12 @@ static RetainPtr<WKWebView> newWebView;
 
 TEST(WebKit, ShouldOpenExternalURLsInWindowOpen)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
     [[window contentView] addSubview:webView.get()];
 
-    auto controller = adoptNS([[ShouldOpenExternalURLsInNewWindowActionsController alloc] init]);
+    RetainPtr controller = adoptNS([[ShouldOpenExternalURLsInNewWindowActionsController alloc] init]);
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
@@ -132,12 +132,12 @@ TEST(WebKit, ShouldOpenExternalURLsInWindowOpen)
 
 TEST(WebKit, ShouldOpenExternalURLsInTargetedLink)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
     [[window contentView] addSubview:webView.get()];
 
-    auto controller = adoptNS([[ShouldOpenExternalURLsInNewWindowActionsController alloc] init]);
+    RetainPtr controller = adoptNS([[ShouldOpenExternalURLsInNewWindowActionsController alloc] init]);
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
@@ -209,10 +209,10 @@ TEST(WebKit, ShouldOpenExternalURLsInTargetedLink)
 
 TEST(WebKit, RestoreShouldOpenExternalURLsPolicyAfterCrash)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
     [[window contentView] addSubview:webView.get()];
-    auto controller = adoptNS([[ShouldOpenExternalURLsInNewWindowActionsController alloc] init]);
+    RetainPtr controller = adoptNS([[ShouldOpenExternalURLsInNewWindowActionsController alloc] init]);
     [webView setNavigationDelegate:controller.get()];
     [webView setUIDelegate:controller.get()];
 
@@ -271,8 +271,8 @@ function clicked() {
 
 TEST(WebKit, IFrameWithSameOriginAsMainFramePropagates)
 {
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"custom"];
 
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
@@ -284,14 +284,14 @@ TEST(WebKit, IFrameWithSameOriginAsMainFramePropagates)
         else if ([[task request].URL.absoluteString containsString:@"mainframe.html"])
             responseText = [NSString stringWithUTF8String:mainFrameBytes];
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:requestURL MIMEType:@"text/html" expectedContentLength:[responseText length] textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:requestURL MIMEType:@"text/html" expectedContentLength:[responseText length] textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[responseText dataUsingEncoding:NSUTF8StringEncoding]];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"custom://firsthost/mainframe.html"]]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -265,11 +265,11 @@ static void enableSiteIsolation(WKWebViewConfiguration *configuration)
 
 static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestNavigationDelegate>> siteIsolatedViewAndDelegate(RetainPtr<WKWebViewConfiguration> configuration, CGRect rect, bool enable)
 {
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     if (enable)
         enableSiteIsolation(configuration.get());
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:rect configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:rect configuration:configuration.get()]);
     webView.get().navigationDelegate = navigationDelegate.get();
     return { WTF::move(webView), WTF::move(navigationDelegate) };
 }
@@ -299,24 +299,24 @@ static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestNavigationDelegate>> si
     [dataStoreConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
     [dataStoreConfiguration setAdditionalDomainsWithUserInteractionForTesting:domainsWithUserInteraction];
 
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
     [dataStore _setResourceLoadStatisticsEnabled:YES];
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
     if (enableProcessCache == EnableProcessCache::Yes) {
-        auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+        RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
         processPoolConfiguration.get().usesWebProcessCache = YES;
         processPoolConfiguration.get().prewarmsProcessesAutomatically = YES;
-        auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+        RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
         [configuration setProcessPool:processPool.get()];
     }
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     enableSiteIsolation(configuration.get());
     enableFeature(configuration.get(), @"SiteIsolationSharedProcessEnabled");
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     webView.get().navigationDelegate = navigationDelegate.get();
     return { WTF::move(webView), WTF::move(navigationDelegate) };
 }
@@ -534,7 +534,7 @@ TEST(SiteIsolation, LoadingCallbacksAndPostMessage)
     }).get();
 
     __block RetainPtr<NSString> alert;
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().runJavaScriptAlertPanelWithMessage = ^(WKWebView *, NSString *message, WKFrameInfo *, void (^completionHandler)(void)) {
         alert = message;
         completionHandler();
@@ -684,7 +684,7 @@ TEST(SiteIsolation, BasicPostMessageWindowOpen)
     __block RetainPtr<WKWebView> openerWebView;
     __block RetainPtr<WKWebView> openedWebView;
 
-    auto openerNavigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr openerNavigationDelegate = adoptNS([TestNavigationDelegate new]);
     [openerNavigationDelegate allowAnyTLSCertificate];
     openerNavigationDelegate.get().didFinishNavigation = ^(WKWebView *opener, WKNavigation *navigation) {
         EXPECT_WK_STREQ(navigation._request.URL.absoluteString, "https://example.com/example");
@@ -692,7 +692,7 @@ TEST(SiteIsolation, BasicPostMessageWindowOpen)
         openerFinishedLoading = true;
     };
 
-    __block auto openedNavigationDelegate = adoptNS([TestNavigationDelegate new]);
+    __block RetainPtr openedNavigationDelegate = adoptNS([TestNavigationDelegate new]);
     [openedNavigationDelegate allowAnyTLSCertificate];
     openedNavigationDelegate.get().didFinishNavigation = ^(WKWebView *, WKNavigation *navigation) {
         EXPECT_WK_STREQ(navigation._request.URL.absoluteString, "https://webkit.org/webkit");
@@ -720,7 +720,7 @@ TEST(SiteIsolation, BasicPostMessageWindowOpen)
     enableSiteIsolation(configuration);
 
     __block RetainPtr<NSString> alert;
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().runJavaScriptAlertPanelWithMessage = ^(WKWebView *, NSString *message, WKFrameInfo *, void (^completionHandler)(void)) {
         alert = message;
         completionHandler();
@@ -901,7 +901,7 @@ TEST(SiteIsolation, PreferencesUpdatesToAllProcesses)
     [navigationDelegate waitForDidFinishNavigation];
     webView.get().configuration.preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     __block bool opened { false };
     uiDelegate.get().createWebViewWithConfiguration = ^WKWebView *(WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures)
     {
@@ -1253,7 +1253,7 @@ TEST(SiteIsolation, PostMessageWithNotAllowedTargetOrigin)
     }).get();
 
     __block RetainPtr<NSString> alert;
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().runJavaScriptAlertPanelWithMessage = ^(WKWebView *, NSString *message, WKFrameInfo *, void (^completionHandler)(void)) {
         alert = message;
         completionHandler();
@@ -1311,7 +1311,7 @@ TEST(SiteIsolation, PostMessageToIFrameWithOpaqueOrigin)
     }).get();
 
     __block RetainPtr<NSString> alert;
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().runJavaScriptAlertPanelWithMessage = ^(WKWebView *, NSString *message, WKFrameInfo *, void (^completionHandler)(void)) {
         alert = message;
         completionHandler();
@@ -1343,7 +1343,7 @@ TEST(SiteIsolation, QueryFramesStateAfterNavigating)
         { "/subframe3.html"_s, { "SubFrame3"_s } },
         { "/subframe4.html"_s, { "SubFrame4"_s } }
     }, HTTPServer::Protocol::Http);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero]);
     [webView synchronouslyLoadRequest:server.request("/page1.html"_s)];
     EXPECT_EQ(3u, [webView mainFrame].childFrames.count);
 
@@ -1576,7 +1576,7 @@ TEST(SiteIsolation, ChildNavigatingToDomainLoadedOnADifferentPage)
 
     [firstWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org/foo"]]];
     
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:firstWebView.get().configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:firstWebView.get().configuration]);
     webView.get().navigationDelegate = navigationDelegate.get();
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
     
@@ -2148,7 +2148,7 @@ TEST(SiteIsolation, RunOpenPanel)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/mainframe"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     [webView setUIDelegate:uiDelegate.get()];
     __block bool fileSelected = false;
     [uiDelegate setRunOpenPanelWithParameters:^(WKWebView *, WKOpenPanelParameters *, WKFrameInfo *, void (^completionHandler)(NSArray<NSURL *> *)) {
@@ -2181,7 +2181,7 @@ TEST(SiteIsolation, CancelOpenPanel)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/mainframe"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     [webView setUIDelegate:uiDelegate.get()];
     [uiDelegate setRunOpenPanelWithParameters:^(WKWebView *, WKOpenPanelParameters *, WKFrameInfo *, void (^completionHandler)(NSArray<NSURL *> *)) {
         completionHandler(nil);
@@ -2219,11 +2219,11 @@ TEST(SiteIsolation, DragEvents)
         { "/subframe"_s, { subframeHTML } }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     auto configuration = server.httpsProxyConfiguration();
     enableSiteIsolation(configuration);
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration]);
     RetainPtr webView = [simulator webView];
     webView.get().navigationDelegate = navigationDelegate.get();
 
@@ -2515,11 +2515,11 @@ TEST(SiteIsolation, OpenerProcessSharing)
     auto [webView, delegate] = siteIsolatedViewAndDelegate(server);
 
     __block RetainPtr<TestWKWebView> openedWebView;
-    __block auto uiDelegate = adoptNS([TestUIDelegate new]);
+    __block RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     webView.get().UIDelegate = uiDelegate.get();
     uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
         openedWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
-        static auto openedNavigationDelegate = adoptNS([TestNavigationDelegate new]);
+        static RetainPtr openedNavigationDelegate = adoptNS([TestNavigationDelegate new]);
         [openedNavigationDelegate allowAnyTLSCertificate];
         openedWebView.get().navigationDelegate = openedNavigationDelegate.get();
         openedWebView.get().UIDelegate = uiDelegate.get();
@@ -2553,8 +2553,8 @@ TEST(SiteIsolation, AppKitText)
     }, HTTPServer::Protocol::HttpsProxy);
     auto configuration = server.httpsProxyConfiguration();
     enableSiteIsolation(configuration);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     webView.get().navigationDelegate = navigationDelegate.get();
 
@@ -2758,7 +2758,7 @@ TEST(SiteIsolation, FindStringInFrame)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain1.com/mainframe"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
-    auto findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
+    RetainPtr findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
     EXPECT_TRUE([[webView findStringAndWait:@"Hello World" withConfiguration:findConfiguration.get()] matchFound]);
     EXPECT_FALSE([[webView findStringAndWait:@"Missing string" withConfiguration:findConfiguration.get()] matchFound]);
 }
@@ -2775,7 +2775,7 @@ TEST(SiteIsolation, FindStringInNestedFrame)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain1.com/mainframe"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
-    auto findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
+    RetainPtr findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
     EXPECT_TRUE([[webView findStringAndWait:@"Hello World" withConfiguration:findConfiguration.get()] matchFound]);
     EXPECT_FALSE([[webView findStringAndWait:@"Missing string" withConfiguration:findConfiguration.get()] matchFound]);
 }
@@ -2793,7 +2793,7 @@ TEST(SiteIsolation, FindStringSelection)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain1.com/mainframe"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
-    auto findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
+    RetainPtr findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
     using SelectionOffsets = std::array<std::pair<int, int>, 3>;
     auto findStringAndValidateResults = [&findConfiguration](TestWKWebView *webView, const SelectionOffsets& offsets) {
         EXPECT_TRUE([[webView findStringAndWait:@"Hello World" withConfiguration:findConfiguration.get()] matchFound]);
@@ -2832,7 +2832,7 @@ TEST(SiteIsolation, FindStringSelectionWithEmptyFrames)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain1.com/mainframe"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
-    auto findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
+    RetainPtr findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
     using SelectionOffsets = std::array<std::pair<int, int>, 3>;
     auto findStringAndValidateResults = [&findConfiguration](TestWKWebView *webView, const SelectionOffsets& offsets) {
         EXPECT_TRUE([[webView findStringAndWait:@"Hello World" withConfiguration:findConfiguration.get()] matchFound]);
@@ -2867,7 +2867,7 @@ TEST(SiteIsolation, FindStringSelectionNoWrap)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain1.com/mainframe"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
-    auto findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
+    RetainPtr findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
     findConfiguration.get().wraps = NO;
     using SelectionOffsets = std::array<std::pair<int, int>, 2>;
     auto findStringAndValidateResults = [findConfiguration](TestWKWebView *webView, const SelectionOffsets& offsets) {
@@ -2902,7 +2902,7 @@ TEST(SiteIsolation, FindStringSelectionBackwards)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain1.com/mainframe"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
-    auto findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
+    RetainPtr findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
     findConfiguration.get().backwards = YES;
     using SelectionOffsets = std::array<std::pair<int, int>, 3>;
     auto findStringAndValidateResults = [&findConfiguration](TestWKWebView *webView, const SelectionOffsets& offsets) {
@@ -2936,7 +2936,7 @@ TEST(SiteIsolation, FindStringSelectionSameOriginFrames)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain1.com/mainframe"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
-    auto findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
+    RetainPtr findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
     using SelectionOffsets = std::array<std::pair<int, int>, 3>;
     auto findStringAndValidateResults = [&findConfiguration](TestWKWebView *webView, const SelectionOffsets& offsets) {
         EXPECT_TRUE([[webView findStringAndWait:@"Hello World" withConfiguration:findConfiguration.get()] matchFound]);
@@ -2975,7 +2975,7 @@ TEST(SiteIsolation, FindStringSelectionNestedFrames)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain1.com/mainframe"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
-    auto findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
+    RetainPtr findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
     using SelectionOffsets = std::array<std::pair<int, int>, 5>;
     auto findStringAndValidateResults = [&findConfiguration](TestWKWebView *webView, const SelectionOffsets& offsets) {
         EXPECT_TRUE([[webView findStringAndWait:@"Hello World" withConfiguration:findConfiguration.get()] matchFound]);
@@ -3013,7 +3013,7 @@ TEST(SiteIsolation, FindStringSelectionMultipleMatchesInMainFrame)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain1.com/mainframe"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
-    auto findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
+    RetainPtr findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
     using SelectionOffsets = std::array<std::pair<int, int>, 2>;
     auto findStringAndValidateResults = [&findConfiguration](TestWKWebView *webView, const SelectionOffsets& offsets) {
         EXPECT_TRUE([[webView findStringAndWait:@"Hello World" withConfiguration:findConfiguration.get()] matchFound]);
@@ -3048,7 +3048,7 @@ TEST(SiteIsolation, FindStringSelectionMultipleMatchesInChildFrame)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain1.com/mainframe"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
-    auto findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
+    RetainPtr findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
     using SelectionOffsets = std::array<std::pair<int, int>, 2>;
     auto findStringAndValidateResults = [&findConfiguration](TestWKWebView *webView, const SelectionOffsets& offsets) {
         EXPECT_TRUE([[webView findStringAndWait:@"Hello World" withConfiguration:findConfiguration.get()] matchFound]);
@@ -3093,7 +3093,7 @@ TEST(SiteIsolation, FindStringSelectionSameOriginFrameBeforeWrap)
     }];
     Util::run(&done);
 
-    auto findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
+    RetainPtr findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
     using SelectionOffsets = std::array<std::pair<int, int>, 3>;
     auto findStringAndValidateResults = [&findConfiguration](TestWKWebView *webView, const SelectionOffsets& offsets) {
         EXPECT_TRUE([[webView findStringAndWait:@"Hello World" withConfiguration:findConfiguration.get()] matchFound]);
@@ -3126,8 +3126,8 @@ TEST(SiteIsolation, FindStringMatchCount)
         { "/subframe"_s, { "<p>Hello world</p>"_s } }
     }, HTTPServer::Protocol::HttpsProxy);
     auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
-    auto findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
-    auto findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
+    RetainPtr findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
+    RetainPtr findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
     [webView _setFindDelegate:findDelegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain1.com/mainframe"]]];
@@ -3144,8 +3144,8 @@ TEST(SiteIsolation, CountStringMatches)
         { "/subframe"_s, { "<p>Hello world</p>"_s } }
     }, HTTPServer::Protocol::HttpsProxy);
     auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
-    auto findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
-    auto findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
+    RetainPtr findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
+    RetainPtr findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
     [webView _setFindDelegate:findDelegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://apple.com/mainframe"]]];
     [navigationDelegate waitForDidFinishNavigation];
@@ -3163,14 +3163,14 @@ TEST(SiteIsolation, ProcessDisplayNames)
         { "/apple"_s, { "<script></script>"_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
-    auto storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
-    auto viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [viewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
     enableSiteIsolation(viewConfiguration.get());
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
     webView.get().navigationDelegate = navigationDelegate.get();
 
     __block bool done { false };
@@ -4114,15 +4114,15 @@ TEST(SiteIsolation, ProtocolProcessSeparation)
         } }
     });
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", secureServer.port()]]];
     [storeConfiguration setHTTPProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", plaintextServer.port()]]];
-    auto viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [viewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
     enableSiteIsolation(viewConfiguration.get());
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
     webView.get().navigationDelegate = navigationDelegate.get();
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://a.com/"]]];
@@ -4224,14 +4224,14 @@ TEST(SiteIsolation, AdvancedPrivacyProtectionsHideScreenMetricsFromBindings)
         { "/example"_s, { "<iframe src='https://frame.com/frame'></iframe>"_s } },
         { "/frame"_s, { frameHTML } }
     }, HTTPServer::Protocol::HttpsProxy);
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     auto configuration = server.httpsProxyConfiguration();
     enableSiteIsolation(configuration);
-    auto preferences = adoptNS([WKWebpagePreferences new]);
+    RetainPtr preferences = adoptNS([WKWebpagePreferences new]);
     [preferences _setNetworkConnectionIntegrityPolicy:_WKWebsiteNetworkConnectionIntegrityPolicyEnhancedTelemetry | _WKWebsiteNetworkConnectionIntegrityPolicyEnabled];
     [configuration setDefaultWebpagePreferences:preferences.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
     webView.get().navigationDelegate = navigationDelegate.get();
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
     [navigationDelegate waitForDidFinishNavigation];
@@ -4253,7 +4253,7 @@ TEST(SiteIsolation, UpdateWebpagePreferences)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/example"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
-    auto preferences = adoptNS([WKWebpagePreferences new]);
+    RetainPtr preferences = adoptNS([WKWebpagePreferences new]);
     [preferences _setCustomUserAgent:@"Custom UserAgent"];
     [webView _updateWebpagePreferences:preferences.get()];
     while (![[webView objectByEvaluatingJavaScript:@"navigator.userAgent" inFrame:[webView firstChildFrame]] isEqualToString:@"Custom UserAgent"])
@@ -4288,8 +4288,8 @@ TEST(SiteIsolation, URLSchemeTask)
         { "/webkit"_s, { ""_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     handler.get().startURLSchemeTaskHandler = ^(WKWebView *, id<WKURLSchemeTask> task) {
         if ([task.request.URL.path isEqualToString:@"/example"])
             respond(task, "<iframe src='customscheme://webkit.org/webkit'></iframe>");
@@ -4303,7 +4303,7 @@ TEST(SiteIsolation, URLSchemeTask)
                 "xhr.send();"
             "</script>");
         } else if ([task.request.URL.path isEqualToString:@"/fetched"]) {
-            auto newRequest = adoptNS([[NSURLRequest alloc] initWithURL:[NSURL URLWithString:@"customscheme://webkit.org/redirected"]]);
+            RetainPtr newRequest = adoptNS([[NSURLRequest alloc] initWithURL:[NSURL URLWithString:@"customscheme://webkit.org/redirected"]]);
             [(id<WKURLSchemeTaskPrivate>)task _willPerformRedirection:adoptNS([NSURLResponse new]).get() newRequest:newRequest.get() completionHandler:^(NSURLRequest *request) {
                 respond(task, "hi");
             }];
@@ -4342,7 +4342,7 @@ TEST(SiteIsolation, ThemeColor)
 
     __block bool observedThemeColor { false };
     __block bool observedUnderPageBackgroundColor { false };
-    auto observer = adoptNS([TestObserver new]);
+    RetainPtr observer = adoptNS([TestObserver new]);
     observer.get().observeValueForKeyPath = ^(NSString *path, id view) {
         auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
         if ([path isEqualToString:@"themeColor"]) {
@@ -4656,7 +4656,7 @@ TEST(SiteIsolation, MultipleWebViewsWithSameOpenedConfiguration)
         { "/popup"_s, { "hi"_s } },
     }, HTTPServer::Protocol::HttpsProxy);
     auto [opener, opened] = openerAndOpenedViews(server, @"https://example.com/example", false);
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:opened.webView.get().configuration]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:opened.webView.get().configuration]);
     [opened.navigationDelegate waitForDidFinishNavigation];
     // FIXME: load something with webView2 without asserting, like https://example.com/popup
 }
@@ -4671,13 +4671,13 @@ TEST(SiteIsolation, RecoverFromCrash)
     }, HTTPServer::Protocol::HttpsProxy);
 
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
     enableSiteIsolation(configuration);
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:navigationDelegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/crash"]]];
@@ -5033,14 +5033,14 @@ TEST(SiteIsolation, ReuseConfiguration)
 
 TEST(SiteIsolation, ReuseConfigurationLoadHTMLString)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     enableSiteIsolation(configuration.get());
     [configuration setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView1 loadHTMLString:@"hi!" baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
     [webView1 _test_waitForDidFinishNavigation];
 
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView2 loadHTMLString:@"hi!" baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
     [webView2 _test_waitForDidFinishNavigation];
 
@@ -5159,7 +5159,7 @@ TEST(SiteIsolation, MutesAndSetsAudioInMultipleFrames)
     }, HTTPServer::Protocol::HttpsProxy);
 
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
     enableSiteIsolation(configuration);
@@ -5248,7 +5248,7 @@ TEST(SiteIsolation, StopsMediaCaptureInRemoteFrame)
     [preferences _setGetUserMediaRequiresFocus:NO];
 
     auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration, CGRectZero, false);
-    auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
@@ -5337,7 +5337,7 @@ TEST(SiteIsolation, FrameServerTrust)
     }, HTTPServer::Protocol::HttpsProxy);
 
     __block bool receivedAlert { false };
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().runJavaScriptAlertPanelWithMessage = ^(WKWebView *, NSString *message, WKFrameInfo *frameInfo, void (^completionHandler)(void)) {
         EXPECT_WK_STREQ(message, "iframe loaded");
         EXPECT_NULL(frameInfo._serverTrust);
@@ -6202,7 +6202,7 @@ TEST(SiteIsolation, DragAndDrop)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(100, 50) to:CGPointMake(100, 300)];
 
     NSArray *registeredTypes = [[simulator sourceItemProviders].firstObject registeredTypeIdentifiers];
@@ -6342,7 +6342,7 @@ TEST(SiteIsolation, SharedProcessLoadIsolatedSiteInSubframeOfNewWindow)
 
     __block auto *sharedNavigationDelegate = navigationDelegate.get();
     __block RetainPtr<TestWKWebView> opendWebView;
-    auto uiDelegate = adoptNS([[TestUIDelegate new] init]);
+    RetainPtr uiDelegate = adoptNS([[TestUIDelegate new] init]);
     webView.get().UIDelegate = uiDelegate.get();
     uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
         opendWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 200) configuration:configuration]);
@@ -6878,7 +6878,7 @@ TEST(SiteIsolation, SharedProcessAfterUserInteractionInSharedProcesss)
     webView.get().configuration.preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
     __block RetainPtr<TestWKWebView> opendWebView;
-    auto uiDelegate = adoptNS([[TestUIDelegate new] init]);
+    RetainPtr uiDelegate = adoptNS([[TestUIDelegate new] init]);
     auto *sharedNavigationDelegate = navigationDelegate.get();
     webView.get().UIDelegate = uiDelegate.get();
     uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
@@ -7619,13 +7619,13 @@ TEST(SiteIsolation, LocalIframeOpensBlobURLFromFileMainFrame)
     RetainPtr messageHandler = adoptNS([TestMessageHandler new]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
 
     __block RetainPtr<WKWebView> blobWindow;
     __block bool blobWindowOpened = false;
     __block bool blobContentChecked = false;
 
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
         EXPECT_WK_STREQ([action.request.URL scheme], @"blob");
         blobWindowOpened = true;
@@ -7744,7 +7744,7 @@ TEST(SiteIsolation, IframeImageTranslation)
 
     RetainPtr configuration = createWebViewConfigurationWithTextRecognitionEnhancements();
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
 
@@ -7790,7 +7790,7 @@ TEST(SiteIsolation, IframeImageTranslationIfIframeIsAddedAfterTranslationCall)
 
     RetainPtr configuration = createWebViewConfigurationWithTextRecognitionEnhancements();
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
 
@@ -7985,7 +7985,7 @@ TEST(SiteIsolation, DecorateFoundTextRangeIOS)
     }, HTTPServer::Protocol::HttpsProxy);
     auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
 
-    auto findDelegate = adoptNS([[TestFindDelegate alloc] init]);
+    RetainPtr findDelegate = adoptNS([[TestFindDelegate alloc] init]);
     [webView _setFindDelegate:findDelegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain1.com/mainframe"]]];
@@ -8074,7 +8074,7 @@ TEST(SiteIsolation, ClearAllDecoratedFoundTextIOS)
     }, HTTPServer::Protocol::HttpsProxy);
     auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
 
-    auto findDelegate = adoptNS([[TestFindDelegate alloc] init]);
+    RetainPtr findDelegate = adoptNS([[TestFindDelegate alloc] init]);
     [webView _setFindDelegate:findDelegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain1.com/mainframe"]]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SnapshotStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SnapshotStore.mm
@@ -229,7 +229,7 @@ TEST(SnapshotStore, ClearSiteDataHeader)
         { "/logout.html"_s, { { { "Content-Type"_s, "text/html"_s }, { "Clear-Site-Data"_s, "\"cache\""_s } }, "Logged out."_s } },
     }, HTTPServer::Protocol::Https);
 
-    auto webView = adoptNS([[SnapshotTestWKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[SnapshotTestWKWebView alloc] init]);
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"ClearSiteDataHTTPHeaderEnabled"]) {
             [[[webView configuration] preferences] _setEnabled:YES forFeature:feature];
@@ -255,7 +255,7 @@ TEST(SnapshotStore, ClearSiteDataHeaderCrossOrigin)
         { "/logout.html"_s, { { { "Content-Type"_s, "text/html"_s }, { "Clear-Site-Data"_s, "\"*\""_s } }, "Logged out."_s } },
     }, HTTPServer::Protocol::Https);
 
-    auto webView = adoptNS([[SnapshotTestWKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[SnapshotTestWKWebView alloc] init]);
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"ClearSiteDataHTTPHeaderEnabled"]) {
             [[[webView configuration] preferences] _setEnabled:YES forFeature:feature];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SpatialAudioExperience.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SpatialAudioExperience.mm
@@ -68,7 +68,7 @@ TEST(SpatialAudioExperience, NoWindow)
     isDone = false;
 
     RetainPtr configuration = autoplayingInternalsConfiguration();
-    auto messageHandler = adoptNS([[SpatialAudioExperienceMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SpatialAudioExperienceMessageHandler alloc] init]);
 
     [messageHandler setExpectedBody:@"{CAHeadTrackedSpatialAudio: soundStageSize(0), anchoringStrategy: {CAAutomaticAnchoringStrategy}}"];
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"media-player-spatial-experience-change"];
@@ -91,7 +91,7 @@ TEST(SpatialAudioExperience, WindowWithWindowScene)
     isDone = false;
 
     RetainPtr configuration = autoplayingInternalsConfiguration();
-    auto messageHandler = adoptNS([[SpatialAudioExperienceMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SpatialAudioExperienceMessageHandler alloc] init]);
 
     [messageHandler setExpectedBody:@"{CAHeadTrackedSpatialAudio: soundStageSize(0), anchoringStrategy: {CAAutomaticAnchoringStrategy}}"];
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"media-player-spatial-experience-change"];
@@ -120,7 +120,7 @@ TEST(SpatialAudioExperience, AudioOnly)
     isDone = false;
 
     RetainPtr configuration = autoplayingInternalsConfiguration();
-    auto messageHandler = adoptNS([[SpatialAudioExperienceMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[SpatialAudioExperienceMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"media-player-spatial-experience-change"];
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SpeechRecognition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SpeechRecognition.mm
@@ -112,14 +112,14 @@ namespace TestWebKitAPI {
 
 TEST(WebKit2, SpeechRecognitionUserPermissionPersistence)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([[SpeechRecognitionMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[SpeechRecognitionMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     auto preferences = [configuration preferences];
     preferences._mockCaptureDevicesEnabled = YES;
     preferences._speechRecognitionEnabled = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([[SpeechRecognitionUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[SpeechRecognitionUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     shouldGrantPermissionRequest = false;
@@ -154,8 +154,8 @@ TEST(WebKit2, SpeechRecognitionErrorWhenStartingAudioCaptureOnDifferentPage)
 {
     shouldGrantPermissionRequest = true;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([[SpeechRecognitionMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[SpeechRecognitionMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     configuration.get()._mediaCaptureEnabled = YES;
     auto preferences = [configuration preferences];
@@ -163,10 +163,10 @@ TEST(WebKit2, SpeechRecognitionErrorWhenStartingAudioCaptureOnDifferentPage)
     preferences._speechRecognitionEnabled = YES;
     preferences._mediaCaptureRequiresSecureConnection = NO;
     preferences._getUserMediaRequiresFocus = NO;
-    auto delegate = adoptNS([[SpeechRecognitionUIDelegate alloc] init]);
-    auto firstWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[SpeechRecognitionUIDelegate alloc] init]);
+    RetainPtr firstWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
     [firstWebView setUIDelegate:delegate.get()];
-    auto secondWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(100, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr secondWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(100, 0, 100, 100) configuration:configuration.get()]);
     [secondWebView setUIDelegate:delegate.get()];
 
     // First page starts recognition successfully.
@@ -208,14 +208,14 @@ TEST(WebKit2, SpeechRecognitionErrorWhenStartingAudioCaptureOnDifferentPage)
 
 TEST(WebKit2, SpeechRecognitionPageBecomesInvisible)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([[SpeechRecognitionMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[SpeechRecognitionMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     auto preferences = [configuration preferences];
     preferences._mockCaptureDevicesEnabled = YES;
     preferences._speechRecognitionEnabled = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([[SpeechRecognitionUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[SpeechRecognitionUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     // Page is visible.
@@ -245,18 +245,18 @@ TEST(WebKit2, SpeechRecognitionPageBecomesInvisible)
 
 TEST(WebKit2, SpeechRecognitionPageIsDestroyed)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto preferences = [configuration preferences];
     preferences._mockCaptureDevicesEnabled = YES;
     preferences._speechRecognitionEnabled = YES;
     preferences.javaScriptCanOpenWindowsAutomatically = YES;
-    auto delegate = adoptNS([[SpeechRecognitionUIDelegate alloc] init]);
-    auto navigationDelegate = adoptNS([[SpeechRecognitionNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[SpeechRecognitionUIDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[SpeechRecognitionNavigationDelegate alloc] init]);
     shouldGrantPermissionRequest = true;
     createdWebView = nullptr;
 
     @autoreleasepool {
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         [webView setUIDelegate:delegate.get()];
         [webView setNavigationDelegate:navigationDelegate.get()];
 
@@ -279,14 +279,14 @@ TEST(WebKit2, SpeechRecognitionPageIsDestroyed)
 
 TEST(WebKit2, SpeechRecognitionMediaCaptureStateChange)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([[SpeechRecognitionMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[SpeechRecognitionMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     auto preferences = [configuration preferences];
     preferences._mockCaptureDevicesEnabled = YES;
     preferences._speechRecognitionEnabled = YES;
-    auto delegate = adoptNS([[SpeechRecognitionUIDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[SpeechRecognitionUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setUIDelegate:delegate.get()];
     shouldGrantPermissionRequest = true;
 
@@ -306,17 +306,17 @@ TEST(WebKit2, SpeechRecognitionMediaCaptureStateChange)
 
 TEST(WebKit2, SpeechRecognitionWebProcessCrash)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([[SpeechRecognitionMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[SpeechRecognitionMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     auto preferences = [configuration preferences];
     preferences._mockCaptureDevicesEnabled = YES;
     preferences._speechRecognitionEnabled = YES;
-    auto delegate = adoptNS([[SpeechRecognitionUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[SpeechRecognitionUIDelegate alloc] init]);
     shouldGrantPermissionRequest = true;
 
     @autoreleasepool {
-        auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
         [webView setUIDelegate:delegate.get()];
 
         receivedScriptMessage = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/StopSuspendResumeAllMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/StopSuspendResumeAllMedia.mm
@@ -38,8 +38,8 @@ namespace TestWebKitAPI {
 
 TEST(WKWebView, StopAllMediaPlayback)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
 
     [webView synchronouslyLoadHTMLString:@"<video src=\"video-with-audio.mp4\" webkit-playsinline></video>"];
 
@@ -58,8 +58,8 @@ TEST(WKWebView, StopAllMediaPlayback)
 
 TEST(WKWebView, SuspendResumeAllMediaPlayback)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
 
     [webView synchronouslyLoadHTMLString:@"<video src=\"video-with-audio.mp4\" webkit-playsinline></video>"];
 
@@ -88,8 +88,8 @@ TEST(WKWebView, SuspendResumeAllMediaPlayback)
 
 TEST(WKWebView, SuspendResumeAllMediaPlaybackMultipleTimes)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
 
     [webView synchronouslyLoadHTMLString:@"<video src=\"video-with-audio.mp4\" webkit-playsinline></video>"];
 
@@ -137,8 +137,8 @@ TEST(WKWebView, SuspendResumeAllMediaPlaybackMultipleTimes)
 
 TEST(WKWebView, CheckMediaPlaybackSuspended)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
 
     [webView synchronouslyLoadHTMLString:@"<video src=\"video-with-audio.mp4\" webkit-playsinline></video>"];
 
@@ -176,8 +176,8 @@ TEST(WKWebView, CheckMediaPlaybackSuspended)
 
 TEST(WKWebView, CheckMediaPlaybackExists)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
 
     [webView synchronouslyLoadHTMLString:@"start network process"];
 
@@ -208,8 +208,8 @@ TEST(WKWebView, CheckMediaPlaybackExists)
 
 TEST(WKWebView, CheckMediaPlaybackPaused)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
 
     [webView synchronouslyLoadHTMLString:@"<video src=\"video-with-audio.mp4\" webkit-playsinline></video>"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/StorageQuota.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/StorageQuota.mm
@@ -249,29 +249,29 @@ static inline void setVisible(TestWKWebView *webView)
 TEST(WebKit, QuotaDelegateHidden)
 {
     done = false;
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [storeConfiguration setPerOriginStorageQuota:1024 * 400];
     // Ensure quota is not calculated by ratio.
     [storeConfiguration.get() setTotalQuotaRatio:nil];
     [storeConfiguration.get() setOriginQuotaRatio:nil];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
     [dataStore removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:dataStore.get()];
 
-    auto messageHandler = adoptNS([[QuotaMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[QuotaMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"qt"];
 
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { TestHiddenBytes } },
     });
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
-    auto delegate = adoptNS([[QuotaDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr delegate = adoptNS([[QuotaDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     setVisible(webView.get());
 
@@ -315,29 +315,29 @@ TEST(WebKit, QuotaDelegate)
 #endif
 {
     done = false;
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [storeConfiguration setPerOriginStorageQuota:1024 * 400];
     // Ensure quota is not calculated by ratio.
     [storeConfiguration.get() setTotalQuotaRatio:nil];
     [storeConfiguration.get() setOriginQuotaRatio:nil];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
     [dataStore removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:dataStore.get()];
 
-    auto messageHandler = adoptNS([[QuotaMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[QuotaMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"qt"];
 
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { TestBytes } },
     });
 
-    auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
-    auto delegate1 = adoptNS([[QuotaDelegate alloc] init]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr delegate1 = adoptNS([[QuotaDelegate alloc] init]);
     [webView1 setUIDelegate:delegate1.get()];
     setVisible(webView1.get());
 
@@ -345,8 +345,8 @@ TEST(WebKit, QuotaDelegate)
     [webView1 loadRequest:server.request()];
     Util::run(&receivedQuotaDelegateCalled);
 
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
-    auto delegate2 = adoptNS([[QuotaDelegate alloc] init]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr delegate2 = adoptNS([[QuotaDelegate alloc] init]);
     [webView2 setUIDelegate:delegate2.get()];
     setVisible(webView2.get());
 
@@ -377,29 +377,29 @@ TEST(WebKit, QuotaDelegate)
 TEST(WebKit, QuotaDelegateReload)
 {
     done = false;
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [storeConfiguration setPerOriginStorageQuota:1024 * 400];
     // Ensure quota is not calculated by ratio.
     [storeConfiguration.get() setTotalQuotaRatio:nil];
     [storeConfiguration.get() setOriginQuotaRatio:nil];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
     [dataStore removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
     
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:dataStore.get()];
     
-    auto messageHandler = adoptNS([[QuotaMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[QuotaMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"qt"];
     
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { TestBytes } },
     });
     
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
-    auto delegate = adoptNS([[QuotaDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr delegate = adoptNS([[QuotaDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     setVisible(webView.get());
 
@@ -428,29 +428,29 @@ TEST(WebKit, QuotaDelegateReload)
 TEST(WebKit, QuotaDelegateNavigateFragment)
 {
     done = false;
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [storeConfiguration setPerOriginStorageQuota:1024 * 400];
     // Ensure quota is not calculated by ratio.
     [storeConfiguration.get() setTotalQuotaRatio:nil];
     [storeConfiguration.get() setOriginQuotaRatio:nil];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
     [dataStore removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:dataStore.get()];
 
-    auto messageHandler = adoptNS([[QuotaMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[QuotaMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"qt"];
 
     TestWebKitAPI::HTTPServer server({
         { "/main.html"_s, { TestBytes } },
     });
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
-    auto delegate = adoptNS([[QuotaDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr delegate = adoptNS([[QuotaDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     setVisible(webView.get());
 
@@ -488,30 +488,30 @@ TEST(WebKit, QuotaDelegateNavigateFragment)
 TEST(WebKit, DefaultQuota)
 {
     done = false;
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
 
     [dataStore removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:dataStore.get()];
 
-    auto messageHandler = adoptNS([[QuotaMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[QuotaMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"qt"];
 
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { TestUrlBytes } },
     });
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
-    auto delegate = adoptNS([[QuotaDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr delegate = adoptNS([[QuotaDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     setVisible(webView.get());
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
         didFinishNavigationBoolean = true;
     }];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SystemColors.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SystemColors.mm
@@ -69,7 +69,7 @@ namespace TestWebKitAPI {
 
 TEST(WebKit, LinkColor)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     [webView synchronouslyLoadHTMLString:@"<a href>Test</a>"];
 
@@ -81,7 +81,7 @@ TEST(WebKit, LinkColor)
 
 TEST(WebKit, LinkColorWithSystemAppearance)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView _setUseSystemAppearance:YES];
 
     [webView synchronouslyLoadHTMLString:@"<a href>Test</a>"];
@@ -150,7 +150,7 @@ TEST(WebKit, AppAccentColorAffectsSystemColors)
 
 TEST(WebKit, TintColorAffectsInteractionColor)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto textInput = [webView textInputContentView];
 
     [webView setTintColor:[UIColor greenColor]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SystemPreview.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SystemPreview.mm
@@ -114,9 +114,9 @@ TEST(WebKit, SystemPreviewLoad)
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration _setSystemPreviewEnabled:YES];
 
-    auto viewController = adoptNS([[UIViewController alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
-    auto uiDelegate = adoptNS([[TestSystemPreviewUIDelegate alloc] init]);
+    RetainPtr viewController = adoptNS([[UIViewController alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr uiDelegate = adoptNS([[TestSystemPreviewUIDelegate alloc] init]);
     uiDelegate.get().viewController = viewController.get();
     [webView setUIDelegate:uiDelegate.get()];
     [viewController setView:webView.get()];
@@ -162,9 +162,9 @@ TEST(WebKit, SystemPreviewBlobRevokedImmediately)
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration _setSystemPreviewEnabled:YES];
 
-    auto viewController = adoptNS([[UIViewController alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
-    auto uiDelegate = adoptNS([[TestSystemPreviewUIDelegate alloc] init]);
+    RetainPtr viewController = adoptNS([[UIViewController alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr uiDelegate = adoptNS([[TestSystemPreviewUIDelegate alloc] init]);
     uiDelegate.get().viewController = viewController.get();
     [webView setUIDelegate:uiDelegate.get()];
     [viewController setView:webView.get()];
@@ -226,9 +226,9 @@ TEST(WebKit, SystemPreviewUnknownMIMEType)
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration _setSystemPreviewEnabled:YES];
 
-    auto viewController = adoptNS([[UIViewController alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
-    auto uiDelegate = adoptNS([[TestSystemPreviewUIDelegate alloc] init]);
+    RetainPtr viewController = adoptNS([[UIViewController alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr uiDelegate = adoptNS([[TestSystemPreviewUIDelegate alloc] init]);
     uiDelegate.get().viewController = viewController.get();
     [webView setUIDelegate:uiDelegate.get()];
     [viewController setView:webView.get()];
@@ -263,11 +263,11 @@ TEST(WebKit, SystemPreviewUnknownMIMEType)
 TEST(WebKit, SystemPreviewTriggered)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto messageHandler = adoptNS([[TestSystemPreviewTriggeredHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSystemPreviewTriggeredHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testSystemPreview"];
     [configuration _setSystemPreviewEnabled:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
     [webView synchronouslyLoadTestPageNamed:@"system-preview-trigger"];
     Util::run(&hasTriggerInfo);
 
@@ -278,11 +278,11 @@ TEST(WebKit, SystemPreviewTriggered)
 TEST(WebKit, SystemPreviewTriggeredOnDetachedElement)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto messageHandler = adoptNS([[TestSystemPreviewTriggeredOnDetachedElementHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[TestSystemPreviewTriggeredOnDetachedElementHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testSystemPreview"];
     [configuration _setSystemPreviewEnabled:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
     [webView synchronouslyLoadTestPageNamed:@"system-preview-trigger"];
     Util::run(&hasTriggerInfo);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TLSDeprecation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TLSDeprecation.mm
@@ -143,8 +143,8 @@ const uint16_t tls1_1 = 0x0302;
 TEST(TLSVersion, DefaultBehavior)
 {
     HTTPServer server(HTTPServer::respondWithOK, HTTPServer::Protocol::HttpsWithLegacyTLS);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
     [delegate setDidReceiveAuthenticationChallenge:^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^callback)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
@@ -160,9 +160,9 @@ TEST(TLSVersion, DefaultBehavior)
 
 RetainPtr<WKWebView> makeWebViewWith(WKWebsiteDataStore *store, RetainPtr<TestNavigationDelegate> delegate)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:store];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:delegate.get()];
     [delegate setDidReceiveAuthenticationChallenge:^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^callback)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
@@ -176,7 +176,7 @@ RetainPtr<WKWebView> makeWebViewWith(WKWebsiteDataStore *store, RetainPtr<TestNa
 TEST(TLSVersion, NetworkSession)
 {
     HTTPServer server(HTTPServer::respondWithOK, HTTPServer::Protocol::HttpsWithLegacyTLS);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     {
         auto webView = makeWebViewWith([WKWebsiteDataStore defaultDataStore], delegate);
         [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]]];
@@ -196,17 +196,17 @@ TEST(TLSVersion, NetworkSession)
 #endif
     }
     {
-        auto configuration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+        RetainPtr configuration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
         [configuration setLegacyTLSEnabled:NO];
-        auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:configuration.get()]);
+        RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:configuration.get()]);
         auto webView = makeWebViewWith(dataStore.get(), delegate);
         [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]]];
         [delegate waitForDidFailProvisionalNavigation];
     }
     {
-        auto configuration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+        RetainPtr configuration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
         [configuration setLegacyTLSEnabled:YES];
-        auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:configuration.get()]);
+        RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:configuration.get()]);
         auto webView = makeWebViewWith(dataStore.get(), delegate);
         [webView loadRequest:server.request()];
         [delegate waitForDidFinishNavigation];
@@ -217,8 +217,8 @@ TEST(TLSVersion, ShouldAllowDeprecatedTLS)
 {
     HTTPServer server(HTTPServer::respondWithOK, HTTPServer::Protocol::HttpsWithLegacyTLS);
     {
-        auto delegate = adoptNS([TLSNavigationDelegate new]);
-        auto webView = adoptNS([WKWebView new]);
+        RetainPtr delegate = adoptNS([TLSNavigationDelegate new]);
+        RetainPtr webView = adoptNS([WKWebView new]);
         [webView setNavigationDelegate:delegate.get()];
         [webView loadRequest:server.request()];
         [delegate waitForDidFailProvisionalNavigation];
@@ -229,16 +229,16 @@ TEST(TLSVersion, ShouldAllowDeprecatedTLS)
 #endif
     }
     {
-        auto delegate = adoptNS([TLSNavigationDelegate new]);
+        RetainPtr delegate = adoptNS([TLSNavigationDelegate new]);
         delegate.get().shouldAllowDeprecatedTLS = YES;
 #if ENABLE(TLS_1_2_DEFAULT_MINIMUM)
-        auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
-        auto configuration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+        RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+        RetainPtr configuration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
         [configuration setLegacyTLSEnabled:YES];
-        auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:configuration.get()]);
+        RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:configuration.get()]);
         auto webView = makeWebViewWith(dataStore.get(), navigationDelegate);
 #else
-        auto webView = adoptNS([WKWebView new]);
+        RetainPtr webView = adoptNS([WKWebView new]);
 #endif
         [webView setNavigationDelegate:delegate.get()];
         [webView loadRequest:server.request()];
@@ -254,10 +254,10 @@ TEST(TLSVersion, Preconnect)
         connectionAttempted = true;
     }, HTTPServer::Protocol::HttpsWithLegacyTLS);
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView loadHTMLString:makeString("<head><link rel='preconnect' href='https://127.0.0.1:"_s, server.port(), "/'></link></head>"_s).createNSString().get() baseURL:nil];
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     [delegate setDidReceiveAuthenticationChallenge:^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^callback)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         EXPECT_TRUE(false);
@@ -271,14 +271,14 @@ TEST(TLSVersion, Preconnect)
 
 static std::pair<RetainPtr<WKWebView>, RetainPtr<TestNavigationDelegate>> webViewWithNavigationDelegate(RetainPtr<WKWebViewConfiguration> configuration = nullptr)
 {
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
 
 #if ENABLE(TLS_1_2_DEFAULT_MINIMUM)
     RetainPtr<WKWebView> webView;
     if (!configuration) {
-        auto configuration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+        RetainPtr configuration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
         [configuration setLegacyTLSEnabled:YES];
-        auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:configuration.get()]);
+        RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:configuration.get()]);
         webView = makeWebViewWith(dataStore.get(), delegate);
     } else
         webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
@@ -304,7 +304,7 @@ TEST(TLSVersion, NegotiatedLegacyTLS)
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
     [webView loadRequest:request];
 
-    auto observer = adoptNS([TLSObserver new]);
+    RetainPtr observer = adoptNS([TLSObserver new]);
     [webView addObserver:observer.get() forKeyPath:@"_negotiatedLegacyTLS" options:NSKeyValueObservingOptionNew context:nil];
     
     EXPECT_FALSE([webView _negotiatedLegacyTLS]);
@@ -333,7 +333,7 @@ TEST(TLSVersion, NavigateBack)
     }, HTTPServer::Protocol::Https);
     
     auto [webView, delegate] = webViewWithNavigationDelegate();
-    auto observer = adoptNS([TLSObserver new]);
+    RetainPtr observer = adoptNS([TLSObserver new]);
     [webView addObserver:observer.get() forKeyPath:@"_negotiatedLegacyTLS" options:NSKeyValueObservingOptionNew context:nil];
 
     [webView loadRequest:legacyTLSServer.request()];
@@ -400,7 +400,7 @@ TEST(TLSVersion, Subresource)
     }, HTTPServer::Protocol::Https);
     
     auto [webView, delegate] = webViewWithNavigationDelegate();
-    auto observer = adoptNS([TLSObserver new]);
+    RetainPtr observer = adoptNS([TLSObserver new]);
     [webView addObserver:observer.get() forKeyPath:@"_negotiatedLegacyTLS" options:NSKeyValueObservingOptionNew context:nil];
 
     EXPECT_FALSE([webView _negotiatedLegacyTLS]);
@@ -426,12 +426,12 @@ TEST(TLSVersion, DidNegotiateModernTLS)
         { "/"_s, { "hello"_s }}
     }, HTTPServer::Protocol::Https);
 
-    auto delegate = adoptNS([TLSNavigationDelegate new]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
-    auto dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr delegate = adoptNS([TLSNavigationDelegate new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     [dataStoreConfiguration setFastServerTrustEvaluationEnabled:YES];
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]).get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:server.request()];
     NSURL *url = [delegate waitForDidNegotiateModernTLS];
@@ -451,13 +451,13 @@ TEST(TLSVersion, LegacySubresources)
         { "/"_s, { makeString("<iframe src='https://127.0.0.1:"_s, legacyServer.port(), "/frame'/>"_s) }}
     }, HTTPServer::Protocol::Https);
 
-    auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [dataStoreConfiguration setFastServerTrustEvaluationEnabled:YES];
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [webViewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]).get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate setDidReceiveAuthenticationChallenge:^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^callback)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
         callback(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
@@ -470,7 +470,7 @@ TEST(TLSVersion, LegacySubresources)
     EXPECT_EQ(legacyServer.totalRequests(), 0u);
     EXPECT_EQ(modernServer.totalRequests(), 1u);
 
-    auto defaultWebView = adoptNS([WKWebView new]);
+    RetainPtr defaultWebView = adoptNS([WKWebView new]);
     [defaultWebView setNavigationDelegate:delegate.get()];
     [defaultWebView loadRequest:modernServer.request()];
     [delegate waitForDidFinishNavigation];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextFragments.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextFragments.mm
@@ -35,8 +35,8 @@
 
 TEST(WebKit, GetTextFragmentMatch)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
 
     auto testTextFragment = ^(NSString *pageContent, NSString *textFragment, NSString *expectedResult) {
         // Load an empty baseURL-less string, otherwise using the same baseURL (modulo the fragment) does a same-document navigation.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextManipulation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextManipulation.mm
@@ -120,8 +120,8 @@ namespace TestWebKitAPI {
 
 TEST(TextManipulation, StartTextManipulationExitEarlyWithoutDelegate)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
         "<html><body>hello<br>world<div>WebKit</div></body></html>"];
@@ -137,8 +137,8 @@ TEST(TextManipulation, StartTextManipulationExitEarlyWithoutDelegate)
 
 TEST(TextManipulation, StartTextManipulationFindSimpleParagraphs)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -164,8 +164,8 @@ TEST(TextManipulation, StartTextManipulationFindSimpleParagraphs)
 
 TEST(TextManipulation, StartTextManipulationFindMultipleParagraphsInSingleTextNode)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -189,8 +189,8 @@ TEST(TextManipulation, StartTextManipulationFindMultipleParagraphsInSingleTextNo
 
 TEST(TextManipulation, StartTextManipulationFindParagraphsWithMultipleTokens)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
     
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -215,8 +215,8 @@ TEST(TextManipulation, StartTextManipulationFindParagraphsWithMultipleTokens)
 
 TEST(TextManipulation, StartTextManipulationFindAttributeContent)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><head><title>hey</title></head>"
@@ -249,8 +249,8 @@ TEST(TextManipulation, StartTextManipulationFindAttributeContent)
 
 TEST(TextManipulation, StartTextManipulationSupportsLegacyDelegateCallback)
 {
-    auto delegate = adoptNS([[LegacyTextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[LegacyTextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body><p>hello, <span>world</span></p><p>WebKit</p></body></html>"];
@@ -272,8 +272,8 @@ TEST(TextManipulation, StartTextManipulationSupportsLegacyDelegateCallback)
 
 TEST(TextManipulation, StartTextManipulationFindNewlyInsertedParagraph)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body><p>hello</p></body></html>"];
@@ -307,8 +307,8 @@ TEST(TextManipulation, StartTextManipulationFindNewlyInsertedParagraph)
 
 TEST(TextManipulation, StartTextManipulationFindNewlyDisplayedParagraph)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body>"
@@ -368,8 +368,8 @@ TEST(TextManipulation, StartTextManipulationFindNewlyDisplayedParagraph)
 
 TEST(TextManipulation, StartTextManipulationFindSameParagraphWithNewContent)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body><p>hello</p></body></html>"];
@@ -403,8 +403,8 @@ TEST(TextManipulation, StartTextManipulationFindSameParagraphWithNewContent)
 
 TEST(TextManipulation, StartTextManipulationApplySingleExcluionRuleForElement)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -439,8 +439,8 @@ TEST(TextManipulation, StartTextManipulationApplySingleExcluionRuleForElement)
 
 TEST(TextManipulation, StartTextManipulationApplyInclusionExclusionRulesForAttributes)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -467,14 +467,14 @@ TEST(TextManipulation, StartTextManipulationApplyInclusionExclusionRulesForAttri
 
 TEST(TextManipulation, StartTextManipulationApplyInclusionExclusionRulesForClass)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
         "<html><body>Message: <span class='someClass exclude'><b>hello, </b><span>world</span></span></body></html>"];
 
-    auto configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
     [configuration setExclusionRules:@[
         adoptNS([[_WKTextManipulationExclusionRule alloc] initExclusion:YES forClass:@"exclude"]).get(),
     ]];
@@ -494,14 +494,14 @@ TEST(TextManipulation, StartTextManipulationApplyInclusionExclusionRulesForClass
 
 TEST(TextManipulation, StartTextManipulationApplyInclusionExclusionRulesForClassAndAttribute)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
         "<html><body><span class='someClass exclude'>Message: <b data-exclude=no>hello, </b><span>world</span></span></body></html>"];
 
-    auto configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
     [configuration setExclusionRules:@[
         adoptNS([[_WKTextManipulationExclusionRule alloc] initExclusion:YES forAttribute:@"data-exclude" value:@"yes"]).get(),
         adoptNS([[_WKTextManipulationExclusionRule alloc] initExclusion:NO forAttribute:@"data-exclude" value:@"no"]).get(),
@@ -523,8 +523,8 @@ TEST(TextManipulation, StartTextManipulationApplyInclusionExclusionRulesForClass
 
 TEST(TextManipulation, StartTextManipulationBreaksParagraphInBetweenListItems)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -581,8 +581,8 @@ TEST(TextManipulation, StartTextManipulationBreaksParagraphInBetweenListItems)
 
 TEST(TextManipulation, StartTextManipulationBreaksParagraphInBetweenFloatingListItems)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -626,8 +626,8 @@ TEST(TextManipulation, StartTextManipulationBreaksParagraphInBetweenFloatingList
 
 TEST(TextManipulation, StartTextManipulationIncludesFullyClippedText)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -660,8 +660,8 @@ TEST(TextManipulation, StartTextManipulationIncludesFullyClippedText)
 
 TEST(TextManipulation, StartTextManipulationFindsInsertedClippedText)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -714,8 +714,8 @@ TEST(TextManipulation, StartTextManipulationFindsInsertedClippedText)
 
 TEST(TextManipulation, StartTextManipulationTreatsInlineBlockLinksAndButtonsAndSpansAsParagraphs)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -763,8 +763,8 @@ TEST(TextManipulation, StartTextManipulationTreatsInlineBlockLinksAndButtonsAndS
 
 TEST(TextManipulation, StartTextManipulationTreatsLinksInNavigationElementsAsParagraphs)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -808,8 +808,8 @@ TEST(TextManipulation, StartTextManipulationTreatsLinksInNavigationElementsAsPar
 
 TEST(TextManipulation, StartTextManipulationTreatsNestedInlineBlockListItemsAndLinksAsParagraphs)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -844,8 +844,8 @@ TEST(TextManipulation, StartTextManipulationTreatsNestedInlineBlockListItemsAndL
 
 TEST(TextManipulation, StartTextManipulationExtractsUserInfo)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -933,8 +933,8 @@ TEST(TextManipulation, StartTextManipulationExtractsUserInfo)
 
 TEST(TextManipulation, StartTextManipulationExtractsValuesFromButtonInputs)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -962,8 +962,8 @@ TEST(TextManipulation, StartTextManipulationExtractsValuesFromButtonInputs)
 
 TEST(TextManipulation, StartTextManipulationExtractsValuesFromTextInputs)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -999,8 +999,8 @@ TEST(TextManipulation, StartTextManipulationExtractsValuesFromTextInputs)
 
 TEST(TextManipulation, StartTextManipulationDoesNotExtractUserModifiedText)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><body><input id='one'><input id='two'></body>"];
 
@@ -1034,8 +1034,8 @@ TEST(TextManipulation, StartTextManipulationDoesNotExtractUserModifiedText)
 
 TEST(TextManipulation, StartTextManipulationExtractsVisibleLineBreaksInTextAsExcludedTokens)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -1068,11 +1068,11 @@ TEST(TextManipulation, StartTextManipulationExtractsVisibleLineBreaksInTextAsExc
 
 TEST(TextManipulation, StartTextManipulationExtractsPrivateUseCharactersAsExcludedTokens)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<body>foobarbaz</body>"];
-    auto configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
 
     done = false;
     [webView _startTextManipulationsWithConfiguration:configuration.get() completion:^{
@@ -1099,8 +1099,8 @@ TEST(TextManipulation, StartTextManipulationExtractsPrivateUseCharactersAsExclud
 
 TEST(TextManipulation, StartTextManipulationExtractsValuesByNode)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -1134,8 +1134,8 @@ TEST(TextManipulation, StartTextManipulationExtractsValuesByNode)
 
 TEST(TextManipulation, StartTextManipulationExcludesTextRenderedAsIcons)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
         "<head>"
@@ -1180,8 +1180,8 @@ TEST(TextManipulation, StartTextManipulationExcludesTextRenderedAsIcons)
 
 TEST(TextManipulation, StartTextManipulationAvoidCrashWhenExtractingOrphanedPositions)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<p>hello world</p>"];
@@ -1218,8 +1218,8 @@ TEST(TextManipulation, StartTextManipulationAvoidCrashWhenExtractingOrphanedPosi
 
 TEST(TextManipulation, RemovedElements)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<p>hello world</p>"];
@@ -1261,8 +1261,8 @@ TEST(TextManipulation, RemovedElements)
 
 TEST(TextManipulation, StartTextManipulationExtractsHeadingElementsAsSeparateItems)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -1290,8 +1290,8 @@ TEST(TextManipulation, StartTextManipulationExtractsHeadingElementsAsSeparateIte
 
 TEST(TextManipulation, StartTextManipulationIgnoresSpaces)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -1315,8 +1315,8 @@ TEST(TextManipulation, StartTextManipulationIgnoresSpaces)
 
 TEST(TextManipulation, StartTextManipulationExtractsTableCellsAsSeparateItems)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -1363,10 +1363,10 @@ TEST(TextManipulation, StartTextManipulationExtractsTableCellsAsSeparateItems)
 
 TEST(TextManipulation, StartTextManipulationDoesNotFindContentInIframeIfIncludeSubframeIsNotSet)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
-    auto configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
     configuration.get().includeSubframes = YES;
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><div>hello</div><div>world</div><iframe src='data:text/html,<p>WebKit</p>'>"];
 
@@ -1388,10 +1388,10 @@ TEST(TextManipulation, StartTextManipulationDoesNotFindContentInIframeIfIncludeS
 
 TEST(TextManipulation, StartTextManipulationFindsContentInIframeIfIncludeSubframeIsSet)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
-    auto configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
     configuration.get().includeSubframes = YES;
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><div>hello</div><div>world</div><iframe src='data:text/html,<p>WebKit</p>'>"];
@@ -1420,10 +1420,10 @@ TEST(TextManipulation, StartTextManipulationFindsContentInIframeIfIncludeSubfram
 
 TEST(TextManipulation, StartTextManipulationFindsContentInIframeInsertedLater)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
-    auto configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
     configuration.get().includeSubframes = YES;
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><div>hello</div><div>world</div>"];
@@ -1474,11 +1474,11 @@ TEST(TextManipulation, StartTextManipulationFindsContentInIframeInsertedLater)
 
 TEST(TextManipulation, StartTextManipulationDoesNotFindContentInNewMainFrame)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
-    auto configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
     configuration.get().includeSubframes = YES;
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
@@ -1541,8 +1541,8 @@ static RetainPtr<_WKTextManipulationItem> createItem(NSString *itemIdentifier, c
 
 TEST(TextManipulation, CompleteTextManipulationReplaceSimpleSingleParagraph)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -1572,8 +1572,8 @@ TEST(TextManipulation, CompleteTextManipulationReplaceSimpleSingleParagraph)
 
 TEST(TextManipulation, LegacyCompleteTextManipulationReplaceSimpleSingleParagraph)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body><p>helllo, wooorld</p></body></html>"];
@@ -1602,8 +1602,8 @@ TEST(TextManipulation, LegacyCompleteTextManipulationReplaceSimpleSingleParagrap
 
 TEST(TextManipulation, CompleteTextManipulationDisgardsTokens)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -1637,11 +1637,11 @@ TEST(TextManipulation, CompleteTextManipulationDisgardsTokens)
 
 TEST(TextManipulation, CompleteTextManipulationReplaceTwoSimpleParagraphs)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<p>hello</p>world"];
-    auto configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
 
     done = false;
     [webView _startTextManipulationsWithConfiguration:configuration.get() completion:^{
@@ -1671,8 +1671,8 @@ TEST(TextManipulation, CompleteTextManipulationReplaceTwoSimpleParagraphs)
 
 TEST(TextManipulation, CompleteTextManipulationReplaceMultipleSimpleParagraphs)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -1723,8 +1723,8 @@ TEST(TextManipulation, CompleteTextManipulationReplaceMultipleSimpleParagraphs)
 
 TEST(TextManipulation, CompleteTextManipulationReplaceMultipleSimpleParagraphsAtOnce)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -1766,8 +1766,8 @@ TEST(TextManipulation, CompleteTextManipulationReplaceMultipleSimpleParagraphsAt
 
 TEST(TextManipulation, CompleteTextManipulationReplaceMultipleSimpleParagraphsSeparatedByBR)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -1801,8 +1801,8 @@ TEST(TextManipulation, CompleteTextManipulationReplaceMultipleSimpleParagraphsSe
 
 TEST(TextManipulation, CompleteTextManipulationReplaceParagraphsSeparatedByWrappedBR)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -1838,8 +1838,8 @@ TEST(TextManipulation, CompleteTextManipulationReplaceParagraphsSeparatedByWrapp
 
 TEST(TextManipulation, CompleteTextManipulationPreservesWhitespacesBetweenItems)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><head><style> a { white-space: nowrap; } div { width: 10px; } </style></head>"
@@ -1872,8 +1872,8 @@ TEST(TextManipulation, CompleteTextManipulationPreservesWhitespacesBetweenItems)
 
 TEST(TextManipulation, CompleteTextManipulationFailWhenBRIsInserted)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body><p>helllo, <b>worrld</b></p></body></html>"];
@@ -1910,8 +1910,8 @@ TEST(TextManipulation, CompleteTextManipulationFailWhenBRIsInserted)
 
 TEST(TextManipulation, CompleteTextManipulationAvoidCrashingWhenContentIsRemoved)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
@@ -1953,8 +1953,8 @@ TEST(TextManipulation, CompleteTextManipulationAvoidCrashingWhenContentIsRemoved
 
 TEST(TextManipulation, CompleteTextManipulationShouldPreserveImagesAsExcludedTokens)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body><div>hello, <img src=\"apple.gif\"> world</div></body></html>"];
@@ -1991,8 +1991,8 @@ TEST(TextManipulation, CompleteTextManipulationShouldPreserveImagesAsExcludedTok
 
 TEST(TextManipulation, CompleteTextManipulationShouldPreserveSVGAsExcludedTokens)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body>"
@@ -2037,8 +2037,8 @@ TEST(TextManipulation, CompleteTextManipulationShouldPreserveSVGAsExcludedTokens
 
 TEST(TextManipulation, CompleteTextManipulationShouldPreserveOrderOfBlockImage)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body><svg viewBox=\"0 0 10 10\" width=\"100\" height=\"100\">"
@@ -2074,8 +2074,8 @@ TEST(TextManipulation, CompleteTextManipulationShouldPreserveOrderOfBlockImage)
 
 TEST(TextManipulation, CompleteTextManipulationShouldReplaceAttributeContent)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><head><title>hey</title></head>"
@@ -2117,8 +2117,8 @@ TEST(TextManipulation, CompleteTextManipulationShouldReplaceAttributeContent)
 
 TEST(TextManipulation, CompleteTextManipulationShouldReplaceContentFollowedAfterImageInCSSTable)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body>"
@@ -2150,8 +2150,8 @@ TEST(TextManipulation, CompleteTextManipulationShouldReplaceContentFollowedAfter
 
 TEST(TextManipulation, CompleteTextManipulationShouldReplaceTextContentWithMultipleTokens)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html>"
@@ -2214,8 +2214,8 @@ TEST(TextManipulation, CompleteTextManipulationShouldReplaceTextContentWithMulti
 
 TEST(TextManipulation, CompleteTextManipulationShouldReplaceContentsAroundParagraphWithJustImage)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body><div>heeey</div><div><img src=\"apple.gif\"></div><span>woorld</span>"];
@@ -2247,8 +2247,8 @@ TEST(TextManipulation, CompleteTextManipulationShouldReplaceContentsAroundParagr
 
 TEST(TextManipulation, CompleteTextManipulationShouldBatchItemCallback)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body></body></html>"];
@@ -2276,8 +2276,8 @@ TEST(TextManipulation, CompleteTextManipulationShouldBatchItemCallback)
 
 TEST(TextManipulation, CompleteTextManipulationReordersContent)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -2313,8 +2313,8 @@ TEST(TextManipulation, CompleteTextManipulationReordersContent)
 
 TEST(TextManipulation, CompleteTextManipulationCanSplitContent)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -2351,8 +2351,8 @@ TEST(TextManipulation, CompleteTextManipulationCanSplitContent)
 
 TEST(TextManipulation, CompleteTextManipulationCanMergeContent)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body><p><b>hello <i>world</i> WebKit</b></p></body></html>"];
@@ -2384,8 +2384,8 @@ TEST(TextManipulation, CompleteTextManipulationCanMergeContent)
 
 TEST(TextManipulation, CompleteTextManipulationFailWhenItemIdentifierIsDuplicated)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body><p>hello, <b>world</b></p></body></html>"];
@@ -2418,8 +2418,8 @@ TEST(TextManipulation, CompleteTextManipulationFailWhenItemIdentifierIsDuplicate
 
 TEST(TextManipulation, CompleteTextManipulationCanHandleSubsetOfItemsToFail)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body><p>hey, <b>dude</b></p><p>this is <b>bad</b></p></body></html>"];
@@ -2455,10 +2455,10 @@ TEST(TextManipulation, CompleteTextManipulationCanHandleSubsetOfItemsToFail)
 
 TEST(TextManipulation, CompleteTextManipulationReplaceContentInIframe)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
-    auto configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
     configuration.get().includeSubframes = YES;
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -2498,8 +2498,8 @@ TEST(TextManipulation, CompleteTextManipulationReplaceContentInIframe)
 
 TEST(TextManipulation, CompleteTextManipulationFailWhenContentIsChanged)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -2540,8 +2540,8 @@ TEST(TextManipulation, CompleteTextManipulationFailWhenContentIsChanged)
 
 TEST(TextManipulation, CompleteTextManipulationFailWhenContentIsRemoved)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body><p>hello, world</p></body></html>"];
@@ -2576,8 +2576,8 @@ TEST(TextManipulation, CompleteTextManipulationFailWhenContentIsRemoved)
 
 TEST(TextManipulation, CompleteTextManipulationFailWhenContentIsAdded)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body><p>hello, world</p></body></html>"];
@@ -2618,10 +2618,10 @@ TEST(TextManipulation, CompleteTextManipulationFailWhenContentIsAdded)
 
 TEST(TextManipulation, CompleteTextManipulationFailWhenContentIsChangedInIframe)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
-    auto configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
     configuration.get().includeSubframes = YES;
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body><p>helllo</p>"
@@ -2663,8 +2663,8 @@ TEST(TextManipulation, CompleteTextManipulationFailWhenContentIsChangedInIframe)
 
 TEST(TextManipulation, CompleteTextManipulationSuccedsWhenContentOutOfParagraphIsAdded)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<p style='white-space:pre;background-color:blue;'><span>hello world</span><u>   </u></p>"];
@@ -2706,8 +2706,8 @@ TEST(TextManipulation, CompleteTextManipulationSuccedsWhenContentOutOfParagraphI
 
 TEST(TextManipulation, CompleteTextManipulationFailWhenDocumentHasBeenNavigatedAway)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
@@ -2752,8 +2752,8 @@ TEST(TextManipulation, CompleteTextManipulationFailWhenDocumentHasBeenNavigatedA
 
 TEST(TextManipulation, CompleteTextManipulationFailWhenExclusionIsViolated)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
@@ -2797,8 +2797,8 @@ TEST(TextManipulation, CompleteTextManipulationFailWhenExclusionIsViolated)
 
 TEST(TextManipulation, CompleteTextManipulationFailWhenExcludedContentAppearsMoreThanOnce)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
@@ -2843,8 +2843,8 @@ TEST(TextManipulation, CompleteTextManipulationFailWhenExcludedContentAppearsMor
 
 TEST(TextManipulation, CompleteTextManipulationPreservesExcludedContent)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body><p>hi, <em>WebKitten</em> bye</p></body></html>"];
@@ -2883,13 +2883,13 @@ TEST(TextManipulation, CompleteTextManipulationPreservesExcludedContent)
 
 TEST(TextManipulation, CompleteTextManipulationDoesNotCreateMoreTextManipulationItems)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body><p>Foo <strong>bar</strong> baz</p></body></html>"];
 
-    auto configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
 
     done = false;
     [webView _startTextManipulationsWithConfiguration:configuration.get() completion:^{
@@ -2927,8 +2927,8 @@ TEST(TextManipulation, CompleteTextManipulationDoesNotCreateMoreTextManipulation
 
 TEST(TextManipulation, CompleteTextManipulationCorrectParagraphRange)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<head><style>ul{display:block}li{display:inline-block}.inline {float: left;}.subframe {height: 42px;}.frame {position: absolute;top: -9999px;}</style></head><body><div class='frame'><div class='subframe'></div></div><style></style><div class='inline'><div><li><a href='#'>holle</a></li><li><a href='#'>wdrlo</a></li></div></div><div class='frame'><div class='subframe'></div></div></body>"];
@@ -2962,8 +2962,8 @@ TEST(TextManipulation, CompleteTextManipulationCorrectParagraphRange)
 
 TEST(TextManipulation, CompleteTextManipulationCanMergeContentAndPreserveLineBreaks)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -3043,8 +3043,8 @@ TEST(TextManipulation, CompleteTextManipulationIgnoreWhiteSpacesBetweenParagraph
 
 TEST(TextManipulation, CompleteTextManipulationDoesNotSkipTabCharacterAtLineWrap)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@""
         "<!DOCTYPE html>"
@@ -3054,7 +3054,7 @@ TEST(TextManipulation, CompleteTextManipulationDoesNotSkipTabCharacterAtLineWrap
             "<strong>If this text is to be translated, then it should be something noteworthy</strong>"
             " (2) A monthly subscription is just&#9;$10.</p>"
         "</div>"];
-    auto configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
 
     done = false;
     [webView _startTextManipulationsWithConfiguration:configuration.get() completion:^{
@@ -3085,8 +3085,8 @@ TEST(TextManipulation, CompleteTextManipulationDoesNotSkipTabCharacterAtLineWrap
 
 TEST(TextManipulation, CompleteTextManipulationShouldPreserveNodesAfterParagraphRange)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -3125,8 +3125,8 @@ TEST(TextManipulation, CompleteTextManipulationShouldPreserveNodesAfterParagraph
 
 TEST(TextManipulation, CompleteTextManipulationSPreserveNodesBeforeParagraphRange)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
@@ -3163,13 +3163,13 @@ TEST(TextManipulation, CompleteTextManipulationSPreserveNodesBeforeParagraphRang
 
 TEST(TextManipulation, InsertingContentIntoAlreadyManipulatedContentCreatesTextManipulationItem)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body><p><i><b>hey</b></i> dude</p></body></html>"];
 
-    auto configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
 
     done = false;
     [webView _startTextManipulationsWithConfiguration:configuration.get() completion:^{
@@ -3208,11 +3208,11 @@ TEST(TextManipulation, InsertingContentIntoAlreadyManipulatedContentCreatesTextM
 
 TEST(TextManipulation, CompleteTextManipulationInButtonsAndTextFields)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<input type='text' value='hello1'><input type='submit' value='hello2'>"];
-    auto configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
 
     done = false;
     [webView _startTextManipulationsWithConfiguration:configuration.get() completion:^{
@@ -3247,8 +3247,8 @@ TEST(TextManipulation, CompleteTextManipulationInButtonsAndTextFields)
 
 TEST(TextManipulation, CompleteTextManipulationForNewlyDisplayedParagraph)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html><body>"
@@ -3308,8 +3308,8 @@ TEST(TextManipulation, CompleteTextManipulationForNewlyDisplayedParagraph)
 
 TEST(TextManipulation, CompleteTextManipulationForNewlyDisplayedText)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
         "<html>"
@@ -3363,8 +3363,8 @@ TEST(TextManipulation, CompleteTextManipulationForNewlyDisplayedText)
 
 TEST(TextManipulation, CompleteTextManipulationForManipulatedTextWithNewContent)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html>"
@@ -3425,8 +3425,8 @@ TEST(TextManipulation, CompleteTextManipulationForManipulatedTextWithNewContent)
 
 TEST(TextManipulation, CompleteTextManipulationForTitleElement)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><html></html>"];
 
@@ -3483,8 +3483,8 @@ TEST(TextManipulation, CompleteTextManipulationForTitleElement)
 
 TEST(TextManipulation, CompleteTextManipulationAvoidExtractingManipulatedTextAfterManipulation)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<p>foo<br>bar</p>"];
@@ -3533,8 +3533,8 @@ TEST(TextManipulation, CompleteTextManipulationAvoidExtractingManipulatedTextAft
 
 TEST(TextManipulation, CompleteTextManipulationAddsOverflowHiddenToAvoidBreakingLayout)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
         "<html>"
@@ -3593,8 +3593,8 @@ TEST(TextManipulation, CompleteTextManipulationAddsOverflowHiddenToAvoidBreaking
 
 TEST(TextManipulation, CompleteTextManipulationParagraphsContainCollapsedSpaces)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
         "<head>"
@@ -3635,8 +3635,8 @@ TEST(TextManipulation, CompleteTextManipulationParagraphsContainCollapsedSpaces)
 
 TEST(TextManipulation, CompleteTextManipulationParagraphContainsCollapsedSpaces)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
         "<body>"
@@ -3684,8 +3684,8 @@ TEST(TextManipulation, CompleteTextManipulationParagraphContainsCollapsedSpaces)
 
 TEST(TextManipulation, CompleteTextManipulationShouldReplaceContentIgnoredByEditing)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
         "<body>"
@@ -3726,8 +3726,8 @@ TEST(TextManipulation, CompleteTextManipulationShouldReplaceContentIgnoredByEdit
 
 TEST(TextManipulation, CompleteTextManipulationShouldOnlyChangeNodesInParagraphRange)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
         "<head>"
@@ -3774,8 +3774,8 @@ TEST(TextManipulation, CompleteTextManipulationShouldOnlyChangeNodesInParagraphR
 
 TEST(TextManipulation, CompleteTextManipulationParagraphBecomesHidden)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
         "<head><style> .hidden { display: none; } </style></head>"
@@ -3814,8 +3814,8 @@ TEST(TextManipulation, CompleteTextManipulationParagraphBecomesHidden)
 
 TEST(TextManipulation, CompleteTextManipulationSkipsEmptyContainers)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<section><a href='#'>Guten<img width='50' src='icon.png'></section>"
         "<section><div id='target'></div><div><a href='#'>Tag</a></div></section>"];
@@ -3854,8 +3854,8 @@ TEST(TextManipulation, CompleteTextManipulationSkipsEmptyContainers)
 
 TEST(TextManipulation, CompleteTextManipulationReplacesShadowDOMContent)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><body><span id='host'><template shadowrootmode='open'>hello</template></span></body>"];
 
@@ -3883,9 +3883,9 @@ TEST(TextManipulation, CompleteTextManipulationReplacesShadowDOMContent)
 
 TEST(TextManipulation, CompleteTextManipulationDoesNotFillAutoFilledField)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
     RetainPtr configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     [webView _setTextManipulationDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html><body><input id='textField'></body>"];
 
@@ -3919,7 +3919,7 @@ TEST(TextManipulation, CompleteTextManipulationDoesNotFillAutoFilledField)
 
 TEST(TextManipulation, TextManipulationTokenDebugDescription)
 {
-    auto token = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr token = adoptNS([[_WKTextManipulationToken alloc] init]);
     [token setIdentifier:@"foo_is_the_identifier"];
     [token setContent:@"bar_is_the_content"];
 
@@ -3934,7 +3934,7 @@ TEST(TextManipulation, TextManipulationTokenDebugDescription)
 
 TEST(TextManipulation, TextManipulationTokenNotEqualToNil)
 {
-    auto tokenA = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenA = adoptNS([[_WKTextManipulationToken alloc] init]);
     [tokenA setIdentifier:@"A"];
     [tokenA setContent:@"A"];
 
@@ -3949,9 +3949,9 @@ TEST(TextManipulation, TextManipulationTokenNotEqualToNil)
 
 TEST(TextManipulation, TextManipulationTokenEqualityWithEqualIdentifiers)
 {
-    auto token1 = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr token1 = adoptNS([[_WKTextManipulationToken alloc] init]);
     [token1 setIdentifier:@"A"];
-    auto token2 = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr token2 = adoptNS([[_WKTextManipulationToken alloc] init]);
     [token2 setIdentifier:@"A"];
 
     EXPECT_TRUE([token1 isEqualToTextManipulationToken:token2.get() includingContentEquality:YES]);
@@ -3980,9 +3980,9 @@ TEST(TextManipulation, TextManipulationTokenEqualityWithEqualIdentifiers)
 
 TEST(TextManipulation, TextManipulationTokenEqualityWithDifferentIdentifiers)
 {
-    auto tokenA = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenA = adoptNS([[_WKTextManipulationToken alloc] init]);
     [tokenA setIdentifier:@"A"];
-    auto tokenB = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenB = adoptNS([[_WKTextManipulationToken alloc] init]);
     [tokenB setIdentifier:@"B"];
 
     EXPECT_FALSE([tokenA isEqualToTextManipulationToken:tokenB.get() includingContentEquality:YES]);
@@ -4011,11 +4011,11 @@ TEST(TextManipulation, TextManipulationTokenEqualityWithDifferentIdentifiers)
 
 TEST(TextManipulation, TextManipulationTokenEqualityWithNilIdentifiers)
 {
-    auto tokenA = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenA = adoptNS([[_WKTextManipulationToken alloc] init]);
     EXPECT_NULL([tokenA identifier]);
-    auto tokenB = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenB = adoptNS([[_WKTextManipulationToken alloc] init]);
     [tokenB setIdentifier:@"B"];
-    auto tokenC = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenC = adoptNS([[_WKTextManipulationToken alloc] init]);
     EXPECT_NULL([tokenC identifier]);
 
     EXPECT_FALSE([tokenA isEqualToTextManipulationToken:tokenB.get() includingContentEquality:YES]);
@@ -4044,11 +4044,11 @@ TEST(TextManipulation, TextManipulationTokenEqualityWithNilIdentifiers)
 
 TEST(TextManipulation, TextManipulationTokenEqualityWithEmptyIdentifiers)
 {
-    auto tokenA = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenA = adoptNS([[_WKTextManipulationToken alloc] init]);
     [tokenA setIdentifier:@""];
-    auto tokenB = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenB = adoptNS([[_WKTextManipulationToken alloc] init]);
     [tokenB setIdentifier:@"B"];
-    auto tokenC = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenC = adoptNS([[_WKTextManipulationToken alloc] init]);
     [tokenC setIdentifier:@""];
 
     EXPECT_FALSE([tokenA isEqualToTextManipulationToken:tokenB.get() includingContentEquality:YES]);
@@ -4077,9 +4077,9 @@ TEST(TextManipulation, TextManipulationTokenEqualityWithEmptyIdentifiers)
 
 TEST(TextManipulation, TextManipulationTokenWithNilContent)
 {
-    auto tokenA = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenA = adoptNS([[_WKTextManipulationToken alloc] init]);
     [tokenA setIdentifier:@"A"];
-    auto tokenB = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenB = adoptNS([[_WKTextManipulationToken alloc] init]);
     [tokenB setIdentifier:@"A"];
 
     EXPECT_NULL([tokenA content]);
@@ -4098,10 +4098,10 @@ TEST(TextManipulation, TextManipulationTokenWithNilContent)
 
 TEST(TextManipulation, TextManipulationTokenWithEmptyContent)
 {
-    auto tokenA = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenA = adoptNS([[_WKTextManipulationToken alloc] init]);
     [tokenA setIdentifier:@"A"];
     [tokenA setContent:@""];
-    auto tokenB = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenB = adoptNS([[_WKTextManipulationToken alloc] init]);
     [tokenB setIdentifier:@"A"];
     [tokenB setContent:@""];
 
@@ -4119,10 +4119,10 @@ TEST(TextManipulation, TextManipulationTokenWithEmptyContent)
 
 TEST(TextManipulation, TextManipulationTokenWithIdenticalContent)
 {
-    auto tokenA = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenA = adoptNS([[_WKTextManipulationToken alloc] init]);
     [tokenA setIdentifier:@"A"];
     [tokenA setContent:@"content"];
-    auto tokenB = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenB = adoptNS([[_WKTextManipulationToken alloc] init]);
     [tokenB setIdentifier:@"A"];
     [tokenB setContent:@"content"];
 
@@ -4132,9 +4132,9 @@ TEST(TextManipulation, TextManipulationTokenWithIdenticalContent)
 
 TEST(TextManipulation, TextManipulationTokenWithPointerEqualContent)
 {
-    auto tokenA = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenA = adoptNS([[_WKTextManipulationToken alloc] init]);
     [tokenA setIdentifier:@"A"];
-    auto tokenB = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenB = adoptNS([[_WKTextManipulationToken alloc] init]);
     [tokenB setIdentifier:@"A"];
 
     NSString *contentString = @"content";
@@ -4147,10 +4147,10 @@ TEST(TextManipulation, TextManipulationTokenWithPointerEqualContent)
 
 TEST(TextManipulation, TextManipulationTokenWithTrailingSpace)
 {
-    auto tokenA = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenA = adoptNS([[_WKTextManipulationToken alloc] init]);
     [tokenA setIdentifier:@"A"];
     [tokenA setContent:@"content"];
-    auto tokenB = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenB = adoptNS([[_WKTextManipulationToken alloc] init]);
     [tokenB setIdentifier:@"A"];
     [tokenB setContent:@"content "];
 
@@ -4160,7 +4160,7 @@ TEST(TextManipulation, TextManipulationTokenWithTrailingSpace)
 
 TEST(TextManipulation, TextManipulationTokenEqualToSelf)
 {
-    auto token = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr token = adoptNS([[_WKTextManipulationToken alloc] init]);
     [token setIdentifier:@"A"];
     [token setContent:@"content"];
 
@@ -4171,13 +4171,13 @@ TEST(TextManipulation, TextManipulationTokenEqualToSelf)
 
 TEST(TextManipulation, TextManipulationTokenNSObjectEqualityWithOtherToken)
 {
-    auto tokenA = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenA = adoptNS([[_WKTextManipulationToken alloc] init]);
     [tokenA setIdentifier:@"A"];
     [tokenA setContent:@"content"];
-    auto tokenB = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenB = adoptNS([[_WKTextManipulationToken alloc] init]);
     [tokenB setIdentifier:@"A"];
     [tokenB setContent:@"content"];
-    auto tokenC = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr tokenC = adoptNS([[_WKTextManipulationToken alloc] init]);
     [tokenC setIdentifier:@"A"];
     [tokenC setContent:@"content "];
 
@@ -4190,7 +4190,7 @@ TEST(TextManipulation, TextManipulationTokenNSObjectEqualityWithOtherToken)
 
 TEST(TextManipulation, TextManipulationTokenNSObjectEqualityWithNonToken)
 {
-    auto token = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr token = adoptNS([[_WKTextManipulationToken alloc] init]);
     [token setIdentifier:@"A"];
     [token setContent:@"content"];
     NSString *string = @"content";
@@ -4201,7 +4201,7 @@ TEST(TextManipulation, TextManipulationTokenNSObjectEqualityWithNonToken)
 
 static RetainPtr<_WKTextManipulationToken> createTextManipulationToken(NSString *identifier, BOOL excluded, NSString *content)
 {
-    auto token = adoptNS([[_WKTextManipulationToken alloc] init]);
+    RetainPtr token = adoptNS([[_WKTextManipulationToken alloc] init]);
     [token setIdentifier:identifier];
     [token setExcluded:excluded];
     [token setContent:content];
@@ -4212,7 +4212,7 @@ TEST(TextManipulation, TextManipulationItemDebugDescription)
 {
     auto tokenA = createTextManipulationToken(@"public_identifier_A", NO, @"private_content_A");
     auto tokenB = createTextManipulationToken(@"public_identifier_B", NO, @"private_content_B");
-    auto item = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"public_item_identifier" tokens:@[ tokenA.get(), tokenB.get() ]]);
+    RetainPtr item = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"public_item_identifier" tokens:@[ tokenA.get(), tokenB.get() ]]);
 
     NSString *debugDescription = [item debugDescription];
     EXPECT_TRUE([debugDescription containsString:@"public_identifier_A"]);
@@ -4231,7 +4231,7 @@ TEST(TextManipulation, TextManipulationItemDebugDescription)
 
 TEST(TextManipulation, TextManipulationItemEqualityToNilItem)
 {
-    auto item = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ ]]);
+    RetainPtr item = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ ]]);
 
     EXPECT_FALSE([item isEqualToTextManipulationItem:nil includingContentEquality:YES]);
     EXPECT_FALSE([item isEqualToTextManipulationItem:nil includingContentEquality:NO]);
@@ -4240,7 +4240,7 @@ TEST(TextManipulation, TextManipulationItemEqualityToNilItem)
 TEST(TextManipulation, TextManipulationItemEqualityToSelf)
 {
     auto token = createTextManipulationToken(@"A", NO, @"token");
-    auto item = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"B" tokens:@[ token.get() ]]);
+    RetainPtr item = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"B" tokens:@[ token.get() ]]);
 
     EXPECT_TRUE([item isEqualToTextManipulationItem:item.get() includingContentEquality:YES]);
     EXPECT_TRUE([item isEqualToTextManipulationItem:item.get() includingContentEquality:NO]);
@@ -4251,8 +4251,8 @@ TEST(TextManipulation, TextManipulationItemBasicEquality)
 {
     auto token1 = createTextManipulationToken(@"1", NO, @"token1");
     auto token2 = createTextManipulationToken(@"1", NO, @"token1");
-    auto itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ token1.get() ]]);
-    auto itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ token2.get() ]]);
+    RetainPtr itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ token1.get() ]]);
+    RetainPtr itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ token2.get() ]]);
 
     EXPECT_TRUE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:YES]);
     EXPECT_TRUE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:NO]);
@@ -4265,8 +4265,8 @@ TEST(TextManipulation, TextManipulationItemBasicEqualityWithMultipleTokens)
     auto tokenB1 = createTextManipulationToken(@"1", NO, @"token1");
     auto tokenB2 = createTextManipulationToken(@"2", NO, @"token2");
 
-    auto itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenA1.get(), tokenA2.get() ]]);
-    auto itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenB1.get(), tokenB2.get() ]]);
+    RetainPtr itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenA1.get(), tokenA2.get() ]]);
+    RetainPtr itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenB1.get(), tokenB2.get() ]]);
 
     EXPECT_TRUE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:YES]);
     EXPECT_TRUE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:NO]);
@@ -4276,8 +4276,8 @@ TEST(TextManipulation, TextManipulationItemEqualitySimilarTokensWithDifferentCon
 {
     auto token1 = createTextManipulationToken(@"1", NO, @"token1");
     auto token2 = createTextManipulationToken(@"1", NO, @"token2");
-    auto itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ token1.get() ]]);
-    auto itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ token2.get() ]]);
+    RetainPtr itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ token1.get() ]]);
+    RetainPtr itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ token2.get() ]]);
 
     EXPECT_FALSE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:YES]);
     EXPECT_TRUE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:NO]);
@@ -4290,8 +4290,8 @@ TEST(TextManipulation, TextManipulationItemEqualityWithOutOfOrderTokens)
     auto tokenB1 = createTextManipulationToken(@"1", NO, @"token1");
     auto tokenB2 = createTextManipulationToken(@"2", NO, @"token2");
 
-    auto itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenA1.get(), tokenA2.get() ]]);
-    auto itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenB2.get(), tokenB1.get() ]]);
+    RetainPtr itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenA1.get(), tokenA2.get() ]]);
+    RetainPtr itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenB2.get(), tokenB1.get() ]]);
 
     EXPECT_FALSE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:YES]);
     EXPECT_FALSE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:NO]);
@@ -4302,8 +4302,8 @@ TEST(TextManipulation, TextManipulationItemEqualityWithPointerEqualTokens)
     auto token1 = createTextManipulationToken(@"1", NO, @"token1");
     auto token2 = createTextManipulationToken(@"2", NO, @"token2");
 
-    auto itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ token1.get(), token2.get() ]]);
-    auto itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ token1.get(), token2.get() ]]);
+    RetainPtr itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ token1.get(), token2.get() ]]);
+    RetainPtr itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ token1.get(), token2.get() ]]);
 
     EXPECT_TRUE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:YES]);
     EXPECT_TRUE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:NO]);
@@ -4315,8 +4315,8 @@ TEST(TextManipulation, TextManipulationItemEqualityWithPointerEqualTokenArrays)
     auto token2 = createTextManipulationToken(@"2", NO, @"token2");
     NSArray<_WKTextManipulationToken *> *tokens = @[ token1.get(), token2.get() ];
 
-    auto itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:tokens]);
-    auto itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:tokens]);
+    RetainPtr itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:tokens]);
+    RetainPtr itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:tokens]);
 
     EXPECT_TRUE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:YES]);
     EXPECT_TRUE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:NO]);
@@ -4330,8 +4330,8 @@ TEST(TextManipulation, TextManipulationItemEqualityWithMismatchedTokenCounts)
     auto tokenB1 = createTextManipulationToken(@"1", NO, @"token1");
     auto tokenB2 = createTextManipulationToken(@"2", NO, @"token2");
 
-    auto itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenA1.get(), tokenA2.get(), tokenA3.get() ]]);
-    auto itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenB1.get(), tokenB2.get() ]]);
+    RetainPtr itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenA1.get(), tokenA2.get(), tokenA3.get() ]]);
+    RetainPtr itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenB1.get(), tokenB2.get() ]]);
 
     EXPECT_FALSE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:YES]);
     EXPECT_FALSE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:NO]);
@@ -4344,8 +4344,8 @@ TEST(TextManipulation, TextManipulationItemEqualityWithDifferentTokenIdentifiers
 {
     auto tokenA = createTextManipulationToken(@"A", NO, @"token");
     auto tokenB = createTextManipulationToken(@"B", NO, @"token");
-    auto itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenA.get() ]]);
-    auto itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenB.get() ]]);
+    RetainPtr itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenA.get() ]]);
+    RetainPtr itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenB.get() ]]);
 
     EXPECT_FALSE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:YES]);
     EXPECT_FALSE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:NO]);
@@ -4354,8 +4354,8 @@ TEST(TextManipulation, TextManipulationItemEqualityWithDifferentTokenIdentifiers
 TEST(TextManipulation, TextManipulationItemEqualityWithNilIdentifiers)
 {
     auto token = createTextManipulationToken(@"A", NO, @"token");
-    auto itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:nil tokens:@[ token.get() ]]);
-    auto itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:nil tokens:@[ token.get() ]]);
+    RetainPtr itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:nil tokens:@[ token.get() ]]);
+    RetainPtr itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:nil tokens:@[ token.get() ]]);
 
     EXPECT_TRUE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:YES]);
     EXPECT_TRUE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:NO]);
@@ -4365,8 +4365,8 @@ TEST(TextManipulation, TextManipulationItemEqualityWithDifferentTokenExclusions)
 {
     auto tokenA = createTextManipulationToken(@"1", NO, @"token");
     auto tokenB = createTextManipulationToken(@"1", YES, @"token");
-    auto itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenA.get() ]]);
-    auto itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenB.get() ]]);
+    RetainPtr itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenA.get() ]]);
+    RetainPtr itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenB.get() ]]);
 
     EXPECT_FALSE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:YES]);
     EXPECT_FALSE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:NO]);
@@ -4379,8 +4379,8 @@ TEST(TextManipulation, TextManipulationItemNSObjectEqualityWithOtherItem)
     auto tokenB1 = createTextManipulationToken(@"1", NO, @"token1");
     auto tokenB2 = createTextManipulationToken(@"2", NO, @"token2");
 
-    auto itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenA1.get(), tokenA2.get() ]]);
-    auto itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenB1.get(), tokenB2.get() ]]);
+    RetainPtr itemA = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenA1.get(), tokenA2.get() ]]);
+    RetainPtr itemB = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ tokenB1.get(), tokenB2.get() ]]);
 
     EXPECT_TRUE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:YES]);
     EXPECT_TRUE([itemA isEqualToTextManipulationItem:itemB.get() includingContentEquality:NO]);
@@ -4396,7 +4396,7 @@ TEST(TextManipulation, TextManipulationItemNSObjectEqualityWithOtherItem)
 TEST(TextManipulation, TextManipulationItemNSObjectEqualityWithNonToken)
 {
     auto token = createTextManipulationToken(@"1", NO, @"token1");
-    auto item = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ token.get() ]]);
+    RetainPtr item = adoptNS([[_WKTextManipulationItem alloc] initWithIdentifier:@"A" tokens:@[ token.get() ]]);
     NSString *string = @"content";
 
     EXPECT_FALSE([token isEqual:string]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextSize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextSize.mm
@@ -34,8 +34,8 @@
 
 TEST(WebKit, TextSize)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView configuration].preferences._textAutosizingEnabled = NO;
     [webView synchronouslyLoadHTMLString:
         @"<!DOCTYPE html>"

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextWidth.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextWidth.mm
@@ -34,8 +34,8 @@
 
 TEST(WebKit, TextWidth)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"TextWidth" withExtension:@"html"]]];
     [webView _test_waitForDidFinishNavigation];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TimeZoneOverride.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TimeZoneOverride.mm
@@ -40,8 +40,8 @@ class TimeZoneOverrideTest : public testing::Test {
 public:
     void SetUp() override
     {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-        auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
         [processPoolConfig setTimeZoneOverride:@"Europe/Berlin"];
 
         _webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UIDelegate.mm
@@ -103,8 +103,8 @@ static bool didReceiveMessage;
 
 TEST(WebKit, WKWebViewIsPlayingAudio)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:adoptNS([[WKWebViewConfiguration alloc] init]).get()]);
-    auto observer = adoptNS([[AudioObserver alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:adoptNS([[WKWebViewConfiguration alloc] init]).get()]);
+    RetainPtr observer = adoptNS([[AudioObserver alloc] init]);
     [webView addObserver:observer.get() forKeyPath:@"_isPlayingAudio" options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:nil];
     [webView synchronouslyLoadTestPageNamed:@"file-with-video"];
     [webView evaluateJavaScript:@"playVideo()" completionHandler:nil];
@@ -129,8 +129,8 @@ TEST(WebKit, WKWebViewIsPlayingAudio)
 TEST(WebKit, WindowOpenWithoutUIDelegate)
 {
     done = false;
-    auto webView = adoptNS([[WKWebView alloc] init]);
-    auto delegate = adoptNS([[NoUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr delegate = adoptNS([[NoUIDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView loadHTMLString:@"<script>window.open('simple2.html');window.location='simple.html'</script>" baseURL:[NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"]];
     TestWebKitAPI::Util::run(&done);
@@ -185,7 +185,7 @@ TEST(WebKit, GeolocationPermission)
         "function(e) { alert('error ' + e.code + ' ' + e.message) })"
     "</script>";
 
-    auto pool = adoptNS([[WKProcessPool alloc] init]);
+    RetainPtr pool = adoptNS([[WKProcessPool alloc] init]);
     
     WKGeolocationProviderV1 providerCallback;
     zeroBytes(providerCallback);
@@ -195,22 +195,22 @@ TEST(WebKit, GeolocationPermission)
     };
     WKGeolocationManagerSetProvider(WKContextGetGeolocationManager((WKContextRef)pool.get()), &providerCallback.base);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().processPool = pool.get();
 
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSURL *requestURL = [task request].URL;
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:requestURL MIMEType:@"text/html" expectedContentLength:[html length] textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:requestURL MIMEType:@"text/html" expectedContentLength:[html length] textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[html dataUsingEncoding:NSUTF8StringEncoding]];
         [task didFinish];
     }];
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"custom"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate1 = adoptNS([[GeolocationDelegate alloc] initWithAllowGeolocation:false]);
+    RetainPtr delegate1 = adoptNS([[GeolocationDelegate alloc] initWithAllowGeolocation:false]);
     [webView setUIDelegate:delegate1.get()];
 
     done = false;
@@ -225,7 +225,7 @@ TEST(WebKit, GeolocationPermission)
     TestWebKitAPI::Util::run(&done);
 
     done = false;
-    auto delegate2 = adoptNS([[GeolocationDelegate alloc] initWithAllowGeolocation:true]);
+    RetainPtr delegate2 = adoptNS([[GeolocationDelegate alloc] initWithAllowGeolocation:true]);
     [delegate2 setValidationHandler:[](WKFrameInfo *frame) {
         EXPECT_TRUE(frame.isMainFrame);
         EXPECT_STREQ(frame.request.URL.absoluteString.UTF8String, "https://example.org/");
@@ -309,7 +309,7 @@ TEST(WebKit, GeolocationPermissionInIFrame)
         { "/frame"_s, { frameText } },
     }, TestWebKitAPI::HTTPServer::Protocol::Https, nullptr, nullptr, 9091);
 
-    auto pool = adoptNS([[WKProcessPool alloc] init]);
+    RetainPtr pool = adoptNS([[WKProcessPool alloc] init]);
 
     WKGeolocationProviderV1 providerCallback;
     zeroBytes(providerCallback);
@@ -319,18 +319,18 @@ TEST(WebKit, GeolocationPermissionInIFrame)
     };
     WKGeolocationManagerSetProvider(WKContextGetGeolocationManager((WKContextRef)pool.get()), &providerCallback.base);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().processPool = pool.get();
 
-    auto messageHandler = adoptNS([[GeolocationPermissionMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GeolocationPermissionMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto permissionDelegate = adoptNS([[GeolocationDelegateNew alloc] init]);
+    RetainPtr permissionDelegate = adoptNS([[GeolocationDelegateNew alloc] init]);
     [webView setUIDelegate:permissionDelegate.get()];
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate setDidReceiveAuthenticationChallenge:^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^callback)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
         callback(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
@@ -362,7 +362,7 @@ TEST(WebKit, GeolocationPermissionInIFrameExampleWebArchive)
         { "/"_s, { mainFrameText } }
     }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
 
-    auto pool = adoptNS([[WKProcessPool alloc] init]);
+    RetainPtr pool = adoptNS([[WKProcessPool alloc] init]);
 
     WKGeolocationProviderV1 providerCallback;
     zeroBytes(providerCallback);
@@ -372,26 +372,26 @@ TEST(WebKit, GeolocationPermissionInIFrameExampleWebArchive)
     };
     WKGeolocationManagerSetProvider(WKContextGetGeolocationManager((WKContextRef)pool.get()), &providerCallback.base);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(server.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().processPool = pool.get();
     [configuration setWebsiteDataStore:dataStore.get()];
 
-    auto messageHandler = adoptNS([[GeolocationPermissionMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GeolocationPermissionMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto permissionDelegate = adoptNS([[GeolocationDelegateNew alloc] init]);
+    RetainPtr permissionDelegate = adoptNS([[GeolocationDelegateNew alloc] init]);
     [webView setUIDelegate:permissionDelegate.get()];
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
 
     webView.get().navigationDelegate = navigationDelegate.get();
@@ -481,7 +481,7 @@ TEST(WebKit, GeolocationPermissionInDisallowedIFrame)
         { "/frame"_s, { frameText } },
     }, TestWebKitAPI::HTTPServer::Protocol::Https, nullptr, nullptr, 9091);
 
-    auto pool = adoptNS([[WKProcessPool alloc] init]);
+    RetainPtr pool = adoptNS([[WKProcessPool alloc] init]);
 
     WKGeolocationProviderV1 providerCallback;
     zeroBytes(providerCallback);
@@ -491,18 +491,18 @@ TEST(WebKit, GeolocationPermissionInDisallowedIFrame)
     };
     WKGeolocationManagerSetProvider(WKContextGetGeolocationManager((WKContextRef)pool.get()), &providerCallback.base);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().processPool = pool.get();
 
-    auto messageHandler = adoptNS([[GeolocationPermissionMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GeolocationPermissionMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto permissionDelegate = adoptNS([[GeolocationDelegateNew alloc] init]);
+    RetainPtr permissionDelegate = adoptNS([[GeolocationDelegateNew alloc] init]);
     [webView setUIDelegate:permissionDelegate.get()];
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate setDidReceiveAuthenticationChallenge:^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^callback)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
         callback(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
@@ -534,8 +534,8 @@ TEST(WebKit, InjectedBundleNodeHandleIsSelectElement)
 {
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"InjectedBundleNodeHandleIsSelectElement"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
-    auto delegate = adoptNS([[InjectedBundleNodeHandleIsSelectElementDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr delegate = adoptNS([[InjectedBundleNodeHandleIsSelectElementDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
     TestWebKitAPI::Util::run(&done);
@@ -558,11 +558,11 @@ TEST(WebKit, LockdownModeDefaultFirstUseMessage)
 {
     InstanceMethodSwizzler swizzler(UIView.class, @selector(_wk_viewControllerForFullScreenPresentation), reinterpret_cast<IMP>(overrideViewControllerForFullscreenPresentation));
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     EXPECT_FALSE(webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled);
     webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get() addToWindow:NO]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get() addToWindow:NO]);
 
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:WebKitLockdownModeAlertShownKey];
     [WKProcessPool _setCaptivePortalModeEnabledGloballyForTesting:YES];
@@ -599,11 +599,11 @@ TEST(WebKit, LockdownModeNoFirstUseMessage)
 {
     InstanceMethodSwizzler swizzler(UIView.class, @selector(_wk_viewControllerForFullScreenPresentation), reinterpret_cast<IMP>(overrideViewControllerForFullscreenPresentation));
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     EXPECT_FALSE(webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled);
     webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get() addToWindow:NO]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get() addToWindow:NO]);
 
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:WebKitLockdownModeAlertShownKey];
     [WKProcessPool _setCaptivePortalModeEnabledGloballyForTesting:YES];
@@ -612,7 +612,7 @@ TEST(WebKit, LockdownModeNoFirstUseMessage)
     presentViewControllerCallCount = 0;
     showedNoFirstUseMessage = false;
 
-    auto delegate = adoptNS([[NoLockdownFirstUseMessage alloc] init]);
+    RetainPtr delegate = adoptNS([[NoLockdownFirstUseMessage alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView addToTestWindow];
 
@@ -653,11 +653,11 @@ TEST(WebKit, LockdownModeAskAgainFirstUseMessage)
 {
     InstanceMethodSwizzler swizzler(UIView.class, @selector(_wk_viewControllerForFullScreenPresentation), reinterpret_cast<IMP>(overrideViewControllerForFullscreenPresentation));
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     EXPECT_FALSE(webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled);
     webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get() addToWindow:NO]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get() addToWindow:NO]);
 
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:WebKitLockdownModeAlertShownKey];
     [WKProcessPool _setCaptivePortalModeEnabledGloballyForTesting:YES];
@@ -667,7 +667,7 @@ TEST(WebKit, LockdownModeAskAgainFirstUseMessage)
     showedCustomFirstUseMessage = false;
     requestFutureFirstUseMessage = false;
 
-    auto delegate = adoptNS([[AskAgainFirstUseMessage alloc] init]);
+    RetainPtr delegate = adoptNS([[AskAgainFirstUseMessage alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView addToTestWindow];
 
@@ -678,7 +678,7 @@ TEST(WebKit, LockdownModeAskAgainFirstUseMessage)
     EXPECT_FALSE([[NSUserDefaults standardUserDefaults] boolForKey:WebKitLockdownModeAlertShownKey]);
 
     // Load a new view and ask again:
-    auto secondWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get() addToWindow:NO]);
+    RetainPtr secondWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get() addToWindow:NO]);
 
     [secondWebView setUIDelegate:delegate.get()];
     [secondWebView addToTestWindow];
@@ -745,9 +745,9 @@ static RetainPtr<UITestDelegate> delegate;
 TEST(WebKit, ShowWebView)
 {
     delegate = adoptNS([[UITestDelegate alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:delegate.get() forURLScheme:@"test"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setUIDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"test:///first"]]];
     TestWebKitAPI::Util::run(&done);
@@ -787,8 +787,8 @@ static bool receivedWindowFrame;
 
 TEST(WebKit, WindowFrame)
 {
-    auto delegate = adoptNS([[WindowFrameDelegate alloc] init]);
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr delegate = adoptNS([[WindowFrameDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView loadHTMLString:@"<script>moveBy(10,20);alert(outerWidth);</script>" baseURL:nil];
     TestWebKitAPI::Util::run(&receivedWindowFrame);
@@ -847,8 +847,8 @@ static bool drawFooterCalled;
 
 TEST(WebKit, PrintFrame)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    auto delegate = adoptNS([[PrintDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr delegate = adoptNS([[PrintDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView loadHTMLString:@"<head><title>test_title</title></head><body onload='setTimeout(function() { print() });'>hello world!</body>" baseURL:[NSURL URLWithString:@"http://example.com/"]];
     TestWebKitAPI::Util::run(&done);
@@ -866,8 +866,8 @@ TEST(WebKit, PrintFrame)
 
 TEST(WebKit, PrintPreview)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    auto delegate = adoptNS([[PrintDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr delegate = adoptNS([[PrintDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView loadHTMLString:@"<head><title>test_title</title></head><body onload='print()'>hello world!</body>" baseURL:[NSURL URLWithString:@"http://example.com/"]];
     TestWebKitAPI::Util::run(&done);
@@ -920,8 +920,8 @@ TEST(WebKit, PrintAdjustMarginsAfterPageClose)
 
 TEST(WebKit, PrintWithCompletionHandler)
 {
-    auto webView = adoptNS([WKWebView new]);
-    auto delegate = adoptNS([PrintDelegateWithCompletionHandler new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    RetainPtr delegate = adoptNS([PrintDelegateWithCompletionHandler new]);
     [webView setUIDelegate:delegate.get()];
     [webView loadHTMLString:@"<head><title>test_title</title></head><body onload='print()'>hello world!</body>" baseURL:[NSURL URLWithString:@"http://example.com/"]];
     [delegate waitForPrintFrameCall];
@@ -967,8 +967,8 @@ TEST(WebKit, PrintWithCompletionHandler)
 TEST(WebKit, NotificationPermission)
 {
     NSString *html = @"<script>function requestPermission() { Notification.requestPermission(function(p){alert('permission '+p)}); }</script>";
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:adoptNS([[WKWebViewConfiguration alloc] init]).get()]);
-    auto uiDelegate = adoptNS([[NotificationDelegate alloc] initWithAllowNotifications:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:adoptNS([[WKWebViewConfiguration alloc] init]).get()]);
+    RetainPtr uiDelegate = adoptNS([[NotificationDelegate alloc] initWithAllowNotifications:YES]);
     [webView setUIDelegate:uiDelegate.get()];
     [webView synchronouslyLoadHTMLString:html baseURL:[NSURL URLWithString:@"https://example.org"]];
     [webView evaluateJavaScript:@"requestPermission()" completionHandler:nil];
@@ -1249,8 +1249,8 @@ TEST(WebKit, AutoFillAvailable)
 {
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"AutoFillAvailable"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
-    auto delegate = adoptNS([[AutoFillAvailableDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr delegate = adoptNS([[AutoFillAvailableDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView evaluateJavaScript:@"" completionHandler: nil]; // Ensure the WebProcess and injected bundle are running.
     TestWebKitAPI::Util::run(&done);
@@ -1274,8 +1274,8 @@ TEST(WebKit, InjectedBundleNodeHandleIsTextField)
 {
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"InjectedBundleNodeHandleIsTextField"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
-    auto delegate = adoptNS([[InjectedBundleNodeHandleIsTextFieldDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr delegate = adoptNS([[InjectedBundleNodeHandleIsTextFieldDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
     TestWebKitAPI::Util::run(&done);
@@ -1300,8 +1300,8 @@ TEST(WebKit, InjectedBundleNodeHandleIsTextField)
 
 TEST(WebKit, PinnedState)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
-    auto observer = adoptNS([[PinnedStateObserver alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr observer = adoptNS([[PinnedStateObserver alloc] init]);
     [webView addObserver:observer.get() forKeyPath:@"_pinnedState" options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:nil];
     [webView loadHTMLString:@"<body onload='scroll(100, 100)' style='height:10000vh;'/>" baseURL:[NSURL URLWithString:@"http://example.com/"]];
     TestWebKitAPI::Util::run(&done);
@@ -1322,8 +1322,8 @@ TEST(WebKit, PinnedState)
 
 TEST(WebKit, DidScroll)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
-    auto delegate = adoptNS([[DidScrollDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr delegate = adoptNS([[DidScrollDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView loadHTMLString:@"<body onload='scroll(100, 100)' style='height:10000vh;'/>" baseURL:[NSURL URLWithString:@"http://example.com/"]];
     TestWebKitAPI::Util::run(&done);
@@ -1368,8 +1368,8 @@ static void synthesizeTab(NSWindow *window, NSView *view, bool withShiftDown)
 
 TEST(WebKit, Focus)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
-    auto delegate = adoptNS([[FocusDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr delegate = adoptNS([[FocusDelegate alloc] init]);
     [delegate setUseShiftTab:YES];
     [webView setUIDelegate:delegate.get()];
     NSString *html = @"<script>function loaded() { document.getElementById('in').focus(); alert('ready'); }</script>"
@@ -1381,10 +1381,10 @@ TEST(WebKit, Focus)
 
 TEST(WebKit, ShiftTabTakesFocusFromEditableWebView)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView _setEditable:YES];
 
-    auto delegate = adoptNS([[FocusDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[FocusDelegate alloc] init]);
     [delegate setUseShiftTab:YES];
     [webView setUIDelegate:delegate.get()];
     NSString *html = @"<script>function loaded() { document.body.focus(); alert('ready'); }</script>"
@@ -1396,10 +1396,10 @@ TEST(WebKit, ShiftTabTakesFocusFromEditableWebView)
 
 TEST(WebKit, ShiftTabDoesNotTakeFocusFromEditableWebViewWhenPreventingKeyPress)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView _setEditable:YES];
 
-    auto delegate = adoptNS([[FocusDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[FocusDelegate alloc] init]);
     [delegate setUseShiftTab:YES];
     [webView setUIDelegate:delegate.get()];
     NSString *markup = @"<script>"
@@ -1424,10 +1424,10 @@ TEST(WebKit, ShiftTabDoesNotTakeFocusFromEditableWebViewWhenPreventingKeyPress)
 
 TEST(WebKit, TabDoesNotTakeFocusFromEditableWebView)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView _setEditable:YES];
 
-    auto delegate = adoptNS([[FocusDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[FocusDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     NSString *html = @"<script>function loaded() { document.body.focus(); alert('ready'); }</script>"
     "<body onload='loaded()'></body>";
@@ -1517,8 +1517,8 @@ static void synthesizeWheelEvents(NSView *view, int x, int y)
 
 TEST(WebKit, DidNotHandleWheelEvent)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
-    auto delegate = adoptNS([[WheelDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr delegate = adoptNS([[WheelDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView loadHTMLString:@"<body onload='alert(\"ready\")' onwheel='()=>{}' style='overflow:hidden; height:10000vh;'></body>" baseURL:[NSURL URLWithString:@"http://example.com/"]];
     TestWebKitAPI::Util::run(&done);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
@@ -206,7 +206,7 @@ TEST_F(UnifiedPDFWithKeyboardScrolling, DisplayModeTransitionLandingPage)
 
 UNIFIED_PDF_TEST(CopyEditingCommandOnEmptySelectionShouldNotCrash)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 600) configuration:configurationForWebViewTestingUnifiedPDF().get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 600) configuration:configurationForWebViewTestingUnifiedPDF().get() addToWindow:YES]);
     [webView setForceWindowToBecomeKey:YES];
 
     RetainPtr request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"multiple-pages" withExtension:@"pdf"]];
@@ -300,7 +300,7 @@ UNIFIED_PDF_TEST(PrintSize)
             mimeType = @"application/pdf";
             data = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"test_print" withExtension:@"pdf"]];
         }
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:url MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:url MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:data];
         [task didFinish];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UploadDirectory.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UploadDirectory.mm
@@ -103,8 +103,8 @@ TEST(WebKit, UploadDirectory)
             });
         });
 
-        auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
-        auto delegate = adoptNS([[UploadDelegate alloc] initWithDirectory:directory]);
+        RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+        RetainPtr delegate = adoptNS([[UploadDelegate alloc] initWithDirectory:directory]);
         [webView setUIDelegate:delegate.get()];
 
         [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UseSelectionAsFindString.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UseSelectionAsFindString.mm
@@ -33,7 +33,7 @@ namespace TestWebKitAPI {
 
 TEST(WebKit, UseSelectionAsFindString)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<body>Hello <span id='text'>world</span></body>"];
     [webView evaluateJavaScript:@"getSelection().selectAllChildren(text)" completionHandler:nil];
     [webView _takeFindStringFromSelection:nil];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm
@@ -577,7 +577,7 @@ TEST(WKUserContentController, UserStyleSheetAffectingOnlySpecificWebView)
     expectScriptEvaluatesToColor(otherWebView.get(), backgroundColorScript, redInRGB);
 
     RetainPtr<WKContentWorld> world = [WKContentWorld worldWithName:@"TestWorld"];
-    auto styleSheet = adoptNS([[_WKUserStyleSheet alloc] initWithSource:styleSheetSource forWKWebView:targetWebView.get() forMainFrameOnly:YES includeMatchPatternStrings:nil excludeMatchPatternStrings:nil baseURL:nil level:_WKUserStyleAuthorLevel contentWorld:world.get()]);
+    RetainPtr styleSheet = adoptNS([[_WKUserStyleSheet alloc] initWithSource:styleSheetSource forWKWebView:targetWebView.get() forMainFrameOnly:YES includeMatchPatternStrings:nil excludeMatchPatternStrings:nil baseURL:nil level:_WKUserStyleAuthorLevel contentWorld:world.get()]);
     [[targetWebView configuration].userContentController _addUserStyleSheet:styleSheet.get()];
 
     expectScriptEvaluatesToColor(targetWebView.get(), backgroundColorScript, greenInRGB);
@@ -615,7 +615,7 @@ TEST(WKUserContentController, UserStyleSheetAffectingSpecificWebViewInjectionAnd
 
 TEST(WKUserContentController, UserStyleSheetAffectingOnlySpecificWebViewSharedConfiguration)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     RetainPtr<WKWebView> targetWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     RetainPtr<WKWebView> otherWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
@@ -704,7 +704,7 @@ TEST(WKUserContentController, UserStyleSheetAffectingOnlySpecificWebViewRemovalA
 
 static RetainPtr<_WKProcessPoolConfiguration> psonProcessPoolConfiguration()
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().processSwapsOnNavigation = YES;
     processPoolConfiguration.get().usesWebProcessCache = YES;
     processPoolConfiguration.get().prewarmsProcessesAutomatically = YES;
@@ -714,9 +714,9 @@ static RetainPtr<_WKProcessPoolConfiguration> psonProcessPoolConfiguration()
 TEST(WKUserContentController, UserStyleSheetAffectingOnlySpecificWebViewRemovalAfterNavigationPSON)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setProcessPool:processPool.get()];
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
@@ -806,7 +806,7 @@ TEST(WKUserContentController, UserScriptRemoveAll)
     RetainPtr<WKContentWorld> world = [WKContentWorld worldWithName:@"TestWorld"];
 
     RetainPtr<WKUserScript> userScript = adoptNS([[WKUserScript alloc] initWithSource:@"" injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:NO]);
-    auto userScriptAssociatedWithWorld = adoptNS([[WKUserScript alloc] _initWithSource:@"" injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:NO includeMatchPatternStrings:@[] excludeMatchPatternStrings:@[] associatedURL:nil contentWorld:world.get() deferRunningUntilNotification:NO]);
+    RetainPtr userScriptAssociatedWithWorld = adoptNS([[WKUserScript alloc] _initWithSource:@"" injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:NO includeMatchPatternStrings:@[] excludeMatchPatternStrings:@[] associatedURL:nil contentWorld:world.get() deferRunningUntilNotification:NO]);
 
     [userContentController addUserScript:userScript.get()];
     [userContentController addUserScript:userScriptAssociatedWithWorld.get()];
@@ -891,16 +891,16 @@ TEST(WKUserContentController, InjectUserScriptImmediately)
     scriptMessagesVector.clear();
     receivedScriptMessage = false;
 
-    auto handler = adoptNS([[ScriptMessageHandler alloc] init]);
-    auto startAllFrames = adoptNS([[WKUserScript alloc] initWithSource:@"window.webkit.messageHandlers.testHandler.postMessage('start all')" injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:NO]);
-    auto endMainFrameOnly = adoptNS([[WKUserScript alloc] initWithSource:@"window.webkit.messageHandlers.testHandler.postMessage('end main')" injectionTime:WKUserScriptInjectionTimeAtDocumentEnd forMainFrameOnly:YES]);
+    RetainPtr handler = adoptNS([[ScriptMessageHandler alloc] init]);
+    RetainPtr startAllFrames = adoptNS([[WKUserScript alloc] initWithSource:@"window.webkit.messageHandlers.testHandler.postMessage('start all')" injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:NO]);
+    RetainPtr endMainFrameOnly = adoptNS([[WKUserScript alloc] initWithSource:@"window.webkit.messageHandlers.testHandler.postMessage('end main')" injectionTime:WKUserScriptInjectionTimeAtDocumentEnd forMainFrameOnly:YES]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[SimpleNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[SimpleNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple-iframe" withExtension:@"html"]];
@@ -925,9 +925,9 @@ TEST(WKUserContentController, AddUserScriptInWorldWithGlobalObjectAvailableInIfr
     RetainPtr<WKContentWorld> testWorld = [WKContentWorld worldWithName:@"testWorld"];
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"ContentWorldPlugIn"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
 
-    auto delegate = adoptNS([[SimpleNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[SimpleNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple-iframe" withExtension:@"html"]];
@@ -936,7 +936,7 @@ TEST(WKUserContentController, AddUserScriptInWorldWithGlobalObjectAvailableInIfr
     [webView loadRequest:request];
     TestWebKitAPI::Util::run(&isDoneWithNavigation);
 
-    auto contentScript = adoptNS([[WKUserScript alloc] _initWithSource:@"window.worldName" injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES includeMatchPatternStrings:@[] excludeMatchPatternStrings:@[] associatedURL:nil contentWorld:testWorld.get() deferRunningUntilNotification:NO]);
+    RetainPtr contentScript = adoptNS([[WKUserScript alloc] _initWithSource:@"window.worldName" injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES includeMatchPatternStrings:@[] excludeMatchPatternStrings:@[] associatedURL:nil contentWorld:testWorld.get() deferRunningUntilNotification:NO]);
     [[webView configuration].userContentController _addUserScriptImmediately:contentScript.get()];
 
     __block bool done = false;
@@ -997,7 +997,7 @@ TEST(WKUserContentController, AddUserScriptInWorldWithGlobalObjectAvailableInIfr
 TEST(WKUserContentController, MessageHandlerAPI)
 {
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([[AsyncScriptMessageHandler alloc] init]);
+    RetainPtr handler = adoptNS([[AsyncScriptMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandlerWithReply:handler.get() contentWorld:WKContentWorld.pageWorld name:@"testHandler1"];
 
     bool hadException = false;
@@ -1015,7 +1015,7 @@ TEST(WKUserContentController, MessageHandlerAPI)
     [[configuration userContentController] addScriptMessageHandlerWithReply:handler.get() contentWorld:world name:@"testHandler4"];
     [[configuration userContentController] addScriptMessageHandlerWithReply:handler.get() contentWorld:world name:@"testHandler5"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     bool done = false;
     NSString *functionBody = @"var p = window.webkit.messageHandlers[handler].postMessage(arg); await p; return p;";
@@ -1120,10 +1120,10 @@ TEST(WKUserContentController, MessageHandlerAPI)
 TEST(WKUserContentController, AsyncScriptMessageHandlerBasicPost)
 {
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([[AsyncScriptMessageHandler alloc] init]);
+    RetainPtr handler = adoptNS([[AsyncScriptMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandlerWithReply:handler.get() contentWorld:WKContentWorld.pageWorld name:@"testHandler"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     bool done = false;
     NSString *functionBody = @"var p = window.webkit.messageHandlers.testHandler.postMessage('Fulfill'); await p; return p;";
@@ -1188,11 +1188,11 @@ TEST(WKUserContentController, AsyncScriptMessageHandlerBasicPost)
 TEST(WKUserContentController, WorldLifetime)
 {
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([[AsyncScriptMessageHandler alloc] init]);
+    RetainPtr handler = adoptNS([[AsyncScriptMessageHandler alloc] init]);
 
     RetainPtr<WKContentWorld> world = [WKContentWorld worldWithName:@"otherWorld"];
     [[configuration userContentController] addScriptMessageHandlerWithReply:handler.get() contentWorld:world.get() name:@"testHandler"];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     // Set a variable in the world.
     bool done = false;
@@ -1230,9 +1230,9 @@ TEST(WKUserContentController, WorldLifetime)
 TEST(WKUserContentController, RemoveAllScriptMessageHandlers)
 {
     WeakObjCPtr<ScriptMessageHandler> weakHandler;
-    auto handler = adoptNS([ScriptMessageHandler new]);
+    RetainPtr handler = adoptNS([ScriptMessageHandler new]);
     weakHandler = handler.get();
-    auto controller = adoptNS([WKUserContentController new]);
+    RetainPtr controller = adoptNS([WKUserContentController new]);
     [controller addScriptMessageHandler:handler.get() name:@"testname"];
     handler = nullptr;
     EXPECT_NOT_NULL(weakHandler.get());
@@ -1757,8 +1757,8 @@ TEST(WKUserContentController, AllowAccessToClosedShadowRoots)
 #if PLATFORM(IOS)
 TEST(WKUserContentController, FireUserTextInputEvent)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id<_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         return _WKFocusStartsInputSessionPolicyAllow;
     }];
@@ -1775,8 +1775,8 @@ TEST(WKUserContentController, FireUserTextInputEvent)
     [webView objectByEvaluatingJavaScript:@"window.didFire = false; document.querySelector('input').addEventListener('webkitusertextinput', () => didFire = true);" inFrame:nil inContentWorld:autofillWorld.get()];
 
     bool doneWaiting = false;
-    auto firstWebEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyDown timeStamp:CFAbsoluteTimeGetCurrent() characters:@"a" charactersIgnoringModifiers:@"a" modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:NO]);
-    auto secondWebEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyUp timeStamp:CFAbsoluteTimeGetCurrent() characters:@"a" charactersIgnoringModifiers:@"a" modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:NO]);
+    RetainPtr firstWebEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyDown timeStamp:CFAbsoluteTimeGetCurrent() characters:@"a" charactersIgnoringModifiers:@"a" modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:NO]);
+    RetainPtr secondWebEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyUp timeStamp:CFAbsoluteTimeGetCurrent() characters:@"a" charactersIgnoringModifiers:@"a" modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:NO]);
     [webView handleKeyEvent:firstWebEvent.get() completion:[&](WebEvent *event, BOOL) {
         EXPECT_TRUE([event isEqual:firstWebEvent.get()]);
         [webView handleKeyEvent:secondWebEvent.get() completion:[&] (WebEvent *event, BOOL) {
@@ -1836,7 +1836,7 @@ TEST(WKUserContentController, DisableLegacyBuiltinOverrides)
 
 TEST(WKUserContentController, FormSubmissionWithUserInfo)
 {
-    auto inputDelegate = adoptNS([[InputDelegateForFormSubmission alloc] init]);
+    RetainPtr inputDelegate = adoptNS([[InputDelegateForFormSubmission alloc] init]);
     isDoneWithFormSubmission = false;
 
     RetainPtr contentWorldConfiguration = adoptNS([[_WKContentWorldConfiguration alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentWorld.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentWorld.mm
@@ -202,15 +202,15 @@ static Vector<String> userContentWorldReceivedMessages;
 
 TEST(UserContentWorld, DefaultClientWorldMessageEvent)
 {
-    auto handler = adoptNS([[UserContentWorldMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[UserContentWorldMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     [[configuration userContentController] addUserScript:[[WKUserScript alloc] initWithSource:
         @"window.addEventListener('message', function(message) { console.error(message.data); });"
         injectionTime:WKUserScriptInjectionTimeAtDocumentStart
         forMainFrameOnly:NO
         inContentWorld:WKContentWorld.defaultClientWorld]];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)  configuration:configuration.get() addToWindow:NO]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)  configuration:configuration.get() addToWindow:NO]);
     [webView synchronouslyLoadTestPageNamed:@"postMessage-various-types"];
     while (userContentWorldReceivedMessages.size() != 4)
         TestWebKitAPI::Util::spinRunLoop();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserInitiatedActionInNavigationAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserInitiatedActionInNavigationAction.mm
@@ -81,7 +81,7 @@ public:
 
     NSURL *URLWithFragment(NSString *fragment)
     {
-        auto urlComponents = adoptNS([[NSURLComponents alloc] initWithURL:URL.get() resolvingAgainstBaseURL:NO]);
+        RetainPtr urlComponents = adoptNS([[NSURLComponents alloc] initWithURL:URL.get() resolvingAgainstBaseURL:NO]);
         [urlComponents setFragment:fragment];
         return [urlComponents URL];
     }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/VerifyUserGestureFromUIProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/VerifyUserGestureFromUIProcess.mm
@@ -52,10 +52,10 @@ static void testWindowOpenMouseEvent(const String& event, bool expectOpenedWindo
 
     auto configuration = server.httpsProxyConfiguration();
     [[configuration preferences] _setVerifyWindowOpenUserGestureFromUIProcess:YES];
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
-    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
     [openerWebView setNavigationDelegate:navigationDelegate.get()];
     [openerWebView setUIDelegate:uiDelegate.get()];
 
@@ -121,10 +121,10 @@ TEST(VerifyUserGesture, WindowOpenKeyEvent)
 
     auto configuration = server.httpsProxyConfiguration();
     [[configuration preferences] _setVerifyWindowOpenUserGestureFromUIProcess:YES];
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
-    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
     [openerWebView setNavigationDelegate:navigationDelegate.get()];
     [openerWebView setUIDelegate:uiDelegate.get()];
 
@@ -164,10 +164,10 @@ TEST(VerifyUserGesture, InvalidateAuthorizationTokensByPage)
 
     auto configuration = server.httpsProxyConfiguration();
     [[configuration preferences] _setVerifyWindowOpenUserGestureFromUIProcess:YES];
-    auto openerNavigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr openerNavigationDelegate = adoptNS([TestNavigationDelegate new]);
     [openerNavigationDelegate allowAnyTLSCertificate];
-    auto openerUIDelegate = adoptNS([TestUIDelegate new]);
-    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr openerUIDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
     [openerWebView setNavigationDelegate:openerNavigationDelegate.get()];
     [openerWebView setUIDelegate:openerUIDelegate.get()];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/VideoQualityDisplayCompositing.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/VideoQualityDisplayCompositing.mm
@@ -34,9 +34,9 @@ namespace TestWebKitAPI {
 
 TEST(VideoQualityDisplayCompositing, Enabled)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().preferences._videoQualityIncludesDisplayCompositingEnabled = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:@"<video>"];
     id result = [webView objectByEvaluatingJavaScript:@"document.querySelector('video').getVideoPlaybackQuality().displayCompositedVideoFrames"];
     EXPECT_NOT_NULL(result);
@@ -46,9 +46,9 @@ TEST(VideoQualityDisplayCompositing, Enabled)
 
 TEST(VideoQualityDisplayCompositing, Disabled)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().preferences._videoQualityIncludesDisplayCompositingEnabled = NO;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:@"<video>"];
     auto result = [webView stringByEvaluatingJavaScript:@"typeof document.querySelector('video').getVideoPlaybackQuality().displayCompositedVideoFrames"];
     EXPECT_STREQ("undefined", result.UTF8String);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/VisibilityState.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/VisibilityState.mm
@@ -38,8 +38,8 @@
 
 TEST(VisibilityState, InitialHiddenState)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get() addToWindow:NO]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get() addToWindow:NO]);
 
     [webView synchronouslyLoadHTMLString:@"foo"];
 
@@ -53,8 +53,8 @@ TEST(VisibilityState, InitialHiddenState)
 
 TEST(VisibilityState, InitialVisibleState)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get() addToWindow:YES]);
 
     [webView synchronouslyLoadHTMLString:@"foo"];
 
@@ -87,7 +87,7 @@ TEST(VisibilityState, PIPKeepsDocumentVisibleQuirk)
 {
     RetainPtr configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration preferences]._allowsPictureInPictureMediaPlayback = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get() addToWindow:YES]);
 
     RetainPtr<PiPUIDelegate> handler = adoptNS([[PiPUIDelegate alloc] init]);
     [webView setUIDelegate:handler.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/VisibleContentRect.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/VisibleContentRect.mm
@@ -53,18 +53,18 @@ namespace TestWebKitAPI {
 
 TEST(WebKit, VisibleContentRect_FullBounds)
 {
-    auto config = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebViewWithEnclosingView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    RetainPtr config = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebViewWithEnclosingView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
 
     EXPECT_TRUE(CGRectEqualToRect([webView _visibleContentRect], CGRectMake(0, 0, 800, 600)));
 }
 
 TEST(WebKit, VisibleContentRect_FullBoundsWithinScrollView)
 {
-    auto config = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebViewWithEnclosingView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    RetainPtr config = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebViewWithEnclosingView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
     auto window = webView.get().window;
-    auto scrollView = adoptNS([[UIScrollView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr scrollView = adoptNS([[UIScrollView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [window addSubview:scrollView.get()];
     [scrollView addSubview:webView.get()];
 
@@ -73,10 +73,10 @@ TEST(WebKit, VisibleContentRect_FullBoundsWithinScrollView)
 
 TEST(WebKit, VisibleContentRect_FullBoundsWhenClippedByNonScrollView)
 {
-    auto config = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebViewWithEnclosingView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    RetainPtr config = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebViewWithEnclosingView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
     auto window = webView.get().window;
-    auto view = adoptNS([[UIView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr view = adoptNS([[UIView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [window addSubview:view.get()];
     [view addSubview:webView.get()];
 
@@ -88,10 +88,10 @@ TEST(WebKit, VisibleContentRect_FullBoundsWhenClippedByNonScrollView)
 TEST(WebKit, VisibleContentRect_ClippedBoundsWhenClippedByScrollView)
 {
     CGRect windowBounds = CGRectMake(0, 0, 800, 600);
-    auto config = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebViewWithEnclosingView alloc] initWithFrame:windowBounds configuration:config.get()]);
+    RetainPtr config = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebViewWithEnclosingView alloc] initWithFrame:windowBounds configuration:config.get()]);
     auto window = webView.get().window;
-    auto scrollView = adoptNS([[UIScrollView alloc] initWithFrame:windowBounds]);
+    RetainPtr scrollView = adoptNS([[UIScrollView alloc] initWithFrame:windowBounds]);
     [window addSubview:scrollView.get()];
     [scrollView addSubview:webView.get()];
 
@@ -104,10 +104,10 @@ TEST(WebKit, VisibleContentRect_ClippedBoundsWhenClippedByScrollView)
 
 TEST(WebKit, VisibleContentRect_ClippedBoundsWhenClippedByEnclosingView)
 {
-    auto config = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebViewWithEnclosingView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    RetainPtr config = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebViewWithEnclosingView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
     auto window = webView.get().window;
-    auto view = adoptNS([[UIView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr view = adoptNS([[UIView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [window addSubview:view.get()];
     [view addSubview:webView.get()];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/VisitedLinkStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/VisitedLinkStore.mm
@@ -32,7 +32,7 @@ namespace TestWebKitAPI {
 
 TEST(WebKit, VisitedLinkStore_Add)
 {
-    auto visitedLinkStore = adoptNS([[_WKVisitedLinkStore alloc] init]);
+    RetainPtr visitedLinkStore = adoptNS([[_WKVisitedLinkStore alloc] init]);
     NSURL *appleURL = [NSURL URLWithString:@"https://www.apple.com"];
     NSURL *webkitURL = [NSURL URLWithString:@"https://www.webkit.org"];
     NSURL *bugzillaURL = [NSURL URLWithString:@"https://bugs.webkit.org"];
@@ -51,7 +51,7 @@ TEST(WebKit, VisitedLinkStore_Add)
 
 TEST(WebKit, VisitedLinkStore_RemoveAll)
 {
-    auto visitedLinkStore = adoptNS([[_WKVisitedLinkStore alloc] init]);
+    RetainPtr visitedLinkStore = adoptNS([[_WKVisitedLinkStore alloc] init]);
     NSURL *appleURL = [NSURL URLWithString:@"https://www.apple.com"];
     NSURL *webkitURL = [NSURL URLWithString:@"https://www.webkit.org"];
     NSURL *bugzillaURL = [NSURL URLWithString:@"https://bugs.webkit.org"];
@@ -69,7 +69,7 @@ TEST(WebKit, VisitedLinkStore_RemoveAll)
 
 TEST(WebKit, VisitedLinkStore_Remove)
 {
-    auto visitedLinkStore = adoptNS([[_WKVisitedLinkStore alloc] init]);
+    RetainPtr visitedLinkStore = adoptNS([[_WKVisitedLinkStore alloc] init]);
     NSURL *appleURL = [NSURL URLWithString:@"https://www.apple.com"];
     NSURL *webkitURL = [NSURL URLWithString:@"https://www.webkit.org"];
     NSURL *bugzillaURL = [NSURL URLWithString:@"https://bugs.webkit.org"];
@@ -97,7 +97,7 @@ TEST(WebKit, VisitedLinkStore_Remove)
 
 TEST(WebKit, VisitedLinkStore_AddAndRemove)
 {
-    auto visitedLinkStore = adoptNS([[_WKVisitedLinkStore alloc] init]);
+    RetainPtr visitedLinkStore = adoptNS([[_WKVisitedLinkStore alloc] init]);
     NSURL *appleURL = [NSURL URLWithString:@"https://www.apple.com"];
     NSURL *webkitURL = [NSURL URLWithString:@"https://www.webkit.org"];
     NSURL *bugzillaURL = [NSURL URLWithString:@"https://bugs.webkit.org"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKAppHighlights.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKAppHighlights.mm
@@ -60,8 +60,8 @@ namespace TestWebKitAPI {
 RetainPtr<_WKAppHighlight> createAppHighlightWithHTML(NSString *HTMLString, NSString *javaScript, NSString *highlightText)
 {
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto delegate = adoptNS([[AppHighlightDelegate alloc] init]);
-    auto webViewCreate = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration]);
+    RetainPtr delegate = adoptNS([[AppHighlightDelegate alloc] init]);
+    RetainPtr webViewCreate = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration]);
     [webViewCreate _setAppHighlightDelegate:delegate.get()];
     [webViewCreate synchronouslyLoadHTMLString:HTMLString];
     [webViewCreate stringByEvaluatingJavaScript:javaScript];
@@ -83,7 +83,7 @@ RetainPtr<_WKAppHighlight> createAppHighlightWithHTML(NSString *HTMLString, NSSt
 RetainPtr<WKWebView> createWebViewForAppHighlightsWithHTML(NSString *HTMLString)
 {
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webViewRestore = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration]);
+    RetainPtr webViewRestore = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration]);
     [webViewRestore synchronouslyLoadHTMLString:HTMLString];
     
     return webViewRestore;
@@ -201,7 +201,7 @@ TEST(AppHighlights, AppHighlightRestoreFromStorageV0)
     
     NSData *storedData = [NSData dataWithBytes:&bytes length:87];
 
-    auto webViewRestore = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration]);
+    RetainPtr webViewRestore = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration]);
 
     [webViewRestore synchronouslyLoadHTMLString:@"Test"];
     [webViewRestore _restoreAppHighlights:@[ storedData ]];
@@ -220,7 +220,7 @@ TEST(AppHighlights, AppHighlightRestoreFromStorageV1)
     
     NSData *storedData = [NSData dataWithBytes:&bytes length:144];
 
-    auto webViewRestore = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration]);
+    RetainPtr webViewRestore = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration]);
 
     [webViewRestore synchronouslyLoadHTMLString:@"Test"];
     [webViewRestore _restoreAppHighlights:@[ storedData ]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKAttachmentTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKAttachmentTests.mm
@@ -178,7 +178,7 @@ static NSURL *testDirectoryAttachmentFileURL()
 
 - (void)_webView:(WKWebView *)webView didInsertAttachment:(_WKAttachment *)wkAttachment withSource:(NSString *)source
 {
-    auto fileWrapper = adoptNS([[NSFileWrapper alloc] initWithURL:testiWorkAttachmentFileURL() options:0 error:NULL]);
+    RetainPtr fileWrapper = adoptNS([[NSFileWrapper alloc] initWithURL:testiWorkAttachmentFileURL() options:0 error:NULL]);
     [wkAttachment setFileWrapper:fileWrapper.get() contentType:nil completion:nil];
 }
 
@@ -253,7 +253,7 @@ static RetainPtr<TestWKWebView> webViewForTestingAttachments(CGSize webViewSize,
     configuration._attachmentElementEnabled = YES;
     WKPreferencesSetCustomPasteboardDataEnabled((__bridge WKPreferencesRef)[configuration preferences], YES);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, webViewSize.width, webViewSize.height) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, webViewSize.width, webViewSize.height) configuration:configuration]);
     [webView synchronouslyLoadHTMLString:attachmentEditingTestMarkup];
 
     return webView;
@@ -261,7 +261,7 @@ static RetainPtr<TestWKWebView> webViewForTestingAttachments(CGSize webViewSize,
 
 static RetainPtr<TestWKWebView> webViewForTestingAttachments(CGSize webViewSize)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     return webViewForTestingAttachments(webViewSize, configuration.get());
 }
 
@@ -336,7 +336,7 @@ static NSData *testJPEGData()
 - (_WKAttachment *)synchronouslyInsertAttachmentWithFilename:(NSString *)filename contentType:(NSString *)contentType data:(NSData *)data
 {
     __block bool done = false;
-    auto fileWrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:data]);
+    RetainPtr fileWrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:data]);
     if (filename)
         [fileWrapper setPreferredFilename:filename];
     RetainPtr<_WKAttachment> attachment = [self _insertAttachmentWithFileWrapper:fileWrapper.get() contentType:contentType completion:^(BOOL) {
@@ -348,7 +348,7 @@ static NSData *testJPEGData()
 
 - (NSArray<NSValue *> *)allBoundingClientRects:(NSString *)querySelector
 {
-    auto rects = adoptNS([[NSMutableArray alloc] init]);
+    RetainPtr rects = adoptNS([[NSMutableArray alloc] init]);
     bool doneEvaluatingScript = false;
     NSString *script = [NSString stringWithFormat:@"Array.from(document.querySelectorAll('%@')).map(e => { const r = e.getBoundingClientRect(); return [r.left, r.top, r.width, r.height]; })", querySelector];
     [self evaluateJavaScript:script completionHandler:[rects, &doneEvaluatingScript] (NSArray<NSArray<NSNumber *> *> *result, NSError *) {
@@ -480,7 +480,7 @@ static NSData *testJPEGData()
 {
     __block RetainPtr<NSError> resultError;
     __block bool done = false;
-    auto fileWrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:data]);
+    RetainPtr fileWrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:data]);
     if (newFilename)
         [fileWrapper setPreferredFilename:newFilename];
 
@@ -551,7 +551,7 @@ static void simulateFolderDragWithURL(DragAndDropSimulator *simulator, NSURL *fo
 #if PLATFORM(MAC)
     [simulator writePromisedFiles:@[ folderURL ]];
 #else
-    auto folderProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr folderProvider = adoptNS([[NSItemProvider alloc] init]);
     [folderProvider setSuggestedName:folderURL.lastPathComponent];
     [folderProvider setPreferredPresentationStyle:UIPreferredPresentationStyleAttachment];
     [folderProvider registerFileRepresentationForTypeIdentifier:UTTypeFolder.identifier fileOptions:0 visibility:NSItemProviderRepresentationVisibilityAll loadHandler:[protectedFolderURL = retainPtr(folderURL)] (void(^completion)(NSURL *, BOOL, NSError *)) -> NSProgress * {
@@ -568,7 +568,7 @@ static void simulateFolderDragWithURL(DragAndDropSimulator *simulator, NSURL *fo
 
 BOOL isCompletelyTransparent(NSImage *image)
 {
-    auto representation = adoptNS([[NSBitmapImageRep alloc] initWithData:image.TIFFRepresentation]);
+    RetainPtr representation = adoptNS([[NSBitmapImageRep alloc] initWithData:image.TIFFRepresentation]);
     for (int row = 0; row < image.size.height; ++row) {
         for (int column = 0; column < image.size.width; ++column) {
             if ([representation colorAtX:column y:row].alphaComponent)
@@ -628,11 +628,11 @@ typedef void(^ItemProviderDataLoadHandler)(NSData *, NSError *);
 
 void platformCopyRichTextWithMultipleAttachments()
 {
-    auto image = adoptNS([[NSTextAttachment alloc] initWithData:testImageData() ofType:UTTypePNG.identifier]);
-    auto pdf = adoptNS([[NSTextAttachment alloc] initWithData:testPDFData() ofType:UTTypePDF.identifier]);
-    auto zip = adoptNS([[NSTextAttachment alloc] initWithData:testZIPData() ofType:UTTypeZIP.identifier]);
+    RetainPtr image = adoptNS([[NSTextAttachment alloc] initWithData:testImageData() ofType:UTTypePNG.identifier]);
+    RetainPtr pdf = adoptNS([[NSTextAttachment alloc] initWithData:testPDFData() ofType:UTTypePDF.identifier]);
+    RetainPtr zip = adoptNS([[NSTextAttachment alloc] initWithData:testZIPData() ofType:UTTypeZIP.identifier]);
 
-    auto richText = adoptNS([[NSMutableAttributedString alloc] init]);
+    RetainPtr richText = adoptNS([[NSMutableAttributedString alloc] init]);
     [richText appendAttributedString:[NSAttributedString attributedStringWithAttachment:image.get()]];
     [richText appendAttributedString:[NSAttributedString attributedStringWithAttachment:pdf.get()]];
     [richText appendAttributedString:[NSAttributedString attributedStringWithAttachment:zip.get()]];
@@ -642,7 +642,7 @@ void platformCopyRichTextWithMultipleAttachments()
     [pasteboard clearContents];
     [pasteboard writeObjects:@[ richText.get() ]];
 #elif PLATFORM(IOS_FAMILY)
-    auto item = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr item = adoptNS([[NSItemProvider alloc] init]);
     [item registerObject:richText.get() visibility:NSItemProviderRepresentationVisibilityAll];
     [UIPasteboard generalPasteboard].itemProviders = @[ item.get() ];
 #endif
@@ -650,8 +650,8 @@ void platformCopyRichTextWithMultipleAttachments()
 
 void platformCopyRichTextWithImage()
 {
-    auto richText = adoptNS([[NSMutableAttributedString alloc] init]);
-    auto image = adoptNS([[NSTextAttachment alloc] initWithData:testImageData() ofType:UTTypePNG.identifier]);
+    RetainPtr richText = adoptNS([[NSMutableAttributedString alloc] init]);
+    RetainPtr image = adoptNS([[NSTextAttachment alloc] initWithData:testImageData() ofType:UTTypePNG.identifier]);
 
     [richText appendAttributedString:adoptNS([[NSAttributedString alloc] initWithString:@"Lorem ipsum "]).get()];
     [richText appendAttributedString:[NSAttributedString attributedStringWithAttachment:image.get()]];
@@ -662,7 +662,7 @@ void platformCopyRichTextWithImage()
     [pasteboard clearContents];
     [pasteboard writeObjects:@[ richText.get() ]];
 #elif PLATFORM(IOS_FAMILY)
-    auto item = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr item = adoptNS([[NSItemProvider alloc] init]);
     [item registerObject:richText.get() visibility:NSItemProviderRepresentationVisibilityAll];
     [UIPasteboard generalPasteboard].itemProviders = @[ item.get() ];
 #endif
@@ -676,7 +676,7 @@ void platformCopyPNG()
     [pasteboard setData:testImageData() forType:NSPasteboardTypePNG];
 #elif PLATFORM(IOS_FAMILY)
     UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
-    auto item = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr item = adoptNS([[NSItemProvider alloc] init]);
     [item setPreferredPresentationStyle:UIPreferredPresentationStyleAttachment];
     [item registerData:testImageData() type:UTTypePNG.identifier];
     pasteboard.itemProviders = @[ item.get() ];
@@ -691,7 +691,7 @@ void platformCopyPDF()
     [pasteboard setData:testPDFData() forType:UTTypePDF.identifier];
 #elif PLATFORM(IOS_FAMILY)
     UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
-    auto item = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr item = adoptNS([[NSItemProvider alloc] init]);
     [item setPreferredPresentationStyle:UIPreferredPresentationStyleAttachment];
     [item registerData:testPDFData() type:UTTypePDF.identifier];
     pasteboard.itemProviders = @[ item.get() ];
@@ -706,7 +706,7 @@ void platformCopyJPEG()
     [pasteboard setData:testJPEGData() forType:UTTypeJPEG.identifier];
 #elif PLATFORM(IOS_FAMILY)
     UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
-    auto item = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr item = adoptNS([[NSItemProvider alloc] init]);
     [item setPreferredPresentationStyle:UIPreferredPresentationStyleAttachment];
     [item registerData:testJPEGData() type:UTTypeJPEG.identifier];
     pasteboard.itemProviders = @[ item.get() ];
@@ -948,10 +948,10 @@ TEST(WKAttachmentTests, AttachmentDataForEmptyFile)
 
 TEST(WKAttachmentTests, DropFolderAsAttachmentAndMoveByDragging)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAttachmentElementEnabled:YES];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     [[simulator webView] synchronouslyLoadHTMLString:attachmentEditingTestMarkup];
 
     runTestWithTemporaryFolder([simulator] (NSURL *folderURL) {
@@ -989,11 +989,11 @@ TEST(WKAttachmentTests, DropFolderAsAttachmentAndMoveByDragging)
 TEST(WKAttachmentTests, InsertFolderAndFileWithUnknownExtension)
 {
     auto webView = webViewForTestingAttachments();
-    auto file = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testHTMLData()]);
+    RetainPtr file = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testHTMLData()]);
     [file setPreferredFilename:@"test.foobar"];
-    auto image = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testImageData()]);
-    auto document = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testPDFData()]);
-    auto folder = adoptNS([[NSFileWrapper alloc] initDirectoryWithFileWrappers:@{ @"image.png": image.get(), @"document.pdf": document.get() }]);
+    RetainPtr image = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testImageData()]);
+    RetainPtr document = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testPDFData()]);
+    RetainPtr folder = adoptNS([[NSFileWrapper alloc] initDirectoryWithFileWrappers:@{ @"image.png": image.get(), @"document.pdf": document.get() }]);
     [folder setPreferredFilename:@"folder"];
 
     RetainPtr<_WKAttachment> firstAttachment;
@@ -1146,9 +1146,9 @@ TEST(WKAttachmentTests, CutAndPastePastedImage)
 
 TEST(WKAttachmentTests, MovePastedImageByDragging)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAttachmentElementEnabled:YES];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     TestWKWebView *webView = [simulator webView];
     [webView synchronouslyLoadHTMLString:attachmentEditingTestMarkup];
 
@@ -1252,7 +1252,7 @@ TEST(WKAttachmentTests, InsertPastedAttributedStringContainingMultipleAttachment
 
 TEST(WKAttachmentTests, InsertDataURLImagesAsAttachments)
 {
-    auto webContentSourceView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)]);
+    RetainPtr webContentSourceView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)]);
     [webContentSourceView synchronouslyLoadTestPageNamed:@"apple-data-url"];
     [webContentSourceView selectAll:nil];
     [webContentSourceView _synchronouslyExecuteEditCommand:@"Copy" argument:nil];
@@ -1276,7 +1276,7 @@ TEST(WKAttachmentTests, InsertAndRemoveDuplicateAttachment)
 {
     auto webView = webViewForTestingAttachments();
     RetainPtr<NSData> data = testHTMLData();
-    auto fileWrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:data.get()]);
+    RetainPtr fileWrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:data.get()]);
     RetainPtr<_WKAttachment> originalAttachment;
     RetainPtr<_WKAttachment> pastedAttachment;
     {
@@ -1318,7 +1318,7 @@ TEST(WKAttachmentTests, InsertDuplicateAttachmentAndUpdateData)
 {
     auto webView = webViewForTestingAttachments();
     auto originalData = retainPtr(testHTMLData());
-    auto fileWrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:originalData.get()]);
+    RetainPtr fileWrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:originalData.get()]);
     RetainPtr<_WKAttachment> originalAttachment;
     RetainPtr<_WKAttachment> pastedAttachment;
     {
@@ -1352,7 +1352,7 @@ TEST(WKAttachmentTests, InsertDuplicateAttachmentAndUpdateData)
 TEST(WKAttachmentTests, InsertAttachmentUsingFileWrapperWithFilePath)
 {
     auto webView = webViewForTestingAttachments();
-    auto originalFileWrapper = adoptNS([[NSFileWrapper alloc] initWithURL:testImageFileURL() options:0 error:nil]);
+    RetainPtr originalFileWrapper = adoptNS([[NSFileWrapper alloc] initWithURL:testImageFileURL() options:0 error:nil]);
     RetainPtr<_WKAttachment> attachment;
     {
         ObserveAttachmentUpdatesForScope observer(webView.get());
@@ -1366,7 +1366,7 @@ TEST(WKAttachmentTests, InsertAttachmentUsingFileWrapperWithFilePath)
     EXPECT_TRUE([originalFileWrapper isEqual:infoBeforeUpdate.fileWrapper]);
     [attachment expectRequestedDataToBe:testImageData()];
 
-    auto newFileWrapper = adoptNS([[NSFileWrapper alloc] initWithURL:testPDFFileURL() options:0 error:nil]);
+    RetainPtr newFileWrapper = adoptNS([[NSFileWrapper alloc] initWithURL:testPDFFileURL() options:0 error:nil]);
     {
         ObserveAttachmentUpdatesForScope observer(webView.get());
         BOOL errorOccurred = [attachment synchronouslySetFileWrapper:newFileWrapper.get() newContentType:nil error:nil];
@@ -1428,7 +1428,7 @@ TEST(WKAttachmentTests, InvalidateAttachmentsAfterWebProcessTermination)
     }
 
     __block bool webProcessTerminated = false;
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *, _WKProcessTerminationReason) {
         webProcessTerminated = true;
@@ -1447,9 +1447,9 @@ TEST(WKAttachmentTests, InvalidateAttachmentsAfterWebProcessTermination)
 
 TEST(WKAttachmentTests, MoveAttachmentElementAsIconByDragging)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAttachmentElementEnabled:YES];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     TestWKWebView *webView = [simulator webView];
     [webView synchronouslyLoadHTMLString:attachmentEditingTestMarkup];
 
@@ -1480,10 +1480,10 @@ TEST(WKAttachmentTests, PasteWebArchiveContainingImages)
 {
     NSData *markupData = [@"<img src='1.png' alt='foo'><div><br></div><img src='2.gif' alt='bar'>" dataUsingEncoding:NSUTF8StringEncoding];
 
-    auto mainResource = adoptNS([[WebResource alloc] initWithData:markupData URL:[NSURL URLWithString:@"foo.html"] MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
-    auto pngResource = adoptNS([[WebResource alloc] initWithData:testImageData() URL:[NSURL URLWithString:@"1.png"] MIMEType:@"image/png" textEncodingName:nil frameName:nil]);
-    auto gifResource = adoptNS([[WebResource alloc] initWithData:testGIFData() URL:[NSURL URLWithString:@"2.gif"] MIMEType:@"image/gif" textEncodingName:nil frameName:nil]);
-    auto archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:@[ pngResource.get(), gifResource.get() ] subframeArchives:@[ ]]);
+    RetainPtr mainResource = adoptNS([[WebResource alloc] initWithData:markupData URL:[NSURL URLWithString:@"foo.html"] MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
+    RetainPtr pngResource = adoptNS([[WebResource alloc] initWithData:testImageData() URL:[NSURL URLWithString:@"1.png"] MIMEType:@"image/png" textEncodingName:nil frameName:nil]);
+    RetainPtr gifResource = adoptNS([[WebResource alloc] initWithData:testGIFData() URL:[NSURL URLWithString:@"2.gif"] MIMEType:@"image/gif" textEncodingName:nil frameName:nil]);
+    RetainPtr archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:@[ pngResource.get(), gifResource.get() ] subframeArchives:@[ ]]);
 
 #if PLATFORM(MAC)
     NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
@@ -1529,7 +1529,7 @@ TEST(WKAttachmentTests, ChangeFileWrapperForPastedImage)
     auto originalImageData = retainPtr([attachment info].fileWrapper);
     EXPECT_WK_STREQ([attachment uniqueIdentifier], [webView stringByEvaluatingJavaScript:@"HTMLAttachmentElement.getAttachmentIdentifier(document.querySelector('img'))"]);
 
-    auto newImage = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testGIFData()]);
+    RetainPtr newImage = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testGIFData()]);
     [newImage setPreferredFilename:@"foo.gif"];
     BOOL errorOccurred = [attachment synchronouslySetFileWrapper:newImage.get() newContentType:nil error:nil];
     EXPECT_EQ(NO, errorOccurred);
@@ -1552,8 +1552,8 @@ TEST(WKAttachmentTests, AddAttachmentToConnectedImageElement)
     EXPECT_WK_STREQ(attachmentIdentifier, [webView stringByEvaluatingJavaScript:@"document.querySelector('img').attachmentIdentifier"]);
     observer.expectAttachmentUpdates(@[ ], @[ attachment.get() ]);
 
-    auto firstImage = adoptNS([[NSFileWrapper alloc] initWithURL:testImageFileURL() options:0 error:nil]);
-    auto secondImage = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testGIFData()]);
+    RetainPtr firstImage = adoptNS([[NSFileWrapper alloc] initWithURL:testImageFileURL() options:0 error:nil]);
+    RetainPtr secondImage = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testGIFData()]);
     [secondImage setPreferredFilename:@"foo.gif"];
 
     BOOL errorOccurred = [attachment synchronouslySetFileWrapper:firstImage.get() newContentType:@"image/png" error:nil];
@@ -1575,7 +1575,7 @@ TEST(WKAttachmentTests, ConnectImageWithAttachmentToDocument)
     ObserveAttachmentUpdatesForScope observer(webView.get());
 
     NSString *identifier = [webView stringByEvaluatingJavaScript:@"image = document.createElement('img'); HTMLAttachmentElement.getAttachmentIdentifier(image)"];
-    auto image = adoptNS([[NSFileWrapper alloc] initWithURL:testImageFileURL() options:0 error:nil]);
+    RetainPtr image = adoptNS([[NSFileWrapper alloc] initWithURL:testImageFileURL() options:0 error:nil]);
     auto attachment = retainPtr([webView _attachmentForIdentifier:identifier]);
     BOOL errorOccurred = [attachment synchronouslySetFileWrapper:image.get() newContentType:nil error:nil];
     EXPECT_EQ(NO, errorOccurred);
@@ -1587,7 +1587,7 @@ TEST(WKAttachmentTests, ConnectImageWithAttachmentToDocument)
     EXPECT_TRUE([attachment isConnected]);
     observer.expectAttachmentUpdates(@[ ], @[ attachment.get() ]);
 
-    auto newImage = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testGIFData()]);
+    RetainPtr newImage = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testGIFData()]);
     [newImage setPreferredFilename:@"test.gif"];
     errorOccurred = [attachment synchronouslySetFileWrapper:newImage.get() newContentType:nil error:nil];
     EXPECT_EQ(NO, errorOccurred);
@@ -1596,7 +1596,7 @@ TEST(WKAttachmentTests, ConnectImageWithAttachmentToDocument)
 
 TEST(WKAttachmentTests, CustomFileWrapperSubclass)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAttachmentElementEnabled:YES];
     RetainPtr<NSException> exception;
     @try {
@@ -1621,13 +1621,13 @@ TEST(WKAttachmentTests, CustomFileWrapperSubclass)
 
 TEST(WKAttachmentTests, CopyAndPasteBetweenWebViews)
 {
-    auto file = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testHTMLData()]);
+    RetainPtr file = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testHTMLData()]);
     [file setPreferredFilename:@"test.foobar"];
-    auto image = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testImageData()]);
-    auto document = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testPDFData()]);
-    auto folder = adoptNS([[NSFileWrapper alloc] initDirectoryWithFileWrappers:@{ @"image.png": image.get(), @"document.pdf": document.get() }]);
+    RetainPtr image = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testImageData()]);
+    RetainPtr document = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testPDFData()]);
+    RetainPtr folder = adoptNS([[NSFileWrapper alloc] initDirectoryWithFileWrappers:@{ @"image.png": image.get(), @"document.pdf": document.get() }]);
     [folder setPreferredFilename:@"folder"];
-    auto archive = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testZIPData()]);
+    RetainPtr archive = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testZIPData()]);
     [archive setPreferredFilename:@"archive"];
 
     @autoreleasepool {
@@ -1667,7 +1667,7 @@ TEST(WKAttachmentTests, CopyAndPasteBetweenWebViews)
 
 TEST(WKAttachmentTests, CopyAndPasteImageBetweenWebViews)
 {
-    auto image = adoptNS([[NSFileWrapper alloc] initWithURL:testImageFileURL() options:0 error:nil]);
+    RetainPtr image = adoptNS([[NSFileWrapper alloc] initWithURL:testImageFileURL() options:0 error:nil]);
     [image setPreferredFilename:@"icon.png"];
     RetainPtr originalData = [image regularFileContents];
 
@@ -1781,13 +1781,13 @@ TEST(WKAttachmentTests, SetFileWrapperForPDFImageAttachment)
     NSString *identifier = [webView stringByEvaluatingJavaScript:@"const i = document.createElement('img'); document.body.appendChild(i); HTMLAttachmentElement.getAttachmentIdentifier(i)"];
     auto attachment = retainPtr([webView _attachmentForIdentifier:identifier]);
 
-    auto pdfFile = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testPDFData()]);
+    RetainPtr pdfFile = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testPDFData()]);
     [attachment setFileWrapper:pdfFile.get() contentType:UTTypePDF.identifier completion:nil];
     [webView waitForImageElementSizeToBecome:CGSizeMake(130, 29)];
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
-    auto zipFile = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testZIPData()]);
+    RetainPtr zipFile = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testZIPData()]);
     [attachment setFileWrapper:zipFile.get() contentType:UTTypeZIP.identifier completion:nil];
     EXPECT_FALSE([attachment isConnected]);
 }
@@ -1826,8 +1826,8 @@ TEST(WKAttachmentTests, CopyAndPasteRemoteImages)
     {
         [TestProtocol registerWithScheme:@"https"];
 
-        auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
-        auto sourceView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+        RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+        RetainPtr sourceView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
         [sourceView setNavigationDelegate:navigationDelegate.get()];
         [sourceView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://bundle-file/multiple-images.html"]]];
         [navigationDelegate waitForDidFinishNavigation];
@@ -1901,16 +1901,16 @@ TEST(WKAttachmentTests, CreateAttachmentsFromExistingImage)
 
 TEST(WKAttachmentTests, UserDragNonePreventsDragOnAttachmentElement)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto styleSheet = adoptNS([[_WKUserStyleSheet alloc] initWithSource:@"attachment { -webkit-user-drag: none; }" forMainFrameOnly:YES]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr styleSheet = adoptNS([[_WKUserStyleSheet alloc] initWithSource:@"attachment { -webkit-user-drag: none; }" forMainFrameOnly:YES]);
     [[configuration userContentController] _addUserStyleSheet:styleSheet.get()];
     [configuration _setAttachmentElementEnabled:YES];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     auto *webView = [simulator webView];
     [webView synchronouslyLoadHTMLString:attachmentEditingTestMarkup];
 
-    auto file = adoptNS([[NSFileWrapper alloc] initWithURL:testPDFFileURL() options:0 error:nil]);
+    RetainPtr file = adoptNS([[NSFileWrapper alloc] initWithURL:testPDFFileURL() options:0 error:nil]);
     [webView synchronouslyInsertAttachmentWithFileWrapper:file.get() contentType:nil];
     [simulator runFrom:NSMakePoint(15, 15) to:NSMakePoint(50, 50)];
 
@@ -2045,9 +2045,9 @@ TEST(WKAttachmentTestsMac, InsertNonExistentImageFileAsAttachment)
 
 TEST(WKAttachmentTestsMac, InsertDroppedFilePromisesAsAttachments)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAttachmentElementEnabled:YES];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     TestWKWebView *webView = [simulator webView];
     [webView synchronouslyLoadHTMLString:attachmentEditingTestMarkup];
     [simulator writePromisedFiles:@[ testPDFFileURL(), testImageFileURL() ]];
@@ -2083,13 +2083,13 @@ TEST(WKAttachmentTestsMac, InsertDroppedFilePromisesAsAttachments)
 
 TEST(WKAttachmentTestsMac, DragAttachmentAsFilePromise)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAttachmentElementEnabled:YES];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     TestWKWebView *webView = [simulator webView];
     [webView synchronouslyLoadHTMLString:attachmentEditingTestMarkup];
 
-    auto fileWrapper = adoptNS([[NSFileWrapper alloc] initWithURL:testPDFFileURL() options:0 error:nil]);
+    RetainPtr fileWrapper = adoptNS([[NSFileWrapper alloc] initWithURL:testPDFFileURL() options:0 error:nil]);
     auto attachment = retainPtr([webView synchronouslyInsertAttachmentWithFileWrapper:fileWrapper.get() contentType:nil]);
     [simulator runFrom:[webView attachmentElementMidPoint] to:CGPointMake(300, 300)];
 
@@ -2102,9 +2102,9 @@ TEST(WKAttachmentTestsMac, DragAttachmentAsFilePromise)
 
 TEST(WKAttachmentTestsMac, DragAttachmentWithNoTypeShouldNotCrash)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAttachmentElementEnabled:YES];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     TestWKWebView *webView = [simulator webView];
     [webView synchronouslyLoadHTMLString:attachmentEditingTestMarkup];
 
@@ -2118,10 +2118,10 @@ TEST(WKAttachmentTestsMac, DragAttachmentWithNoTypeShouldNotCrash)
 
 TEST(WKAttachmentTestsMac, DropImageOverImageWithControls)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAttachmentElementEnabled:YES];
     [configuration _setImageControlsEnabled:YES];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     TestWKWebView *webView = [simulator webView];
     [webView synchronouslyLoadHTMLString:attachmentEditingTestMarkup];
 
@@ -2145,9 +2145,9 @@ static NSImage *_icon(id, SEL)
 TEST(WKAttachmentTestsMac, DragDirectoryAttachment)
 {
     didLoadIcon = false;
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAttachmentElementEnabled:YES];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     TestWKWebView *webView = [simulator webView];
     [webView synchronouslyLoadHTMLString:attachmentEditingTestMarkup];
 
@@ -2157,7 +2157,7 @@ TEST(WKAttachmentTestsMac, DragDirectoryAttachment)
         reinterpret_cast<IMP>(_icon)
     };
 
-    auto fileWrapper = adoptNS([[NSFileWrapper alloc] initWithURL:testDirectoryAttachmentFileURL() options:0 error:nil]);
+    RetainPtr fileWrapper = adoptNS([[NSFileWrapper alloc] initWithURL:testDirectoryAttachmentFileURL() options:0 error:nil]);
     auto attachment = retainPtr([webView synchronouslyInsertAttachmentWithFileWrapper:fileWrapper.get() contentType:nil]);
     [simulator runFrom:[webView attachmentElementMidPoint] to:CGPointMake(300, 300)];
     TestWebKitAPI::Util::run(&didLoadIcon);
@@ -2165,13 +2165,13 @@ TEST(WKAttachmentTestsMac, DragDirectoryAttachment)
 
 TEST(WKAttachmentTestsMac, CallAcceptsFirstMouseWhileDraggingAttachment)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAttachmentElementEnabled:YES];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     TestWKWebView *webView = [simulator webView];
     [webView synchronouslyLoadHTMLString:attachmentEditingTestMarkup];
 
-    auto fileWrapper = adoptNS([[NSFileWrapper alloc] initWithURL:testPDFFileURL() options:0 error:nil]);
+    RetainPtr fileWrapper = adoptNS([[NSFileWrapper alloc] initWithURL:testPDFFileURL() options:0 error:nil]);
     RetainPtr attachment = [webView synchronouslyInsertAttachmentWithFileWrapper:fileWrapper.get() contentType:@"application/pdf"];
     [simulator setWillBeginDraggingHandler:^{
         [webView acceptsFirstMouseAtPoint:NSMakePoint(100, 100)];
@@ -2188,10 +2188,10 @@ TEST(WKAttachmentTestsMac, CallAcceptsFirstMouseWhileDraggingAttachment)
 
 static RetainPtr<UITargetedDragPreview> targetedImageDragPreview(WKWebView *webView, NSData *imageData, CGSize size)
 {
-    auto imageView = adoptNS([[UIImageView alloc] initWithImage:[UIImage imageWithData:imageData]]);
+    RetainPtr imageView = adoptNS([[UIImageView alloc] initWithImage:[UIImage imageWithData:imageData]]);
     [imageView setBounds:CGRectMake(0, 0, size.width, size.height)];
-    auto defaultDropTarget = adoptNS([[UIDragPreviewTarget alloc] initWithContainer:webView center:CGPointMake(450, 450)]);
-    auto parameters = adoptNS([[UIDragPreviewParameters alloc] init]);
+    RetainPtr defaultDropTarget = adoptNS([[UIDragPreviewTarget alloc] initWithContainer:webView center:CGPointMake(450, 450)]);
+    RetainPtr parameters = adoptNS([[UIDragPreviewParameters alloc] init]);
     return adoptNS([[UITargetedDragPreview alloc] initWithView:imageView.get() parameters:parameters.get() target:defaultDropTarget.get()]);
 }
 
@@ -2200,18 +2200,18 @@ TEST(WKAttachmentTestsIOS, TargetedPreviewsWhenDroppingImages)
     auto webView = webViewForTestingAttachments();
     [webView _setEditable:YES];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     // The first item preview should be scaled down by a factor of 2.
     auto firstPreview = targetedImageDragPreview(webView.get(), testImageData(), CGSizeMake(430, 348));
-    auto firstItem = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr firstItem = adoptNS([[NSItemProvider alloc] init]);
     [firstItem registerDataRepresentationForTypeIdentifier:UTTypePNG.identifier withData:testImageData() loadingDelay:0.5];
     [firstItem setPreferredPresentationSize:CGSizeMake(215, 174)];
     [firstItem setSuggestedName:@"icon"];
 
     // The second item preview should be scaled up by a factor of 2.
     auto secondPreview = targetedImageDragPreview(webView.get(), testGIFData(), CGSizeMake(26, 32));
-    auto secondItem = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr secondItem = adoptNS([[NSItemProvider alloc] init]);
     [secondItem registerDataRepresentationForTypeIdentifier:UTTypeGIF.identifier withData:testGIFData() loadingDelay:0.5];
     [secondItem setPreferredPresentationSize:CGSizeMake(52, 64)];
     [secondItem setSuggestedName:@"apple"];
@@ -2247,10 +2247,10 @@ TEST(WKAttachmentTestsIOS, TargetedPreviewIsClippedWhenDroppingTallImage)
     [webView _setEditable:YES];
 
     auto imageData = retainPtr([NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]]);
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     auto preview = targetedImageDragPreview(webView.get(), imageData.get(), CGSizeMake(100, 100));
-    auto item = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr item = adoptNS([[NSItemProvider alloc] init]);
     [item registerDataRepresentationForTypeIdentifier:UTTypePNG.identifier withData:imageData.get() loadingDelay:0.5];
     [item setPreferredPresentationSize:CGSizeMake(400, 400)];
     [item setSuggestedName:@"green"];
@@ -2273,8 +2273,8 @@ TEST(WKAttachmentTestsIOS, TargetedPreviewIsClippedWhenDroppingTallImage)
 TEST(WKAttachmentTestsIOS, InsertDroppedImageAsAttachment)
 {
     auto webView = webViewForTestingAttachments();
-    auto dragAndDropSimulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
-    auto item = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr dragAndDropSimulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr item = adoptNS([[NSItemProvider alloc] init]);
     [item registerData:testImageData() type:UTTypePNG.identifier];
     [dragAndDropSimulator setExternalItemProviders:@[ item.get() ]];
     [dragAndDropSimulator runFrom:CGPointZero to:CGPointMake(50, 50)];
@@ -2296,8 +2296,8 @@ TEST(WKAttachmentTestsIOS, InsertDroppedImageAsAttachment)
 TEST(WKAttachmentTestsIOS, InsertDroppedImageWithPreferredPresentationSize)
 {
     auto webView = webViewForTestingAttachments();
-    auto dragAndDropSimulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
-    auto item = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr dragAndDropSimulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr item = adoptNS([[NSItemProvider alloc] init]);
     [item registerData:testImageData() type:UTTypePNG.identifier];
     [item setPreferredPresentationSize:CGSizeMake(200, 100)];
     [dragAndDropSimulator setExternalItemProviders:@[ item.get() ]];
@@ -2311,9 +2311,9 @@ TEST(WKAttachmentTestsIOS, InsertDroppedImageWithPreferredPresentationSize)
 TEST(WKAttachmentTestsIOS, InsertDroppedAttributedStringContainingAttachment)
 {
     auto webView = webViewForTestingAttachments();
-    auto dragAndDropSimulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
-    auto image = adoptNS([[NSTextAttachment alloc] initWithData:testImageData() ofType:UTTypePNG.identifier]);
-    auto item = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr dragAndDropSimulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr image = adoptNS([[NSTextAttachment alloc] initWithData:testImageData() ofType:UTTypePNG.identifier]);
+    RetainPtr item = adoptNS([[NSItemProvider alloc] init]);
     [item registerObject:[NSAttributedString attributedStringWithAttachment:image.get()] visibility:NSItemProviderRepresentationVisibilityAll];
 
     [dragAndDropSimulator setExternalItemProviders:@[ item.get() ]];
@@ -2342,19 +2342,19 @@ TEST(WKAttachmentTestsIOS, InsertDroppedRichAndPlainTextFilesAsAttachments)
     // areas in the absence of attachment elements. However, due to the explicitly set attachment presentation style
     // on the item providers, we should instead treat them as dropped files and insert attachment elements.
     // This exercises the scenario of dragging rich and plain text files from Files to Mail.
-    auto richTextItem = adoptNS([[NSItemProvider alloc] init]);
-    auto richText = adoptNS([[NSAttributedString alloc] initWithString:@"Hello world" attributes:@{ NSFontAttributeName: [UIFont boldSystemFontOfSize:12] }]);
+    RetainPtr richTextItem = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr richText = adoptNS([[NSAttributedString alloc] initWithString:@"Hello world" attributes:@{ NSFontAttributeName: [UIFont boldSystemFontOfSize:12] }]);
     [richTextItem setPreferredPresentationStyle:UIPreferredPresentationStyleAttachment];
     [richTextItem registerObject:richText.get() visibility:NSItemProviderRepresentationVisibilityAll];
     [richTextItem setSuggestedName:@"hello.rtf"];
 
-    auto plainTextItem = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr plainTextItem = adoptNS([[NSItemProvider alloc] init]);
     [plainTextItem setPreferredPresentationStyle:UIPreferredPresentationStyleAttachment];
     [plainTextItem registerObject:@"Hello world" visibility:NSItemProviderRepresentationVisibilityAll];
     [plainTextItem setSuggestedName:@"world.txt"];
 
     auto webView = webViewForTestingAttachments();
-    auto dragAndDropSimulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr dragAndDropSimulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [dragAndDropSimulator setExternalItemProviders:@[ richTextItem.get(), plainTextItem.get() ]];
     [dragAndDropSimulator runFrom:CGPointZero to:CGPointMake(50, 50)];
 
@@ -2377,13 +2377,13 @@ TEST(WKAttachmentTestsIOS, InsertDroppedZipArchiveAsAttachment)
     // Since WebKit doesn't have any default DOM representation for ZIP archives, we should fall back to inserting
     // attachment elements. This exercises the flow of dragging a ZIP file from an app that doesn't specify a preferred
     // presentation style (e.g. Notes) into Mail.
-    auto item = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr item = adoptNS([[NSItemProvider alloc] init]);
     NSData *data = testZIPData();
     [item registerData:data type:UTTypeZIP.identifier];
     [item setSuggestedName:@"archive.zip"];
 
     auto webView = webViewForTestingAttachments();
-    auto dragAndDropSimulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr dragAndDropSimulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [dragAndDropSimulator setExternalItemProviders:@[ item.get() ]];
     [dragAndDropSimulator runFrom:CGPointZero to:CGPointMake(50, 50)];
 
@@ -2399,21 +2399,21 @@ TEST(WKAttachmentTestsIOS, InsertDroppedItemProvidersInOrder)
 {
     // Tests that item providers are inserted in the order they are specified. In this case, the two inserted attachments
     // should be separated by a link.
-    auto firstAttachmentItem = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr firstAttachmentItem = adoptNS([[NSItemProvider alloc] init]);
     [firstAttachmentItem setPreferredPresentationStyle:UIPreferredPresentationStyleAttachment];
     [firstAttachmentItem registerObject:@"FIRST" visibility:NSItemProviderRepresentationVisibilityAll];
     [firstAttachmentItem setSuggestedName:@"first.txt"];
 
-    auto inlineTextItem = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr inlineTextItem = adoptNS([[NSItemProvider alloc] init]);
     auto appleURL = retainPtr([NSURL URLWithString:@"https://www.apple.com/"]);
     [inlineTextItem registerObject:appleURL.get() visibility:NSItemProviderRepresentationVisibilityAll];
 
-    auto secondAttachmentItem = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr secondAttachmentItem = adoptNS([[NSItemProvider alloc] init]);
     [secondAttachmentItem registerData:testPDFData() type:UTTypePDF.identifier];
     [secondAttachmentItem setSuggestedName:@"second.pdf"];
 
     auto webView = webViewForTestingAttachments();
-    auto dragAndDropSimulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr dragAndDropSimulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [dragAndDropSimulator setExternalItemProviders:@[ firstAttachmentItem.get(), inlineTextItem.get(), secondAttachmentItem.get() ]];
     [dragAndDropSimulator runFrom:CGPointZero to:CGPointMake(50, 50)];
 
@@ -2435,13 +2435,13 @@ TEST(WKAttachmentTestsIOS, InsertDroppedItemProvidersInOrder)
 
 TEST(WKAttachmentTestsIOS, DragAttachmentInsertedAsFile)
 {
-    auto item = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr item = adoptNS([[NSItemProvider alloc] init]);
     auto data = retainPtr(testPDFData());
     [item registerData:data.get() type:UTTypePDF.identifier];
     [item setSuggestedName:@"document.pdf"];
 
     auto webView = webViewForTestingAttachments();
-    auto dragAndDropSimulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr dragAndDropSimulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [dragAndDropSimulator setExternalItemProviders:@[ item.get() ]];
     [dragAndDropSimulator runFrom:CGPointZero to:CGPointMake(50, 50)];
 
@@ -2482,7 +2482,7 @@ TEST(WKAttachmentTestsIOS, DragAttachmentInsertedAsData)
     EXPECT_WK_STREQ("application/pdf", [webView valueOfAttribute:@"type" forQuerySelector:@"attachment"]);
 
     [webView evaluateJavaScript:@"getSelection().removeAllRanges()" completionHandler:nil];
-    auto dragAndDropSimulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr dragAndDropSimulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [dragAndDropSimulator runFrom:CGPointMake(25, 25) to:CGPointMake(-100, -100)];
 
     // Next, verify that dragging the attachment produces an item provider with a PDF attachment.
@@ -2496,11 +2496,11 @@ TEST(WKAttachmentTestsIOS, DragAttachmentInsertedAsData)
 
 static RetainPtr<NSItemProvider> mapItemForTesting()
 {
-    auto placemark = adoptNS([allocMKPlacemarkInstance() initWithCoordinate:CLLocationCoordinate2DMake(37.3327, -122.0053)]);
-    auto mapItem = adoptNS([allocMKMapItemInstance() initWithPlacemark:placemark.get()]);
+    RetainPtr placemark = adoptNS([allocMKPlacemarkInstance() initWithCoordinate:CLLocationCoordinate2DMake(37.3327, -122.0053)]);
+    RetainPtr mapItem = adoptNS([allocMKMapItemInstance() initWithPlacemark:placemark.get()]);
     [mapItem setName:@"Apple Park.vcf"];
 
-    auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
     [itemProvider registerObject:mapItem.get() visibility:NSItemProviderRepresentationVisibilityAll];
     [itemProvider setSuggestedName:[mapItem name]];
     return itemProvider;
@@ -2520,11 +2520,11 @@ static RetainPtr<NSItemProvider> calendarInviteForTesting()
 
 static RetainPtr<NSItemProvider> contactItemForTesting()
 {
-    auto contact = adoptNS([allocCNMutableContactInstance() init]);
+    RetainPtr contact = adoptNS([allocCNMutableContactInstance() init]);
     [contact setGivenName:@"Foo"];
     [contact setFamilyName:@"Bar"];
 
-    auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
     [itemProvider registerObject:contact.get() visibility:NSItemProviderRepresentationVisibilityAll];
     [itemProvider setSuggestedName:@"Foo Bar.vcf"];
     return itemProvider;
@@ -2534,7 +2534,7 @@ TEST(WKAttachmentTestsIOS, InsertDroppedMapItemAsAttachment)
 {
     auto itemProvider = mapItemForTesting();
     auto webView = webViewForTestingAttachments();
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setExternalItemProviders:@[ itemProvider.get() ]];
     [simulator runFrom:CGPointMake(25, 25) to:CGPointMake(100, 100)];
 
@@ -2553,7 +2553,7 @@ TEST(WKAttachmentTestsIOS, InsertDroppedCalendarInviteAsAttachment)
 {
     auto itemProvider = calendarInviteForTesting();
     auto webView = webViewForTestingAttachments();
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setExternalItemProviders:@[ itemProvider.get() ]];
     [simulator runFrom:CGPointMake(25, 25) to:CGPointMake(100, 100)];
 
@@ -2569,7 +2569,7 @@ TEST(WKAttachmentTestsIOS, InsertDroppedContactAsAttachment)
 {
     auto itemProvider = contactItemForTesting();
     auto webView = webViewForTestingAttachments();
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setExternalItemProviders:@[ itemProvider.get() ]];
     [simulator runFrom:CGPointMake(25, 25) to:CGPointMake(100, 100)];
 
@@ -2619,11 +2619,11 @@ TEST(WKAttachmentTestsIOS, InsertPastedMapItemAsAttachment)
 
 TEST(WKAttachmentTestsIOS, InsertPastedFilesAsAttachments)
 {
-    auto pdfItem = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr pdfItem = adoptNS([[NSItemProvider alloc] init]);
     [pdfItem setSuggestedName:@"doc"];
     [pdfItem registerData:testPDFData() type:UTTypePDF.identifier];
 
-    auto textItem = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr textItem = adoptNS([[NSItemProvider alloc] init]);
     [textItem setSuggestedName:@"hello"];
     [textItem registerData:[@"helloworld" dataUsingEncoding:NSUTF8StringEncoding] type:UTTypePlainText.identifier];
 
@@ -2661,7 +2661,7 @@ TEST(WKAttachmentTestsIOS, InsertPastedFilesAsAttachments)
 TEST(WKAttachmentTestsIOS, InsertDroppedImageWithNonImageFileExtension)
 {
     runTestWithTemporaryImageFile(@"image.hello", ^(NSURL *fileURL) {
-        auto item = adoptNS([[NSItemProvider alloc] init]);
+        RetainPtr item = adoptNS([[NSItemProvider alloc] init]);
         [item setSuggestedName:@"image.hello"];
         [item registerFileRepresentationForTypeIdentifier:UTTypePNG.identifier fileOptions:NSItemProviderFileOptionOpenInPlace visibility:NSItemProviderRepresentationVisibilityAll loadHandler:^NSProgress *(void (^callback)(NSURL *, BOOL, NSError *))
         {
@@ -2670,7 +2670,7 @@ TEST(WKAttachmentTestsIOS, InsertDroppedImageWithNonImageFileExtension)
         }];
 
         auto webView = webViewForTestingAttachments();
-        auto dragAndDropSimulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+        RetainPtr dragAndDropSimulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
         [dragAndDropSimulator setExternalItemProviders:@[ item.get() ]];
         [dragAndDropSimulator runFrom:CGPointZero to:CGPointMake(50, 50)];
 
@@ -2692,7 +2692,7 @@ TEST(WKAttachmentTestsIOS, CopyAttachmentUsingElementAction)
     [webView _setEditable:YES];
     [webView synchronouslyLoadHTMLString:@"<body></body><script>document.body.focus();</script>"];
 
-    auto document = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testPDFData()]);
+    RetainPtr document = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:testPDFData()]);
     [document setPreferredFilename:@"hello.pdf"];
 
     auto attachment = retainPtr([webView synchronouslyInsertAttachmentWithFileWrapper:document.get() contentType:UTTypePDF.identifier]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
@@ -53,7 +53,7 @@ static NSString *loadableURL3 = @"data:text/html,no%20error%20C";
 
 TEST(WKBackForwardList, RemoveCurrentItem)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL1]]];
     [webView _test_waitForDidFinishNavigation];
@@ -88,7 +88,7 @@ TEST(WKBackForwardList, RemoveCurrentItemWithNeighbors)
     // Regression test: when the current item is filtered out, the currentIndex should
     // be decremented (so the predecessor becomes current), not left unchanged (which
     // would make the successor current).
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL1]]];
     [webView _test_waitForDidFinishNavigation];
@@ -124,7 +124,7 @@ TEST(WKBackForwardList, RemoveCurrentItemWithNeighbors)
 
 TEST(WKBackForwardList, CanNotGoBackAfterRestoringEmptySessionState)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL1]]];
     [webView _test_waitForDidFinishNavigation];
@@ -138,7 +138,7 @@ TEST(WKBackForwardList, CanNotGoBackAfterRestoringEmptySessionState)
     EXPECT_EQ((NSUInteger)1, list.backList.count);
     EXPECT_EQ((NSUInteger)0, list.forwardList.count);
 
-    auto singlePageWebView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr singlePageWebView = adoptNS([[WKWebView alloc] init]);
 
     [singlePageWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL1]]];
     [singlePageWebView _test_waitForDidFinishNavigation];
@@ -155,7 +155,7 @@ TEST(WKBackForwardList, CanNotGoBackAfterRestoringEmptySessionState)
 
 TEST(WKBackForwardList, RestoringNilSessionState)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL1]]];
     [webView _test_waitForDidFinishNavigation];
@@ -169,7 +169,7 @@ TEST(WKBackForwardList, RestoringNilSessionState)
     EXPECT_EQ((NSUInteger)1, list.backList.count);
     EXPECT_EQ((NSUInteger)0, list.forwardList.count);
 
-    auto singlePageWebView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr singlePageWebView = adoptNS([[WKWebView alloc] init]);
 
     [singlePageWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL1]]];
     [singlePageWebView _test_waitForDidFinishNavigation];
@@ -211,8 +211,8 @@ TEST(WKBackForwardList, WindowLocationAsyncPolicyDecision)
 {
     NSURL *simple = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     NSURL *simple2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    auto webView = adoptNS([[WKWebView alloc] init]);
-    auto delegate = adoptNS([[AsyncPolicyDecisionDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr delegate = adoptNS([[AsyncPolicyDecisionDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView loadHTMLString:@"<script>window.location='simple.html'</script>" baseURL:simple2];
     TestWebKitAPI::Util::run(&done);
@@ -221,7 +221,7 @@ TEST(WKBackForwardList, WindowLocationAsyncPolicyDecision)
 
 TEST(WKBackForwardList, InteractionStateRestoration)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
 
     NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
@@ -302,7 +302,7 @@ TEST(WKBackForwardList, InteractionStateRestoration)
 
 TEST(WKBackForwardList, InteractionStateRestorationNil)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
 
     NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
@@ -332,7 +332,7 @@ TEST(WKBackForwardList, InteractionStateRestorationNil)
 
 TEST(WKBackForwardList, InteractionStateRestorationInvalid)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
 
     NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
     NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
@@ -444,11 +444,11 @@ static RetainPtr<WKNavigation> lastNavigation;
 
 TEST(WKBackForwardList, BackSwipeNavigationSkipsItemsWithoutUserGesture)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView setAllowsBackForwardNavigationGestures:YES];
     [webView becomeFirstResponder];
 
-    auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
     webView.get().navigationDelegate = navigationDelegate.get();
 
     NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
@@ -486,11 +486,11 @@ TEST(WKBackForwardList, BackSwipeNavigationSkipsItemsWithoutUserGesture)
 
 TEST(WKBackForwardList, BackSwipeNavigationDoesNotSkipItemsWithUserGesture)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView setAllowsBackForwardNavigationGestures:YES];
     [webView becomeFirstResponder];
 
-    auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
     webView.get().navigationDelegate = navigationDelegate.get();
 
     NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
@@ -522,9 +522,9 @@ TEST(WKBackForwardList, BackSwipeNavigationDoesNotSkipItemsWithUserGesture)
 
 static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<void(WKWebView *, ASCIILiteral destination)>&& navigate)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
 
-    auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
     webView.get().navigationDelegate = navigationDelegate.get();
 
     NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
@@ -660,9 +660,9 @@ TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGestureSubfram
         { "/iframe.html"_s, { "<script>onload = () => { setTimeout(() => { history.pushState(null, document.title, '#'); }, 0); };</script>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
 
-    auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
     webView.get().navigationDelegate = navigationDelegate.get();
 
     [webView loadRequest:server.request("/source.html"_s)];
@@ -700,9 +700,9 @@ TEST(WKBackForwardList, BackForwardNavigationSkipsClientSideRedirectWithCOOP)
         { "/destination.html"_s, { "foo"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Https);
 
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
 
-    auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
     webView.get().navigationDelegate = navigationDelegate.get();
 
     [webView loadRequest:server.request("/source.html"_s)];
@@ -736,9 +736,9 @@ TEST(WKBackForwardList, BackForwardNavigationSkipsClientSideRedirectWithCOOP)
 
 static void runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest(Function<void(WKWebView *, ASCIILiteral fragment)>&& navigate)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
 
-    auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
     webView.get().navigationDelegate = navigationDelegate.get();
 
     // Test case: url1 -> url2 -> url2#a (with user gesture)
@@ -828,9 +828,9 @@ TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsWithRecentUserGestu
 
 TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipUpdatedItemWithRecentUserGesture)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
 
-    auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
     webView.get().navigationDelegate = navigationDelegate.get();
 
     NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
@@ -859,9 +859,9 @@ TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipUpdatedItemWithRecentUse
 
 TEST(WKBackForwardList, BackNavigationHijacking)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
 
-    auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
     webView.get().navigationDelegate = navigationDelegate.get();
 
     NSURL *url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
@@ -904,10 +904,10 @@ TEST(WKBackForwardList, BackForwardListRemoveAndAddSubframes)
         { "/frame2"_s, { "<script> alert('frame2'); </script>"_s } },
         { "/frame3"_s, { "<script> alert('frame3'); </script>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Https);
-    auto webView = adoptNS([[WKWebView alloc] init]);
-    auto navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
     webView.get().navigationDelegate = navigationDelegate.get();
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     webView.get().UIDelegate = uiDelegate.get();
 
     [webView loadRequest:server.request("/index"_s)];
@@ -947,7 +947,7 @@ TEST(WKBackForwardList, SessionStateTitleTruncation)
         { "/"_s, { "<script>document.title='a'.repeat(10000);window.history.pushState({}, '', window.location+'?a=b');</script>"_s } }
     });
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView loadRequest:server.request()];
     while (!webView.get().canGoBack)
         TestWebKitAPI::Util::spinRunLoop();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKContentExtensionStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKContentExtensionStore.mm
@@ -382,14 +382,14 @@ TEST_F(WKContentRuleListStoreTest, CrossOriginCookieBlocking)
             }
         }, HTTPServer::Protocol::HttpsProxy);
 
-        auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+        RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
         [storeConfiguration setAllowsServerPreconnect:NO];
         [storeConfiguration setProxyConfiguration:@{
             (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
             (NSString *)kCFStreamPropertyHTTPSProxyPort: @(server.port())
         }];
 
-        auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+        RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
         [dataStore _setResourceLoadStatisticsEnabled:NO];
         __block bool setPolicy { false };
         [dataStore.get().httpCookieStore _setCookieAcceptPolicy:NSHTTPCookieAcceptPolicyAlways completionHandler:^{
@@ -397,7 +397,7 @@ TEST_F(WKContentRuleListStoreTest, CrossOriginCookieBlocking)
         }];
         Util::run(&setPolicy);
 
-        auto viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+        RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
         [viewConfiguration setWebsiteDataStore:dataStore.get()];
 
         if (blockCookies) {
@@ -411,8 +411,8 @@ TEST_F(WKContentRuleListStoreTest, CrossOriginCookieBlocking)
             TestWebKitAPI::Util::run(&doneCompiling);
         }
 
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
-        auto delegate = adoptNS([TestNavigationDelegate new]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
+        RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
         delegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
             completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
         };
@@ -591,12 +591,12 @@ TEST_F(WKContentRuleListStoreTest, AddRemove)
     TestWebKitAPI::Util::run(&doneCompiling);
     EXPECT_NOT_NULL(ruleList);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addContentRuleList:ruleList.get()];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[ContentRuleListDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[ContentRuleListDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"contentBlockerCheck" withExtension:@"html"]];
@@ -687,7 +687,7 @@ static RetainPtr<WKContentRuleList> compileContentRuleList(const char* json, NSS
 
 static RetainPtr<TestNavigationDelegate> navigationDelegateAllowingActiveActionsOnTestHost()
 {
-    static auto delegate = adoptNS([TestNavigationDelegate new]);
+    static RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         preferences._activeContentRuleListActionPatterns = @{
             @"testidentifier": [NSSet setWithObject:@"testscheme://testhost/*"],
@@ -732,7 +732,7 @@ TEST_F(WKContentRuleListStoreTest, ModifyHeaders)
     )JSON");
 
     __block bool receivedAllRequests { false };
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     handler.get().startURLSchemeTaskHandler = ^(WKWebView *, id <WKURLSchemeTask> task) {
         NSString *path = task.request.URL.path;
         NSDictionary<NSString *, NSString *> *fields = [task.request allHTTPHeaderFields];
@@ -758,10 +758,10 @@ TEST_F(WKContentRuleListStoreTest, ModifyHeaders)
         ASSERT_NOT_REACHED();
     };
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [[configuration userContentController] addContentRuleList:list.get()];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testscheme"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
     auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
     webView.get().navigationDelegate = delegate;
     __block bool receivedActionNotification { false };
@@ -831,7 +831,7 @@ TEST_F(WKContentRuleListStoreTest, ModifyHeadersWithCompetingRulesWhereAppendWin
     )JSON");
 
     __block bool receivedAllRequests { false };
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     handler.get().startURLSchemeTaskHandler = ^(WKWebView *, id <WKURLSchemeTask> task) {
         NSString *path = task.request.URL.path;
         NSDictionary<NSString *, NSString *> *fields = [task.request allHTTPHeaderFields];
@@ -844,10 +844,10 @@ TEST_F(WKContentRuleListStoreTest, ModifyHeadersWithCompetingRulesWhereAppendWin
         ASSERT_NOT_REACHED();
     };
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [[configuration userContentController] addContentRuleList:list.get()];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testscheme"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
     auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
     webView.get().navigationDelegate = delegate;
     __block bool receivedActionNotification { false };
@@ -920,7 +920,7 @@ TEST_F(WKContentRuleListStoreTest, ModifyHeadersWithCompetingRulesWhereSetWins)
     )JSON");
 
     __block bool receivedAllRequests { false };
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     handler.get().startURLSchemeTaskHandler = ^(WKWebView *, id <WKURLSchemeTask> task) {
         NSString *path = task.request.URL.path;
         NSDictionary<NSString *, NSString *> *fields = [task.request allHTTPHeaderFields];
@@ -933,10 +933,10 @@ TEST_F(WKContentRuleListStoreTest, ModifyHeadersWithCompetingRulesWhereSetWins)
         ASSERT_NOT_REACHED();
     };
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [[configuration userContentController] addContentRuleList:list.get()];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testscheme"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
     auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
     webView.get().navigationDelegate = delegate;
     __block bool receivedActionNotification { false };
@@ -987,7 +987,7 @@ TEST_F(WKContentRuleListStoreTest, ModifyHeadersWithCompetingRulesWhereRemoveWin
     )JSON");
 
     __block bool receivedAllRequests { false };
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     handler.get().startURLSchemeTaskHandler = ^(WKWebView *, id <WKURLSchemeTask> task) {
         NSString *path = task.request.URL.path;
         NSDictionary<NSString *, NSString *> *fields = [task.request allHTTPHeaderFields];
@@ -999,10 +999,10 @@ TEST_F(WKContentRuleListStoreTest, ModifyHeadersWithCompetingRulesWhereRemoveWin
         ASSERT_NOT_REACHED();
     };
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [[configuration userContentController] addContentRuleList:list.get()];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testscheme"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
     auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
     webView.get().navigationDelegate = delegate;
     __block bool receivedActionNotification { false };
@@ -1058,7 +1058,7 @@ TEST_F(WKContentRuleListStoreTest, ModifyHeadersWithMultipleRuleLists)
     )JSON", @"testidentifier2");
 
     __block bool receivedAllRequests { false };
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     handler.get().startURLSchemeTaskHandler = ^(WKWebView *, id <WKURLSchemeTask> task) {
         NSString *path = task.request.URL.path;
         NSDictionary<NSString *, NSString *> *fields = [task.request allHTTPHeaderFields];
@@ -1070,11 +1070,11 @@ TEST_F(WKContentRuleListStoreTest, ModifyHeadersWithMultipleRuleLists)
         ASSERT_NOT_REACHED();
     };
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [[configuration userContentController] addContentRuleList:list.get()];
     [[configuration userContentController] addContentRuleList:secondList.get()];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testscheme"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
     auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
     webView.get().navigationDelegate = delegate;
     __block bool receivedActionNotification { false };
@@ -1159,8 +1159,8 @@ TEST_F(WKContentRuleListStoreTest, Redirect)
     )JSON");
 
     __block bool receivedAllRequests { false };
-    __block auto urls = adoptNS([NSMutableArray new]);
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    __block RetainPtr urls = adoptNS([NSMutableArray new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     handler.get().startURLSchemeTaskHandler = ^(WKWebView *, id <WKURLSchemeTask> task) {
         NSURL *url = task.request.URL;
         [urls addObject:url];
@@ -1190,11 +1190,11 @@ TEST_F(WKContentRuleListStoreTest, Redirect)
         respond(task, "");
     };
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [[configuration userContentController] addContentRuleList:list.get()];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testscheme"];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"othertestscheme"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
     auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
     webView.get().navigationDelegate = delegate;
     __block bool receivedActionNotification { false };
@@ -1247,9 +1247,9 @@ TEST_F(WKContentRuleListStoreTest, MainResourceCrossOriginRedirect)
 
     auto configuration = server.httpsProxyConfiguration();
     [[configuration userContentController] addContentRuleList:list.get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         preferences._activeContentRuleListActionPatterns = @{
             @"testidentifier": [NSSet setWithObject:@"https://example.com/*"]
@@ -1279,9 +1279,9 @@ TEST_F(WKContentRuleListStoreTest, MainResourceSameOriginRedirect)
 
     auto configuration = server.httpsProxyConfiguration();
     [configuration.userContentController addContentRuleList:list.get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         preferences._activeContentRuleListActionPatterns = @{
             @"testidentifier": [NSSet setWithObject:@"https://example.com/*"]
@@ -1315,9 +1315,9 @@ TEST_F(WKContentRuleListStoreTest, MainResourceCrossOriginRedirectFromLoadedPage
 
     auto configuration = server.httpsProxyConfiguration();
     [[configuration userContentController] addContentRuleList:list.get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         preferences._activeContentRuleListActionPatterns = @{
             @"testidentifier": [NSSet setWithObject:@"https://webkit.org/*"]
@@ -1346,7 +1346,7 @@ TEST_F(WKContentRuleListStoreTest, NullPatternSet)
     )JSON");
 
     __block std::optional<bool> redirectedResult;
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     handler.get().startURLSchemeTaskHandler = ^(WKWebView *, id <WKURLSchemeTask> task) {
         NSString *path = task.request.URL.path;
         if ([path isEqualToString:@"/main.html"])
@@ -1363,7 +1363,7 @@ TEST_F(WKContentRuleListStoreTest, NullPatternSet)
         AllowNone,
         AllowTestHost,
     } delegateAction;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         EXPECT_NOT_NULL(preferences._activeContentRuleListActionPatterns);
         EXPECT_EQ(preferences._activeContentRuleListActionPatterns.count, 0u);
@@ -1381,10 +1381,10 @@ TEST_F(WKContentRuleListStoreTest, NullPatternSet)
         decisionHandler(WKNavigationActionPolicyAllow, preferences);
     };
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [[configuration userContentController] addContentRuleList:list.get()];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testscheme"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
     webView.get().navigationDelegate = delegate.get();
 
     auto getRedirectResult = ^(DelegateAction action) {
@@ -1412,23 +1412,23 @@ TEST_F(WKContentRuleListStoreTest, ExtensionPath)
     )JSON");
 
     __block RetainPtr<NSURL> redirectedURL;
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     handler.get().startURLSchemeTaskHandler = ^(WKWebView *, id <WKURLSchemeTask> task) {
         redirectedURL = task.request.URL;
         respond(task, "");
     };
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         preferences._activeContentRuleListActionPatterns = [NSDictionary dictionaryWithObject:[NSSet setWithObject:@"testscheme://testhost/*"] forKey:@"testidentifier"];
         decisionHandler(WKNavigationActionPolicyAllow, preferences);
     };
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [[configuration userContentController] _addContentRuleList:list.get() extensionBaseURL:[NSURL URLWithString:@"extension-scheme://extension-host/"]];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testscheme"];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"extension-scheme"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
     webView.get().navigationDelegate = delegate.get();
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"testscheme://testhost/main.html"]]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKContentViewEditingActions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKContentViewEditingActions.mm
@@ -71,7 +71,7 @@ TEST(WebKit, WKContentViewEditingActions)
 
 TEST(WebKit, InvokeShareWithoutSelection)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
     [webView shareSelection];
     [webView waitForNextPresentationUpdate];
@@ -81,7 +81,7 @@ TEST(WebKit, CopyInAutoFilledAndViewablePasswordField)
 {
     RetainPtr configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration.get()]);
     auto *contentView = [webView textInputContentView];
     [webView synchronouslyLoadHTMLString:@"<input type='password' value='hunter2' autofocus /><input type='password' value='hunter2' id='autofill' />"];
     [webView selectAll:nil];
@@ -106,12 +106,12 @@ TEST(WebKit, DISABLED_AppHighlightsInImageOverlays)
     auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES]);
     [configuration _setAppHighlightsEnabled:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"simple-image-overlay" asStringWithBaseURL:[NSURL URLWithString:@"http://webkit.org/simple-image-overlay.html"]];
     [webView stringByEvaluatingJavaScript:@"selectImageOverlay()"];
     [webView waitForNextPresentationUpdate];
 
-    auto menuBuilder = adoptNS([[TestUIMenuBuilder alloc] init]);
+    RetainPtr menuBuilder = adoptNS([[TestUIMenuBuilder alloc] init]);
     [webView buildMenuWithBuilder:menuBuilder.get()];
     EXPECT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTagAddHighlightToNewQuickNote().createNSString().get()]);
     EXPECT_NULL([menuBuilder actionWithTitle:WebCore::contextMenuItemTagAddHighlightToCurrentQuickNote().createNSString().get()]);
@@ -139,12 +139,12 @@ TEST(WebKit, CaptureTextFromCamera)
     gCanPerformActionWithSenderResult = YES;
     InstanceMethodSwizzler swizzler { UIResponder.class, @selector(canPerformAction:withSender:), reinterpret_cast<IMP>(canPerformActionWithSender) };
 
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) {
         return _WKFocusStartsInputSessionPolicyAllow;
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView _setInputDelegate:inputDelegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<input style='display: block; font-size: 100px;' value='foo' autofocus><input value='bar' readonly>"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKContentViewTargetForAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKContentViewTargetForAction.mm
@@ -46,7 +46,7 @@
 
 TEST(WebKit, WKContentViewTargetForAction)
 {
-    auto webView = adoptNS([[TestWKContentViewTargetForActionView alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKContentViewTargetForActionView alloc] init]);
     [webView synchronouslyLoadTestPageNamed:@"rich-and-plain-text"];
     [webView becomeFirstResponder];
     [webView stringByEvaluatingJavaScript:@"selectPlainText()"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKHTTPCookieStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKHTTPCookieStore.mm
@@ -73,9 +73,9 @@ static void runTestWithWebsiteDataStore(WKWebsiteDataStore* dataStore)
 {
     observerCallbacks = 0;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = dataStore;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView loadHTMLString:@"Oh hello" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     [webView _test_waitForDidFinishNavigation];
@@ -245,9 +245,9 @@ TEST(WKHTTPCookieStore, HttpOnly)
 {
     WKWebsiteDataStore* dataStore = [WKWebsiteDataStore defaultDataStore];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = dataStore;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView loadHTMLString:@"WebKit Test" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     [webView _test_waitForDidFinishNavigation];
@@ -269,7 +269,7 @@ TEST(WKHTTPCookieStore, HttpOnly)
     gotFlag = false;
     ASSERT_EQ([cookies count], 0u);
 
-    auto cookieProperties = adoptNS([[NSMutableDictionary alloc] init]);
+    RetainPtr cookieProperties = adoptNS([[NSMutableDictionary alloc] init]);
     [cookieProperties setObject:@"cookieName" forKey:NSHTTPCookieName];
     [cookieProperties setObject:@"cookieValue" forKey:NSHTTPCookieValue];
     [cookieProperties setObject:@".www.webkit.org" forKey:NSHTTPCookieDomain];
@@ -359,9 +359,9 @@ TEST(WKHTTPCookieStore, HttpOnly)
 TEST(WKHTTPCookieStore, CreationTime)
 {   
     auto dataStore = [WKWebsiteDataStore defaultDataStore];
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = dataStore;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView loadHTMLString:@"WebKit Test" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     [webView _test_waitForDidFinishNavigation];
@@ -374,7 +374,7 @@ TEST(WKHTTPCookieStore, CreationTime)
 
     globalCookieStore = dataStore.httpCookieStore;
 
-    auto cookieProperties = adoptNS([[NSMutableDictionary alloc] init]);
+    RetainPtr cookieProperties = adoptNS([[NSMutableDictionary alloc] init]);
     [cookieProperties setObject:@"cookieName" forKey:NSHTTPCookieName];
     [cookieProperties setObject:@"cookieValue" forKey:NSHTTPCookieValue];
     [cookieProperties setObject:@".www.webkit.org" forKey:NSHTTPCookieDomain];
@@ -434,11 +434,11 @@ TEST(WKHTTPCookieStore, Custom)
     EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:cookieStorageFile.path]);
     EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:idbPath.path]);
 
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get()._indexedDBDatabaseDirectory = idbPath;
     websiteDataStoreConfiguration.get()._cookieStorageFile = cookieStorageFile;
 
-    auto customDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr customDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
     runTestWithWebsiteDataStore(customDataStore.get());
 }
 #endif // PLATFORM(MAC) && __MAC_OS_X_VERSION_MAX_ALLOWED <= 101301
@@ -450,10 +450,10 @@ TEST(WebKit, CookieObserverCrash)
         nonPersistentDataStore = [WKWebsiteDataStore nonPersistentDataStore];
     }
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = nonPersistentDataStore.get();
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView loadHTMLString:@"Oh hello" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     [webView _test_waitForDidFinishNavigation];
@@ -483,17 +483,17 @@ TEST(WKHTTPCookieStore, ObserveCookiesReceivedFromHTTP)
     TestWebKitAPI::HTTPServer server({{ "/"_s, {{{ "Set-Cookie"_s, "testkey=testvalue"_s }}, "hello"_s }}});
 
     auto runTest = [&] (WKWebsiteDataStore *dataStore) {
-        auto configuration = adoptNS([WKWebViewConfiguration new]);
+        RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
         configuration.get().websiteDataStore = dataStore;
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-        auto observer = adoptNS([CookieObserver new]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+        RetainPtr observer = adoptNS([CookieObserver new]);
         globalCookieStore = webView.get().configuration.websiteDataStore.httpCookieStore;
         clearCookies(dataStore);
         [globalCookieStore addObserver:observer.get()];
 
         // Also observing with an EmptyCookieObserver tests whether or
         // not WebKit makes an unrecognized selector call
-        auto emptyCookieObserver = adoptNS([EmptyCookieObserver new]);
+        RetainPtr emptyCookieObserver = adoptNS([EmptyCookieObserver new]);
         [globalCookieStore addObserver:emptyCookieObserver.get()];
 
         observerCallbacks = 0;
@@ -571,15 +571,15 @@ void runWKHTTPCookieStoreWithoutProcessPool(ShouldEnableProcessPrewarming should
     TestWebKitAPI::Util::run(&finished);
     finished = false;
 
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().prewarmsProcessesAutomatically = shouldEnableProcessPrewarming == ShouldEnableProcessPrewarming::Yes;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = ephemeralStoreWithCookies.get();
     [configuration setProcessPool:processPool.get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([[CookieUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[CookieUIDelegate alloc] init]);
     webView.get().UIDelegate = delegate.get();
     [webView loadHTMLString:alertCookieHTML baseURL:[NSURL URLWithString:@"http://127.0.0.1"]];
     TestWebKitAPI::Util::run(&finished);
@@ -670,7 +670,7 @@ TEST(WKHTTPCookieStore, WithoutProcessPoolWithPrewarming)
 
 TEST(WebKit, WKHTTPCookieStoreMultipleViews)
 {
-    auto webView1 = adoptNS([TestWKWebView new]);
+    RetainPtr webView1 = adoptNS([TestWKWebView new]);
     [webView1 synchronouslyLoadHTMLString:@"start network process"];
 
     NSHTTPCookie *sessionCookie = [NSHTTPCookie cookieWithProperties:@{
@@ -686,13 +686,13 @@ TEST(WebKit, WKHTTPCookieStoreMultipleViews)
     }];
     TestWebKitAPI::Util::run(&setCookieDone);
 
-    auto delegate = adoptNS([CheckSessionCookieUIDelegate new]);
+    RetainPtr delegate = adoptNS([CheckSessionCookieUIDelegate new]);
     [webView1 setUIDelegate:delegate.get()];
 
     [webView1 loadHTMLString:[delegate alertCookieHTML] baseURL:[NSURL URLWithString:@"http://127.0.0.1"]];
     EXPECT_WK_STREQ([delegate waitForMessage], "SessionCookieName=CookieValue");
 
-    auto webView2 = adoptNS([TestWKWebView new]);
+    RetainPtr webView2 = adoptNS([TestWKWebView new]);
     [webView2 setUIDelegate:delegate.get()];
     [webView2 loadHTMLString:[delegate alertCookieHTML] baseURL:[NSURL URLWithString:@"http://127.0.0.1"]];
     EXPECT_WK_STREQ([delegate waitForMessage], "SessionCookieName=CookieValue");
@@ -702,11 +702,11 @@ TEST(WKHTTPCookieStore, WithoutProcessPoolEphemeralSession)
 {
     RetainPtr<WKWebsiteDataStore> ephemeralStoreWithCookies = [WKWebsiteDataStore nonPersistentDataStore];
     
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = ephemeralStoreWithCookies.get();
     
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([[CheckSessionCookieUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[CheckSessionCookieUIDelegate alloc] init]);
     webView.get().UIDelegate = delegate.get();
     
     RetainPtr<NSHTTPCookie> sessionCookie = [NSHTTPCookie cookieWithProperties:@{
@@ -741,7 +741,7 @@ TEST(WKHTTPCookieStore, WithoutProcessPoolDuplicates)
         NSHTTPCookieDomain: @"127.0.0.1",
     }];
 
-    auto properties = adoptNS([sessionCookie.get().properties mutableCopy]);
+    RetainPtr properties = adoptNS([sessionCookie.get().properties mutableCopy]);
     properties.get()[NSHTTPCookieDomain] = @"localhost";
     RetainPtr<NSHTTPCookie> sessionCookieDifferentDomain = [NSHTTPCookie cookieWithProperties:properties.get()];
     properties.get()[NSHTTPCookieValue] = @"OtherCookieValue";
@@ -800,7 +800,7 @@ TEST(WKHTTPCookieStore, CookiesForURL)
     }];
 
     __block bool done = false;
-    auto webView = adoptNS([TestWKWebView new]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
     [webView synchronouslyLoadHTMLString:@"start network process"];
     [cookieStore setCookie:webKitCookie completionHandler:^{
         [cookieStore setCookie:albuquerque completionHandler:^{
@@ -820,7 +820,7 @@ TEST(WKHTTPCookieStore, CookiesForURL)
 
 TEST(WKHTTPCookieStore, CookieAccessAfterNetworkProcessTermination)
 {
-    auto webView = adoptNS([TestWKWebView new]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
     [webView synchronouslyLoadHTMLString:@"start network process" baseURL:[NSURL URLWithString:@"http://example.com/"]];
     kill([WKWebsiteDataStore.defaultDataStore _networkProcessIdentifier], SIGKILL);
     TestWebKitAPI::Util::runFor(Seconds(0.1));
@@ -859,7 +859,7 @@ TEST(WKHTTPCookieStore, WebSocketCookies)
     } });
     serverPort = server.port();
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [[[webView configuration] websiteDataStore] _setResourceLoadStatisticsEnabled:YES];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/com", serverPort]]]];
     [webView _test_waitForDidFinishNavigation];
@@ -916,7 +916,7 @@ TEST(WKHTTPCookieStore, WebSocketCookiesFromRedirect)
     } });
     serverPort = server.port();
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [[[webView configuration] websiteDataStore] _setResourceLoadStatisticsEnabled:YES];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/redirect", serverPort]]]];
     [webView _test_waitForDidFinishNavigation];
@@ -968,7 +968,7 @@ TEST(WKHTTPCookieStore, WebSocketCookiesThroughRedirect)
     } });
     serverPort = server.port();
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [[[webView configuration] websiteDataStore] _setResourceLoadStatisticsEnabled:YES];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/redirect", serverPort]]]];
     Util::run(&receivedWebSocket);
@@ -1010,7 +1010,7 @@ TEST(WKHTTPCookieStore, WebSocketSetCookiesThroughFirstPartyRedirect)
     } });
     serverPort = server.port();
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [[[webView configuration] websiteDataStore] _setResourceLoadStatisticsEnabled:YES];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/ninja", serverPort]]]];
     Util::run(&receivedWebSocket);
@@ -1065,7 +1065,7 @@ TEST(WKHTTPCookieStore, WebSocketSetCookiesThroughRedirectToThirdParty)
     } });
     serverPort = server.port();
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [[[webView configuration] websiteDataStore] _setResourceLoadStatisticsEnabled:YES];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/ninja", serverPort]]]];
     Util::run(&receivedWebSocket);
@@ -1190,15 +1190,15 @@ TEST(WKHTTPCookieStore, PartitionedCookieShouldNotHavePartitionProperty)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s }, { "Set-Cookie"_s, "test=value;Secure;SameSite=None;Partitioned"_s } }, ""_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
-    auto viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [viewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
 
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
     [webView setNavigationDelegate:delegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/"]]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKInspectorDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKInspectorDelegate.mm
@@ -132,7 +132,7 @@ static void resetInspectorGlobalState()
     [inspector setDelegate:sharedInspectorDelegate.get()];
 
     sharedSimpleURLSchemeHandler = adoptNS([[SimpleURLSchemeHandler alloc] init]);
-    auto inspectorConfiguration = adoptNS([[_WKInspectorConfiguration alloc] init]);
+    RetainPtr inspectorConfiguration = adoptNS([[_WKInspectorConfiguration alloc] init]);
     [inspectorConfiguration setURLSchemeHandler:sharedSimpleURLSchemeHandler.get() forURLScheme:@"testing"];
     return inspectorConfiguration.autorelease();
 }
@@ -169,10 +169,10 @@ TEST(WKInspectorDelegate, InspectorLifecycleCallbacks)
 {
     resetInspectorGlobalState();
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().preferences._developerExtrasEnabled = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto uiDelegate = adoptNS([UIDelegateForTesting new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr uiDelegate = adoptNS([UIDelegateForTesting new]);
 
     [webView setUIDelegate:uiDelegate.get()];
     [webView loadHTMLString:@"<head><title>Test page to be inspected</title></head><body><p>Filler content</p></body>" baseURL:[NSURL URLWithString:@"http://example.com/"]];
@@ -193,10 +193,10 @@ TEST(WKInspectorDelegate, InspectorCloseCalledReentrantly)
 {
     resetInspectorGlobalState();
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().preferences._developerExtrasEnabled = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto uiDelegate = adoptNS([UIDelegateForTesting new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr uiDelegate = adoptNS([UIDelegateForTesting new]);
 
     [webView setUIDelegate:uiDelegate.get()];
     [webView loadHTMLString:@"<head><title>Test page to be inspected</title></head><body><p>Filler content</p></body>" baseURL:[NSURL URLWithString:@"http://example.com/"]];
@@ -217,10 +217,10 @@ TEST(WKInspectorDelegate, ShowURLExternally)
 {
     resetInspectorGlobalState();
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().preferences._developerExtrasEnabled = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto uiDelegate = adoptNS([UIDelegateForTesting new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr uiDelegate = adoptNS([UIDelegateForTesting new]);
 
     [webView setUIDelegate:uiDelegate.get()];
     [webView loadHTMLString:@"<head><title>Test page to be inspected</title></head><body><p>Filler content</p></body>" baseURL:[NSURL URLWithString:@"http://example.com/"]];
@@ -244,10 +244,10 @@ TEST(WKInspectorDelegate, InspectorConfiguration)
 {
     resetInspectorGlobalState();
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().preferences._developerExtrasEnabled = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto uiDelegate = adoptNS([UIDelegateForTesting new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr uiDelegate = adoptNS([UIDelegateForTesting new]);
 
     [webView setUIDelegate:uiDelegate.get()];
     [webView loadHTMLString:@"<head><title>Test page to be inspected</title></head><body><p>Filler content</p></body>" baseURL:[NSURL URLWithString:@"http://example.com/"]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKInspectorExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKInspectorExtension.mm
@@ -59,7 +59,7 @@ static RetainPtr<NSObject> evaluationResult;
     if (!sharedURLSchemeHandler)
         sharedURLSchemeHandler = adoptNS([[TestInspectorURLSchemeHandler alloc] init]);
 
-    auto inspectorConfiguration = adoptNS([[_WKInspectorConfiguration alloc] init]);
+    RetainPtr inspectorConfiguration = adoptNS([[_WKInspectorConfiguration alloc] init]);
     [inspectorConfiguration setURLSchemeHandler:sharedURLSchemeHandler.get() forURLScheme:@"test-resource"];
     return inspectorConfiguration.autorelease();
 }
@@ -89,10 +89,10 @@ TEST(WKInspectorExtension, CanEvaluateScriptInExtensionTab)
 {
     resetGlobalState();
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().preferences._developerExtrasEnabled = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto uiDelegate = adoptNS([UIDelegateForTestingInspectorExtension new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr uiDelegate = adoptNS([UIDelegateForTestingInspectorExtension new]);
 
     [webView setUIDelegate:uiDelegate.get()];
     [webView loadHTMLString:@"<head><title>Test page to be inspected</title></head><body><p>Filler content</p></body>" baseURL:[NSURL URLWithString:@"http://example.com/"]];
@@ -115,7 +115,7 @@ TEST(WKInspectorExtension, CanEvaluateScriptInExtensionTab)
     }];
     TestWebKitAPI::Util::run(&pendingCallbackWasCalled);
 
-    auto extensionDelegate = adoptNS([InspectorExtensionDelegateForTestingInspectorExtension new]);
+    RetainPtr extensionDelegate = adoptNS([InspectorExtensionDelegateForTestingInspectorExtension new]);
     [sharedInspectorExtension setDelegate:extensionDelegate.get()];
 
     // Create and show an extension tab.
@@ -185,10 +185,10 @@ TEST(WKInspectorExtension, ExtensionTabIsPersistent)
 {
     resetGlobalState();
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().preferences._developerExtrasEnabled = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto uiDelegate = adoptNS([UIDelegateForTestingInspectorExtension new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr uiDelegate = adoptNS([UIDelegateForTestingInspectorExtension new]);
 
     [webView setUIDelegate:uiDelegate.get()];
     [webView loadHTMLString:@"<head><title>Test page to be inspected</title></head><body><p>Filler content</p></body>" baseURL:[NSURL URLWithString:@"http://example.com/"]];
@@ -211,7 +211,7 @@ TEST(WKInspectorExtension, ExtensionTabIsPersistent)
     }];
     TestWebKitAPI::Util::run(&pendingCallbackWasCalled);
 
-    auto extensionDelegate = adoptNS([InspectorExtensionDelegateForTestingInspectorExtension new]);
+    RetainPtr extensionDelegate = adoptNS([InspectorExtensionDelegateForTestingInspectorExtension new]);
     [sharedInspectorExtension setDelegate:extensionDelegate.get()];
 
     // Create and show an extension tab.
@@ -303,10 +303,10 @@ TEST(WKInspectorExtension, EvaluateScriptInExtensionTabCanReturnPromises)
 {
     resetGlobalState();
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().preferences._developerExtrasEnabled = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto uiDelegate = adoptNS([UIDelegateForTestingInspectorExtension new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr uiDelegate = adoptNS([UIDelegateForTestingInspectorExtension new]);
 
     [webView setUIDelegate:uiDelegate.get()];
     [webView loadHTMLString:@"<head><title>Test page to be inspected</title></head><body><p>Filler content</p></body>" baseURL:[NSURL URLWithString:@"http://example.com/"]];
@@ -329,7 +329,7 @@ TEST(WKInspectorExtension, EvaluateScriptInExtensionTabCanReturnPromises)
     }];
     TestWebKitAPI::Util::run(&pendingCallbackWasCalled);
 
-    auto extensionDelegate = adoptNS([InspectorExtensionDelegateForTestingInspectorExtension new]);
+    RetainPtr extensionDelegate = adoptNS([InspectorExtensionDelegateForTestingInspectorExtension new]);
     [sharedInspectorExtension setDelegate:extensionDelegate.get()];
 
     // Create and show an extension tab.
@@ -397,11 +397,11 @@ TEST(WKInspectorExtension, EvaluateScriptOnPage)
 {
     resetGlobalState();
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().preferences._developerExtrasEnabled = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto uiDelegate = adoptNS([UIDelegateForTestingInspectorExtension new]);
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr uiDelegate = adoptNS([UIDelegateForTestingInspectorExtension new]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
 
     auto *testPageFileURL = [NSBundle.test_resourcesBundle URLForResource:@"WKInspectorExtensionEvaluateScriptOnPage" withExtension:@"html"];
 
@@ -428,7 +428,7 @@ TEST(WKInspectorExtension, EvaluateScriptOnPage)
     }];
     TestWebKitAPI::Util::run(&pendingCallbackWasCalled);
 
-    auto extensionDelegate = adoptNS([InspectorExtensionDelegateForTestingInspectorExtension new]);
+    RetainPtr extensionDelegate = adoptNS([InspectorExtensionDelegateForTestingInspectorExtension new]);
     [sharedInspectorExtension setDelegate:extensionDelegate.get()];
 
     // Create and show an extension tab.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKInspectorExtensionDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKInspectorExtensionDelegate.mm
@@ -61,7 +61,7 @@ static bool extensionTabDidNavigateWasCalled;
     if (!sharedURLSchemeHandler)
         sharedURLSchemeHandler = adoptNS([[TestInspectorURLSchemeHandler alloc] init]);
 
-    auto inspectorConfiguration = adoptNS([[_WKInspectorConfiguration alloc] init]);
+    RetainPtr inspectorConfiguration = adoptNS([[_WKInspectorConfiguration alloc] init]);
     [inspectorConfiguration setURLSchemeHandler:sharedURLSchemeHandler.get() forURLScheme:@"test-resource"];
     return inspectorConfiguration.autorelease();
 }
@@ -103,10 +103,10 @@ TEST(WKInspectorExtensionDelegate, DISABLED_ShowAndHideTabCallbacks)
 {
     resetGlobalState();
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().preferences._developerExtrasEnabled = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto uiDelegate = adoptNS([UIDelegateForTestingInspectorExtensionDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr uiDelegate = adoptNS([UIDelegateForTestingInspectorExtensionDelegate new]);
 
     [webView setUIDelegate:uiDelegate.get()];
     [webView loadHTMLString:@"<head><title>Test page to be inspected</title></head><body><p>Filler content</p></body>" baseURL:[NSURL URLWithString:@"http://example.com/"]];
@@ -129,7 +129,7 @@ TEST(WKInspectorExtensionDelegate, DISABLED_ShowAndHideTabCallbacks)
     }];
     TestWebKitAPI::Util::run(&pendingCallbackWasCalled);
 
-    auto extensionDelegate = adoptNS([InspectorExtensionDelegateForTesting new]);
+    RetainPtr extensionDelegate = adoptNS([InspectorExtensionDelegateForTesting new]);
     [sharedInspectorExtension setDelegate:extensionDelegate.get()];
 
     // Create an extension tab.
@@ -177,12 +177,12 @@ TEST(WKInspectorExtensionDelegate, DISABLED_InspectedPageNavigatedCallbacks)
     if (!sharedURLSchemeHandler)
         sharedURLSchemeHandler = adoptNS([[TestInspectorURLSchemeHandler alloc] init]);
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().preferences._developerExtrasEnabled = YES;
     [webViewConfiguration setURLSchemeHandler:sharedURLSchemeHandler.get() forURLScheme:@"test-resource"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto uiDelegate = adoptNS([UIDelegateForTestingInspectorExtensionDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr uiDelegate = adoptNS([UIDelegateForTestingInspectorExtensionDelegate new]);
 
     [webView setUIDelegate:uiDelegate.get()];
 
@@ -203,7 +203,7 @@ TEST(WKInspectorExtensionDelegate, DISABLED_InspectedPageNavigatedCallbacks)
     }];
     TestWebKitAPI::Util::run(&pendingCallbackWasCalled);
 
-    auto extensionDelegate = adoptNS([InspectorExtensionDelegateForTesting new]);
+    RetainPtr extensionDelegate = adoptNS([InspectorExtensionDelegateForTesting new]);
     [sharedInspectorExtension setDelegate:extensionDelegate.get()];
 
     [webView loadHTMLString:@"<head><title>Test page to be inspected</title></head><body><p>Filler content</p></body>" baseURL:[NSURL URLWithString:@"http://example.com/"]];
@@ -246,12 +246,12 @@ TEST(WKInspectorExtensionDelegate, DISABLED_ExtensionTabNavigatedCallbacks)
     if (!sharedURLSchemeHandler)
         sharedURLSchemeHandler = adoptNS([[TestInspectorURLSchemeHandler alloc] init]);
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().preferences._developerExtrasEnabled = YES;
     [webViewConfiguration setURLSchemeHandler:sharedURLSchemeHandler.get() forURLScheme:@"test-resource"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto uiDelegate = adoptNS([UIDelegateForTestingInspectorExtensionDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr uiDelegate = adoptNS([UIDelegateForTestingInspectorExtensionDelegate new]);
 
     [webView setUIDelegate:uiDelegate.get()];
 
@@ -272,7 +272,7 @@ TEST(WKInspectorExtensionDelegate, DISABLED_ExtensionTabNavigatedCallbacks)
     }];
     TestWebKitAPI::Util::run(&pendingCallbackWasCalled);
 
-    auto extensionDelegate = adoptNS([InspectorExtensionDelegateForTesting new]);
+    RetainPtr extensionDelegate = adoptNS([InspectorExtensionDelegateForTesting new]);
     [sharedInspectorExtension setDelegate:extensionDelegate.get()];
 
     auto baseURL = [NSURL URLWithString:@"http://example.com/"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKInspectorExtensionHost.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKInspectorExtensionHost.mm
@@ -53,10 +53,10 @@ TEST(WKInspectorExtensionHost, RegisterExtension)
 {
     resetGlobalState();
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().preferences._developerExtrasEnabled = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto uiDelegate = adoptNS([UIDelegateForTestingInspectorExtensionHost new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr uiDelegate = adoptNS([UIDelegateForTestingInspectorExtensionHost new]);
 
     [webView setUIDelegate:uiDelegate.get()];
     [webView loadHTMLString:@"<head><title>Test page to be inspected</title></head><body><p>Filler content</p></body>" baseURL:[NSURL URLWithString:@"http://example.com/"]];
@@ -103,10 +103,10 @@ TEST(WKInspectorExtensionHost, UnregisterExtension)
 {
     resetGlobalState();
 
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().preferences._developerExtrasEnabled = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto uiDelegate = adoptNS([UIDelegateForTestingInspectorExtensionHost new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr uiDelegate = adoptNS([UIDelegateForTestingInspectorExtensionHost new]);
 
     [webView setUIDelegate:uiDelegate.get()];
     [webView loadHTMLString:@"<head><title>Test page to be inspected</title></head><body><p>Filler content</p></body>" baseURL:[NSURL URLWithString:@"http://example.com/"]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKNavigationResponse.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKNavigationResponse.mm
@@ -84,11 +84,11 @@
 TEST(WebKit, WKNavigationResponseJSONMIMEType)
 {
     isDone = false;
-    auto schemeHandler = adoptNS([[WKNavigationResponseTestSchemeHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[WKNavigationResponseTestSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"test"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
-    auto navigationDelegate = adoptNS([[WKNavigationResponseTestNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[WKNavigationResponseTestNavigationDelegate alloc] init]);
     webView.get().navigationDelegate = navigationDelegate.get();
 
     schemeHandler.get().mimeType = @"application/json";
@@ -102,11 +102,11 @@ TEST(WebKit, WKNavigationResponseJSONMIMEType)
 TEST(WebKit, WKNavigationResponseJSONMIMEType2)
 {
     isDone = false;
-    auto schemeHandler = adoptNS([[WKNavigationResponseTestSchemeHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[WKNavigationResponseTestSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"test"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
-    auto navigationDelegate = adoptNS([[WKNavigationResponseTestNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[WKNavigationResponseTestNavigationDelegate alloc] init]);
     webView.get().navigationDelegate = navigationDelegate.get();
 
     schemeHandler.get().mimeType = @"application/vnd.api+json";
@@ -120,11 +120,11 @@ TEST(WebKit, WKNavigationResponseJSONMIMEType2)
 TEST(WebKit, WKNavigationResponseUnknownMIMEType)
 {
     isDone = false;
-    auto schemeHandler = adoptNS([[WKNavigationResponseTestSchemeHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[WKNavigationResponseTestSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"test"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
-    auto navigationDelegate = adoptNS([[WKNavigationResponseTestNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[WKNavigationResponseTestNavigationDelegate alloc] init]);
     webView.get().navigationDelegate = navigationDelegate.get();
 
     schemeHandler.get().mimeType = @"garbage/json";
@@ -238,8 +238,8 @@ TEST(WebKit, WKNavigationResponseDownloadAttribute)
                 });
             });
         });
-        auto delegate = adoptNS([NavigationResponseTestDelegate new]);
-        auto webView = adoptNS([WKWebView new]);
+        RetainPtr delegate = adoptNS([NavigationResponseTestDelegate new]);
+        RetainPtr webView = adoptNS([WKWebView new]);
         [webView setNavigationDelegate:delegate.get()];
 
         [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
@@ -274,8 +274,8 @@ TEST(WebKit, SkipDecidePolicyForResponse)
 
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"SkipDecidePolicyForResponsePlugIn"];
     configuration.preferences.fraudulentWebsiteWarningEnabled = NO;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     __block bool responseDelegateCalled { false };
     delegate.get().decidePolicyForNavigationResponse = ^(WKNavigationResponse *, void (^completionHandler)(WKNavigationResponsePolicy)) {
         responseDelegateCalled = true;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKObject.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKObject.mm
@@ -63,7 +63,7 @@ TEST(WebKit, WKObject_classInDictionary)
     Class wkObjectClass = NSClassFromString(@"WKObject");
     ASSERT_NE((Class)0, wkObjectClass);
 
-    auto map = adoptNS([[NSMapTable alloc] initWithKeyOptions:NSMapTableStrongMemory valueOptions:NSMapTableWeakMemory capacity:0]);
+    RetainPtr map = adoptNS([[NSMapTable alloc] initWithKeyOptions:NSMapTableStrongMemory valueOptions:NSMapTableWeakMemory capacity:0]);
     [map setObject:@"test" forKey:wkObjectClass];
     ASSERT_TRUE([@"test" isEqualToString:(NSString *)[map objectForKey: wkObjectClass]]);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKPageHasMediaStreamingActivity.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKPageHasMediaStreamingActivity.mm
@@ -45,10 +45,10 @@ static const char *WebKitMediaStreamingActivity = "com.apple.WebKit.mediaStreami
 
 TEST(WebKit, MSEHasMediaStreamingActivity)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [[configuration preferences] _setMediaSourceEnabled:YES];
     [[configuration preferences] _setAllowFileAccessFromFileURLs:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"file-with-mse"];
 
     // Bail out of the test early if the platform does not support MSE.
@@ -90,10 +90,10 @@ TEST(WebKit, MSEHasMediaStreamingActivity)
 #if ENABLE(MEDIA_SOURCE)
 TEST(WebKit, ManagedMSEHasMediaStreamingActivity)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [[configuration preferences] _setManagedMediaSourceEnabled:YES];
     [[configuration preferences] _setAllowFileAccessFromFileURLs:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"file-with-managedmse"];
 
     // Bail out of the test early if the platform does not support Managed MSE.
@@ -134,10 +134,10 @@ TEST(WebKit, ManagedMSEHasMediaStreamingActivity)
 
 TEST(WebKit, ManagedMSEHasMediaStreamingActivityWithPolicy)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [[configuration preferences] _setManagedMediaSourceEnabled:YES];
     [[configuration preferences] _setAllowFileAccessFromFileURLs:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"file-with-managedmse"];
 
     // Bail out of the test early if the platform does not support Managed MSE.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKPrinting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKPrinting.mm
@@ -80,9 +80,9 @@ typedef void (^CallCompletionBlock)();
 
 TEST(Printing, PrintWithDelayedCompletion)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([PrintWithSimulatedPageComputationUIDelegate new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([PrintWithSimulatedPageComputationUIDelegate new]);
     [webView setUIDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
@@ -121,7 +121,7 @@ TEST(Printing, PrintWithDelayedCompletion)
 
 - (void)_webView:(WKWebView *)webView printFrame:(_WKFrameHandle *)frame pdfFirstPageSize:(CGSize)size completionHandler:(void (^)(void))completionHandler
 {
-    auto printInfo = adoptNS([[NSPrintInfo alloc] init]);
+    RetainPtr printInfo = adoptNS([[NSPrintInfo alloc] init]);
 
     NSPrintOperation *operation = [webView _printOperationWithPrintInfo:printInfo.get() forFrame:frame];
 
@@ -139,9 +139,9 @@ TEST(Printing, PrintWithDelayedCompletion)
 
 TEST(Printing, PrintPageBorders)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
-    auto webView = adoptNS([[WKPrintPageBordersWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([PrintShowingPrintPanelUIDelegate new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webView = adoptNS([[WKPrintPageBordersWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([PrintShowingPrintPanelUIDelegate new]);
     [webView setUIDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKProcessPoolConfiguration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKProcessPoolConfiguration.mm
@@ -33,7 +33,7 @@
 
 TEST(WKProcessPoolConfiguration, Copy)
 {
-    auto configuration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     
     [configuration setInjectedBundleURL:[NSURL fileURLWithPath:@"/path/to/injected.wkbundle"]];
     [configuration setIgnoreSynchronousMessagingTimeoutsForTesting:YES];
@@ -52,7 +52,7 @@ TEST(WKProcessPoolConfiguration, Copy)
     [configuration setPrewarmsProcessesAutomatically:YES];
     [configuration setPageCacheEnabled:YES];
 
-    auto copy = adoptNS([configuration copy]);
+    RetainPtr copy = adoptNS([configuration copy]);
 
     EXPECT_TRUE([[configuration injectedBundleURL] isEqual:[copy injectedBundleURL]]);
     EXPECT_EQ([configuration ignoreSynchronousMessagingTimeoutsForTesting], [copy ignoreSynchronousMessagingTimeoutsForTesting]);
@@ -93,9 +93,9 @@ TEST(WKProcessPool, JavaScriptConfiguration)
     BOOL result = [contents writeToURL:[tempDir URLByAppendingPathComponent:@"JSC.config"] atomically:YES];
     EXPECT_TRUE(result);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().processPool._javaScriptConfigurationDirectory = tempDir;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
     [webView loadHTMLString:@"<html>hello</html>" baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
 
     NSString *path = [tempDir URLByAppendingPathComponent:@"Log.txt"].path;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKRequestActivatedElementInfo.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKRequestActivatedElementInfo.mm
@@ -51,7 +51,7 @@ static void checkElementTypeAndBoundingRect(_WKActivatedElementInfo *elementInfo
 
 TEST(_WKActivatedElementInfo, InfoForLink)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView loadHTMLString:@"<html><head><meta name='viewport' content='initial-scale=1'></head><body style='margin: 0px;'><a href='testURL.test' style='display: block; height: 100%;' title='HitTestLinkTitle' id='testID'></a></body></html>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
 
@@ -76,7 +76,7 @@ TEST(_WKActivatedElementInfo, InfoForLink)
 
 TEST(_WKActivatedElementInfo, InfoForImage)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 215, 174)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 215, 174)]);
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"image" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
@@ -96,7 +96,7 @@ TEST(_WKActivatedElementInfo, InfoForImage)
 
 TEST(_WKActivatedElementInfo, InfoForMediaDocument)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 215, 174)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 215, 174)]);
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
@@ -120,7 +120,7 @@ TEST(_WKActivatedElementInfo, InfoForMediaDocument)
 
 TEST(_WKActivatedElementInfo, InfoForLinkAroundImage)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"link-with-image" withExtension:@"html"]];
     [webView loadRequest:request];
     [webView _test_waitForDidFinishNavigation];
@@ -145,7 +145,7 @@ TEST(_WKActivatedElementInfo, InfoForLinkAroundImage)
 
 TEST(_WKActivatedElementInfo, InfoForRotatedImage)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto imagePixels = [](CGImageRef image) -> Vector<unsigned> {
         static const size_t bytesPerPixel = 4;
         static const size_t bitsPerComponent = 8;
@@ -202,7 +202,7 @@ IGNORE_WARNINGS_END
 
 TEST(_WKActivatedElementInfo, InfoForBlank)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView loadHTMLString:@"<html><head><meta name='viewport' content='initial-scale=1'></head><body style='margin: 0px;'></body></html>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
 
@@ -221,7 +221,7 @@ TEST(_WKActivatedElementInfo, InfoForBlank)
 
 TEST(_WKActivatedElementInfo, InfoForBrokenImage)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView loadHTMLString:@"<html><head><meta name='viewport' content='initial-scale=1'></head><body style='margin: 0px;'><img  src='missing.gif' height='100' width='100'></body></html>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
 
@@ -240,10 +240,10 @@ TEST(_WKActivatedElementInfo, InfoForBrokenImage)
 
 TEST(_WKActivatedElementInfo, InfoForAttachment)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAttachmentElementEnabled:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
     [webView loadHTMLString:@"<html><head><meta name='viewport' content='initial-scale=1'></head><body style='margin: 0px;'><attachment  /></body></html>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
 
@@ -259,7 +259,7 @@ TEST(_WKActivatedElementInfo, InfoForAttachment)
 
 TEST(_WKActivatedElementInfo, InfoWithNestedSynchronousUpdates)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='initial-scale=1'><style>body { margin:0 } a { display:block; width:200px; height:200px }</style><a href='https://www.apple.com'>FOO</a>"];
 
     __block bool finished = false;
@@ -283,7 +283,7 @@ TEST(_WKActivatedElementInfo, InfoWithNestedSynchronousUpdates)
 
 TEST(_WKActivatedElementInfo, InfoWithNestedRequests)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"image-and-contenteditable"];
 
     __block bool finishedWithInner = false;
@@ -315,7 +315,7 @@ TEST(_WKActivatedElementInfo, InfoWithNestedRequests)
 
 TEST(_WKActivatedElementInfo, HitTestPointOutsideView)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)]);
     [webView synchronouslyLoadHTMLString:@R"(
         <!DOCTYPE html>
         <html>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKURLSchemeHandler-1.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKURLSchemeHandler-1.mm
@@ -189,20 +189,20 @@ TEST(URLSchemeHandler, BasicWithHTTPS)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, mainBytes } },
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
 
     RetainPtr<SchemeHandler> handler = adoptNS([[SchemeHandler alloc] initWithData:mainBytesData().get() mimeType:@"text/html"]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testing"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
 
     delegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
@@ -228,7 +228,7 @@ TEST(URLSchemeHandler, BasicWithAsyncPolicyDelegate)
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testing"];
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([[URLSchemeHandlerAsyncNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[URLSchemeHandlerAsyncNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"testing:main"]];
@@ -338,13 +338,13 @@ static bool responsePolicyDecided;
 - (void)webView:(WKWebView *)webView startURLSchemeTask:(id <WKURLSchemeTask>)task
 {
     ASSERT_STREQ(task.request.URL.absoluteString.UTF8String, "testing:///initial");
-    auto redirectResponse = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:nil expectedContentLength:0 textEncodingName:nil]);
-    auto request = adoptNS([[NSURLRequest alloc] initWithURL:[NSURL URLWithString:@"testing:///redirected"]]);
+    RetainPtr redirectResponse = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:nil expectedContentLength:0 textEncodingName:nil]);
+    RetainPtr request = adoptNS([[NSURLRequest alloc] initWithURL:[NSURL URLWithString:@"testing:///redirected"]]);
     [(id<WKURLSchemeTaskPrivate>)task _didPerformRedirection:redirectResponse.get() newRequest:request.get()];
     ASSERT_FALSE(receivedRedirect);
     ASSERT_STREQ(task.request.URL.absoluteString.UTF8String, "testing:///redirected");
     NSString *html = @"<script>window.webkit.messageHandlers.testHandler.postMessage('Document URL: ' + document.URL);</script>";
-    auto finalResponse = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:html.length textEncodingName:nil]);
+    RetainPtr finalResponse = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:html.length textEncodingName:nil]);
     [task didReceiveResponse:finalResponse.get()];
     [task didReceiveData:[html dataUsingEncoding:NSUTF8StringEncoding]];
     [task didFinish];
@@ -379,11 +379,11 @@ static bool responsePolicyDecided;
 
 TEST(URLSchemeHandler, Redirection)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([[RedirectSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[RedirectSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testing"];
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:handler.get()];
     
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"testing:///initial"]];
@@ -470,10 +470,10 @@ enum class ShouldRaiseException : bool { No, Yes };
 static void checkCallSequence(Vector<Command>&& commands, ShouldRaiseException shouldRaiseException)
 {
     done = false;
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([[TaskSchemeHandler alloc] initWithCommands:WTF::move(commands) expectedException:shouldRaiseException == ShouldRaiseException::Yes]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[TaskSchemeHandler alloc] initWithCommands:WTF::move(commands) expectedException:shouldRaiseException == ShouldRaiseException::Yes]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testing"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"testing:///initial"]]];
     TestWebKitAPI::Util::run(&done);
 }
@@ -592,17 +592,17 @@ constexpr auto syncXHRBytes = "My XHR text!"_s;
 TEST(URLSchemeHandler, SyncXHR)
 {
     @autoreleasepool {
-        auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
-        auto handler = adoptNS([[SyncScheme alloc] init]);
+        RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr handler = adoptNS([[SyncScheme alloc] init]);
         [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"syncxhr"];
 
         handler.get()->resources.set("syncxhr://host/main.html"_s, SchemeResourceInfo { @"text/html", syncMainBytes, true });
         handler.get()->resources.set("syncxhr://host/test.dat"_s, SchemeResourceInfo { @"text/plain", syncXHRBytes, true });
 
-        auto messageHandler = adoptNS([[SyncMessageHandler alloc] init]);
+        RetainPtr messageHandler = adoptNS([[SyncMessageHandler alloc] init]);
         [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sync"];
 
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
         NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"syncxhr://host/main.html"]];
         [webView loadRequest:request];
@@ -661,10 +661,10 @@ TEST(URLSchemeHandler, SyncXHR)
 
 TEST(URLSchemeHandler, SyncXHRError)
 {
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([[SyncErrorScheme alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[SyncErrorScheme alloc] init]);
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"syncerror"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     [webView setUIDelegate:handler.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"syncerror:///main.html"]]];
     TestWebKitAPI::Util::run(&done);
@@ -725,10 +725,10 @@ Hello world!
 
 TEST(URLSchemeHandler, XHRPost)
 {
-    auto handler = adoptNS([[TestURLSchemeHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"xhrpost"];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
 
     static bool done;
     static uint8_t seenTasks;
@@ -788,7 +788,7 @@ TEST(URLSchemeHandler, XHRPost)
             FAIL();
         }
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didFinish];
         
@@ -807,14 +807,14 @@ TEST(URLSchemeHandler, Threads)
     static RefPtr<Thread> theThread;
 
     @autoreleasepool {
-        auto handler = adoptNS([[TestURLSchemeHandler alloc] init]);
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr handler = adoptNS([[TestURLSchemeHandler alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         [configuration setURLSchemeHandler:handler.get() forURLScheme:@"threads"];
-        auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
         [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
             theTask.get() = retainPtr(task);
             theThread = Thread::create("A"_s, [task] {
-                auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+                RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
                 [task didReceiveResponse:response.get()];
                 [task didFinish];
                 done = true;
@@ -838,10 +838,10 @@ TEST(URLSchemeHandler, Threads)
 
 TEST(URLSchemeHandler, CORS)
 {
-    auto handler = adoptNS([[TestURLSchemeHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"cors"];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
 
     __block bool done = false;
     __block bool includeCORSHeaderFieldInResponse = false;
@@ -900,9 +900,9 @@ TEST(URLSchemeHandler, DisableCORS)
     bool corsfailure = false;
     bool done = false;
 
-    auto handler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr handler = adoptNS([[TestURLSchemeHandler alloc] init]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"cors"];
 
     NSString *testJS = [NSString stringWithFormat:
@@ -933,7 +933,7 @@ TEST(URLSchemeHandler, DisableCORS)
     }];
     
     {
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
         [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"cors://host1/main.html"]]];
         TestWebKitAPI::Util::run(&done);
     }
@@ -945,7 +945,7 @@ TEST(URLSchemeHandler, DisableCORS)
     done = false;
 
     configuration.get()._corsDisablingPatterns = @[@"*://*/*"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"cors://host1/main.html"]]];
     TestWebKitAPI::Util::run(&done);
     EXPECT_TRUE(corssuccess);
@@ -966,9 +966,9 @@ TEST(URLSchemeHandler, DisableCORSCredentials)
     bool corsfailure = false;
     bool done = false;
 
-    auto handler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr handler = adoptNS([[TestURLSchemeHandler alloc] init]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"cors"];
 
     [handler setStartURLSchemeTaskHandler:[&](WKWebView *, id<WKURLSchemeTask> task) {
@@ -988,7 +988,7 @@ TEST(URLSchemeHandler, DisableCORSCredentials)
     }];
     
     {
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
         [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"cors://host1/main.html"]]];
         TestWebKitAPI::Util::run(&done);
     }
@@ -1001,7 +1001,7 @@ TEST(URLSchemeHandler, DisableCORSCredentials)
 
     configuration.get()._crossOriginAccessControlCheckEnabled = NO;
     {
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
         [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"cors://host1/main.html"]]];
         TestWebKitAPI::Util::run(&done);
     }
@@ -1019,9 +1019,9 @@ TEST(URLSchemeHandler, DisableCORSScript)
     bool loadFail = false;
     bool done = false;
 
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"cors"];
 
     [handler setStartURLSchemeTaskHandler:[&](WKWebView *, id<WKURLSchemeTask> task) {
@@ -1042,7 +1042,7 @@ TEST(URLSchemeHandler, DisableCORSScript)
     }];
 
     {
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
         [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"cors://host1/main.html"]]];
         TestWebKitAPI::Util::run(&done);
     }
@@ -1055,7 +1055,7 @@ TEST(URLSchemeHandler, DisableCORSScript)
 
     configuration.get()._corsDisablingPatterns = @[@"*://*/*"];
     {
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
         [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"cors://host1/main.html"]]];
         TestWebKitAPI::Util::run(&done);
     }
@@ -1069,9 +1069,9 @@ TEST(URLSchemeHandler, DisableCORSCanvas)
     bool corsfailure = false;
     bool done = false;
 
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"cors"];
 
     [handler setStartURLSchemeTaskHandler:[&](WKWebView *, id<WKURLSchemeTask> task) {
@@ -1113,7 +1113,7 @@ TEST(URLSchemeHandler, DisableCORSCanvas)
     }];
 
     {
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
         [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"cors://host1/main.html"]]];
         TestWebKitAPI::Util::run(&done);
     }
@@ -1126,7 +1126,7 @@ TEST(URLSchemeHandler, DisableCORSCanvas)
 
     configuration.get()._corsDisablingPatterns = @[@"cors://*/*"];
     {
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
         [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"cors://host1/main.html"]]];
         TestWebKitAPI::Util::run(&done);
     }
@@ -1144,9 +1144,9 @@ TEST(URLSchemeHandler, DisableCORSAndCORP)
     bool corsfailure = false;
     bool done = false;
 
-    auto handler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr handler = adoptNS([[TestURLSchemeHandler alloc] init]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"cors"];
 
     NSString *testJS = [NSString stringWithFormat:
@@ -1174,7 +1174,7 @@ TEST(URLSchemeHandler, DisableCORSAndCORP)
             ASSERT_NOT_REACHED();
     }];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"cors://host1/main.html"]]];
 
     TestWebKitAPI::Util::run(&done);
@@ -1198,9 +1198,9 @@ TEST(URLSchemeHandler, DisableCORSAndCORP)
 
 TEST(WebKit, OriginHeaderWithCORSDisablingPatternsInUnrelatedWebView)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     configuration.get()._corsDisablingPatterns = @[ @"*://*/*" ];
-    auto addPatterns = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr addPatterns = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [addPatterns synchronouslyLoadHTMLString:@"start network process and add patterns"];
 
     using namespace TestWebKitAPI;
@@ -1217,9 +1217,9 @@ TEST(WebKit, OriginHeaderWithCORSDisablingPatternsInUnrelatedWebView)
             }
         });
     }, HTTPServer::Protocol::HttpsProxy);
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:server.httpsProxyConfiguration()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:server.httpsProxyConfiguration()]);
     webView.get().navigationDelegate = navigationDelegate.get();
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/"]]];
     TestWebKitAPI::Util::run(&done);
@@ -1240,9 +1240,9 @@ TEST(URLSchemeHandler, LoadsFromNetwork)
     std::optional<bool> webSocketSuccess;
     bool done = false;
 
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"test"];
 
     [handler setStartURLSchemeTaskHandler:[&](WKWebView *, id<WKURLSchemeTask> task) {
@@ -1280,7 +1280,7 @@ TEST(URLSchemeHandler, LoadsFromNetwork)
         loadSuccess = std::nullopt;
         webSocketSuccess = std::nullopt;
         done = false;
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
         [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"test://host1/main.html"]]];
         TestWebKitAPI::Util::run(&done);
     };
@@ -1330,9 +1330,9 @@ TEST(URLSchemeHandler, AllowedNetworkHostsRedirect)
     std::optional<bool> loadSuccess;
     bool done = false;
 
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"test"];
 
     [handler setStartURLSchemeTaskHandler:[&](WKWebView *, id<WKURLSchemeTask> task) {
@@ -1358,7 +1358,7 @@ TEST(URLSchemeHandler, AllowedNetworkHostsRedirect)
         loadSuccess = std::nullopt;
         done = false;
         configuration.get().websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
         [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"test://host1/main.html"]]];
         TestWebKitAPI::Util::run(&done);
     };
@@ -1409,14 +1409,14 @@ TEST(WKWebViewConfiguration, LoadsSubresources)
     bool loadedImage = false;
     bool loadedIFrame = false;
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     TestWebKitAPI::HTTPServer server([&] (const TestWebKitAPI::Connection& connection) {
         serverLoop(connection, loadedIFrame, loadedImage);
     });
 
     {
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
         [webView loadRequest:server.request("/main.html"_s)];
         TestWebKitAPI::Util::run(&loadedImage);
         TestWebKitAPI::Util::run(&loadedIFrame);
@@ -1427,8 +1427,8 @@ TEST(WKWebViewConfiguration, LoadsSubresources)
 
     configuration.get()._loadsSubresources = NO;
     {
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
-        auto delegate = adoptNS([TestNavigationDelegate new]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
         webView.get().navigationDelegate = delegate.get();
         [webView loadRequest:server.request("/main.html"_s)];
         [delegate waitForDidFinishNavigation];
@@ -1504,10 +1504,10 @@ TEST(WKWebViewConfiguration, LoadsSubresources)
 
 TEST(URLSchemeHandler, Frame)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
-    auto handler = adoptNS([FrameSchemeHandler new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr handler = adoptNS([FrameSchemeHandler new]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"frame"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [handler setExpectedWebView:webView.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"frame://host1/main"]]];
     [handler waitForAllRequests];
@@ -1515,8 +1515,8 @@ TEST(URLSchemeHandler, Frame)
 
 TEST(URLSchemeHandler, Frames)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     __block size_t grandchildFramesLoaded = 0;
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSString *responseString = nil;
@@ -1534,13 +1534,13 @@ TEST(URLSchemeHandler, Frames)
         }
 
         ASSERT(responseString);
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:responseString.length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:responseString.length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[responseString dataUsingEncoding:NSUTF8StringEncoding]];
         [task didFinish];
     }];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"frame"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"frame://host1/"]]];
 
     while (grandchildFramesLoaded < 2)
@@ -1595,7 +1595,7 @@ TEST(URLSchemeHandler, Frames)
     TestWebKitAPI::Util::run(&done);
     
     done = false;
-    auto emptyWebView = adoptNS([WKWebView new]);
+    RetainPtr emptyWebView = adoptNS([WKWebView new]);
     [emptyWebView _frames:^(_WKFrameTreeNode *mainFrame) {
 #if PLATFORM(MAC)
         EXPECT_NULL(mainFrame);
@@ -1611,8 +1611,8 @@ TEST(URLSchemeHandler, Frames)
 
 TEST(URLSchemeHandler, Origin)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSString *responseString = @"<script>alert("
             "new URL('registered://host:123/path').origin + ', ' + "
@@ -1622,9 +1622,9 @@ TEST(URLSchemeHandler, Origin)
         [task didReceiveData:[responseString dataUsingEncoding:NSUTF8StringEncoding]];
         [task didFinish];
     }];
-    auto delegate = adoptNS([TestUIDelegate new]);
+    RetainPtr delegate = adoptNS([TestUIDelegate new]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"registered"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setUIDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"registered:///"]]];
     EXPECT_WK_STREQ([delegate waitForAlert], "registered://host:123, null");
@@ -1644,8 +1644,8 @@ TEST(URLSchemeHandler, Origin)
 
 TEST(URLSchemeHandler, isSecureContext)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([TestURLSchemeHandler new]);
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSString *responseString = @"<script>window.webkit.messageHandlers.testHandler.postMessage(window.isSecureContext ? 'secure': 'not secure');</script>";
         [task didReceiveResponse:adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:responseString.length textEncodingName:nil]).get()];
@@ -1655,10 +1655,10 @@ TEST(URLSchemeHandler, isSecureContext)
 
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"testing"];
 
-    auto messageHandler = adoptNS([[URLSchemeHandlerMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[URLSchemeHandlerMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     receivedScriptMessage = false;
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"testing://localhost/test.html"]]];
@@ -1673,15 +1673,15 @@ TEST(URLSchemeHandler, isSecureContext)
 
 TEST(URLSchemeHandler, APIRedirect)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto schemeHandler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([TestURLSchemeHandler new]);
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        auto redirectResponse = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:nil expectedContentLength:0 textEncodingName:nil]);
-        auto redirectRequest = adoptNS([[NSURLRequest alloc] initWithURL:[NSURL URLWithString:@"redirectone://bar.com/anothertest.html"]]);
+        RetainPtr redirectResponse = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:nil expectedContentLength:0 textEncodingName:nil]);
+        RetainPtr redirectRequest = adoptNS([[NSURLRequest alloc] initWithURL:[NSURL URLWithString:@"redirectone://bar.com/anothertest.html"]]);
 
         [(id<WKURLSchemeTaskPrivate>)task _willPerformRedirection:redirectResponse.get() newRequest:redirectRequest.get() completionHandler:^(NSURLRequest *proposedRequest) {
             NSString *html = @"<script>window.webkit.messageHandlers.testHandler.postMessage('Document URL: ' + document.URL);</script>";
-            auto finalResponse = adoptNS([[NSURLResponse alloc] initWithURL:proposedRequest.URL MIMEType:@"text/html" expectedContentLength:html.length textEncodingName:nil]);
+            RetainPtr finalResponse = adoptNS([[NSURLResponse alloc] initWithURL:proposedRequest.URL MIMEType:@"text/html" expectedContentLength:html.length textEncodingName:nil]);
 
             [task didReceiveResponse:finalResponse.get()];
             [task didReceiveData:[html dataUsingEncoding:NSUTF8StringEncoding]];
@@ -1691,10 +1691,10 @@ TEST(URLSchemeHandler, APIRedirect)
 
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"redirectone"];
 
-    auto messageHandler = adoptNS([[URLSchemeHandlerMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[URLSchemeHandlerMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     receivedScriptMessage = false;
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"redirectone://foo.com/test.html"]]];
@@ -1706,11 +1706,11 @@ TEST(URLSchemeHandler, Ranges)
 {
     RetainPtr<NSData> videoData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"mp4"]];
 
-    auto handler = adoptNS([[TestURLSchemeHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"ranges"];
     configuration.get().mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     __block bool foundRangeRequest = false;
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         if ([task.request.URL.path isEqualToString:@"/main.html"]) {
@@ -1738,7 +1738,7 @@ TEST(URLSchemeHandler, Ranges)
         auto rangeEnd = rangeEndString.isEmpty() ? [videoData length] - 1 : parseInteger<uint64_t>(rangeEndString).value_or(0);
         auto contentLength = rangeEnd - rangeBegin + 1;
 
-        auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://webkit.org/"] statusCode:206 HTTPVersion:@"HTTP/1.1" headerFields:@{
+        RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://webkit.org/"] statusCode:206 HTTPVersion:@"HTTP/1.1" headerFields:@{
             @"Content-Range" : [NSString stringWithFormat:@"bytes %llu-%llu/%lu", rangeBegin, rangeEnd, (unsigned long)[videoData length]],
             @"Content-Length" : [NSString stringWithFormat:@"%llu", contentLength]
         }]);
@@ -1757,14 +1757,14 @@ TEST(URLSchemeHandler, HandleURLRewrittenByPlugIn)
 {
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"SchemeChangingPlugIn"];
     configuration._allowedNetworkHosts = [NSSet set];
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     __block bool done = false;
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         EXPECT_WK_STREQ(task.request.URL.absoluteString, "test+rewritten+scheme://webkit.org/testpath");
         done = true;
     }];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"test+rewritten+scheme"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org/testpath"]]];
     TestWebKitAPI::Util::run(&done);
 }
@@ -1772,7 +1772,7 @@ TEST(URLSchemeHandler, HandleURLRewrittenByPlugIn)
 TEST(URLSchemeHandler, ModulePreload)
 {
     __block bool done = false;
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         if ([task.request.URL.path isEqualToString:@"/main.html"])
             return respond(task, "<link rel=modulepreload href='test://webkit.org/module.js'/><script>import('test://webkit.org/module.js')</script>");
@@ -1780,9 +1780,9 @@ TEST(URLSchemeHandler, ModulePreload)
         EXPECT_WK_STREQ(task.request.allHTTPHeaderFields[@"Origin"], "test://webkit.org");
         done = true;
     }];
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"test"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"test://webkit.org/main.html"]]];
     TestWebKitAPI::Util::run(&done);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtension.mm
@@ -2294,8 +2294,8 @@ TEST(WKWebExtension, LoadFromDirectory)
     auto *extensionURL = [NSBundle.test_resourcesBundle URLForResource:@"web-extension" withExtension:@""];
     EXPECT_NOT_NULL(extensionURL);
 
-    auto extension = adoptNS([[WKWebExtension alloc] _initWithResourceBaseURL:extensionURL error:nullptr]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+    RetainPtr extension = adoptNS([[WKWebExtension alloc] _initWithResourceBaseURL:extensionURL error:nullptr]);
+    RetainPtr manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
     [manager load];
     [manager runUntilTestMessage:@"Load Tab"];
@@ -2318,8 +2318,8 @@ TEST(WKWebExtension, LoadFromDirectoryWithoutTrailingSlash)
     auto *extensionURL = [NSURL URLWithString:extensionURLAbsoluteStringWithoutTrailingSlash];
     EXPECT_NOT_NULL(extensionURL);
 
-    auto extension = adoptNS([[WKWebExtension alloc] _initWithResourceBaseURL:extensionURL error:nullptr]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+    RetainPtr extension = adoptNS([[WKWebExtension alloc] _initWithResourceBaseURL:extensionURL error:nullptr]);
+    RetainPtr manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
     [manager load];
     [manager runUntilTestMessage:@"Load Tab"];
@@ -2340,8 +2340,8 @@ TEST(WKWebExtension, LoadFromZipArchiveWithoutParentDirectory)
     auto *extensionURL = [NSBundle.test_resourcesBundle URLForResource:@"web-extension-without-parent-directory" withExtension:@"zip"];
     EXPECT_NOT_NULL(extensionURL);
 
-    auto extension = adoptNS([[WKWebExtension alloc] _initWithResourceBaseURL:extensionURL error:nullptr]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+    RetainPtr extension = adoptNS([[WKWebExtension alloc] _initWithResourceBaseURL:extensionURL error:nullptr]);
+    RetainPtr manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
     [manager load];
     [manager runUntilTestMessage:@"Load Tab"];
@@ -2362,8 +2362,8 @@ TEST(WKWebExtension, LoadFromZipArchiveWithParentDirectory)
     auto *extensionURL = [NSBundle.test_resourcesBundle URLForResource:@"web-extension-with-parent-directory" withExtension:@"zip"];
     EXPECT_NOT_NULL(extensionURL);
 
-    auto extension = adoptNS([[WKWebExtension alloc] _initWithResourceBaseURL:extensionURL error:nullptr]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+    RetainPtr extension = adoptNS([[WKWebExtension alloc] _initWithResourceBaseURL:extensionURL error:nullptr]);
+    RetainPtr manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
     [manager load];
     [manager runUntilTestMessage:@"Load Tab"];
@@ -2384,8 +2384,8 @@ TEST(WKWebExtension, LoadFromChromeExtensionArchive)
     auto *extensionURL = [NSBundle.test_resourcesBundle URLForResource:@"web-extension" withExtension:@"crx"];
     EXPECT_NOT_NULL(extensionURL);
 
-    auto extension = adoptNS([[WKWebExtension alloc] _initWithResourceBaseURL:extensionURL error:nullptr]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+    RetainPtr extension = adoptNS([[WKWebExtension alloc] _initWithResourceBaseURL:extensionURL error:nullptr]);
+    RetainPtr manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
     [manager load];
     [manager runUntilTestMessage:@"Load Tab"];
@@ -2409,8 +2409,8 @@ TEST(WKWebExtension, LoadFromMacAppExtensionBundle)
     auto *extensionBundle = [NSBundle bundleWithURL:extensionBundleURL];
     EXPECT_NOT_NULL(extensionBundle);
 
-    auto extension = adoptNS([[WKWebExtension alloc] _initWithAppExtensionBundle:extensionBundle error:nullptr]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+    RetainPtr extension = adoptNS([[WKWebExtension alloc] _initWithAppExtensionBundle:extensionBundle error:nullptr]);
+    RetainPtr manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
     [manager load];
     [manager runUntilTestMessage:@"Load Tab"];
@@ -2434,8 +2434,8 @@ TEST(WKWebExtension, LoadFromiOSAppExtensionBundle)
     auto *extensionBundle = [NSBundle bundleWithURL:extensionBundleURL];
     EXPECT_NOT_NULL(extensionBundle);
 
-    auto extension = adoptNS([[WKWebExtension alloc] _initWithAppExtensionBundle:extensionBundle error:nullptr]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+    RetainPtr extension = adoptNS([[WKWebExtension alloc] _initWithAppExtensionBundle:extensionBundle error:nullptr]);
+    RetainPtr manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
     [manager load];
     [manager runUntilTestMessage:@"Load Tab"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPICommands.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPICommands.mm
@@ -205,8 +205,8 @@ TEST(WKWebExtensionAPICommands, CommandEvent)
 
 TEST(WKWebExtensionAPICommands, CommandForEvent)
 {
-    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:commandsManifest resources:@{ }]);
-    auto context = adoptNS([[WKWebExtensionContext alloc] initForExtension:extension.get()]);
+    RetainPtr extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:commandsManifest resources:@{ }]);
+    RetainPtr context = adoptNS([[WKWebExtensionContext alloc] initForExtension:extension.get()]);
 
     auto *keyCommandEvent = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSZeroPoint modifierFlags:(NSEventModifierFlagCommand | NSEventModifierFlagOption)
         timestamp:0 windowNumber:0 context:nil characters:@"Ω" charactersIgnoringModifiers:@"z" isARepeat:NO keyCode:kVK_ANSI_Z];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDeclarativeNetRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDeclarativeNetRequest.mm
@@ -73,7 +73,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, BlockedLoadTest)
     [manager runUntilTestMessage:@"Load Tab"];
 
     auto webView = manager.get().defaultTab.webView;
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
 
     __block bool receivedActionNotification { false };
     navigationDelegate.get().contentRuleListPerformedAction = ^(WKWebView *, NSString *identifier, _WKContentRuleListAction *action, NSURL *url) {
@@ -133,7 +133,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, BlockedLoadInPrivateBrowsingTest)
     auto privateTab = privateWindow.tabs.firstObject;
     auto webView = privateTab.webView;
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
 
     __block bool receivedActionNotification { false };
     navigationDelegate.get().contentRuleListPerformedAction = ^(WKWebView *, NSString *identifier, _WKContentRuleListAction *action, NSURL *url) {
@@ -298,7 +298,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, UpdateEnabledRulesetsPerformsCompil
     [manager runUntilTestMessage:@"Load Tab"];
 
     auto webView = manager.get().defaultTab.webView;
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
 
     __block bool receivedActionNotification { false };
     navigationDelegate.get().contentRuleListPerformedAction = ^(WKWebView *, NSString *identifier, _WKContentRuleListAction *action, NSURL *url) {
@@ -398,7 +398,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, SetExtensionActionOptions)
 
     auto *defaultTab = manager.get().defaultTab;
     auto *webView = defaultTab.webView;
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
 
     __block bool receivedActionNotification { false };
     navigationDelegate.get().contentRuleListPerformedAction = ^(WKWebView *, NSString *identifier, _WKContentRuleListAction *action, NSURL *url) {
@@ -512,7 +512,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, SessionRules)
     EXPECT_TRUE(manager.get().context.hasContentModificationRules);
 
     auto webView = manager.get().defaultTab.webView;
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
 
     __block bool receivedActionNotification { false };
     navigationDelegate.get().contentRuleListPerformedAction = ^(WKWebView *, NSString *identifier, _WKContentRuleListAction *action, NSURL *url) {
@@ -671,7 +671,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, DynamicRules)
     [manager runUntilTestMessage:@"Load Tab"];
 
     auto webView = manager.get().defaultTab.webView;
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
 
     __block bool receivedActionNotification { false };
     navigationDelegate.get().contentRuleListPerformedAction = ^(WKWebView *, NSString *identifier, _WKContentRuleListAction *action, NSURL *url) {
@@ -854,7 +854,7 @@ static void runRedirectRule(bool useEnhancedSecurity)
 
     auto manager = Util::loadExtension(manifest, resources, extensionConfiguration, useEnhancedSecurity);
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     navigationDelegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *navigationAction, void (^decisionHandler)(WKNavigationActionPolicy)) {
         decisionHandler(WKNavigationActionPolicyAllow);
 
@@ -3947,7 +3947,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RemoveAllContentRuleListsDoesNotRem
     [manager.get().defaultTab.webView.configuration.userContentController removeAllContentRuleLists];
 
     auto webView = manager.get().defaultTab.webView;
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
 
     __block bool receivedActionNotification { false };
     navigationDelegate.get().contentRuleListPerformedAction = ^(WKWebView *, NSString *identifier, _WKContentRuleListAction *action, NSURL *url) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPILocalization.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPILocalization.mm
@@ -1131,8 +1131,8 @@ TEST(WKWebExtensionAPILocalization, i18nChineseTraditionalFallback)
         @"_locales/zh/messages.json": genericChineseMessages,
     };
 
-    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+    RetainPtr extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    RetainPtr manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
     [manager loadAndRun];
 }
@@ -1169,8 +1169,8 @@ TEST(WKWebExtensionAPILocalization, i18nChineseSimplifiedFallback)
         @"_locales/zh/messages.json": genericChineseMessages,
     };
 
-    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+    RetainPtr extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:localizationManifest resources:resources]);
+    RetainPtr manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
     [manager loadAndRun];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIMenus.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIMenus.mm
@@ -1690,7 +1690,7 @@ TEST(WKWebExtensionAPIMenus, MacContextMenuItems)
         @"browser.test.sendMessage('Menus Created')",
     ]);
 
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotContextMenu = false;
     delegate.get().getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
@@ -1733,10 +1733,10 @@ TEST(WKWebExtensionAPIMenus, MacContextMenuItems)
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     webView.get().UIDelegate = delegate.get();
 
     manager.get().defaultTab.webView = webView.get();
@@ -1785,7 +1785,7 @@ TEST(WKWebExtensionAPIMenus, MacActiveTabContextMenuItems)
         @"browser.test.sendMessage('Menus Created')",
     ]);
 
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotContextMenu = false;
     delegate.get().getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
@@ -1816,10 +1816,10 @@ TEST(WKWebExtensionAPIMenus, MacActiveTabContextMenuItems)
 
     EXPECT_FALSE([manager.get().context hasActiveUserGestureInTab:manager.get().defaultTab]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     webView.get().UIDelegate = delegate.get();
 
     manager.get().defaultTab.webView = webView.get();
@@ -1881,7 +1881,7 @@ TEST(WKWebExtensionAPIMenus, MacURLPatternContextMenuItems)
         @"browser.test.sendMessage('Menus Created')",
     ]);
 
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotContextMenu = false;
     delegate.get().getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
@@ -1915,10 +1915,10 @@ TEST(WKWebExtensionAPIMenus, MacURLPatternContextMenuItems)
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     webView.get().UIDelegate = delegate.get();
 
     manager.get().defaultTab.webView = webView.get();
@@ -1966,7 +1966,7 @@ TEST(WKWebExtensionAPIMenus, MacSelectionContextMenuItems)
         @"browser.test.sendMessage('Menus Created')",
     ]);
 
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotContextMenu = false;
     delegate.get().getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
@@ -1999,10 +1999,10 @@ TEST(WKWebExtensionAPIMenus, MacSelectionContextMenuItems)
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     webView.get().UIDelegate = delegate.get();
 
     manager.get().defaultTab.webView = webView.get();
@@ -2052,7 +2052,7 @@ TEST(WKWebExtensionAPIMenus, MacLinkContextMenuItems)
         @"browser.test.sendMessage('Menus Created')",
     ]);
 
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotContextMenu = false;
     delegate.get().getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
@@ -2084,10 +2084,10 @@ TEST(WKWebExtensionAPIMenus, MacLinkContextMenuItems)
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     webView.get().UIDelegate = delegate.get();
 
     manager.get().defaultTab.webView = webView.get();
@@ -2136,7 +2136,7 @@ TEST(WKWebExtensionAPIMenus, MacImageContextMenuItems)
         @"browser.test.sendMessage('Menus Created')",
     ]);
 
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotContextMenu = false;
     delegate.get().getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
@@ -2169,10 +2169,10 @@ TEST(WKWebExtensionAPIMenus, MacImageContextMenuItems)
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     webView.get().UIDelegate = delegate.get();
 
     manager.get().defaultTab.webView = webView.get();
@@ -2221,7 +2221,7 @@ TEST(WKWebExtensionAPIMenus, MacVideoContextMenuItems)
         @"browser.test.sendMessage('Menus Created')",
     ]);
 
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotContextMenu = false;
     delegate.get().getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
@@ -2254,10 +2254,10 @@ TEST(WKWebExtensionAPIMenus, MacVideoContextMenuItems)
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     webView.get().UIDelegate = delegate.get();
 
     manager.get().defaultTab.webView = webView.get();
@@ -2306,7 +2306,7 @@ TEST(WKWebExtensionAPIMenus, MacAudioContextMenuItems)
         @"browser.test.sendMessage('Menus Created')",
     ]);
 
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotContextMenu = false;
     delegate.get().getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
@@ -2339,10 +2339,10 @@ TEST(WKWebExtensionAPIMenus, MacAudioContextMenuItems)
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     webView.get().UIDelegate = delegate.get();
 
     manager.get().defaultTab.webView = webView.get();
@@ -2387,7 +2387,7 @@ TEST(WKWebExtensionAPIMenus, MacEditableContextMenuItems)
         @"browser.test.sendMessage('Menus Created')",
     ]);
 
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotContextMenu = false;
     delegate.get().getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
@@ -2419,10 +2419,10 @@ TEST(WKWebExtensionAPIMenus, MacEditableContextMenuItems)
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     webView.get().UIDelegate = delegate.get();
 
     manager.get().defaultTab.webView = webView.get();
@@ -2469,7 +2469,7 @@ TEST(WKWebExtensionAPIMenus, MacFrameContextMenuItems)
         @"browser.test.sendMessage('Menus Created')",
     ]);
 
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotContextMenu = false;
     delegate.get().getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
@@ -2503,10 +2503,10 @@ TEST(WKWebExtensionAPIMenus, MacFrameContextMenuItems)
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:server.requestWithLocalhost("/frame.html"_s).URL];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     webView.get().UIDelegate = delegate.get();
 
     manager.get().defaultTab.webView = webView.get();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIPermissions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIPermissions.mm
@@ -127,7 +127,7 @@ TEST(WKWebExtensionAPIPermissions, Basics)
     WKWebExtensionMatchPattern *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://webkit.org/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
     [manager run];
@@ -151,12 +151,12 @@ TEST(WKWebExtensionAPIPermissions, AcceptPermissionsRequest)
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
     NSSet<NSString *> *permissions = [NSSet setWithArray:@[ @"declarativeNetRequest" ]];
     NSSet<WKWebExtensionMatchPattern *> *matchPatterns = [NSSet setWithArray:@[ [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.apple.com/*" ]]];
-    auto requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+    RetainPtr requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
     __block bool requestComplete = false;
 
     // Implement the delegate methods that're called when a call to permissions.request() is made.
@@ -198,10 +198,10 @@ TEST(WKWebExtensionAPIPermissions, DenyPermissionsRequest)
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
-    auto requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+    RetainPtr requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
     __block bool requestComplete = false;
 
     // Implement the delegate methods, but don't grant the permissions.
@@ -236,10 +236,10 @@ TEST(WKWebExtensionAPIPermissions, AcceptPermissionsDenyMatchPatternsRequest)
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
-    auto requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+    RetainPtr requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
     __block bool requestComplete = false;
 
     // Grant the requested permissions.
@@ -275,10 +275,10 @@ TEST(WKWebExtensionAPIPermissions, RequestPermissionsOnly)
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
-    auto requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+    RetainPtr requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
     __block bool requestComplete = false;
 
     // Grant the requested permissions.
@@ -316,10 +316,10 @@ TEST(WKWebExtensionAPIPermissions, RequestMatchPatternsOnly)
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
-    auto requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+    RetainPtr requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
     __block bool requestComplete = false;
 
     // Permissions method should not be called.
@@ -356,10 +356,10 @@ TEST(WKWebExtensionAPIPermissions, RequestAllURLsMatchPattern)
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
-    auto requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+    RetainPtr requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
     __block bool requestComplete = false;
 
     // Permissions method should not be called.
@@ -405,7 +405,7 @@ TEST(WKWebExtensionAPIPermissions, ImplicitAllHostsAndURLsPermissions)
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:WKWebExtensionMatchPattern.allHostsAndSchemesMatchPattern];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
     [manager runUntilTestMessage:@"Loaded"];
@@ -443,7 +443,7 @@ TEST(WKWebExtensionAPIPermissions, AllHostsHostPermissions)
     WKWebExtensionMatchPattern *allURLsMatchPattern = [WKWebExtensionMatchPattern allURLsMatchPattern];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:allHostsMatchPattern];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
     [manager runUntilTestMessage:@"Loaded"];
@@ -488,7 +488,7 @@ TEST(WKWebExtensionAPIPermissions, AllURLsHostPermissions)
     WKWebExtensionMatchPattern *allURLsMatchPattern = [WKWebExtensionMatchPattern allURLsMatchPattern];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:allHostsMatchPattern];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
     [manager runUntilTestMessage:@"Loaded"];
@@ -533,7 +533,7 @@ TEST(WKWebExtensionAPIPermissions, AllHostsOptionalHostPermissions)
     WKWebExtensionMatchPattern *allURLsMatchPattern = [WKWebExtensionMatchPattern allURLsMatchPattern];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:allHostsMatchPattern];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
     [manager runUntilTestMessage:@"Loaded"];
@@ -578,7 +578,7 @@ TEST(WKWebExtensionAPIPermissions, AllURLsOptionalHostPermissions)
     WKWebExtensionMatchPattern *allURLsMatchPattern = [WKWebExtensionMatchPattern allURLsMatchPattern];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:allHostsMatchPattern];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
     [manager runUntilTestMessage:@"Loaded"];
@@ -623,7 +623,7 @@ TEST(WKWebExtensionAPIPermissions, AllHostsAndURLsHostPermissions)
     WKWebExtensionMatchPattern *allURLsMatchPattern = [WKWebExtensionMatchPattern allURLsMatchPattern];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:allHostsMatchPattern];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
     [manager runUntilTestMessage:@"Loaded"];
@@ -668,7 +668,7 @@ TEST(WKWebExtensionAPIPermissions, AllHostsAndURLsOptionalHostPermissions)
     WKWebExtensionMatchPattern *allURLsMatchPattern = [WKWebExtensionMatchPattern allURLsMatchPattern];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:allHostsMatchPattern];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
     [manager runUntilTestMessage:@"Loaded"];
@@ -714,7 +714,7 @@ TEST(WKWebExtensionAPIPermissions, AllHostsAndURLsOptionalAndHostPermissions)
     WKWebExtensionMatchPattern *allURLsMatchPattern = [WKWebExtensionMatchPattern allURLsMatchPattern];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:allHostsMatchPattern];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
     [manager runUntilTestMessage:@"Loaded"];
@@ -747,10 +747,10 @@ TEST(WKWebExtensionAPIPermissions, GrantOnlySomePermissions)
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
-    auto requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+    RetainPtr requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
     __block bool requestComplete = false;
 
     // Grant the requested permissions.
@@ -788,10 +788,10 @@ TEST(WKWebExtensionAPIPermissions, GrantOnlySomeMatchPatterns)
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
-    auto requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+    RetainPtr requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
     __block bool requestComplete = false;
 
     // Permissions method should not be called.
@@ -978,7 +978,7 @@ TEST(WKWebExtensionAPIPermissions, ClipboardWriteWithRequest)
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
 
-    auto requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+    RetainPtr requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
 
     requestDelegate.get().promptForPermissions = ^(id<WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *, NSDate *)) {
         EXPECT_EQ(requestedPermissions.count, 1ul);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIRuntime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIRuntime.mm
@@ -981,7 +981,7 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToOpenedWindow)
 
     __block RetainPtr<TestWebExtensionWindow> testWindow;
 
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     uiDelegate.get().createWebViewWithConfiguration = ^WKWebView *(WKWebViewConfiguration *configuration, WKNavigationAction *, WKWindowFeatures *) {
         testWindow = [manager openNewWindowUsingPrivateBrowsing:NO];
         testWindow.get().activeTab.webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]).get();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm
@@ -1335,7 +1335,7 @@ TEST(WKWebExtensionAPITabs, ReplacedEvent)
     [manager runUntilTestMessage:@"Replace Tab"];
 
     auto initialTab = manager.get().defaultWindow.tabs.firstObject;
-    auto newTab = adoptNS([[TestWebExtensionTab alloc] initWithWindow:manager.get().defaultWindow extensionController:manager.get().controller]);
+    RetainPtr newTab = adoptNS([[TestWebExtensionTab alloc] initWithWindow:manager.get().defaultWindow extensionController:manager.get().controller]);
 
     [manager.get().defaultWindow replaceTab:initialTab withTab:newTab.get()];
     [manager run];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITest.mm
@@ -136,8 +136,8 @@ TEST(WKWebExtensionAPITest, MessageEventInWebPage)
         @"background.js": @"// This script is intentionally left blank."
     };
 
-    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+    RetainPtr extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources]);
+    RetainPtr manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
     [manager load];
 
@@ -172,8 +172,8 @@ TEST(WKWebExtensionAPITest, MessageEventInContentScript)
         @"content.js": contentScript
     };
 
-    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+    RetainPtr extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources]);
+    RetainPtr manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
@@ -281,8 +281,8 @@ TEST(WKWebExtensionAPITest, SendMessageBeforeListenerAdded)
         @"content.js": contentScript
     };
 
-    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources]);
-    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+    RetainPtr extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources]);
+    RetainPtr manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionController.mm
@@ -519,11 +519,11 @@ TEST(WKWebExtensionController, ContentScriptLoading)
     WKWebExtensionMatchPattern *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://localhost/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
 
     navigationDelegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^callback)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionDataRecord.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionDataRecord.mm
@@ -62,7 +62,7 @@ TEST(WKWebExtensionDataRecord, GetDataRecords)
         @"await browser?.storage?.sync?.set(data)",
     ]);
 
-    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:dataRecordTestManifest resources:@{ @"background.js": backgroundScript  }]);
+    RetainPtr extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:dataRecordTestManifest resources:@{ @"background.js": backgroundScript  }]);
     auto *testController = [[WKWebExtensionController alloc] initWithConfiguration:WKWebExtensionControllerConfiguration._temporaryConfiguration];
 
     auto *context = [[WKWebExtensionContext alloc] initForExtension:extension.get()];
@@ -183,7 +183,7 @@ TEST(WKWebExtensionDataRecord, DISABLED_RemoveDataRecords)
         @"await browser?.storage?.sync?.set(data)",
     ]);
 
-    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:dataRecordTestManifest resources:@{ @"background.js": backgroundScript  }]);
+    RetainPtr extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:dataRecordTestManifest resources:@{ @"background.js": backgroundScript  }]);
     auto *testController = [[WKWebExtensionController alloc] initWithConfiguration:WKWebExtensionControllerConfiguration._temporaryConfiguration];
 
     auto *context = [[WKWebExtensionContext alloc] initForExtension:extension.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionTab.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionTab.mm
@@ -42,30 +42,30 @@ namespace TestWebKitAPI {
 
 TEST(WKWebExtensionTab, OpenTabs)
 {
-    auto testExtensionOne = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:@{ @"manifest_version": @3 }]);
-    auto testContextOne = adoptNS([[WKWebExtensionContext alloc] initForExtension:testExtensionOne.get()]);
+    RetainPtr testExtensionOne = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:@{ @"manifest_version": @3 }]);
+    RetainPtr testContextOne = adoptNS([[WKWebExtensionContext alloc] initForExtension:testExtensionOne.get()]);
 
-    auto testExtensionTwo = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:@{ @"manifest_version": @3 }]);
-    auto testContextTwo = adoptNS([[WKWebExtensionContext alloc] initForExtension:testExtensionTwo.get()]);
+    RetainPtr testExtensionTwo = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:@{ @"manifest_version": @3 }]);
+    RetainPtr testContextTwo = adoptNS([[WKWebExtensionContext alloc] initForExtension:testExtensionTwo.get()]);
 
-    auto testWindowOne = adoptNS([[TestWebExtensionWindow alloc] init]);
-    auto testWindowTwo = adoptNS([[TestWebExtensionWindow alloc] init]);
+    RetainPtr testWindowOne = adoptNS([[TestWebExtensionWindow alloc] init]);
+    RetainPtr testWindowTwo = adoptNS([[TestWebExtensionWindow alloc] init]);
 
-    auto testTabOne = adoptNS([[TestWebExtensionTab alloc] init]);
-    auto testTabTwo = adoptNS([[TestWebExtensionTab alloc] init]);
-    auto testTabThree = adoptNS([[TestWebExtensionTab alloc] init]);
-    auto testTabFour = adoptNS([[TestWebExtensionTab alloc] init]);
+    RetainPtr testTabOne = adoptNS([[TestWebExtensionTab alloc] init]);
+    RetainPtr testTabTwo = adoptNS([[TestWebExtensionTab alloc] init]);
+    RetainPtr testTabThree = adoptNS([[TestWebExtensionTab alloc] init]);
+    RetainPtr testTabFour = adoptNS([[TestWebExtensionTab alloc] init]);
 
     testWindowOne.get().tabs = @[ testTabOne.get() ];
     testWindowTwo.get().tabs = @[ testTabTwo.get(), testTabThree.get() ];
 
-    auto controllerDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+    RetainPtr controllerDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
 
     controllerDelegate.get().openWindows = ^NSArray<id<WKWebExtensionWindow>> *(WKWebExtensionContext *context) {
         return @[ testWindowOne.get(), testWindowTwo.get() ];
     };
 
-    auto testController = adoptNS([[WKWebExtensionController alloc] init]);
+    RetainPtr testController = adoptNS([[WKWebExtensionController alloc] init]);
     testController.get().delegate = controllerDelegate.get();
 
     EXPECT_NS_EQUAL(testContextOne.get().openTabs, [NSSet set]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionWindow.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionWindow.mm
@@ -42,25 +42,25 @@ namespace TestWebKitAPI {
 
 TEST(WKWebExtensionWindow, OpenWindows)
 {
-    auto testExtensionOne = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:@{ @"manifest_version": @3 }]);
-    auto testContextOne = adoptNS([[WKWebExtensionContext alloc] initForExtension:testExtensionOne.get()]);
+    RetainPtr testExtensionOne = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:@{ @"manifest_version": @3 }]);
+    RetainPtr testContextOne = adoptNS([[WKWebExtensionContext alloc] initForExtension:testExtensionOne.get()]);
 
-    auto testExtensionTwo = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:@{ @"manifest_version": @3 }]);
-    auto testContextTwo = adoptNS([[WKWebExtensionContext alloc] initForExtension:testExtensionTwo.get()]);
+    RetainPtr testExtensionTwo = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:@{ @"manifest_version": @3 }]);
+    RetainPtr testContextTwo = adoptNS([[WKWebExtensionContext alloc] initForExtension:testExtensionTwo.get()]);
 
-    auto testWindowOne = adoptNS([[TestWebExtensionWindow alloc] init]);
-    auto testWindowTwo = adoptNS([[TestWebExtensionWindow alloc] init]);
+    RetainPtr testWindowOne = adoptNS([[TestWebExtensionWindow alloc] init]);
+    RetainPtr testWindowTwo = adoptNS([[TestWebExtensionWindow alloc] init]);
 
     auto *openWindows = @[ testWindowOne.get(), testWindowTwo.get() ];
     auto *reversedOpenWindows = @[ testWindowTwo.get(), testWindowOne.get() ];
 
-    auto controllerDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+    RetainPtr controllerDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
 
     controllerDelegate.get().openWindows = ^NSArray<id<WKWebExtensionWindow>> *(WKWebExtensionContext *context) {
         return context == testContextOne ? openWindows : reversedOpenWindows;
     };
 
-    auto testController = adoptNS([[WKWebExtensionController alloc] init]);
+    RetainPtr testController = adoptNS([[WKWebExtensionController alloc] init]);
     testController.get().delegate = controllerDelegate.get();
 
     EXPECT_NS_EQUAL(testContextOne.get().openWindows, @[ ]);
@@ -114,16 +114,16 @@ TEST(WKWebExtensionWindow, OpenWindows)
 
 TEST(WKWebExtensionWindow, FocusedWindow)
 {
-    auto testExtensionOne = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:@{ @"manifest_version": @3 }]);
-    auto testContextOne = adoptNS([[WKWebExtensionContext alloc] initForExtension:testExtensionOne.get()]);
+    RetainPtr testExtensionOne = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:@{ @"manifest_version": @3 }]);
+    RetainPtr testContextOne = adoptNS([[WKWebExtensionContext alloc] initForExtension:testExtensionOne.get()]);
 
-    auto testExtensionTwo = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:@{ @"manifest_version": @3 }]);
-    auto testContextTwo = adoptNS([[WKWebExtensionContext alloc] initForExtension:testExtensionTwo.get()]);
+    RetainPtr testExtensionTwo = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:@{ @"manifest_version": @3 }]);
+    RetainPtr testContextTwo = adoptNS([[WKWebExtensionContext alloc] initForExtension:testExtensionTwo.get()]);
 
-    auto testWindowOne = adoptNS([[TestWebExtensionWindow alloc] init]);
-    auto testWindowTwo = adoptNS([[TestWebExtensionWindow alloc] init]);
+    RetainPtr testWindowOne = adoptNS([[TestWebExtensionWindow alloc] init]);
+    RetainPtr testWindowTwo = adoptNS([[TestWebExtensionWindow alloc] init]);
 
-    auto controllerDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
+    RetainPtr controllerDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
 
     controllerDelegate.get().openWindows = ^NSArray<id<WKWebExtensionWindow>> *(WKWebExtensionContext *context) {
         return @[ testWindowOne.get(), testWindowTwo.get() ];
@@ -133,7 +133,7 @@ TEST(WKWebExtensionWindow, FocusedWindow)
         return context == testContextOne ? testWindowTwo.get() : nil;
     };
 
-    auto testController = adoptNS([[WKWebExtensionController alloc] init]);
+    RetainPtr testController = adoptNS([[WKWebExtensionController alloc] init]);
     testController.get().delegate = controllerDelegate.get();
 
     EXPECT_NULL(testContextOne.get().focusedWindow);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewCandidateTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewCandidateTests.mm
@@ -129,7 +129,7 @@ static NSString *GetDocumentScrollTopJSExpression = @"document.body.scrollTop";
 
 + (RetainPtr<CandidateTestWebView>)setUpWithFrame:(NSRect)frame testPage:(NSString *)testPageName
 {
-    auto wkWebView = adoptNS([[CandidateTestWebView alloc] initWithFrame:frame]);
+    RetainPtr wkWebView = adoptNS([[CandidateTestWebView alloc] initWithFrame:frame]);
 
     [wkWebView loadTestPageNamed:testPageName];
     [wkWebView waitForMessage:@"focused"];
@@ -214,7 +214,7 @@ TEST(WKWebViewCandidateTests, ClickingInTextFieldDoesNotThrashCandidateVisibilit
 
 TEST(WKWebViewCandidateTests, ShouldNotRequestCandidatesInPasswordField)
 {
-    auto wkWebView = adoptNS([[CandidateTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr wkWebView = adoptNS([[CandidateTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [wkWebView loadTestPageNamed:@"text-and-password-inputs"];
     [wkWebView waitForMessage:@"loaded"];
     [wkWebView _forceRequestCandidates];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewCloseAllMediaPresentations.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewCloseAllMediaPresentations.mm
@@ -81,7 +81,7 @@ TEST(WKWebViewCloseAllMediaPresentations, PictureInPicture)
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [[configuration preferences] _setAllowsPictureInPictureMediaPlayback:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
 
     loadPictureInPicture(webView);
 
@@ -112,7 +112,7 @@ TEST(WKWebViewCloseAllMediaPresentationsInternal, PictureInPicture)
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [[configuration preferences] _setAllowsPictureInPictureMediaPlayback:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
 
     loadPictureInPicture(webView);
 
@@ -141,7 +141,7 @@ TEST(WKWebViewCloseAllMediaPresentations, VideoFullscreen)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration preferences].elementFullscreenEnabled = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
 
     [webView synchronouslyLoadHTMLString:@"<video src=video-with-audio.mp4 webkit-playsinline playsinline loop></video>"];
     [webView objectByEvaluatingJavaScript:@"document.querySelector('video').addEventListener('webkitpresentationmodechanged', event => { window.webkit.messageHandlers.testHandler.postMessage('presentationmodechanged'); });"];
@@ -178,7 +178,7 @@ TEST(WKWebViewCloseAllMediaPresentations, ElementFullscreen)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration preferences].elementFullscreenEnabled = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
 
     [webView synchronouslyLoadHTMLString:@"<div id=\"target\" style=\"width:100px;height:100px;background-color:red\"></div>"];
     [webView objectByEvaluatingJavaScript:@"document.querySelector('#target').addEventListener('webkitfullscreenchange', event => { window.webkit.messageHandlers.testHandler.postMessage('fullscreenchange'); });"];
@@ -220,7 +220,7 @@ TEST(WKWebViewCloseAllMediaPresentations, MultipleSequentialCloseAllMediaPresent
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [[configuration preferences] _setAllowsPictureInPictureMediaPlayback:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
 
     loadPictureInPicture(webView);
 
@@ -246,7 +246,7 @@ TEST(WKWebViewCloseAllMediaPresentations, RemovedCloseAllMediaPresentationAPIs)
     // binary compatability of apps linked against older SDKs. Ensure calling the removed API does not crash.
 
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
 
     EXPECT_TRUE([webView respondsToSelector:@selector(closeAllMediaPresentations)]);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewConfiguration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewConfiguration.mm
@@ -75,10 +75,10 @@
 
 TEST(WebKit, ConfigurationSubclass)
 {
-    auto configuration = adoptNS([SubclassWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([SubclassWebViewConfiguration new]);
     [configuration setSubclassData:@"original"];
     EXPECT_WK_STREQ([configuration subclassData], "original");
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     EXPECT_WK_STREQ([(SubclassWebViewConfiguration *)[webView configuration] subclassData], "copied");
 }
 
@@ -86,9 +86,9 @@ TEST(WebKit, InvalidConfiguration)
 {
     auto shouldThrowExceptionWhenUsed = [](Function<void(WKWebViewConfiguration *)>&& modifier, bool expectException) {
         @try {
-            auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+            RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
             modifier(configuration.get());
-            auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+            RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
             EXPECT_FALSE(expectException);
         } @catch (NSException *exception) {
             EXPECT_TRUE(expectException);
@@ -115,9 +115,9 @@ TEST(WebKit, InvalidConfiguration)
     IGNORE_NULL_CHECK_WARNINGS_END
 
     // Related WebViews cannot use different data stores.
-    auto configurationForEphemeralView = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configurationForEphemeralView = adoptNS([[WKWebViewConfiguration alloc] init]);
     configurationForEphemeralView.get().websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
-    auto ephemeralWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configurationForEphemeralView.get()]);
+    RetainPtr ephemeralWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configurationForEphemeralView.get()]);
     shouldThrowExceptionWhenUsed([&](WKWebViewConfiguration *configuration) {
         ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         [configuration _setRelatedWebView:ephemeralWebView.get()];
@@ -127,18 +127,18 @@ TEST(WebKit, InvalidConfiguration)
 
 TEST(WebKit, ConfigurationGroupIdentifierIsCopied)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setGroupIdentifier:@"TestGroupIdentifier"];
 
-    auto configurationCopy = adoptNS([configuration copy]);
+    RetainPtr configurationCopy = adoptNS([configuration copy]);
     EXPECT_STREQ([configuration _groupIdentifier].UTF8String, [configurationCopy _groupIdentifier].UTF8String);
 }
 
 TEST(WebKit, DefaultConfigurationEME)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     EXPECT_TRUE([configuration _legacyEncryptedMediaAPIEnabled]);
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
     [webView loadHTMLString:@"<html>hi</html>" baseURL:nil];
     __block bool done = false;
     [webView evaluateJavaScript:@"window.WebKitMediaKeys ? 'ENABLED' : 'DISABLED'" completionHandler:^(id result, NSError *){
@@ -162,7 +162,7 @@ TEST(WebKit, ConfigurationHTTPSUpgrade)
 
     auto runTest = [&] (bool upgrade) {
         done = false;
-        auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+        RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
         [storeConfiguration setAllowsServerPreconnect:NO];
         [storeConfiguration setProxyConfiguration:@{
             (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
@@ -170,11 +170,11 @@ TEST(WebKit, ConfigurationHTTPSUpgrade)
             (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
             (NSString *)kCFStreamPropertyHTTPProxyPort: @(server.port()),
         }];
-        auto store = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-        auto configuration = adoptNS([WKWebViewConfiguration new]);
+        RetainPtr store = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+        RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
         [configuration setWebsiteDataStore:store.get()];
         [configuration setUpgradeKnownHostsToHTTPS:upgrade];
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
         auto request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.opengl.org/"]];
         [webView loadRequest:request];
         Util::run(&done);
@@ -201,10 +201,10 @@ TEST(WebKit, ConfigurationHTTPSUpgrade)
 
 TEST(WebKit, ConfigurationDisableJavaScript)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     EXPECT_TRUE([configuration _allowsJavaScriptMarkup]);
     [configuration _setAllowsJavaScriptMarkup:NO];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:@"<body onload=\"document.write('FAIL');\">PASS</body>"];
     NSString *bodyHTML = [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"];
     EXPECT_WK_STREQ(bodyHTML, @"PASS");
@@ -212,10 +212,10 @@ TEST(WebKit, ConfigurationDisableJavaScript)
 
 TEST(WebKit, ConfigurationDisableJavaScriptNestedBody)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     EXPECT_TRUE([configuration _allowsJavaScriptMarkup]);
     [configuration _setAllowsJavaScriptMarkup:NO];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:@"<table><body onload=\"document.write('FAIL');\"></table>"];
     NSString *bodyHTML = [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"];
     EXPECT_WK_STREQ(bodyHTML, @"<table></table>");
@@ -223,10 +223,10 @@ TEST(WebKit, ConfigurationDisableJavaScriptNestedBody)
 
 TEST(WebKit, ConfigurationDisableJavaScriptSVGAnimateElement)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     EXPECT_TRUE([configuration _allowsJavaScriptMarkup]);
     [configuration _setAllowsJavaScriptMarkup:NO];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:@"<svg><a><rect fill=\"green\" width=\"10\" height=\"10\"></rect><animate attributeName=\"href\" to=\"javascript:document.write('FAIL')\"/></a></svg>"];
     NSString *bodyHTML = [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"];
     EXPECT_WK_STREQ(bodyHTML, @"<svg><a><rect fill=\"green\" width=\"10\" height=\"10\"></rect><animate attributeName=\"href\"></animate></a></svg>");
@@ -234,10 +234,10 @@ TEST(WebKit, ConfigurationDisableJavaScriptSVGAnimateElement)
 
 TEST(WebKit, ConfigurationDisableJavaScriptSVGAnimateElementComplex)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     EXPECT_TRUE([configuration _allowsJavaScriptMarkup]);
     [configuration _setAllowsJavaScriptMarkup:NO];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:@"<svg><a><rect fill=\"green\" width=\"10\" height=\"10\"></rect><animate attributeName=\"href\" dur=\"4s\" calcMode=\"spline\" repeatCount=\"indefinite\" values=\"javascript:document.write('FAIL'); javascript:document.write('FAIL'); javascript:document.write(location.href); javascript:document.write('FAIL'); javascript:document.write('FAIL')\" keyTimes=\"0; 0.25; 0.5; 0.75; 1\" keySplines=\"0.5 0 0.5 1; 0.5 0 0.5 1; 0.5 0 0.5 1; 0.5 0 0.5 1\"/></a></svg>"];
     NSString *bodyHTML = [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"];
     EXPECT_WK_STREQ(bodyHTML, @"<svg><a><rect fill=\"green\" width=\"10\" height=\"10\"></rect><animate attributeName=\"href\" dur=\"4s\" calcMode=\"spline\" repeatCount=\"indefinite\" keyTimes=\"0; 0.25; 0.5; 0.75; 1\" keySplines=\"0.5 0 0.5 1; 0.5 0 0.5 1; 0.5 0 0.5 1; 0.5 0 0.5 1\"></animate></a></svg>");
@@ -247,12 +247,12 @@ TEST(WebKit, ConfigurationMaskedURLSchemes)
 {
     [TestProtocol registerWithScheme:@"https"];
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
 
     EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet set]);
 
 #if ENABLE(WK_WEB_EXTENSIONS)
-    auto extensionController = adoptNS([[WKWebExtensionController alloc] init]);
+    RetainPtr extensionController = adoptNS([[WKWebExtensionController alloc] init]);
     [configuration setWebExtensionController:extensionController.get()];
 
     EXPECT_NS_EQUAL([configuration _maskedURLSchemes], [NSSet setWithObject:@"webkit-extension"]);
@@ -271,8 +271,8 @@ TEST(WebKit, ConfigurationMaskedURLSchemes)
     [configuration _setMaskedURLSchemes:[NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]];
     EXPECT_NS_EQUAL([configuration _maskedURLSchemes], ([NSSet setWithObjects:@"test-scheme", @"another-scheme", nil]));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
-    auto delegate = adoptNS([TestUIDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([TestUIDelegate new]);
     [webView setUIDelegate:delegate.get()];
 
     [webView synchronouslyLoadHTMLString:@"<img src=\"test-scheme://foo.com/bar.jpg\"><img src=\"baz.png\">" baseURL:[NSURL URLWithString:@"https://example.com"]];
@@ -340,7 +340,7 @@ TEST(WebKit, ConfigurationMaskedURLSchemes)
     [webView synchronouslyLoadHTMLString:@""];
 
     NSURL *scriptURL = [NSURL URLWithString:@"another-scheme://foo.com/bar.js"];
-    auto userScript = adoptNS([[WKUserScript alloc] _initWithSource:@"alert((new Error).stack)" injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES includeMatchPatternStrings:@[] excludeMatchPatternStrings:@[] associatedURL:scriptURL contentWorld:nil deferRunningUntilNotification:NO]);
+    RetainPtr userScript = adoptNS([[WKUserScript alloc] _initWithSource:@"alert((new Error).stack)" injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES includeMatchPatternStrings:@[] excludeMatchPatternStrings:@[] associatedURL:scriptURL contentWorld:nil deferRunningUntilNotification:NO]);
 
     [[webView configuration].userContentController _addUserScriptImmediately:userScript.get()];
 
@@ -356,12 +356,12 @@ TEST(WebKit, ConfigurationMaskedURLSchemes)
 
 TEST(WebKit, ConfigurationWebViewToCloneSessionStorageFrom)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:@"<script>sessionStorage.setItem('key', 'value')</script>" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
 
     [configuration _setWebViewToCloneSessionStorageFrom:webView.get()];
-    auto copiedWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr copiedWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [copiedWebView synchronouslyLoadHTMLString:@"" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
     __block bool done = false;
     [copiedWebView evaluateJavaScript:@"sessionStorage.getItem('key')" completionHandler:^(id result, NSError *error) {
@@ -404,8 +404,8 @@ TEST(WebKit, OverrideReferrer)
         EXPECT_FALSE(true);
     } }, HTTPServer::Protocol::HttpsProxy);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:server.httpsProxyConfiguration()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:server.httpsProxyConfiguration()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     auto addReferrer = ^(WKNavigationAction *, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         preferences._overrideReferrerForAllRequests = @"overridereferer";
         completionHandler(WKNavigationActionPolicyAllow, preferences);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewDiagnosticLogging.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewDiagnosticLogging.mm
@@ -55,11 +55,11 @@
 
 TEST(WKWebView, PrivateSessionDiagnosticLoggingDelegate)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     
-    auto testLoggingDelegate = adoptNS([[TestLoggingDelegate alloc] init]);
+    RetainPtr testLoggingDelegate = adoptNS([[TestLoggingDelegate alloc] init]);
     webView.get()._diagnosticLoggingDelegate = testLoggingDelegate.get();
     
     EXPECT_EQ(testLoggingDelegate.get(), webView.get()._diagnosticLoggingDelegate);
@@ -70,9 +70,9 @@ TEST(WKWebView, PrivateSessionDiagnosticLoggingDelegate)
 
 TEST(WKWebView, DiagnosticLoggingDelegateAfterClose)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     
-    auto testLoggingDelegate = adoptNS([[TestLoggingDelegate alloc] init]);
+    RetainPtr testLoggingDelegate = adoptNS([[TestLoggingDelegate alloc] init]);
     webView.get()._diagnosticLoggingDelegate = testLoggingDelegate.get();
     
     EXPECT_EQ(testLoggingDelegate.get(), webView.get()._diagnosticLoggingDelegate);
@@ -86,8 +86,8 @@ TEST(WKWebView, DiagnosticLoggingDelegateAfterClose)
 
 TEST(WKWebView, DiagnosticLoggingDictionary)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:[WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES]]);
-    auto testLoggingDelegate = adoptNS([TestLoggingDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:[WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES]]);
+    RetainPtr testLoggingDelegate = adoptNS([TestLoggingDelegate new]);
     [webView _setDiagnosticLoggingDelegate:testLoggingDelegate.get()];
     [webView configuration].preferences._diagnosticLoggingEnabled = YES;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewDoesNotLogDuringInitialization.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewDoesNotLogDuringInitialization.mm
@@ -44,12 +44,12 @@ TEST(WKWebView, InitializingWebViewWithEphemeralStorageDoesNotLog)
     dup2(p[1], STDERR_FILENO);
     close(p[1]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     [configuration setProcessPool:adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]).get()];
     [configuration setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     FILE *stderrFileHandle = fdopen(p[0], "r");
     char buffer[1024];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewEditActions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewEditActions.mm
@@ -85,7 +85,7 @@ namespace TestWebKitAPI {
 
 static RetainPtr<TestWKWebView> webViewForEditActionTesting(NSString *markup)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:markup];
     [webView _setEditable:YES];
     [webView becomeFirstResponder];
@@ -95,7 +95,7 @@ static RetainPtr<TestWKWebView> webViewForEditActionTesting(NSString *markup)
 
 static RetainPtr<TestWKWebView> webViewForEditActionTestingWithPageNamed(NSString *testPageName)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadTestPageNamed:testPageName];
     [webView _setEditable:YES];
     [webView becomeFirstResponder];
@@ -358,7 +358,7 @@ TEST(WKWebViewEditActions, SetFontFamily)
 
 TEST(WebKit, CanInvokeTranslateWithTextSelection)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
     auto translateSelector = ^{
 #if USE(BROWSERENGINEKIT)
         if ([webView hasAsyncTextInput])
@@ -414,8 +414,8 @@ TEST(WKWebViewEditActions, CopyFontAtCaretSelection)
     [webView objectByEvaluatingJavaScript:@"getSelection().setPosition(source.childNodes[0], 3)"];
 
     auto validateAndPerformAction = [](TestWKWebView *webView, SEL action) {
-        auto menu = adoptNS([NSMenu new]);
-        auto item = adoptNS([NSMenuItem new]);
+        RetainPtr menu = adoptNS([NSMenu new]);
+        RetainPtr item = adoptNS([NSMenuItem new]);
         [item setTarget:webView];
         [item setAction:action];
         [menu addItem:item.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewEvaluateJavaScript.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewEvaluateJavaScript.mm
@@ -120,8 +120,8 @@ TEST(WKWebView, EvaluateJavaScriptErrorCases)
         TestWebKitAPI::Util::run(&isDone);
     }
 
-    auto handler = adoptNS([TestScriptMessageHandler new]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([TestScriptMessageHandler new]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     NSString *handlerName = @"testHandler";
     [[webView configuration].userContentController addScriptMessageHandler:handler.get() name:handlerName];
     NSString *postMessages = @""
@@ -248,7 +248,7 @@ TEST(WKWebView, EvaluateJavaScriptInWorlds)
 
     // Add a scriptMessageHandler in a named world.
     RetainPtr<WKContentWorld> namedWorld = [WKContentWorld worldWithName:@"NamedWorld"];
-    auto handler = adoptNS([[DummyMessageHandler alloc] init]);
+    RetainPtr handler = adoptNS([[DummyMessageHandler alloc] init]);
     [webView.get().configuration.userContentController _addScriptMessageHandler:handler.get() name:@"testHandlerName" userContentWorld:namedWorld.get()._userContentWorld];
 
     // Set a variable value in that named world.
@@ -345,7 +345,7 @@ TEST(WKWebView, EvaluateJavaScriptInWorlds)
 TEST(WKWebView, EvaluateJavaScriptInWorldsWithGlobalObjectAvailable)
 {
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"ContentWorldPlugIn"];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
     [webView synchronouslyLoadHTMLString:@"<html></html>"];
 
     __block bool done = false;
@@ -359,7 +359,7 @@ TEST(WKWebView, EvaluateJavaScriptInWorldsWithGlobalObjectAvailable)
 TEST(WKWebView, EvaluateJavaScriptInWorldsWithGlobalObjectAvailableInCrossOriginIframe)
 {
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"ContentWorldPlugIn"];
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     __block bool childFrameLoaded = false;
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSString *responseString = nil;
@@ -373,13 +373,13 @@ TEST(WKWebView, EvaluateJavaScriptInWorldsWithGlobalObjectAvailableInCrossOrigin
         }
 
         ASSERT(responseString);
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:responseString.length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:responseString.length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[responseString dataUsingEncoding:NSUTF8StringEncoding]];
         [task didFinish];
     }];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"frame"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"frame://host1/"]]];
 
     TestWebKitAPI::Util::run(&childFrameLoaded);
@@ -396,7 +396,7 @@ TEST(WKWebView, EvaluateJavaScriptInWorldsWithGlobalObjectAvailableInCrossOrigin
 
 TEST(WebKit, GetFrameInfo_detachedFrame)
 {
-    auto webView = adoptNS([TestWKWebView new]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
     [webView synchronouslyLoadHTMLString:@"<iframe id='testFrame' src='about:blank'></iframe>"];
 
     __block bool done = false;
@@ -435,7 +435,7 @@ TEST(WebKit, EvaluateJavaScriptInAttachments)
             "Content-Disposition: attachment; filename=fromHeader.txt;\r\n\r\n"
             "Hello world!"_s);
     });
-    auto webView = adoptNS([TestWKWebView new]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
 
     __block bool done = false;
@@ -567,7 +567,7 @@ TEST(WebKit, SPIJavascriptMarkupVsAPIContentJavaScript)
 {
     // There's not a dynamically configuration setting for javascript markup,
     // but it can be configured at WKWebView creation time.
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAllowsJavaScriptMarkup:NO];
     RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
@@ -626,14 +626,14 @@ static NSString *userScriptSource = @"window.webkit.messageHandlers.framesTester
 TEST(EvaluateJavaScript, JavaScriptInFramesFromPostMessage)
 {
     allFrames = adoptNS([[NSMutableSet<WKFrameInfo *> alloc] init]);
-    auto messageHandler = adoptNS([[FramesMessageHandler alloc] init]);
-    auto userScript = adoptNS([[WKUserScript alloc] initWithSource:userScriptSource injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:NO inContentWorld:WKContentWorld.defaultClientWorld]);
+    RetainPtr messageHandler = adoptNS([[FramesMessageHandler alloc] init]);
+    RetainPtr userScript = adoptNS([[WKUserScript alloc] initWithSource:userScriptSource injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:NO inContentWorld:WKContentWorld.defaultClientWorld]);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addUserScript:userScript.get()];
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() contentWorld:WKContentWorld.defaultClientWorld name:@"framesTester"];
 
-    auto handler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr handler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [handler setStartURLSchemeTaskHandler:[&](WKWebView *, id<WKURLSchemeTask> task) {
         if ([task.request.URL.absoluteString isEqualToString:@"framestest://test/index.html"]) {
             NSData *data = [[NSString stringWithFormat:@"%s", framesMainResource] dataUsingEncoding:NSUTF8StringEncoding];
@@ -650,7 +650,7 @@ TEST(EvaluateJavaScript, JavaScriptInFramesFromPostMessage)
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"framestest"];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"otherprotocol"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"framestest://test/index.html"]]];
 
     EXPECT_EQ([allFrames count], 2u);
@@ -700,7 +700,7 @@ TEST(EvaluateJavaScript, JavaScriptInFramesFromNavigationDelegate)
 {
     allFrames = adoptNS([[NSMutableSet<WKFrameInfo *> alloc] init]);
 
-    auto handler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr handler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [handler setStartURLSchemeTaskHandler:[&](WKWebView *, id<WKURLSchemeTask> task) {
         if ([task.request.URL.absoluteString isEqualToString:@"framestest://test/index.html"]) {
             NSData *data = [[NSString stringWithFormat:@"%s", framesMainResource] dataUsingEncoding:NSUTF8StringEncoding];
@@ -716,13 +716,13 @@ TEST(EvaluateJavaScript, JavaScriptInFramesFromNavigationDelegate)
             ASSERT_NOT_REACHED();
     }];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"framestest"];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"otherprotocol"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
 
     __block bool didFinishNavigation = false;
     [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
@@ -785,7 +785,7 @@ TEST(EvaluateJavaScript, JavaScriptInMissingFrameError)
 {
     allFrames = adoptNS([[NSMutableSet<WKFrameInfo *> alloc] init]);
 
-    auto handler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr handler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [handler setStartURLSchemeTaskHandler:[&](WKWebView *, id<WKURLSchemeTask> task) {
         if ([task.request.URL.absoluteString isEqualToString:@"framestest://test/index.html"]) {
             NSData *data = [[NSString stringWithFormat:@"%s", framesMainResource] dataUsingEncoding:NSUTF8StringEncoding];
@@ -801,13 +801,13 @@ TEST(EvaluateJavaScript, JavaScriptInMissingFrameError)
             ASSERT_NOT_REACHED();
     }];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"framestest"];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"otherprotocol"];
 
     RetainPtr<WKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
 
     __block bool didFinishNavigation = false;
     [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
@@ -854,13 +854,13 @@ TEST(EvaluateJavaScript, JavaScriptInMissingFrameError)
 // This test verifies that evaluating JavaScript in a frame from the previous main navigation results in an error
 TEST(EvaluateJavaScript, JavaScriptInMissingFrameAfterNavigationError)
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol = YES;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
     allFrames = adoptNS([[NSMutableSet<WKFrameInfo *> alloc] init]);
 
-    auto handler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr handler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [handler setStartURLSchemeTaskHandler:[&](WKWebView *, id<WKURLSchemeTask> task) {
         if ([task.request.URL.absoluteString isEqualToString:@"framestest://test/index.html"]) {
             NSData *data = [[NSString stringWithFormat:@"%s", framesMainResource] dataUsingEncoding:NSUTF8StringEncoding];
@@ -881,14 +881,14 @@ TEST(EvaluateJavaScript, JavaScriptInMissingFrameAfterNavigationError)
             ASSERT_NOT_REACHED();
     }];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setProcessPool:processPool.get()];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"framestest"];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"otherprotocol"];
 
     RetainPtr<WKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
 
     __block bool didFinishNavigation = false;
     [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
@@ -940,10 +940,10 @@ TEST(EvaluateJavaScript, JavaScriptInMissingFrameAfterNavigationError)
 
 TEST(EvaluateJavaScript, WindowPersistency)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     __block bool didFinishNavigation = false;
     [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
         didFinishNavigation = true;
@@ -966,8 +966,8 @@ TEST(EvaluateJavaScript, WindowPersistency)
 
 TEST(EvaluateJavaScript, ReturnTypes)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     __block bool didEvaluateJavaScript = false;
     NSString *jsTopLevelReplacedByDict = @"(function(){return /hello/})()";
     // Behaves the same as if sending "(function(){ return {} })()" because of JSValue's containerValueToObject filtering

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewFindString.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewFindString.mm
@@ -82,15 +82,15 @@ TEST(WKWebViewFindString, DoNotFocusMatchWhenWebViewResignedAndHardwareKeyboardA
     ClassMethodSwizzler swizzler([UIKeyboard class], @selector(isInHardwareKeyboardMode), reinterpret_cast<IMP>(returnYes));
 #endif
 
-    auto inputDelegate = adoptNS([[WKWebViewFindStringInputDelegate alloc] init]);
-    auto findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto firstWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr inputDelegate = adoptNS([[WKWebViewFindStringInputDelegate alloc] init]);
+    RetainPtr findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr firstWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
     [firstWebView synchronouslyLoadHTMLString:@"<input type='text' value='hello'>"];
     [firstWebView _setInputDelegate:inputDelegate.get()];
     [firstWebView _setFindDelegate:findDelegate.get()];
 
-    auto secondWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(300, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr secondWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(300, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
     EXPECT_TRUE([secondWebView becomeFirstResponder]);
     EXPECT_FALSE(viewIsFirstResponder(firstWebView.get()));
 
@@ -107,15 +107,15 @@ TEST(WKWebViewFindString, DoNotFocusMatchWhenWebViewResigned)
 {
     ClassMethodSwizzler swizzler([UIKeyboard class], @selector(isInHardwareKeyboardMode), reinterpret_cast<IMP>(returnNo));
 
-    auto inputDelegate = adoptNS([[WKWebViewFindStringInputDelegate alloc] init]);
-    auto findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto firstWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr inputDelegate = adoptNS([[WKWebViewFindStringInputDelegate alloc] init]);
+    RetainPtr findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr firstWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
     [firstWebView synchronouslyLoadHTMLString:@"<input type='text' value='hello'>"];
     [firstWebView _setInputDelegate:inputDelegate.get()];
     [firstWebView _setFindDelegate:findDelegate.get()];
 
-    auto secondWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(300, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr secondWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(300, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
     EXPECT_TRUE([secondWebView becomeFirstResponder]);
     EXPECT_FALSE([firstWebView isFirstResponder]);
 
@@ -130,9 +130,9 @@ TEST(WKWebViewFindString, DoNotFocusMatchWhenWebViewResigned)
 
 TEST(WKWebViewFindString, DoNotUpdateMatchIndexWhenGivenNoIndexChangeOption)
 {
-    auto findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto firstWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr firstWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
     [firstWebView synchronouslyLoadHTMLString:@"<p>hello</p><p>hello</p>"];
     [firstWebView _setFindDelegate:findDelegate.get()];
 
@@ -149,9 +149,9 @@ TEST(WKWebViewFindString, DoNotUpdateMatchIndexWhenGivenNoIndexChangeOption)
 
 TEST(WKWebViewFindString, MatchIndexIsCorrectWhenNavigatingForwardAndBackward)
 {
-    auto findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
     [webView synchronouslyLoadHTMLString:@"<p>hello</p><p>hello</p><p>hello</p>"];
     [webView _setFindDelegate:findDelegate.get()];
 
@@ -177,9 +177,9 @@ TEST(WKWebViewFindString, MatchIndexIsCorrectWhenNavigatingForwardAndBackward)
 
 TEST(WKWebViewFindString, MatchIndexDoesNotUpdateWithoutDetermineMatchIndexOption)
 {
-    auto findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
     [webView synchronouslyLoadHTMLString:@"<p>hello</p><p>hello</p><p>hello</p>"];
     [webView _setFindDelegate:findDelegate.get()];
 
@@ -205,9 +205,9 @@ TEST(WKWebViewFindString, MatchIndexDoesNotUpdateWithoutDetermineMatchIndexOptio
 
 TEST(WKWebViewFindString, MatchIndexIsCorrectNavigatingWrapAround)
 {
-    auto findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
     [webView synchronouslyLoadHTMLString:@"<p>hello</p><p>hello</p><p>hello</p>"];
     [webView _setFindDelegate:findDelegate.get()];
 
@@ -235,9 +235,9 @@ TEST(WKWebViewFindString, MatchIndexIsCorrectNavigatingWrapAround)
 
 TEST(WKWebViewFindString, MatchIndexIsCorrectNavigatingWrapAroundBackwards)
 {
-    auto findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
     [webView synchronouslyLoadHTMLString:@"<p>hello</p><p>hello</p><p>hello</p>"];
     [webView _setFindDelegate:findDelegate.get()];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewFirstResponderTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewFirstResponderTests.mm
@@ -72,7 +72,7 @@ namespace TestWebKitAPI {
 
 TEST(WKWebViewFirstResponderTests, ContentViewIsFirstResponder)
 {
-    auto webView = adoptNS([[FirstResponderTestingView alloc] init]);
+    RetainPtr webView = adoptNS([[FirstResponderTestingView alloc] init]);
     EXPECT_FALSE([webView isFirstResponder]);
     EXPECT_TRUE([webView _contentViewIsFirstResponder]);
     EXPECT_FALSE([webView inputField].isFirstResponder);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewGetContents.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewGetContents.mm
@@ -97,7 +97,7 @@ TEST(WKWebView, GetContentsShouldReturnString)
 
 TEST(WKWebView, GetContentsShouldFailWhenClosingPage)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
@@ -218,7 +218,7 @@ TEST(WKWebView, GetContentsWithOpticallySizedFontShouldReturnAttributedString)
 
 TEST(WKWebView, AttributedStringAccessibilityLabel)
 {
-    auto webView = adoptNS([TestWKWebView new]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
 
     NSString *imagePath = [NSBundle.test_resourcesBundle pathForResource:@"icon" ofType:@"png"];
     [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<html><body><b>Hello</b> <img src='file://%@' width='100' height='100' alt='alt text'> <img src='file://%@' width='100' height='100' alt='aria label text'></body></html>", imagePath, imagePath]];
@@ -263,7 +263,7 @@ TEST(WKWebView, AttributedStringAttributeTypes)
     "</body>"
     "</html>";
 
-    auto webView = adoptNS([TestWKWebView new]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
     [webView synchronouslyLoadHTMLString:html];
 
     __block bool finished { false };
@@ -296,7 +296,7 @@ TEST(WKWebView, AttributedStringAttributeTypes)
 
 TEST(WKWebView, AttributedStringFromTable)
 {
-    auto webView = adoptNS([TestWKWebView new]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
     [webView synchronouslyLoadHTMLString:@"<html>"
         "  <head>"
         "  <style>"
@@ -372,7 +372,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 TEST(WKWebView, AttributedStringWithLinksInTableCell)
 {
-    auto webView = adoptNS([TestWKWebView new]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
     [webView synchronouslyLoadHTMLString:@"<html>"
         "  <body>"
         "    <table>"
@@ -420,7 +420,7 @@ TEST(WKWebView, AttributedStringWithLinksInTableCell)
 
 TEST(WKWebView, AttributedStringFromList)
 {
-    auto webView = adoptNS([TestWKWebView new]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
     [webView synchronouslyLoadHTMLString:@"<html>"
         "  <body>"
         "    <ol>"
@@ -560,7 +560,7 @@ TEST(WKWebView, AttributedStringWithoutNetworkLoads)
         "</body>";
 
     __block bool attemptedImageLoad = false;
-    auto resourceLoadDelegate = adoptNS([TestResourceLoadDelegate new]);
+    RetainPtr resourceLoadDelegate = adoptNS([TestResourceLoadDelegate new]);
     [resourceLoadDelegate setDidSendRequest:^(WKWebView *, _WKResourceLoadInfo *info, NSURLRequest *) {
         if (info.resourceType == _WKResourceLoadInfoResourceTypeImage)
             attemptedImageLoad = true;
@@ -625,7 +625,7 @@ TEST(WKWebView, AttributedStringWithSourceApplicationBundleID)
 TEST(WKWebView, TextWithWebFontAsAttributedString)
 {
     auto archiveURL = [NSBundle.test_resourcesBundle URLForResource:@"text-with-web-font" withExtension:@"webarchive"];
-    auto archiveData = adoptNS([[NSData alloc] initWithContentsOfURL:archiveURL]);
+    RetainPtr archiveData = adoptNS([[NSData alloc] initWithContentsOfURL:archiveURL]);
 
     RetainPtr<NSAttributedString> result;
     bool done = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewInspection.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewInspection.mm
@@ -31,7 +31,7 @@
 
 TEST(WKWebViewInspection, UseInspectionAPIAfterClose)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
 
     [webView setInspectable:YES];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewLoadAPIs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewLoadAPIs.mm
@@ -44,9 +44,9 @@ static NSString *htmlString2 = @"<html><body><h1>Hello, new world!</h1></body></
 
 TEST(WKWebView, LoadSimulatedRequestUsingResponseHTMLString)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *loadRequest = [NSURLRequest requestWithURL:exampleURL];
@@ -63,15 +63,15 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 TEST(WKWebView, LoadSimulatedRequestUsingResponseData)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *loadRequest = [NSURLRequest requestWithURL:exampleURL];
 
     NSData *data = [htmlString dataUsingEncoding:NSUTF8StringEncoding];
-    auto response = adoptNS([[NSURLResponse alloc] initWithURL:exampleURL MIMEType:@"text/HTML" expectedContentLength:[data length] textEncodingName:@"UTF-8"]);
+    RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:exampleURL MIMEType:@"text/HTML" expectedContentLength:[data length] textEncodingName:@"UTF-8"]);
 
     [webView loadSimulatedRequest:loadRequest response:response.get() responseData:data];
     [delegate waitForDidFinishNavigation];
@@ -103,7 +103,7 @@ TEST(WKWebView, LoadSimulatedRequestDelegateCallbacks)
 
     __block Vector<Callback> callbacks;
     __block bool finished = false;
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *, void (^completionHandler)(WKNavigationActionPolicy)) {
         callbacks.append(Callback::NavigationAction);
         completionHandler(WKNavigationActionPolicyAllow);
@@ -123,7 +123,7 @@ TEST(WKWebView, LoadSimulatedRequestDelegateCallbacks)
         finished = true;
     };
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     webView.get().navigationDelegate = delegate.get();
     NSURL *url = [NSURL URLWithString:@"https://webkit.org/"];
     [webView loadHTMLString:@"hi!" baseURL:url];
@@ -140,9 +140,9 @@ TEST(WKWebView, LoadSimulatedRequestDelegateCallbacks)
 
 TEST(WKWebView, LoadFileRequest)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURL *file = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
@@ -154,9 +154,9 @@ TEST(WKWebView, LoadFileRequest)
 
 TEST(WKWebView, LoadSimulatedRequestUpdatesBackForwardList)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *loadRequest = [NSURLRequest requestWithURL:exampleURL];
@@ -202,7 +202,7 @@ TEST(WKWebView, LoadSimulatedRequestUpdatesBackForwardList)
     
     // loadHTMLString is peculiarly different than loadSimulatedRequest, but we need to leave it
     // like it is until we decide to change it, probably with a linked-on-or-after check.
-    auto webView2 = adoptNS([WKWebView new]);
+    RetainPtr webView2 = adoptNS([WKWebView new]);
     [webView2 setNavigationDelegate:delegate.get()];
     [webView2 loadHTMLString:htmlString baseURL:loadRequest.URL];
     [delegate waitForDidFinishNavigation];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewLogging.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewLogging.mm
@@ -32,26 +32,26 @@
 
 TEST(WKWebView, LoggingEnabledByDefault)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero]);
 
     EXPECT_TRUE([webView _isLoggerEnabledForTesting]);
 }
 
 TEST(WKWebView, LoggingDisabledInNonPersistentDataStore)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:WKWebsiteDataStore.nonPersistentDataStore];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     EXPECT_FALSE([webView _isLoggerEnabledForTesting]);
 }
 
 TEST(WKWebView, LoggingEnabledInNonPersistentDataStoreWhenAllowed)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:WKWebsiteDataStore.nonPersistentDataStore];
     [configuration preferences]._allowPrivacySensitiveOperationsInNonPersistentDataStores = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
     EXPECT_TRUE([webView _isLoggerEnabledForTesting]);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewNotificationForwarding.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewNotificationForwarding.mm
@@ -52,9 +52,9 @@ TEST(WKWebView, NotifyStateIsInitiallySetAndForwarded)
     EXPECT_EQ(notify_register_check(name, &token), 0u);
     EXPECT_EQ(notify_set_state(token, 42), 0u);
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     NSURLRequest *loadRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com"]];
     [webView loadSimulatedRequest:loadRequest responseHTMLString:@"Hello world!"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewPrintFormatter.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewPrintFormatter.mm
@@ -107,13 +107,13 @@ TEST(WKWebView, PrintFormatterHangsIfWebProcessCrashesBeforeWaiting)
 
 TEST(WKWebView, PrintToPDFUsingPrintPageRenderer)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
     [webView waitForNextPresentationUpdate];
 
     CGRect pageRect = CGRectMake(0, 0, 100, 100);
-    auto printPageRenderer = adoptNS([[UIPrintPageRenderer alloc] init]);
+    RetainPtr printPageRenderer = adoptNS([[UIPrintPageRenderer alloc] init]);
     [printPageRenderer addPrintFormatter:[webView viewPrintFormatter] startingAtPageAtIndex:0];
     [printPageRenderer setPaperRect:pageRect];
     [printPageRenderer setPrintableRect:pageRect];
@@ -136,17 +136,17 @@ TEST(WKWebView, PrintToPDFUsingPrintPageRenderer)
 #if HAVE(PDFKIT)
 TEST(WKWebView, PrintToPDFShouldPrintBackgrounds)
 {
-    auto config = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr config = adoptNS([[WKWebViewConfiguration alloc] init]);
     [config preferences].shouldPrintBackgrounds = NO;
     
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:config.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:config.get()]);
 
     [webView synchronouslyLoadTestPageNamed:@"red"];
     [webView waitForNextPresentationUpdate];
     
     auto runTest = [&] (BOOL shouldPrintBackgrounds) {
         CGRect pageRect = CGRectMake(0, 0, 100, 100);
-        auto printPageRenderer = adoptNS([[UIPrintPageRenderer alloc] init]);
+        RetainPtr printPageRenderer = adoptNS([[UIPrintPageRenderer alloc] init]);
         [printPageRenderer addPrintFormatter:[webView viewPrintFormatter] startingAtPageAtIndex:0];
         [printPageRenderer setPaperRect:pageRect];
         [printPageRenderer setPrintableRect:pageRect];
@@ -182,15 +182,15 @@ TEST(WKWebView, PrintToPDFShouldPrintBackgrounds)
 
 TEST(WKWebView, PrintToPDFUsingPrintInteractionController)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
     [webView waitForNextPresentationUpdate];
 
-    auto printPageRenderer = adoptNS([[UIPrintPageRenderer alloc] init]);
+    RetainPtr printPageRenderer = adoptNS([[UIPrintPageRenderer alloc] init]);
     [printPageRenderer addPrintFormatter:[webView viewPrintFormatter] startingAtPageAtIndex:0];
 
-    auto printInteractionController = adoptNS([[UIPrintInteractionController alloc] init]);
+    RetainPtr printInteractionController = adoptNS([[UIPrintInteractionController alloc] init]);
     [printInteractionController setPrintPageRenderer:printPageRenderer.get()];
 
     __block NSUInteger pdfDataLength = 0;
@@ -199,7 +199,7 @@ TEST(WKWebView, PrintToPDFUsingPrintInteractionController)
     [printInteractionController _setupPrintPanel:nil];
     [printInteractionController _generatePrintPreview:^(NSURL *pdfURL, BOOL shouldRenderOnChosenPaper) {
         dispatch_async(mainDispatchQueueSingleton(), ^{
-            auto pdfData = adoptNS([[NSData alloc] initWithContentsOfURL:pdfURL]);
+            RetainPtr pdfData = adoptNS([[NSData alloc] initWithContentsOfURL:pdfURL]);
             pdfDataLength = [pdfData length];
 
             [printInteractionController _cleanPrintState];
@@ -213,7 +213,7 @@ TEST(WKWebView, PrintToPDFUsingPrintInteractionController)
 
 TEST(WKWebView, PrintToPDFUsingMultiplePrintInteractionControllers)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
     [webView waitForNextPresentationUpdate];
@@ -221,17 +221,17 @@ TEST(WKWebView, PrintToPDFUsingMultiplePrintInteractionControllers)
     __block NSUInteger numCompleted = 0;
     __block bool done = false;
 
-    auto printPageRenderer = adoptNS([[UIPrintPageRenderer alloc] init]);
+    RetainPtr printPageRenderer = adoptNS([[UIPrintPageRenderer alloc] init]);
     [printPageRenderer addPrintFormatter:[webView viewPrintFormatter] startingAtPageAtIndex:0];
 
-    auto printInteractionController = adoptNS([[UIPrintInteractionController alloc] init]);
+    RetainPtr printInteractionController = adoptNS([[UIPrintInteractionController alloc] init]);
     [printInteractionController setPrintPageRenderer:printPageRenderer.get()];
 
     __block NSUInteger pdfDataLength = 0;
     [printInteractionController _setupPrintPanel:nil];
     [printInteractionController _generatePrintPreview:^(NSURL *pdfURL, BOOL shouldRenderOnChosenPaper) {
         dispatch_async(mainDispatchQueueSingleton(), ^{
-            auto pdfData = adoptNS([[NSData alloc] initWithContentsOfURL:pdfURL]);
+            RetainPtr pdfData = adoptNS([[NSData alloc] initWithContentsOfURL:pdfURL]);
             pdfDataLength = [pdfData length];
 
             [printInteractionController _cleanPrintState];
@@ -241,17 +241,17 @@ TEST(WKWebView, PrintToPDFUsingMultiplePrintInteractionControllers)
         });
     }];
 
-    auto printPageRenderer2 = adoptNS([[UIPrintPageRenderer alloc] init]);
+    RetainPtr printPageRenderer2 = adoptNS([[UIPrintPageRenderer alloc] init]);
     [printPageRenderer2 addPrintFormatter:[webView viewPrintFormatter] startingAtPageAtIndex:0];
 
-    auto printInteractionController2 = adoptNS([[UIPrintInteractionController alloc] init]);
+    RetainPtr printInteractionController2 = adoptNS([[UIPrintInteractionController alloc] init]);
     [printInteractionController2 setPrintPageRenderer:printPageRenderer2.get()];
 
     __block NSUInteger pdfDataLength2 = 0;
     [printInteractionController2 _setupPrintPanel:nil];
     [printInteractionController2 _generatePrintPreview:^(NSURL *pdfURL, BOOL shouldRenderOnChosenPaper) {
         dispatch_async(mainDispatchQueueSingleton(), ^{
-            auto pdfData = adoptNS([[NSData alloc] initWithContentsOfURL:pdfURL]);
+            RetainPtr pdfData = adoptNS([[NSData alloc] initWithContentsOfURL:pdfURL]);
             pdfDataLength2 = [pdfData length];
 
             [printInteractionController2 _cleanPrintState];
@@ -268,15 +268,15 @@ TEST(WKWebView, PrintToPDFUsingMultiplePrintInteractionControllers)
 
 TEST(WKWebView, PrintToPDFUsingPrintInteractionControllerAndPrintPageRenderer)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
     [webView waitForNextPresentationUpdate];
 
-    auto printPageRenderer = adoptNS([[UIPrintPageRenderer alloc] init]);
+    RetainPtr printPageRenderer = adoptNS([[UIPrintPageRenderer alloc] init]);
     [printPageRenderer addPrintFormatter:[webView viewPrintFormatter] startingAtPageAtIndex:0];
 
-    auto printInteractionController = adoptNS([[UIPrintInteractionController alloc] init]);
+    RetainPtr printInteractionController = adoptNS([[UIPrintInteractionController alloc] init]);
     [printInteractionController setPrintPageRenderer:printPageRenderer.get()];
 
     __block bool done = false;
@@ -285,7 +285,7 @@ TEST(WKWebView, PrintToPDFUsingPrintInteractionControllerAndPrintPageRenderer)
     [printInteractionController _setupPrintPanel:nil];
     [printInteractionController _generatePrintPreview:^(NSURL *pdfURL, BOOL shouldRenderOnChosenPaper) {
         dispatch_async(mainDispatchQueueSingleton(), ^{
-            auto pdfData = adoptNS([[NSData alloc] initWithContentsOfURL:pdfURL]);
+            RetainPtr pdfData = adoptNS([[NSData alloc] initWithContentsOfURL:pdfURL]);
             printInteractionControllerPDFDataLength = [pdfData length];
 
             [printInteractionController _cleanPrintState];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewResize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewResize.mm
@@ -34,7 +34,7 @@
 
 TEST(WKWebViewResize, DoesNotAssertInDeallocAfterChangingFrame)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_FALSE([webView _hasResizeAssertion]);
 
     [webView setFrame:NSMakeRect(0, 0, 400, 300)];
@@ -51,7 +51,7 @@ TEST(WKWebViewResize, DoesNotAssertInDeallocAfterChangingFrame)
 
 TEST(WKWebViewResize, DoesNotAssertInDeallocAfterChangingBounds)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_FALSE([webView _hasResizeAssertion]);
 
     [webView setBounds:NSMakeRect(0, 0, 400, 300)];
@@ -68,13 +68,13 @@ TEST(WKWebViewResize, DoesNotAssertInDeallocAfterChangingBounds)
 
 TEST(WKWebViewResize, RemovesAssertionsAfterMovingToWindow)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_FALSE([webView _hasResizeAssertion]);
 
     [webView setFrame:NSMakeRect(0, 0, 400, 300)];
     EXPECT_TRUE([webView _hasResizeAssertion]);
 
-    auto window = adoptNS([[UIWindow alloc] initWithFrame:NSMakeRect(0, 0, 320, 568)]);
+    RetainPtr window = adoptNS([[UIWindow alloc] initWithFrame:NSMakeRect(0, 0, 320, 568)]);
 
     [window addSubview:webView.get()];
     EXPECT_FALSE([webView _hasResizeAssertion]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewServerTrustKVC.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewServerTrustKVC.mm
@@ -30,6 +30,6 @@
 
 TEST(WKWebView, ServerTrustKVC)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
     EXPECT_NULL([webView valueForKey:@"serverTrust"]);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewSnapshot.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewSnapshot.mm
@@ -101,7 +101,7 @@ TEST(WKWebView, SnapshotImageError)
 {
     CGFloat viewWidth = 800;
     CGFloat viewHeight = 600;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
     
     [webView loadHTMLString:@"<body style='background-color: red;'></body>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -126,7 +126,7 @@ TEST(WKWebView, SnapshotImageEmptyRect)
 {
     CGFloat viewWidth = 800;
     CGFloat viewHeight = 600;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     [webView loadHTMLString:@"<body style='background-color: red;'></body>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -154,7 +154,7 @@ TEST(WKWebView, SnapshotImageZeroWidth)
 {
     CGFloat viewWidth = 800;
     CGFloat viewHeight = 600;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     [webView loadHTMLString:@"<body style='background-color: red;'></body>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -180,7 +180,7 @@ TEST(WKWebView, SnapshotImageZeroSizeView)
 {
     CGFloat viewWidth = 0;
     CGFloat viewHeight = 0;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     [webView loadHTMLString:@"<body style='background-color: red;'></body>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -208,7 +208,7 @@ TEST(WKWebView, SnapshotImageZeroSizeViewNoConfiguration)
 {
     CGFloat viewWidth = 0;
     CGFloat viewHeight = 0;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     [webView loadHTMLString:@"<body style='background-color: red;'></body>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -232,7 +232,7 @@ TEST(WKWebView, SnapshotImageEmptyWithOutOfScopeCompletionHandler)
 {
     CGFloat viewWidth = 0;
     CGFloat viewHeight = 0;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     [webView loadHTMLString:@"<body style='background-color: red;'></body>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -245,7 +245,7 @@ TEST(WKWebView, SnapshotImageEmptyWithOutOfScopeCompletionHandler)
 
     isDone = false;
 
-    auto snapshotWrapper = adoptNS([[TestSnapshotWrapper alloc] init]);
+    RetainPtr snapshotWrapper = adoptNS([[TestSnapshotWrapper alloc] init]);
     [snapshotWrapper takeSnapshotWithWebView:webView.get() configuration:snapshotConfiguration.get() completionHandler:^{
         isDone = true;
     }];
@@ -265,7 +265,7 @@ TEST(WKWebView, SnapshotImageBaseCase)
 {
     NSInteger viewWidth = 800;
     NSInteger viewHeight = 600;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     RetainPtr<Util::PlatformWindow> window;
     CGFloat backingScaleFactor;
@@ -332,7 +332,7 @@ TEST(WKWebView, SnapshotImageScale)
     CGFloat viewWidth = 800;
     CGFloat viewHeight = 600;
     CGFloat scaleFactor = 2;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     [webView loadHTMLString:@"<body style='background-color: red;'></body>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -358,7 +358,7 @@ TEST(WKWebView, SnapshotImageNilConfiguration)
 {
     CGFloat viewWidth = 800;
     CGFloat viewHeight = 600;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     [webView loadHTMLString:@"<body style='background-color: red;'></body>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -379,7 +379,7 @@ TEST(WKWebView, SnapshotImageUninitializedConfiguration)
 {
     CGFloat viewWidth = 800;
     CGFloat viewHeight = 600;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     [webView loadHTMLString:@"<body style='background-color: red;'></body>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -402,7 +402,7 @@ TEST(WKWebView, SnapshotImageUninitializedSnapshotWidth)
 {
     CGFloat viewWidth = 800;
     CGFloat viewHeight = 600;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     [webView loadHTMLString:@"<body style='background-color: red;'></body>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -427,13 +427,13 @@ TEST(WKWebView, SnapshotImageLargeAsyncDecoding)
     NSInteger viewWidth = 800;
     NSInteger viewHeight = 600;
     // FIXME: This test fails when adopting TestWKWebView; it might be interesting to investigate why.
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     NSURL *fileURL = [NSBundle.test_resourcesBundle URLForResource:@"large-red-square-image" withExtension:@"html"];
     [webView loadFileURL:fileURL allowingReadAccessToURL:fileURL];
     [webView _test_waitForDidFinishNavigation];
 
-    auto snapshotConfiguration = adoptNS([[WKSnapshotConfiguration alloc] init]);
+    RetainPtr snapshotConfiguration = adoptNS([[WKSnapshotConfiguration alloc] init]);
     [snapshotConfiguration setRect:NSMakeRect(0, 0, viewWidth, viewHeight)];
     [snapshotConfiguration setSnapshotWidth:@(viewWidth)];
 
@@ -484,7 +484,7 @@ TEST(WKWebView, SnapshotAfterScreenUpdates)
     // pass this test.
     NSInteger viewWidth = 800;
     NSInteger viewHeight = 600;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
     
     RetainPtr<Util::PlatformWindow> window;
     CGFloat backingScaleFactor;
@@ -547,7 +547,7 @@ TEST(WKWebView, SnapshotWithoutAfterScreenUpdates)
     // then we would expect the pixels to be red instead of blue.
     NSInteger viewWidth = 800;
     NSInteger viewHeight = 600;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
     
     RetainPtr<Util::PlatformWindow> window;
     CGFloat backingScaleFactor;
@@ -607,7 +607,7 @@ TEST(WKWebView, SnapshotWebGL)
 {
     NSInteger viewWidth = 800;
     NSInteger viewHeight = 600;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     RetainPtr<Util::PlatformWindow> window;
     CGFloat backingScaleFactor;
@@ -666,7 +666,7 @@ TEST(WKWebView, SnapshotWithoutSelectionHighlighting)
 {
     NSInteger viewWidth = 800;
     NSInteger viewHeight = 600;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     RetainPtr<Util::PlatformWindow> window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSBorderlessWindowMask backing:NSBackingStoreBuffered defer:NO]);
     [[window contentView] addSubview:webView.get()];
@@ -713,16 +713,16 @@ TEST(WKWebView, SnapshotWithContentsRect)
 {
     CGFloat viewWidth = 200;
     CGFloat viewHeight = 200;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSBorderlessWindowMask backing:NSBackingStoreBuffered defer:NO]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSBorderlessWindowMask backing:NSBackingStoreBuffered defer:NO]);
     [[window contentView] addSubview:webView.get()];
     CGFloat backingScaleFactor = [window backingScaleFactor];
 
     [webView loadHTMLString:@"<body><div style='position: absolute; left: 200px; width: 800px; height: 600px; background-color: blue;'></div>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
 
-    auto snapshotConfiguration = adoptNS([[WKSnapshotConfiguration alloc] init]);
+    RetainPtr snapshotConfiguration = adoptNS([[WKSnapshotConfiguration alloc] init]);
     [snapshotConfiguration _setUsesContentsRect:YES];
 
     isDone = false;
@@ -833,7 +833,7 @@ TEST(WKWebView, RemoteSnapshotWithTransform)
 
     [webView synchronouslyLoadHTMLString:@"<style> body { margin: 0; } .box { position: relative; width: 100px; height: 50px; } .top { top: 50px; transform: translateY(-100%); border-radius: 50px 50px 0 0; background-color: green; } .bottom { border-radius: 0 0 50px 50px; overflow: hidden; } </style> <body><div class='top box'></div> <div class='bottom box'> <img height='50' width='100' src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAD0lEQVR4AQEEAPv/AACAAAEEAIEu/TP9AAAAAElFTkSuQmCC'> </div></body>"];
 
-    auto snapshotConfiguration = adoptNS([[WKSnapshotConfiguration alloc] init]);
+    RetainPtr snapshotConfiguration = adoptNS([[WKSnapshotConfiguration alloc] init]);
     [snapshotConfiguration setRect:NSMakeRect(0, 0, viewWidth, viewHeight)];
     [snapshotConfiguration setSnapshotWidth:@(viewWidth)];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewSpatialTrackingLabels.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewSpatialTrackingLabels.mm
@@ -37,7 +37,7 @@
 TEST(WKWebView, DefaultSTSLabel)
 {
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration addToWindow:YES]);
 
     [webView synchronouslyLoadHTMLString:@"<body></body>"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewSuspendAllMediaPlayback.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewSuspendAllMediaPlayback.mm
@@ -34,12 +34,12 @@
 
 TEST(WKWebViewSuspendAllMediaPlayback, BeforeLoading)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
 #if TARGET_OS_IPHONE
     configuration.get().allowsInlineMediaPlayback = YES;
 #endif
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
     [webView _suspendAllMediaPlayback];
 
     __block bool notPlaying = false;
@@ -55,12 +55,12 @@ TEST(WKWebViewSuspendAllMediaPlayback, DISABLED_AfterLoading)
 TEST(WKWebViewSuspendAllMediaPlayback, AfterLoading)
 #endif
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
 #if TARGET_OS_IPHONE
     configuration.get().allowsInlineMediaPlayback = YES;
 #endif
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
 
     __block bool isPlaying = false;
     [webView performAfterReceivingMessage:@"playing" action:^{ isPlaying = true; }];
@@ -86,12 +86,12 @@ TEST(WKWebViewSuspendAllMediaPlayback, AfterLoading)
 
 TEST(WKWebViewSuspendAllMediaPlayback, PauseWhenResume)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
 #if TARGET_OS_IPHONE
     configuration.get().allowsInlineMediaPlayback = YES;
 #endif
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
 
     [webView synchronouslyLoadTestPageNamed:@"video-with-audio"];
 
@@ -117,10 +117,10 @@ TEST(WKWebViewSuspendAllMediaPlayback, PauseWhenResume)
 
 TEST(WKWebViewSuspendAllMediaPlayback, FullscreenWhileSuspended)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration preferences].elementFullscreenEnabled = YES;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
 
     [webView synchronouslyLoadTestPageNamed:@"video-with-audio"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewTextInput.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewTextInput.mm
@@ -48,7 +48,7 @@ static void insertText(WKWebView *webView, NSString *text)
 
 TEST(WKWebView, InsertTextWithRangedSelection)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 320)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 320)]);
     [webView synchronouslyLoadHTMLString:@"<div id='editor' contenteditable>foo bar baz</div>"];
 
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(editor.childNodes[0], 4, editor.childNodes[0], 8)"];
@@ -66,7 +66,7 @@ TEST(WKWebView, InsertTextWithRangedSelection)
 
 TEST(WKWebView, InsertTextWithCaretSelection)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 320)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 320)]);
     [webView synchronouslyLoadHTMLString:@"<div id='editor' contenteditable>foo bar baz</div>"];
 
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(editor.childNodes[0], 3, editor.childNodes[0], 3)"];
@@ -86,7 +86,7 @@ TEST(WKWebView, InsertTextWithCaretSelection)
 
 TEST(WKWebView, ShouldHaveInputContextForEditableContent)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadTestPageNamed:@"editable-body"];
     [webView waitForNextPresentationUpdate];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewThemeColor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewThemeColor.mm
@@ -39,7 +39,7 @@
 
 TEST(WKWebViewThemeColor, MetaElementValidNameAndColor)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_TRUE(![webView themeColor]);
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<meta name='theme-color' content='red'>"];
@@ -51,7 +51,7 @@ TEST(WKWebViewThemeColor, MetaElementValidNameAndColor)
 
 TEST(WKWebViewThemeColor, MetaElementValidNameAndColorAndMedia)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_TRUE(![webView themeColor]);
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<meta name='theme-color' content='red' media='screen'>"];
@@ -63,7 +63,7 @@ TEST(WKWebViewThemeColor, MetaElementValidNameAndColorAndMedia)
 
 TEST(WKWebViewThemeColor, MetaElementInvalidName)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_TRUE(![webView themeColor]);
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<meta name='not-theme-color' content='blue'><meta name='theme-color' content='red'>"];
@@ -75,7 +75,7 @@ TEST(WKWebViewThemeColor, MetaElementInvalidName)
 
 TEST(WKWebViewThemeColor, MetaElementInvalidColor)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_TRUE(![webView themeColor]);
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<meta name='theme-color' content='invalid'><meta name='theme-color' content='red'>"];
@@ -87,7 +87,7 @@ TEST(WKWebViewThemeColor, MetaElementInvalidColor)
 
 TEST(WKWebViewThemeColor, MetaElementInvalidMedia)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_TRUE(![webView themeColor]);
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<meta name='theme-color' content='blue' media='invalid'><meta name='theme-color' content='red' media='screen'>"];
@@ -99,7 +99,7 @@ TEST(WKWebViewThemeColor, MetaElementInvalidMedia)
 
 TEST(WKWebViewThemeColor, MetaElementMultipleValid)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_TRUE(![webView themeColor]);
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<div><meta name='theme-color' content='red'></div><meta name='theme-color' content='blue'>"];
@@ -111,7 +111,7 @@ TEST(WKWebViewThemeColor, MetaElementMultipleValid)
 
 TEST(WKWebViewThemeColor, MetaElementValidSubframe)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_TRUE(![webView themeColor]);
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<iframe srcdoc=\"<meta name='theme-color' content='blue'>\"></iframe><meta name='theme-color' content='red'>"];
@@ -219,8 +219,8 @@ TEST(WKWebViewThemeColor, KVO)
     auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
     auto blueColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blueColorComponents));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    auto themeColorObserver = adoptNS([[WKWebViewThemeColorObserver alloc] initWithWebView:webView.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr themeColorObserver = adoptNS([[WKWebViewThemeColorObserver alloc] initWithWebView:webView.get()]);
     EXPECT_NSSTRING_EQ("after-init", [themeColorObserver state]);
     EXPECT_TRUE(![webView themeColor]);
 
@@ -291,7 +291,7 @@ TEST(WKWebViewThemeColor, ApplicationManifest)
     auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
     auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_TRUE(![webView themeColor]);
 
     NSDictionary *manifestObject = @{ @"name": @"Test", @"theme_color": @"red" };
@@ -311,7 +311,7 @@ TEST(WKWebViewThemeColor, ApplicationManifest)
 
 TEST(WKWebViewThemeColor, MetaElementOverridesApplicationManifest)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_TRUE(![webView themeColor]);
 
     NSDictionary *manifestObject = @{ @"name": @"Test", @"theme_color": @"blue" };

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewUnderPageBackgroundColor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewUnderPageBackgroundColor.mm
@@ -58,7 +58,7 @@ static RetainPtr<CGColor> defaultBackgroundColor()
 
 TEST(WKWebViewUnderPageBackgroundColor, OnLoad)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_TRUE(CGColorEqualToColor([webView underPageBackgroundColor].CGColor, defaultBackgroundColor().get()));
 }
 
@@ -67,7 +67,7 @@ TEST(WKWebViewUnderPageBackgroundColor, SingleSolidColor)
     auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
     auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_TRUE(CGColorEqualToColor([webView underPageBackgroundColor].CGColor, defaultBackgroundColor().get()));
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<style> body { background-color: red; } </style>"];
@@ -76,7 +76,7 @@ TEST(WKWebViewUnderPageBackgroundColor, SingleSolidColor)
 
 TEST(WKWebViewUnderPageBackgroundColor, SingleBlendedColor)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_TRUE(CGColorEqualToColor([webView underPageBackgroundColor].CGColor, defaultBackgroundColor().get()));
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<style> body { background-color: rgba(255, 0, 0, 0.5); } </style>"];
@@ -92,7 +92,7 @@ TEST(WKWebViewUnderPageBackgroundColor, MultipleSolidColors)
     auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
     auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_TRUE(CGColorEqualToColor([webView underPageBackgroundColor].CGColor, defaultBackgroundColor().get()));
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<style> html { background-color: blue; } body { background-color: red; } </style>"];
@@ -101,7 +101,7 @@ TEST(WKWebViewUnderPageBackgroundColor, MultipleSolidColors)
 
 TEST(WKWebViewUnderPageBackgroundColor, MultipleBlendedColors)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_TRUE(CGColorEqualToColor([webView underPageBackgroundColor].CGColor, defaultBackgroundColor().get()));
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<style> html { background-color: rgba(255, 0, 0, 0.5); } body { background-color: rgba(0, 0, 255, 0.5); } </style>"];
@@ -185,8 +185,8 @@ TEST(WKWebViewUnderPageBackgroundColor, KVO)
     auto redColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), redColorComponents));
     auto blueColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blueColorComponents));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    auto underPageBackgroundColorObserver = adoptNS([[WKWebViewUnderPageBackgroundColorObserver alloc] initWithWebView:webView.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr underPageBackgroundColorObserver = adoptNS([[WKWebViewUnderPageBackgroundColorObserver alloc] initWithWebView:webView.get()]);
     EXPECT_NSSTRING_EQ("after-init", [underPageBackgroundColorObserver state]);
     EXPECT_TRUE(CGColorEqualToColor([webView underPageBackgroundColor].CGColor, defaultBackgroundColor().get()));
 
@@ -290,7 +290,7 @@ TEST(WKWebViewUnderPageBackgroundColor, MatchesScrollView)
     auto blueColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blueColorComponents));
     auto whiteColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), whiteColorComponents));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     EXPECT_TRUE(CGColorEqualToColor([webView underPageBackgroundColor].CGColor, defaultBackgroundColor().get()));
     EXPECT_TRUE(CGColorEqualToColor([webView scrollView].backgroundColor.CGColor, defaultBackgroundColor().get()));
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
@@ -145,9 +145,9 @@ TEST(WKWebsiteDataStore, RemoveAndFetchData)
 
 TEST(WKWebsiteDataStore, RemoveEphemeralData)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
     __block bool done = false;
     [[configuration websiteDataStore] removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler: ^{
@@ -260,11 +260,11 @@ TEST(WKWebsiteDataStore, FetchNonPersistentCredentials)
     HTTPServer server(HTTPServer::respondWithChallengeThenOK);
     
     usePersistentCredentialStorage = false;
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     auto websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
     [configuration setWebsiteDataStore:websiteDataStore];
-    auto navigationDelegate = adoptNS([[NavigationTestDelegate alloc] init]);
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[NavigationTestDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
     [navigationDelegate waitForDidFinishNavigation];
@@ -291,12 +291,12 @@ TEST(WKWebsiteDataStore, FetchPersistentCredentials)
 
     usePersistentCredentialStorage = true;
     auto websiteDataStore = [WKWebsiteDataStore defaultDataStore];
-    auto navigationDelegate = adoptNS([[NavigationTestDelegate alloc] init]);
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr navigationDelegate = adoptNS([[NavigationTestDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     // Make sure no credential left by previous tests.
-    auto protectionSpace = adoptNS([[NSURLProtectionSpace alloc] initWithHost:@"127.0.0.1" port:server.port() protocol:NSURLProtectionSpaceHTTP realm:@"testrealm" authenticationMethod:NSURLAuthenticationMethodHTTPBasic]);
+    RetainPtr protectionSpace = adoptNS([[NSURLProtectionSpace alloc] initWithHost:@"127.0.0.1" port:server.port() protocol:NSURLProtectionSpaceHTTP realm:@"testrealm" authenticationMethod:NSURLAuthenticationMethodHTTPBasic]);
     [[webView configuration].processPool _clearPermanentCredentialsForProtectionSpace:protectionSpace.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
@@ -319,11 +319,11 @@ TEST(WKWebsiteDataStore, RemoveNonPersistentCredentials)
     HTTPServer server(HTTPServer::respondWithChallengeThenOK);
 
     usePersistentCredentialStorage = false;
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     auto websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
     [configuration setWebsiteDataStore:websiteDataStore];
-    auto navigationDelegate = adoptNS([[NavigationTestDelegate alloc] init]);
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[NavigationTestDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
     [navigationDelegate waitForDidFinishNavigation];
@@ -369,7 +369,7 @@ TEST(WKWebsiteDataStore, RemoveNonPersistentCredentials)
 
 TEST(WebKit, SettingNonPersistentDataStorePathsThrowsException)
 {
-    auto configuration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr configuration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
 
     auto shouldThrowExceptionWhenUsed = [](Function<void(void)>&& modifier) {
         @try {
@@ -424,8 +424,8 @@ TEST(WKWebsiteDataStore, FetchPersistentWebStorage)
     TestWebKitAPI::Util::run(&readyToContinue);
 
     @autoreleasepool {
-        auto webView = adoptNS([[WKWebView alloc] init]);
-        auto navigationDelegate = adoptNS([[NavigationTestDelegate alloc] init]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] init]);
+        RetainPtr navigationDelegate = adoptNS([[NavigationTestDelegate alloc] init]);
         [webView setNavigationDelegate:navigationDelegate.get()];
         [webView loadHTMLString:@"<script>sessionStorage.setItem('session', 'storage'); localStorage.setItem('local', 'storage');</script>" baseURL:[NSURL URLWithString:@"http://localhost"]];
         [navigationDelegate waitForDidFinishNavigation];
@@ -443,10 +443,10 @@ TEST(WKWebsiteDataStore, FetchPersistentWebStorage)
 TEST(WKWebsiteDataStore, FetchNonPersistentWebStorage)
 {
     auto nonPersistentDataStore = [WKWebsiteDataStore nonPersistentDataStore];
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:nonPersistentDataStore];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto navigationDelegate = adoptNS([[NavigationTestDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[NavigationTestDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [webView loadHTMLString:@"<script>sessionStorage.setItem('session', 'storage');localStorage.setItem('local', 'storage');</script>" baseURL:[NSURL URLWithString:@"http://localhost"]];
     [navigationDelegate waitForDidFinishNavigation];
@@ -495,19 +495,19 @@ TEST(WKWebsiteDataStore, SessionSetCount)
         return result;
     };
     @autoreleasepool {
-        auto webView0 = adoptNS([WKWebView new]);
+        RetainPtr webView0 = adoptNS([WKWebView new]);
         EXPECT_EQ(countSessionSets(), 0u);
-        auto configuration = adoptNS([WKWebViewConfiguration new]);
+        RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
         EXPECT_NULL(configuration.get()._attributedBundleIdentifier);
         configuration.get()._attributedBundleIdentifier = @"test.bundle.id.1";
-        auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
+        RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
         [webView1 loadHTMLString:@"hi" baseURL:nil];
         EXPECT_EQ(countSessionSets(), 1u);
-        auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
+        RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
         [webView2 loadHTMLString:@"hi" baseURL:nil];
         EXPECT_EQ(countSessionSets(), 1u);
         configuration.get()._attributedBundleIdentifier = @"test.bundle.id.2";
-        auto webView3 = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
+        RetainPtr webView3 = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
         [webView3 loadHTMLString:@"hi" baseURL:nil];
         EXPECT_EQ(countSessionSets(), 2u);
     }
@@ -558,13 +558,13 @@ TEST(WKWebsiteDataStore, ClearCustomDataStoreNoWebViews)
 
 
     NSURL *fileURL = [NSURL fileURLWithPath:@"/tmp/testcookiefile.cookie"];
-    auto configuration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [configuration _setCookieStorageFile:fileURL];
 
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:configuration.get()]);
-    auto viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:configuration.get()]);
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [viewConfiguration setWebsiteDataStore:dataStore.get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:viewConfiguration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:viewConfiguration.get() addToWindow:YES]);
 
     auto *url = [NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/index.html", server.port()]];
 
@@ -587,22 +587,22 @@ TEST(WKWebsiteDataStore, ClearCustomDataStoreNoWebViews)
 
 TEST(WKWebsiteDataStore, DoNotCreateDefaultDataStore)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration.get() copy];
     EXPECT_FALSE([WKWebsiteDataStore _defaultDataStoreExists]);
 }
 
 TEST(WKWebsiteDataStore, DefaultHSTSStorageDirectory)
 {
-    auto configuration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     EXPECT_NOT_NULL(configuration.get().hstsStorageDirectory);
 }
 
 static RetainPtr<WKWebsiteDataStore> createWebsiteDataStoreAndPrepare(NSUUID *uuid, NSString *pushPartition)
 {
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid]);
     websiteDataStoreConfiguration.get().webPushPartitionString = pushPartition;
-    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
     EXPECT_TRUE([websiteDataStoreConfiguration.get().identifier isEqual:uuid]);
     EXPECT_TRUE([websiteDataStore.get()._identifier isEqual:uuid]);
     EXPECT_TRUE([websiteDataStoreConfiguration.get().webPushPartitionString isEqual:pushPartition]);
@@ -610,14 +610,14 @@ static RetainPtr<WKWebsiteDataStore> createWebsiteDataStoreAndPrepare(NSUUID *uu
 
     pid_t webprocessIdentifier;
     @autoreleasepool {
-        auto handler = adoptNS([[TestMessageHandler alloc] init]);
+        RetainPtr handler = adoptNS([[TestMessageHandler alloc] init]);
         [handler addMessage:@"continue" withHandler:^{
             receivedScriptMessage = true;
         }];
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
         [configuration setWebsiteDataStore:websiteDataStore.get()];
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         NSString *htmlString = @"<script> \
             indexedDB.open('testDB').onsuccess = function(event) { \
                 window.webkit.messageHandlers.testHandler.postMessage('continue'); \
@@ -649,7 +649,7 @@ TEST(WKWebsiteDataStore, DataStoreWithIdentifierAndPushPartition)
 TEST(WKWebsiteDataStore, RemoveDataStoreWithIdentifier)
 {
     NSString *uuidString = @"68753a44-4d6f-1226-9c60-0050e4c00067";
-    auto uuid = adoptNS([[NSUUID alloc] initWithUUIDString:uuidString]);
+    RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:uuidString]);
     RetainPtr<NSURL> generalStorageDirectory;
     @autoreleasepool {
         // Make sure WKWebsiteDataStore with identifier does not exist.
@@ -712,11 +712,11 @@ TEST(WKWebsiteDataStore, RemoveDataStoreWithIdentifierRemoveCredentials)
     // FIXME: we should use persistent credential for test after rdar://100722784 is in build.
     usePersistentCredentialStorage = false;
     done = false;
-    auto uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00067"]);
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
+    RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00067"]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
     pid_t networkProcessIdentifier;
     @autoreleasepool {
-        auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+        RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
         [websiteDataStore removeDataOfTypes:[WKWebsiteDataStore _allWebsiteDataTypesIncludingPrivate] modifiedSince:[NSDate distantPast] completionHandler:^{
             done = true;
         }];
@@ -724,10 +724,10 @@ TEST(WKWebsiteDataStore, RemoveDataStoreWithIdentifierRemoveCredentials)
         done = false;
 
         HTTPServer server(HTTPServer::respondWithChallengeThenOK);
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         [configuration setWebsiteDataStore:websiteDataStore.get()];
-        auto navigationDelegate = adoptNS([[NavigationTestDelegate alloc] init]);
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr navigationDelegate = adoptNS([[NavigationTestDelegate alloc] init]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         [webView setNavigationDelegate:navigationDelegate.get()];
         [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
         [navigationDelegate waitForDidFinishNavigation];
@@ -755,7 +755,7 @@ TEST(WKWebsiteDataStore, RemoveDataStoreWithIdentifierRemoveCredentials)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
     [websiteDataStore fetchDataRecordsOfTypes:[NSSet setWithObject:_WKWebsiteDataTypeCredentials] completionHandler:^(NSArray<WKWebsiteDataRecord *> *dataRecords) {
         int credentialCount = dataRecords.count;
         EXPECT_EQ(credentialCount, 0);
@@ -766,11 +766,11 @@ TEST(WKWebsiteDataStore, RemoveDataStoreWithIdentifierRemoveCredentials)
 
 TEST(WKWebsiteDataStore, RemoveDataStoreWithIdentifierErrorWhenInUse)
 {
-    auto uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00067"]);
+    RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00067"]);
     auto websiteDataStore = createWebsiteDataStoreAndPrepare(uuid.get(), @"");
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:websiteDataStore.get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadHTMLString:@"" baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
 
     __block bool done = false;
@@ -814,13 +814,13 @@ TEST(WKWebsiteDataStorePrivate, FetchWithSize)
     }];
     TestWebKitAPI::Util::run(&readyToContinue);
 
-    auto handler = adoptNS([[TestMessageHandler alloc] init]);
+    RetainPtr handler = adoptNS([[TestMessageHandler alloc] init]);
     [handler addMessage:@"continue" withHandler:^{
         receivedScriptMessage = true;
     }];
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     NSString *htmlString = @"<script> \
         localStorage.setItem('key', 'value'); \
         indexedDB.open('testDB').onsuccess = function(event) { \
@@ -880,18 +880,18 @@ TEST(WKWebsiteDataStore, DataStoreForEmptyIdentifier)
 
 TEST(WKWebsiteDataStoreConfiguration, OriginQuotaRatio)
 {
-    auto uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00067"]);
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
+    RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00067"]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
     [websiteDataStoreConfiguration.get() setVolumeCapacityOverride:[NSNumber numberWithInteger:2 * MB]];
     auto ratioNumber = [NSNumber numberWithDouble:0.5];
     [websiteDataStoreConfiguration.get() setOriginQuotaRatio:ratioNumber];
     EXPECT_TRUE([[websiteDataStoreConfiguration.get() originQuotaRatio] isEqualToNumber:ratioNumber]);
-    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
-    auto handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     [configuration setWebsiteDataStore:websiteDataStore.get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     NSString *htmlString = @"<script> \
         var messageSent = false; \
         function sendMessage(message) { \
@@ -920,7 +920,7 @@ TEST(WKWebsiteDataStoreConfiguration, OriginQuotaRatioInvalidValue)
 {
     bool hasException = false;
     @try {
-        auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+        RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
         [websiteDataStoreConfiguration.get() setOriginQuotaRatio:[NSNumber numberWithDouble:-1.0]];
     } @catch (NSException *exception) {
         EXPECT_WK_STREQ(NSInvalidArgumentException, exception.name);
@@ -934,7 +934,7 @@ TEST(WKWebsiteDataStoreConfiguration, TotalQuotaRatio)
 {
     done = false;
     receivedScriptMessage = false;
-    auto uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00067"]);
+    RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00067"]);
     // Clear existing data.
     [WKWebsiteDataStore _removeDataStoreWithIdentifier:uuid.get() completionHandler:^(NSError *error) {
         done = true;
@@ -952,16 +952,16 @@ TEST(WKWebsiteDataStoreConfiguration, TotalQuotaRatio)
             window.webkit.messageHandlers.testHandler.postMessage('error'); \
         }); \
     </script>";
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
     [websiteDataStoreConfiguration.get() setTotalQuotaRatio:[NSNumber numberWithDouble:0.5]];
     [websiteDataStoreConfiguration.get() setVolumeCapacityOverride:[NSNumber numberWithInteger:100000]];
-    auto handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
-    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
     [websiteDataStore _setResourceLoadStatisticsEnabled:NO];
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     [configuration setWebsiteDataStore:websiteDataStore.get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://first.com"]];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
     receivedScriptMessage = false;
@@ -1017,7 +1017,7 @@ TEST(WKWebsiteDataStoreConfiguration, TotalQuotaRatioWithResourceLoadStatisticsE
 {
     done = false;
     receivedScriptMessage = false;
-    auto uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00067"]);
+    RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00067"]);
     // Clear existing data.
     [WKWebsiteDataStore _removeDataStoreWithIdentifier:uuid.get() completionHandler:^(NSError *error) {
         done = true;
@@ -1035,16 +1035,16 @@ TEST(WKWebsiteDataStoreConfiguration, TotalQuotaRatioWithResourceLoadStatisticsE
             window.webkit.messageHandlers.testHandler.postMessage('error'); \
         }); \
     </script>";
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
     [websiteDataStoreConfiguration.get() setTotalQuotaRatio:[NSNumber numberWithDouble:0.5]];
     [websiteDataStoreConfiguration.get() setVolumeCapacityOverride:[NSNumber numberWithDouble:100000]];
-    auto handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
-    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
     [websiteDataStore _setResourceLoadStatisticsEnabled:YES];
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     [configuration setWebsiteDataStore:websiteDataStore.get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://first.com"]];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
     receivedScriptMessage = false;
@@ -1236,7 +1236,7 @@ TEST(WKWebsiteDataStoreConfiguration, TotalQuotaRatioInvalidValue)
 {
     bool hasException = false;
     @try {
-        auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+        RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
         [websiteDataStoreConfiguration.get() setTotalQuotaRatio:[NSNumber numberWithDouble:2.0]];
     } @catch (NSException *exception) {
         EXPECT_WK_STREQ(NSInvalidArgumentException, exception.name);
@@ -1248,7 +1248,7 @@ TEST(WKWebsiteDataStoreConfiguration, TotalQuotaRatioInvalidValue)
 
 TEST(WKWebsiteDataStoreConfiguration, QuotaRatioDefaultValue)
 {
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     EXPECT_TRUE([websiteDataStoreConfiguration.get() originQuotaRatio]);
     EXPECT_EQ([[websiteDataStoreConfiguration.get() originQuotaRatio] doubleValue], 0.6);
 
@@ -1258,24 +1258,24 @@ TEST(WKWebsiteDataStoreConfiguration, QuotaRatioDefaultValue)
 
 TEST(WKWebsiteDataStoreConfiguration, StandardVolumeCapacity)
 {
-    auto uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00067"]);
+    RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00067"]);
     readyToContinue = false;
     [WKWebsiteDataStore _removeDataStoreWithIdentifier:uuid.get() completionHandler:^(NSError *error) {
         readyToContinue = true;
     }];
     TestWebKitAPI::Util::run(&readyToContinue);
 
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
     // Origin quota is 7 MB; standard reported origin quota is 1 MB.
     [websiteDataStoreConfiguration.get() setVolumeCapacityOverride:[NSNumber numberWithInteger:14 * MB]];
     [websiteDataStoreConfiguration.get() setStandardVolumeCapacity:[NSNumber numberWithInteger:2 * MB]];
     [websiteDataStoreConfiguration.get() setOriginQuotaRatio:[NSNumber numberWithDouble:0.5]];
-    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
-    auto handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     [configuration setWebsiteDataStore:websiteDataStore.get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     NSString *htmlString = @"<script> \
         var db = null; \
         var number = 0; \
@@ -1346,9 +1346,9 @@ TEST(WKWebsiteDataStorePrivate, CompletionHandlerForRemovalFromNetworkProcess)
     __block unsigned completionHandlerNumber = 0;
 
     // Create a web view that keeps default network process running.
-    auto defaultConfiguration = adoptNS([WKWebViewConfiguration new]);
-    auto defaultNavigationDelegate = adoptNS([[NavigationTestDelegate alloc] init]);
-    auto defaultWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:defaultConfiguration.get()]);
+    RetainPtr defaultConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr defaultNavigationDelegate = adoptNS([[NavigationTestDelegate alloc] init]);
+    RetainPtr defaultWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:defaultConfiguration.get()]);
     [defaultWebView setNavigationDelegate:defaultNavigationDelegate.get()];
     [defaultWebView loadHTMLString:@"" baseURL:[NSURL URLWithString:@"http://apple.com"]];
     [defaultNavigationDelegate waitForDidFinishNavigation];
@@ -1356,12 +1356,12 @@ TEST(WKWebsiteDataStorePrivate, CompletionHandlerForRemovalFromNetworkProcess)
     @autoreleasepool {
         // Create a new data store to be removed from network process.
         auto websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
-        auto configuration = adoptNS([WKWebViewConfiguration new]);
+        RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
         [configuration setWebsiteDataStore:websiteDataStore];
-        auto handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
+        RetainPtr handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
         [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-        auto navigationDelegate = adoptNS([[NavigationTestDelegate alloc] init]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr navigationDelegate = adoptNS([[NavigationTestDelegate alloc] init]);
         [webView setNavigationDelegate:navigationDelegate.get()];
         [webView loadHTMLString:@"" baseURL:[NSURL URLWithString:@"http://webkit.org/"]];
         [navigationDelegate waitForDidFinishNavigation];
@@ -1419,11 +1419,11 @@ TEST(WKWebsiteDataStore, DoNotLogNetworkConnectionsInEphemeralSessions)
     HTTPServer server { { }, HTTPServer::Protocol::Http };
     server.addResponse("/index.html"_s, { "<html><body>Hello world</body></html>"_s });
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:WKWebsiteDataStore.nonPersistentDataStore];
 
     auto urlToLoad = [NSURL URLWithString:[NSString stringWithFormat:@"http://localhost:%u/index.html", server.port()]];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:urlToLoad]];
 
     EXPECT_EQ(server.totalConnections(), 1U);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebContentProcessDidTerminate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebContentProcessDidTerminate.mm
@@ -108,15 +108,15 @@ static NSString *testHTML = @"<script>window.webkit.messageHandlers.testHandler.
 
 TEST(WKNavigation, FailureToStartWebProcessRecovery)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([[CrashRecoveryScriptMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[CrashRecoveryScriptMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
 
     [configuration.get().processPool _makeNextWebProcessLaunchFailForTesting];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[CrashOnStartNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[CrashOnStartNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     finishedLoad = false;
@@ -135,13 +135,13 @@ TEST(WKNavigation, FailureToStartWebProcessRecovery)
 
 TEST(WKNavigation, FailureToStartWebProcessAfterCrashRecovery)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto handler = adoptNS([[CrashRecoveryScriptMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[CrashRecoveryScriptMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[CrashOnStartNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[CrashOnStartNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     receivedScriptMessage = false;
@@ -182,10 +182,10 @@ TEST(WKNavigation, FailureToStartWebProcessAfterCrashRecovery)
 
 TEST(WKNavigation, AutomaticVisibleViewReloadAfterWebProcessCrash)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
 
-    auto delegate = adoptNS([[BasicNavigationDelegateWithoutCrashHandler alloc] init]);
+    RetainPtr delegate = adoptNS([[BasicNavigationDelegateWithoutCrashHandler alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     startedLoad = false;
@@ -217,10 +217,10 @@ TEST(WKNavigation, AutomaticVisibleViewReloadAfterWebProcessCrash)
 
 TEST(WKNavigation, AutomaticHiddenViewDelayedReloadAfterWebProcessCrash)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
 
-    auto delegate = adoptNS([[BasicNavigationDelegateWithoutCrashHandler alloc] init]);
+    RetainPtr delegate = adoptNS([[BasicNavigationDelegateWithoutCrashHandler alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     // Make sure the view is not visible.
@@ -254,9 +254,9 @@ TEST(WKNavigation, AutomaticHiddenViewDelayedReloadAfterWebProcessCrash)
 
 TEST(WKNavigation, ProcessCrashDuringCallback)
 {
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
-    auto delegate = adoptNS([[BasicNavigationDelegateWithoutCrashHandler alloc] init]);
+    RetainPtr delegate = adoptNS([[BasicNavigationDelegateWithoutCrashHandler alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     startedLoad = false;
@@ -348,8 +348,8 @@ TEST(WKNavigation, ProcessCrashDuringCallback)
 TEST(WKNavigation, ReloadRelatedViewsInProcessDidTerminate)
 {
     const unsigned numberOfViews = 20;
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
 
     Vector<RetainPtr<WKWebView>> webViews;
     webViews.append(webView1);
@@ -358,10 +358,10 @@ TEST(WKNavigation, ReloadRelatedViewsInProcessDidTerminate)
     configuration.get()._relatedWebView = webView1.get();
     ALLOW_DEPRECATED_DECLARATIONS_END
     for (unsigned i = 0; i < numberOfViews - 1; ++i) {
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
         webViews.append(webView);
     }
-    auto delegate = adoptNS([[NavigationDelegateWithCrashHandlerThatLoadsAgain alloc] init]);
+    RetainPtr delegate = adoptNS([[NavigationDelegateWithCrashHandlerThatLoadsAgain alloc] init]);
     for (auto& webView : webViews)
         [webView setNavigationDelegate:delegate.get()];
 
@@ -398,14 +398,14 @@ TEST(WKNavigation, ReloadRelatedViewsInProcessDidTerminate)
 
 TEST(WKNavigation, WebViewURLInProcessDidTerminate)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
 
     [webView synchronouslyLoadTestPageNamed:@"simple"];
     NSString *viewURL = [webView URL].absoluteString;
     EXPECT_TRUE(!!viewURL);
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     __block bool done = false;
@@ -423,13 +423,13 @@ TEST(WKNavigation, WebProcessLimit)
     constexpr unsigned maxProcessCount = 10;
     [WKProcessPool _setWebProcessCountLimit:maxProcessCount];
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
         finishedLoad = true;
     }];
     auto createWebView = [&] {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
         [webView setNavigationDelegate:navigationDelegate.get()];
         finishedLoad = false;
         [webView loadTestPageNamed:@"simple"];
@@ -484,12 +484,12 @@ TEST(WKNavigation, WebProcessLimit)
 
 TEST(WKNavigation, MultipleProcessCrashesRelatedWebViews)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
 
     __block bool webview1FinishedLoad = false;
     __block bool webview2FinishedLoad = false;
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView1 setNavigationDelegate:navigationDelegate.get()];
     [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
         webview1FinishedLoad = true;
@@ -502,7 +502,7 @@ TEST(WKNavigation, MultipleProcessCrashesRelatedWebViews)
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     configuration.get()._relatedWebView = webView1.get();
     ALLOW_DEPRECATED_DECLARATIONS_END
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
     [webView2 setNavigationDelegate:navigationDelegate.get()];
 
     [navigationDelegate setDidFinishNavigation:^(WKWebView *view, WKNavigation *) {
@@ -566,10 +566,10 @@ TEST(WKNavigation, CrashRecoveryRightAfterLoadRequest)
         { "/index.html"_s, { "foo"_s } },
     });
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
 
-    auto navigationDelegate = adoptNS([[BasicNavigationDelegateWithoutCrashHandler alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[BasicNavigationDelegateWithoutCrashHandler alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     // This is to make sure that a WebProcess is launched since we sometimes delay the launch of the

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebCryptoMasterKey.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebCryptoMasterKey.mm
@@ -60,8 +60,8 @@ TEST(WebKit, WebCryptoNilMasterKey)
 {
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"navigation-client-default-crypto" withExtension:@"html"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[WebCryptoMasterKeyNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[WebCryptoMasterKeyNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebLocks.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebLocks.mm
@@ -45,7 +45,7 @@ static void runSnapshotAcrossPagesTest(ShouldUseSameProcess shouldUseSameProcess
         { "/"_s, { "foo"_s } }
     });
 
-    auto configuration1 = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration1 = adoptNS([[WKWebViewConfiguration alloc] init]);
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"WebLocksAPIEnabled"]) {
             [[configuration1 preferences] _setEnabled:YES forFeature:feature];
@@ -53,7 +53,7 @@ static void runSnapshotAcrossPagesTest(ShouldUseSameProcess shouldUseSameProcess
         }
     }
 
-    auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration1.get()]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration1.get()]);
     [webView1 synchronouslyLoadRequest:server.request()];
 
     auto pid1 = [webView1 _webProcessIdentifier];
@@ -69,7 +69,7 @@ static void runSnapshotAcrossPagesTest(ShouldUseSameProcess shouldUseSameProcess
     }];
     TestWebKitAPI::Util::run(&done);
 
-    auto configuration2 = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration2 = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration2.get().processPool = [configuration1 processPool];
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"WebLocksAPIEnabled"]) {
@@ -82,7 +82,7 @@ static void runSnapshotAcrossPagesTest(ShouldUseSameProcess shouldUseSameProcess
         configuration2.get()._relatedWebView = webView1.get();
         ALLOW_DEPRECATED_DECLARATIONS_END
     }
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration2.get()]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration2.get()]);
     [webView2 synchronouslyLoadRequest:server.request()];
 
     auto pid2 = [webView2 _webProcessIdentifier];
@@ -141,7 +141,7 @@ static void runLockRequestWaitingOnAnotherPage(ShouldUseSameProcess shouldUseSam
         { "/"_s, { "foo"_s } }
     });
 
-    auto configuration1 = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration1 = adoptNS([[WKWebViewConfiguration alloc] init]);
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"WebLocksAPIEnabled"]) {
             [[configuration1 preferences] _setEnabled:YES forFeature:feature];
@@ -149,7 +149,7 @@ static void runLockRequestWaitingOnAnotherPage(ShouldUseSameProcess shouldUseSam
         }
     }
 
-    auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration1.get()]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration1.get()]);
     [webView1 synchronouslyLoadRequest:server.request()];
 
     auto pid1 = [webView1 _webProcessIdentifier];
@@ -165,7 +165,7 @@ static void runLockRequestWaitingOnAnotherPage(ShouldUseSameProcess shouldUseSam
     }];
     TestWebKitAPI::Util::run(&done);
 
-    auto configuration2 = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration2 = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration2.get().processPool = [configuration1 processPool];
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"WebLocksAPIEnabled"]) {
@@ -178,7 +178,7 @@ static void runLockRequestWaitingOnAnotherPage(ShouldUseSameProcess shouldUseSam
         configuration2.get()._relatedWebView = webView1.get();
         ALLOW_DEPRECATED_DECLARATIONS_END
     }
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration2.get()]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration2.get()]);
     [webView2 synchronouslyLoadRequest:server.request()];
 
     auto pid2 = [webView2 _webProcessIdentifier];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebProcessKillIDBCleanup.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebProcessKillIDBCleanup.mm
@@ -90,8 +90,8 @@ TEST(IndexedDB, WebProcessKillIDBCleanup)
 
 TEST(IndexedDB, KillWebProcessWithOpenConnection)
 {
-    auto handler = adoptNS([[IndexedDBWebProcessKillMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[IndexedDBWebProcessKillMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
 
     __block bool readyToContinue = false;
@@ -100,13 +100,13 @@ TEST(IndexedDB, KillWebProcessWithOpenConnection)
     }];
     TestWebKitAPI::Util::run(&readyToContinue);
 
-    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     NSURLRequest *request1 = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"KillWebProcessWithOpenConnection-1" withExtension:@"html"]];
     [webView1 loadRequest:request1];
     auto string1 = RetainPtr { getNextMessage().body };
     EXPECT_WK_STREQ(@"Open Succeeded", string1.get());
 
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     NSURLRequest *request2 = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"KillWebProcessWithOpenConnection-2" withExtension:@"html"]];
     [webView2 loadRequest:request2];
     auto string2 = RetainPtr { getNextMessage().body };

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebProcessTerminate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebProcessTerminate.mm
@@ -52,7 +52,7 @@ TEST(WebKit, WebProcessTerminate)
 
 TEST(WebKit, TerminateAllProcessesDuringLaunch)
 {
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
 
     // Initiate a load to make sure the process actually launches.
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebPushDaemon.mm
@@ -923,7 +923,7 @@ public:
             { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScriptSource } }
         }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
 
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         // This step is required early to make sure the first NetworkProcess access has the correct
         // setting in the NetworkProcessInitializationParameters
         if (builtInNotificationsEnabled == BuiltInNotificationsEnabled::Yes)
@@ -992,7 +992,7 @@ public:
 
         [m_webView setUIDelegate:m_delegate.get()];
 
-        auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+        RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
         navigationDelegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
             completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
         };
@@ -1378,8 +1378,8 @@ public:
 
     void SetUp() override
     {
-        auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
-        auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+        RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+        RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
         m_notificationProvider = makeUnique<TestWebKitAPI::TestNotificationProvider>(Vector<WKNotificationManagerRef> { [processPool _notificationManagerForTesting], WKNotificationManagerGetSharedServiceWorkerNotificationManager() });
 
@@ -2683,9 +2683,9 @@ TEST(WebPushD, DeclarativeParsing)
 
     auto utilityConnection = createAndConfigureConnectionToService("org.webkit.webpushtestdaemon.service");
 
-    auto dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     dataStoreConfiguration.get().webPushMachServiceName = @"org.webkit.webpushtestdaemon.service";
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
     clearWebsiteDataStore(dataStore.get());
 
     auto sender = WebPushXPCConnectionMessageSender { utilityConnection.get() };
@@ -2732,13 +2732,13 @@ TEST(WebPushD, DeclarativeWebPushHandling)
 {
     setUpTestWebPushD();
 
-    auto dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    RetainPtr dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     dataStoreConfiguration.get().webPushMachServiceName = @"org.webkit.webpushtestdaemon.service";
     dataStoreConfiguration.get().isDeclarativeWebPushEnabled = YES;
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
     clearWebsiteDataStore(dataStore.get());
 
-    auto delegate = adoptNS([[PushNotificationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[PushNotificationDelegate alloc] init]);
     dataStore.get()._delegate = delegate.get();
 
     auto utilityConnection = createAndConfigureConnectionToService("org.webkit.webpushtestdaemon.service");
@@ -2794,11 +2794,11 @@ TEST(WebPushD, WKWebPushDaemonConnectionRequestPushPermission)
 {
     setUpTestWebPushD();
 
-    auto configuration = adoptNS([[_WKWebPushDaemonConnectionConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[_WKWebPushDaemonConnectionConfiguration alloc] init]);
     configuration.get().machServiceName = @"org.webkit.webpushtestdaemon.service";
     configuration.get().hostApplicationAuditToken = getSelfAuditToken();
-    auto connection = adoptNS([[_WKWebPushDaemonConnection alloc] initWithConfiguration:configuration.get()]);
-    auto url = adoptNS([[NSURL alloc] initWithString:@"https://webkit.org"]);
+    RetainPtr connection = adoptNS([[_WKWebPushDaemonConnection alloc] initWithConfiguration:configuration.get()]);
+    RetainPtr url = adoptNS([[NSURL alloc] initWithString:@"https://webkit.org"]);
 
     __block bool done = false;
     [connection getPushPermissionStateForOrigin:url.get() completionHandler:^(_WKWebPushPermissionState state) {
@@ -2827,13 +2827,13 @@ TEST(WebPushD, WKWebPushDaemonConnectionPushNotifications)
 {
     setUpTestWebPushD();
 
-    auto configuration = adoptNS([[_WKWebPushDaemonConnectionConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[_WKWebPushDaemonConnectionConfiguration alloc] init]);
     configuration.get().machServiceName = @"org.webkit.webpushtestdaemon.service";
     // Bundle identifier is required for making push subscription.
     configuration.get().bundleIdentifierOverrideForTesting = @"com.apple.WebKit.TestWebKitAPI";
     configuration.get().hostApplicationAuditToken = getSelfAuditToken();
-    auto connection = adoptNS([[_WKWebPushDaemonConnection alloc] initWithConfiguration:configuration.get()]);
-    auto url = adoptNS([[NSURL alloc] initWithString:@"https://webkit.org/sw.js"]);
+    RetainPtr connection = adoptNS([[_WKWebPushDaemonConnection alloc] initWithConfiguration:configuration.get()]);
+    RetainPtr url = adoptNS([[NSURL alloc] initWithString:@"https://webkit.org/sw.js"]);
     RetainPtr applicationServerKey = [NSData dataWithBytes:(const void *)validServerKey.characters() length:validServerKey.length()];
 
     __block bool done = false;
@@ -3002,13 +3002,13 @@ TEST(WebPushD, WKWebPushDaemonConnectionSubscribeWithBadIPCVersionRaisesExceptio
     });
     TestWebKitAPI::Util::run(&done);
 
-    auto configuration = adoptNS([[_WKWebPushDaemonConnectionConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[_WKWebPushDaemonConnectionConfiguration alloc] init]);
     configuration.get().machServiceName = @"org.webkit.webpushtestdaemon.service";
     // Bundle identifier is required for making push subscription.
     configuration.get().bundleIdentifierOverrideForTesting = @"com.apple.WebKit.TestWebKitAPI";
     configuration.get().hostApplicationAuditToken = getSelfAuditToken();
-    auto connection = adoptNS([[_WKWebPushDaemonConnection alloc] initWithConfiguration:configuration.get()]);
-    auto url = adoptNS([[NSURL alloc] initWithString:@"https://webkit.org/sw.js"]);
+    RetainPtr connection = adoptNS([[_WKWebPushDaemonConnection alloc] initWithConfiguration:configuration.get()]);
+    RetainPtr url = adoptNS([[NSURL alloc] initWithString:@"https://webkit.org/sw.js"]);
     RetainPtr applicationServerKey = [NSData dataWithBytes:(const void *)validServerKey.characters() length:validServerKey.length()];
 
     done = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebRTC.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebRTC.mm
@@ -141,16 +141,16 @@ TEST(WebKit2, RTCDataChannelPostMessage)
     }, HTTPServer::Protocol::Https);
     auto* request = server.request();
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate setDidReceiveAuthenticationChallenge:^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^callback)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         callback(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
     }];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[WebRTCMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[WebRTCMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"webrtc"];
 
-    auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
     webView1.get().navigationDelegate = navigationDelegate.get();
 
     [messageHandler setMessageHandler:[](WKScriptMessage *message) {
@@ -161,7 +161,7 @@ TEST(WebKit2, RTCDataChannelPostMessage)
     [webView1 loadRequest:request];
     TestWebKitAPI::Util::run(&isReady);
 
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
     webView2.get().navigationDelegate = navigationDelegate.get();
 
     [messageHandler setMessageHandler:[](WKScriptMessage *message) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebSQLBasics.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebSQLBasics.mm
@@ -50,11 +50,11 @@
 
 TEST(WebSQL, OpenDatabaseAlwaysExists)
 {
-    auto handler = adoptNS([[WebSQLBasicsMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[WebSQLBasicsMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     receivedScriptMessage = false;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"opendatabase-always-exists" withExtension:@"html"]];
     [webView loadRequest:request];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebSocket.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebSocket.mm
@@ -83,7 +83,7 @@ TEST(WebSocket, LongMessageNoDeflate)
         "    ws.onmessage = function(msg) { alert(msg.data.length == twoMegabytes ? 'PASS' : 'FAIL - wrong receive length'); };"
         "    ws.onerror = function(error) { alert('FAIL - error ' + error.message); }"
         "</script>", server.port()];
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView loadHTMLString:html baseURL:nil];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "PASS");
 }
@@ -102,9 +102,9 @@ TEST(WebSocket, PageWithAttributedBundleIdentifierDestroyed)
     "</script>", server.port()];
 
     pid_t originalNetworkProcessPID { 0 };
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     __block size_t webSocketsConnected { 0 };
-    auto delegate = adoptNS([TestUIDelegate new]);
+    RetainPtr delegate = adoptNS([TestUIDelegate new]);
     delegate.get().runJavaScriptAlertPanelWithMessage = ^(WKWebView *, NSString *message, WKFrameInfo *, void (^completionHandler)(void)) {
         EXPECT_WK_STREQ(message, "opened successfully");
         webSocketsConnected++;
@@ -185,7 +185,7 @@ TEST(WebSocket, CloseCode)
             vector.append(string[i]);
     };
 
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView loadRequest:httpServer.request("/navigateAway"_s)];
     Util::run(&receivedWebSocketClose);
     Vector<uint8_t> expected { 0x3, 0xe9 }; // NSURLSessionWebSocketCloseCodeGoingAway
@@ -229,13 +229,13 @@ TEST(WebSocket, BlockedWithSubresources)
     "</script>", server.port()];
 
     {
-        auto configuration = adoptNS([WKWebViewConfiguration new]);
+        RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
         configuration.get()._loadsSubresources = NO;
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
         [webView loadHTMLString:html baseURL:nil];
         EXPECT_WK_STREQ([webView _test_waitForAlert], "FAIL - error undefined");
     }
-    auto webView = adoptNS([WKWebView new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
     [webView loadHTMLString:html baseURL:nil];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "opened successfully");
 }
@@ -245,13 +245,13 @@ TEST(WebSocket, LoadRequestWSS)
     HTTPServer tlsServer({ }, HTTPServer::Protocol::HttpsProxy);
     HTTPServer plaintextServer({ });
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", tlsServer.port()]]];
     [storeConfiguration setHTTPProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", plaintextServer.port()]]];
-    auto viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
     [viewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]).get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     webView.get().navigationDelegate = delegate.get();
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebTransport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebTransport.mm
@@ -92,10 +92,10 @@ TEST(WebTransport, ClientBidirectional)
         co_await connection.awaitableSend(WTF::move(request));
     });
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     enableWebTransport(configuration.get());
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     __block bool challenged { false };
     __block uint16_t port = echoServer.port();
@@ -158,10 +158,10 @@ TEST(WebTransport, Datagram)
         co_await datagramConnection.awaitableSend(WTF::move(request));
     });
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     enableWebTransport(configuration.get());
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     __block bool challenged { false };
     __block uint16_t port = echoServer.port();
@@ -217,10 +217,10 @@ TEST(WebTransport, Unidirectional)
         co_await serverUnidirectionalStream.awaitableSend(WTF::move(request));
     });
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     enableWebTransport(configuration.get());
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     __block bool challenged { false };
     __block uint16_t port = echoServer.port();
@@ -267,10 +267,10 @@ TEST(WebTransport, ServerBidirectional)
         co_await serverBidirectionalStream.awaitableSend(WTF::move(request));
     });
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     enableWebTransport(configuration.get());
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     __block bool challenged { false };
     __block uint16_t port = echoServer.port();
@@ -319,10 +319,10 @@ TEST(WebTransport, NetworkProcessCrash)
         co_await uniConnection.awaitableSend(@"abc", false);
     });
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     enableWebTransport(configuration.get());
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
     __block bool challenged { false };
     __block uint16_t port = echoServer.port();
@@ -529,7 +529,7 @@ TEST(WebTransport, Worker)
     RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     enableWebTransport(configuration.get());
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:loadingServer.request()];
@@ -581,7 +581,7 @@ TEST(WebTransport, WorkerAfterNetworkProcessCrash)
     RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     enableWebTransport(configuration.get());
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:loadingServer.request()];
@@ -691,7 +691,7 @@ TEST(WebTransport, CreateStreamsBeforeReady)
     RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     enableWebTransport(configuration.get());
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:delegate.get()];
 
@@ -744,7 +744,7 @@ TEST(WebTransport, DISABLED_CSP)
     RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     enableWebTransport(configuration.get());
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:delegate.get()];
 
@@ -831,10 +831,10 @@ TEST(WebTransport, ServerCertificateHashes)
             "}; test();"
             "</script>", certificateBytes.toString().utf8().data(), echoServer.port()];
 
-        auto configuration = adoptNS([WKWebViewConfiguration new]);
+        RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
         enableWebTransport(configuration.get());
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-        auto delegate = adoptNS([TestNavigationDelegate new]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+        RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
         [webView setNavigationDelegate:delegate.get()];
 
         __block bool challenged { false };
@@ -866,10 +866,10 @@ TEST(WebTransport, ServerConnectionTermination)
         group.cancel();
     });
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     enableWebTransport(configuration.get());
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:delegate.get()];
 
@@ -923,10 +923,10 @@ TEST(WebTransport, BackForwardCache)
         { "/other"_s, { @"<script>alert('loaded')</script>" } }
     });
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     enableWebTransport(configuration.get());
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:delegate.get()];
 
@@ -957,10 +957,10 @@ TEST(WebTransport, ServerDrain)
         group.drainWebTransportSession();
     });
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     enableWebTransport(configuration.get());
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:delegate.get()];
 
@@ -1009,10 +1009,10 @@ TEST(WebTransport, DISABLED_ClientStreamAborts)
         co_await group.awaitableFailure();
     });
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     enableWebTransport(configuration.get());
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:delegate.get()];
 
@@ -1062,10 +1062,10 @@ TEST(WebTransport, DISABLED_ServerStreamAborts)
         co_await group.awaitableFailure();
     });
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     enableWebTransport(configuration.get());
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:delegate.get()];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsiteDataStoreCustomPaths.mm
@@ -285,14 +285,14 @@ TEST(WebKit, CustomDataStoreDestroyWhileFetchingNetworkProcessData)
     NSURL *cookieStorageFile = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/CookieStorage/Cookie.File" stringByExpandingTildeInPath] isDirectory:NO];
     [[NSFileManager defaultManager] removeItemAtURL:cookieStorageFile error:nil];
 
-    auto websiteDataTypes = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeCookies]]);
+    RetainPtr websiteDataTypes = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeCookies]]);
     static bool readyToContinue;
 
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get()._cookieStorageFile = cookieStorageFile;
 
     @autoreleasepool {
-        auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+        RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
 
         // Fetch records
         [dataStore fetchDataRecordsOfTypes:websiteDataTypes.get() completionHandler:^(NSArray<WKWebsiteDataRecord *> *dataRecords) {
@@ -313,7 +313,7 @@ TEST(WebKit, CustomDataStoreDestroyWhileFetchingNetworkProcessData)
     readyToContinue = false;
 
     @autoreleasepool {
-        auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+        RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
         [dataStore fetchDataRecordsOfTypes:websiteDataTypes.get() completionHandler:^(NSArray<WKWebsiteDataRecord *> *dataRecords) {
             EXPECT_EQ((int)dataRecords.count, 0);
             readyToContinue = true;
@@ -386,16 +386,16 @@ TEST(WebKit, AlternativeServicesDefaultDirectoryCreation)
     [[NSFileManager defaultManager] removeItemAtURL:defaultDirectory error:nil];
     EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:defaultDirectory.path]);
 
-    auto webView1 = adoptNS([[TestWKWebView alloc] init]);
+    RetainPtr webView1 = adoptNS([[TestWKWebView alloc] init]);
     [webView1 synchronouslyLoadHTMLString:@"start auxiliary processes" baseURL:nil];
 
 #if HAVE(ALTERNATIVE_SERVICE)
     // We always create the path, even if HTTP/3 is turned off.
     EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:defaultDirectory.path]);
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]).get()]).get()];
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView2 synchronouslyLoadHTMLString:@"start auxiliary processes" baseURL:nil];
 
     EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:defaultDirectory.path]);
@@ -454,12 +454,12 @@ TEST(WebKit, WebsiteDataStoreEphemeralViaConfiguration)
 
 TEST(WebKit, DoLoadWithNonDefaultDataStoreAfterTerminatingNetworkProcess)
 {
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     webViewConfiguration.get().websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get();
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]];
     [webView loadRequest:request];
@@ -482,7 +482,7 @@ TEST(WebKit, WebsiteDataStoreConfigurationPathNull)
 
 TEST(WebKit, WebsiteDataStoreIfExists)
 {
-    auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     EXPECT_FALSE([webViewConfiguration _websiteDataStoreIfExists]);
     WKWebsiteDataStore *dataStore = [webViewConfiguration websiteDataStore];
     EXPECT_TRUE([webViewConfiguration _websiteDataStoreIfExists]);
@@ -499,10 +499,10 @@ TEST(WebKit, WebsiteDataStoreRenameOriginForIndexedDatabase)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto handler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
+    RetainPtr handler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     NSString *testString = @"<script> \
         var request = window.indexedDB.open('testDB'); \
@@ -535,7 +535,7 @@ TEST(WebKit, WebsiteDataStoreRenameOriginForIndexedDatabase)
     [webView stringByEvaluatingJavaScript:@"localStorage.setItem('testkey', 'testvalue')"];
 
     auto dataStore = webView.get().configuration.websiteDataStore;
-    auto indexedDBType = adoptNS([[NSSet alloc] initWithObjects:WKWebsiteDataTypeIndexedDBDatabases, nil]);
+    RetainPtr indexedDBType = adoptNS([[NSSet alloc] initWithObjects:WKWebsiteDataTypeIndexedDBDatabases, nil]);
     [dataStore _renameOrigin:exampleURL to:webKitURL forDataOfTypes:indexedDBType.get() completionHandler:^{
         done = true;
     }];
@@ -560,7 +560,7 @@ TEST(WebKit, WebsiteDataStoreRenameOriginForIndexedDatabase)
 
 TEST(WebKit, WebsiteDataStoreRenameOrigin)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] init]);
     [webView synchronouslyLoadHTMLString:@"<script>localStorage.setItem('testkey', 'testvalue')</script>" baseURL:[NSURL URLWithString:@"https://example.com/"]];
     
     __block bool done = false;
@@ -603,13 +603,13 @@ TEST(WebKit, NetworkCacheDirectory)
     
     NSURL *tempDir = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"CustomPathsTest"] isDirectory:YES];
     
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [websiteDataStoreConfiguration setNetworkCacheDirectory:tempDir];
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
     NSString *path = tempDir.path;
     NSFileManager *fileManager = [NSFileManager defaultManager];
@@ -638,13 +638,13 @@ TEST(WebKit, NetworkCacheExcludedFromBackup)
     [fileManager removeItemAtURL:networkCacheDirectory error:nil];
     [fileManager createDirectoryAtURL:networkCacheDirectory withIntermediateDirectories:YES attributes:nil error:nil];
 
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [websiteDataStoreConfiguration setNetworkCacheDirectory:networkCacheDirectory];
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
 
     NSArray *networkCacheFiles = [fileManager contentsOfDirectoryAtPath:networkCacheDirectory.path error:nil];
@@ -682,9 +682,9 @@ TEST(WebKit, DISABLED_AlternativeService)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtPath:path error:&error];
 
-    auto dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [dataStoreConfiguration setAlternativeServicesStorageDirectory:tempDir];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
 
     __block bool done = false;
     [dataStore fetchDataRecordsOfTypes:[NSSet setWithObject:_WKWebsiteDataTypeAlternativeServices] completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
@@ -693,10 +693,10 @@ TEST(WebKit, DISABLED_AlternativeService)
     }];
     Util::run(&done);
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setWebsiteDataStore:dataStore.get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     delegate.get().didReceiveAuthenticationChallenge = ^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^completionHandler)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
         EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
@@ -779,13 +779,13 @@ TEST(WebKit, MediaCache)
     NSFileManager *fileManager = [NSFileManager defaultManager];
     EXPECT_FALSE([fileManager fileExistsAtPath:path]);
 
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [websiteDataStoreConfiguration setMediaCacheDirectory:tempDir];
 
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [webViewConfiguration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
 
     NSError *error = nil;
@@ -818,17 +818,17 @@ TEST(WebKit, MigrateLocalStorageDataToGeneralStorageDirectory)
             result = '[null]'; \
         window.webkit.messageHandlers.testHandler.postMessage(result); \
         </script>";
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get()._webStorageDirectory = localStorageDirectory;
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelNone;
-    auto messageHandler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
 
     @autoreleasepool {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
         [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         receivedScriptMessage = false;
         [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
         TestWebKitAPI::Util::run(&receivedScriptMessage);
@@ -836,7 +836,7 @@ TEST(WebKit, MigrateLocalStorageDataToGeneralStorageDirectory)
         [webView stringByEvaluatingJavaScript:@"localStorage.setItem('testkey', 'testvalue')"];
 
         // Ensure item is stored by getting it in another WKWebView.
-        auto secondWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr secondWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         receivedScriptMessage = false;
         [secondWebView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
         TestWebKitAPI::Util::run(&receivedScriptMessage);
@@ -847,10 +847,10 @@ TEST(WebKit, MigrateLocalStorageDataToGeneralStorageDirectory)
 
     // Create a new WebsiteDataStore that performs migration.
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelBasic;
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
-    auto thirdWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr thirdWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     receivedScriptMessage = false;
     [thirdWebView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
@@ -899,24 +899,24 @@ TEST(WebKit, MigrateIndexedDBDataToGeneralStorageDirectory)
             }; \
         }; \
         </script>";
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get()._indexedDBDatabaseDirectory = indexedDBDirectory;
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelNone;
-    auto messageHandler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
 
     @autoreleasepool {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
         [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         receivedScriptMessage = false;
         [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
         TestWebKitAPI::Util::run(&receivedScriptMessage);
         EXPECT_WK_STREQ("database is created", getNextMessage().body);
 
         // Ensure item is stored by getting it in another WKWebView.
-        auto secondWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr secondWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         receivedScriptMessage = false;
         [secondWebView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
         TestWebKitAPI::Util::run(&receivedScriptMessage);
@@ -926,10 +926,10 @@ TEST(WebKit, MigrateIndexedDBDataToGeneralStorageDirectory)
 
     // Create a new WebsiteDataStore that performs migration.
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelBasic;
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
-    auto thirdWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr thirdWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     receivedScriptMessage = false;
     [thirdWebView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
@@ -975,12 +975,12 @@ TEST(WebKit, FetchDataAfterEnablingGeneralStorageDirectory)
     [fileManager copyItemAtURL:resourceOriginFile toURL:[webkitGeneralStorageDirectory URLByAppendingPathComponent:@"origin"] error:nil];
     [fileManager copyItemAtURL:resourceLocalStorageFile toURL:webKitGeneralLocalStorageFile error:nil];
 
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get()._webStorageDirectory = customLocalStorageDirectory;
     websiteDataStoreConfiguration.get()._indexedDBDatabaseDirectory = customIndexedDBStorageDirectory;
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelBasic;
-    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
 
     // Ensure data is fetched from both custom path and new path.
     auto dataTypes = [NSSet setWithObjects:WKWebsiteDataTypeLocalStorage, WKWebsiteDataTypeIndexedDBDatabases, nil];
@@ -1053,12 +1053,12 @@ TEST(WebKit, DeleteDataAfterEnablingGeneralStorageDirectory)
     [fileManager copyItemAtURL:resourceOriginFile toURL:[webkitGeneralStorageDirectory URLByAppendingPathComponent:@"origin"] error:nil];
     [fileManager copyItemAtURL:resourceLocalStorageFile toURL:webKitGeneralLocalStorageFile error:nil];
 
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get()._webStorageDirectory = customLocalStorageDirectory;
     websiteDataStoreConfiguration.get()._indexedDBDatabaseDirectory = customIndexedDBStorageDirectory;
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelBasic;
-    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
 
     auto dataTypes = [NSSet setWithObjects:WKWebsiteDataTypeLocalStorage, WKWebsiteDataTypeIndexedDBDatabases, nil];
     done = false;
@@ -1095,15 +1095,15 @@ TEST(WebKit, CreateOriginFileWhenNeeded)
     [fileManager copyItemAtURL:resourceSalt toURL:[generalStorageDirectory URLByAppendingPathComponent:@"salt"] error:nil];
     NSURL *originFile = [generalStorageDirectory URLByAppendingPathComponent:@"YUn_wgR51VLVo9lc5xiivAzZ8TMmojoa0IbW323qibs/YUn_wgR51VLVo9lc5xiivAzZ8TMmojoa0IbW323qibs/origin"];
 
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [fileManager removeItemAtURL:websiteDataStoreConfiguration.get()._webStorageDirectory error:nil];
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelBasic;
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
-    auto handler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
+    RetainPtr handler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     NSString *htmlString = @"<script> \
         localStorage.getItem('testkey'); \
         window.webkit.messageHandlers.testHandler.postMessage('done'); \
@@ -1122,7 +1122,7 @@ TEST(WebKit, CreateOriginFileWhenNeeded)
 
 TEST(WKWebsiteDataStoreConfiguration, SameCustomPathForDifferentTypes)
 {
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     auto dataTypes = [NSSet setWithObjects:WKWebsiteDataTypeLocalStorage, WKWebsiteDataTypeIndexedDBDatabases, WKWebsiteDataTypeCookies, nil];
 
     NSURL *sharedDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/SamePathForDifferentTypes" stringByExpandingTildeInPath] isDirectory:YES];
@@ -1136,12 +1136,12 @@ TEST(WKWebsiteDataStoreConfiguration, SameCustomPathForDifferentTypes)
     websiteDataStoreConfiguration.get().generalStorageDirectory = [sharedDirectory URLByAppendingPathComponent:@"Default" isDirectory:YES];
 
     @autoreleasepool {
-        auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         [configuration setWebsiteDataStore:websiteDataStore.get()];
-        auto messageHandler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
+        RetainPtr messageHandler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
         [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"WebsiteDataStoreCustomPaths" withExtension:@"html"]];
         [webView loadRequest:request];
 
@@ -1165,7 +1165,7 @@ TEST(WKWebsiteDataStoreConfiguration, SameCustomPathForDifferentTypes)
         TestWebKitAPI::Util::run(&done);
     }
 
-    auto newWebsiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr newWebsiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
     done = false;
     [newWebsiteDataStore fetchDataRecordsOfTypes:dataTypes completionHandler:^(NSArray<WKWebsiteDataRecord *> * records) {
         EXPECT_EQ([records count], 1u);
@@ -1189,11 +1189,11 @@ TEST(WebKit, DeleteEmptyOriginDirectoryWhenFetchData)
     [fileManager createDirectoryAtURL:originDirectory withIntermediateDirectories:YES attributes:nil error:nil];
     [fileManager copyItemAtURL:resourceOriginFile toURL:[originDirectory URLByAppendingPathComponent:@"origin"] error:nil];
 
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [fileManager removeItemAtURL:websiteDataStoreConfiguration.get()._webStorageDirectory error:nil];
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelBasic;
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
     done = false;
     [dataStore fetchDataRecordsOfTypes:[NSSet setWithObjects:WKWebsiteDataTypeLocalStorage, nil] completionHandler:^(NSArray<WKWebsiteDataRecord *> * records) {
         done = true;
@@ -1249,16 +1249,16 @@ TEST(WebKit, DeleteEmptyOriginDirectoryWhenOriginIsGone)
     // Baked origin file webkit.org.
     [fileManager copyItemAtURL:resourceOriginFile toURL:[originDirectory URLByAppendingPathComponent:@"origin"] error:nil];
 
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     [fileManager removeItemAtURL:websiteDataStoreConfiguration.get()._webStorageDirectory error:nil];
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelBasic;
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:dataStore.get()];
-    auto handler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
+    RetainPtr handler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     NSString *htmlString = @"<script> \
         localStorage.getItem('testkey'); \
         window.webkit.messageHandlers.testHandler.postMessage('done'); \
@@ -1290,21 +1290,21 @@ TEST(WebKit, OriginDirectoryExcludedFromBackup)
     [fileManager createDirectoryAtURL:generalStorageDirectory withIntermediateDirectories:YES attributes:nil error:nil];
     [fileManager copyItemAtURL:resourceSalt toURL:[generalStorageDirectory URLByAppendingPathComponent:@"salt"] error:nil];
 
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelBasic;
-    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
 
     NSString *htmlString = @"<script> \
         localStorage.setItem('local', 'storage'); \
         sessionStorage.setItem('session', 'storage'); \
         window.webkit.messageHandlers.testHandler.postMessage('done'); \
         </script>";
-    auto handler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     [configuration setWebsiteDataStore:websiteDataStore.get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     receivedScriptMessage = false;
     [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://webkit.org"]];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
@@ -1322,7 +1322,7 @@ TEST(WebKit, OriginDirectoryExcludedFromBackup)
     }];
     TestWebKitAPI::Util::run(&done);
 
-    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     receivedScriptMessage = false;
     [webView2 loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://webkit.org"]];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
@@ -1362,9 +1362,9 @@ TEST(WebKit, RemoveStaleWebSQLData)
     [fileManager copyItemAtURL:resourceSalt toURL:salt error:nil];
 
     // Ensure WebSQL files are deleted.
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get()._webSQLDatabaseDirectory = customWebSQLDirectory;
-    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
     done = false;
     [websiteDataStore fetchDataRecordsOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] completionHandler:^(NSArray*) {
         done = true;
@@ -1398,9 +1398,9 @@ TEST(WKWebsiteDataStore, FetchDiskCacheDataFromDifferentStores)
             connection.send(response);
         });
     });
-    auto uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00067"]);
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
-    auto customWebsiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00067"]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
+    RetainPtr customWebsiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
 
     // Clear data before test.
     auto types = [NSSet setWithObject:WKWebsiteDataTypeDiskCache];
@@ -1423,8 +1423,8 @@ TEST(WKWebsiteDataStore, FetchDiskCacheDataFromDifferentStores)
     TestWebKitAPI::Util::run(&done);
 
     // Create view with default store.
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
 
     static bool cached = false;
@@ -1456,7 +1456,7 @@ TEST(WKWebsiteDataStore, FetchDiskCacheDataFromDifferentStores)
 
     // Create view with custom store.
     [configuration setWebsiteDataStore:customWebsiteDataStore.get()];
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView2 synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
     cached = false;
     while (!cached) {
@@ -1486,18 +1486,18 @@ TEST(WKWebsiteDataStoreConfiguration, InitWithIdentifier)
         document.cookie = \"testkey=value; expires=Mon, 01 Jan 2035 00:00:00 GMT\"; \
     </script>";
     NSString *uuidString = @"68753a44-4d6f-1226-9c60-0050e4c00067";
-    auto uuid = adoptNS([[NSUUID alloc] initWithUUIDString:uuidString]);
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
+    RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:uuidString]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
     NSURL *cookieStorageFile = websiteDataStoreConfiguration.get()._cookieStorageFile;
     EXPECT_TRUE([cookieStorageFile.path containsString:uuidString]);
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtURL:cookieStorageFile error:nil];
     EXPECT_FALSE([fileManager fileExistsAtPath:cookieStorageFile.path]);
 
-    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:websiteDataStore.get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
     while (![fileManager fileExistsAtPath:cookieStorageFile.path])
         TestWebKitAPI::Util::spinRunLoop();
@@ -1513,7 +1513,7 @@ TEST(WKWebsiteDataStoreConfiguration, InitWithInvalidIdentifier)
 {
     bool hasException = false;
     @try {
-        auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:[[NSUUID alloc] initWithUUIDString:@"1234"]]);
+        RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:[[NSUUID alloc] initWithUUIDString:@"1234"]]);
     } @catch (NSException *exception) {
         EXPECT_WK_STREQ(NSInvalidArgumentException, exception.name);
         hasException = true;
@@ -1528,7 +1528,7 @@ TEST(WKWebsiteDataStoreConfiguration, InitWithEmptyIdentifier)
         auto data = [NSMutableData dataWithLength:16];
         unsigned char* dataBytes = (unsigned char*) [data mutableBytes];
         auto emptyUUID = [[NSUUID alloc] initWithUUIDBytes:dataBytes];
-        auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:emptyUUID]);
+        RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:emptyUUID]);
     } @catch (NSException *exception) {
         EXPECT_WK_STREQ(NSInvalidArgumentException, exception.name);
         hasException = true;
@@ -1540,8 +1540,8 @@ TEST(WKWebsiteDataStoreConfiguration, SetPathOnConfigurationWithIdentifier)
 {
     bool hasException = false;
     @try {
-        auto uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753A44-4D6F-1226-9C60-0050E4C00067"]);
-        auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
+        RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753A44-4D6F-1226-9C60-0050E4C00067"]);
+        RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
         NSURL *cookieStorageFile = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/CookieStorage/Cookies.binarycookies" stringByExpandingTildeInPath] isDirectory:NO];
         websiteDataStoreConfiguration.get()._cookieStorageFile = cookieStorageFile;
     } @catch (NSException *exception) {
@@ -1589,17 +1589,17 @@ TEST(WKWebsiteDataStore, MigrateCacheStorageDataToGeneralStorageDirectory)
             window.webkit.messageHandlers.testHandler.postMessage('failed'); \
         }); \
         </script>";
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get()._cacheStorageDirectory = cacheStorageDirectory;
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelNone;
-    auto messageHandler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
 
     @autoreleasepool {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
         [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         receivedScriptMessage = false;
         [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
         TestWebKitAPI::Util::run(&receivedScriptMessage);
@@ -1616,10 +1616,10 @@ TEST(WKWebsiteDataStore, MigrateCacheStorageDataToGeneralStorageDirectory)
 
     // Create a new WebsiteDataStore that performs migration.
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelStandard;
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
-    auto thirdWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr thirdWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     receivedScriptMessage = false;
     [thirdWebView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
@@ -1684,18 +1684,18 @@ TEST(WKWebsiteDataStore, MigrateServiceWorkerRegistrationToGeneralStorageDirecto
         { "/migratetest/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
     });
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get()._serviceWorkerRegistrationDirectory = serviceWorkerDirectory;
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelNone;
-    auto messageHandler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
 
     pid_t networkProcessIdentifier;
     @autoreleasepool {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
         [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         [webView loadRequest:server.request()];
         EXPECT_WK_STREQ("Message from ServiceWorker: Hello", getNextMessage().body);
 
@@ -1716,10 +1716,10 @@ TEST(WKWebsiteDataStore, MigrateServiceWorkerRegistrationToGeneralStorageDirecto
 
     // Create a new WebsiteDataStore that performs migration.
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelStandard;
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get()];
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadRequest:server.request()];
     EXPECT_WK_STREQ("Found registration", getNextMessage().body);
     
@@ -1739,10 +1739,10 @@ TEST(WKWebsiteDataStore, MigrateServiceWorkerRegistrationToGeneralStorageDirecto
 static RetainPtr<WKWebsiteDataStore> createCustomWebsiteDataStoreForServiceWorker(TestWebKitAPI::HTTPServer* server)
 {
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     NSURL *generalStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/Origins" stringByExpandingTildeInPath] isDirectory:YES];
     websiteDataStoreConfiguration.get().generalStorageDirectory = generalStorageDirectory;
-    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
 
     done = false;
     [websiteDataStore removeDataOfTypes:[WKWebsiteDataStore _allWebsiteDataTypesIncludingPrivate] modifiedSince:[NSDate distantPast] completionHandler:^() {
@@ -1752,11 +1752,11 @@ static RetainPtr<WKWebsiteDataStore> createCustomWebsiteDataStoreForServiceWorke
 
     // Ensure web view is closed, so ServiceWorker directory is not in use and can be removed.
     @autoreleasepool {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         [configuration setWebsiteDataStore:websiteDataStore.get()];
-        auto messageHandler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
+        RetainPtr messageHandler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
         [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
-        auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         [webView loadRequest:server->request()];
         EXPECT_WK_STREQ("Message from ServiceWorker: Hello", getNextMessage().body);
 
@@ -1918,10 +1918,10 @@ TEST(WKWebsiteDataStore, FetchAndDeleteMediaKeysData)
     [fileManager copyItemAtURL:resourceSalt toURL:[customVersionDirectory URLByAppendingPathComponent:@"salt"] error:nil];
     NSURL *newWebKitDirectory = [customVersionDirectory URLByAppendingPathComponent:@"XLb5EY_51d2Xcs65bSUthGKAVscdhhcHXCR6DndbBnc"];
 
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get().mediaKeysStorageDirectory = customMediaKeysStorageDirectory;
-    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
-    auto mediaKeysType = adoptNS([[NSSet alloc] initWithObjects:WKWebsiteDataTypeMediaKeys, nil]);
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr mediaKeysType = adoptNS([[NSSet alloc] initWithObjects:WKWebsiteDataTypeMediaKeys, nil]);
 
     done = false;
     __block RetainPtr<NSArray<WKWebsiteDataRecord *>> dataRecords;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm
@@ -115,7 +115,7 @@ static size_t alertCount;
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction preferences:(WKWebpagePreferences *)preferences decisionHandler:(void (^)(WKNavigationActionPolicy, WKWebpagePreferences *))decisionHandler
 {
-    auto websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
+    RetainPtr websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
     switch (alertCount) {
     case 0:
         // Verify the content blockers behave correctly with the default behavior.
@@ -149,7 +149,7 @@ TEST(WebpagePreferences, WebsitePoliciesContentBlockersEnabled)
 {
     [[WKContentRuleListStore defaultStore] _removeAllContentRuleLists];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     doneCompiling = false;
     NSString* contentBlocker = @"[{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\".*\"}}]";
@@ -160,9 +160,9 @@ TEST(WebpagePreferences, WebsitePoliciesContentBlockersEnabled)
     }];
     TestWebKitAPI::Util::run(&doneCompiling);
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[ContentBlockingWebsitePoliciesDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[ContentBlockingWebsitePoliciesDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
 
@@ -199,7 +199,7 @@ TEST(WebpagePreferences, WebsitePoliciesContentBlockersEnabled)
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction preferences:(WKWebpagePreferences *)preferences decisionHandler:(void (^)(WKNavigationActionPolicy, WKWebpagePreferences *))decisionHandler
 {
-    auto websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
+    RetainPtr websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
     if (_allowedAutoplayQuirksForURL)
         [websitePolicies _setAllowedAutoplayQuirks:_allowedAutoplayQuirksForURL(navigationAction.request.URL)];
     if (_autoplayPolicyForURL)
@@ -232,7 +232,7 @@ TEST(WebpagePreferences, WebsitePoliciesContentBlockersEnabled)
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction preferences:(WKWebpagePreferences *)preferences decisionHandler:(void (^)(WKNavigationActionPolicy, WKWebpagePreferences *))decisionHandler
 {
     dispatch_async(mainDispatchQueueSingleton(), ^{
-        auto websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
+        RetainPtr websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
         if (_allowedAutoplayQuirksForURL)
             [websitePolicies _setAllowedAutoplayQuirks:_allowedAutoplayQuirksForURL(navigationAction.request.URL)];
         if (_autoplayPolicyForURL)
@@ -267,16 +267,16 @@ TEST(WebpagePreferences, WebsitePoliciesContentBlockersEnabled)
 
 TEST(WebpagePreferences, WebsitePoliciesAutoplayEnabled)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
 #if PLATFORM(IOS_FAMILY)
     configuration.get().allowsInlineMediaPlayback = YES;
     configuration.get()._inlineMediaPlaybackRequiresPlaysInlineAttribute = NO;
 #endif
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *requestWithAudio = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"autoplay-check" withExtension:@"html"]];
@@ -314,7 +314,7 @@ TEST(WebpagePreferences, WebsitePoliciesAutoplayEnabled)
     [webView waitForMessage:@"did-not-play"];
 
     // Test updating website policies.
-    auto websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
+    RetainPtr websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
     [websitePolicies _setAutoplayPolicy:_WKWebsiteAutoplayPolicyAllow];
     [webView _updateWebpagePreferences:websitePolicies.get()];
     [webView stringByEvaluatingJavaScript:@"playVideo()"];
@@ -369,10 +369,10 @@ static void runUntilReceivesAutoplayEvent(_WKAutoplayEvent event)
 #if PLATFORM(MAC)
 TEST(WebpagePreferences, WebsitePoliciesPlayAfterPreventedAutoplay)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 336, 276) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 336, 276) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
     [delegate setAutoplayPolicyForURL:^(NSURL *) {
         return _WKWebsiteAutoplayPolicyDeny;
     }];
@@ -441,15 +441,15 @@ TEST(WebpagePreferences, WebsitePoliciesPlayAfterPreventedAutoplay)
 
 TEST(WebpagePreferences, WebsitePoliciesPlayingWithUserGesture)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 #if PLATFORM(IOS_FAMILY)
     configuration.get().allowsInlineMediaPlayback = YES;
     configuration.get()._inlineMediaPlaybackRequiresPlaysInlineAttribute = NO;
 #endif
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
     [delegate setAutoplayPolicyForURL:^(NSURL *) {
         return _WKWebsiteAutoplayPolicyAllow;
     }];
@@ -497,15 +497,15 @@ TEST(WebpagePreferences, WebsitePoliciesPlayingWithUserGesture)
 
 TEST(WebpagePreferences, WebsitePoliciesPlayingWithoutInterference)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 #if PLATFORM(IOS_FAMILY)
     configuration.get().allowsInlineMediaPlayback = YES;
     configuration.get()._inlineMediaPlaybackRequiresPlaysInlineAttribute = NO;
 #endif
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 336, 276) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 336, 276) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
     [delegate setAutoplayPolicyForURL:^(NSURL *) {
         return _WKWebsiteAutoplayPolicyAllow;
     }];
@@ -521,15 +521,15 @@ TEST(WebpagePreferences, WebsitePoliciesPlayingWithoutInterference)
 
 TEST(WebpagePreferences, WebsitePoliciesUserInterferenceWithPlaying)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 #if PLATFORM(IOS_FAMILY)
     configuration.get().allowsInlineMediaPlayback = YES;
     configuration.get()._inlineMediaPlaybackRequiresPlaysInlineAttribute = NO;
 #endif
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 336, 276) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 336, 276) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
     [delegate setAutoplayPolicyForURL:^(NSURL *) {
         return _WKWebsiteAutoplayPolicyAllow;
     }];
@@ -582,10 +582,10 @@ TEST(WebpagePreferences, WebsitePoliciesUserInterferenceWithPlaying)
 #if PLATFORM(MAC)
 TEST(WebpagePreferences, WebsitePoliciesPerDocumentAutoplayBehaviorMediaLoading)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool receivedLoadedEvent = false;
@@ -622,9 +622,9 @@ TEST(WebpagePreferences, WebsitePoliciesPerDocumentAutoplayBehaviorMediaLoading)
 
 TEST(WebpagePreferences, WebsitePoliciesWithBridgingCast)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 336, 276) configuration:configuration.get()]);
-    auto delegate = adoptNS([[WebsitePoliciesNavigationDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 336, 276) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[WebsitePoliciesNavigationDelegate alloc] init]);
 
     __block bool didInvokeDecisionHandler = false;
     [delegate setDecidePolicyForNavigationActionWithWebsitePolicies:^(WKNavigationAction *, WKWebpagePreferences *, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
@@ -705,7 +705,7 @@ struct ParsedRange {
     auto& range = *parsedRange.range;
     
     NSDictionary *headerFields = @{ @"Content-Length": [@(range.second - range.first + 1) stringValue], @"Content-Range": [NSString stringWithFormat:@"bytes %lu-%lu/%lu", range.first, range.second, [videoData length]] };
-    auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:task.request.URL statusCode:200 HTTPVersion:(NSString *)kCFHTTPVersion1_1 headerFields:headerFields]);
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:task.request.URL statusCode:200 HTTPVersion:(NSString *)kCFHTTPVersion1_1 headerFields:headerFields]);
     [task didReceiveResponse:response.get()];
     [task didReceiveData:[videoData subdataWithRange:NSMakeRange(range.first, range.second - range.first + 1)]];
     [task didFinish];
@@ -720,12 +720,12 @@ struct ParsedRange {
 
 TEST(WebpagePreferences, WebsitePoliciesDuringRedirect)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto videoData = adoptNS([[NSData alloc] initWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"mp4"]]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr videoData = adoptNS([[NSData alloc] initWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"mp4"]]);
     [configuration setURLSchemeHandler:adoptNS([[TestSchemeHandler alloc] initWithVideoData:WTF::move(videoData)]).get() forURLScheme:@"test"];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     
-    auto delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
     [delegate setAutoplayPolicyForURL:^(NSURL *url) {
         if ([url.path isEqualToString:@"/should-redirect"])
             return _WKWebsiteAutoplayPolicyDeny;
@@ -741,14 +741,14 @@ TEST(WebpagePreferences, WebsitePoliciesDuringRedirect)
 
 TEST(WebpagePreferences, WebsitePoliciesUpdates)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 #if PLATFORM(IOS_FAMILY)
     configuration.get().allowsInlineMediaPlayback = YES;
     configuration.get()._inlineMediaPlaybackRequiresPlaysInlineAttribute = NO;
 #endif
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
 
@@ -760,7 +760,7 @@ TEST(WebpagePreferences, WebsitePoliciesUpdates)
     [webView loadRequest:requestWithAudio];
     [webView waitForMessage:@"did-not-play"];
 
-    auto policies = adoptNS([[WKWebpagePreferences alloc] init]);
+    RetainPtr policies = adoptNS([[WKWebpagePreferences alloc] init]);
     [policies _setAutoplayPolicy:_WKWebsiteAutoplayPolicyAllow];
     [webView _updateWebpagePreferences:policies.get()];
 
@@ -770,7 +770,7 @@ TEST(WebpagePreferences, WebsitePoliciesUpdates)
 
     [webView stringByEvaluatingJavaScript:@"pauseVideo()"];
 
-    auto preferences = adoptNS([[WKWebpagePreferences alloc] init]);
+    RetainPtr preferences = adoptNS([[WKWebpagePreferences alloc] init]);
     [preferences _setAutoplayPolicy:_WKWebsiteAutoplayPolicyDeny];
     [webView _updateWebpagePreferences:preferences.get()];
 
@@ -783,10 +783,10 @@ TEST(WebpagePreferences, WebsitePoliciesUpdates)
 #if PLATFORM(MAC)
 TEST(WebpagePreferences, WebsitePoliciesAutoplayQuirks)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     configuration.get().preferences._needsSiteSpecificQuirks = YES;
@@ -839,9 +839,9 @@ TEST(WebpagePreferences, WebsitePoliciesAutoplayQuirks)
 TEST(WebpagePreferences, WebsitePoliciesPerDocumentAutoplayBehaviorQuirks)
 {
     auto* configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
 
-    auto delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     configuration.preferences._needsSiteSpecificQuirks = YES;
@@ -910,15 +910,15 @@ TEST(WebpagePreferences, WebsitePoliciesPerDocumentAutoplayBehaviorQuirks)
 
 TEST(WebpagePreferences, WebsitePoliciesAutoplayQuirksAsyncPolicyDelegate)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 #if PLATFORM(IOS_FAMILY)
     configuration.get().allowsInlineMediaPlayback = YES;
     configuration.get()._inlineMediaPlaybackRequiresPlaysInlineAttribute = NO;
 #endif
     [configuration preferences].siteSpecificQuirksModeEnabled = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[AsyncAutoplayPoliciesDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[AsyncAutoplayPoliciesDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     NSURLRequest *requestWithAudio = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"autoplay-check" withExtension:@"html"]];
@@ -953,7 +953,7 @@ TEST(WebpagePreferences, WebsitePoliciesAutoplayQuirksAsyncPolicyDelegate)
 
 TEST(WebpagePreferences, InvalidCustomHeaders)
 {
-    auto customHeaderFields = adoptNS([[_WKCustomHeaderFields alloc] init]);
+    RetainPtr customHeaderFields = adoptNS([[_WKCustomHeaderFields alloc] init]);
     [customHeaderFields setFields:@{@"invalidheader" : @"", @"noncustom" : @"header", @"    x-Custom ":@"  Needs Canonicalization\t ", @"x-other" : @"other value"}];
     NSDictionary<NSString *, NSString *> *canonicalized = [customHeaderFields fields];
     EXPECT_EQ(canonicalized.count, 2u);
@@ -993,7 +993,7 @@ static void respond(id <WKURLSchemeTask>task, NSString *html = nil)
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction preferences:(WKWebpagePreferences *)preferences decisionHandler:(void (^)(WKNavigationActionPolicy, WKWebpagePreferences *))decisionHandler
 {
-    auto headerFields = adoptNS([[_WKCustomHeaderFields alloc] init]);
+    RetainPtr headerFields = adoptNS([[_WKCustomHeaderFields alloc] init]);
     [headerFields setFields:@{@"X-key3": @"value3", @"X-key4": @"value4"}];
     [headerFields setThirdPartyDomains:@[
         @"*.hostwithasterisk.com",
@@ -1072,10 +1072,10 @@ static void respond(id <WKURLSchemeTask>task, NSString *html = nil)
 
 TEST(WebpagePreferences, CustomHeaderFields)
 {
-    auto delegate = adoptNS([[CustomHeaderFieldsDelegate alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr delegate = adoptNS([[CustomHeaderFieldsDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:delegate.get() forURLScheme:@"test"];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"test:///mainresource"]]];
     TestWebKitAPI::Util::run(&firstTestDone);
@@ -1120,7 +1120,7 @@ static unsigned loadCount;
     if (_taskHandler)
         _taskHandler(task);
 
-    auto response = adoptNS([[NSURLResponse alloc] initWithURL:finalURL MIMEType:@"text/html" expectedContentLength:1 textEncodingName:nil]);
+    RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:finalURL MIMEType:@"text/html" expectedContentLength:1 textEncodingName:nil]);
     [task didReceiveResponse:response.get()];
 
     if (RetainPtr data = _dataMappings.get([finalURL absoluteString]))
@@ -1146,7 +1146,7 @@ constexpr auto customUserAgent = "Foo Custom UserAgent"_s;
 
 - (void)_webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction preferences:(WKWebpagePreferences *)preferences userInfo:(id <NSSecureCoding>)userInfo decisionHandler:(void (^)(WKNavigationActionPolicy, WKWebpagePreferences *))decisionHandler
 {
-    auto websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
+    RetainPtr websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
     if (navigationAction.targetFrame.mainFrame)
         [websitePolicies _setCustomUserAgent:[NSString stringWithUTF8String:customUserAgent]];
 
@@ -1192,9 +1192,9 @@ onload = () => {
 
 TEST(WebpagePreferences, WebsitePoliciesCustomUserAgent)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto schemeHandler = adoptNS([[DataMappingSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[DataMappingSchemeHandler alloc] init]);
     [schemeHandler addMappingFromURLString:@"test://www.webkit.org/main.html" toData:customUserAgentMainFrameTestBytes];
     [schemeHandler addMappingFromURLString:@"test://www.apple.com/subframe.html" toData:customUserAgentSubFrameTestBytes];
     [schemeHandler setTaskHandler:[](id <WKURLSchemeTask> task) {
@@ -1202,9 +1202,9 @@ TEST(WebpagePreferences, WebsitePoliciesCustomUserAgent)
     }];
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"test"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[CustomUserAgentDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[CustomUserAgentDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     loadCount = 0;
@@ -1238,7 +1238,7 @@ constexpr auto customUserAgentAsSiteSpecificQuirk = "Foo Site Specific Quirks Us
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction preferences:(WKWebpagePreferences *)preferences decisionHandler:(void (^)(WKNavigationActionPolicy, WKWebpagePreferences *))decisionHandler
 {
-    auto websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
+    RetainPtr websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
     if (navigationAction.targetFrame.mainFrame) {
         [websitePolicies _setCustomUserAgentAsSiteSpecificQuirks:[NSString stringWithUTF8String:customUserAgentAsSiteSpecificQuirk]];
         if (_setCustomUserAgent)
@@ -1257,9 +1257,9 @@ constexpr auto customUserAgentAsSiteSpecificQuirk = "Foo Site Specific Quirks Us
 
 TEST(WebpagePreferences, WebsitePoliciesCustomUserAgentAsSiteSpecificQuirksDisabled)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto schemeHandler = adoptNS([[DataMappingSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[DataMappingSchemeHandler alloc] init]);
     [schemeHandler addMappingFromURLString:@"test://www.webkit.org/main.html" toData:customUserAgentMainFrameTestBytes];
     [schemeHandler addMappingFromURLString:@"test://www.apple.com/subframe.html" toData:customUserAgentSubFrameTestBytes];
     [schemeHandler setTaskHandler:[](id <WKURLSchemeTask> task) {
@@ -1270,9 +1270,9 @@ TEST(WebpagePreferences, WebsitePoliciesCustomUserAgentAsSiteSpecificQuirksDisab
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"test"];
     [configuration preferences].siteSpecificQuirksModeEnabled = NO;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[CustomJavaScriptUserAgentDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[CustomJavaScriptUserAgentDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     loadCount = 0;
@@ -1296,9 +1296,9 @@ TEST(WebpagePreferences, WebsitePoliciesCustomUserAgentAsSiteSpecificQuirksDisab
 
 TEST(WebpagePreferences, WebsitePoliciesCustomUserAgentAsSiteSpecificQuirks)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto schemeHandler = adoptNS([[DataMappingSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[DataMappingSchemeHandler alloc] init]);
     [schemeHandler addMappingFromURLString:@"test://www.webkit.org/main.html" toData:customUserAgentMainFrameTestBytes];
     [schemeHandler addMappingFromURLString:@"test://www.apple.com/subframe.html" toData:customUserAgentSubFrameTestBytes];
     [schemeHandler setTaskHandler:[](id <WKURLSchemeTask> task) {
@@ -1307,9 +1307,9 @@ TEST(WebpagePreferences, WebsitePoliciesCustomUserAgentAsSiteSpecificQuirks)
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"test"];
     [configuration preferences].siteSpecificQuirksModeEnabled = YES;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[CustomJavaScriptUserAgentDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[CustomJavaScriptUserAgentDelegate alloc] init]);
     delegate.get().setCustomUserAgent = YES;
     [webView setNavigationDelegate:delegate.get()];
 
@@ -1329,18 +1329,18 @@ TEST(WebpagePreferences, WebsitePoliciesCustomUserAgentAsSiteSpecificQuirks)
 
 TEST(WebpagePreferences, WebViewCustomUserAgentOverridesWebsitePoliciesCustomUserAgentAsSiteSpecificQuirks)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto schemeHandler = adoptNS([[DataMappingSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[DataMappingSchemeHandler alloc] init]);
     [schemeHandler setTaskHandler:[](id<WKURLSchemeTask> task) {
         EXPECT_STREQ(customUserAgentAsSiteSpecificQuirk, [[task.request valueForHTTPHeaderField:@"User-Agent"] UTF8String]);
     }];
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"test"];
     [configuration preferences].siteSpecificQuirksModeEnabled = YES;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[CustomJavaScriptUserAgentDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[CustomJavaScriptUserAgentDelegate alloc] init]);
     delegate.get().setCustomUserAgent = YES;
     [webView setNavigationDelegate:delegate.get()];
 
@@ -1365,7 +1365,7 @@ TEST(WebpagePreferences, WebViewCustomUserAgentOverridesWebsitePoliciesCustomUse
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction preferences:(WKWebpagePreferences *)preferences decisionHandler:(void (^)(WKNavigationActionPolicy, WKWebpagePreferences *))decisionHandler
 {
-    auto websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
+    RetainPtr websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
     if (navigationAction.targetFrame.mainFrame)
         [websitePolicies _setCustomNavigatorPlatform:@"Test Custom Platform"];
 
@@ -1381,11 +1381,11 @@ TEST(WebpagePreferences, WebViewCustomUserAgentOverridesWebsitePoliciesCustomUse
 
 TEST(WebpagePreferences, WebsitePoliciesCustomNavigatorPlatform)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[CustomNavigatorPlatformDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[CustomNavigatorPlatformDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"data:text/html,hello"]];
@@ -1424,7 +1424,7 @@ addEventListener("deviceorientation", (event) => {
 
 - (void)_webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction preferences:(WKWebpagePreferences *)preferences userInfo:(id <NSSecureCoding>)userInfo decisionHandler:(void (^)(WKNavigationActionPolicy, WKWebpagePreferences *))decisionHandler
 {
-    auto websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
+    RetainPtr websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
     [websitePolicies _setDeviceOrientationAndMotionAccessPolicy:_accessPolicy];
 
     decisionHandler(WKNavigationActionPolicyAllow, websitePolicies.get());
@@ -1455,17 +1455,17 @@ static bool calledShouldAllowDeviceOrientationAndMotionAccessDelegate = false;
 
 static void runWebsitePoliciesDeviceOrientationEventTest(_WKWebsiteDeviceOrientationAndMotionAccessPolicy accessPolicy)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto schemeHandler = adoptNS([[DataMappingSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[DataMappingSchemeHandler alloc] init]);
     [schemeHandler addMappingFromURLString:@"test://localhost/main.html" toData:deviceOrientationEventTestBytes];
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"test"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[WebsitePoliciesDeviceOrientationDelegate alloc] initWithDeviceOrientationAccessPolicy:accessPolicy]);
+    RetainPtr delegate = adoptNS([[WebsitePoliciesDeviceOrientationDelegate alloc] initWithDeviceOrientationAccessPolicy:accessPolicy]);
     [webView setNavigationDelegate:delegate.get()];
-    auto uiDelegate = adoptNS([[WebsitePoliciesDeviceOrientationUIDelegate alloc] init]);
+    RetainPtr uiDelegate = adoptNS([[WebsitePoliciesDeviceOrientationUIDelegate alloc] init]);
     [webView setUIDelegate:uiDelegate.get()];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"test://localhost/main.html"]];
@@ -1531,7 +1531,7 @@ TEST(WebpagePreferences, WebsitePoliciesDeviceOrientationAskAccess)
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction preferences:(WKWebpagePreferences *)preferences decisionHandler:(void (^)(WKNavigationActionPolicy, WKWebpagePreferences *))decisionHandler
 {
-    auto websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
+    RetainPtr websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
     if (_popUpPolicyForURL)
         [websitePolicies _setPopUpPolicy:_popUpPolicyForURL(navigationAction.request.URL)];
     decisionHandler(WKNavigationActionPolicyAllow, websitePolicies.get());
@@ -1546,11 +1546,11 @@ TEST(WebpagePreferences, WebsitePoliciesDeviceOrientationAskAccess)
 
 TEST(WebpagePreferences, WebsitePoliciesPopUp)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[PopUpPoliciesDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[PopUpPoliciesDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
 
@@ -1580,7 +1580,7 @@ TEST(WebpagePreferences, WebsitePoliciesPopUp)
 {
     NSURL *url = navigationAction.request.URL;
     if ([url.path isEqualToString:@"/invalid"]) {
-        auto websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
+        RetainPtr websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
         [websitePolicies _setWebsiteDataStore:adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]).get()]).get()];
 
         bool sawException = false;
@@ -1596,12 +1596,12 @@ TEST(WebpagePreferences, WebsitePoliciesPopUp)
     if ([url.path isEqualToString:@"/checkStorage"]
         || [url.path isEqualToString:@"/checkCookies"]
         || [url.path isEqualToString:@"/mainFrame"]) {
-        auto websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
+        RetainPtr websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
         [websitePolicies _setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
         decisionHandler(WKNavigationActionPolicyAllow, websitePolicies.get());
     }
     if ([url.path isEqualToString:@"/subFrame"]) {
-        auto websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
+        RetainPtr websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
         [websitePolicies _setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
         bool sawException = false;
         @try {
@@ -1640,11 +1640,11 @@ TEST(WebpagePreferences, WebsitePoliciesPopUp)
 
 RetainPtr<WKWebView> websiteDataStoreTestWebView()
 {
-    auto delegate = adoptNS([[WebsitePoliciesWebsiteDataStoreDelegate alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr delegate = adoptNS([[WebsitePoliciesWebsiteDataStoreDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:delegate.get() forURLScheme:@"test"];
     [configuration setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
     return webView;
@@ -1653,7 +1653,7 @@ RetainPtr<WKWebView> websiteDataStoreTestWebView()
 TEST(WebpagePreferences, UpdateWebsitePoliciesInvalid)
 {
     auto webView = websiteDataStoreTestWebView();
-    auto policies = adoptNS([[WKWebpagePreferences alloc] init]);
+    RetainPtr policies = adoptNS([[WKWebpagePreferences alloc] init]);
     [policies _setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
     bool sawException = false;
     @try {
@@ -1692,12 +1692,12 @@ TEST(WebpagePreferences, WebsitePoliciesUserContentController)
     auto makeScript = [] (NSString *script, BOOL forMainFrameOnly = YES) {
         return adoptNS([[WKUserScript alloc] initWithSource:script injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:forMainFrameOnly]);
     };
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [[configuration userContentController] addUserScript:makeScript(@"alert('testAlert1')").get()];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
     [webView setUIDelegate:uiDelegate.get()];
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     __block RetainPtr<WKUserContentController> replacementUserContentController;
     __block RetainPtr iframeController = adoptNS([WKUserContentController new]);
     RetainPtr messageHandler = adoptNS([TestScriptMessageHandler new]);
@@ -1706,14 +1706,14 @@ TEST(WebpagePreferences, WebsitePoliciesUserContentController)
         if ([action.request.URL.path hasSuffix:@"/simple-iframe.html"])
             return completionHandler(WKNavigationActionPolicyAllow, nil);
         if ([action.request.URL.path hasSuffix:@"/simple.html"]) {
-            auto preferences = adoptNS([WKWebpagePreferences new]);
+            RetainPtr preferences = adoptNS([WKWebpagePreferences new]);
             [preferences _setUserContentController:iframeController.get()];
             completionHandler(WKNavigationActionPolicyAllow, preferences.get());
             return;
         }
         
         EXPECT_TRUE([action.request.URL.path hasSuffix:@"/simple2.html"]);
-        auto preferences = adoptNS([WKWebpagePreferences new]);
+        RetainPtr preferences = adoptNS([WKWebpagePreferences new]);
         replacementUserContentController = adoptNS([WKUserContentController new]);
         [replacementUserContentController addUserScript:makeScript(@"alert('testAlert2')").get()];
         [preferences _setUserContentController:replacementUserContentController.get()];
@@ -1736,7 +1736,7 @@ TEST(WebpagePreferences, WebsitePoliciesUserContentController)
 
     bool caughtException = false;
     @try {
-        auto preferences = adoptNS([WKWebpagePreferences new]);
+        RetainPtr preferences = adoptNS([WKWebpagePreferences new]);
         [preferences _setUserContentController:adoptNS([WKUserContentController new]).get()];
         [webView _updateWebpagePreferences:preferences.get()];
     } @catch (NSException *exception) {
@@ -1750,11 +1750,11 @@ TEST(WebpagePreferences, WebsitePoliciesUserContentController)
 
 TEST(WebpagePreferences, UserExplicitlyPrefersColorSchemeLight)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     configuration.get().defaultWebpagePreferences._colorSchemePreference = _WKWebsiteColorSchemePreferenceLight;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView forceDarkMode];
 
     [webView loadTestPageNamed:@"color-scheme"];
@@ -1763,11 +1763,11 @@ TEST(WebpagePreferences, UserExplicitlyPrefersColorSchemeLight)
 
 TEST(WebpagePreferences, UserExplicitlyPrefersColorSchemeDark)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     configuration.get().defaultWebpagePreferences._colorSchemePreference = _WKWebsiteColorSchemePreferenceDark;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView loadTestPageNamed:@"color-scheme"];
     [webView waitForMessage:@"dark-detected"];
@@ -1775,8 +1775,8 @@ TEST(WebpagePreferences, UserExplicitlyPrefersColorSchemeDark)
 
 TEST(WebpagePreferences, UserExplicitlyPrefersColorSchemeDarkForContentThatDoesNotSupportDarkMode)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"color-scheme"];
 
     NSString *backgroundColorWithoutPreference = [webView stringByEvaluatingJavaScript:@"getComputedStyle(document.body).backgroundColor"];
@@ -1822,7 +1822,7 @@ TEST(WebpagePreferences, ContentRuleListEnablement)
         "\"action\": { \"type\": \"block\" }"
         "}]";
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration defaultWebpagePreferences] _setContentRuleListsEnabled:YES exceptions:[NSSet setWithObject:identifierToDisable]];
 
     auto rulesToDisable = compileRuleList(identifierToDisable, @(contentRulesToDisable));
@@ -1831,7 +1831,7 @@ TEST(WebpagePreferences, ContentRuleListEnablement)
     auto rulesToEnable = compileRuleList(identifierToEnable, @(contentRulesToEnable));
     [[configuration userContentController] addContentRuleList:rulesToEnable.get()];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     RetainPtr request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://bundle-file/load-image.html"]];
     [webView synchronouslyLoadRequest:request.get()];
 
@@ -1852,7 +1852,7 @@ TEST(WebpagePreferences, ContentRuleListEnablement)
     EXPECT_FALSE(canLoadImage(@"./sunset-in-cupertino-200px.png"));
     EXPECT_TRUE(canLoadImage(@"./sunset-in-cupertino-100px.tiff"));
 
-    auto newPreferences = adoptNS([WKWebpagePreferences new]);
+    RetainPtr newPreferences = adoptNS([WKWebpagePreferences new]);
     [newPreferences _setContentRuleListsEnabled:NO exceptions:[NSSet setWithObject:identifierToEnable]];
     [webView synchronouslyLoadRequest:request.get() preferences:newPreferences.get()];
 
@@ -1863,7 +1863,7 @@ TEST(WebpagePreferences, ContentRuleListEnablement)
 
 TEST(WebpagePreferences, ToggleAdvancedPrivacyProtections)
 {
-    auto preferences = adoptNS([WKWebpagePreferences new]);
+    RetainPtr preferences = adoptNS([WKWebpagePreferences new]);
     EXPECT_FALSE([preferences _networkConnectionIntegrityEnabled]);
     [preferences _setNetworkConnectionIntegrityEnabled:YES];
     EXPECT_TRUE([preferences _networkConnectionIntegrityEnabled]);
@@ -1877,7 +1877,7 @@ TEST(WebpagePreferences, AlternateRequestSPIToAPI)
 {
     RetainPtr request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]];
 
-    auto preferences = adoptNS([WKWebpagePreferences new]);
+    RetainPtr preferences = adoptNS([WKWebpagePreferences new]);
     EXPECT_NULL([preferences alternateRequest]);
     EXPECT_NULL([preferences _alternateRequest]);
 
@@ -1898,7 +1898,7 @@ TEST(WebpagePreferences, OverrideReferrerSPIToAPI)
 {
     NSString *referrer = @"hello";
 
-    auto preferences = adoptNS([WKWebpagePreferences new]);
+    RetainPtr preferences = adoptNS([WKWebpagePreferences new]);
     EXPECT_NULL([preferences overrideReferrer]);
     EXPECT_NULL([preferences _overrideReferrerForAllRequests]);
 
@@ -1919,7 +1919,7 @@ TEST(WebpagePreferences, HttpPageContentBlockers)
 {
     [[WKContentRuleListStore defaultStore] _removeAllContentRuleLists];
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     navigationDelegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         [preferences _setContentBlockersEnabled:YES];
         if (action.targetFrame.mainFrame)
@@ -1942,7 +1942,7 @@ TEST(WebpagePreferences, HttpPageContentBlockers)
         { "/subframe.html"_s, { "<script src='test:///script_subframe.js'></script>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSString *path = task.request.URL.path;
         NSString *type = nil;
@@ -1960,13 +1960,13 @@ TEST(WebpagePreferences, HttpPageContentBlockers)
             return;
         }
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:type expectedContentLength:[result length] textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:type expectedContentLength:[result length] textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[result dataUsingEncoding:NSUTF8StringEncoding]];
         [task didFinish];
     }];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"test"];
 
     doneCompiling = false;
@@ -1978,7 +1978,7 @@ TEST(WebpagePreferences, HttpPageContentBlockers)
     }];
     TestWebKitAPI::Util::run(&doneCompiling);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     [webView loadRequest:server.requestWithLocalhost("/index.html"_s)];
@@ -1999,7 +1999,7 @@ TEST(WebpagePreferences, ExtensionPageContentBlockers)
 {
     [[WKContentRuleListStore defaultStore] _removeAllContentRuleLists];
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     navigationDelegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         [preferences _setContentBlockersEnabled:YES];
         if (action.targetFrame.mainFrame)
@@ -2013,7 +2013,7 @@ TEST(WebpagePreferences, ExtensionPageContentBlockers)
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     __block auto port = server.port();
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSString *path = task.request.URL.path;
         NSString *type = nil;
@@ -2042,13 +2042,13 @@ TEST(WebpagePreferences, ExtensionPageContentBlockers)
             return;
         }
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:type expectedContentLength:[result length] textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:type expectedContentLength:[result length] textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[result dataUsingEncoding:NSUTF8StringEncoding]];
         [task didFinish];
     }];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"test"];
 
     doneCompiling = false;
@@ -2060,7 +2060,7 @@ TEST(WebpagePreferences, ExtensionPageContentBlockers)
     }];
     TestWebKitAPI::Util::run(&doneCompiling);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     auto request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"test:///index.html"]];
@@ -2083,7 +2083,7 @@ TEST(WebpagePreferences, ExtensionPageAdvancedPrivacyProtectionsReferrer)
     auto *store = WKWebsiteDataStore.nonPersistentDataStore;
     store._resourceLoadStatisticsEnabled = YES;
 
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     navigationDelegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         [preferences _setNetworkConnectionIntegrityEnabled:YES];
         if (action.targetFrame.mainFrame)
@@ -2099,7 +2099,7 @@ TEST(WebpagePreferences, ExtensionPageAdvancedPrivacyProtectionsReferrer)
     server.addResponse("/subframe1.html"_s, { makeString("<iframe src='http://127.0.0.1:"_s, server.port(), "/subframe2.html'></iframe>"_s) });
 
     __block auto port = server.port();
-    auto handler = adoptNS([TestURLSchemeHandler new]);
+    RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         NSString *path = task.request.URL.path;
         NSString *type = nil;
@@ -2122,17 +2122,17 @@ TEST(WebpagePreferences, ExtensionPageAdvancedPrivacyProtectionsReferrer)
             return;
         }
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:type expectedContentLength:[result length] textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:type expectedContentLength:[result length] textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[result dataUsingEncoding:NSUTF8StringEncoding]];
         [task didFinish];
     }];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setWebsiteDataStore:store];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"test"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     auto request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"test:///index.html"]];
@@ -2154,7 +2154,7 @@ TEST(WebpagePreferences, ExtensionPageAdvancedPrivacyProtectionsReferrer)
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction preferences:(WKWebpagePreferences *)preferences decisionHandler:(void (^)(WKNavigationActionPolicy, WKWebpagePreferences *))decisionHandler
 {
-    auto websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
+    RetainPtr websitePolicies = adoptNS([[WKWebpagePreferences alloc] init]);
     [websitePolicies _setPushAndNotificationAPIEnabled:_pushAndNotificationAPIEnabled];
     decisionHandler(WKNavigationActionPolicyAllow, websitePolicies.get());
 }
@@ -2166,7 +2166,7 @@ TEST(WebpagePreferences, PushAndNotificationsEnabled)
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[PushAndNotificationsEnabledPoliciesDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[PushAndNotificationsEnabledPoliciesDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool finishedNavigation = false;
@@ -2190,7 +2190,7 @@ TEST(WebpagePreferences, PushAndNotificationsDisabled)
     [[configuration preferences] _setNotificationsEnabled:YES];
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[PushAndNotificationsEnabledPoliciesDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[PushAndNotificationsEnabledPoliciesDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool finishedNavigation = false;
@@ -2209,8 +2209,8 @@ TEST(WebpagePreferences, PushAndNotificationsDisabled)
 
 TEST(WebpagePreferences, LoadHTMLString)
 {
-    auto webView = adoptNS([TestWKWebView new]);
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     __block RetainPtr replacement = adoptNS([WKUserContentController new]);
     RetainPtr messageHandler = adoptNS([TestScriptMessageHandler new]);
     [replacement addScriptMessageHandler:messageHandler.get() name:@"testMessageHandler"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WritingSuggestions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WritingSuggestions.mm
@@ -79,7 +79,7 @@
 
 TEST(WritingSuggestionsWebAPI, DefaultState)
 {
-    auto webView = adoptNS([[WritingSuggestionsWebAPIWKWebView alloc] initWithHTMLString:@"<body><div id='div' contenteditable>This is some text.</div></body>"]);
+    RetainPtr webView = adoptNS([[WritingSuggestionsWebAPIWKWebView alloc] initWithHTMLString:@"<body><div id='div' contenteditable>This is some text.</div></body>"]);
     [webView focusElementAndEnsureEditorStateUpdate:@"document.getElementById('div')"];
 
     EXPECT_EQ(UITextInlinePredictionTypeDefault, [webView effectiveTextInputTraits].inlinePredictionType);
@@ -87,7 +87,7 @@ TEST(WritingSuggestionsWebAPI, DefaultState)
 
 TEST(WritingSuggestionsWebAPI, DefaultStateWithInput)
 {
-    auto webView = adoptNS([[WritingSuggestionsWebAPIWKWebView alloc] initWithHTMLString:@"<body><input id='input' type='text'></input></body>"]);
+    RetainPtr webView = adoptNS([[WritingSuggestionsWebAPIWKWebView alloc] initWithHTMLString:@"<body><input id='input' type='text'></input></body>"]);
     [webView focusElementAndEnsureEditorStateUpdate:@"document.getElementById('input')"];
 
     EXPECT_EQ(UITextInlinePredictionTypeDefault, [webView effectiveTextInputTraits].inlinePredictionType);
@@ -95,7 +95,7 @@ TEST(WritingSuggestionsWebAPI, DefaultStateWithInput)
 
 TEST(WritingSuggestionsWebAPI, ExplicitlyEnabled)
 {
-    auto webView = adoptNS([[WritingSuggestionsWebAPIWKWebView alloc] initWithHTMLString:@"<body><div id='div' contenteditable writingsuggestions='true'>This is some text.</div></body>"]);
+    RetainPtr webView = adoptNS([[WritingSuggestionsWebAPIWKWebView alloc] initWithHTMLString:@"<body><div id='div' contenteditable writingsuggestions='true'>This is some text.</div></body>"]);
     [webView focusElementAndEnsureEditorStateUpdate:@"document.getElementById('div')"];
 
     EXPECT_EQ(UITextInlinePredictionTypeDefault, [webView effectiveTextInputTraits].inlinePredictionType);
@@ -103,7 +103,7 @@ TEST(WritingSuggestionsWebAPI, ExplicitlyEnabled)
 
 TEST(WritingSuggestionsWebAPI, ExplicitlyDisabled)
 {
-    auto webView = adoptNS([[WritingSuggestionsWebAPIWKWebView alloc] initWithHTMLString:@"<body><div id='div' contenteditable writingsuggestions='false'>This is some text.</div></body>"]);
+    RetainPtr webView = adoptNS([[WritingSuggestionsWebAPIWKWebView alloc] initWithHTMLString:@"<body><div id='div' contenteditable writingsuggestions='false'>This is some text.</div></body>"]);
     [webView focusElementAndEnsureEditorStateUpdate:@"document.getElementById('div')"];
 
     EXPECT_EQ(UITextInlinePredictionTypeNo, [webView effectiveTextInputTraits].inlinePredictionType);
@@ -111,7 +111,7 @@ TEST(WritingSuggestionsWebAPI, ExplicitlyDisabled)
 
 TEST(WritingSuggestionsWebAPI, ExplicitlyDisabledOnParent)
 {
-    auto webView = adoptNS([[WritingSuggestionsWebAPIWKWebView alloc] initWithHTMLString:@"<body><div writingsuggestions='false'><div id='div' contenteditable>This is some text.</div></div></body>"]);
+    RetainPtr webView = adoptNS([[WritingSuggestionsWebAPIWKWebView alloc] initWithHTMLString:@"<body><div writingsuggestions='false'><div id='div' contenteditable>This is some text.</div></div></body>"]);
     [webView focusElementAndEnsureEditorStateUpdate:@"document.getElementById('div')"];
 
     EXPECT_EQ(UITextInlinePredictionTypeNo, [webView effectiveTextInputTraits].inlinePredictionType);
@@ -119,7 +119,7 @@ TEST(WritingSuggestionsWebAPI, ExplicitlyDisabledOnParent)
 
 TEST(WritingSuggestionsWebAPI, DefaultStateWithDisabledAutocomplete)
 {
-    auto webView = adoptNS([[WritingSuggestionsWebAPIWKWebView alloc] initWithHTMLString:@"<body><input id='input' type='text' autocomplete='off'></input></body>"]);
+    RetainPtr webView = adoptNS([[WritingSuggestionsWebAPIWKWebView alloc] initWithHTMLString:@"<body><input id='input' type='text' autocomplete='off'></input></body>"]);
     [webView focusElementAndEnsureEditorStateUpdate:@"document.getElementById('input')"];
 
     EXPECT_EQ(UITextInlinePredictionTypeNo, [webView effectiveTextInputTraits].inlinePredictionType);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WritingTools.mm
@@ -346,9 +346,9 @@ static void checkColor(WebCore::CocoaColor *color, std::optional<ColorExpectatio
 
 TEST(WritingTools, ProofreadingAcceptReject)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>"]);
 
     constexpr unsigned start = 0;
     constexpr unsigned end = 14;
@@ -390,8 +390,8 @@ TEST(WritingTools, ProofreadingAcceptReject)
 
         // Test `didReceiveSuggestions`.
 
-        auto firstSuggestion = adoptNS([[WTTextSuggestion alloc] initWithOriginalRange:NSMakeRange(0, 4) replacement:@"ZZZZ"]);
-        auto secondSuggestion = adoptNS([[WTTextSuggestion alloc] initWithOriginalRange:NSMakeRange(10, 4) replacement:@"YYYY"]);
+        RetainPtr firstSuggestion = adoptNS([[WTTextSuggestion alloc] initWithOriginalRange:NSMakeRange(0, 4) replacement:@"ZZZZ"]);
+        RetainPtr secondSuggestion = adoptNS([[WTTextSuggestion alloc] initWithOriginalRange:NSMakeRange(10, 4) replacement:@"YYYY"]);
 
         auto suggestions = [NSMutableArray array];
         [suggestions addObject:firstSuggestion.get()];
@@ -456,9 +456,9 @@ TEST(WritingTools, ProofreadingAcceptReject)
 
 TEST(WritingTools, ProofreadingWithStreamingSuggestions)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='first'>AAAA BBBB CCCC DDDD</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='first'>AAAA BBBB CCCC DDDD</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     NSString *originalText = @"AAAA BBBB CCCC DDDD";
@@ -493,9 +493,9 @@ TEST(WritingTools, ProofreadingWithStreamingSuggestions)
 
 TEST(WritingTools, ProofreadingWithLongReplacement)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='first'>I don't thin so. I didn't quite here him.</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='first'>I don't thin so. I didn't quite here him.</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     NSString *originalText = @"I don't thin so. I didn't quite here him.";
@@ -532,9 +532,9 @@ TEST(WritingTools, ProofreadingWithLongReplacement)
 
 TEST(WritingTools, ProofreadingShowOriginal)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='first'>I don't thin so. I didn't quite here him.</p><p id='second'>Who's over they're. I could come their.</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='first'>I don't thin so. I didn't quite here him.</p><p id='second'>Who's over they're. I could come their.</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     NSString *originalText = @"I don't thin so. I didn't quite here him.\n\nWho's over they're. I could come their.";
@@ -643,9 +643,9 @@ TEST(WritingTools, ProofreadingShowOriginalWithMultiwordSuggestions)
 
 TEST(WritingTools, ProofreadingRevert)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='first'>Look, Ive been really invested on watchin all the dragon ball sagas, i think iv done a prety good job since now.</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='first'>Look, Ive been really invested on watchin all the dragon ball sagas, i think iv done a prety good job since now.</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     NSString *originalText = @"Look, Ive been really invested on watchin all the dragon ball sagas, i think iv done a prety good job since now.";
@@ -686,9 +686,9 @@ TEST(WritingTools, ProofreadingRevert)
 
 TEST(WritingTools, ProofreadingRevertWithSuggestionAtEndOfText)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='first'>Hey wanna go to the movies this weekend</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='first'>Hey wanna go to the movies this weekend</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     NSString *originalText = @"Hey wanna go to the movies this weekend";
@@ -786,9 +786,9 @@ TEST(WritingTools, ProofreadingRevertWithMultiwordSuggestions)
 
 TEST(WritingTools, ProofreadingWithImage)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p>AAAA BBBB</p><img src='sunset-in-cupertino-200px.png'></img><p>CCCC DDDD</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p>AAAA BBBB</p><img src='sunset-in-cupertino-200px.png'></img><p>CCCC DDDD</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     // FIXME: Figure out which one of these newline positions is correct, and fix the discrepancy;
@@ -900,12 +900,12 @@ TEST(WritingTools, ProofreadingWithLinks)
 
 TEST(WritingTools, ProofreadingWithAttemptedEditing)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:nil]);
 
     NSString *originalText = @"I frequetly misspell thigs.";
     NSString *proofreadText = @"I frequently misspell things.";
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:[NSString stringWithFormat:@"<body contenteditable><p>%@</p></body>", originalText]]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:[NSString stringWithFormat:@"<body contenteditable><p>%@</p></body>", originalText]]);
 
     [webView focusDocumentBodyAndSelectAll];
 
@@ -945,9 +945,9 @@ TEST(WritingTools, ProofreadingWithAttemptedEditing)
 
 TEST(WritingTools, ProofreadingReview)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='first'>This is a test of system. This is what we are doings.</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='first'>This is a test of system. This is what we are doings.</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     NSString *originalText = @"This is a test of system. This is what we are doings.";
@@ -964,8 +964,8 @@ TEST(WritingTools, ProofreadingReview)
         [[webView writingToolsDelegate] didBeginWritingToolsSession:session.get() contexts:contexts];
 
         auto suggestions = [NSMutableArray array];
-        auto firstSuggestion = adoptNS([[WTTextSuggestion alloc] initWithOriginalRange:NSMakeRange(15, 2) replacement:@"of the"]);
-        auto secondSuggestion = adoptNS([[WTTextSuggestion alloc] initWithOriginalRange:NSMakeRange(46, 6) replacement:@"doing"]);
+        RetainPtr firstSuggestion = adoptNS([[WTTextSuggestion alloc] initWithOriginalRange:NSMakeRange(15, 2) replacement:@"of the"]);
+        RetainPtr secondSuggestion = adoptNS([[WTTextSuggestion alloc] initWithOriginalRange:NSMakeRange(46, 6) replacement:@"doing"]);
 
         [suggestions addObject:firstSuggestion.get()];
         [suggestions addObject:secondSuggestion.get()];
@@ -1006,11 +1006,11 @@ TEST(WritingTools, ProofreadingReview)
 
 TEST(WritingTools, CompositionWithAttemptedEditing)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
     NSString *source = @"<html><head></head><body contenteditable dir=\"auto\" style=\"overflow-wrap: break-word; -webkit-nbsp-mode: space; line-break: after-white-space;\"><div>An NSAttributedString object manage character strings and associated sets of attributes (for example, font and kerning) that apply to individual characters or ranges of characters in the string. An association of characters and their attributes is called an attributed string. The cluster's two public classes, NSAttributedString and NSMutableAttributedString, declare the programmatic interface for read-only attbuted strings and modifiable attributed strings, respectively.</div><div><br></div><div>An attributed string identifies attributes by name, using an NSDictionary object to store a value under the specified name. You can assign any attribute name/value pair you wish to a range of characters—it is up to your application to interpret custom attributes (see Attributed String Programming Guide). If you are using attributed strings with the Core Text framework, you can also use the attribute keys defined by that framework</div></body></html>";
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:source]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:source]);
     [webView focusDocumentBodyAndSelectAll];
 
     __block bool finished = false;
@@ -1024,7 +1024,7 @@ TEST(WritingTools, CompositionWithAttemptedEditing)
 
         [[webView writingToolsDelegate] writingToolsSession:session.get() didReceiveAction:WTActionCompositionRestart];
 
-        auto attributedText = adoptNS([[NSAttributedString alloc] initWithString:@"NSAttributedString is a class in the Objective-C programming language that represents a string with attributes. It allows you to set and retrieve attributes for individual characters or ranges of characters in the string. NSAttributedString is a subclass of NSMutableAttributedString, which is a class that allows you to modify the attributes of an attributed string."]);
+        RetainPtr attributedText = adoptNS([[NSAttributedString alloc] initWithString:@"NSAttributedString is a class in the Objective-C programming language that represents a string with attributes. It allows you to set and retrieve attributes for individual characters or ranges of characters in the string. NSAttributedString is a subclass of NSMutableAttributedString, which is a class that allows you to modify the attributes of an attributed string."]);
 
         [[webView writingToolsDelegate] compositionSession:session.get() didReceiveText:attributedText.get() replacementRange:NSMakeRange(0, 476) inContext:contexts.firstObject finished:NO];
         // FIXME: Remove this, and all other delays, once there is testing infrastructure in place to be able to wait for animations to finish.
@@ -1035,7 +1035,7 @@ TEST(WritingTools, CompositionWithAttemptedEditing)
 
         NSString *result = @"NSAttributedString is a class in the Objective-C programming language that represents a string with attributes. It allows you to set and retrieve attributes for individual characters or ranges of characters in the string. NSAttributedString is a subclass of NSMutableAttributedString, which is a class that allows you to modify the attributes of an attributed string.\n\nAn attributed string is a type of string that can contain attributes. Attributes are properties that can be set on a string and can be accessed and manipulated by other code. The attributes can be used to add custom information to a string, such as colors, fonts, or images. The Core Text framework provides a set of attribute keys that can be used to define the attributes that can be used in attributed strings.";
 
-        auto longerAttributedText = adoptNS([[NSAttributedString alloc] initWithString:result]);
+        RetainPtr longerAttributedText = adoptNS([[NSAttributedString alloc] initWithString:result]);
 
         [[webView writingToolsDelegate] compositionSession:session.get() didReceiveText:longerAttributedText.get() replacementRange:NSMakeRange(0, 910) inContext:contexts.firstObject finished:NO];
 
@@ -1060,9 +1060,9 @@ TEST(WritingTools, CompositionWithAttemptedEditing)
 
 TEST(WritingTools, CompositionWithUndoAfterEnding)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>Hey do you wanna go see a movie this weekend</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>Hey do you wanna go see a movie this weekend</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     __block bool finished = false;
@@ -1075,7 +1075,7 @@ TEST(WritingTools, CompositionWithUndoAfterEnding)
         __auto_type rewrite = ^(NSString *rewrittenText) {
             [[webView writingToolsDelegate] writingToolsSession:session.get() didReceiveAction:WTActionCompositionRestart];
 
-            auto attributedText = adoptNS([[NSAttributedString alloc] initWithString:rewrittenText]);
+            RetainPtr attributedText = adoptNS([[NSAttributedString alloc] initWithString:rewrittenText]);
 
             [[webView writingToolsDelegate] compositionSession:session.get() didReceiveText:attributedText.get() replacementRange:NSMakeRange(0, 44) inContext:contexts.firstObject finished:NO];
             TestWebKitAPI::Util::runFor(0.1_s);
@@ -1166,9 +1166,9 @@ TEST(WritingTools, CompositionWithMultipleUndoAfterEndingAfterShowOriginalAndRew
 
 TEST(WritingTools, CompositionWithUndo)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>Hey do you wanna go see a movie this weekend</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>Hey do you wanna go see a movie this weekend</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     __block bool finished = false;
@@ -1181,7 +1181,7 @@ TEST(WritingTools, CompositionWithUndo)
         __auto_type rewrite = ^(NSString *rewrittenText) {
             [[webView writingToolsDelegate] writingToolsSession:session.get() didReceiveAction:WTActionCompositionRestart];
 
-            auto attributedText = adoptNS([[NSAttributedString alloc] initWithString:rewrittenText]);
+            RetainPtr attributedText = adoptNS([[NSAttributedString alloc] initWithString:rewrittenText]);
 
             [[webView writingToolsDelegate] compositionSession:session.get() didReceiveText:attributedText.get() replacementRange:NSMakeRange(0, 44) inContext:contexts.firstObject finished:NO];
             TestWebKitAPI::Util::runFor(0.1_s);
@@ -1251,9 +1251,9 @@ TEST(WritingTools, CompositionWithRestart)
 
 TEST(WritingTools, CompositionWithMultipleUndosAndRestarts)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>Hey do you wanna go see a movie this weekend - start</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>Hey do you wanna go see a movie this weekend - start</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     __block bool finished = false;
@@ -1266,7 +1266,7 @@ TEST(WritingTools, CompositionWithMultipleUndosAndRestarts)
         __auto_type rewrite = ^(NSString *rewrittenText) {
             [[webView writingToolsDelegate] writingToolsSession:session.get() didReceiveAction:WTActionCompositionRestart];
 
-            auto attributedText = adoptNS([[NSAttributedString alloc] initWithString:rewrittenText]);
+            RetainPtr attributedText = adoptNS([[NSAttributedString alloc] initWithString:rewrittenText]);
 
             [[webView writingToolsDelegate] compositionSession:session.get() didReceiveText:attributedText.get() replacementRange:NSMakeRange(0, 52) inContext:contexts.firstObject finished:NO];
             TestWebKitAPI::Util::runFor(0.1_s);
@@ -1298,9 +1298,9 @@ TEST(WritingTools, CompositionWithMultipleUndosAndRestarts)
 
 TEST(WritingTools, CompositionWithUndoAndRestart)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>Hey do you wanna go see a movie this weekend</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>Hey do you wanna go see a movie this weekend</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     __block bool finished = false;
@@ -1315,7 +1315,7 @@ TEST(WritingTools, CompositionWithUndoAndRestart)
         __auto_type rewrite = ^(NSString *rewrittenText) {
             [[webView writingToolsDelegate] writingToolsSession:session.get() didReceiveAction:WTActionCompositionRestart];
 
-            auto attributedText = adoptNS([[NSAttributedString alloc] initWithString:rewrittenText]);
+            RetainPtr attributedText = adoptNS([[NSAttributedString alloc] initWithString:rewrittenText]);
 
             [[webView writingToolsDelegate] compositionSession:session.get() didReceiveText:attributedText.get() replacementRange:NSMakeRange(0, 44) inContext:contexts.firstObject finished:NO];
             TestWebKitAPI::Util::runFor(0.1_s);
@@ -1354,9 +1354,9 @@ TEST(WritingTools, CompositionWithUndoAndRestart)
 
 TEST(WritingTools, Composition)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     constexpr unsigned start = 5;
@@ -1397,14 +1397,14 @@ TEST(WritingTools, Composition)
 
         EXPECT_WK_STREQ(@"AAAA BBBB CCCC", [webView contentsAsStringWithoutNBSP]);
 
-        auto attributedText = adoptNS([[NSAttributedString alloc] initWithString:@"ZZZZ"]);
+        RetainPtr attributedText = adoptNS([[NSAttributedString alloc] initWithString:@"ZZZZ"]);
 
         [[webView writingToolsDelegate] compositionSession:session.get() didReceiveText:attributedText.get() replacementRange:NSMakeRange(5, 4) inContext:contexts.firstObject finished:NO];
 
         [webView waitForContentValue:@"AAAA ZZZZ CCCC"];
         EXPECT_WK_STREQ(@"AAAA ZZZZ CCCC", [webView contentsAsStringWithoutNBSP]);
 
-        auto longerAttributedText = adoptNS([[NSAttributedString alloc] initWithString:@"ZZZZX YYY"]);
+        RetainPtr longerAttributedText = adoptNS([[NSAttributedString alloc] initWithString:@"ZZZZX YYY"]);
 
         [[webView writingToolsDelegate] compositionSession:session.get() didReceiveText:longerAttributedText.get() replacementRange:NSMakeRange(5, 9) inContext:contexts.firstObject finished:NO];
 
@@ -1437,9 +1437,9 @@ TEST(WritingTools, Composition)
 
 TEST(WritingTools, CompositionRevert)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     __block bool finished = false;
@@ -1453,7 +1453,7 @@ TEST(WritingTools, CompositionRevert)
 
         EXPECT_WK_STREQ(@"AAAA BBBB CCCC", [webView contentsAsStringWithoutNBSP]);
 
-        auto attributedText = adoptNS([[NSAttributedString alloc] initWithString:@"ZZZZ"]);
+        RetainPtr attributedText = adoptNS([[NSAttributedString alloc] initWithString:@"ZZZZ"]);
 
         [[webView writingToolsDelegate] compositionSession:session.get() didReceiveText:attributedText.get() replacementRange:NSMakeRange(5, 4) inContext:contexts.firstObject finished:NO];
 
@@ -1481,9 +1481,9 @@ TEST(WritingTools, CompositionRevert)
 
 TEST(WritingTools, CompositionWithAttributedStringAttributes)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'><span style=\"color: blue\">AAAA</span> <span style=\"color: red\">BBBB</span> CCCC</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'><span style=\"color: blue\">AAAA</span> <span style=\"color: red\">BBBB</span> CCCC</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     constexpr unsigned start = 0;
@@ -1557,7 +1557,7 @@ TEST(WritingTools, CompositionWithAttributedStringAttributes)
 
         EXPECT_WK_STREQ(@"AAAA BBBB CCCC", [webView contentsAsStringWithoutNBSP]);
 
-        auto attributedText = adoptNS([[NSAttributedString alloc] initWithString:@"ZZZZ" attributes:@{ NSForegroundColorAttributeName : [WebCore::CocoaColor greenColor] }]);
+        RetainPtr attributedText = adoptNS([[NSAttributedString alloc] initWithString:@"ZZZZ" attributes:@{ NSForegroundColorAttributeName : [WebCore::CocoaColor greenColor] }]);
 
         [[webView writingToolsDelegate] compositionSession:session.get() didReceiveText:attributedText.get() replacementRange:NSMakeRange(5, 4) inContext:contexts.firstObject finished:NO];
         TestWebKitAPI::Util::runFor(0.1_s);
@@ -1638,9 +1638,9 @@ TEST(WritingTools, CompositionWithTabCharacters)
 
 TEST(WritingTools, CompositionWithUnderline)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><a href='https://www.webkit.org'>Link</a><br><p>Text</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><a href='https://www.webkit.org'>Link</a><br><p>Text</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     __block bool finished = false;
@@ -1751,9 +1751,9 @@ TEST(WritingTools, CompositionWithTable)
 
 TEST(WritingTools, CompositionWithList)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p>Broccoli, peas, and carrots</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p>Broccoli, peas, and carrots</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     __block bool finished = false;
@@ -1799,9 +1799,9 @@ TEST(WritingTools, CompositionWithList)
 
 TEST(WritingTools, CompositionWithTextAttachment)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p>Sunset in Cupertino</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p>Sunset in Cupertino</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     __block bool finished = false;
@@ -1846,9 +1846,9 @@ RetainPtr<_WKAttachment> synchronouslyInsertAttachmentWithFilename(TestWKWebView
 
 TEST(WritingTools, CompositionWithImageRoundTrip)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<p>AAAA BBBB</p><img src='sunset-in-cupertino-200px.png'></img><p>CCCC DDDD</p>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<p>AAAA BBBB</p><img src='sunset-in-cupertino-200px.png'></img><p>CCCC DDDD</p>"]);
 
     [webView selectAll:nil];
 
@@ -1876,9 +1876,9 @@ TEST(WritingTools, CompositionWithImageRoundTrip)
 
 TEST(WritingTools, CompositionWithImageAttachmentRoundTrip)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<p>AAAA BBBB</p><img src='sunset-in-cupertino-200px.png'></img><p>CCCC DDDD</p>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete attachmentElementEnabled:YES]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<p>AAAA BBBB</p><img src='sunset-in-cupertino-200px.png'></img><p>CCCC DDDD</p>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete attachmentElementEnabled:YES]);
 
     [webView selectAll:nil];
 
@@ -1917,9 +1917,9 @@ TEST(WritingTools, CompositionWithImageAttachmentRoundTrip)
 
 TEST(WritingTools, CompositionWithNonImageAttachmentRoundTrip)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete attachmentElementEnabled:YES]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete attachmentElementEnabled:YES]);
 
     __auto_type modifySelection = ^(unsigned start, unsigned end) {
         NSString *modifySelectionJavascript = [NSString stringWithFormat:@""
@@ -1975,9 +1975,9 @@ TEST(WritingTools, CompositionWithNonImageAttachmentRoundTrip)
 
 TEST(WritingTools, CompositionWithSystemFont)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p style='font: -apple-system-body;'>Early morning in Cupertino</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p style='font: -apple-system-body;'>Early morning in Cupertino</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     __block bool finished = false;
@@ -2002,11 +2002,11 @@ TEST(WritingTools, CompositionWithSystemFont)
 
 TEST(WritingTools, CompositionWithMultipleChunks)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
     NSString *source = @"<html><head></head><body contenteditable dir=\"auto\" style=\"overflow-wrap: break-word; -webkit-nbsp-mode: space; line-break: after-white-space;\"><div>An NSAttributedString object manage character strings and associated sets of attributes (for example, font and kerning) that apply to individual characters or ranges of characters in the string. An association of characters and their attributes is called an attributed string. The cluster's two public classes, NSAttributedString and NSMutableAttributedString, declare the programmatic interface for read-only attbuted strings and modifiable attributed strings, respectively.</div><div><br></div><div>An attributed string identifies attributes by name, using an NSDictionary object to store a value under the specified name. You can assign any attribute name/value pair you wish to a range of characters—it is up to your application to interpret custom attributes (see Attributed String Programming Guide). If you are using attributed strings with the Core Text framework, you can also use the attribute keys defined by that framework</div></body></html>";
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:source]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:source]);
     [webView focusDocumentBodyAndSelectAll];
 
     __block bool finished = false;
@@ -2017,14 +2017,14 @@ TEST(WritingTools, CompositionWithMultipleChunks)
 
         [[webView writingToolsDelegate] writingToolsSession:session.get() didReceiveAction:WTActionCompositionRestart];
 
-        auto attributedText = adoptNS([[NSAttributedString alloc] initWithString:@"NSAttributedString is a class in the Objective-C programming language that represents a string with attributes. It allows you to set and retrieve attributes for individual characters or ranges of characters in the string. NSAttributedString is a subclass of NSMutableAttributedString, which is a class that allows you to modify the attributes of an attributed string."]);
+        RetainPtr attributedText = adoptNS([[NSAttributedString alloc] initWithString:@"NSAttributedString is a class in the Objective-C programming language that represents a string with attributes. It allows you to set and retrieve attributes for individual characters or ranges of characters in the string. NSAttributedString is a subclass of NSMutableAttributedString, which is a class that allows you to modify the attributes of an attributed string."]);
 
         [[webView writingToolsDelegate] compositionSession:session.get() didReceiveText:attributedText.get() replacementRange:NSMakeRange(0, 476) inContext:contexts.firstObject finished:NO];
         TestWebKitAPI::Util::runFor(0.1_s);
 
         NSString *result = @"NSAttributedString is a class in the Objective-C programming language that represents a string with attributes. It allows you to set and retrieve attributes for individual characters or ranges of characters in the string. NSAttributedString is a subclass of NSMutableAttributedString, which is a class that allows you to modify the attributes of an attributed string.\n\nAn attributed string is a type of string that can contain attributes. Attributes are properties that can be set on a string and can be accessed and manipulated by other code. The attributes can be used to add custom information to a string, such as colors, fonts, or images. The Core Text framework provides a set of attribute keys that can be used to define the attributes that can be used in attributed strings.";
 
-        auto longerAttributedText = adoptNS([[NSAttributedString alloc] initWithString:result]);
+        RetainPtr longerAttributedText = adoptNS([[NSAttributedString alloc] initWithString:result]);
 
         [[webView writingToolsDelegate] compositionSession:session.get() didReceiveText:longerAttributedText.get() replacementRange:NSMakeRange(0, 910) inContext:contexts.firstObject finished:NO];
 
@@ -2115,11 +2115,11 @@ TEST(WritingTools, CompositionShowOriginalHasNoTransparentMarkers)
 
 TEST(WritingTools, CompositionWithTrailingNewlines)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
     NSString *source = @"<body contenteditable id='first'><p style=\"margin: 0px;\">Hey wanna go to the movies this weekend</p><p style=\"margin: 0px;\"><br></p><p style=\"margin: 0px;\">A</p></body>";
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:source]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:source]);
     [webView focusDocumentBodyAndSelectAll];
 
     __auto_type modifySelection = ^{
@@ -2153,7 +2153,7 @@ TEST(WritingTools, CompositionWithTrailingNewlines)
         [[webView writingToolsDelegate] writingToolsSession:session.get() didReceiveAction:WTActionCompositionRestart];
         TestWebKitAPI::Util::runFor(0.1_s);
 
-        auto attributedText = adoptNS([[NSAttributedString alloc] initWithString:@"Hey, wanna catch a flick this weekend?"]);
+        RetainPtr attributedText = adoptNS([[NSAttributedString alloc] initWithString:@"Hey, wanna catch a flick this weekend?"]);
 
         [[webView writingToolsDelegate] compositionSession:session.get() didReceiveText:attributedText.get() replacementRange:NSMakeRange(0, 39) inContext:contexts.firstObject finished:NO];
 
@@ -2171,11 +2171,11 @@ TEST(WritingTools, CompositionWithTrailingNewlines)
 
 TEST(WritingTools, CompositionWithTrailingBreaks)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
     NSString *source = @"<html><head></head><body contenteditable dir=\"auto\"><div><div>On Mar 5, 224, Bob wrote:</div><div><p>A</p></div><br></div></body></html>";
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:source]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:source]);
     [webView focusDocumentBodyAndSelectAll];
 
     __block bool finished = false;
@@ -2184,7 +2184,7 @@ TEST(WritingTools, CompositionWithTrailingBreaks)
         [[webView writingToolsDelegate] writingToolsSession:session.get() didReceiveAction:WTActionCompositionRestart];
         TestWebKitAPI::Util::runFor(0.1_s);
 
-        auto attributedText = adoptNS([[NSAttributedString alloc] initWithString:@"On March 5, 224, Bob wrote:\nA\n\n"]);
+        RetainPtr attributedText = adoptNS([[NSAttributedString alloc] initWithString:@"On March 5, 224, Bob wrote:\nA\n\n"]);
 
         [[webView writingToolsDelegate] compositionSession:session.get() didReceiveText:attributedText.get() replacementRange:NSMakeRange(0, 26) inContext:contexts.firstObject finished:NO];
 
@@ -2282,14 +2282,14 @@ TEST(WritingTools, RevealOffScreenSuggestionWhenActive)
 TEST(WritingTools, DISABLED_RevealOffScreenSuggestionWhenActive)
 #endif
 {
-    auto firstSuggestion = adoptNS([[WTTextSuggestion alloc] initWithOriginalRange:NSMakeRange(0, 4) replacement:@"ZZZZ"]);
-    auto secondSuggestion = adoptNS([[WTTextSuggestion alloc] initWithOriginalRange:NSMakeRange(12, 4) replacement:@"YYYY"]);
+    RetainPtr firstSuggestion = adoptNS([[WTTextSuggestion alloc] initWithOriginalRange:NSMakeRange(0, 4) replacement:@"ZZZZ"]);
+    RetainPtr secondSuggestion = adoptNS([[WTTextSuggestion alloc] initWithOriginalRange:NSMakeRange(12, 4) replacement:@"YYYY"]);
 
     auto suggestions = [NSMutableArray array];
     [suggestions addObject:firstSuggestion.get()];
     [suggestions addObject:secondSuggestion.get()];
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable style='font-size: 40px; line-height: 1000px;'><p id='first'>AAAA</p><p id='second'>BBBB</p><p id='third'>CCCC</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable style='font-size: 40px; line-height: 1000px;'><p id='first'>AAAA</p><p id='second'>BBBB</p><p id='third'>CCCC</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     NSString *originalText = @"AAAA\n\nBBBB\n\nCCCC";
@@ -2305,9 +2305,9 @@ TEST(WritingTools, DISABLED_RevealOffScreenSuggestionWhenActive)
     };
 #endif
 
-    auto textViewDelegate = adoptNS([[WKConcreteWTTextViewDelegate alloc] initWithWritingToolsDelegate:[webView writingToolsDelegate] suggestions:suggestions expectedRects:expectedRects]);
+    RetainPtr textViewDelegate = adoptNS([[WKConcreteWTTextViewDelegate alloc] initWithWritingToolsDelegate:[webView writingToolsDelegate] suggestions:suggestions expectedRects:expectedRects]);
 
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:(id<WTTextViewDelegate>)textViewDelegate.get()]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:(id<WTTextViewDelegate>)textViewDelegate.get()]);
     [textViewDelegate setSession:session.get()];
 
     [webView selectAll:nil];
@@ -2352,14 +2352,14 @@ TEST(WritingTools, DISABLED_RevealOffScreenSuggestionWhenActive)
 
 TEST(WritingTools, ShowDetailsForSuggestions)
 {
-    auto firstSuggestion = adoptNS([[WTTextSuggestion alloc] initWithOriginalRange:NSMakeRange(0, 4) replacement:@"ZZZZ"]);
-    auto secondSuggestion = adoptNS([[WTTextSuggestion alloc] initWithOriginalRange:NSMakeRange(10, 4) replacement:@"YYYY"]);
+    RetainPtr firstSuggestion = adoptNS([[WTTextSuggestion alloc] initWithOriginalRange:NSMakeRange(0, 4) replacement:@"ZZZZ"]);
+    RetainPtr secondSuggestion = adoptNS([[WTTextSuggestion alloc] initWithOriginalRange:NSMakeRange(10, 4) replacement:@"YYYY"]);
 
     auto suggestions = [NSMutableArray array];
     [suggestions addObject:firstSuggestion.get()];
     [suggestions addObject:secondSuggestion.get()];
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
 #if PLATFORM(MAC)
@@ -2374,9 +2374,9 @@ TEST(WritingTools, ShowDetailsForSuggestions)
     };
 #endif
 
-    auto textViewDelegate = adoptNS([[WKConcreteWTTextViewDelegate alloc] initWithWritingToolsDelegate:[webView writingToolsDelegate] suggestions:suggestions expectedRects:expectedRects]);
+    RetainPtr textViewDelegate = adoptNS([[WKConcreteWTTextViewDelegate alloc] initWithWritingToolsDelegate:[webView writingToolsDelegate] suggestions:suggestions expectedRects:expectedRects]);
 
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:(id<WTTextViewDelegate>)textViewDelegate.get()]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:(id<WTTextViewDelegate>)textViewDelegate.get()]);
     [textViewDelegate setSession:session.get()];
 
     constexpr unsigned start = 0;
@@ -2444,7 +2444,7 @@ TEST(WritingTools, ShowDetailsForSuggestions)
 
 TEST(WritingTools, WantsInlineEditing)
 {
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable>Hello World</body>" writingToolsBehavior:CocoaWritingToolsBehaviorDefault]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable>Hello World</body>" writingToolsBehavior:CocoaWritingToolsBehaviorDefault]);
 
     [webView _setEditable:NO];
     EXPECT_EQ([webView writingToolsBehaviorForTesting], CocoaWritingToolsBehaviorNone);
@@ -2455,7 +2455,7 @@ TEST(WritingTools, WantsInlineEditing)
 
 TEST(WritingTools, WritingToolsBehaviorNonEditableWithSelection)
 {
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body>Hello World</body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body>Hello World</body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
 
     [webView selectAll:nil];
     [webView waitForNextPresentationUpdate];
@@ -2465,14 +2465,14 @@ TEST(WritingTools, WritingToolsBehaviorNonEditableWithSelection)
 
 TEST(WritingTools, WritingToolsBehaviorWithNoSelection)
 {
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable>Hello World</body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable>Hello World</body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
 
     EXPECT_EQ([webView writingToolsBehaviorForTesting], CocoaWritingToolsBehaviorNone);
 }
 
 TEST(WritingTools, WritingToolsBehaviorEditableWithSelection)
 {
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable>Hello World</body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable>Hello World</body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
     [webView focusDocumentBodyAndSelectAll];
 
     EXPECT_EQ([webView writingToolsBehaviorForTesting], CocoaWritingToolsBehaviorComplete);
@@ -2480,14 +2480,14 @@ TEST(WritingTools, WritingToolsBehaviorEditableWithSelection)
 
 TEST(WritingTools, AllowedInputOptionsNonEditable)
 {
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body></body>"]);
 
     EXPECT_EQ(CocoaWritingToolsResultPlainText | CocoaWritingToolsResultRichText | CocoaWritingToolsResultList | CocoaWritingToolsResultTable, [webView allowedWritingToolsResultOptionsForTesting]);
 }
 
 TEST(WritingTools, AllowedInputOptionsEditable)
 {
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body></body>"]);
     [webView _setEditable:YES];
     [webView focusDocumentBodyAndSelectAll];
 
@@ -2496,7 +2496,7 @@ TEST(WritingTools, AllowedInputOptionsEditable)
 
 TEST(WritingTools, AllowedInputOptionsRichText)
 {
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     EXPECT_EQ(CocoaWritingToolsResultPlainText | CocoaWritingToolsResultRichText | CocoaWritingToolsResultList | CocoaWritingToolsResultTable, [webView allowedWritingToolsResultOptionsForTesting]);
@@ -2504,7 +2504,7 @@ TEST(WritingTools, AllowedInputOptionsRichText)
 
 TEST(WritingTools, AllowedInputOptionsPlainText)
 {
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable=\"plaintext-only\"></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable=\"plaintext-only\"></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     EXPECT_EQ(CocoaWritingToolsResultPlainText, [webView allowedWritingToolsResultOptionsForTesting]);
@@ -2512,7 +2512,7 @@ TEST(WritingTools, AllowedInputOptionsPlainText)
 
 TEST(WritingTools, EphemeralSessionWithDifferingTextLengths)
 {
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<p>AAAA BBBB CCCC DDDD</p><img src='sunset-in-cupertino-200px.png'></img><p>CCCC DDDD</p>" writingToolsBehavior:CocoaWritingToolsBehaviorDefault]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<p>AAAA BBBB CCCC DDDD</p><img src='sunset-in-cupertino-200px.png'></img><p>CCCC DDDD</p>" writingToolsBehavior:CocoaWritingToolsBehaviorDefault]);
     [webView _setEditable:NO];
     [webView selectAll:nil];
 
@@ -2536,7 +2536,7 @@ TEST(WritingTools, EphemeralSessionWithDeeplyNestedContent)
 {
     NSString *text = @"The oceanic whitetip shark is a large requiem shark inhabiting tropical and warm temperate seas. It has a stocky body with long, white-tipped, rounded fins. The species is typically solitary but can congregate around food concentrations.";
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:[NSString stringWithFormat:@"<body><div><div><div><div><div><div><div><div><div><div><p>%@</p></div></div></div></div></div></div></div></div></div></div></body>", text] writingToolsBehavior:CocoaWritingToolsBehaviorDefault]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:[NSString stringWithFormat:@"<body><div><div><div><div><div><div><div><div><div><div><p>%@</p></div></div></div></div></div></div></div></div></div></div></body>", text] writingToolsBehavior:CocoaWritingToolsBehaviorDefault]);
     [webView selectAll:nil];
 
     [webView waitForNextPresentationUpdate];
@@ -2554,7 +2554,7 @@ TEST(WritingTools, EphemeralSessionWithDeeplyNestedContent)
 
 TEST(WritingTools, EphemeralSession)
 {
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='first'>This is the first sentence in a paragraph I want to rewrite. Only this sentence is selected.</p><p id='second'>This is the first sentence of the second paragraph. The previous sentence is selected, but this one is not.</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='first'>This is the first sentence in a paragraph I want to rewrite. Only this sentence is selected.</p><p id='second'>This is the first sentence of the second paragraph. The previous sentence is selected, but this one is not.</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     NSString *setSelectionJavaScript = @""
@@ -2644,9 +2644,9 @@ TEST(WritingTools, TransparencyMarkersForInlineEditing)
 
 TEST(WritingTools, NoCrashWhenWebProcessTerminates)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable>Early morning in Cupertino</body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable>Early morning in Cupertino</body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     auto waitForValue = [webView](NSUInteger expectedValue) {
@@ -2674,7 +2674,7 @@ TEST(WritingTools, NoCrashWhenWebProcessTerminates)
     TestWebKitAPI::Util::run(&finished);
 
     __block bool webProcessTerminated = false;
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *, _WKProcessTerminationReason) {
         webProcessTerminated = true;
@@ -2718,7 +2718,7 @@ TEST(WritingTools, APIWithBehaviorNone)
     }));
 #endif
 
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
 #if PLATFORM(MAC)
     __block RetainPtr<NSMenu> proposedMenu;
@@ -2730,7 +2730,7 @@ TEST(WritingTools, APIWithBehaviorNone)
     }];
 #endif
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorNone]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorNone]);
     [webView setUIDelegate:delegate.get()];
 
     [webView focusDocumentBodyAndSelectAll];
@@ -2768,7 +2768,7 @@ TEST(WritingTools, APIWithBehaviorDefault)
     }));
 #endif
 
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
 #if PLATFORM(MAC)
     __block RetainPtr<NSMenu> proposedMenu;
@@ -2780,7 +2780,7 @@ TEST(WritingTools, APIWithBehaviorDefault)
     }];
 #endif
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorDefault]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorDefault]);
     [webView setUIDelegate:delegate.get()];
 
     [webView focusDocumentBodyAndSelectAll];
@@ -2818,7 +2818,7 @@ TEST(WritingTools, APIWithBehaviorComplete)
     }));
 #endif
 
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
 #if PLATFORM(MAC)
     __block RetainPtr<NSMenu> proposedMenu;
@@ -2830,7 +2830,7 @@ TEST(WritingTools, APIWithBehaviorComplete)
     }];
 #endif
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
     [webView setUIDelegate:delegate.get()];
 
     [webView focusDocumentBodyAndSelectAll];
@@ -2899,7 +2899,7 @@ TEST(WritingTools, APIWithBehaviorComplete)
 static void waitForIsWritingToolsActiveToChange(TestWKWebView *webView, Function<void()>&& trigger)
 {
     bool done = false;
-    auto isWritingToolsActiveObserver = adoptNS([[IsWritingToolsAvailableKVOWrapper alloc] initWithObservable:webView keyPath:@"writingToolsActive" callback:[&] {
+    RetainPtr isWritingToolsActiveObserver = adoptNS([[IsWritingToolsAvailableKVOWrapper alloc] initWithObservable:webView keyPath:@"writingToolsActive" callback:[&] {
         done = true;
     }]);
 
@@ -2911,9 +2911,9 @@ static void waitForIsWritingToolsActiveToChange(TestWKWebView *webView, Function
 
 TEST(WritingTools, IsWritingToolsActiveAPI)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     EXPECT_FALSE([webView isWritingToolsActive]);
@@ -2933,7 +2933,7 @@ TEST(WritingTools, IsWritingToolsActiveAPI)
 
 TEST(WritingTools, IsWritingToolsActiveAPIWithNoInlineEditing)
 {
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     EXPECT_FALSE([webView isWritingToolsActive]);
@@ -2996,7 +2996,7 @@ TEST(WritingTools, ShowAffordance)
         didCallScheduleShowAffordanceForSelectionRect = true;
     }));
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body id='p' contenteditable><p id='first'>AAAA BBBB CCCC</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
     [webView focusDocumentBodyAndSelectAll];
 
     expectScheduleShowAffordanceForSelectionRectCalled(true);
@@ -3043,7 +3043,7 @@ TEST(WritingTools, DISABLED_ShowAffordanceForMultipleLines)
         count++;
     }));
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='first'>AAAA BBBB CCCC</p><p>DDDD</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='first'>AAAA BBBB CCCC</p><p>DDDD</p></body>" writingToolsBehavior:CocoaWritingToolsBehaviorComplete]);
     [webView focusDocumentBodyAndSelectAll];
 
     expectScheduleShowAffordanceForSelectionRectCalled(true);
@@ -3218,7 +3218,7 @@ TEST(WritingTools, FocusWebViewAfterAnimation)
 
         EXPECT_WK_STREQ(@"AAAA BBBB CCCC", [webView contentsAsStringWithoutNBSP]);
 
-        auto attributedText = adoptNS([[NSAttributedString alloc] initWithString:@"ZZZZ"]);
+        RetainPtr attributedText = adoptNS([[NSAttributedString alloc] initWithString:@"ZZZZ"]);
 
         [[webView writingToolsDelegate] compositionSession:session.get() didReceiveText:attributedText.get() replacementRange:NSMakeRange(0, 14) inContext:contexts.firstObject finished:NO];
 
@@ -3555,9 +3555,9 @@ TEST(WritingTools, AppMenuEditableEmpty)
 
 TEST(WritingTools, SmartRepliesMatchStyle)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable style='font-size: 30px;'><p id='p'></p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable style='font-size: 30px;'><p id='p'></p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     NSString *setSelectionJavaScript = @""
@@ -3691,9 +3691,9 @@ TEST(WritingTools, ContextRangeWithNoSelection)
 
 TEST(WritingTools, ContextRangeFromCaretSelection)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable id='p'><p>AAAA BBBB CCCC</p><p>XXXX YYYY ZZZZ</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable id='p'><p>AAAA BBBB CCCC</p><p>XXXX YYYY ZZZZ</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     NSString *setSelectionJavaScript = @""
@@ -3745,9 +3745,9 @@ TEST(WritingTools, ContextRangeFromCaretSelection)
 
 TEST(WritingTools, ContextRangeFromRangeSelection)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable id='p'><p>AAAA BBBB CCCC</p><p>XXXX YYYY ZZZZ</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable id='p'><p>AAAA BBBB CCCC</p><p>XXXX YYYY ZZZZ</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     NSString *setSelectionJavaScript = @""
@@ -3811,10 +3811,10 @@ TEST(WritingTools, ContextRangeFromRangeSelection)
 
 TEST(WritingTools, SuggestedTextIsSelectedAfterSmartReply)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
     [session setCompositionSessionType:WTCompositionSessionTypeSmartReply];
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='p'>AAAA</p><p>BBBB</p></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='p'>AAAA</p><p>BBBB</p></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     NSString *setSelectionJavaScript = @""
@@ -3933,9 +3933,9 @@ TEST(WritingTools, SuggestedTextIsSelectedAfterCompose)
 
 TEST(WritingTools, BlockquoteAndPreContentsAreIgnored)
 {
-    auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
 
-    auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p>AAAA</p><blockquote>BBBB</blockquote><p>CCCC</p><pre>DDDD</pre></body>"]);
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p>AAAA</p><blockquote>BBBB</blockquote><p>CCCC</p><pre>DDDD</pre></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
     __block bool finished = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/YoutubeReplacementPlugin.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/YoutubeReplacementPlugin.mm
@@ -30,8 +30,8 @@
 
 TEST(YoutubeReplacementPlugin, CannotRunScript)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
     NSString *body = @"PASS<object data=\"http://youtu.be/\" type=\"application/futuresplash\"><param name=\"src\" value=\"javascript:top.document.write('FAIL');\"></param></object>";
     [webView synchronouslyLoadHTMLString:body];
     NSString *bodyHTML = [webView stringByEvaluatingJavaScript:@"document.body.innerText"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKInputDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKInputDelegate.mm
@@ -183,8 +183,8 @@ TEST(WebKit, FormSubmissionLegacyAPI)
 
 TEST(WebKit, FocusedElementInfo)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([[InputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[InputDelegate alloc] init]);
     [webView _setInputDelegate:delegate.get()];
 
     __block RetainPtr<id <_WKFocusedElementInfo>> currentElement;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm
@@ -163,7 +163,7 @@ static bool laContextRequested = false;
 - (void)panel:(_WKWebAuthenticationPanel *)panel selectAssertionResponse:(NSArray < _WKWebAuthenticationAssertionResponse *> *)responses source:(_WKWebAuthenticationSource)source completionHandler:(void (^)(_WKWebAuthenticationAssertionResponse *))completionHandler
 {
     if (responses.count == 1) {
-        auto laContext = adoptNS([[LAContext alloc] init]);
+        RetainPtr laContext = adoptNS([[LAContext alloc] init]);
         [responses.firstObject setLAContext:laContext.get()];
 
         completionHandler(responses.firstObject);
@@ -175,7 +175,7 @@ static bool laContextRequested = false;
     if (source == _WKWebAuthenticationSourceLocal) {
         auto *object = responses.lastObject;
 
-        auto laContext = adoptNS([[LAContext alloc] init]);
+        RetainPtr laContext = adoptNS([[LAContext alloc] init]);
         [object setLAContext:laContext.get()];
 
         webAuthenticationPanelSelectedCredentialName = object.name;
@@ -372,8 +372,8 @@ bool addKeyToKeychain(const String& privateKeyBase64, const String& rpId, const 
     if (errorRef)
         return false;
 
-    auto credentialID = adoptNS([[NSData alloc] initWithBase64EncodedString:@"SMSXHngF7hEOsElA73C3RY+8bR4=" options:0]);
-    auto addQuery = adoptNS([[NSMutableDictionary alloc] init]);
+    RetainPtr credentialID = adoptNS([[NSData alloc] initWithBase64EncodedString:@"SMSXHngF7hEOsElA73C3RY+8bR4=" options:0]);
+    RetainPtr addQuery = adoptNS([[NSMutableDictionary alloc] init]);
     [addQuery setDictionary:@{
         (id)kSecValueRef: (id)key.get(),
         (id)kSecClass: (id)kSecClassKey,
@@ -419,7 +419,7 @@ static RetainPtr<TestWKWebView> setUpTestWebViewForTestAuthenticationPanel()
     auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration _setAllowTestOnlyIPC:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
     return webView;
 }
 
@@ -463,7 +463,7 @@ TEST(WebAuthenticationPanel, PanelHidSuccess1)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -487,7 +487,7 @@ TEST(WebAuthenticationPanel, PanelHidSuccess2)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -511,7 +511,7 @@ TEST(WebAuthenticationPanel, PanelRacy1)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-nfc" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [delegate setIsRacy:true];
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -532,7 +532,7 @@ TEST(WebAuthenticationPanel, PanelRacy2)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-nfc" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [delegate setIsRacy:true];
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -558,7 +558,7 @@ TEST(WebAuthenticationPanel, PanelTwice)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -578,7 +578,7 @@ TEST(WebAuthenticationPanel, ReloadHidCancel)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -595,7 +595,7 @@ TEST(WebAuthenticationPanel, LocationChangeHidCancel)
     RetainPtr<NSURL> otherURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -612,7 +612,7 @@ TEST(WebAuthenticationPanel, NewLoadHidCancel)
     RetainPtr<NSURL> otherURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -628,7 +628,7 @@ TEST(WebAuthenticationPanel, CloseHidCancel)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -665,7 +665,7 @@ TEST(WebAuthenticationPanel, SubFrameChangeLocationHidCancel)
     });
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -709,7 +709,7 @@ TEST(WebAuthenticationPanel, SubFrameDestructionHidCancel)
     });
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -725,7 +725,7 @@ TEST(WebAuthenticationPanel, PanelHidCancel)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -751,7 +751,7 @@ TEST(WebAuthenticationPanel, PanelHidCtapNoCredentialsFound)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-no-credentials" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -766,7 +766,7 @@ TEST(WebAuthenticationPanel, PanelU2fCtapNoCredentialsFound)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-u2f-no-credentials" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -786,7 +786,7 @@ TEST(WebAuthenticationPanel, FakePanelHidSuccess)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [delegate setIsFake:true];
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -802,7 +802,7 @@ TEST(WebAuthenticationPanel, FakePanelHidCtapNoCredentialsFound)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-no-credentials" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [delegate setIsFake:true];
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -823,7 +823,7 @@ TEST(WebAuthenticationPanel, NullPanelHidSuccess)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [delegate setIsNull:true];
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -839,7 +839,7 @@ TEST(WebAuthenticationPanel, NullPanelHidCtapNoCredentialsFound)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-no-credentials" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [delegate setIsNull:true];
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -856,7 +856,7 @@ TEST(WebAuthenticationPanel, PanelMultipleNFCTagsPresent)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-nfc-multiple-tags" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -872,7 +872,7 @@ TEST(WebAuthenticationPanel, PanelHidCancelReloadNoCrash)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-cancel" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -894,7 +894,7 @@ TEST(WebAuthenticationPanel, PanelHidSuccessCancelNoCrash)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
     webAuthenticationPanelCancelImmediately = true;
@@ -914,7 +914,7 @@ TEST(WebAuthenticationPanel, PanelHidCtapNoCredentialsFoundCancelNoCrash)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-no-credentials" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
     webAuthenticationPanelCancelImmediately = true;
@@ -962,7 +962,7 @@ TEST(WebAuthenticationPanel, PinRequestPinErrorNullDelegate)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [delegate setIsNull:true];
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -977,7 +977,7 @@ TEST(WebAuthenticationPanel, PinRequestPinError)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-get-pin-token-fake-pin-invalid-error-retry" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -994,7 +994,7 @@ TEST(WebAuthenticationPanel, PinGetPinTokenPinBlockedError)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-get-pin-token-pin-blocked-error" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1011,7 +1011,7 @@ TEST(WebAuthenticationPanel, PinGetPinTokenPinAuthBlockedError)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-get-pin-token-pin-auth-blocked-error" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1028,7 +1028,7 @@ TEST(WebAuthenticationPanel, PinGetPinTokenPinInvalidErrorAndRetry)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-get-pin-token-pin-invalid-error-retry" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1044,7 +1044,7 @@ TEST(WebAuthenticationPanel, PinGetPinTokenPinAuthInvalidErrorAndRetry)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-get-pin-token-pin-auth-invalid-error-retry" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1060,7 +1060,7 @@ TEST(WebAuthenticationPanel, MakeCredentialInternalUV)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-internal-uv" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1074,7 +1074,7 @@ TEST(WebAuthenticationPanel, MakeCredentialPin)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1089,7 +1089,7 @@ TEST(WebAuthenticationPanel, MakeCredentialPinAuthBlockedError)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-auth-blocked-error" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1105,7 +1105,7 @@ TEST(WebAuthenticationPanel, MakeCredentialPinInvalidErrorAndRetry)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-hid-pin-invalid-error-retry" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1126,7 +1126,7 @@ TEST(WebAuthenticationPanel, GetAssertionPin)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-pin" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1146,7 +1146,7 @@ TEST(WebAuthenticationPanel, GetAssertionInternalUV)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-internal-uv" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1165,7 +1165,7 @@ TEST(WebAuthenticationPanel, GetAssertionInternalUVPinFallback)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-internal-uv-pin-fallback" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1185,7 +1185,7 @@ TEST(WebAuthenticationPanel, GetAssertionPinAuthBlockedError)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-pin-auth-blocked-error" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1206,7 +1206,7 @@ TEST(WebAuthenticationPanel, GetAssertionPinInvalidErrorAndRetry)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-pin-invalid-error-retry" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1223,7 +1223,7 @@ TEST(WebAuthenticationPanel, NfcPinCachedDisconnect)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-nfc-pin-disconnect" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
 
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1240,7 +1240,7 @@ TEST(WebAuthenticationPanel, MultipleAccountsNullDelegate)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-multiple-accounts" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [delegate setIsNull:true];
     [webView setUIDelegate:delegate.get()];
     [webView focus];
@@ -1260,7 +1260,7 @@ TEST(WebAuthenticationPanel, MultipleAccounts)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-hid-multiple-accounts" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1279,7 +1279,7 @@ TEST(WebAuthenticationPanel, LAError)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-la-error" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1293,7 +1293,7 @@ TEST(WebAuthenticationPanel, LADuplicateCredential)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-la-duplicate-credential" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1312,7 +1312,7 @@ TEST(WebAuthenticationPanel, LADuplicateCredentialWithConsent)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-la-duplicate-credential" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1334,7 +1334,7 @@ TEST(WebAuthenticationPanel, LANoCredential)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-la" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1353,7 +1353,7 @@ TEST(WebAuthenticationPanel, LAMakeCredentialAllowLocalAuthenticator)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-make-credential-la" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1375,7 +1375,7 @@ TEST(WebAuthenticationPanel, LAGetAssertion)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-la" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1395,7 +1395,7 @@ TEST(WebAuthenticationPanel, LAGetAssertionMultipleCredentialStore)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-la" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1426,7 +1426,7 @@ TEST(WebAuthenticationPanel, LAGetAssertionNoMockNoUserGesture)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-la-no-mock" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1447,7 +1447,7 @@ TEST(WebAuthenticationPanel, LAGetAssertionMultipleOrder)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"web-authentication-get-assertion-la" withExtension:@"html"];
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -1473,13 +1473,13 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMinimum)
 {
     auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
     RetainPtr nsIdentifier = toNSData(identifier);
-    auto parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
+    RetainPtr parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
 
-    auto rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
+    RetainPtr rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
+    RetainPtr user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ parameters.get() ];
 
-    auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
     auto result = [_WKWebAuthenticationPanel convertToCoreCreationOptionsWithOptions:options.get()];
 
     EXPECT_WK_STREQ(result.rp.name, "example.com");
@@ -1506,17 +1506,17 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximumDefault)
 {
     auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
     RetainPtr nsIdentifier = toNSData(identifier);
-    auto parameters1 = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
-    auto parameters2 = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-257]);
-    auto descriptor = adoptNS([[_WKPublicKeyCredentialDescriptor alloc] initWithIdentifier:nsIdentifier.get()]);
+    RetainPtr parameters1 = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
+    RetainPtr parameters2 = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-257]);
+    RetainPtr descriptor = adoptNS([[_WKPublicKeyCredentialDescriptor alloc] initWithIdentifier:nsIdentifier.get()]);
 
-    auto rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
+    RetainPtr rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
+    RetainPtr user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ parameters1.get(), parameters2.get() ];
-    auto authenticatorSelection = adoptNS([[_WKAuthenticatorSelectionCriteria alloc] init]);
-    auto extensions = adoptNS([[_WKAuthenticationExtensionsClientInputs alloc] init]);
+    RetainPtr authenticatorSelection = adoptNS([[_WKAuthenticatorSelectionCriteria alloc] init]);
+    RetainPtr extensions = adoptNS([[_WKAuthenticationExtensionsClientInputs alloc] init]);
 
-    auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
     [options setTimeout:@120];
     [options setExcludeCredentials:@[ descriptor.get() ]];
     [options setAuthenticatorSelection:authenticatorSelection.get()];
@@ -1557,19 +1557,19 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum1)
 {
     auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
     RetainPtr nsIdentifier = toNSData(identifier);
-    auto parameters1 = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
-    auto parameters2 = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-257]);
+    RetainPtr parameters1 = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
+    RetainPtr parameters2 = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-257]);
 
-    auto rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
+    RetainPtr rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
     [rp setIcon:@"https//www.example.com/icon.jpg"];
     [rp setIdentifier:@"example.com"];
 
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
+    RetainPtr user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     [user setIcon:@"https//www.example.com/icon.jpg"];
 
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ parameters1.get(), parameters2.get() ];
 
-    auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
     [options setTimeout:@120];
 
     RetainPtr usb = [NSNumber numberWithInt:_WKWebAuthenticationTransportUSB];
@@ -1580,7 +1580,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum1)
     [credential setTransports:@[ usb.get(), nfc.get(), internal.get(), hybrid.get() ]];
     [options setExcludeCredentials:@[ credential.get(), credential.get() ]];
 
-    auto authenticatorSelection = adoptNS([[_WKAuthenticatorSelectionCriteria alloc] init]);
+    RetainPtr authenticatorSelection = adoptNS([[_WKAuthenticatorSelectionCriteria alloc] init]);
     [authenticatorSelection setAuthenticatorAttachment:_WKAuthenticatorAttachmentPlatform];
     [authenticatorSelection setRequireResidentKey:YES];
     [authenticatorSelection setUserVerification:_WKUserVerificationRequirementRequired];
@@ -1627,19 +1627,19 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum2)
 {
     auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
     RetainPtr nsIdentifier = toNSData(identifier);
-    auto parameters1 = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
-    auto parameters2 = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-257]);
+    RetainPtr parameters1 = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
+    RetainPtr parameters2 = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-257]);
 
-    auto rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
+    RetainPtr rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
     [rp setIcon:@"https//www.example.com/icon.jpg"];
     [rp setIdentifier:@"example.com"];
 
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
+    RetainPtr user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     [user setIcon:@"https//www.example.com/icon.jpg"];
 
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ parameters1.get(), parameters2.get() ];
 
-    auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
     [options setTimeout:@120];
 
     RetainPtr usb = [NSNumber numberWithInt:_WKWebAuthenticationTransportUSB];
@@ -1649,7 +1649,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum2)
     [credential setTransports:@[ usb.get(), nfc.get(), internal.get() ]];
     [options setExcludeCredentials:@[ credential.get(), credential.get() ]];
 
-    auto authenticatorSelection = adoptNS([[_WKAuthenticatorSelectionCriteria alloc] init]);
+    RetainPtr authenticatorSelection = adoptNS([[_WKAuthenticatorSelectionCriteria alloc] init]);
     [authenticatorSelection setAuthenticatorAttachment:_WKAuthenticatorAttachmentCrossPlatform]; //
     [authenticatorSelection setRequireResidentKey:YES];
     [authenticatorSelection setUserVerification:_WKUserVerificationRequirementDiscouraged]; //
@@ -1704,15 +1704,15 @@ TEST(WebAuthenticationPanel, MakeCredentialSPITimeout)
     uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
     RetainPtr nsIdentifier = toNSData(identifier);
     NSData *nsHash = [NSData dataWithBytes:hash length:sizeof(hash)];
-    auto parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
+    RetainPtr parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
 
-    auto rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
+    RetainPtr rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
+    RetainPtr user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ parameters.get() ];
-    auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
     [options setTimeout:@10];
 
-    auto panel = adoptNS([[_WKWebAuthenticationPanel alloc] init]);
+    RetainPtr panel = adoptNS([[_WKWebAuthenticationPanel alloc] init]);
     [panel makeCredentialWithChallenge:nsHash origin:@"" options:options.get() completionHandler:^(_WKAuthenticatorAttestationResponse *response, NSError *error) {
         webAuthenticationPanelRan = true;
 
@@ -1733,18 +1733,18 @@ TEST(WebAuthenticationPanel, MakeCredentialLA)
     auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
     uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
     RetainPtr nsIdentifier = toNSData(identifier);
-    auto nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
-    auto parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
+    RetainPtr nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
+    RetainPtr parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
 
-    auto rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
+    RetainPtr rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
     [rp setIdentifier:@"example.com"];
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
+    RetainPtr user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ parameters.get() ];
-    auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
 
-    auto panel = adoptNS([[_WKWebAuthenticationPanel alloc] init]);
+    RetainPtr panel = adoptNS([[_WKWebAuthenticationPanel alloc] init]);
     [panel setMockConfiguration:@{ @"privateKeyBase64": testES256PrivateKeyBase64.createNSString().get() }];
-    auto delegate = adoptNS([[TestWebAuthenticationPanelDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelDelegate alloc] init]);
     [panel setDelegate:delegate.get()];
 
     [panel makeCredentialWithChallenge:nsHash.get() origin:@"https://example.com" options:options.get() completionHandler:^(_WKAuthenticatorAttestationResponse *response, NSError *error) {
@@ -1770,18 +1770,18 @@ TEST(WebAuthenticationPanel, MakeCredentialLAClientDataHashMediation)
     auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
     uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
     RetainPtr nsIdentifier = toNSData(identifier);
-    auto nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
-    auto parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
+    RetainPtr nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
+    RetainPtr parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
 
-    auto rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
+    RetainPtr rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
     [rp setIdentifier:@"example.com"];
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
+    RetainPtr user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ parameters.get() ];
-    auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
 
-    auto panel = adoptNS([[_WKWebAuthenticationPanel alloc] init]);
+    RetainPtr panel = adoptNS([[_WKWebAuthenticationPanel alloc] init]);
     [panel setMockConfiguration:@{ @"privateKeyBase64": testES256PrivateKeyBase64.createNSString().get() }];
-    auto delegate = adoptNS([[TestWebAuthenticationPanelDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelDelegate alloc] init]);
     [panel setDelegate:delegate.get()];
 
     [panel makeCredentialWithMediationRequirement:_WKWebAuthenticationMediationRequirementOptional clientDataHash:nsHash.get() options:options.get() completionHandler:^(_WKAuthenticatorAttestationResponse *response, NSError *error) {
@@ -1807,19 +1807,19 @@ TEST(WebAuthenticationPanel, MakeCredentialLAAttestationFalback)
     auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
     uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
     RetainPtr nsIdentifier = toNSData(identifier);
-    auto nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
-    auto parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
+    RetainPtr nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
+    RetainPtr parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
 
-    auto rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
+    RetainPtr rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
     [rp setIdentifier:@"example.com"];
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
+    RetainPtr user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ parameters.get() ];
-    auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
     options.get().attestation = _WKAttestationConveyancePreferenceDirect;
 
-    auto panel = adoptNS([[_WKWebAuthenticationPanel alloc] init]);
+    RetainPtr panel = adoptNS([[_WKWebAuthenticationPanel alloc] init]);
     [panel setMockConfiguration:@{ @"privateKeyBase64": testES256PrivateKeyBase64.createNSString().get() }];
-    auto delegate = adoptNS([[TestWebAuthenticationPanelDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelDelegate alloc] init]);
     [panel setDelegate:delegate.get()];
 
     [panel makeCredentialWithClientDataHash:nsHash.get() options:options.get() completionHandler:^(_WKAuthenticatorAttestationResponse *response, NSError *error) {
@@ -1836,7 +1836,7 @@ TEST(WebAuthenticationPanel, MakeCredentialLAAttestationFalback)
 
 TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMinimun)
 {
-    auto options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
     auto result = [_WKWebAuthenticationPanel convertToCoreRequestOptionsWithOptions:options.get()];
 
     EXPECT_EQ(result.timeout, std::nullopt);
@@ -1850,10 +1850,10 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMaximumDefault)
 {
     auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
     RetainPtr nsIdentifier = toNSData(identifier);
-    auto descriptor = adoptNS([[_WKPublicKeyCredentialDescriptor alloc] initWithIdentifier:nsIdentifier.get()]);
-    auto extensions = adoptNS([[_WKAuthenticationExtensionsClientInputs alloc] init]);
+    RetainPtr descriptor = adoptNS([[_WKPublicKeyCredentialDescriptor alloc] initWithIdentifier:nsIdentifier.get()]);
+    RetainPtr extensions = adoptNS([[_WKAuthenticationExtensionsClientInputs alloc] init]);
 
-    auto options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
     [options setTimeout:@120];
     [options setAllowCredentials:@[ descriptor.get() ]];
     [options setExtensions:extensions.get()];
@@ -1875,7 +1875,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMaximum)
     auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
     RetainPtr nsIdentifier = toNSData(identifier);
 
-    auto options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
     [options setTimeout:@120];
 
     RetainPtr usb = [NSNumber numberWithInt:_WKWebAuthenticationTransportUSB];
@@ -1914,10 +1914,10 @@ TEST(WebAuthenticationPanel, GetAssertionSPITimeout)
     uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
     NSData *nsHash = [NSData dataWithBytes:hash length:sizeof(hash)];
 
-    auto options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
     [options setTimeout:@120];
 
-    auto panel = adoptNS([[_WKWebAuthenticationPanel alloc] init]);
+    RetainPtr panel = adoptNS([[_WKWebAuthenticationPanel alloc] init]);
     [panel getAssertionWithChallenge:nsHash origin:@"" options:options.get() completionHandler:^(_WKAuthenticatorAssertionResponse *response, NSError *error) {
         webAuthenticationPanelRan = true;
 
@@ -1934,7 +1934,7 @@ TEST(WebAuthenticationPanel, GetAssertionSPITimeout)
 TEST(WebAuthenticationPanel, GetAssertionLA)
 {
     reset();
-    auto beforeTime = adoptNS([[NSDate alloc] init]);
+    RetainPtr beforeTime = adoptNS([[NSDate alloc] init]);
 
     ASSERT_TRUE(addKeyToKeychain(testES256PrivateKeyBase64, "example.com"_s, testUserEntityBundleBase64));
     
@@ -1948,12 +1948,12 @@ TEST(WebAuthenticationPanel, GetAssertionLA)
     uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
     NSData *nsHash = [NSData dataWithBytes:hash length:sizeof(hash)];
 
-    auto options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
     [options setRelyingPartyIdentifier:@"example.com"];
 
-    auto panel = adoptNS([[_WKWebAuthenticationPanel alloc] init]);
+    RetainPtr panel = adoptNS([[_WKWebAuthenticationPanel alloc] init]);
     [panel setMockConfiguration:@{ }];
-    auto delegate = adoptNS([[TestWebAuthenticationPanelDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelDelegate alloc] init]);
     [panel setDelegate:delegate.get()];
 
     [panel getAssertionWithChallenge:nsHash origin:@"https://example.com" options:options.get() completionHandler:^(_WKAuthenticatorAssertionResponse *response, NSError *error) {
@@ -2002,12 +2002,12 @@ TEST(WebAuthenticationPanel, GetAssertionLAClientDataHashMediation)
     uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
     NSData *nsHash = [NSData dataWithBytes:hash length:sizeof(hash)];
 
-    auto options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
     [options setRelyingPartyIdentifier:@"example.com"];
 
-    auto panel = adoptNS([[_WKWebAuthenticationPanel alloc] init]);
+    RetainPtr panel = adoptNS([[_WKWebAuthenticationPanel alloc] init]);
     [panel setMockConfiguration:@{ }];
-    auto delegate = adoptNS([[TestWebAuthenticationPanelDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelDelegate alloc] init]);
     [panel setDelegate:delegate.get()];
 
     [panel getAssertionWithMediationRequirement:_WKWebAuthenticationMediationRequirementOptional clientDataHash:nsHash options:options.get() completionHandler:^(_WKAuthenticatorAssertionResponse *response, NSError *error) {
@@ -2051,12 +2051,12 @@ TEST(WebAuthenticationPanel, GetAssertionNullUserHandle)
     uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
     NSData *nsHash = [NSData dataWithBytes:hash length:sizeof(hash)];
 
-    auto options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
     [options setRelyingPartyIdentifier:@"example.com"];
 
-    auto panel = adoptNS([[_WKWebAuthenticationPanel alloc] init]);
+    RetainPtr panel = adoptNS([[_WKWebAuthenticationPanel alloc] init]);
     [panel setMockConfiguration:@{ }];
-    auto delegate = adoptNS([[TestWebAuthenticationPanelDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelDelegate alloc] init]);
     [panel setDelegate:delegate.get()];
 
     [panel getAssertionWithClientDataHash:nsHash options:options.get() completionHandler:^(_WKAuthenticatorAssertionResponse *response, NSError *error) {
@@ -2079,14 +2079,14 @@ TEST(WebAuthenticationPanel, GetAssertionCrossPlatform)
     uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
     NSData *nsHash = [NSData dataWithBytes:hash length:sizeof(hash)];
 
-    auto options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
     [options setRelyingPartyIdentifier:@""];
     [options setAuthenticatorAttachment:_WKAuthenticatorAttachmentCrossPlatform];
     [options setTimeout:@120];
 
-    auto panel = adoptNS([[_WKWebAuthenticationPanel alloc] init]);
+    RetainPtr panel = adoptNS([[_WKWebAuthenticationPanel alloc] init]);
     [panel setMockConfiguration:@{ }];
-    auto delegate = adoptNS([[TestWebAuthenticationPanelDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelDelegate alloc] init]);
     [panel setDelegate:delegate.get()];
 
     [panel getAssertionWithChallenge:nsHash origin:@"" options:options.get() completionHandler:^(_WKAuthenticatorAssertionResponse *response, NSError *error) {
@@ -2104,11 +2104,11 @@ TEST(WebAuthenticationPanel, GetAllCredential)
 {
     reset();
 
-    auto before = adoptNS([[NSDate alloc] init]);
+    RetainPtr before = adoptNS([[NSDate alloc] init]);
 
     ASSERT_TRUE(addKeyToKeychain(testES256PrivateKeyBase64, "example.com"_s, testUserEntityBundleBase64));
 
-    auto after = adoptNS([[NSDate alloc] init]);
+    RetainPtr after = adoptNS([[NSDate alloc] init]);
 
     auto *credentials = [_WKWebAuthenticationPanel getAllLocalAuthenticatorCredentialsWithAccessGroup:@"com.apple.TestWebKitAPI"];
     EXPECT_NOT_NULL(credentials);
@@ -2133,7 +2133,7 @@ TEST(WebAuthenticationPanel, GetAllCredentialNullUserHandle)
 
     ASSERT_TRUE(addKeyToKeychain(testES256PrivateKeyBase64, "example.com"_s, testUserEntityBundleNoUserHandleBase64));
 
-    auto after = adoptNS([[NSDate alloc] init]);
+    RetainPtr after = adoptNS([[NSDate alloc] init]);
 
     auto *credentials = [_WKWebAuthenticationPanel getAllLocalAuthenticatorCredentialsWithAccessGroup:@"com.apple.TestWebKitAPI"];
     EXPECT_NOT_NULL(credentials);
@@ -2152,7 +2152,7 @@ TEST(WebAuthenticationPanel, GetAllCredentialWithDisplayName)
     // {"id": h'00010203040506070809', "name": "John", "displayName": "Johnny"}
     ASSERT_TRUE(addKeyToKeychain(testES256PrivateKeyBase64, "example.com"_s, "o2JpZEoAAQIDBAUGBwgJZG5hbWVkSm9obmtkaXNwbGF5TmFtZWZKb2hubnk="_s));
 
-    auto after = adoptNS([[NSDate alloc] init]);
+    RetainPtr after = adoptNS([[NSDate alloc] init]);
 
     auto *credentials = [_WKWebAuthenticationPanel getAllLocalAuthenticatorCredentialsWithAccessGroup:@"com.apple.TestWebKitAPI"];
     EXPECT_NOT_NULL(credentials);
@@ -2221,8 +2221,8 @@ TEST(WebAuthenticationPanel, GetAllCredentialByCredentialID)
 TEST(WebAuthenticationPanel, EncodeCTAPAssertion)
 {
     uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
-    auto nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
-    auto options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
+    RetainPtr nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
 
     auto *command = [_WKWebAuthenticationPanel encodeGetAssertionCommandWithClientDataHash:nsHash.get() options: options.get() userVerificationAvailability:_WKWebAuthenticationUserVerificationAvailabilityNotSupported];
 
@@ -2234,23 +2234,23 @@ TEST(WebAuthenticationPanel, EncodeCTAPAssertion)
 TEST(WebAuthenticationPanel, EncodeClientDataJSONWithTopOrigin)
 {
     uint8_t challenge[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
-    auto nsChallenge = adoptNS([[NSData alloc] initWithBytes:challenge length:sizeof(challenge)]);
+    RetainPtr nsChallenge = adoptNS([[NSData alloc] initWithBytes:challenge length:sizeof(challenge)]);
     EXPECT_WK_STREQ("{\"type\":\"webauthn.get\",\"challenge\":\"AQIDBAECAwQBAgMEAQIDBAECAwQBAgMEAQIDBAECAwQ\",\"origin\":\"https://a.com\",\"crossOrigin\":true,\"topOrigin\":\"https://b.com\"}", [[NSString alloc] initWithData:[_WKWebAuthenticationPanel getClientDataJSONWithTopOrigin:_WKWebAuthenticationTypeGet challenge:nsChallenge.get() origin:@"https://a.com" topOrigin:@"https://b.com" crossOrigin:YES] encoding:NSUTF8StringEncoding]);
 }
 
 TEST(WebAuthenticationPanel, EncodeCTAPCreation)
 {
     uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
-    auto nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
+    RetainPtr nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
     auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
     RetainPtr nsIdentifier = toNSData(identifier);
-    auto parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
+    RetainPtr parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
 
-    auto rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
+    RetainPtr rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
+    RetainPtr user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ parameters.get() ];
 
-    auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
 
     auto *command = [_WKWebAuthenticationPanel encodeMakeCredentialCommandWithClientDataHash:nsHash.get() options: options.get() userVerificationAvailability:_WKWebAuthenticationUserVerificationAvailabilityNotSupported];
 
@@ -2262,19 +2262,19 @@ TEST(WebAuthenticationPanel, EncodeCTAPCreation)
 TEST(WebAuthenticationPanel, EncodeCTAPCreationTrimmedParametersGetInfoNoneES256)
 {
     uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
-    auto nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
+    RetainPtr nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
     auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
     RetainPtr nsIdentifier = toNSData(identifier);
-    auto es256Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
-    auto rs256Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-257]);
-    auto ec2Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@2]);
+    RetainPtr es256Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
+    RetainPtr rs256Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-257]);
+    RetainPtr ec2Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@2]);
 
-    auto rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
+    RetainPtr rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
+    RetainPtr user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ es256Parameters.get(), rs256Parameters.get(), ec2Parameters.get()];
     NSArray<_WKPublicKeyCredentialParameters *> *authenticatorSupportedCredentialParamaters = @[];
 
-    auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
 
     auto *command = [_WKWebAuthenticationPanel encodeMakeCredentialCommandWithClientDataHash:nsHash.get() options: options.get() userVerificationAvailability:_WKWebAuthenticationUserVerificationAvailabilityNotSupported authenticatorSupportedCredentialParameters:authenticatorSupportedCredentialParamaters];
 
@@ -2287,18 +2287,18 @@ TEST(WebAuthenticationPanel, EncodeCTAPCreationTrimmedParametersGetInfoNoneES256
 TEST(WebAuthenticationPanel, EncodeCTAPCreationTrimmedParametersGetInfoNoneRS256)
 {
     uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
-    auto nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
+    RetainPtr nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
     auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
     RetainPtr nsIdentifier = toNSData(identifier);
-    auto rs256Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-257]);
-    auto ec2Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@2]);
+    RetainPtr rs256Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-257]);
+    RetainPtr ec2Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@2]);
 
-    auto rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
+    RetainPtr rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
+    RetainPtr user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ rs256Parameters.get(), ec2Parameters.get() ];
     NSArray<_WKPublicKeyCredentialParameters *> *authenticatorSupportedCredentialParamaters = @[];
 
-    auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
 
     auto *command = [_WKWebAuthenticationPanel encodeMakeCredentialCommandWithClientDataHash:nsHash.get() options: options.get() userVerificationAvailability:_WKWebAuthenticationUserVerificationAvailabilityNotSupported authenticatorSupportedCredentialParameters:authenticatorSupportedCredentialParamaters];
 
@@ -2311,19 +2311,19 @@ TEST(WebAuthenticationPanel, EncodeCTAPCreationTrimmedParametersGetInfoNoneRS256
 TEST(WebAuthenticationPanel, EncodeCTAPCreationTrimmedParametersGetInfoSupportsEC2)
 {
     uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
-    auto nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
+    RetainPtr nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
     auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
     RetainPtr nsIdentifier = toNSData(identifier);
-    auto es256Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
-    auto rs256Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-257]);
-    auto ec2Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@2]);
+    RetainPtr es256Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
+    RetainPtr rs256Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-257]);
+    RetainPtr ec2Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@2]);
 
-    auto rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
+    RetainPtr rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
+    RetainPtr user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ es256Parameters.get(), rs256Parameters.get(), ec2Parameters.get()];
     NSArray<_WKPublicKeyCredentialParameters *> *authenticatorSupportedCredentialParamaters = @[ ec2Parameters.get() ];
 
-    auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
 
     auto *command = [_WKWebAuthenticationPanel encodeMakeCredentialCommandWithClientDataHash:nsHash.get() options: options.get() userVerificationAvailability:_WKWebAuthenticationUserVerificationAvailabilityNotSupported authenticatorSupportedCredentialParameters:authenticatorSupportedCredentialParamaters];
 
@@ -2336,19 +2336,19 @@ TEST(WebAuthenticationPanel, EncodeCTAPCreationTrimmedParametersGetInfoSupportsE
 TEST(WebAuthenticationPanel, EncodeCTAPCreationTrimmedParametersGetInfoSupportsDisjoint)
 {
     uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
-    auto nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
+    RetainPtr nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
     auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
     RetainPtr nsIdentifier = toNSData(identifier);
-    auto rs256Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-257]);
-    auto ec2Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@2]);
-    auto es256Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
+    RetainPtr rs256Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-257]);
+    RetainPtr ec2Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@2]);
+    RetainPtr es256Parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
 
-    auto rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
+    RetainPtr rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
+    RetainPtr user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ rs256Parameters.get(), ec2Parameters.get()];
     NSArray<_WKPublicKeyCredentialParameters *> *authenticatorSupportedCredentialParamaters = @[ es256Parameters.get() ];
 
-    auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
+    RetainPtr options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
 
     auto *command = [_WKWebAuthenticationPanel encodeMakeCredentialCommandWithClientDataHash:nsHash.get() options: options.get() userVerificationAvailability:_WKWebAuthenticationUserVerificationAvailabilityNotSupported authenticatorSupportedCredentialParameters:authenticatorSupportedCredentialParamaters];
 
@@ -2564,7 +2564,7 @@ TEST(WebAuthenticationPanel, MakeCredentialPinProtocol2)
     "</script>";
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -2613,7 +2613,7 @@ TEST(WebAuthenticationPanel, GetAssertionPinProtocol2)
     "</script>";
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 
@@ -2681,7 +2681,7 @@ TEST(WebAuthenticationPanel, InvalidAuthenticatorAttachmentDoesNotThrow)
     "</script>";
 
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
-    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [webView focus];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/iOSStylusSupport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/iOSStylusSupport.mm
@@ -55,7 +55,7 @@ static RetainPtr<TestWKWebView> createWebView(HasStylusDevice hasStylusDevice)
     [stylusDeviceObserver start];
     stylusDeviceObserver.hasStylusDevice = hasStylusDevice == HasStylusDevice::Yes;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:@""];
     return webView;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/AccessibilityTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/AccessibilityTestsIOS.mm
@@ -70,7 +70,7 @@ namespace TestWebKitAPI {
 
 TEST(AccessibilityTests, RectsForSpeakingSelectionBasic)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width,initial-scale=1'><span id='first'>first</span><span id='second'> second</span><br><span id='third'> third</span>"];
     [webView stringByEvaluatingJavaScript:@"document.execCommand('SelectAll')"];
 
@@ -87,7 +87,7 @@ TEST(AccessibilityTests, RectsForSpeakingSelectionBasic)
 
 TEST(AccessibilityTests, RectsForSpeakingSelectionWithLineWrapping)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width,initial-scale=1'><body style='font-size: 100px; word-wrap: break-word'><span id='text'>abcdefghijklmnopqrstuvwxyz</span></body>"];
     [webView stringByEvaluatingJavaScript:@"document.execCommand('SelectAll')"];
 
@@ -109,7 +109,7 @@ TEST(AccessibilityTests, RectsForSpeakingSelectionWithLineWrapping)
 
 TEST(AccessibilityTests, RectsForSpeakingSelectionDoNotCrashWhenChangingSelection)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width,initial-scale=1'><span id='first'>first</span><span id='second'> second</span><br><span id='third'> third</span>"];
 
     [webView stringByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(third, 0, third, 1)"];
@@ -123,7 +123,7 @@ TEST(AccessibilityTests, RectsForSpeakingSelectionDoNotCrashWhenChangingSelectio
 
 TEST(AccessibilityTests, StoreSelection)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width,initial-scale=1'><span id='first'>first</span><br><span id='second'>first</span>"];
     
     // Select first node and store the selection
@@ -158,7 +158,7 @@ TEST(AccessibilityTests, WebProcessLoaderBundleLoaded)
     _AXSApplicationAccessibilitySetEnabled(true);
 
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"AccessibilityTestPlugin"];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration]);
     _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(AccessibilityTestSupportProtocol)];
     id <AccessibilityTestSupportProtocol> remoteObjectProxy = [[webView _remoteObjectRegistry] remoteObjectProxyWithInterface:interface];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ActionSheetTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ActionSheetTests.mm
@@ -142,15 +142,15 @@ TEST(ActionSheetTests, DISABLED_DismissingActionSheetShouldNotDismissPresentingV
     IPadUserInterfaceSwizzler iPadUserInterface;
     TestWebKitAPI::Util::instantiateUIApplicationIfNeeded();
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
-    auto window = adoptNS([[TestWKWebViewControllerWindow alloc] initWithFrame:CGRectMake(0, 0, 1024, 768)]);
-    auto rootViewController = adoptNS([[UIViewController alloc] init]);
-    auto navigationController = adoptNS([[UINavigationController alloc] initWithRootViewController:rootViewController.get()]);
-    auto observer = adoptNS([[ActionSheetObserver alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr window = adoptNS([[TestWKWebViewControllerWindow alloc] initWithFrame:CGRectMake(0, 0, 1024, 768)]);
+    RetainPtr rootViewController = adoptNS([[UIViewController alloc] init]);
+    RetainPtr navigationController = adoptNS([[UINavigationController alloc] initWithRootViewController:rootViewController.get()]);
+    RetainPtr observer = adoptNS([[ActionSheetObserver alloc] init]);
     [window setRootViewController:navigationController.get()];
     [window makeKeyAndVisible];
 
-    auto webViewController = adoptNS([[TestWKWebViewController alloc] initWithFrame:CGRectMake(0, 0, 1024, 768) configuration:nil]);
+    RetainPtr webViewController = adoptNS([[TestWKWebViewController alloc] initWithFrame:CGRectMake(0, 0, 1024, 768) configuration:nil]);
     TestWKWebView *webView = [webViewController webView];
     webView.UIDelegate = observer.get();
     [webView synchronouslyLoadTestPageNamed:@"link-and-input"];
@@ -194,8 +194,8 @@ TEST(ActionSheetTests, ImageMapDoesNotDestroySelection)
 {
     IPadUserInterfaceSwizzler iPadUserInterface;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 1024, 768)]);
-    auto observer = adoptNS([[ActionSheetObserver alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 1024, 768)]);
+    RetainPtr observer = adoptNS([[ActionSheetObserver alloc] init]);
     [webView setUIDelegate:observer.get()];
     [webView synchronouslyLoadTestPageNamed:@"image-map"];
     [webView stringByEvaluatingJavaScript:@"selectTextNode(h1.childNodes[0])"];
@@ -227,8 +227,8 @@ TEST(ActionSheetTests, DataDetectorsLinkIsNotPresentedAsALink)
         reinterpret_cast<IMP>(swizzledResizableSnapshotViewFromRect)
     };
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 1024, 768)]);
-    auto observer = adoptNS([[ActionSheetObserver alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 1024, 768)]);
+    RetainPtr observer = adoptNS([[ActionSheetObserver alloc] init]);
     [webView setUIDelegate:observer.get()];
 
     auto runTest = ^(NSString *phoneNumber) {
@@ -294,8 +294,8 @@ TEST(ActionSheetTests, CopyImageElementWithHREFAndTitle)
     TestWebKitAPI::Util::instantiateUIApplicationIfNeeded();
     [UIPasteboard generalPasteboard].items = @[ ];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto observer = adoptNS([[ActionSheetObserver alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr observer = adoptNS([[ActionSheetObserver alloc] init]);
     [webView setUIDelegate:observer.get()];
     [webView synchronouslyLoadTestPageNamed:@"image-in-link-and-input"];
     [webView stringByEvaluatingJavaScript:@"document.querySelector('a').setAttribute('title', 'hello world')"];
@@ -335,8 +335,8 @@ TEST(ActionSheetTests, CopyImageElementWithHREF)
     TestWebKitAPI::Util::instantiateUIApplicationIfNeeded();
     [UIPasteboard generalPasteboard].items = @[ ];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto observer = adoptNS([[ActionSheetObserver alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr observer = adoptNS([[ActionSheetObserver alloc] init]);
     [webView setUIDelegate:observer.get()];
     [webView synchronouslyLoadTestPageNamed:@"image-in-link-and-input"];
 
@@ -375,8 +375,8 @@ TEST(ActionSheetTests, CopyImageElementWithoutHREF)
     TestWebKitAPI::Util::instantiateUIApplicationIfNeeded();
     [UIPasteboard generalPasteboard].items = @[ ];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto observer = adoptNS([[ActionSheetObserver alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr observer = adoptNS([[ActionSheetObserver alloc] init]);
     [webView setUIDelegate:observer.get()];
     [webView synchronouslyLoadTestPageNamed:@"image-and-contenteditable"];
 
@@ -402,8 +402,8 @@ TEST(ActionSheetTests, CopyLinkWritesURLAndPlainText)
     TestWebKitAPI::Util::instantiateUIApplicationIfNeeded();
     [UIPasteboard generalPasteboard].items = @[ ];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto observer = adoptNS([[ActionSheetObserver alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr observer = adoptNS([[ActionSheetObserver alloc] init]);
     [webView setUIDelegate:observer.get()];
     [webView synchronouslyLoadTestPageNamed:@"link-and-input"];
 
@@ -463,8 +463,8 @@ static void performLongPressAction(WKWebView *webView, ActionSheetObserver *obse
 static void playPauseAnimationTest(NSString *testFilename)
 {
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebViewForAnimationControls alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration addToWindow:YES]);
-    auto observer = adoptNS([[ActionSheetObserver alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebViewForAnimationControls alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration addToWindow:YES]);
+    RetainPtr observer = adoptNS([[ActionSheetObserver alloc] init]);
     [webView setUIDelegate:observer.get()];
     [webView synchronouslyLoadTestPageNamed:testFilename];
     // Pause animations globally to establish a known state.
@@ -496,8 +496,8 @@ TEST(ActionSheetTests, PlayPauseAnimationSheetActionsNotPresentByDefault)
     // Note that this is a TestWKWebView, not a TestWKWebViewForAnimationControls, which has the necessary testing only override.
     // Without the testing override, the only way "Play Animation" and "Pause Animation" should appear is when a system setting is in a non-default state.
     // So this test ensures these actions are not available by default.
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration addToWindow:YES]);
-    auto observer = adoptNS([[ActionSheetObserver alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration addToWindow:YES]);
+    RetainPtr observer = adoptNS([[ActionSheetObserver alloc] init]);
     [webView setUIDelegate:observer.get()];
     [webView synchronouslyLoadTestPageNamed:@"img-animation-in-anchor"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ApplicationStateTracking.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ApplicationStateTracking.mm
@@ -39,7 +39,7 @@ namespace TestWebKitAPI {
 
 TEST(ApplicationStateTracking, WindowDeallocDoesNotPermanentlyFreezeLayerTree)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
 
     RetainPtr<TestWKWebView> webView;
     RetainPtr<UIWindow> window;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/AutocorrectionTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/AutocorrectionTestsIOS.mm
@@ -65,8 +65,8 @@ static UIFont *returnNil(Class, SEL)
 
 TEST(AutocorrectionTests, FontAtCaretWhenUsingUICTFontTextStyle)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         return _WKFocusStartsInputSessionPolicyAllow;
     }];
@@ -120,7 +120,7 @@ TEST(AutocorrectionTests, FontAtCaretWhenUsingUICTFontTextStyle)
 
 TEST(AutocorrectionTests, RequestAutocorrectionContextAfterClosingPage)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
     [webView synchronouslyLoadTestPageNamed:@"autofocused-text-input"];
 
     auto contentView = [webView textInputContentView];
@@ -136,7 +136,7 @@ TEST(AutocorrectionTests, AutocorrectionContextDoesNotIncludeNewlineInTextField)
 {
     if ([UIKeyboard usesInputSystemUI])
         return;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
     [webView synchronouslyLoadTestPageNamed:@"autofocused-text-input"];
 
     auto contextBeforeTyping = [webView autocorrectionContext];
@@ -155,8 +155,8 @@ TEST(AutocorrectionTests, AutocorrectionContextDoesNotIncludeNewlineInTextField)
 
 TEST(AutocorrectionTests, MultiWordAutocorrectionFromStartOfText)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
-    auto inputDelegate = adoptNS([TestInputDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
     bool startedInputSession = false;
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id<_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         startedInputSession = true;
@@ -178,8 +178,8 @@ TEST(AutocorrectionTests, MultiWordAutocorrectionFromStartOfText)
 
 TEST(AutocorrectionTests, DoNotLearnCorrectionsAfterChangingInputTypeFromPassword)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
-    auto inputDelegate = adoptNS([TestInputDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
 
     bool startedInputSession = false;
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id<_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
@@ -212,8 +212,8 @@ TEST(AutocorrectionTests, AutocorrectionIndicatorsDismissAfterNextWord)
 {
     auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id<_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         return _WKFocusStartsInputSessionPolicyAllow;
     }];
@@ -254,8 +254,8 @@ TEST(AutocorrectionTests, AutocorrectionIndicatorsMultiWord)
 {
     auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id<_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         return _WKFocusStartsInputSessionPolicyAllow;
     }];
@@ -294,8 +294,8 @@ TEST(AutocorrectionTests, AutocorrectionContextBeforeAndAfterEditing)
 {
     if ([UIKeyboard usesInputSystemUI])
         return;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         return _WKFocusStartsInputSessionPolicyAllow;
     }];
@@ -330,11 +330,11 @@ TEST(AutocorrectionTests, AutocorrectionContextBeforeAndAfterEditing)
 
 TEST(AutocorrectionTests, AvoidDeadlockWithGPUProcessCreationInEmptyView)
 {
-    auto poolConfiguration = adoptNS([_WKProcessPoolConfiguration new]);
+    RetainPtr poolConfiguration = adoptNS([_WKProcessPoolConfiguration new]);
     [poolConfiguration setIgnoreSynchronousMessagingTimeoutsForTesting:YES];
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get() processPoolConfiguration:poolConfiguration.get()]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get() processPoolConfiguration:poolConfiguration.get()]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id<_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         return _WKFocusStartsInputSessionPolicyAllow;
     }];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/BacklightLevelNotification.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/BacklightLevelNotification.mm
@@ -35,9 +35,9 @@
 TEST(WebKit, BacklightLevelNotificationCrash)
 {
     {
-        auto poolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
-        auto pool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:poolConfiguration.get()]);
-        auto viewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr poolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+        RetainPtr pool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:poolConfiguration.get()]);
+        RetainPtr viewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
         [viewConfiguration setProcessPool:pool.get()];
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/CustomContentViewGestures.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/CustomContentViewGestures.mm
@@ -40,16 +40,16 @@ namespace TestWebKitAPI {
 TEST(CustomContentViewGestures, DoNotCrashWhenCheckingGestureDelegateInNewWebView)
 {
     auto frame = CGRectMake(0, 0, 320, 600);
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:frame]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:frame]);
     [webView _close];
 
-    auto hostWindow = adoptNS([[UIWindow alloc] initWithFrame:frame]);
+    RetainPtr hostWindow = adoptNS([[UIWindow alloc] initWithFrame:frame]);
     [hostWindow setHidden:NO];
     [hostWindow addSubview:webView.get()];
 
     auto contentView = static_cast<UIView<UIGestureRecognizerDelegate> *>([webView textInputContentView]);
     auto addGesture = [&] {
-        auto gesture = adoptNS([UITapGestureRecognizer new]);
+        RetainPtr gesture = adoptNS([UITapGestureRecognizer new]);
         [contentView addGestureRecognizer:gesture.get()];
         [gesture setDelegate:contentView];
         return gesture;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/DataDetectorsTestIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/DataDetectorsTestIOS.mm
@@ -38,10 +38,10 @@ TEST(DataDetectorTests, LoadWKWebViewWithDataDetectorTypePhoneNumber)
 {
     NSString *const phoneNumber = @"(555) 867-5309";
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().dataDetectorTypes = WKDataDetectorTypePhoneNumber;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<!DOCTYPE><html><head></head><body><p>Call Jenny at %@</p></body></html>", phoneNumber]];
 
     // Ensure that the phone number is linked by Data Detectors.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/DataListTextSuggestionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/DataListTextSuggestionTests.mm
@@ -137,7 +137,7 @@ namespace TestWebKitAPI {
 
 TEST(DataListTextSuggestionTestView, InsertSuggestion)
 {
-    auto webView = adoptNS([[DataListTextSuggestionTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[DataListTextSuggestionTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
 
     [webView synchronouslyLoadHTMLString:@""
         "<input id='input' list='fruits'>"

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/DragAndDropTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/DragAndDropTestsIOS.mm
@@ -246,10 +246,10 @@ namespace TestWebKitAPI {
 
 TEST(DragAndDropTests, ImageToContentEditable)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"image-and-contenteditable"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(100, 50) to:CGPointMake(100, 300)];
 
     EXPECT_TRUE([webView editorContainsImageElement]);
@@ -266,10 +266,10 @@ TEST(DragAndDropTests, ImageToContentEditable)
 
 TEST(DragAndDropTests, CanStartDragOnEnormousImage)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<img src='enormous.svg'></img>"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(100, 100) to:CGPointMake(100, 100)];
 
     NSArray *registeredTypes = [[simulator sourceItemProviders].firstObject registeredTypeIdentifiers];
@@ -278,10 +278,10 @@ TEST(DragAndDropTests, CanStartDragOnEnormousImage)
 
 TEST(DragAndDropTests, ImageToTextarea)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"image-and-textarea"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(100, 50) to:CGPointMake(100, 300)];
 
     EXPECT_WK_STREQ("", [webView editorValue]);
@@ -296,10 +296,10 @@ TEST(DragAndDropTests, ImageToTextarea)
 
 TEST(DragAndDropTests, ImageInLinkToInput)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"image-in-link-and-input"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(100, 50) to:CGPointMake(100, 300)];
 
     EXPECT_WK_STREQ("https://www.apple.com/", [webView editorValue].UTF8String);
@@ -311,11 +311,11 @@ TEST(DragAndDropTests, ImageInLinkToInput)
 
 TEST(DragAndDropTests, AvoidPreciseDropNearTopOfTextArea)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width, initial-scale=1'><body style='margin: 0'><textarea style='height: 100px'></textarea></body>"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
-    auto firstItem = adoptNS([[NSItemProvider alloc] initWithObject:[NSURL URLWithString:@"https://webkit.org"]]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr firstItem = adoptNS([[NSItemProvider alloc] initWithObject:[NSURL URLWithString:@"https://webkit.org"]]);
     [simulator setExternalItemProviders:@[ firstItem.get() ]];
     [simulator runFrom:CGPointMake(320, 10) to:CGPointMake(20, 10)];
 
@@ -323,7 +323,7 @@ TEST(DragAndDropTests, AvoidPreciseDropNearTopOfTextArea)
     EXPECT_FALSE([simulator lastKnownDropProposal].precise);
     [webView evaluateJavaScript:@"document.querySelector('textarea').value = ''" completionHandler:nil];
 
-    auto secondItem = adoptNS([[NSItemProvider alloc] initWithObject:[NSURL URLWithString:@"https://apple.com"]]);
+    RetainPtr secondItem = adoptNS([[NSItemProvider alloc] initWithObject:[NSURL URLWithString:@"https://apple.com"]]);
     [simulator setExternalItemProviders:@[ secondItem.get() ]];
     [simulator runFrom:CGPointMake(320, 50) to:CGPointMake(20, 50)];
     EXPECT_WK_STREQ("https://apple.com/", [webView stringByEvaluatingJavaScript:@"document.querySelector('textarea').value"]);
@@ -332,11 +332,11 @@ TEST(DragAndDropTests, AvoidPreciseDropNearTopOfTextArea)
 
 TEST(DragAndDropTests, ImageInLinkWithoutHREFToInput)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"image-in-link-and-input"];
     [webView stringByEvaluatingJavaScript:@"link.href = ''"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(100, 50) to:CGPointMake(100, 300)];
 
     EXPECT_WK_STREQ("", [webView editorValue]);
@@ -346,10 +346,10 @@ TEST(DragAndDropTests, ImageInLinkWithoutHREFToInput)
 
 TEST(DragAndDropTests, ImageDoesNotUseElementSizeAsEstimatedSize)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"gif-and-file-input"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom: { 100, 100 } to: { 100, 300 }];
 
     checkTypeIdentifierIsRegisteredAtIndex(simulator.get(), UTTypeGIF.identifier, 0);
@@ -359,8 +359,8 @@ TEST(DragAndDropTests, ImageDoesNotUseElementSizeAsEstimatedSize)
 
 TEST(DragAndDropTests, ContentEditableToContentEditable)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     loadTestPageAndEnsureInputSession(simulator.get(), @"autofocus-contenteditable");
     [simulator runFrom:CGPointMake(100, 50) to:CGPointMake(100, 300)];
@@ -380,8 +380,8 @@ TEST(DragAndDropTests, ContentEditableToContentEditable)
 
 TEST(DragAndDropTests, ContentEditableToTextarea)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     loadTestPageAndEnsureInputSession(simulator.get(), @"contenteditable-and-textarea");
     [simulator runFrom:CGPointMake(100, 50) to:CGPointMake(100, 300)];
@@ -400,8 +400,8 @@ TEST(DragAndDropTests, ContentEditableToTextarea)
 
 TEST(DragAndDropTests, NonEditableTextSelectionToTextarea)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     [webView synchronouslyLoadTestPageNamed:@"selected-text-and-textarea"];
     [simulator runFrom:CGPointMake(160, 100) to:CGPointMake(160, 300)];
@@ -411,8 +411,8 @@ TEST(DragAndDropTests, NonEditableTextSelectionToTextarea)
 
 TEST(DragAndDropTests, DoNotPerformSelectionDragWhenNotFirstResponder)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setShouldBecomeFirstResponder:NO];
 
     [webView synchronouslyLoadTestPageNamed:@"selected-text-and-textarea"];
@@ -423,8 +423,8 @@ TEST(DragAndDropTests, DoNotPerformSelectionDragWhenNotFirstResponder)
 
 TEST(DragAndDropTests, CanDragImageWhenNotFirstResponder)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setShouldBecomeFirstResponder:NO];
 
     [webView synchronouslyLoadTestPageNamed:@"image-and-contenteditable"];
@@ -436,8 +436,8 @@ TEST(DragAndDropTests, CanDragImageWhenNotFirstResponder)
 
 TEST(DragAndDropTests, ContentEditableMoveParagraphs)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     loadTestPageAndEnsureInputSession(simulator.get(), @"two-paragraph-contenteditable");
     [simulator runFrom:CGPointMake(100, 50) to:CGPointMake(250, 450)];
@@ -455,8 +455,8 @@ TEST(DragAndDropTests, ContentEditableMoveParagraphs)
 
 TEST(DragAndDropTests, DragImageFromContentEditable)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     [webView synchronouslyLoadTestPageNamed:@"contenteditable-and-target"];
     [simulator runFrom:CGPointMake(100, 100) to:CGPointMake(100, 300)];
@@ -466,8 +466,8 @@ TEST(DragAndDropTests, DragImageFromContentEditable)
 
 TEST(DragAndDropTests, TextAreaToInput)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     loadTestPageAndEnsureInputSession(simulator.get(), @"textarea-to-input");
     [simulator runFrom:CGPointMake(100, 50) to:CGPointMake(100, 300)];
@@ -479,8 +479,8 @@ TEST(DragAndDropTests, TextAreaToInput)
 
 TEST(DragAndDropTests, SinglePlainTextWordTypeIdentifiers)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     loadTestPageAndEnsureInputSession(simulator.get(), @"textarea-to-input");
     [webView stringByEvaluatingJavaScript:@"source.value = 'pneumonoultramicroscopicsilicovolcanoconiosis'"];
@@ -499,8 +499,8 @@ TEST(DragAndDropTests, SinglePlainTextWordTypeIdentifiers)
 
 TEST(DragAndDropTests, SinglePlainTextURLTypeIdentifiers)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     loadTestPageAndEnsureInputSession(simulator.get(), @"textarea-to-input");
     [webView stringByEvaluatingJavaScript:@"source.value = 'https://webkit.org/'"];
@@ -520,10 +520,10 @@ TEST(DragAndDropTests, SinglePlainTextURLTypeIdentifiers)
 
 TEST(DragAndDropTests, LinkToInput)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"link-and-input"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(100, 50) to:CGPointMake(100, 300)];
 
     EXPECT_WK_STREQ("https://www.apple.com/", [webView editorValue].UTF8String);
@@ -549,10 +549,10 @@ TEST(DragAndDropTests, LinkToInput)
 
 TEST(DragAndDropTests, BackgroundImageLinkToInput)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"background-image-link-and-input"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(100, 50) to:CGPointMake(100, 300)];
 
     EXPECT_WK_STREQ("https://www.apple.com/", [webView editorValue].UTF8String);
@@ -567,10 +567,10 @@ TEST(DragAndDropTests, BackgroundImageLinkToInput)
 
 TEST(DragAndDropTests, CanPreventStart)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"prevent-start"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(100, 50) to:CGPointMake(100, 300)];
 
     EXPECT_EQ(DragAndDropPhaseCancelled, [simulator phase]);
@@ -584,10 +584,10 @@ TEST(DragAndDropTests, CanPreventStart)
 
 TEST(DragAndDropTests, CanPreventOperation)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"prevent-operation"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(100, 50) to:CGPointMake(100, 300)];
 
     EXPECT_FALSE([webView editorContainsImageElement]);
@@ -600,10 +600,10 @@ TEST(DragAndDropTests, CanPreventOperation)
 
 TEST(DragAndDropTests, EnterAndLeaveEvents)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"link-and-input"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(100, 50) to:CGPointMake(100, 450)];
 
     EXPECT_WK_STREQ("", [webView editorValue].UTF8String);
@@ -618,10 +618,10 @@ TEST(DragAndDropTests, EnterAndLeaveEvents)
 
 TEST(DragAndDropTests, CanStartDragOnDivWithDraggableAttribute)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"custom-draggable-div"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(100, 100) to:CGPointMake(100, 250)];
 
     EXPECT_GT([simulator sourceItemProviders].count, 0UL);
@@ -633,13 +633,13 @@ TEST(DragAndDropTests, CanStartDragOnDivWithDraggableAttribute)
 
 TEST(DragAndDropTests, ExternalSourcePlainTextToIFrame)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"contenteditable-in-iframe"];
 
-    auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
     [itemProvider registerObject:@"Hello world" visibility:NSItemProviderRepresentationVisibilityAll];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setExternalItemProviders:@[ itemProvider.get() ]];
     [simulator runFrom:CGPointMake(0, 0) to:CGPointMake(160, 250)];
 
@@ -652,14 +652,14 @@ TEST(DragAndDropTests, ExternalSourcePlainTextToIFrame)
 
 TEST(DragAndDropTests, ExternalSourceInlineTextToFileInput)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"file-uploading"];
 
-    auto simulatedItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulatedItemProvider = adoptNS([[NSItemProvider alloc] init]);
     [simulatedItemProvider setPreferredPresentationStyle:UIPreferredPresentationStyleInline];
     [simulatedItemProvider registerObject:@"This item provider requested inline presentation style." visibility:NSItemProviderRepresentationVisibilityAll];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setExternalItemProviders:@[ simulatedItemProvider.get() ]];
     [simulator runFrom:CGPointMake(200, 100) to:CGPointMake(100, 100)];
 
@@ -669,14 +669,14 @@ TEST(DragAndDropTests, ExternalSourceInlineTextToFileInput)
 
 TEST(DragAndDropTests, ExternalSourceJSONToFileInput)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"file-uploading"];
 
-    auto simulatedJSONItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulatedJSONItemProvider = adoptNS([[NSItemProvider alloc] init]);
     NSData *jsonData = [@"{ \"foo\": \"bar\",  \"bar\": \"baz\" }" dataUsingEncoding:NSUTF8StringEncoding];
     [simulatedJSONItemProvider registerDataRepresentationForTypeIdentifier:UTTypeJSON.identifier withData:jsonData];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setExternalItemProviders:@[ simulatedJSONItemProvider.get() ]];
     [simulator runFrom:CGPointMake(200, 100) to:CGPointMake(100, 100)];
 
@@ -686,14 +686,14 @@ TEST(DragAndDropTests, ExternalSourceJSONToFileInput)
 
 TEST(DragAndDropTests, ExternalSourceImageToFileInput)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"file-uploading"];
 
-    auto simulatedImageItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulatedImageItemProvider = adoptNS([[NSItemProvider alloc] init]);
     NSData *imageData = UIImageJPEGRepresentation(testIconImage(), 0.5);
     [simulatedImageItemProvider registerDataRepresentationForTypeIdentifier:UTTypeJPEG.identifier withData:imageData];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setExternalItemProviders:@[ simulatedImageItemProvider.get() ]];
     [simulator runFrom:CGPointMake(200, 100) to:CGPointMake(100, 100)];
 
@@ -704,15 +704,15 @@ TEST(DragAndDropTests, ExternalSourceImageToFileInput)
 
 TEST(DragAndDropTests, ExternalSourceHTMLToUploadArea)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"file-uploading"];
 
-    auto simulatedHTMLItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulatedHTMLItemProvider = adoptNS([[NSItemProvider alloc] init]);
     NSData *htmlData = [@"<body contenteditable></body>" dataUsingEncoding:NSUTF8StringEncoding];
     [simulatedHTMLItemProvider registerDataRepresentationForTypeIdentifier:UTTypeHTML.identifier withData:htmlData];
     [simulatedHTMLItemProvider setSuggestedName:@"index.html"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setShouldAllowMoveOperation:NO];
     [simulator setExternalItemProviders:@[ simulatedHTMLItemProvider.get() ]];
     [simulator runFrom:CGPointMake(200, 300) to:CGPointMake(100, 300)];
@@ -724,15 +724,15 @@ TEST(DragAndDropTests, ExternalSourceHTMLToUploadArea)
 
 TEST(DragAndDropTests, ExternalSourceMoveOperationNotAllowed)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"file-uploading"];
     [webView stringByEvaluatingJavaScript:@"upload.dropEffect = 'move'"];
 
-    auto simulatedHTMLItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulatedHTMLItemProvider = adoptNS([[NSItemProvider alloc] init]);
     NSData *htmlData = [@"<body contenteditable></body>" dataUsingEncoding:NSUTF8StringEncoding];
     [simulatedHTMLItemProvider registerDataRepresentationForTypeIdentifier:UTTypeHTML.identifier withData:htmlData];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setShouldAllowMoveOperation:NO];
     [simulator setExternalItemProviders:@[ simulatedHTMLItemProvider.get() ]];
     [simulator runFrom:CGPointMake(200, 300) to:CGPointMake(100, 300)];
@@ -742,13 +742,13 @@ TEST(DragAndDropTests, ExternalSourceMoveOperationNotAllowed)
 
 TEST(DragAndDropTests, ExternalSourcePKCS12ToSingleFileInput)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"file-uploading"];
 
-    auto item = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr item = adoptNS([[NSItemProvider alloc] init]);
     [item registerDataRepresentationForTypeIdentifier:UTTypePKCS12.identifier withData:[@"Not a real p12 file." dataUsingEncoding:NSUTF8StringEncoding]];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setExternalItemProviders:@[ item.get() ]];
     [simulator runFrom:CGPointMake(200, 100) to:CGPointMake(100, 100)];
 
@@ -757,16 +757,16 @@ TEST(DragAndDropTests, ExternalSourcePKCS12ToSingleFileInput)
 
 TEST(DragAndDropTests, ExternalSourceZIPArchiveAndURLToSingleFileInput)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"file-uploading"];
 
-    auto archiveProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr archiveProvider = adoptNS([[NSItemProvider alloc] init]);
     [archiveProvider registerDataRepresentationForTypeIdentifier:UTTypeZIP.identifier withData:testZIPArchive()];
 
-    auto urlProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr urlProvider = adoptNS([[NSItemProvider alloc] init]);
     [urlProvider registerObject:[NSURL URLWithString:@"https://webkit.org"] visibility:NSItemProviderRepresentationVisibilityAll];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setExternalItemProviders:@[ archiveProvider.get(), urlProvider.get() ]];
     [simulator runFrom:CGPointMake(200, 100) to:CGPointMake(100, 100)];
 
@@ -777,13 +777,13 @@ TEST(DragAndDropTests, ExternalSourceZIPArchiveAndURLToSingleFileInput)
 
 TEST(DragAndDropTests, ExternalSourceZIPArchiveToUploadArea)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"file-uploading"];
 
-    auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
     [itemProvider registerDataRepresentationForTypeIdentifier:UTTypeZIP.identifier withData:testZIPArchive()];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setExternalItemProviders:@[ itemProvider.get() ]];
     [simulator runFrom:CGPointMake(200, 300) to:CGPointMake(100, 300)];
 
@@ -794,18 +794,18 @@ TEST(DragAndDropTests, ExternalSourceZIPArchiveToUploadArea)
 
 TEST(DragAndDropTests, ExternalSourceImageAndHTMLToSingleFileInput)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"file-uploading"];
 
-    auto simulatedImageItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulatedImageItemProvider = adoptNS([[NSItemProvider alloc] init]);
     NSData *imageData = UIImageJPEGRepresentation(testIconImage(), 0.5);
     [simulatedImageItemProvider registerDataRepresentationForTypeIdentifier:UTTypeJPEG.identifier withData:imageData];
 
-    auto simulatedHTMLItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulatedHTMLItemProvider = adoptNS([[NSItemProvider alloc] init]);
     NSData *htmlData = [@"<body contenteditable></body>" dataUsingEncoding:NSUTF8StringEncoding];
     [simulatedHTMLItemProvider registerDataRepresentationForTypeIdentifier:UTTypeHTML.identifier withData:htmlData];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setExternalItemProviders:@[ simulatedHTMLItemProvider.get(), simulatedImageItemProvider.get() ]];
     [simulator runFrom:CGPointMake(200, 100) to:CGPointMake(100, 100)];
 
@@ -816,19 +816,19 @@ TEST(DragAndDropTests, ExternalSourceImageAndHTMLToSingleFileInput)
 
 TEST(DragAndDropTests, ExternalSourceImageAndHTMLToMultipleFileInput)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"file-uploading"];
     [webView stringByEvaluatingJavaScript:@"input.setAttribute('multiple', '')"];
 
-    auto simulatedImageItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulatedImageItemProvider = adoptNS([[NSItemProvider alloc] init]);
     NSData *imageData = UIImageJPEGRepresentation(testIconImage(), 0.5);
     [simulatedImageItemProvider registerDataRepresentationForTypeIdentifier:UTTypeJPEG.identifier withData:imageData];
 
-    auto simulatedHTMLItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulatedHTMLItemProvider = adoptNS([[NSItemProvider alloc] init]);
     NSData *htmlData = [@"<body contenteditable></body>" dataUsingEncoding:NSUTF8StringEncoding];
     [simulatedHTMLItemProvider registerDataRepresentationForTypeIdentifier:UTTypeHTML.identifier withData:htmlData];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setExternalItemProviders:@[ simulatedHTMLItemProvider.get(), simulatedImageItemProvider.get() ]];
     [simulator runFrom:CGPointMake(200, 100) to:CGPointMake(100, 100)];
 
@@ -839,22 +839,22 @@ TEST(DragAndDropTests, ExternalSourceImageAndHTMLToMultipleFileInput)
 
 TEST(DragAndDropTests, ExternalSourceImageAndHTMLToUploadArea)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"file-uploading"];
 
-    auto simulatedImageItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulatedImageItemProvider = adoptNS([[NSItemProvider alloc] init]);
     NSData *imageData = UIImageJPEGRepresentation(testIconImage(), 0.5);
     [simulatedImageItemProvider registerDataRepresentationForTypeIdentifier:UTTypeJPEG.identifier withData:imageData];
 
-    auto firstSimulatedHTMLItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr firstSimulatedHTMLItemProvider = adoptNS([[NSItemProvider alloc] init]);
     NSData *firstHTMLData = [@"<body contenteditable></body>" dataUsingEncoding:NSUTF8StringEncoding];
     [firstSimulatedHTMLItemProvider registerDataRepresentationForTypeIdentifier:UTTypeHTML.identifier withData:firstHTMLData];
 
-    auto secondSimulatedHTMLItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr secondSimulatedHTMLItemProvider = adoptNS([[NSItemProvider alloc] init]);
     NSData *secondHTMLData = [@"<html><body>hello world</body></html>" dataUsingEncoding:NSUTF8StringEncoding];
     [secondSimulatedHTMLItemProvider registerDataRepresentationForTypeIdentifier:UTTypeHTML.identifier withData:secondHTMLData];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setShouldAllowMoveOperation:NO];
     [simulator setExternalItemProviders:@[ simulatedImageItemProvider.get(), firstSimulatedHTMLItemProvider.get(), secondSimulatedHTMLItemProvider.get() ]];
     [simulator runFrom:CGPointMake(200, 300) to:CGPointMake(100, 300)];
@@ -866,12 +866,12 @@ TEST(DragAndDropTests, ExternalSourceImageAndHTMLToUploadArea)
 
 TEST(DragAndDropTests, ExternalSourceHTMLToContentEditable)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"autofocus-contenteditable"];
     [webView stringByEvaluatingJavaScript:@"getSelection().removeAllRanges()"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
-    auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
     NSData *htmlData = [@"<h1>This is a test</h1>" dataUsingEncoding:NSUTF8StringEncoding];
     [itemProvider registerDataRepresentationForTypeIdentifier:UTTypeHTML.identifier withData:htmlData];
     [simulator setExternalItemProviders:@[ itemProvider.get() ]];
@@ -884,14 +884,14 @@ TEST(DragAndDropTests, ExternalSourceHTMLToContentEditable)
 
 TEST(DragAndDropTests, ExternalSourceBoldSystemAttributedStringToContentEditable)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"autofocus-contenteditable"];
     [webView stringByEvaluatingJavaScript:@"getSelection().removeAllRanges()"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     NSDictionary *textAttributes = @{ NSFontAttributeName: [UIFont boldSystemFontOfSize:20] };
-    auto richText = adoptNS([[NSAttributedString alloc] initWithString:@"This is a test" attributes:textAttributes]);
-    auto itemProvider = adoptNS([[NSItemProvider alloc] initWithObject:richText.get()]);
+    RetainPtr richText = adoptNS([[NSAttributedString alloc] initWithString:@"This is a test" attributes:textAttributes]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] initWithObject:richText.get()]);
     [simulator setExternalItemProviders:@[ itemProvider.get() ]];
     [simulator runFrom:CGPointMake(300, 400) to:CGPointMake(100, 300)];
 
@@ -900,14 +900,14 @@ TEST(DragAndDropTests, ExternalSourceBoldSystemAttributedStringToContentEditable
 
 TEST(DragAndDropTests, ExternalSourceColoredAttributedStringToContentEditable)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"autofocus-contenteditable"];
     [webView stringByEvaluatingJavaScript:@"getSelection().removeAllRanges()"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     NSDictionary *textAttributes = @{ NSForegroundColorAttributeName: [UIColor redColor] };
-    auto richText = adoptNS([[NSAttributedString alloc] initWithString:@"This is a test" attributes:textAttributes]);
-    auto itemProvider = adoptNS([[NSItemProvider alloc] initWithObject:richText.get()]);
+    RetainPtr richText = adoptNS([[NSAttributedString alloc] initWithString:@"This is a test" attributes:textAttributes]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] initWithObject:richText.get()]);
     [simulator setExternalItemProviders:@[ itemProvider.get() ]];
     [simulator runFrom:CGPointMake(300, 400) to:CGPointMake(100, 300)];
 
@@ -917,16 +917,16 @@ TEST(DragAndDropTests, ExternalSourceColoredAttributedStringToContentEditable)
 
 TEST(DragAndDropTests, ExternalSourceMultipleURLsToContentEditable)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"autofocus-contenteditable"];
     [webView stringByEvaluatingJavaScript:@"getSelection().removeAllRanges()"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
-    auto firstItem = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr firstItem = adoptNS([[NSItemProvider alloc] init]);
     [firstItem registerObject:[NSURL URLWithString:@"https://www.apple.com/iphone/"] visibility:NSItemProviderRepresentationVisibilityAll];
-    auto secondItem = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr secondItem = adoptNS([[NSItemProvider alloc] init]);
     [secondItem registerObject:[NSURL URLWithString:@"https://www.apple.com/mac/"] visibility:NSItemProviderRepresentationVisibilityAll];
-    auto thirdItem = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr thirdItem = adoptNS([[NSItemProvider alloc] init]);
     [thirdItem registerObject:[NSURL URLWithString:@"https://webkit.org/"] visibility:NSItemProviderRepresentationVisibilityAll];
     [simulator setExternalItemProviders:@[ firstItem.get(), secondItem.get(), thirdItem.get() ]];
     [simulator runFrom:CGPointMake(300, 400) to:CGPointMake(100, 300)];
@@ -946,17 +946,17 @@ TEST(DragAndDropTests, ExternalSourceMultipleURLsToContentEditable)
 
 TEST(DragAndDropTests, RespectsExternalSourceFidelityRankings)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"autofocus-contenteditable"];
     [webView stringByEvaluatingJavaScript:@"getSelection().removeAllRanges()"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     // Here, our source item provider vends two representations: plain text, and then an image. If we don't respect the
     // fidelity order requested by the source, we'll end up assuming that the image is a higher fidelity representation
     // than the plain text, and erroneously insert the image. If we respect source fidelities, we'll insert text rather
     // than an image.
-    auto simulatedItemProviderWithTextFirst = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulatedItemProviderWithTextFirst = adoptNS([[NSItemProvider alloc] init]);
     [simulatedItemProviderWithTextFirst registerObject:@"Hello world" visibility:NSItemProviderRepresentationVisibilityAll];
     [simulatedItemProviderWithTextFirst registerObject:testIconImage() visibility:NSItemProviderRepresentationVisibilityAll];
     [simulator setExternalItemProviders:@[ simulatedItemProviderWithTextFirst.get() ]];
@@ -967,7 +967,7 @@ TEST(DragAndDropTests, RespectsExternalSourceFidelityRankings)
     [webView stringByEvaluatingJavaScript:@"editor.innerHTML = ''"];
 
     // Now we register the item providers in reverse, and expect the image to be inserted instead of text.
-    auto simulatedItemProviderWithImageFirst = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulatedItemProviderWithImageFirst = adoptNS([[NSItemProvider alloc] init]);
     [simulatedItemProviderWithImageFirst registerObject:testIconImage() visibility:NSItemProviderRepresentationVisibilityAll];
     [simulatedItemProviderWithImageFirst registerObject:@"Hello world" visibility:NSItemProviderRepresentationVisibilityAll];
     [simulator setExternalItemProviders:@[ simulatedItemProviderWithImageFirst.get() ]];
@@ -986,12 +986,12 @@ TEST(DragAndDropTests, ExternalSourceUTF8PlainTextOnly)
 {
     ClassMethodSwizzler swizzler([UIKeyboard class], @selector(isInHardwareKeyboardMode), reinterpret_cast<IMP>(overrideIsInHardwareKeyboardMode));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"autofocus-contenteditable"];
 
     NSString *textPayload = @"Ceci n'est pas une string";
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
-    auto simulatedItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulatedItemProvider = adoptNS([[NSItemProvider alloc] init]);
     [simulatedItemProvider registerDataRepresentationForTypeIdentifier:UTTypeUTF8PlainText.identifier visibility:NSItemProviderRepresentationVisibilityAll loadHandler:^NSProgress *(DataLoadCompletionBlock completionBlock)
     {
         completionBlock([textPayload dataUsingEncoding:NSUTF8StringEncoding], nil);
@@ -1007,11 +1007,11 @@ TEST(DragAndDropTests, ExternalSourceJPEGOnly)
 {
     ClassMethodSwizzler swizzler([UIKeyboard class], @selector(isInHardwareKeyboardMode), reinterpret_cast<IMP>(overrideIsInHardwareKeyboardMode));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"autofocus-contenteditable"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
-    auto simulatedItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulatedItemProvider = adoptNS([[NSItemProvider alloc] init]);
     [simulatedItemProvider registerDataRepresentationForTypeIdentifier:UTTypeJPEG.identifier visibility:NSItemProviderRepresentationVisibilityAll loadHandler:^NSProgress *(DataLoadCompletionBlock completionBlock)
     {
         completionBlock(UIImageJPEGRepresentation(testIconImage(), 0.5), nil);
@@ -1025,16 +1025,16 @@ TEST(DragAndDropTests, ExternalSourceJPEGOnly)
 
 TEST(DragAndDropTests, ExternalSourceTitledNSURL)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"autofocus-contenteditable"];
     [webView stringByEvaluatingJavaScript:@"getSelection().removeAllRanges()"];
 
     NSURL *titledURL = [NSURL URLWithString:@"https://www.apple.com"];
     titledURL._title = @"Apple";
-    auto simulatedItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulatedItemProvider = adoptNS([[NSItemProvider alloc] init]);
     [simulatedItemProvider registerObject:titledURL visibility:NSItemProviderRepresentationVisibilityAll];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setExternalItemProviders:@[ simulatedItemProvider.get() ]];
     [simulator runFrom:CGPointMake(300, 400) to:CGPointMake(100, 300)];
 
@@ -1044,14 +1044,14 @@ TEST(DragAndDropTests, ExternalSourceTitledNSURL)
 
 TEST(DragAndDropTests, ExternalSourceFileURL)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"autofocus-contenteditable"];
     [webView stringByEvaluatingJavaScript:@"getSelection().removeAllRanges()"];
 
     NSURL *URL = [NSURL URLWithString:@"file:///some/file/that/is/not/real"];
     NSItemProvider *simulatedItemProvider = [NSItemProvider itemProviderWithURL:URL title:@""];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setExternalItemProviders:@[ simulatedItemProvider ]];
     [simulator runFrom:CGPointMake(300, 400) to:CGPointMake(100, 300)];
 
@@ -1061,19 +1061,19 @@ TEST(DragAndDropTests, ExternalSourceFileURL)
 
 TEST(DragAndDropTests, ExternalSourceOverrideDropFileUpload)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"file-uploading"];
 
-    auto simulatedImageItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulatedImageItemProvider = adoptNS([[NSItemProvider alloc] init]);
     NSData *imageData = UIImageJPEGRepresentation(testIconImage(), 0.5);
     [simulatedImageItemProvider registerDataRepresentationForTypeIdentifier:UTTypeJPEG.identifier withData:imageData];
 
-    auto simulatedHTMLItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulatedHTMLItemProvider = adoptNS([[NSItemProvider alloc] init]);
     NSData *firstHTMLData = [@"<body contenteditable></body>" dataUsingEncoding:NSUTF8StringEncoding];
     [simulatedHTMLItemProvider registerDataRepresentationForTypeIdentifier:UTTypeHTML.identifier withData:firstHTMLData];
     [simulatedHTMLItemProvider setPreferredPresentationStyle:UIPreferredPresentationStyleAttachment];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setOverridePerformDropBlock:^NSArray<UIDragItem *> *(id <UIDropSession> session)
     {
         EXPECT_EQ(2UL, session.items.count);
@@ -1094,11 +1094,11 @@ TEST(DragAndDropTests, ExternalSourceOverrideDropFileUpload)
 
 static RetainPtr<NSItemProvider> createMapItemForTesting()
 {
-    auto placemark = adoptNS([allocMKPlacemarkInstance() initWithCoordinate:CLLocationCoordinate2DMake(37.3327, -122.0053)]);
-    auto item = adoptNS([allocMKMapItemInstance() initWithPlacemark:placemark.get()]);
+    RetainPtr placemark = adoptNS([allocMKPlacemarkInstance() initWithCoordinate:CLLocationCoordinate2DMake(37.3327, -122.0053)]);
+    RetainPtr item = adoptNS([allocMKMapItemInstance() initWithPlacemark:placemark.get()]);
     [item setName:@"Apple Park"];
 
-    auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
     [itemProvider registerObject:item.get() visibility:NSItemProviderRepresentationVisibilityAll];
     [itemProvider setSuggestedName:[item name]];
 
@@ -1107,11 +1107,11 @@ static RetainPtr<NSItemProvider> createMapItemForTesting()
 
 static RetainPtr<NSItemProvider> createContactItemForTesting()
 {
-    auto contact = adoptNS([allocCNMutableContactInstance() init]);
+    RetainPtr contact = adoptNS([allocCNMutableContactInstance() init]);
     [contact setGivenName:@"Foo"];
     [contact setFamilyName:@"Bar"];
 
-    auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
     [itemProvider registerObject:contact.get() visibility:NSItemProviderRepresentationVisibilityAll];
     [itemProvider setSuggestedName:@"Foo Bar"];
 
@@ -1120,11 +1120,11 @@ static RetainPtr<NSItemProvider> createContactItemForTesting()
 
 TEST(DragAndDropTests, ExternalSourceMapItemIntoEditableAreas)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"contenteditable-and-textarea"];
     [webView _synchronouslyExecuteEditCommand:@"Delete" argument:nil];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setExternalItemProviders:@[ createMapItemForTesting().get() ]];
     [simulator runFrom:CGPointMake(0, 0) to:CGPointMake(100, 100)];
     EXPECT_WK_STREQ("Apple Park", [webView stringByEvaluatingJavaScript:@"document.querySelector('div[contenteditable]').textContent"]);
@@ -1138,11 +1138,11 @@ TEST(DragAndDropTests, ExternalSourceMapItemIntoEditableAreas)
 
 TEST(DragAndDropTests, ExternalSourceContactIntoEditableAreas)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"contenteditable-and-textarea"];
     [webView _synchronouslyExecuteEditCommand:@"Delete" argument:nil];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setExternalItemProviders:@[ createContactItemForTesting().get() ]];
     [simulator runFrom:CGPointMake(0, 0) to:CGPointMake(100, 100)];
     EXPECT_WK_STREQ("", [webView stringByEvaluatingJavaScript:@"document.querySelector('div[contenteditable]').textContent"]);
@@ -1153,10 +1153,10 @@ TEST(DragAndDropTests, ExternalSourceContactIntoEditableAreas)
 
 TEST(DragAndDropTests, ExternalSourceMapItemAndContactToUploadArea)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"file-uploading"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setExternalItemProviders:@[ createMapItemForTesting().get(), createContactItemForTesting().get() ]];
     [simulator runFrom:CGPointMake(200, 100) to:CGPointMake(100, 300)];
 
@@ -1165,7 +1165,7 @@ TEST(DragAndDropTests, ExternalSourceMapItemAndContactToUploadArea)
 
 static RetainPtr<TestWKWebView> setUpTestWebViewForDataTransferItems()
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"DataTransferItem-getAsEntry"];
 
     auto preferences = (__bridge WKPreferencesRef)[[webView configuration] preferences];
@@ -1197,14 +1197,14 @@ TEST(DragAndDropTests, ExternalSourceDataTransferItemGetFolderAsEntry)
     }];
 
     runTestWithTemporaryFolder(^(NSURL *folderURL) {
-        auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+        RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
         [itemProvider setSuggestedName:@"somedirectory"];
         [itemProvider registerFileRepresentationForTypeIdentifier:UTTypeFolder.identifier fileOptions:0 visibility:NSItemProviderRepresentationVisibilityAll loadHandler:[capturedFolderURL = retainPtr(folderURL)] (FileLoadCompletionBlock completionHandler) -> NSProgress * {
             completionHandler(capturedFolderURL.get(), NO, nil);
             return nil;
         }];
 
-        auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+        RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
         [simulator setExternalItemProviders:@[ itemProvider.get() ]];
         [simulator runFromElement:@"#output" toElement:@"#droparea"];
     });
@@ -1227,14 +1227,14 @@ TEST(DragAndDropTests, ExternalSourceDataTransferItemGetPlainTextFileAsEntry)
     }];
 
     runTestWithTemporaryTextFile(^(NSURL *fileURL) {
-        auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+        RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
         [itemProvider setSuggestedName:@"foo"];
         [itemProvider registerFileRepresentationForTypeIdentifier:UTTypeUTF8PlainText.identifier fileOptions:0 visibility:NSItemProviderRepresentationVisibilityAll loadHandler:[capturedFileURL = retainPtr(fileURL)](FileLoadCompletionBlock completionHandler) -> NSProgress * {
             completionHandler(capturedFileURL.get(), NO, nil);
             return nil;
         }];
 
-        auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+        RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
         [simulator setExternalItemProviders:@[ itemProvider.get() ]];
         [simulator runFromElement:@"#output" toElement:@"#droparea"];
     });
@@ -1245,11 +1245,11 @@ TEST(DragAndDropTests, ExternalSourceDataTransferItemGetPlainTextFileAsEntry)
 
 TEST(DragAndDropTests, ExternalSourceOverrideDropInsertURL)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"autofocus-contenteditable"];
     [webView stringByEvaluatingJavaScript:@"getSelection().removeAllRanges()"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setOverridePerformDropBlock:^NSArray<UIDragItem *> *(id <UIDropSession> session)
     {
         NSMutableArray<UIDragItem *> *allowedItems = [NSMutableArray array];
@@ -1261,9 +1261,9 @@ TEST(DragAndDropTests, ExternalSourceOverrideDropInsertURL)
         return allowedItems;
     }];
 
-    auto firstItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr firstItemProvider = adoptNS([[NSItemProvider alloc] init]);
     [firstItemProvider registerObject:@"This is a string." visibility:NSItemProviderRepresentationVisibilityAll];
-    auto secondItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr secondItemProvider = adoptNS([[NSItemProvider alloc] init]);
     [secondItemProvider registerObject:[NSURL URLWithString:@"https://webkit.org/"] visibility:NSItemProviderRepresentationVisibilityAll];
     [simulator setExternalItemProviders:@[ firstItemProvider.get(), secondItemProvider.get() ]];
     [simulator runFrom:CGPointMake(300, 400) to:CGPointMake(100, 300)];
@@ -1274,14 +1274,14 @@ TEST(DragAndDropTests, ExternalSourceOverrideDropInsertURL)
 
 TEST(DragAndDropTests, OverrideDrop)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
-    auto simulatedItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulatedItemProvider = adoptNS([[NSItemProvider alloc] init]);
     [simulatedItemProvider registerDataRepresentationForTypeIdentifier:UTTypeHTML.identifier withData:[@"<body></body>" dataUsingEncoding:NSUTF8StringEncoding]];
 
     __block bool finishedLoadingData = false;
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setExternalItemProviders:@[ simulatedItemProvider.get() ]];
     [simulator setOverrideDragUpdateBlock:[] (UIDropOperation operation, id <UIDropSession> session) {
         EXPECT_EQ(UIDropOperationCancel, operation);
@@ -1290,7 +1290,7 @@ TEST(DragAndDropTests, OverrideDrop)
     [simulator setDropCompletionBlock:^(BOOL handled, NSArray *itemProviders) {
         EXPECT_FALSE(handled);
         [itemProviders.firstObject loadDataRepresentationForTypeIdentifier:UTTypeHTML.identifier completionHandler:^(NSData *data, NSError *error) {
-            auto text = adoptNS([[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
+            RetainPtr text = adoptNS([[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
             EXPECT_WK_STREQ("<body></body>", [text UTF8String]);
             EXPECT_FALSE(!!error);
             finishedLoadingData = true;
@@ -1305,18 +1305,18 @@ TEST(DragAndDropTests, InjectedBundleOverridePerformTwoStepDrop)
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"BundleEditingDelegatePlugIn"];
     [configuration.processPool _setObject:@YES forBundleParameter:@"BundleOverridePerformTwoStepDrop"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration]);
     [webView loadTestPageNamed:@"autofocus-contenteditable"];
     [webView stringByEvaluatingJavaScript:@"getSelection().removeAllRanges()"];
 
-    auto simulatedItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulatedItemProvider = adoptNS([[NSItemProvider alloc] init]);
     [simulatedItemProvider registerDataRepresentationForTypeIdentifier:UTTypeUTF8PlainText.identifier visibility:NSItemProviderRepresentationVisibilityAll loadHandler:^NSProgress *(DataLoadCompletionBlock completionBlock)
     {
         completionBlock([@"Hello world" dataUsingEncoding:NSUTF8StringEncoding], nil);
         return [NSProgress discreteProgressWithTotalUnitCount:100];
     }];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setExternalItemProviders:@[ simulatedItemProvider.get() ]];
     [simulator runFrom:CGPointMake(300, 400) to:CGPointMake(100, 300)];
 
@@ -1328,18 +1328,18 @@ TEST(DragAndDropTests, InjectedBundleAllowPerformTwoStepDrop)
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"BundleEditingDelegatePlugIn"];
     [configuration.processPool _setObject:@NO forBundleParameter:@"BundleOverridePerformTwoStepDrop"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration]);
     [webView synchronouslyLoadTestPageNamed:@"autofocus-contenteditable"];
     [webView stringByEvaluatingJavaScript:@"getSelection().removeAllRanges()"];
 
-    auto simulatedItemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulatedItemProvider = adoptNS([[NSItemProvider alloc] init]);
     [simulatedItemProvider registerDataRepresentationForTypeIdentifier:UTTypeUTF8PlainText.identifier visibility:NSItemProviderRepresentationVisibilityAll loadHandler:^NSProgress *(DataLoadCompletionBlock completionBlock)
     {
         completionBlock([@"Hello world" dataUsingEncoding:NSUTF8StringEncoding], nil);
         return [NSProgress discreteProgressWithTotalUnitCount:100];
     }];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setExternalItemProviders:@[ simulatedItemProvider.get() ]];
     [simulator runFrom:CGPointMake(300, 400) to:CGPointMake(100, 300)];
 
@@ -1350,11 +1350,11 @@ TEST(DragAndDropTests, InjectedBundleImageElementData)
 {
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"BundleEditingDelegatePlugIn"];
     [configuration _setAttachmentElementEnabled:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration]);
     [webView synchronouslyLoadTestPageNamed:@"image-and-contenteditable"];
 
     __block RetainPtr<NSString> injectedString;
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setConvertItemProvidersBlock:^NSArray *(NSItemProvider *itemProvider, NSArray *, NSDictionary *data)
     {
         injectedString = adoptNS([[NSString alloc] initWithData:data[InjectedBundlePasteboardDataType] encoding:NSUTF8StringEncoding]);
@@ -1370,11 +1370,11 @@ TEST(DragAndDropTests, InjectedBundleAttachmentElementData)
 {
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"BundleEditingDelegatePlugIn"];
     [configuration _setAttachmentElementEnabled:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration]);
     [webView synchronouslyLoadTestPageNamed:@"attachment-element"];
 
     __block RetainPtr<NSString> injectedString;
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setConvertItemProvidersBlock:^NSArray *(NSItemProvider *itemProvider, NSArray *, NSDictionary *data)
     {
         injectedString = adoptNS([[NSString alloc] initWithData:data[InjectedBundlePasteboardDataType] encoding:NSUTF8StringEncoding]);
@@ -1389,13 +1389,13 @@ TEST(DragAndDropTests, InjectedBundleAttachmentElementData)
 
 TEST(DragAndDropTests, LargeImageToTargetDiv)
 {
-    auto testWebViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr testWebViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[testWebViewConfiguration preferences] _setLargeImageAsyncDecodingEnabled:NO];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:testWebViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:testWebViewConfiguration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"div-and-large-image"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(200, 400) to:CGPointMake(200, 150)];
     EXPECT_WK_STREQ("PASS", [webView stringByEvaluatingJavaScript:@"target.textContent"].UTF8String);
     checkFirstTypeIsPresentAndSecondTypeIsMissing(simulator.get(), UTTypePNG.identifier, UTTypeFileURL.identifier);
@@ -1404,11 +1404,11 @@ TEST(DragAndDropTests, LargeImageToTargetDiv)
 
 TEST(DragAndDropTests, LinkWithEmptyHREF)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"link-and-input"];
     [webView stringByEvaluatingJavaScript:@"document.querySelector('a').href = ''"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(100, 50) to:CGPointMake(100, 300)];
 
     EXPECT_EQ(DragAndDropPhaseCancelled, [simulator phase]);
@@ -1417,10 +1417,10 @@ TEST(DragAndDropTests, LinkWithEmptyHREF)
 
 TEST(DragAndDropTests, CancelledLiftDoesNotCauseSubsequentDragsToFail)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"link-and-target-div"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setConvertItemProvidersBlock:^NSArray *(NSItemProvider *, NSArray *, NSDictionary *)
     {
         return @[ ];
@@ -1444,9 +1444,9 @@ TEST(DragAndDropTests, CancelledLiftDoesNotCauseSubsequentDragsToFail)
 
 TEST(DragAndDropTests, WebProcessTerminationDuringDrag)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"link-and-target-div"];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setSessionWillBeginBlock:^{
         [webView _killWebContentProcessAndResetState];
     }];
@@ -1455,9 +1455,9 @@ TEST(DragAndDropTests, WebProcessTerminationDuringDrag)
 
 TEST(DragAndDropTests, WebViewRemovedFromViewHierarchyDuringDrag)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"link-and-target-div"];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setConvertItemProvidersBlock:[webView] (NSItemProvider *item, NSArray *, NSDictionary *) -> NSArray * {
         [webView removeFromSuperview];
         return @[ item ];
@@ -1468,7 +1468,7 @@ TEST(DragAndDropTests, WebViewRemovedFromViewHierarchyDuringDrag)
 
 static void testDragAndDropOntoTargetElements(TestWKWebView *webView)
 {
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView]);
     [simulator runFrom:CGPointMake(50, 50) to:CGPointMake(50, 250)];
     EXPECT_WK_STREQ("rgb(0, 128, 0)", [webView stringByEvaluatingJavaScript:@"getComputedStyle(target1).backgroundColor"]);
     EXPECT_WK_STREQ("PASS", [webView stringByEvaluatingJavaScript:@"target1.textContent"]);
@@ -1484,7 +1484,7 @@ static void testDragAndDropOntoTargetElements(TestWKWebView *webView)
 
 TEST(DragAndDropTests, DragEventClientCoordinatesBasic)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"drop-targets"];
 
     testDragAndDropOntoTargetElements(webView.get());
@@ -1492,7 +1492,7 @@ TEST(DragAndDropTests, DragEventClientCoordinatesBasic)
 
 TEST(DragAndDropTests, DragEventClientCoordinatesWithScrollOffset)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"drop-targets"];
     [webView stringByEvaluatingJavaScript:@"document.body.style.margin = '1000px 0'"];
     [webView stringByEvaluatingJavaScript:@"document.scrollingElement.scrollTop = 1000"];
@@ -1503,7 +1503,7 @@ TEST(DragAndDropTests, DragEventClientCoordinatesWithScrollOffset)
 
 TEST(DragAndDropTests, DragEventPageCoordinatesBasic)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"drop-targets"];
     [webView stringByEvaluatingJavaScript:@"window.usePageCoordinates = true"];
 
@@ -1512,7 +1512,7 @@ TEST(DragAndDropTests, DragEventPageCoordinatesBasic)
 
 TEST(DragAndDropTests, DragEventPageCoordinatesWithScrollOffset)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"drop-targets"];
     [webView stringByEvaluatingJavaScript:@"document.body.style.margin = '1000px 0'"];
     [webView stringByEvaluatingJavaScript:@"document.scrollingElement.scrollTop = 1000"];
@@ -1524,10 +1524,10 @@ TEST(DragAndDropTests, DragEventPageCoordinatesWithScrollOffset)
 
 TEST(DragAndDropTests, DoNotCrashWhenSelectionIsClearedInDragStart)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"dragstart-clear-selection"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(100, 100) to:CGPointMake(100, 100)];
 
     EXPECT_WK_STREQ("PASS", [webView stringByEvaluatingJavaScript:@"paragraph.textContent"]);
@@ -1537,10 +1537,10 @@ TEST(DragAndDropTests, DoNotCrashWhenSelectionIsClearedInDragStart)
 #if 0
 TEST(DragAndDropTests, CustomActionSheetPopover)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"link-and-target-div"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setShouldEnsureUIApplication:YES];
 
     __block BOOL didInvokeCustomActionSheet = NO;
@@ -1559,15 +1559,15 @@ TEST(DragAndDropTests, CustomActionSheetPopover)
 
 TEST(DragAndDropTests, UnresponsivePageDoesNotHangUI)
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     [processPoolConfiguration setIgnoreSynchronousMessagingTimeoutsForTesting:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:adoptNS([[WKWebViewConfiguration alloc] init]).get() processPoolConfiguration:processPoolConfiguration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:adoptNS([[WKWebViewConfiguration alloc] init]).get() processPoolConfiguration:processPoolConfiguration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
     [webView evaluateJavaScript:@"while(1);" completionHandler:nil];
 
     // The test passes if we can prepare for a drag session without timing out.
-    auto dragSession = adoptNS([[MockDragSession alloc] init]);
+    RetainPtr dragSession = adoptNS([[MockDragSession alloc] init]);
 #if USE(BROWSERENGINEKIT)
     [[webView dragInteractionDelegate] dragInteraction:[webView dragInteraction] prepareDragSession:dragSession.get() completion:^{
         return NO;
@@ -1583,14 +1583,14 @@ TEST(DragAndDropTests, WebItemProviderPasteboardLoading)
     static NSString *slowString = @"This data loads slowly";
 
     WebItemProviderPasteboard *pasteboard = [WebItemProviderPasteboard sharedInstance];
-    auto fastItem = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr fastItem = adoptNS([[NSItemProvider alloc] init]);
     [fastItem registerDataRepresentationForTypeIdentifier:UTTypeUTF8PlainText.identifier visibility:NSItemProviderRepresentationVisibilityAll loadHandler:^NSProgress *(DataLoadCompletionBlock completionBlock)
     {
         completionBlock([fastString dataUsingEncoding:NSUTF8StringEncoding], nil);
         return nil;
     }];
 
-    auto slowItem = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr slowItem = adoptNS([[NSItemProvider alloc] init]);
     [slowItem registerDataRepresentationForTypeIdentifier:UTTypeUTF8PlainText.identifier visibility:NSItemProviderRepresentationVisibilityAll loadHandler:^NSProgress *(DataLoadCompletionBlock completionBlock)
     {
         sleep(2_s);
@@ -1602,8 +1602,8 @@ TEST(DragAndDropTests, WebItemProviderPasteboardLoading)
     pasteboard.itemProviders = @[ fastItem.get(), slowItem.get() ];
     [pasteboard doAfterLoadingProvidedContentIntoFileURLs:^(NSArray<NSURL *> *urls) {
         EXPECT_EQ(2UL, urls.count);
-        auto firstString = adoptNS([[NSString alloc] initWithContentsOfURL:urls[0] encoding:NSUTF8StringEncoding error:nil]);
-        auto secondString = adoptNS([[NSString alloc] initWithContentsOfURL:urls[1] encoding:NSUTF8StringEncoding error:nil]);
+        RetainPtr firstString = adoptNS([[NSString alloc] initWithContentsOfURL:urls[0] encoding:NSUTF8StringEncoding error:nil]);
+        RetainPtr secondString = adoptNS([[NSString alloc] initWithContentsOfURL:urls[1] encoding:NSUTF8StringEncoding error:nil]);
         EXPECT_WK_STREQ(fastString, [firstString UTF8String]);
         EXPECT_WK_STREQ(slowString, [secondString UTF8String]);
         hasRunFirstCompletionBlock = true;
@@ -1613,8 +1613,8 @@ TEST(DragAndDropTests, WebItemProviderPasteboardLoading)
     __block bool hasRunSecondCompletionBlock = false;
     [pasteboard doAfterLoadingProvidedContentIntoFileURLs:^(NSArray<NSURL *> *urls) {
         EXPECT_EQ(2UL, urls.count);
-        auto firstString = adoptNS([[NSString alloc] initWithContentsOfURL:urls[0] encoding:NSUTF8StringEncoding error:nil]);
-        auto secondString = adoptNS([[NSString alloc] initWithContentsOfURL:urls[1] encoding:NSUTF8StringEncoding error:nil]);
+        RetainPtr firstString = adoptNS([[NSString alloc] initWithContentsOfURL:urls[0] encoding:NSUTF8StringEncoding error:nil]);
+        RetainPtr secondString = adoptNS([[NSString alloc] initWithContentsOfURL:urls[1] encoding:NSUTF8StringEncoding error:nil]);
         EXPECT_WK_STREQ(fastString, [firstString UTF8String]);
         EXPECT_WK_STREQ(slowString, [secondString UTF8String]);
         hasRunSecondCompletionBlock = true;
@@ -1625,10 +1625,10 @@ TEST(DragAndDropTests, WebItemProviderPasteboardLoading)
 
 TEST(DragAndDropTests, DoNotCrashWhenSelectionMovesOffscreenAfterDragStart)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"dragstart-change-selection-offscreen"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(100, 100) to:CGPointMake(100, 100)];
 
     EXPECT_WK_STREQ("FAR OFFSCREEN", [webView stringByEvaluatingJavaScript:@"getSelection().getRangeAt(0).toString()"]);
@@ -1636,12 +1636,12 @@ TEST(DragAndDropTests, DoNotCrashWhenSelectionMovesOffscreenAfterDragStart)
 
 TEST(DragAndDropTests, AdditionalItemsCanBePreventedOnDragStart)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"selected-text-image-link-and-editable"];
     [webView stringByEvaluatingJavaScript:@"link.addEventListener('dragstart', e => e.preventDefault())"];
     [webView stringByEvaluatingJavaScript:@"image.addEventListener('dragstart', e => e.preventDefault())"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(50, 50) to:CGPointMake(50, 400) additionalItemRequestLocations:@{
         @0.33: [NSValue valueWithCGPoint:CGPointMake(50, 150)],
         @0.66: [NSValue valueWithCGPoint:CGPointMake(50, 250)]
@@ -1651,10 +1651,10 @@ TEST(DragAndDropTests, AdditionalItemsCanBePreventedOnDragStart)
 
 TEST(DragAndDropTests, AdditionalLinkAndImageIntoContentEditable)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"selected-text-image-link-and-editable"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(50, 50) to:CGPointMake(50, 400) additionalItemRequestLocations:@{
         @0.33: [NSValue valueWithCGPoint:CGPointMake(50, 150)],
         @0.66: [NSValue valueWithCGPoint:CGPointMake(50, 250)]
@@ -1666,9 +1666,9 @@ TEST(DragAndDropTests, AdditionalLinkAndImageIntoContentEditable)
 
 TEST(DragAndDropTests, DragLiftPreviewDataTransferSetDragImage)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"DataTransfer-setDragImage"];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     // Use DataTransfer.setDragImage to specify an existing image element in the DOM.
     [simulator runFrom:CGPointMake(100, 50) to:CGPointMake(250, 50)];
@@ -1698,12 +1698,12 @@ static NSData *testIconImageData()
 
 TEST(DragAndDropTests, DataTransferGetDataWhenDroppingImageAndMarkup)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     WKPreferencesSetCustomPasteboardDataEnabled((__bridge WKPreferencesRef)[webView configuration].preferences, true);
     [webView synchronouslyLoadTestPageNamed:@"DataTransfer"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
-    auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
     [itemProvider registerDataRepresentationForTypeIdentifier:UTTypePNG.identifier withData:testIconImageData()];
     NSString *markupString = @"<script>bar()</script><strong onmousedown=javascript:void(0)>HELLO WORLD</strong>";
     [itemProvider registerDataRepresentationForTypeIdentifier:UTTypeHTML.identifier withData:[markupString dataUsingEncoding:NSUTF8StringEncoding]];
@@ -1722,9 +1722,9 @@ TEST(DragAndDropTests, DataTransferGetDataWhenDroppingImageAndMarkup)
 
 TEST(DragAndDropTests, DataTransferGetDataWhenDroppingPlainText)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"dump-datatransfer-types"];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     [webView stringByEvaluatingJavaScript:@"select(plain)"];
     [simulator runFrom:CGPointMake(50, 75) to:CGPointMake(50, 375)];
@@ -1736,9 +1736,9 @@ TEST(DragAndDropTests, DataTransferGetDataWhenDroppingPlainText)
 
 TEST(DragAndDropTests, DataTransferGetDataWhenDroppingCustomData)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"dump-datatransfer-types"];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     [webView stringByEvaluatingJavaScript:@"select(rich)"];
     [webView stringByEvaluatingJavaScript:@"writeCustomData = true"];
@@ -1765,9 +1765,9 @@ TEST(DragAndDropTests, DataTransferGetDataWhenDroppingCustomData)
 
 TEST(DragAndDropTests, DataTransferGetDataWhenDroppingURL)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"dump-datatransfer-types"];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     [webView stringByEvaluatingJavaScript:@"rich.innerHTML = '<a href=\"https://www.apple.com/\">This is a link.</a>'"];
     [simulator runFrom:CGPointMake(50, 225) to:CGPointMake(50, 375)];
@@ -1785,11 +1785,11 @@ TEST(DragAndDropTests, DataTransferGetDataWhenDroppingURL)
 
 TEST(DragAndDropTests, DataTransferGetDataWhenDroppingImageWithFileURL)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"dump-datatransfer-types"];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
-    auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
     NSURL *iconURL = [NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"];
     [itemProvider registerFileRepresentationForTypeIdentifier:UTTypePNG.identifier fileOptions:0 visibility:NSItemProviderRepresentationVisibilityAll loadHandler:[protectedIconURL = retainPtr(iconURL)] (FileLoadCompletionBlock completionHandler) -> NSProgress * {
         completionHandler(protectedIconURL.get(), NO, nil);
@@ -1809,11 +1809,11 @@ TEST(DragAndDropTests, DataTransferGetDataWhenDroppingImageWithFileURL)
 
 TEST(DragAndDropTests, DataTransferGetDataWhenDroppingImageWithHTTPURL)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"dump-datatransfer-types"];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
-    auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
     [itemProvider registerDataRepresentationForTypeIdentifier:UTTypeJPEG.identifier visibility:NSItemProviderRepresentationVisibilityAll loadHandler:^NSProgress *(DataLoadCompletionBlock completionHandler)
     {
         completionHandler(UIImageJPEGRepresentation(testIconImage(), 0.5), nil);
@@ -1831,12 +1831,12 @@ TEST(DragAndDropTests, DataTransferGetDataWhenDroppingImageWithHTTPURL)
 
 TEST(DragAndDropTests, DataTransferGetDataWhenDroppingRespectsPresentationStyle)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"dump-datatransfer-types"];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     runTestWithTemporaryTextFile(^(NSURL *fileURL) {
-        auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+        RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
         [itemProvider registerFileRepresentationForTypeIdentifier:UTTypeUTF8PlainText.identifier fileOptions:0 visibility:NSItemProviderRepresentationVisibilityAll loadHandler:[protectedFileURL = retainPtr(fileURL)] (FileLoadCompletionBlock completionHandler) -> NSProgress * {
             completionHandler(protectedFileURL.get(), NO, nil);
             return nil;
@@ -1861,9 +1861,9 @@ TEST(DragAndDropTests, DataTransferGetDataWhenDroppingRespectsPresentationStyle)
 
 TEST(DragAndDropTests, DataTransferSetDataCannotWritePlatformTypes)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"dump-datatransfer-types"];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     [webView stringByEvaluatingJavaScript:@"select(rich)"];
     [webView stringByEvaluatingJavaScript:@"customData = { 'text/plain' : 'foo', 'com.adobe.pdf' : 'try and decode me!' }"];
@@ -1885,13 +1885,13 @@ TEST(DragAndDropTests, DataTransferSetDataCannotWritePlatformTypes)
 
 TEST(DragAndDropTests, DataTransferGetDataReadPlainAndRichText)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"DataTransfer"];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
-    auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
     NSDictionary *textAttributes = @{ NSFontAttributeName: [UIFont boldSystemFontOfSize:20] };
-    auto richText = adoptNS([[NSAttributedString alloc] initWithString:@"WebKit" attributes:textAttributes]);
+    RetainPtr richText = adoptNS([[NSAttributedString alloc] initWithString:@"WebKit" attributes:textAttributes]);
     [itemProvider registerObject:richText.get() visibility:NSItemProviderRepresentationVisibilityAll];
     [itemProvider registerObject:[NSURL URLWithString:@"https://www.webkit.org/"] visibility:NSItemProviderRepresentationVisibilityAll];
     [itemProvider registerObject:@"WebKit" visibility:NSItemProviderRepresentationVisibilityAll];
@@ -1909,11 +1909,11 @@ TEST(DragAndDropTests, DataTransferGetDataReadPlainAndRichText)
 
 TEST(DragAndDropTests, DataTransferSuppressGetDataDueToPresenceOfTextFile)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"DataTransfer"];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
-    auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
     [itemProvider registerObject:@"Hello world" visibility:NSItemProviderRepresentationVisibilityAll];
     [itemProvider setSuggestedName:@"hello.txt"];
 
@@ -1930,11 +1930,11 @@ TEST(DragAndDropTests, DataTransferSuppressGetDataDueToPresenceOfTextFile)
 
 TEST(DragAndDropTests, DataTransferExposePlainTextWithFileURLAsFile)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"DataTransfer"];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
-    auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
     NSData *urlAsData = [@"file:///some/file/path.txt" dataUsingEncoding:NSUTF8StringEncoding];
     [itemProvider registerDataRepresentationForTypeIdentifier:UTTypeFileURL.identifier withData:urlAsData];
     [itemProvider registerDataRepresentationForTypeIdentifier:UTTypeURL.identifier withData:urlAsData];
@@ -1956,11 +1956,11 @@ TEST(DragAndDropTests, DataTransferExposePlainTextWithFileURLAsFile)
 
 TEST(DragAndDropTests, DataTransferGetDataCannotReadPrivateArbitraryTypes)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"dump-datatransfer-types"];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
-    auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
     [itemProvider registerDataRepresentationForTypeIdentifier:UTTypeMP3.identifier visibility:NSItemProviderRepresentationVisibilityAll loadHandler:^NSProgress *(DataLoadCompletionBlock completionHandler)
     {
         completionHandler([@"this is a test" dataUsingEncoding:NSUTF8StringEncoding], nil);
@@ -1982,9 +1982,9 @@ TEST(DragAndDropTests, DataTransferGetDataCannotReadPrivateArbitraryTypes)
 
 TEST(DragAndDropTests, DataTransferSetDataValidURL)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"dump-datatransfer-types"];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     [webView stringByEvaluatingJavaScript:@"select(rich)"];
     [webView stringByEvaluatingJavaScript:@"customData = { 'url' : 'https://webkit.org/b/123' }"];
@@ -2019,9 +2019,9 @@ TEST(DragAndDropTests, DataTransferSetDataValidURL)
 
 TEST(DragAndDropTests, DataTransferSetDataUnescapedURL)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"dump-datatransfer-types"];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     [webView stringByEvaluatingJavaScript:@"select(rich)"];
     [webView stringByEvaluatingJavaScript:@"customData = { 'url' : 'http://webkit.org/b/\u4F60\u597D;?x=8 + 6' }"];
@@ -2056,9 +2056,9 @@ TEST(DragAndDropTests, DataTransferSetDataUnescapedURL)
 
 TEST(DragAndDropTests, DataTransferSetDataInvalidURL)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"dump-datatransfer-types"];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     [webView stringByEvaluatingJavaScript:@"select(rich)"];
     [webView stringByEvaluatingJavaScript:@"customData = { 'url' : 'some random string' }"];
@@ -2079,9 +2079,9 @@ TEST(DragAndDropTests, DataTransferSetDataInvalidURL)
 
 TEST(DragAndDropTests, DataTransferSanitizeHTML)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"dump-datatransfer-types"];
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
 
     [webView stringByEvaluatingJavaScript:@"select(rich)"];
     [webView stringByEvaluatingJavaScript:@"customData = { 'text/html' : '<meta content=\"secret\">"
@@ -2095,7 +2095,7 @@ TEST(DragAndDropTests, DataTransferSanitizeHTML)
         auto *item = session.items[0].itemProvider;
         EXPECT_TRUE([item.registeredTypeIdentifiers containsObject:UTTypeHTML.identifier]);
         [item loadDataRepresentationForTypeIdentifier:UTTypeHTML.identifier completionHandler:^(NSData *data, NSError *error) {
-            auto markup = adoptNS([[NSString alloc] initWithData:(NSData *)data encoding:NSUTF8StringEncoding]);
+            RetainPtr markup = adoptNS([[NSString alloc] initWithData:(NSData *)data encoding:NSUTF8StringEncoding]);
             EXPECT_TRUE([markup containsString:@"hello"]);
             EXPECT_TRUE([markup containsString:@", world"]);
             EXPECT_FALSE([markup containsString:@"secret"]);
@@ -2134,13 +2134,13 @@ static BOOL isCompletelyWhite(UIImage *image)
 
 TEST(DragAndDropTests, DropPreviewForImageInEditableArea)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"image-and-contenteditable"];
 
     // Ensure that the resulting snapshot on drop contains only the dragged image.
     [webView stringByEvaluatingJavaScript:@"editor.style.border = 'none'; editor.style.outline = 'none'"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(100, 50) to:CGPointMake(100, 300)];
 
     NSArray *dropPreviews = [simulator dropPreviews];
@@ -2157,10 +2157,10 @@ TEST(DragAndDropTests, DropPreviewForImageInEditableArea)
 
 TEST(DragAndDropTests, DropUserSelectAllUserDragElementDiv)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"contenteditable-user-select-user-drag"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(100, 100) to:CGPointMake(100, 300)];
 
     NSArray *liftPreviews = [simulator liftPreviews];
@@ -2174,18 +2174,18 @@ TEST(DragAndDropTests, DropUserSelectAllUserDragElementDiv)
 
 TEST(DragAndDropTests, SuggestedNameContainsDot)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"gif-and-file-input"];
 
-    auto firstItem = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr firstItem = adoptNS([[NSItemProvider alloc] init]);
     [firstItem registerDataRepresentationForTypeIdentifier:UTTypePNG.identifier withData:testIconImageData()];
     [firstItem setSuggestedName:@"one.foo"];
 
-    auto secondItem = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr secondItem = adoptNS([[NSItemProvider alloc] init]);
     [secondItem registerDataRepresentationForTypeIdentifier:UTTypePNG.identifier withData:testIconImageData()];
     [secondItem setSuggestedName:@"two.foo.PNG"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setExternalItemProviders:@[ firstItem.get(), secondItem.get() ]];
     [simulator runFrom:CGPointMake(0, 0) to:CGPointMake(100, 300)];
 
@@ -2194,7 +2194,7 @@ TEST(DragAndDropTests, SuggestedNameContainsDot)
 
 TEST(DragAndDropTests, CanStartDragOnModel)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAllowTestOnlyIPC:YES];
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"ModelElementEnabled"])
@@ -2210,7 +2210,7 @@ TEST(DragAndDropTests, CanStartDragOnModel)
     while (![messageHandler didLoadModel])
         Util::spinRunLoop();
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(20, 20) to:CGPointMake(100, 100)];
 
     NSArray *registeredTypes = [[simulator sourceItemProviders].firstObject registeredTypeIdentifiers];
@@ -2220,7 +2220,7 @@ TEST(DragAndDropTests, CanStartDragOnModel)
 #if ENABLE(MODEL_PROCESS)
 TEST(DragAndDropTests, CheckModelDragPreview)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAllowTestOnlyIPC:YES];
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"ModelElementEnabled"] || [feature.key isEqualToString:@"ModelProcessEnabled"])
@@ -2240,7 +2240,7 @@ TEST(DragAndDropTests, CheckModelDragPreview)
 
     bool done = false;
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator setDragProgressMidPointReachedBlock:makeBlockPtr([&done, simulator, webView] () mutable {
         EXPECT_TRUE([[simulator liftPreviews].firstObject.view window] != nil);
 
@@ -2376,10 +2376,10 @@ TEST(DragAndDropTests, CanHitTestNestedStageModeModel)
 
 TEST(DragAndDropTests, DragEnterAndLeaveRelatedTarget)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"drag-relatedTarget"];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
     [simulator runFrom:CGPointMake(160, 90) to:CGPointMake(160, 400)];
 
     EXPECT_WK_STREQ("null", [webView stringByEvaluatingJavaScript:@"enterARelatedTarget"]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ElementActionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ElementActionTests.mm
@@ -71,10 +71,10 @@ static void runTest(TestWKWebView *webView, TestNavigationDelegate *navigationDe
 TEST(ElementActionTests, OpenLinkWithHoverMenu)
 {
     auto frame = CGRectMake(0, 0, 320, 500);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:frame]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:frame]);
     [webView synchronouslyLoadTestPageNamed:@"link-with-hover-menu"];
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     runTest(webView.get(), navigationDelegate.get(), @"#link");

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/EnterKeyHintTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/EnterKeyHintTests.mm
@@ -70,8 +70,8 @@ Vector<EnterKeyHintTestCase> enterKeyHintTestCases(UIReturnKeyType fallbackRetur
 
 static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestInputDelegate>> createWebViewAndInputDelegateForTesting()
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id <_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         return _WKFocusStartsInputSessionPolicyAllow;
     }];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/FocusPreservationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/FocusPreservationTests.mm
@@ -39,13 +39,13 @@
 
 static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestInputDelegate>> webViewForTestingFocusPreservation(void(^focusHandler)(id <_WKFocusedElementInfo>))
 {
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&, focusHandler = makeBlockPtr(focusHandler)] (WKWebView *, id<_WKFocusedElementInfo> info) {
         focusHandler(info);
         return _WKFocusStartsInputSessionPolicyAllow;
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView _setInputDelegate:inputDelegate.get()];
     [webView synchronouslyLoadHTMLString:@"<input></input><select><option selected>foo</option><option>bar</option></select>"];
     return { webView, inputDelegate };

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/FullscreenLayoutParameters.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/FullscreenLayoutParameters.mm
@@ -115,7 +115,7 @@ TEST(Fullscreen, OverriddenLayoutParameters)
 {
     auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     configuration.preferences.elementFullscreenEnabled = YES;
-    auto webView = adoptNS([[FullscreenLayoutParametersWebView alloc] initWithFrame:CGRectMake(0, 0, 390, 800) configuration:configuration]);
+    RetainPtr webView = adoptNS([[FullscreenLayoutParametersWebView alloc] initWithFrame:CGRectMake(0, 0, 390, 800) configuration:configuration]);
     [webView synchronouslyLoadTestPageNamed:@"element-fullscreen"];
 
     auto layoutSize = CGSizeMake(390, 745);
@@ -132,7 +132,7 @@ TEST(Fullscreen, ResizeEventOrder)
 {
     auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     configuration.preferences.elementFullscreenEnabled = YES;
-    auto webView = adoptNS([[FullscreenLayoutParametersWebView alloc] initWithFrame:CGRectMake(0, 0, 390, 800) configuration:configuration]);
+    RetainPtr webView = adoptNS([[FullscreenLayoutParametersWebView alloc] initWithFrame:CGRectMake(0, 0, 390, 800) configuration:configuration]);
     [webView synchronouslyLoadTestPageNamed:@"element-fullscreen"];
 
     [webView waitForNextPresentationUpdate];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/GestureRecognizerTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/GestureRecognizerTests.mm
@@ -35,9 +35,9 @@ namespace TestWebKitAPI {
 TEST(GestureRecognizerTests, DoNotAllowTapToRecognizeAlongsideReparentedScrollViewPanGesture)
 {
     auto frame = CGRectMake(0, 0, 320, 568);
-    auto hiddenScrollView = adoptNS([[UIScrollView alloc] initWithFrame:frame]);
-    auto webViewContainer = adoptNS([[UIView alloc] initWithFrame:frame]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:frame]);
+    RetainPtr hiddenScrollView = adoptNS([[UIScrollView alloc] initWithFrame:frame]);
+    RetainPtr webViewContainer = adoptNS([[UIView alloc] initWithFrame:frame]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:frame]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
     [[webView window] addSubview:webViewContainer.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/GrantAccessToMobileAssets.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/GrantAccessToMobileAssets.mm
@@ -33,7 +33,7 @@
 
 TEST(WebKit, GrantAccessToMobileAssetsCrash)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300)]);
 
     [webView _grantAccessToAssetServices];
     [webView _revokeAccessToAssetServices];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/KeyboardInputTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/KeyboardInputTestsIOS.mm
@@ -95,7 +95,7 @@ enum class CaretVisibility : bool { Hidden, Visible };
     static dispatch_once_t onceToken;
     static RetainPtr<UIBarButtonItemGroup> sharedItems;
     dispatch_once(&onceToken, ^{
-        auto leadingItem = adoptNS([[UIBarButtonItem alloc] initWithImage:self.barButtonIcon style:UIBarButtonItemStylePlain target:webView action:@selector(fakeLeadingBarButtonItemAction)]);
+        RetainPtr leadingItem = adoptNS([[UIBarButtonItem alloc] initWithImage:self.barButtonIcon style:UIBarButtonItemStylePlain target:webView action:@selector(fakeLeadingBarButtonItemAction)]);
         sharedItems = adoptNS([[UIBarButtonItemGroup alloc] initWithBarButtonItems:@[ leadingItem.get() ] representativeItem:nil]);
     });
     return sharedItems.get();
@@ -106,7 +106,7 @@ enum class CaretVisibility : bool { Hidden, Visible };
     static dispatch_once_t onceToken;
     static RetainPtr<UIBarButtonItemGroup> sharedItems;
     dispatch_once(&onceToken, ^{
-        auto trailingItem = adoptNS([[UIBarButtonItem alloc] initWithImage:self.barButtonIcon style:UIBarButtonItemStylePlain target:webView action:@selector(fakeTrailingBarButtonItemAction)]);
+        RetainPtr trailingItem = adoptNS([[UIBarButtonItem alloc] initWithImage:self.barButtonIcon style:UIBarButtonItemStylePlain target:webView action:@selector(fakeTrailingBarButtonItemAction)]);
         sharedItems = adoptNS([[UIBarButtonItemGroup alloc] initWithBarButtonItems:@[ trailingItem.get() ] representativeItem:nil]);
     });
     return sharedItems.get();
@@ -114,7 +114,7 @@ enum class CaretVisibility : bool { Hidden, Visible };
 
 - (UITextInputAssistantItem *)inputAssistantItem
 {
-    auto assistantItem = adoptNS([[UITextInputAssistantItem alloc] init]);
+    RetainPtr assistantItem = adoptNS([[UITextInputAssistantItem alloc] init]);
     [assistantItem setLeadingBarButtonGroups:@[[InputAssistantItemTestingWebView leadingItemsForWebView:self]]];
     [assistantItem setTrailingBarButtonGroups:@[[InputAssistantItemTestingWebView trailingItemsForWebView:self]]];
     return assistantItem.autorelease();
@@ -249,7 +249,7 @@ static CGRect rounded(CGRect rect)
 
 static RetainPtr<TestWKWebView> webViewWithAutofocusedInput(const RetainPtr<TestInputDelegate>& inputDelegate)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
 
     __block bool doneWaiting = false;
     [inputDelegate setFocusStartsInputSessionPolicyHandler:^_WKFocusStartsInputSessionPolicy(WKWebView *, id <_WKFocusedElementInfo>) {
@@ -266,7 +266,7 @@ static RetainPtr<TestWKWebView> webViewWithAutofocusedInput(const RetainPtr<Test
 
 static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestInputDelegate>> webViewAndInputDelegateWithAutofocusedInput()
 {
-    auto inputDelegate = adoptNS([TestInputDelegate new]);
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
     return { webViewWithAutofocusedInput(inputDelegate), inputDelegate };
 }
 
@@ -276,8 +276,8 @@ TEST(KeyboardInputTests, FormNavigationAssistantBarButtonItems)
 {
     IPadUserInterfaceSwizzler iPadUserInterface;
 
-    auto inputDelegate = adoptNS([TestInputDelegate new]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView _setInputDelegate:inputDelegate.get()];
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id <_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         return _WKFocusStartsInputSessionPolicyAllow;
@@ -297,8 +297,8 @@ TEST(KeyboardInputTests, FormNavigationAssistantBarButtonItems)
 
 TEST(KeyboardInputTests, ModifyInputAssistantItemBarButtonGroups)
 {
-    auto inputDelegate = adoptNS([TestInputDelegate new]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView _setInputDelegate:inputDelegate.get()];
     [webView synchronouslyLoadHTMLString:@"<body contenteditable>"];
     UITextInputAssistantItem *item = [webView inputAssistantItem];
@@ -327,8 +327,8 @@ TEST(KeyboardInputTests, ModifyInputAssistantItemBarButtonGroups)
 
 TEST(KeyboardInputTests, OverrideInputAssistantItemBarButtonGroups)
 {
-    auto inputDelegate = adoptNS([TestInputDelegate new]);
-    auto webView = adoptNS([[InputAssistantItemTestingWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
+    RetainPtr webView = adoptNS([[InputAssistantItemTestingWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView _setInputDelegate:inputDelegate.get()];
     [webView synchronouslyLoadHTMLString:@"<body contenteditable>"];
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id <_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
@@ -353,9 +353,9 @@ TEST(KeyboardInputTests, OverrideInputAssistantItemBarButtonGroups)
 
 TEST(KeyboardInputTests, CustomInputViewAndInputAccessoryView)
 {
-    auto inputView = adoptNS([[UIView alloc] init]);
-    auto inputAccessoryView = adoptNS([[UIView alloc] init]);
-    auto inputDelegate = adoptNS([TestInputDelegate new]);
+    RetainPtr inputView = adoptNS([[UIView alloc] init]);
+    RetainPtr inputAccessoryView = adoptNS([[UIView alloc] init]);
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
     [inputDelegate setWillStartInputSessionHandler:[inputView, inputAccessoryView] (WKWebView *, id<_WKFormInputSession> session) {
         session.customInputView = inputView.get();
         session.customInputAccessoryView = inputAccessoryView.get();
@@ -371,8 +371,8 @@ TEST(KeyboardInputTests, CanHandleKeyEventInCompletionHandler)
     auto [webView, inputDelegate] = webViewAndInputDelegateWithAutofocusedInput();
     bool doneWaiting = false;
 
-    auto firstWebEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyDown timeStamp:CFAbsoluteTimeGetCurrent() characters:@"a" charactersIgnoringModifiers:@"a" modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:NO]);
-    auto secondWebEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyUp timeStamp:CFAbsoluteTimeGetCurrent() characters:@"a" charactersIgnoringModifiers:@"a" modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:NO]);
+    RetainPtr firstWebEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyDown timeStamp:CFAbsoluteTimeGetCurrent() characters:@"a" charactersIgnoringModifiers:@"a" modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:NO]);
+    RetainPtr secondWebEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyUp timeStamp:CFAbsoluteTimeGetCurrent() characters:@"a" charactersIgnoringModifiers:@"a" modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:NO]);
     [webView handleKeyEvent:firstWebEvent.get() completion:[&](WebEvent *event, BOOL) {
         EXPECT_TRUE([event isEqual:firstWebEvent.get()]);
         [webView handleKeyEvent:secondWebEvent.get() completion:[&] (WebEvent *event, BOOL) {
@@ -389,7 +389,7 @@ TEST(KeyboardInputTests, CanHandleKeyEventInCompletionHandler)
 TEST(KeyboardInputTests, ResigningFirstResponderCancelsKeyEvents)
 {
     auto [webView, inputDelegate] = webViewAndInputDelegateWithAutofocusedInput();
-    auto keyDownEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyDown timeStamp:CFAbsoluteTimeGetCurrent() characters:@"a" charactersIgnoringModifiers:@"a" modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:NO]);
+    RetainPtr keyDownEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyDown timeStamp:CFAbsoluteTimeGetCurrent() characters:@"a" charactersIgnoringModifiers:@"a" modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:NO]);
 
     [webView becomeFirstResponder];
     [webView evaluateJavaScript:@"while(1);" completionHandler:nil];
@@ -407,8 +407,8 @@ TEST(KeyboardInputTests, ResigningFirstResponderCancelsKeyEvents)
 
 TEST(KeyboardInputTests, WaitForKeyEventHandlerInFirstResponder)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto keyDownEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyDown timeStamp:CFAbsoluteTimeGetCurrent() characters:@"a" charactersIgnoringModifiers:@"a" modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:NO]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr keyDownEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyDown timeStamp:CFAbsoluteTimeGetCurrent() characters:@"a" charactersIgnoringModifiers:@"a" modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:NO]);
 
     [webView becomeFirstResponder];
     [webView synchronouslyLoadHTMLString:@"<body></body>"];
@@ -426,9 +426,9 @@ TEST(KeyboardInputTests, WaitForKeyEventHandlerInFirstResponder)
 
 TEST(KeyboardInputTests, HandleKeyEventsInCrashedOrUninitializedWebProcess)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     {
-        auto keyDownEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyDown timeStamp:CFAbsoluteTimeGetCurrent() characters:@"a" charactersIgnoringModifiers:@"a" modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:65 isTabKey:NO]);
+        RetainPtr keyDownEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyDown timeStamp:CFAbsoluteTimeGetCurrent() characters:@"a" charactersIgnoringModifiers:@"a" modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:65 isTabKey:NO]);
         bool doneWaiting = false;
         [webView synchronouslyLoadHTMLString:@"<body></body>"];
         [webView evaluateJavaScript:@"while (1);" completionHandler:nil];
@@ -441,7 +441,7 @@ TEST(KeyboardInputTests, HandleKeyEventsInCrashedOrUninitializedWebProcess)
         TestWebKitAPI::Util::run(&doneWaiting);
     }
     {
-        auto keyUpEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyUp timeStamp:CFAbsoluteTimeGetCurrent() characters:@"a" charactersIgnoringModifiers:@"a" modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:65 isTabKey:NO]);
+        RetainPtr keyUpEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyUp timeStamp:CFAbsoluteTimeGetCurrent() characters:@"a" charactersIgnoringModifiers:@"a" modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:65 isTabKey:NO]);
         bool doneWaiting = false;
         [webView _close];
         [webView handleKeyEvent:keyUpEvent.get() completion:[&](WebEvent *event, BOOL handled) {
@@ -457,14 +457,14 @@ TEST(KeyboardInputTests, HandleKeyEventsWhileSwappingWebProcess)
 {
     [TestProtocol registerWithScheme:@"https"];
 
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     [processPoolConfiguration setProcessSwapsOnNavigation:YES];
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setProcessPool:processPool.get()];
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [webView loadHTMLString:@"<body>webkit.org</body>" baseURL:[NSURL URLWithString:@"https://webkit.org"]];
     [navigationDelegate waitForDidFinishNavigation];
@@ -473,7 +473,7 @@ TEST(KeyboardInputTests, HandleKeyEventsWhileSwappingWebProcess)
     [navigationDelegate waitForDidStartProvisionalNavigation];
 
     bool done = false;
-    auto keyEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyDown timeStamp:CFAbsoluteTimeGetCurrent() characters:@"a" charactersIgnoringModifiers:@"a" modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:65 isTabKey:NO]);
+    RetainPtr keyEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyDown timeStamp:CFAbsoluteTimeGetCurrent() characters:@"a" charactersIgnoringModifiers:@"a" modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:65 isTabKey:NO]);
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.01 * NSEC_PER_SEC)), mainDispatchQueueSingleton(), [keyEvent, webView, &done] {
         [webView handleKeyEvent:keyEvent.get() completion:[keyEvent, &done](WebEvent *event, BOOL handled) {
             EXPECT_TRUE([event isEqual:keyEvent.get()]);
@@ -552,8 +552,8 @@ TEST(KeyboardInputTests, RangedSelectionRectAfterRestoringFirstResponder)
 
 TEST(KeyboardInputTests, IsSingleLineDocument)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
@@ -574,8 +574,8 @@ TEST(KeyboardInputTests, IsSingleLineDocument)
 
 TEST(KeyboardInputTests, KeyboardTypeForInput)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
 
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id <_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         return _WKFocusStartsInputSessionPolicyAllow;
@@ -645,10 +645,10 @@ TEST(KeyboardInputTests, KeyboardTypeForInput)
 
 TEST(KeyboardInputTests, OverrideInputViewAndInputAccessoryView)
 {
-    auto inputView = adoptNS([[UIView alloc] init]);
-    auto inputAccessoryView = adoptNS([[UIView alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[CustomInputWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration.get() inputView:inputView.get() inputAccessoryView:inputAccessoryView.get()]);
+    RetainPtr inputView = adoptNS([[UIView alloc] init]);
+    RetainPtr inputAccessoryView = adoptNS([[UIView alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[CustomInputWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration.get() inputView:inputView.get() inputAccessoryView:inputAccessoryView.get()]);
     auto contentView = [webView textInputContentView];
 
     EXPECT_EQ(inputAccessoryView.get(), [contentView inputAccessoryView]);
@@ -659,8 +659,8 @@ TEST(KeyboardInputTests, OverrideTextInputTraits)
 {
     UIKeyboardType keyboardType = UIKeyboardTypeNumberPad;
 
-    auto webView = adoptNS([[CustomTextInputTraitsWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) keyboardType:keyboardType]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[CustomTextInputTraitsWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) keyboardType:keyboardType]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id<_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         return _WKFocusStartsInputSessionPolicyAllow;
     }];
@@ -674,8 +674,8 @@ TEST(KeyboardInputTests, OverrideTextInputTraits)
 
 TEST(KeyboardInputTests, ClearSelectedTextRange)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id<_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         return _WKFocusStartsInputSessionPolicyAllow;
     }];
@@ -694,8 +694,8 @@ TEST(KeyboardInputTests, ClearSelectedTextRange)
 
 TEST(KeyboardInputTests, DisableSpellChecking)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id <_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         return _WKFocusStartsInputSessionPolicyAllow;
     }];
@@ -728,8 +728,8 @@ TEST(KeyboardInputTests, DisableSpellChecking)
 // FIXME: rdar://163669257 (REGRESSION(iOS26):TestWebKitAPI.KeyboardInputTests.SelectionClipRectsWhenPresentingInputView is a constant failure (301658))
 TEST(KeyboardInputTests, DISABLED_SelectionClipRectsWhenPresentingInputView)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id <_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         return _WKFocusStartsInputSessionPolicyAllow;
     }];
@@ -752,8 +752,8 @@ TEST(KeyboardInputTests, TestWebViewAdditionalContextForStrongPasswordAssistance
 {
     NSDictionary *expected = @{ @"strongPasswordAdditionalContext" : @"testUUID" };
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
 
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id <_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         return _WKFocusStartsInputSessionPolicyAllow;
@@ -783,8 +783,8 @@ TEST(KeyboardInputTests, TestWebViewAdditionalContextForStrongPasswordAssistance
 
 TEST(KeyboardInputTests, TestWebViewAdditionalContextForNonAutofillCredentialType)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
 
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id<_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         return _WKFocusStartsInputSessionPolicyAllow;
@@ -807,8 +807,8 @@ TEST(KeyboardInputTests, TestWebViewAdditionalContextForNonAutofillCredentialTyp
 
 TEST(KeyboardInputTests, AsyncFocusRequiresStrongPasswordAssistanceAfterBlurNoStartSession)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
 
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id<_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         return _WKFocusStartsInputSessionPolicyAllow;
@@ -839,8 +839,8 @@ TEST(KeyboardInputTests, AsyncFocusRequiresStrongPasswordAssistanceAfterBlurNoSt
 
 TEST(KeyboardInputTests, TestWebViewAccessoryDoneDuringStrongPasswordAssistance)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
 
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id<_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         return _WKFocusStartsInputSessionPolicyAllow;
@@ -862,11 +862,11 @@ TEST(KeyboardInputTests, TestWebViewAccessoryDoneDuringStrongPasswordAssistance)
 
 TEST(KeyboardInputTests, SuppressSoftwareKeyboard)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView _setSuppressSoftwareKeyboard:YES];
     [[webView window] makeKeyWindow];
 
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&](WKWebView *, id <_WKFocusedElementInfo>) {
         return _WKFocusStartsInputSessionPolicyAllow;
     }];
@@ -886,8 +886,8 @@ TEST(KeyboardInputTests, InsertTextSimulatingKeyboardInput)
 {
     InstanceMethodSwizzler overrideShouldSimulateKeyboardInputOnTextInsertion { NSClassFromString(@"WKContentView"), @selector(_shouldSimulateKeyboardInputOnTextInsertion), reinterpret_cast<IMP>(shouldSimulateKeyboardInputOnTextInsertionOverride) };
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&](WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
@@ -902,8 +902,8 @@ TEST(KeyboardInputTests, InsertDictationAlternativesSimulatingKeyboardInput)
 {
     InstanceMethodSwizzler overrideShouldSimulateKeyboardInputOnTextInsertion { NSClassFromString(@"WKContentView"), @selector(_shouldSimulateKeyboardInputOnTextInsertion), reinterpret_cast<IMP>(shouldSimulateKeyboardInputOnTextInsertionOverride) };
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&](WKWebView *, id <_WKFocusedElementInfo>) { return _WKFocusStartsInputSessionPolicyAllow; }];
     [webView _setInputDelegate:inputDelegate.get()];
 
@@ -916,25 +916,25 @@ TEST(KeyboardInputTests, InsertDictationAlternativesSimulatingKeyboardInput)
 
 TEST(KeyboardInputTests, OverrideUndoManager)
 {
-    auto webView = adoptNS([[CustomUndoManagerWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[CustomUndoManagerWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto contentView = [webView wkContentView];
     EXPECT_EQ(contentView.undoManager, contentView.undoManagerForWebView);
 
-    auto undoManager = adoptNS([[NSUndoManager alloc] init]);
+    RetainPtr undoManager = adoptNS([[NSUndoManager alloc] init]);
     [webView setCustomUndoManager:undoManager.get()];
     EXPECT_EQ(contentView.undoManager, undoManager);
 }
 
 TEST(KeyboardInputTests, DoNotRegisterActionsInOverriddenUndoManager)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setUndoManagerAPIEnabled:YES];
 
-    auto webView = adoptNS([[CustomUndoManagerWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[CustomUndoManagerWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
     auto contentView = [webView wkContentView];
     EXPECT_FALSE([contentView.undoManagerForWebView canUndo]);
 
-    auto overrideUndoManager = adoptNS([[NSUndoManager alloc] init]);
+    RetainPtr overrideUndoManager = adoptNS([[NSUndoManager alloc] init]);
     [webView setCustomUndoManager:overrideUndoManager.get()];
 
     __block bool doneWaiting = false;
@@ -950,8 +950,8 @@ TEST(KeyboardInputTests, DoNotRegisterActionsInOverriddenUndoManager)
 
 TEST(KeyboardInputTests, NewUndoGroupClosesPreviousTypingCommand)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
-    auto inputDelegate = adoptNS([TestInputDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[](WKWebView *, id<_WKFocusedElementInfo>) {
         return _WKFocusStartsInputSessionPolicyAllow;
     }];
@@ -998,8 +998,8 @@ static UIView * nilResizableSnapshotViewFromRect(id, SEL, CGRect, BOOL, UIEdgeIn
 
 TEST(KeyboardInputTests, DoNotCrashWhenFocusingSelectWithoutViewSnapshot)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([TestInputDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([TestInputDelegate new]);
     [webView _setInputDelegate:delegate.get()];
     [delegate setFocusStartsInputSessionPolicyHandler:[](WKWebView *, id <_WKFocusedElementInfo>) {
         return _WKFocusStartsInputSessionPolicyAllow;
@@ -1021,8 +1021,8 @@ TEST(KeyboardInputTests, EditableWebViewRequiresKeyboardWhenFirstResponder)
     InstanceMethodSwizzler hardwareKeyboardAttachedSwizzler { UIKeyboardImpl.class, @selector(hardwareKeyboardAttached), returnNo };
     ClassMethodSwizzler hardwareKeyboardModeSwizzler { UIKeyboard.class, @selector(isInHardwareKeyboardMode), returnNo };
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([TestInputDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([TestInputDelegate new]);
     [webView _setInputDelegate:delegate.get()];
     [delegate setFocusStartsInputSessionPolicyHandler:[](WKWebView *, id <_WKFocusedElementInfo>) {
         return _WKFocusStartsInputSessionPolicyAllow;
@@ -1044,7 +1044,7 @@ TEST(KeyboardInputTests, EditableWebViewRequiresKeyboardWhenFirstResponder)
 TEST(KeyboardInputTests, InputSessionWhenEvaluatingJavaScript)
 {
     __block bool done = false;
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     bool willStartInputSession = false;
     [inputDelegate setWillStartInputSessionHandler:[&] (WKWebView *, id<_WKFormInputSession>) {
         willStartInputSession = true;
@@ -1054,7 +1054,7 @@ TEST(KeyboardInputTests, InputSessionWhenEvaluatingJavaScript)
         didStartInputSession = true;
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView _setInputDelegate:inputDelegate.get()];
     [webView synchronouslyLoadHTMLString:@"<input value='foo'>"];
 
@@ -1098,15 +1098,15 @@ TEST(KeyboardInputTests, InputSessionWhenEvaluatingJavaScript)
 
 TEST(KeyboardInputTests, NoCrashWhenDiscardingMarkedText)
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     [processPoolConfiguration setProcessSwapsOnNavigation:YES];
 
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setProcessPool:processPool.get()];
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [webView _setEditable:YES];
 
@@ -1158,8 +1158,8 @@ TEST(KeyboardInputTests, NoCrashWithEmptyAttributedMarkedText)
 
 TEST(KeyboardInputTests, CharactersAroundCaretSelection)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto delegate = adoptNS([TestInputDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([TestInputDelegate new]);
     [webView _setInputDelegate:delegate.get()];
 
     bool focused = false;
@@ -1192,10 +1192,10 @@ TEST(KeyboardInputTests, CharactersAroundCaretSelection)
 TEST(KeyboardInputTests, MarkedTextSegmentsWithUnderlines)
 {
     auto frame = CGRectMake(0, 0, 100, 100);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:frame configuration:configuration.get() addToWindow:NO]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:frame configuration:configuration.get() addToWindow:NO]);
 
-    auto window = adoptNS([[UIWindow alloc] initWithFrame:[webView frame]]);
+    RetainPtr window = adoptNS([[UIWindow alloc] initWithFrame:[webView frame]]);
     [window addSubview:webView.get()];
 
     [webView _setEditable:YES];
@@ -1203,7 +1203,7 @@ TEST(KeyboardInputTests, MarkedTextSegmentsWithUnderlines)
     [webView selectAll:nil];
 
     auto setMarkedTextWithUnderlines = [&](NSUnderlineStyle firstUnderlineStyle, NSUnderlineStyle secondUnderlineStyle) {
-        auto composition = adoptNS([[NSMutableAttributedString alloc] initWithString:@"なんですか？"]);
+        RetainPtr composition = adoptNS([[NSMutableAttributedString alloc] initWithString:@"なんですか？"]);
         [composition addAttributes:@{
             NSMarkedClauseSegmentAttributeName: @(0),
             NSUnderlineStyleAttributeName: @(firstUnderlineStyle),
@@ -1222,7 +1222,7 @@ TEST(KeyboardInputTests, MarkedTextSegmentsWithUnderlines)
     setMarkedTextWithUnderlines(NSUnderlineStyleSingle, NSUnderlineStyleThick);
     [webView waitForNextPresentationUpdate];
 
-    auto snapshotConfiguration = adoptNS([[WKSnapshotConfiguration alloc] init]);
+    RetainPtr snapshotConfiguration = adoptNS([[WKSnapshotConfiguration alloc] init]);
     [snapshotConfiguration setAfterScreenUpdates:YES];
 
     auto takeSnapshot = [&] {
@@ -1258,13 +1258,13 @@ TEST(KeyboardInputTests, MarkedTextSegmentsWithUnderlines)
 
 TEST(KeyboardInputTests, HasTextAfterFocusingTextField)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 600)]);
 
     enum class HasText : bool { No, Yes };
     __block Vector<std::pair<WKInputType, HasText>, 3> results;
     __block bool doneWaitingForInputSession = false;
 
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setDidStartInputSessionHandler:^(WKWebView *webView, id<_WKFormInputSession> session) {
         results.append({
             session.focusedElementInfo.type,
@@ -1310,16 +1310,16 @@ TEST(KeyboardInputTests, HasTextAfterFocusingTextField)
 TEST(KeyboardInputTests, AutocorrectionIndicatorColorNotAffectedByAuthorDefinedAncestorColorProperty)
 {
     auto frame = CGRectMake(0, 0, 320, 568);
-    auto window = adoptNS([[UIWindow alloc] initWithFrame:frame]);
+    RetainPtr window = adoptNS([[UIWindow alloc] initWithFrame:frame]);
 
     auto createSnapshotForHTMLString = ^(NSString *HTMLString) {
         auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
 
-        auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:frame configuration:configuration addToWindow:NO]);
+        RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:frame configuration:configuration addToWindow:NO]);
 
         [window addSubview:webView.get()];
 
-        auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+        RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
         [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id<_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
             return _WKFocusStartsInputSessionPolicyAllow;
         }];
@@ -1352,7 +1352,7 @@ TEST(KeyboardInputTests, AutocorrectionIndicatorColorNotAffectedByAuthorDefinedA
 
         [webView waitForNextPresentationUpdate];
 
-        auto snapshotConfiguration = adoptNS([[WKSnapshotConfiguration alloc] init]);
+        RetainPtr snapshotConfiguration = adoptNS([[WKSnapshotConfiguration alloc] init]);
         [snapshotConfiguration setAfterScreenUpdates:YES];
 
         __block RetainPtr<CGImage> result;
@@ -1445,9 +1445,9 @@ TEST(KeyboardInputTests, DeviceEIDAndIMEIAutoFill)
     };
     [WKWebView _setApplicationBundleIdentifier:@"org.webkit.SomeTelephonyApp"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
-    auto inputDelegate = adoptNS([TestInputDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[](WKWebView *, id<_WKFocusedElementInfo>) {
         return _WKFocusStartsInputSessionPolicyAllow;
     }];
@@ -1499,7 +1499,7 @@ TEST(KeyboardInputTests, DeviceEIDAndIMEIAutoFill)
 
 TEST(KeyboardInputTests, ImplementAllOptionalTextInputTraits)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
     auto traits = [webView effectiveTextInputTraits];
     EXPECT_EQ(traits.autocapitalizationType, UITextAutocapitalizationTypeSentences);
     EXPECT_EQ(traits.spellCheckingType, UITextSpellCheckingTypeDefault);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/OverflowScrollViewTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/OverflowScrollViewTests.mm
@@ -45,9 +45,9 @@ namespace TestWebKitAPI {
 
 TEST(OverflowScrollViewTests, ContentChangeMaintainsScrollbars)
 {
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"overflow-scroll" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
@@ -76,9 +76,9 @@ TEST(OverflowScrollViewTests, ContentChangeMaintainsScrollbars)
 
 TEST(OverflowScrollViewTests, CompositingChangeMaintainsCustomView)
 {
-    auto webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"composited" withExtension:@"html"];
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
@@ -88,7 +88,7 @@ TEST(OverflowScrollViewTests, CompositingChangeMaintainsCustomView)
     UIView *compositingView = [webView wkFirstSubviewWithBoundsSize:CGSizeMake(200, 200)];
     EXPECT_NOT_NULL(compositingView);
 
-    auto customView = adoptNS([[UIView alloc] initWithFrame:CGRectMake(20, 20, 200, 100)]);
+    RetainPtr customView = adoptNS([[UIView alloc] initWithFrame:CGRectMake(20, 20, 200, 100)]);
     [compositingView addSubview:customView.get()];
 
     bool contentChanged = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/RenderingProgressTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/RenderingProgressTests.mm
@@ -50,11 +50,11 @@
 
 TEST(RenderingProgressTests, DidRenderSignificantAmountOfText)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 156, 195)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 156, 195)]);
     [webView _setObservedRenderingProgressEvents:_WKRenderingProgressEventDidRenderSignificantAmountOfText];
 
     bool observedSignificantRenderedText = false;
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [navigationDelegate setRenderingProgressDidChange:[&] (WKWebView *, _WKRenderingProgressEvents events) {
         if (events & _WKRenderingProgressEventDidRenderSignificantAmountOfText)
             observedSignificantRenderedText = true;
@@ -75,15 +75,15 @@ TEST(RenderingProgressTests, DidRenderSignificantAmountOfText)
 
 TEST(RenderingProgressTests, FirstPaintWithSignificantArea)
 {
-    auto schemeHandler = adoptNS([[MissingResourceSchemeHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[MissingResourceSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"missing"];
     // A full-height, but very narrow web view (for instance, a navigation sidebar embedded in an app).
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 160, 568) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 160, 568) configuration:configuration.get()]);
     [webView _setObservedRenderingProgressEvents:_WKRenderingProgressEventFirstPaintWithSignificantArea];
 
     bool observedSignificantPaint = false;
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [navigationDelegate setRenderingProgressDidChange:[&] (WKWebView *, _WKRenderingProgressEvents events) {
         if (events & _WKRenderingProgressEventFirstPaintWithSignificantArea)
             observedSignificantPaint = true;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ScrollViewBouncesTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ScrollViewBouncesTests.mm
@@ -52,7 +52,7 @@ static NSString *overscrollBehaviorContainY = @"<meta name='viewport' content='w
 
 TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoNotSet)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     EXPECT_EQ([[webView scrollView] bounces], YES);
     [webView synchronouslyLoadHTMLString:overscrollBehaviorAuto];
     EXPECT_EQ([[webView scrollView] bounces], YES);
@@ -60,7 +60,7 @@ TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoNotSet)
 
 TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoSet)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:overscrollBehaviorAuto];
     [[webView scrollView] setBounces:NO];
     EXPECT_EQ([[webView scrollView] bounces], NO);
@@ -68,7 +68,7 @@ TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoSet)
 
 TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoNotSetDynamicallyChange)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:overscrollBehaviorNone];
     EXPECT_EQ([[webView scrollView] bounces], NO);
     [webView stringByEvaluatingJavaScript:@"document.documentElement.style.overscrollBehavior = 'auto'"];
@@ -78,7 +78,7 @@ TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoNotSetDynamicallyChange)
 
 TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoSetDynamicallyChange)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:overscrollBehaviorNone];
     EXPECT_EQ([[webView scrollView] bounces], NO);
     [[webView scrollView] setBounces:NO];
@@ -90,7 +90,7 @@ TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoSetDynamicallyChange)
 
 TEST(ScrollViewBouncesTests, OverscrollBehaviorNoneDynamicallyChange)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:overscrollBehaviorAuto];
     EXPECT_EQ([[webView scrollView] bounces], YES);
     [webView objectByEvaluatingJavaScript:@"document.documentElement.style.overscrollBehavior = 'none'"];
@@ -100,7 +100,7 @@ TEST(ScrollViewBouncesTests, OverscrollBehaviorNoneDynamicallyChange)
 
 TEST(ScrollViewBouncesTests, OverscrollBehaviorNoneSet)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:overscrollBehaviorNone];
     [[webView scrollView] setBounces:NO];
     EXPECT_EQ([[webView scrollView] bounces], NO);
@@ -108,14 +108,14 @@ TEST(ScrollViewBouncesTests, OverscrollBehaviorNoneSet)
 
 TEST(ScrollViewBouncesTests, OverscrollBehaviorContainNotSet)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:overscrollBehaviorContain];
     EXPECT_EQ([[webView scrollView] bounces], YES);
 }
 
 TEST(ScrollViewBouncesTests, OverscrollBehaviorContainSet)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:overscrollBehaviorContain];
     [[webView scrollView] setBounces:NO];
     EXPECT_EQ([[webView scrollView] bounces], NO);
@@ -123,14 +123,14 @@ TEST(ScrollViewBouncesTests, OverscrollBehaviorContainSet)
 
 TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoNotSetX)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:overscrollBehaviorAutoX];
     EXPECT_EQ([[webView scrollView] bounces], YES);
 }
 
 TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoSetX)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:overscrollBehaviorAutoX];
     [[webView scrollView] setBounces:NO];
     EXPECT_EQ([[webView scrollView] bounces], NO);
@@ -138,14 +138,14 @@ TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoSetX)
 
 TEST(ScrollViewBouncesTests, OverscrollBehaviorNoneNotSetX)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:overscrollBehaviorNoneX];
     EXPECT_EQ([[webView scrollView] bounces], NO);
 }
 
 TEST(ScrollViewBouncesTests, OverscrollBehaviorNoneSetX)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:overscrollBehaviorNoneX];
     [[webView scrollView] setBounces:NO];
     EXPECT_EQ([[webView scrollView] bounces], NO);
@@ -153,14 +153,14 @@ TEST(ScrollViewBouncesTests, OverscrollBehaviorNoneSetX)
 
 TEST(ScrollViewBouncesTests, OverscrollBehaviorContainNotSetX)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:overscrollBehaviorContainX];
     EXPECT_EQ([[webView scrollView] bounces], YES);
 }
 
 TEST(ScrollViewBouncesTests, OverscrollBehaviorContainSetX)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:overscrollBehaviorContainX];
     [[webView scrollView] setBounces:NO];
     EXPECT_EQ([[webView scrollView] bounces], NO);
@@ -168,14 +168,14 @@ TEST(ScrollViewBouncesTests, OverscrollBehaviorContainSetX)
 
 TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoNotSetY)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:overscrollBehaviorAutoY];
     EXPECT_EQ([[webView scrollView] bounces], YES);
 }
 
 TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoSety)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:overscrollBehaviorAutoY];
     [[webView scrollView] setBounces:NO];
     EXPECT_EQ([[webView scrollView] bounces], NO);
@@ -183,14 +183,14 @@ TEST(ScrollViewBouncesTests, OverscrollBehaviorAutoSety)
 
 TEST(ScrollViewBouncesTests, OverscrollBehaviorNoneNotSetY)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:overscrollBehaviorNoneY];
     EXPECT_EQ([[webView scrollView] bounces], NO);
 }
 
 TEST(ScrollViewBouncesTests, OverscrollBehaviorNoneSetY)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:overscrollBehaviorNoneY];
     [[webView scrollView] setBounces:NO];
     EXPECT_EQ([[webView scrollView] bounces], NO);
@@ -198,14 +198,14 @@ TEST(ScrollViewBouncesTests, OverscrollBehaviorNoneSetY)
 
 TEST(ScrollViewBouncesTests, OverscrollBehaviorContainNotSetY)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:overscrollBehaviorContainY];
     EXPECT_EQ([[webView scrollView] bounces], YES);
 }
 
 TEST(ScrollViewBouncesTests, OverscrollBehaviorContainSetY)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:overscrollBehaviorContainY];
     [[webView scrollView] setBounces:NO];
     EXPECT_EQ([[webView scrollView] bounces], NO);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ScrollViewInsetTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ScrollViewInsetTests.mm
@@ -104,7 +104,7 @@ static void waitUntilInnerHeightIs(TestWKWebView *webView, CGFloat expectedValue
 
 TEST(ScrollViewInsetTests, InnerHeightWithLargeTopContentInset)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView scrollView].contentInset = UIEdgeInsetsMake(400, 0, 0, 0);
     [webView synchronouslyLoadHTMLString:veryTallDocumentMarkup];
 
@@ -126,7 +126,7 @@ TEST(ScrollViewInsetTests, InnerHeightWithLargeTopContentInset)
 
 TEST(ScrollViewInsetTests, InnerHeightWithLargeBottomContentInset)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView scrollView].contentInset = UIEdgeInsetsMake(0, 0, 400, 0);
     [webView synchronouslyLoadHTMLString:veryTallDocumentMarkup];
     [webView stringByEvaluatingJavaScript:@"scrollTo(0, 10)"];
@@ -147,7 +147,7 @@ TEST(ScrollViewInsetTests, InnerHeightWithLargeBottomContentInset)
 
 TEST(ScrollViewInsetTests, RestoreInitialContentOffsetAfterNavigation)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView scrollView].contentInset = UIEdgeInsetsMake(400, 0, 0, 0);
     [webView synchronouslyLoadHTMLString:veryTallDocumentMarkup];
     [webView stringByEvaluatingJavaScript:@"scrollTo(0, 1000)"];
@@ -167,8 +167,8 @@ TEST(ScrollViewInsetTests, RestoreInitialContentOffsetAfterNavigation)
 
 TEST(ScrollViewInsetTests, RestoreInitialContentOffsetAfterCrash)
 {
-    auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView scrollView].contentInset = UIEdgeInsetsMake(400, 0, 0, 0);
     [webView synchronouslyLoadHTMLString:veryTallDocumentMarkup];
     [webView setNavigationDelegate:delegate.get()];
@@ -192,8 +192,8 @@ TEST(ScrollViewInsetTests, RestoreInitialContentOffsetAfterCrash)
 
 TEST(ScrollViewInsetTests, RestoreInitialContentOffsetAfterCrashWithAsyncPolicyDelegates)
 {
-    auto delegate = adoptNS([[AsyncPolicyDelegateForInsetTest alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr delegate = adoptNS([[AsyncPolicyDelegateForInsetTest alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView scrollView].contentInset = UIEdgeInsetsMake(400, 0, 0, 0);
     [webView setNavigationDelegate:delegate.get()];
     delegate->_navigationComplete = false;
@@ -226,7 +226,7 @@ TEST(ScrollViewInsetTests, RestoreInitialContentOffsetAfterCrashWithAsyncPolicyD
 
 TEST(ScrollViewInsetTests, RestoreContentOffsetAfterBackWithInsetChange)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView scrollView].contentInset = UIEdgeInsetsMake(100, 0, 0, 0);
 
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"scrollable-page" withExtension:@"html"];
@@ -261,8 +261,8 @@ TEST(ScrollViewInsetTests, ChangeInsetWithoutAutomaticAdjustmentWhileWebProcessI
     constexpr CGFloat initialTopInset = 100;
     constexpr CGFloat updatedTopInset = 70;
 
-    auto scrollViewDelegate = adoptNS([[ScrollViewDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr scrollViewDelegate = adoptNS([[ScrollViewDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView scrollView].scrollEnabled = NO;
     [webView scrollView].delegate = scrollViewDelegate.get();
     [webView _setObscuredInsets:UIEdgeInsetsMake(initialTopInset, 0, 0, 0)];
@@ -294,7 +294,7 @@ TEST(ScrollViewInsetTests, ChangeInsetWithoutAutomaticAdjustmentWhileWebProcessI
 
 TEST(ScrollViewInsetTests, PreserveContentOffsetForRefreshControl)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView scrollView].refreshControl = adoptNS([[UIRefreshControl alloc] init]).get();
     [webView synchronouslyLoadHTMLString:@""];
 
@@ -310,7 +310,7 @@ TEST(ScrollViewInsetTests, PreserveContentOffsetForRefreshControl)
 
 TEST(ScrollViewInsetTests, ScrollabilityWithInsets)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 320, 500)]);
     [webView scrollView].contentInset = UIEdgeInsetsMake(50, 0, 50, 0);
 
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width, initial-scale=1'><style> body { overflow: hidden; height: 2000px; } </style>"];
@@ -325,7 +325,7 @@ TEST(ScrollViewInsetTests, ScrollabilityWithInsets)
 
 TEST(ScrollViewInsetTests, ScrollabilityWithObscuredInsets)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 390, 844)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 390, 844)]);
     auto insets = UIEdgeInsetsMake(47, 0, 133, 0);
     [webView scrollView].contentInset = insets;
     [webView _setObscuredInsets:insets];
@@ -342,7 +342,7 @@ TEST(ScrollViewInsetTests, ScrollabilityWithObscuredInsets)
 
 TEST(ScrollViewInsetTests, ScrollabilityWithObscuredInsetsAndOverrideSizes)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 390, 844)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 390, 844)]);
     auto insets = UIEdgeInsetsMake(47, 0, 133, 0);
     [webView scrollView].contentInset = insets;
     [webView _setObscuredInsets:insets];
@@ -362,7 +362,7 @@ TEST(ScrollViewInsetTests, ScrollabilityWithObscuredInsetsAndOverrideSizes)
 
 TEST(ScrollViewInsetTests, ScrollabilityWithMaxOverrideSize)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 390, 844)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 390, 844)]);
 
     auto insets = UIEdgeInsetsMake(47, 0, 0, 0);
     [webView scrollView].contentInset = insets;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ScrollViewScrollabilityTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ScrollViewScrollabilityTests.mm
@@ -44,7 +44,7 @@ static const CGFloat viewHeight = 500;
 
 static RetainPtr<TestWKWebView> webViewWithAutofocusedInput(const RetainPtr<TestInputDelegate>& inputDelegate)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
 
     bool doneWaiting = false;
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id <_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
@@ -61,21 +61,21 @@ static RetainPtr<TestWKWebView> webViewWithAutofocusedInput(const RetainPtr<Test
 
 TEST(ScrollViewScrollabilityTests, ScrollableWithOverflowVisible)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:scrollableDocumentMarkup];
     EXPECT_EQ([[webView scrollView] isScrollEnabled], YES);
 }
 
 TEST(ScrollViewScrollabilityTests, NonScrollableWithOverflowHidden)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:nonScrollableDocumentMarkup];
     EXPECT_EQ([[webView scrollView] isScrollEnabled], NO);
 }
 
 TEST(ScrollViewScrollabilityTests, ScrollableWithOverflowHiddenWhenZoomed)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
     [webView synchronouslyLoadHTMLString:nonScrollableDocumentMarkup];
     [[webView scrollView] setZoomScale:1.5 animated:NO];
     [webView waitForNextPresentationUpdate];
@@ -84,9 +84,9 @@ TEST(ScrollViewScrollabilityTests, ScrollableWithOverflowHiddenWhenZoomed)
 
 TEST(ScrollViewScrollabilityTests, ScrollableWithOverflowHiddenAndInputView)
 {
-    auto inputView = adoptNS([[UIView alloc] init]);
-    auto inputAccessoryView = adoptNS([[UIView alloc] init]);
-    auto inputDelegate = adoptNS([TestInputDelegate new]);
+    RetainPtr inputView = adoptNS([[UIView alloc] init]);
+    RetainPtr inputAccessoryView = adoptNS([[UIView alloc] init]);
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
     [inputDelegate setWillStartInputSessionHandler:[inputView, inputAccessoryView] (WKWebView *, id<_WKFormInputSession> session) {
         session.customInputView = inputView.get();
         session.customInputAccessoryView = inputAccessoryView.get();
@@ -102,7 +102,7 @@ TEST(ScrollViewScrollabilityTests, ScrollableWithOverflowHiddenAndInputView)
 
 TEST(ScrollViewScrollabilityTests, ScrollableWithOverflowHiddenAndVisibleUI)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, viewHeight)]);
 
     // Simulate portrait phone with:
     // Top bar size: 50
@@ -125,7 +125,7 @@ TEST(ScrollViewScrollabilityTests, ScrollableWithOverflowHiddenAndVisibleUI)
 
 TEST(ScrollViewScrollabilityTests, ScrollableWithOverflowHiddenAndShrunkUI)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, viewHeight, 375)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, viewHeight, 375)]);
 
     // Simulate MobileSafari on landscape iPhone 8 with hidden bars.
     UIEdgeInsets obscuredInsets;
@@ -145,7 +145,7 @@ TEST(ScrollViewScrollabilityTests, ScrollableWithOverflowHiddenAndShrunkUI)
 
 TEST(ScrollViewScrollabilityTests, ScrollableAfterNavigateToPDF)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, viewHeight, 414)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, viewHeight, 414)]);
 
     [webView synchronouslyLoadHTMLString:nonScrollableDocumentMarkup];
     [webView waitForNextPresentationUpdate];
@@ -161,7 +161,7 @@ TEST(ScrollViewScrollabilityTests, ScrollableAfterNavigateToPDF)
 
 TEST(ScrollViewScrollabilityTests, TouchActionPanAPI)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, viewHeight, 414)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, viewHeight, 414)]);
 
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='initial-scale=1'><body style='margin: 0'><div style='width: 100px; height: 100px; display: inline-block;'></div><div style='width: 100px; height: 100px; display: inline-block; touch-action: none;'></div></body>"];
     [webView waitForNextPresentationUpdate];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/SelectionByWord.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/SelectionByWord.mm
@@ -35,7 +35,7 @@
 
 TEST(SelectionTests, ByWordAtEndOfDocument)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] init]);
 
     [webView synchronouslyLoadHTMLString:@"<body><p>Paragraph One</p><p style='-webkit-user-select: none'>Paragraph Two</p><p>Paragraph Three</p><p></p></body>"];
 
@@ -57,7 +57,7 @@ TEST(SelectionTests, ByWordAtEndOfDocument)
 
 TEST(SelectionTests, SelectWordForReplacementWithDictationAlternative)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 320)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 320)]);
     [webView synchronouslyLoadTestPageNamed:@"editable-responsive-body"];
 
     auto contentView = [webView textInputContentView];
@@ -65,7 +65,7 @@ TEST(SelectionTests, SelectWordForReplacementWithDictationAlternative)
     [contentView insertText:@"foo bar"];
     [webView waitForNextPresentationUpdate];
 
-    auto alternatives = adoptNS([[NSTextAlternatives alloc] initWithPrimaryString:@"foo bar" alternativeStrings:@[ @"baz" ]]);
+    RetainPtr alternatives = adoptNS([[NSTextAlternatives alloc] initWithPrimaryString:@"foo bar" alternativeStrings:@[ @"baz" ]]);
     [[webView textInputContentView] addTextAlternatives:alternatives.get()];
     [[webView textInputContentView] selectWordForReplacement];
     [webView waitForNextPresentationUpdate];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/SelectionModifyByParagraphBoundary.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/SelectionModifyByParagraphBoundary.mm
@@ -37,8 +37,8 @@ typedef UITextInputArrowKeyHistory *(*MoveParagraphSelectorType)(id, SEL, BOOL, 
 
 TEST(SelectionTests, ModifyByParagraphBoundary)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] init]);
-    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] init]);
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         return _WKFocusStartsInputSessionPolicyAllow;
     }];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ShareSheetTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ShareSheetTests.mm
@@ -89,8 +89,8 @@ TEST(ShareSheetTests, DISABLED_ShareImgElementWithBase64URL)
 TEST(ShareSheetTests, ShareImgElementWithBase64URL)
 #endif
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto observer = adoptNS([[ShareSheetObserver alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr observer = adoptNS([[ShareSheetObserver alloc] init]);
     [webView setUIDelegate:observer.get()];
     [webView synchronouslyLoadTestPageNamed:@"img-with-base64-url"];
 
@@ -108,8 +108,8 @@ TEST(ShareSheetTests, ShareImgElementWithBase64URL)
 
 TEST(ShareSheetTests, ShareAnchorElementAsURL)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
-    auto observer = adoptNS([[ShareSheetObserver alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr observer = adoptNS([[ShareSheetObserver alloc] init]);
     [webView setUIDelegate:observer.get()];
     [webView synchronouslyLoadTestPageNamed:@"link-and-input"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/SynchronousTimeoutTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/SynchronousTimeoutTests.mm
@@ -40,7 +40,7 @@ namespace TestWebKitAPI {
 
 TEST(SynchronousTimeoutTests, UnresponsivePageDoesNotCausePositionInformationToHangUI)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
     [webView evaluateJavaScript:@"while(1);" completionHandler:nil];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/TextAlternatives.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/TextAlternatives.mm
@@ -52,7 +52,7 @@ namespace TestWebKitAPI {
 static RetainPtr<TestWKWebView> createWebViewForTestingTextAlternatives()
 {
     auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration]);
     [webView _setEditable:YES];
     return webView;
 }
@@ -63,7 +63,7 @@ TEST(TextAlternatives, AddAndRemoveTextAlternativesWithMatch)
     [webView synchronouslyLoadHTMLString:@"<body>hello world&nbsp;</body>"];
     [webView stringByEvaluatingJavaScript:@"getSelection().setPosition(document.body, 1)"];
 
-    auto alternatives = adoptNS([[NSTextAlternatives alloc] initWithPrimaryString:@"hello world" alternativeStrings:@[ @"👋🌎" ]]);
+    RetainPtr alternatives = adoptNS([[NSTextAlternatives alloc] initWithPrimaryString:@"hello world" alternativeStrings:@[ @"👋🌎" ]]);
     [[webView textInputContentView] addTextAlternatives:alternatives.get()];
     [webView waitForNextPresentationUpdate];
 
@@ -89,7 +89,7 @@ TEST(TextAlternatives, AddAndRemoveTextAlternativesWithTextAndEmojis)
     [webView synchronouslyLoadHTMLString:@"<body>hello world</body>"];
     [webView stringByEvaluatingJavaScript:@"getSelection().setPosition(document.body, 1)"];
 
-    auto alternatives = adoptNS([[NSTextAlternatives alloc] initWithPrimaryString:@"hello world" alternativeStrings:@[ @"👋🌎", @"Hello world" ]]);
+    RetainPtr alternatives = adoptNS([[NSTextAlternatives alloc] initWithPrimaryString:@"hello world" alternativeStrings:@[ @"👋🌎", @"Hello world" ]]);
     [[webView textInputContentView] addTextAlternatives:alternatives.get()];
     [webView waitForNextPresentationUpdate];
 
@@ -108,7 +108,7 @@ TEST(TextAlternatives, AddTextAlternativesWithSelectedMatch)
     [webView synchronouslyLoadHTMLString:@"<body>hello world&nbsp;</body>"];
     [webView stringByEvaluatingJavaScript:@"getSelection().selectAllChildren(document.body)"];
 
-    auto alternatives = adoptNS([[NSTextAlternatives alloc] initWithPrimaryString:@"hello world" alternativeStrings:@[ @"👋🌎" ]]);
+    RetainPtr alternatives = adoptNS([[NSTextAlternatives alloc] initWithPrimaryString:@"hello world" alternativeStrings:@[ @"👋🌎" ]]);
     [[webView textInputContentView] addTextAlternatives:alternatives.get()];
     [webView waitForNextPresentationUpdate];
 
@@ -121,7 +121,7 @@ TEST(TextAlternatives, AddTextAlternativesWithoutMatch)
     [webView synchronouslyLoadHTMLString:@"<body>hello world&nbsp;</body>"];
     [webView stringByEvaluatingJavaScript:@"getSelection().setPosition(document.body, 1)"];
 
-    auto alternatives = adoptNS([[NSTextAlternatives alloc] initWithPrimaryString:@"goodbye world" alternativeStrings:@[ @"👋🌎" ]]);
+    RetainPtr alternatives = adoptNS([[NSTextAlternatives alloc] initWithPrimaryString:@"goodbye world" alternativeStrings:@[ @"👋🌎" ]]);
     [[webView textInputContentView] addTextAlternatives:alternatives.get()];
     [webView waitForNextPresentationUpdate];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/TextAutosizingBoost.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/TextAutosizingBoost.mm
@@ -44,7 +44,7 @@ TEST(TextAutosizingBoost, ChangeAutosizingBoostAtRuntime)
 
     InstanceMethodSwizzler screenSizeSwizzler(UIScreen.class, @selector(_referenceBounds), reinterpret_cast<IMP>(mainScreenReferenceBoundsOverride));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 960, 360)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 960, 360)]);
     WKPreferencesSetTextAutosizingEnabled((__bridge WKPreferencesRef)[webView configuration].preferences, true);
     WKPreferencesSetTextAutosizingUsesIdempotentMode((__bridge WKPreferencesRef)[webView configuration].preferences, false);
     [webView synchronouslyLoadHTMLString:testMarkup];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/TextServicesTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/TextServicesTests.mm
@@ -50,7 +50,7 @@ TEST(TextServicesTests, LookUpPresentationRect)
 {
     InstanceMethodSwizzler swizzler { UIWKTextInteractionAssistant.class, @selector(lookup:withRange:fromRect:), reinterpret_cast<IMP>(handleLookup) };
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width'><style>p { font-size: 20px; }</style><p>Foo</p><p>Hello World</p>"];
     [webView stringByEvaluatingJavaScript:@"getSelection().selectAllChildren(document.querySelector('p'))"];
     [webView waitForNextPresentationUpdate];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/TextStyleFontSize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/TextStyleFontSize.mm
@@ -60,7 +60,7 @@ TEST(TextStyleFontSize, Startup)
 
     static NSString *testMarkup = @"<html><head></head><body><div id='target' style='-webkit-text-size-adjust: none; font: -apple-system-body;'>Hello</div></body></html>";
 
-    auto webView = adoptNS([[TextStyleFontSizeWebView alloc] initWithFrame:CGRectMake(0, 0, 960, 360)]);
+    RetainPtr webView = adoptNS([[TextStyleFontSizeWebView alloc] initWithFrame:CGRectMake(0, 0, 960, 360)]);
     [webView synchronouslyLoadHTMLString:testMarkup];
     auto actual = [webView stringByEvaluatingJavaScript:@"parseInt(window.getComputedStyle(document.getElementById('target')).getPropertyValue('font-size'))"].integerValue;
     
@@ -81,7 +81,7 @@ TEST(TextStyleFontSize, AfterCrash)
 
     static NSString *testMarkup = @"<html><head></head><body><div id='target' style='-webkit-text-size-adjust: none; font: -apple-system-body;'>Hello</div></body></html>";
 
-    auto webView = adoptNS([[TextStyleFontSizeWebView alloc] initWithFrame:CGRectMake(0, 0, 960, 360)]);
+    RetainPtr webView = adoptNS([[TextStyleFontSizeWebView alloc] initWithFrame:CGRectMake(0, 0, 960, 360)]);
     [webView synchronouslyLoadHTMLString:testMarkup];
     [webView _killWebContentProcessAndResetState];
     [webView synchronouslyLoadHTMLString:testMarkup];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/UIFocusTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/UIFocusTests.mm
@@ -52,13 +52,13 @@ namespace TestWebKitAPI {
 
 TEST(UIFocusTests, ContentViewCanBecomeFocused)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"simple-form"];
 
     auto contentView = [webView textInputContentView];
     EXPECT_FALSE(contentView.canBecomeFocused);
 
-    auto delegate = adoptNS([[UIFocusDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[UIFocusDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
     [delegate setCanBecomeFocused:YES];
     EXPECT_TRUE(contentView.canBecomeFocused);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/UIPasteboardTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/UIPasteboardTests.mm
@@ -99,7 +99,7 @@ RetainPtr<TestWKWebView> setUpWebViewForPasteboardTests(NSString *pageName)
     EXPECT_TRUE(!dataForPasteboardType(UTTypeUTF8PlainText.identifier).length);
     EXPECT_TRUE(!dataForPasteboardType(UTTypeUTF16PlainText.identifier).length);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     WKPreferences *preferences = [webView configuration].preferences;
     preferences._javaScriptCanAccessClipboard = YES;
     preferences._domPasteAllowed = YES;
@@ -113,7 +113,7 @@ TEST(UIPasteboardTests, CopyPlainTextWritesConcreteTypes)
     [webView stringByEvaluatingJavaScript:@"selectPlainText()"];
     [webView stringByEvaluatingJavaScript:@"document.execCommand('copy')"];
 
-    auto utf8Result = adoptNS([[NSString alloc] initWithData:dataForPasteboardType(UTTypeUTF8PlainText.identifier) encoding:NSUTF8StringEncoding]);
+    RetainPtr utf8Result = adoptNS([[NSString alloc] initWithData:dataForPasteboardType(UTTypeUTF8PlainText.identifier) encoding:NSUTF8StringEncoding]);
     EXPECT_WK_STREQ("Hello world", [utf8Result UTF8String]);
 }
 
@@ -126,7 +126,7 @@ TEST(UIPasteboardTests, CopyPlainTextRetainsEscapeCharactersInURLRepresentation)
 
     EXPECT_FALSE(UIPasteboard.generalPasteboard.URL);
 
-    auto utf8Result = adoptNS([[NSString alloc] initWithData:dataForPasteboardType(UTTypeUTF8PlainText.identifier) encoding:NSUTF8StringEncoding]);
+    RetainPtr utf8Result = adoptNS([[NSString alloc] initWithData:dataForPasteboardType(UTTypeUTF8PlainText.identifier) encoding:NSUTF8StringEncoding]);
     EXPECT_WK_STREQ("hello:<", [utf8Result UTF8String]);
 }
 
@@ -136,7 +136,7 @@ TEST(UIPasteboardTests, CopyRichTextWritesConcreteTypes)
     [webView stringByEvaluatingJavaScript:@"selectRichText()"];
     [webView stringByEvaluatingJavaScript:@"document.execCommand('copy')"];
 
-    auto utf8Result = adoptNS([[NSString alloc] initWithData:dataForPasteboardType(UTTypeUTF8PlainText.identifier) encoding:NSUTF8StringEncoding]);
+    RetainPtr utf8Result = adoptNS([[NSString alloc] initWithData:dataForPasteboardType(UTTypeUTF8PlainText.identifier) encoding:NSUTF8StringEncoding]);
     EXPECT_WK_STREQ("Hello world", [utf8Result UTF8String]);
 }
 
@@ -238,7 +238,7 @@ TEST(UIPasteboardTests, DataTransferGetDataWhenPastingPlatformRepresentations)
     RetainPtr<NSURL> testURL = [NSURL URLWithString:@"https://www.apple.com/"];
     RetainPtr<NSString> testPlainTextString = @"WebKit";
     RetainPtr<NSString> testMarkupString = @"<a href=\"https://www.webkit.org/\">The WebKit Project</a>";
-    auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
     [itemProvider registerDataRepresentationForTypeIdentifier:UTTypeHTML.identifier visibility:NSItemProviderRepresentationVisibilityAll loadHandler:^NSProgress *(DataLoadCompletionBlock completionHandler)
     {
         completionHandler([testMarkupString dataUsingEncoding:NSUTF8StringEncoding], nil);
@@ -263,7 +263,7 @@ TEST(UIPasteboardTests, DataTransferGetDataWhenPastingImageAndText)
 {
     auto webView = setUpWebViewForPasteboardTests(@"DataTransfer");
     auto copiedText = retainPtr(@"Apple Inc.");
-    auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
     [itemProvider registerDataRepresentationForTypeIdentifier:UTTypePNG.identifier visibility:NSItemProviderRepresentationVisibilityAll loadHandler:[] (DataLoadCompletionBlock completionHandler) -> NSProgress * {
         completionHandler([NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]], nil);
         return nil;
@@ -313,7 +313,7 @@ TEST(UIPasteboardTests, DataTransferSetDataCannotWritePlatformTypes)
 TEST(UIPasteboardTests, DataTransferGetDataCannotReadArbitraryPlatformTypes)
 {
     auto webView = setUpWebViewForPasteboardTests(@"dump-datatransfer-types");
-    auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
     [itemProvider registerDataRepresentationForTypeIdentifier:UTTypeMP3.identifier visibility:NSItemProviderRepresentationVisibilityAll loadHandler:^NSProgress *(DataLoadCompletionBlock completionHandler)
     {
         completionHandler([@"this is a test" dataUsingEncoding:NSUTF8StringEncoding], nil);
@@ -375,7 +375,7 @@ TEST(UIPasteboardTests, PasteDataBackedURL)
 TEST(UIPasteboardTests, ValidPreferredPresentationSizeForImage)
 {
     auto webView = setUpWebViewForPasteboardTests(@"autofocus-contenteditable");
-    auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
     [itemProvider setPreferredPresentationSize:CGSizeMake(10, 20)];
     [itemProvider registerDataRepresentationForTypeIdentifier:UTTypePNG.identifier visibility:NSItemProviderRepresentationVisibilityAll loadHandler:[] (DataLoadCompletionBlock completionHandler) -> NSProgress * {
         completionHandler([NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]], nil);
@@ -391,7 +391,7 @@ TEST(UIPasteboardTests, ValidPreferredPresentationSizeForImage)
 TEST(UIPasteboardTests, InvalidPreferredPresentationSizeForImage)
 {
     auto webView = setUpWebViewForPasteboardTests(@"autofocus-contenteditable");
-    auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
     [itemProvider setPreferredPresentationSize:CGSizeMake(-10, -20)];
     [itemProvider registerDataRepresentationForTypeIdentifier:UTTypePNG.identifier visibility:NSItemProviderRepresentationVisibilityAll loadHandler:[] (DataLoadCompletionBlock completionHandler) -> NSProgress * {
         completionHandler([NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]], nil);
@@ -407,7 +407,7 @@ TEST(UIPasteboardTests, InvalidPreferredPresentationSizeForImage)
 TEST(UIPasteboardTests, MissingPreferredPresentationSizeForImage)
 {
     auto webView = setUpWebViewForPasteboardTests(@"autofocus-contenteditable");
-    auto itemProvider = adoptNS([[NSItemProvider alloc] init]);
+    RetainPtr itemProvider = adoptNS([[NSItemProvider alloc] init]);
     [itemProvider registerDataRepresentationForTypeIdentifier:UTTypePNG.identifier visibility:NSItemProviderRepresentationVisibilityAll loadHandler:[] (DataLoadCompletionBlock completionHandler) -> NSProgress * {
         completionHandler([NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]], nil);
         return nil;
@@ -521,13 +521,13 @@ TEST(UIPasteboardTests, PasteConfigurationContainsValidUniformTypeIdentifiers)
         }
     };
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)]);
     verifyPasteConfigurationContainsValidUniformTypeIdentifiers(webView.get());
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setAttachmentElementEnabled:YES];
 
-    auto webViewWithAttachmentElementEnabled = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
+    RetainPtr webViewWithAttachmentElementEnabled = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
     verifyPasteConfigurationContainsValidUniformTypeIdentifiers(webViewWithAttachmentElementEnabled.get());
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/UIWKInteractionViewProtocol.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/UIWKInteractionViewProtocol.mm
@@ -115,7 +115,7 @@ namespace TestWebKitAPI {
 
 TEST(UIWKInteractionViewProtocol, SelectTextWithCharacterGranularity)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"<body style='font-size: 20px;'>Hello world</body>"];
     [webView selectTextWithGranularity:UITextGranularityCharacter atPoint:CGPointMake(10, 20)];
     [webView updateSelectionWithExtentPoint:CGPointMake(300, 20) withBoundary:UITextGranularityCharacter];
@@ -124,7 +124,7 @@ TEST(UIWKInteractionViewProtocol, SelectTextWithCharacterGranularity)
 
 TEST(UIWKInteractionViewProtocol, UpdateSelectionWithExtentPoint)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"<body contenteditable style='font-size: 20px;'>Hello world</body>"];
 
     RetainPtr mouseTouchGesture = [&] -> UIGestureRecognizer * {
@@ -152,8 +152,8 @@ TEST(UIWKInteractionViewProtocol, SelectPositionAtPointAfterBecomingFirstRespond
 {
     IPhoneUserInterfaceSwizzler userInterfaceSwizzler;
 
-    auto inputDelegate = adoptNS([TestInputDelegate new]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
     [webView _setInputDelegate:inputDelegate.get()];
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id <_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         return _WKFocusStartsInputSessionPolicyAllow;
@@ -177,8 +177,8 @@ TEST(UIWKInteractionViewProtocol, SelectPositionAtPointAfterBecomingFirstRespond
 
 TEST(UIWKInteractionViewProtocol, SelectPositionAtPointInFocusedElementStartsInputSession)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
-    auto inputDelegate = adoptNS([TestInputDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
     [webView _setInputDelegate:inputDelegate.get()];
 
     bool didCallDecidePolicyForFocusedElement = false;
@@ -201,8 +201,8 @@ TEST(UIWKInteractionViewProtocol, SelectPositionAtPointInFocusedElementStartsInp
 
 TEST(UIWKInteractionViewProtocol, SelectPositionAtPointInElementInNonFocusedFrame)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
-    auto inputDelegate = adoptNS([TestInputDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
     [webView _setInputDelegate:inputDelegate.get()];
 
     bool didStartInputSession = false;
@@ -222,8 +222,8 @@ TEST(UIWKInteractionViewProtocol, SelectPositionAtPointInElementInNonFocusedFram
 
 static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestInputDelegate>> setUpEditableWebViewAndWaitForInputSession()
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 320)]);
-    auto inputDelegate = adoptNS([TestInputDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 320)]);
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
     [webView _setInputDelegate:inputDelegate.get()];
 
     bool didStartInputSession = false;
@@ -272,7 +272,7 @@ TEST(UIWKInteractionViewProtocol, SuppressSelectionChangesDuringDictation)
     [contentView insertText:@"Hello world"];
     [webView waitForNextPresentationUpdate];
 
-    auto observer = adoptNS([[EditorStateObserver alloc] initWithWebView:webView.get()]);
+    RetainPtr observer = adoptNS([[EditorStateObserver alloc] initWithWebView:webView.get()]);
     [contentView willInsertFinalDictationResult];
     [contentView replaceDictatedText:@"Hello world" withText:@""];
     [contentView insertText:@"Foo"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/UserInterfaceIdiomUpdate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/UserInterfaceIdiomUpdate.mm
@@ -37,8 +37,8 @@ namespace TestWebKitAPI {
 
 TEST(UserInterfaceIdiomUpdate, SelectPopoverCrash)
 {
-    auto inputDelegate = adoptNS([TestInputDelegate new]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView _setInputDelegate:inputDelegate.get()];
     [webView synchronouslyLoadHTMLString:@"<select id='select'><option selected>foo</option><option>bar</option></select>"];
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id <_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/Viewport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/Viewport.mm
@@ -51,7 +51,7 @@ TEST(Viewport, MinimumEffectiveDeviceWidthWithInitialScale)
 {
     IPadUserInterfaceSwizzler iPadUserInterface;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 690, 690)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 690, 690)]);
 
     [webView synchronouslyLoadHTMLString:makeViewportMetaTag(1000, 0.69).get()];
     [webView waitForNextPresentationUpdate];
@@ -67,9 +67,9 @@ TEST(Viewport, RespectInitialScaleExceptOnWikipediaDomain)
     IPadUserInterfaceSwizzler iPadUserInterface;
 
     auto screenDimensions = CGRectMake(0, 0, 2732, 2048);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:screenDimensions]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:screenDimensions]);
     [[webView configuration] preferences]._shouldIgnoreMetaViewport = YES;
-    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     auto runTest = [&webView, &navigationDelegate, screenWidth = screenDimensions.size.width] (StringView requestURL, Function<void(float, float)>&& scaleExpectation) mutable {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewDelegate.mm
@@ -54,8 +54,8 @@ namespace TestWebKitAPI {
 
 TEST(WKWebView, WKScrollViewDelegateCrash)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
-    auto delegateForScrollView = adoptNS([[TestDelegateForScrollView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr delegateForScrollView = adoptNS([[TestDelegateForScrollView alloc] init]);
     @autoreleasepool {
         [webView scrollView].delegate = delegateForScrollView.get();
     }
@@ -93,8 +93,8 @@ namespace TestWebKitAPI {
 
 TEST(WKWebView, WKScrollViewDelegateCannotOverrideViewForZooming)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] init]);
-    auto delegateForScrollView = adoptNS([[WKScrollViewDelegateWithViewForZoomingOverridden alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] init]);
+    RetainPtr delegateForScrollView = adoptNS([[WKScrollViewDelegateWithViewForZoomingOverridden alloc] init]);
     @autoreleasepool {
         [webView scrollView].delegate = delegateForScrollView.get();
     }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewTests.mm
@@ -240,7 +240,7 @@ inline static UIScrollPhase legacyScrollPhase(WKBEScrollViewScrollUpdatePhase ph
 
 inline static RetainPtr<WKBEScrollViewScrollUpdate> createScrollUpdate(WKBEScrollViewScrollUpdatePhase phase, CGPoint location, CGVector delta)
 {
-    auto event = adoptNS([[WKUIScrollEvent alloc] initWithPhase:legacyScrollPhase(phase) location:location delta:delta]);
+    RetainPtr event = adoptNS([[WKUIScrollEvent alloc] initWithPhase:legacyScrollPhase(phase) location:location delta:delta]);
 #if USE(BROWSERENGINEKIT)
     return adoptNS(static_cast<BEScrollViewScrollUpdate *>([[WKTestScrollViewScrollUpdate alloc] initWithScrollEvent:event.get() phase:phase]));
 #else
@@ -288,7 +288,7 @@ static void traverseLayerTree(CALayer *layer, void(^block)(CALayer *))
 
 TEST(WKScrollViewTests, PositionFixedLayerAfterScrolling)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadTestPageNamed:@"fixed-nav-bar"];
 
     __block bool done = false;
@@ -699,7 +699,7 @@ TEST(WKScrollViewTests, WheelEventDispatchedToCrossOriginSubframeWithSiteIsolati
 
 TEST(WKScrollViewTests, IndicatorStyleSetByClient)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 320, 500)]);
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<style> body { background-color: black; } </style>"];
     EXPECT_EQ([webView scrollView].indicatorStyle, UIScrollViewIndicatorStyleWhite);
@@ -732,7 +732,7 @@ TEST(WKScrollViewTests, BackgroundColorSetByClient)
     auto blackColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), blackColorComponents));
     auto whiteColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), whiteColorComponents));
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 320, 500)]);
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<style> body { background-color: black; } </style>"];
     EXPECT_TRUE(CGColorEqualToColor([webView scrollView].backgroundColor.CGColor, blackColor.get()));
@@ -761,7 +761,7 @@ TEST(WKScrollViewTests, BackgroundColorSetByClient)
 
 TEST(WKScrollViewTests, DecelerationSetByClient)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 320, 500)]);
 
     [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"first"];
     EXPECT_FLOAT_EQ([webView scrollView].decelerationRate, UIScrollViewDecelerationRateNormal);
@@ -776,15 +776,15 @@ TEST(WKScrollViewTests, DecelerationSetByClient)
 #if HAVE(UISCROLLVIEW_ALLOWS_KEYBOARD_SCROLLING)
 TEST(WKScrollViewTests, AllowsKeyboardScrolling)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 300)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 300)]);
 
     [webView synchronouslyLoadTestPageNamed:@"simple-tall"];
     [webView waitForNextPresentationUpdate];
 
     auto pressSpacebar = ^(void(^completionHandler)(void)) {
-        auto firstWebEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyDown timeStamp:CFAbsoluteTimeGetCurrent() characters:@" " charactersIgnoringModifiers:@" " modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:NO]);
+        RetainPtr firstWebEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyDown timeStamp:CFAbsoluteTimeGetCurrent() characters:@" " charactersIgnoringModifiers:@" " modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:NO]);
 
-        auto secondWebEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyUp timeStamp:CFAbsoluteTimeGetCurrent() characters:@" " charactersIgnoringModifiers:@" " modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:NO]);
+        RetainPtr secondWebEvent = adoptNS([[WebEvent alloc] initWithKeyEventType:WebEventKeyUp timeStamp:CFAbsoluteTimeGetCurrent() characters:@" " charactersIgnoringModifiers:@" " modifiers:0 isRepeating:NO withFlags:0 withInputManagerHint:nil keyCode:0 isTabKey:NO]);
 
         [webView handleKeyEvent:firstWebEvent.get() completion:^(WebEvent *theEvent, BOOL wasHandled) {
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), mainDispatchQueueSingleton(), ^{

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKWebViewAutofillTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKWebViewAutofillTests.mm
@@ -92,7 +92,7 @@ namespace TestWebKitAPI {
 
 TEST(WKWebViewAutoFillTests, UsernameAndPasswordField)
 {
-    auto webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<input id='user' type='email'><input id='password' type='password'>"];
     [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"user.focus()"];
     EXPECT_TRUE([webView acceptsAutoFillLoginCredentials]);
@@ -111,7 +111,7 @@ TEST(WKWebViewAutoFillTests, UsernameAndPasswordField)
 
 TEST(WKWebViewAutoFillTests, UsernameAndPasswordFieldAcrossShadowBoundaries)
 {
-    auto webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<div id=emailHost></div><div id=passwordHost></div><script>"
         "emailRoot = emailHost.attachShadow({mode: 'closed'}); emailRoot.innerHTML = '<input id=user type=email>';"
         "passwordRoot = passwordHost.attachShadow({mode: 'closed'}); passwordRoot.innerHTML = '<input id=password type=password>';"
@@ -133,7 +133,7 @@ TEST(WKWebViewAutoFillTests, UsernameAndPasswordFieldAcrossShadowBoundaries)
 
 TEST(WKWebViewAutoFillTests, UsernameAndPasswordFieldSeparatedByRadioButton)
 {
-    auto webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<input id='user' type='email'><input type='radio' name='radio_button' value='radio'><input id='password' type='password'>"];
     [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"user.focus()"];
     EXPECT_TRUE([webView acceptsAutoFillLoginCredentials]);
@@ -153,7 +153,7 @@ TEST(WKWebViewAutoFillTests, UsernameAndPasswordFieldSeparatedByRadioButton)
 
 TEST(WKWebViewAutoFillTests, TwoTextFields)
 {
-    auto webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<input id='text1' type='email'><input id='text2' type='text'>"];
     [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"text1.focus()"];
     EXPECT_FALSE([webView acceptsAutoFillLoginCredentials]);
@@ -164,7 +164,7 @@ TEST(WKWebViewAutoFillTests, TwoTextFields)
 
 TEST(WKWebViewAutoFillTests, StandalonePasswordField)
 {
-    auto webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<input id='password' type='password'>"];
     [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"password.focus()"];
     EXPECT_TRUE([webView acceptsAutoFillLoginCredentials]);
@@ -180,7 +180,7 @@ TEST(WKWebViewAutoFillTests, StandalonePasswordField)
 
 TEST(WKWebViewAutoFillTests, StandaloneUsernameField)
 {
-    auto webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<input id='username' autocomplete='username'>"];
     [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"username.focus()"];
     EXPECT_TRUE([webView acceptsAutoFillLoginCredentials]);
@@ -196,7 +196,7 @@ TEST(WKWebViewAutoFillTests, StandaloneUsernameField)
 
 TEST(WKWebViewAutoFillTests, StandaloneUsernameWebauthnField)
 {
-    auto webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<input id='username' autocomplete='username webauthn'>"];
     [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"username.focus()"];
     EXPECT_TRUE([webView acceptsAutoFillLoginCredentials]);
@@ -212,7 +212,7 @@ TEST(WKWebViewAutoFillTests, StandaloneUsernameWebauthnField)
 
 TEST(WKWebViewAutoFillTests, StandaloneTextField)
 {
-    auto webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<input id='textfield' type='text'>"];
     [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"textfield.focus()"];
     EXPECT_FALSE([webView acceptsAutoFillLoginCredentials]);
@@ -220,7 +220,7 @@ TEST(WKWebViewAutoFillTests, StandaloneTextField)
 
 TEST(WKWebViewAutoFillTests, AccountCreationPage)
 {
-    auto webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<input id='user' type='email'><input id='password' type='password'><input id='confirm_password' type='password'>"];
     [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"user.focus()"];
     EXPECT_TRUE([webView acceptsAutoFillLoginCredentials]);
@@ -234,7 +234,7 @@ TEST(WKWebViewAutoFillTests, AccountCreationPage)
 
 TEST(WKWebViewAutoFillTests, AccountCreationPageAcrossShadowBoundaries)
 {
-    auto webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [webView synchronouslyLoadHTMLString:@"<div id=emailHost></div><div id=passwordHost></div><div id=confirmHost></div><script>"
         "emailRoot = emailHost.attachShadow({mode: 'closed'}); emailRoot.innerHTML = '<input id=user type=email>';"
         "passwordRoot = passwordHost.attachShadow({mode: 'closed'}); passwordRoot.innerHTML = '<input id=password type=password>';"
@@ -260,7 +260,7 @@ TEST(WKWebViewAutoFillTests, AutoFillRequiresInputSession)
     ClassMethodSwizzler swizzler([UIKeyboard class], @selector(isInHardwareKeyboardMode), reinterpret_cast<IMP>(overrideIsInHardwareKeyboardMode));
 
     bool done = false;
-    auto webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [(TestInputDelegate *)[webView _inputDelegate] setFocusStartsInputSessionPolicyHandler:[&done] (WKWebView *, id <_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
         done = true;
         return _WKFocusStartsInputSessionPolicyAuto;
@@ -277,7 +277,7 @@ TEST(WKWebViewAutoFillTests, AutoFillRequiresInputSession)
 TEST(WKWebViewAutoFillTests, AutoFillPreservesTextSuggestion)
 {
     __block bool doneFocusing = false;
-    auto webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     auto inputDelegate = static_cast<TestInputDelegate *>([webView _inputDelegate]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:^(WKWebView *, id<_WKFocusedElementInfo>) {
         doneFocusing = true;
@@ -294,7 +294,7 @@ TEST(WKWebViewAutoFillTests, AutoFillPreservesTextSuggestion)
     [webView stringByEvaluatingJavaScript:@"user.focus()"];
     Util::run(&doneFocusing);
 
-    auto suggestion = adoptNS([[BETextSuggestion alloc] _initWithUIKitTextSuggestion:customSuggestion.get()]);
+    RetainPtr suggestion = adoptNS([[BETextSuggestion alloc] _initWithUIKitTextSuggestion:customSuggestion.get()]);
     [[webView asyncTextInput] insertTextSuggestion:suggestion.get()];
     EXPECT_TRUE(insertedSuggestion);
 }
@@ -305,9 +305,9 @@ TEST(WKWebViewAutoFillTests, AutoFillPreservesTextSuggestion)
 
 TEST(WKWebViewAutoFillTests, DoNotShowBlankTextSuggestions)
 {
-    auto webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [(TestInputDelegate *)[webView _inputDelegate] setWillStartInputSessionHandler:[](WKWebView *, id <_WKFormInputSession> session) {
-        auto emptySuggestion = adoptNS([[UITextSuggestion alloc] init]);
+        RetainPtr emptySuggestion = adoptNS([[UITextSuggestion alloc] init]);
         [emptySuggestion setDisplayText:@""];
         session.suggestions = @[ emptySuggestion.get() ];
     }];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKWebViewOpaque.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKWebViewOpaque.mm
@@ -68,14 +68,14 @@ static void isOpaque(TestWKWebView *webView, BOOL opaque)
 
 TEST(WKWebView, IsOpaqueDefault)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
 
     isOpaque(webView.get(), YES);
 }
 
 TEST(WKWebView, SetOpaqueYes)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
 
     [webView setOpaque:YES];
 
@@ -84,7 +84,7 @@ TEST(WKWebView, SetOpaqueYes)
 
 TEST(WKWebView, SetOpaqueNo)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
 
     [webView setOpaque:NO];
 
@@ -93,21 +93,21 @@ TEST(WKWebView, SetOpaqueNo)
 
 TEST(WKWebView, IsOpaqueYesSubclassOverridden)
 {
-    auto webView = adoptNS([[OpaqueTestWKWebView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr webView = adoptNS([[OpaqueTestWKWebView alloc] initWithFrame:NSZeroRect]);
 
     isOpaque(webView.get(), YES);
 }
 
 TEST(WKWebView, IsOpaqueNoSubclassOverridden)
 {
-    auto webView = adoptNS([[NonOpaqueTestWKWebView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr webView = adoptNS([[NonOpaqueTestWKWebView alloc] initWithFrame:NSZeroRect]);
 
     isOpaque(webView.get(), NO);
 }
 
 TEST(WKWebView, IsOpaqueYesDecodedFromArchive)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
 
     [webView setOpaque:YES];
 
@@ -121,7 +121,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 TEST(WKWebView, IsOpaqueNoDecodedFromArchive)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
 
     [webView setOpaque:NO];
 
@@ -135,26 +135,26 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 TEST(WKWebView, IsOpaqueDrawsBackgroundYesConfiguration)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     [configuration _setDrawsBackground:YES];
 
     EXPECT_EQ([configuration _drawsBackground], YES);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
 
     isOpaque(webView.get(), YES);
 }
 
 TEST(WKWebView, IsOpaqueDrawsBackgroundNoConfiguration)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
     [configuration _setDrawsBackground:NO];
 
     EXPECT_EQ([configuration _drawsBackground], NO);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
 
     isOpaque(webView.get(), NO);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKWebViewPausePlayingAudioTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKWebViewPausePlayingAudioTests.mm
@@ -36,7 +36,7 @@ namespace TestWebKitAPI {
 
 static RetainPtr<WKWebViewConfiguration> autoplayingConfiguration()
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
     configuration.get().allowsInlineMediaPlayback = YES;
     configuration.get()._inlineMediaPlaybackRequiresPlaysInlineAttribute = NO;
@@ -45,7 +45,7 @@ static RetainPtr<WKWebViewConfiguration> autoplayingConfiguration()
 
 TEST(WKWebViewPausePlayingAudioTests, InWindow)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:autoplayingConfiguration().get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:autoplayingConfiguration().get() addToWindow:YES]);
 
     bool isPlaying = false;
     [webView performAfterReceivingMessage:@"playing" action:[&] { isPlaying = true; }];
@@ -71,7 +71,7 @@ TEST(WKWebViewPausePlayingAudioTests, InWindow)
 
 TEST(WKWebViewPausePlayingAudioTests, OutOfWindow)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:autoplayingConfiguration().get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:autoplayingConfiguration().get() addToWindow:YES]);
 
     bool isPlaying = false;
     [webView performAfterReceivingMessage:@"playing" action:[&] { isPlaying = true; }];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKWebViewResize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKWebViewResize.mm
@@ -119,7 +119,7 @@ TEST(WKWebView, EnsureUnobscuredContentRectMatchesWebViewBounds)
     CGRect initialFrame = CGRectMake(0, 0, 800, 600);
     CGRect largerFrame = CGRectMake(0, 0, 1200, 800);
     CGRect smallerFrame = CGRectMake(0, 0, 400, 300);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:initialFrame]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:initialFrame]);
     [webView setFrame:largerFrame];
 
     webViewHasExpectedBounds(webView.get(), largerFrame);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/AcceptsFirstMouse.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/AcceptsFirstMouse.mm
@@ -79,7 +79,7 @@ TEST_F(AcceptsFirstMouse, WebKit2)
 
 TEST(WebKit2, AcceptsFirstMouseDuringWebProcessLaunch)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView loadHTMLString:@"<body>" baseURL:nil];
 
     auto mouseEvent = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown location:NSMakePoint(1, 1) modifierFlags:0 timestamp:GetCurrentEventTime() windowNumber:[webView window].windowNumber context:NSGraphicsContext.currentContext eventNumber:1 clickCount:1 pressure:0];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/AttributedSubstringForProposedRange.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/AttributedSubstringForProposedRange.mm
@@ -49,7 +49,7 @@ TEST(AttributedSubstringForProposedRange, TextAlignmentParagraphStyles)
         "</body>"
         "<script>getSelection().setPosition(document.body)</script>";
 
-    auto webView = adoptNS([[TestWKWebView<NSTextInputClient_Async> alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView<NSTextInputClient_Async> alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:markup];
 
     __block bool finished = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/BackgroundColor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/BackgroundColor.mm
@@ -42,7 +42,7 @@ namespace TestWebKitAPI {
 
 TEST(WebKit, BackgroundColorDefault)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     NSColor *defaultColor = DEFAULT_BACKGROUND_COLOR;
     NSColor *backgroundColor = [webView _backgroundColor];
@@ -56,7 +56,7 @@ TEST(WebKit, BackgroundColorDefault)
 
 TEST(WebKit, BackgroundColorSystemColor)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     NSColor *systemColor = [NSColor textBackgroundColor];
     [webView _setBackgroundColor:systemColor];
@@ -72,7 +72,7 @@ TEST(WebKit, BackgroundColorSystemColor)
 
 TEST(WebKit, BackgroundColorNil)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     [webView _setBackgroundColor:nil];
 
@@ -88,7 +88,7 @@ TEST(WebKit, BackgroundColorNil)
 
 TEST(WebKit, BackgroundColorNoDrawsBackground)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     [webView _setDrawsBackground:NO];
 
@@ -104,7 +104,7 @@ TEST(WebKit, BackgroundColorNoDrawsBackground)
 
 TEST(WebKit, BackgroundColorCustomColorNoDrawsBackground)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     [webView _setDrawsBackground:NO];
     [webView _setBackgroundColor:[NSColor textBackgroundColor]];
@@ -122,7 +122,7 @@ TEST(WebKit, BackgroundColorToggleAppearance)
 {
     const NSInteger width = 800;
     const NSInteger height = 600;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, width, height)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, width, height)]);
 
     const auto& checkWhitePixel = [&] {
         uint8_t* pixelBuffer = static_cast<uint8_t*>(calloc(width * height, 4));

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/CandidateTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/CandidateTests.mm
@@ -89,8 +89,8 @@ namespace TestWebKitAPI {
 
 TEST(CandidateTests, DISABLED_DoNotLeakViewThatLoadsEditableArea)
 {
-    auto webView = adoptNS([[DoNotLeakWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)]);
-    auto delegate = adoptNS([[DoNotLeakFrameLoadDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[DoNotLeakWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)]);
+    RetainPtr delegate = adoptNS([[DoNotLeakFrameLoadDelegate alloc] init]);
     [webView setFrameLoadDelegate:delegate.get()];
     
     NSURL *contentURL = [NSBundle.test_resourcesBundle URLForResource:@"autofocused-text-input" withExtension:@"html"];
@@ -105,9 +105,9 @@ TEST(CandidateTests, DISABLED_DoNotLeakViewThatLoadsEditableArea)
 
 TEST(CandidateTests, DISABLED_RequestCandidatesForTextInput)
 {
-    auto webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)]);
+    RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)]);
     [webView forceRequestCandidatesForTesting];
-    auto delegate = adoptNS([[CandidateRequestFrameLoadDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[CandidateRequestFrameLoadDelegate alloc] init]);
     [webView setFrameLoadDelegate:delegate.get()];
     
     NSURL *contentURL = [NSBundle.test_resourcesBundle URLForResource:@"focus-inputs" withExtension:@"html"];
@@ -126,9 +126,9 @@ TEST(CandidateTests, DISABLED_RequestCandidatesForTextInput)
 
 TEST(CandidateTests, DoNotRequestCandidatesForPasswordInput)
 {
-    auto webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)]);
+    RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)]);
     [webView forceRequestCandidatesForTesting];
-    auto delegate = adoptNS([[CandidateRequestFrameLoadDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[CandidateRequestFrameLoadDelegate alloc] init]);
     [webView setFrameLoadDelegate:delegate.get()];
     
     NSURL *contentURL = [NSBundle.test_resourcesBundle URLForResource:@"focus-inputs" withExtension:@"html"];
@@ -159,15 +159,15 @@ TEST(CandidateTests, DoNotHideCandidatesDuringTextReplacement)
 {
     InstanceMethodSwizzler visibilityUpdateSwizzler { NSCandidateListTouchBarItem.class, @selector(updateWithInsertionPointVisibility:), reinterpret_cast<IMP>(updateCandidateListWithVisibility) };
 
-    auto webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)]);
+    RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100)]);
     [webView forceRequestCandidatesForTesting];
 
-    auto delegate = adoptNS([[CandidateRequestFrameLoadDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[CandidateRequestFrameLoadDelegate alloc] init]);
     [webView setFrameLoadDelegate:delegate.get()];
     [[webView mainFrame] loadHTMLString:@"<body contenteditable>Hello world<script>document.body.focus()</script>" baseURL:nil];
     TestWebKitAPI::Util::run(&didFinishLoad);
 
-    auto textToInsert = adoptNS([[NSMutableAttributedString alloc] initWithString:@"Goodbye"]);
+    RetainPtr textToInsert = adoptNS([[NSMutableAttributedString alloc] initWithString:@"Goodbye"]);
     [textToInsert addAttribute:NSTextInputReplacementRangeAttributeName value:NSStringFromRange(NSMakeRange(0, 5)) range:NSMakeRange(0, 7)];
     [webView insertText:textToInsert.get()];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/CloseWhileCommittingLoad.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/CloseWhileCommittingLoad.mm
@@ -49,8 +49,8 @@ namespace TestWebKitAPI {
 
 TEST(WebKitLegacy, CloseWhileCommittingLoad)
 {
-    auto webView = adoptNS([WebView new]);
-    auto delegate = adoptNS([CloseWhileCommittingLoadDelegate new]);
+    RetainPtr webView = adoptNS([WebView new]);
+    RetainPtr delegate = adoptNS([CloseWhileCommittingLoadDelegate new]);
     [webView setFrameLoadDelegate:delegate.get()];
 
     didCloseWhileCommittingLoad = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ColorInputTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ColorInputTests.mm
@@ -46,7 +46,7 @@ static bool isShowingColorPicker(TestWKWebView *webView)
 
 TEST(ColorInputTests, SetColorUsingColorPicker)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"<input type='color' id='color' style='width: 200px; height: 200px;'>"];
 
     [webView sendClickAtPoint:NSMakePoint(50, 350)];
@@ -64,7 +64,7 @@ TEST(ColorInputTests, SetColorUsingColorPicker)
 
 TEST(ColorInputTests, SetColorWithAlphaUsingColorPicker)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"<input type='color' id='color' style='width: 200px; height: 200px;'>"];
 
     [webView sendClickAtPoint:NSMakePoint(50, 350)];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContentFiltering.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContentFiltering.mm
@@ -67,8 +67,8 @@ static void loadAlternateTest(Decision decision, DecisionPoint decisionPoint)
         settings.setBlockedString("blocked"_s);
         [TestProtocol registerWithScheme:@"http"];
 
-        auto webView = adoptNS([[WebView alloc] initWithFrame:NSZeroRect]);
-        auto frameLoadDelegate = adoptNS([[LoadAlternateFrameLoadDelegate alloc] init]);
+        RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:NSZeroRect]);
+        RetainPtr frameLoadDelegate = adoptNS([[LoadAlternateFrameLoadDelegate alloc] init]);
         [webView setFrameLoadDelegate:frameLoadDelegate.get()];
         [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://redirect/?result"]]];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuMouseEvents.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuMouseEvents.mm
@@ -40,10 +40,10 @@ namespace TestWebKitAPI {
     
 static void runTest(NSEventModifierFlags flags, NSEventType mouseDownType, NSEventType mouseUpType)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView synchronouslyLoadTestPageNamed:@"context-menu-control-click"];
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     __block bool navigationAttempted = false;
@@ -52,7 +52,7 @@ static void runTest(NSEventModifierFlags flags, NSEventType mouseDownType, NSEve
         navigationAttempted = true;
     }];
 
-    auto uiDelegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr uiDelegate = adoptNS([[TestUIDelegate alloc] init]);
     [webView setUIDelegate:uiDelegate.get()];
 
     __block bool done = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuTests.mm
@@ -115,7 +115,7 @@ namespace TestWebKitAPI {
 
 TEST(ContextMenuTests, ProposedMenuContainsSpellingMenu)
 {
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block RetainPtr<NSMenu> proposedMenu;
     __block bool gotProposedMenu = false;
@@ -125,7 +125,7 @@ TEST(ContextMenuTests, ProposedMenuContainsSpellingMenu)
         gotProposedMenu = true;
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView setUIDelegate:delegate.get()];
     [webView _setEditable:YES];
     [webView synchronouslyLoadTestPageNamed:@"simple"];
@@ -144,8 +144,8 @@ TEST(ContextMenuTests, ProposedMenuContainsSpellingMenu)
 
 TEST(ContextMenuTests, NavigationTypeWhenOpeningLink)
 {
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [webView loadHTMLString:@"<a href='simple.html' style='font-size: 100px;'>Hello world</a>" baseURL:NSBundle.test_resourcesBundle.resourceURL];
     [navigationDelegate waitForDidFinishNavigation];
@@ -174,7 +174,7 @@ TEST(ContextMenuTests, ShowColorPanel)
 {
     InstanceMethodSwizzler swizzler { NSApplication.class, @selector(orderFrontColorPanel:), reinterpret_cast<IMP>(swizzledOrderFrontColorPanel) };
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setEditable:YES];
     [webView synchronouslyLoadTestPageNamed:@"simple"];
     [webView rightClick:NSMakePoint(16, 16) andSelectItemMatching:^BOOL(NSMenuItem *item) {
@@ -233,12 +233,12 @@ TEST(ContextMenuTests, ShowSharePopoverForImage)
 TEST(ContextMenuTests, SharePopoverDoesNotClearSelection)
 {
     bool didShowPopover = false;
-    auto listener = adoptNS([[PopoverNotificationListener alloc] initWithCallback:[&](NSNotification *notification) {
+    RetainPtr listener = adoptNS([[PopoverNotificationListener alloc] initWithCallback:[&](NSNotification *notification) {
         if ([notification.name isEqualToString:NSPopoverDidShowNotification])
             didShowPopover = true;
     }]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     auto presentingViewSwizzler = InstanceMethodSwizzler {
         NSMenu.class,
         @selector(_presentingView),
@@ -262,7 +262,7 @@ TEST(ContextMenuTests, SharePopoverDoesNotClearSelection)
 
 TEST(ContextMenuTests, ContextMenuElementInfoContainsHitTestResult)
 {
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotProposedMenu = false;
     [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
@@ -271,7 +271,7 @@ TEST(ContextMenuTests, ContextMenuElementInfoContainsHitTestResult)
         gotProposedMenu = true;
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView setUIDelegate:delegate.get()];
     [webView _setEditable:YES];
     [webView synchronouslyLoadTestPageNamed:@"simple"];
@@ -282,7 +282,7 @@ TEST(ContextMenuTests, ContextMenuElementInfoContainsHitTestResult)
 
 TEST(ContextMenuTests, HitTestResultDoesNotContainEmptyURLs)
 {
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotProposedMenu = false;
     [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
@@ -299,7 +299,7 @@ TEST(ContextMenuTests, HitTestResultDoesNotContainEmptyURLs)
         gotProposedMenu = true;
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView setUIDelegate:delegate.get()];
     [webView _setEditable:YES];
     [webView synchronouslyLoadTestPageNamed:@"simple"];
@@ -317,7 +317,7 @@ static NSString *qrCodeSVGString()
 
 TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringDefaultConfiguration)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600)]);
     [webView synchronouslyLoadHTMLString:@"<img src='qr-code.png'></img>"];
 
     _WKContextMenuElementInfo *elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(300, 300)];
@@ -331,10 +331,10 @@ TEST(ContextMenuTests, DISABLED_ContextMenuElementInfoContainsQRCodePayloadStrin
 TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadString)
 #endif
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setContextMenuQRCodeDetectionEnabled:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:@"<img src='qr-code.png'></img>"];
 
     _WKContextMenuElementInfo *elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(150, 150)];
@@ -346,10 +346,10 @@ TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadString)
 
 TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringInsideLink)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setContextMenuQRCodeDetectionEnabled:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:@"<a href='https://www.webkit.org'><img src='qr-code.png'></img></a>"];
 
     _WKContextMenuElementInfo *elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(300, 300)];
@@ -358,18 +358,18 @@ TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringInsideLi
 
 TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringCanvas)
 {
-    auto testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
+    RetainPtr testMessageHandler = adoptNS([[TestMessageHandler alloc] init]);
 
     __block bool imageLoaded = false;
     [testMessageHandler addMessage:@"imageLoaded" withHandler:^{
         imageLoaded = true;
     }];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:testMessageHandler.get() name:@"testHandler"];
     [configuration _setContextMenuQRCodeDetectionEnabled:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:@"<canvas id='canvas' width='400' height='400'></canvas>"];
 
     NSString *drawImageToCanvasScript = @""
@@ -394,10 +394,10 @@ TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringCanvas)
 
 TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringSVG)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setContextMenuQRCodeDetectionEnabled:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:qrCodeSVGString()];
 
     _WKContextMenuElementInfo *elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(150, 150)];
@@ -409,10 +409,10 @@ TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringSVG)
 
 TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringObscuredSVG)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setContextMenuQRCodeDetectionEnabled:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"%@<div style='width: 400px; height: 100px; background: red; position: absolute; top: 0px; left: 0px;'></div>", qrCodeSVGString()]];
 
     _WKContextMenuElementInfo *elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(150, 550)];
@@ -424,10 +424,10 @@ TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringObscured
 
 TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringSVGInsideTransformedElement)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setContextMenuQRCodeDetectionEnabled:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
     [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<div style='transform: translateX(100px);'>%@</div>", qrCodeSVGString()]];
 
     _WKContextMenuElementInfo *elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(50, 550)];
@@ -439,10 +439,10 @@ TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringSVGInsid
 
 TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringSVGPageZoom)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration _setContextMenuQRCodeDetectionEnabled:YES];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
     [webView setPageZoom:1.3];
     [webView synchronouslyLoadHTMLString:qrCodeSVGString()];
 
@@ -457,9 +457,9 @@ TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringSVGPageZ
 TEST(ContextMenuElementInfoWithQRCodeDetectionCrash, DISABLED_ContextMenuTests)
 {
     auto createWebView = [] {
-        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
         [configuration _setContextMenuQRCodeDetectionEnabled:YES];
-        auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
+        RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
         [webView synchronouslyLoadHTMLString:@"<img src='qr-code.png'></img>"];
         return webView;
     };
@@ -482,7 +482,7 @@ TEST(ContextMenuTests, ContextMenuElementInfoHasEntireImage)
 {
     CGFloat iconWidth = 215;
     CGFloat iconHeight = 174;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, iconWidth * 2, iconHeight * 2)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, iconWidth * 2, iconHeight * 2)]);
     [webView synchronouslyLoadHTMLString:@"<img src='icon.png'></img>"];
 
     _WKContextMenuElementInfo *elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(iconWidth, iconHeight)];
@@ -494,7 +494,7 @@ TEST(ContextMenuTests, ContextMenuElementInfoHasEntireImage)
 
 TEST(ContextMenuTests, HitTestResultElementTypeNone)
 {
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotProposedMenu = false;
     [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
@@ -504,7 +504,7 @@ TEST(ContextMenuTests, HitTestResultElementTypeNone)
         gotProposedMenu = true;
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView setUIDelegate:delegate.get()];
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
@@ -515,7 +515,7 @@ TEST(ContextMenuTests, HitTestResultElementTypeNone)
 
 TEST(ContextMenuTests, HitTestResultElementTypeVideo)
 {
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotProposedMenu = false;
     [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
@@ -525,7 +525,7 @@ TEST(ContextMenuTests, HitTestResultElementTypeVideo)
         gotProposedMenu = true;
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView setUIDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<video src=\"video-without-audio.mp4\" controls></video>"];
 
@@ -536,7 +536,7 @@ TEST(ContextMenuTests, HitTestResultElementTypeVideo)
 
 TEST(ContextMenuTests, HitTestResultWithElementSelected)
 {
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotProposedMenu = false;
     [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
@@ -546,7 +546,7 @@ TEST(ContextMenuTests, HitTestResultWithElementSelected)
         gotProposedMenu = true;
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView setUIDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<body style='font-size: 100px;'>This text can be selected.</body>"];
     [[webView window] makeFirstResponder:webView.get()];
@@ -560,7 +560,7 @@ TEST(ContextMenuTests, HitTestResultWithElementSelected)
 
 TEST(ContextMenuTests, HitTestResultWithNoElementSelected)
 {
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotProposedMenu = false;
     [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
@@ -570,7 +570,7 @@ TEST(ContextMenuTests, HitTestResultWithNoElementSelected)
         gotProposedMenu = true;
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView setUIDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<body style='font-size: 100px; -webkit-user-select: none;'>This text cannot be selected.</body>"];
 
@@ -584,7 +584,7 @@ TEST(ContextMenuTests, HitTestResultWhenClickingInSubframe)
     // This is the escaped version of "data:text/html,<body>Hello from a frame!</body>" since that's what -[NSURL absoluteString] returns.
     NSString *subframeContentsString = @"data:text/html,%3Cbody%3EHello%20from%20a%20frame!%3C/body%3E";
 
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotProposedMenu = false;
     [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
@@ -599,7 +599,7 @@ TEST(ContextMenuTests, HitTestResultWhenClickingInSubframe)
         gotProposedMenu = true;
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView setUIDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<iframe width='400' height='400' src='%@'</iframe>", subframeContentsString]];
     [webView waitForNextPresentationUpdate];
@@ -611,7 +611,7 @@ TEST(ContextMenuTests, HitTestResultWhenClickingInSubframe)
 
 TEST(ContextMenuTests, HitTestResultNonFullscreenMedia)
 {
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotProposedMenu = false;
     [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
@@ -621,7 +621,7 @@ TEST(ContextMenuTests, HitTestResultNonFullscreenMedia)
         gotProposedMenu = true;
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView setUIDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<video src=\"video-without-audio.mp4\" controls></video>"];
 
@@ -632,7 +632,7 @@ TEST(ContextMenuTests, HitTestResultNonFullscreenMedia)
 
 TEST(ContextMenuTests, HitTestResultMediaDownloadable)
 {
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotProposedMenu = false;
     [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
@@ -642,7 +642,7 @@ TEST(ContextMenuTests, HitTestResultMediaDownloadable)
         gotProposedMenu = true;
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView setUIDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<video src=\"video-without-audio.mp4\" controls></video>"];
 
@@ -653,7 +653,7 @@ TEST(ContextMenuTests, HitTestResultMediaDownloadable)
 
 TEST(ContextMenuTests, HitTestResultImageMIMEType)
 {
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotProposedMenu = false;
     [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
@@ -663,7 +663,7 @@ TEST(ContextMenuTests, HitTestResultImageMIMEType)
         gotProposedMenu = true;
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView setUIDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<img src='sunset-in-cupertino-600px.jpg'></img>"];
 
@@ -677,7 +677,7 @@ TEST(ContextMenuTests, HitTestResultLinkLocalResourceResponse)
     _WKContextMenuElementInfo *elementInfo;
     NSURLResponse* linkLocalResourceResponse;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"<a href='sunset-in-cupertino-600px.jpg'><img src='sunset-in-cupertino-600px.jpg'></img></a>"];
     elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(200, 200)];
     linkLocalResourceResponse = elementInfo.hitTestResult.linkLocalResourceResponse;
@@ -693,7 +693,7 @@ TEST(ContextMenuTests, HitTestResultLinkLocalResourceResponse)
 
 TEST(ContextMenuTests, HitTestResultLinkSuggestedFilename)
 {
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotProposedMenu = false;
     [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
@@ -703,7 +703,7 @@ TEST(ContextMenuTests, HitTestResultLinkSuggestedFilename)
         gotProposedMenu = true;
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView setUIDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<a href='sunset-in-cupertino-600px.jpg' download='Sunset.jpg'><img src='sunset-in-cupertino-600px.jpg'></img></a>"];
 
@@ -714,7 +714,7 @@ TEST(ContextMenuTests, HitTestResultLinkSuggestedFilename)
 
 TEST(ContextMenuTests, HitTestResultImageSuggestedFilename)
 {
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
     __block bool gotProposedMenu = false;
     [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
@@ -725,7 +725,7 @@ TEST(ContextMenuTests, HitTestResultImageSuggestedFilename)
         gotProposedMenu = true;
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView setUIDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<img src='sunset-in-cupertino-600px.jpg'></img>"];
 
@@ -748,7 +748,7 @@ TEST(ContextMenuTests, ContextMenuElementInfoAllowsFollowingImageURL)
     _WKContextMenuElementInfo *elementInfo;
     CGFloat iconWidth = 215;
     CGFloat iconHeight = 174;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, iconWidth * 2, iconHeight * 2)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, iconWidth * 2, iconHeight * 2)]);
 
     [webView synchronouslyLoadHTMLString:@"<img src='icon.png'></img>"];
     elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(iconWidth, iconHeight)];
@@ -762,7 +762,7 @@ TEST(ContextMenuTests, ContextMenuElementInfoAllowsFollowingImageURL)
 TEST(ContextMenuTests, ContextMenuElementInfoAllowsFollowingLink)
 {
     _WKContextMenuElementInfo *elementInfo;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
 
     [webView synchronouslyLoadHTMLString:@"<a href='icon.png' style='font-size: 100px;'>Link</a>"];
     elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(50, 350)];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/CrossPartitionFileSchemeAccess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/CrossPartitionFileSchemeAccess.mm
@@ -99,7 +99,7 @@ TEST(WebKitLegacy, CrossPartitionFileSchemeAccess)
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     
-    auto delegate = adoptNS([[CrossPartitionFileSchemeAccessNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[CrossPartitionFileSchemeAccessNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     
     NSURLRequest *request = [NSURLRequest requestWithURL:url];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DOMNodeFromJSObject.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DOMNodeFromJSObject.mm
@@ -36,7 +36,7 @@ namespace TestWebKitAPI {
 
 TEST(WebKitLegacy, DOMNodeFromJSObject)
 {
-    auto webView = adoptNS([[WebView alloc] initWithFrame:NSZeroRect frameName:nil groupName:nil]);
+    RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:NSZeroRect frameName:nil groupName:nil]);
 
     [webView stringByEvaluatingJavaScriptFromString:@"document.body.mainWorldProperty = true"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DateInputTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DateInputTests.mm
@@ -34,7 +34,7 @@
 
 static RetainPtr<TestWKWebView> createWebViewForTest()
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     for (_WKFeature *feature in [WKPreferences _features]) {
         if ([feature.key isEqualToString:@"InputTypeDateEnabled"]) {
             [[configuration preferences] _setEnabled:YES forFeature:feature];
@@ -42,7 +42,7 @@ static RetainPtr<TestWKWebView> createWebViewForTest()
         }
     }
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
     return webView;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DisableAutomaticSpellingCorrection.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DisableAutomaticSpellingCorrection.mm
@@ -30,11 +30,11 @@
 
 TEST(DisableAutomaticSpellingCorrection, AutocorrectAttribute)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"<body><input autocorrect='off' autofocus><input autocorrect='on'></body>"];
     [webView waitForNextPresentationUpdate];
 
-    auto item = adoptNS([[NSMenuItem alloc] init]);
+    RetainPtr item = adoptNS([[NSMenuItem alloc] init]);
     [item setAction:@selector(toggleAutomaticSpellingCorrection:)];
     EXPECT_FALSE([webView validateUserInterfaceItem:item.get()]);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm
@@ -44,7 +44,7 @@ TEST(DragAndDropTests, NumberOfValidItemsForDrop)
     [pasteboard declareTypes:@[NSFilenamesPboardType] owner:nil];
     [pasteboard setPropertyList:@[@"file-name"] forType:NSFilenamesPboardType];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
     TestWKWebView *webView = [simulator webView];
     [simulator setExternalDragPasteboard:pasteboard];
     [webView synchronouslyLoadTestPageNamed:@"full-page-dropzone"];
@@ -202,7 +202,7 @@ TEST(DragAndDropTests, DraggableElementWithOnlyCustomPasteboardDataFiresDragEven
 
 TEST(DragAndDropTests, DropUserSelectAllUserDragElementDiv)
 {
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 320, 500)]);
 
     TestWKWebView *webView = [simulator webView];
     [webView synchronouslyLoadTestPageNamed:@"contenteditable-user-select-user-drag"];
@@ -218,7 +218,7 @@ TEST(DragAndDropTests, DropColor)
     [pasteboard declareTypes:@[NSColorPboardType] owner:nil];
     [[NSColor colorWithRed:1 green:0 blue:0 alpha:1] writeToPasteboard:pasteboard];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
     TestWKWebView *webView = [simulator webView];
     [simulator setExternalDragPasteboard:pasteboard];
 
@@ -229,7 +229,7 @@ TEST(DragAndDropTests, DropColor)
 
 TEST(DragAndDropTests, DragImageElementIntoFileUpload)
 {
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
     TestWKWebView *webView = [simulator webView];
     [webView synchronouslyLoadTestPageNamed:@"image-and-file-upload"];
     [simulator runFrom:NSMakePoint(100, 100) to:NSMakePoint(100, 300)];
@@ -242,7 +242,7 @@ TEST(DragAndDropTests, DragImageElementIntoFileUpload)
 
 TEST(DragAndDropTests, DragPromisedImageFileIntoFileUpload)
 {
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
     TestWKWebView *webView = [simulator webView];
     [webView synchronouslyLoadTestPageNamed:@"image-and-file-upload"];
 
@@ -268,7 +268,7 @@ TEST(DragAndDropTests, DragPromisedImageFileIntoFileUpload)
 
 TEST(DragAndDropTests, ReadURLWhenDroppingPromisedWebLoc)
 {
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
     auto *webView = [simulator webView];
     [webView synchronouslyLoadTestPageNamed:@"dump-datatransfer-types"];
 
@@ -291,7 +291,7 @@ TEST(DragAndDropTests, ReadURLWhenDroppingPromisedWebLoc)
 
 TEST(DragAndDropTests, DragImageFileIntoFileUpload)
 {
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
     TestWKWebView *webView = [simulator webView];
     [webView synchronouslyLoadTestPageNamed:@"image-and-file-upload"];
 
@@ -322,7 +322,7 @@ TEST(DragAndDropTests, DragImageWithOptionKeyDown)
 {
     InstanceMethodSwizzler swizzler([NSApp class], @selector(currentEvent), reinterpret_cast<IMP>(overrideCurrentEvent));
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
     TestWKWebView *webView = [simulator webView];
 
     [webView synchronouslyLoadTestPageNamed:@"image-and-contenteditable"];
@@ -335,7 +335,7 @@ TEST(DragAndDropTests, DragImageWithOptionKeyDown)
 
 TEST(DragAndDropTests, ProvideImageDataForMultiplePasteboards)
 {
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
     TestWKWebView *webView = [simulator webView];
     [webView synchronouslyLoadTestPageNamed:@"image-and-contenteditable"];
     [simulator runFrom:NSMakePoint(100, 100) to:NSMakePoint(100, 300)];
@@ -359,10 +359,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 TEST(DragAndDropTests, ProvideImageDataAsTypeIdentifiers)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration preferences] _setLargeImageAsyncDecodingEnabled:NO];
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     TestWKWebView *webView = [simulator webView];
 
     auto uniquePasteboard = retainPtr(NSPasteboard.pasteboardWithUniqueName);
@@ -407,7 +407,7 @@ TEST(DragAndDropTests, DragLocationForImageInScrolledSubframe)
 
 TEST(DragAndDropTests, DragEnterAndLeaveRelatedTarget)
 {
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 320, 500)]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 320, 500)]);
     TestWKWebView *webView = [simulator webView];
     [webView synchronouslyLoadTestPageNamed:@"drag-relatedTarget"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/EarlyKVOCrash.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/EarlyKVOCrash.mm
@@ -80,8 +80,8 @@ namespace TestWebKitAPI {
 
 TEST(WebKitLegacy, EarlyKVOCrash)
 {
-    auto webView = adoptNS([[WebView alloc] initWithFrame:NSZeroRect frameName:nil groupName:nil]);
-    auto earlyKVOCrashResponder = adoptNS([[EarlyKVOCrashResponder alloc] initWithWebView:webView.get()]);
+    RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:NSZeroRect frameName:nil groupName:nil]);
+    RetainPtr earlyKVOCrashResponder = adoptNS([[EarlyKVOCrashResponder alloc] initWithWebView:webView.get()]);
 
     [webView setNextResponder:earlyKVOCrashResponder.get()];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/EditableLegacyWebView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/EditableLegacyWebView.mm
@@ -54,8 +54,8 @@ namespace TestWebKitAPI {
 
 TEST(WebKitLegacy, SelectionAppearanceUpdatesInEditableWebView)
 {
-    auto webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 300)]);
-    auto delegate = adoptNS([EditableLegacyWebViewLoadDelegate new]);
+    RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 300)]);
+    RetainPtr delegate = adoptNS([EditableLegacyWebViewLoadDelegate new]);
     [webView setEditable:YES];
     [webView setFrameLoadDelegate:delegate.get()];
     [[webView mainFrame] loadHTMLString:@"<html><body>Hello world.<br>This is a test.</body>" baseURL:nil];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/FontManagerTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/FontManagerTests.mm
@@ -91,7 +91,7 @@
 
 static RetainPtr<FontManagerTestWKWebView> webViewForFontManagerTesting(NSFontManager *fontManager, NSString *markup)
 {
-    auto webView = adoptNS([[FontManagerTestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[FontManagerTestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:markup];
     [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
     [webView _setEditable:YES];
@@ -109,8 +109,8 @@ static RetainPtr<FontManagerTestWKWebView> webViewForFontManagerTesting(NSFontMa
 
 static RetainPtr<NSMenuItemCell> menuItemCellForFontAction(NSUInteger tag)
 {
-    auto menuItem = adoptNS([[NSMenuItem alloc] init]);
-    auto menuItemCell = adoptNS([[NSMenuItemCell alloc] init]);
+    RetainPtr menuItem = adoptNS([[NSMenuItem alloc] init]);
+    RetainPtr menuItemCell = adoptNS([[NSMenuItemCell alloc] init]);
     [menuItemCell setMenuItem:menuItem.get()];
     [menuItemCell setTag:tag];
     return menuItemCell;
@@ -214,8 +214,8 @@ TEST(FontManagerTests, ChangeFontWithPanel)
     [webView waitForNextPresentationUpdate];
 
     auto expectSameAttributes = [](NSFont *font1, NSFont *font2) {
-        auto fontAttributes1 = adoptNS(font1.fontDescriptor.fontAttributes.mutableCopy);
-        auto fontAttributes2 = adoptNS(font2.fontDescriptor.fontAttributes.mutableCopy);
+        RetainPtr fontAttributes1 = adoptNS(font1.fontDescriptor.fontAttributes.mutableCopy);
+        RetainPtr fontAttributes2 = adoptNS(font2.fontDescriptor.fontAttributes.mutableCopy);
         [fontAttributes1 removeObjectForKey:NSFontVariationAttribute];
         [fontAttributes2 removeObjectForKey:NSFontVariationAttribute];
         BOOL attributesAreEqual = [fontAttributes1 isEqualToDictionary:fontAttributes2.get()];
@@ -427,7 +427,7 @@ TEST(FontManagerTests, ChangeFontColorWithColorPanel)
 TEST(FontManagerTests, ChangeTypingAttributesWithInspectorBar)
 {
     auto webView = webViewForFontManagerTesting(NSFontManager.sharedFontManager);
-    auto inspectorBar = adoptNS([[TestInspectorBar alloc] initWithWebView:webView.get()]);
+    RetainPtr inspectorBar = adoptNS([[TestInspectorBar alloc] initWithWebView:webView.get()]);
     {
         [webView selectAll:nil];
         [webView waitForNextPresentationUpdate];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/FullscreenFocus.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/FullscreenFocus.mm
@@ -62,10 +62,10 @@ TEST(Fullscreen, DISABLED_Focus)
 TEST(Fullscreen, Focus)
 #endif
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration preferences].elementFullscreenEnabled = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
-    auto handler = adoptNS([[FullscreenFocusUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr handler = adoptNS([[FullscreenFocusUIDelegate alloc] init]);
     [webView _setFullscreenDelegate:handler.get()];
 
     bool canplaythrough = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/FullscreenPointerLeave.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/FullscreenPointerLeave.mm
@@ -38,9 +38,9 @@ namespace TestWebKitAPI {
 
 TEST(Fullscreen, PointerLeave)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration preferences].elementFullscreenEnabled = YES;
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
 
     bool pointerenter = false;
     bool pointerleave = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/GetMatchedCSSRules.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/GetMatchedCSSRules.mm
@@ -33,7 +33,7 @@ namespace TestWebKitAPI {
 
 TEST(WebKit2, GetMatchedCSSRulesTest)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200)]);
     auto html = @"<!DOCTYPE html>"
     "<html>"
     "<head><style type=\"text/css\">p { font-size: 100px; }</style></head>"

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/HIDGamepads.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/HIDGamepads.mm
@@ -103,21 +103,21 @@ TEST(Gamepad, Basic)
 
     auto keyWindowSwizzler = makeUnique<InstanceMethodSwizzler>([NSApplication class], @selector(keyWindow), reinterpret_cast<IMP>(getKeyWindowForTesting));
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[GamepadMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GamepadMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"gamepad"];
 
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"gamepad"];
 
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[NSData dataWithBytes:mainBytes length:strlen(mainBytes)]];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     keyWindowForTesting = [webView window];
     [webView.get().configuration.processPool _setUsesOnlyHIDGamepadProviderForTesting:YES];
 
@@ -160,21 +160,21 @@ TEST(Gamepad, GCFVersusHID)
 {
     auto keyWindowSwizzler = makeUnique<InstanceMethodSwizzler>([NSApplication class], @selector(keyWindow), reinterpret_cast<IMP>(getKeyWindowForTesting));
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[GamepadMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GamepadMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"gamepad"];
 
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"gamepad"];
 
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[NSData dataWithBytes:mainBytes length:strlen(mainBytes)]];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     keyWindowForTesting = [webView window];
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"gamepad://host/main.html"]]];
 
@@ -283,21 +283,21 @@ TEST(Gamepad, GamepadState)
 
     auto keyWindowSwizzler = makeUnique<InstanceMethodSwizzler>([NSApplication class], @selector(keyWindow), reinterpret_cast<IMP>(getKeyWindowForTesting));
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[GamepadMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GamepadMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"gamepad"];
 
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"gamepad"];
 
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[NSData dataWithBytes:mainBytes length:strlen(mainBytes)]];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
 
     RetainPtr uiDelegate = adoptNS([[GamepadUIDelegate alloc] init]);
     webView.get().UIDelegate = uiDelegate.get();
@@ -413,21 +413,21 @@ TEST(Gamepad, Dualshock3Basic)
 
     auto keyWindowSwizzler = makeUnique<InstanceMethodSwizzler>([NSApplication class], @selector(keyWindow), reinterpret_cast<IMP>(getKeyWindowForTesting));
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[GamepadMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GamepadMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"gamepad"];
 
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"gamepad"];
 
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[NSData dataWithBytes:mainBytes length:strlen(mainBytes)]];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     keyWindowForTesting = [webView window];
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"gamepad://host/main.html"]]];
 
@@ -480,21 +480,21 @@ TEST(Gamepad, Stadia)
 
     auto keyWindowSwizzler = makeUnique<InstanceMethodSwizzler>([NSApplication class], @selector(keyWindow), reinterpret_cast<IMP>(getKeyWindowForTesting));
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[GamepadMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GamepadMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"gamepad"];
 
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"gamepad"];
 
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[NSData dataWithBytes:mainBytes length:strlen(mainBytes)]];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     keyWindowForTesting = [webView window];
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"gamepad://host/main.html"]]];
 
@@ -566,21 +566,21 @@ TEST(Gamepad, LogitechBasic)
 
     auto keyWindowSwizzler = makeUnique<InstanceMethodSwizzler>([NSApplication class], @selector(keyWindow), reinterpret_cast<IMP>(getKeyWindowForTesting));
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[GamepadMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GamepadMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"gamepad"];
 
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"gamepad"];
 
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[NSData dataWithBytes:mainBytes length:strlen(mainBytes)]];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     keyWindowForTesting = [webView window];
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"gamepad://host/main.html"]]];
 
@@ -641,21 +641,21 @@ TEST(Gamepad, FullInfoAfterConnection)
 
     auto keyWindowSwizzler = makeUnique<InstanceMethodSwizzler>([NSApplication class], @selector(keyWindow), reinterpret_cast<IMP>(getKeyWindowForTesting));
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[GamepadMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GamepadMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"gamepad"];
 
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"gamepad"];
 
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[NSData dataWithBytes:mainBytes length:strlen(mainBytes)]];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     keyWindowForTesting = [webView window];
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"gamepad://host/main.html"]]];
 
@@ -696,7 +696,7 @@ TEST(Gamepad, FullInfoAfterConnection)
     done = false;
 
     // Make a second web view to make the same gamepad visible to it.
-    auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     keyWindowForTesting = [webView2 window];
     [webView2 synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"gamepad://host/main.html"]]];
     [[webView2 window] makeFirstResponder:webView2.get()];
@@ -726,21 +726,21 @@ TEST(Gamepad, DisconnectDuringInput)
 
     auto keyWindowSwizzler = makeUnique<InstanceMethodSwizzler>([NSApplication class], @selector(keyWindow), reinterpret_cast<IMP>(getKeyWindowForTesting));
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[GamepadMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[GamepadMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"gamepad"];
 
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"gamepad"];
 
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[NSData dataWithBytes:mainBytes length:strlen(mainBytes)]];
         [task didFinish];
     }];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     keyWindowForTesting = [webView window];
     [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"gamepad://host/main.html"]]];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ImmediateActionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ImmediateActionTests.mm
@@ -71,7 +71,7 @@ TEST(ImmediateActionTests, ImmediateActionOverText)
 {
     swizzlePresentingContextInitialization();
 
-    auto webView = adoptNS([[WKWebViewForTestingImmediateActions alloc] initWithFrame:NSMakeRect(0, 0, 500, 500)]);
+    RetainPtr webView = adoptNS([[WKWebViewForTestingImmediateActions alloc] initWithFrame:NSMakeRect(0, 0, 500, 500)]);
     [webView synchronouslyLoadHTMLString:@"<div style='font-size: 32px;'>Foobar</div>"];
 
     auto [hitTestResult, actionType] = [webView simulateImmediateAction:NSMakePoint(16, 16)];
@@ -83,7 +83,7 @@ TEST(ImmediateActionTests, ImmediateActionOverText)
 
 TEST(ImmediateActionTests, ImmediateActionOverBody)
 {
-    auto webView = adoptNS([[WKWebViewForTestingImmediateActions alloc] initWithFrame:NSMakeRect(0, 0, 500, 500)]);
+    RetainPtr webView = adoptNS([[WKWebViewForTestingImmediateActions alloc] initWithFrame:NSMakeRect(0, 0, 500, 500)]);
     [webView synchronouslyLoadHTMLString:@"<div style='font-size: 32px;'>Foobar</div>"];
 
     auto [hitTestResult, actionType] = [webView simulateImmediateAction:NSMakePoint(490, 490)];
@@ -97,7 +97,7 @@ TEST(ImmediateActionTests, ImmediateActionOverBody)
 TEST(ImmediateActionTests, ImmediateActionOverImageOverlay)
 {
     auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[WKWebViewForTestingImmediateActions alloc] initWithFrame:NSMakeRect(0, 0, 500, 500) configuration:configuration]);
+    RetainPtr webView = adoptNS([[WKWebViewForTestingImmediateActions alloc] initWithFrame:NSMakeRect(0, 0, 500, 500) configuration:configuration]);
     [webView synchronouslyLoadTestPageNamed:@"simple-image-overlay"];
 
     auto [hitTestResult, actionType] = [webView simulateImmediateAction:NSMakePoint(50, 50)];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/InWindowFullscreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/InWindowFullscreen.mm
@@ -37,7 +37,7 @@ static RetainPtr<TestWKWebView> createInWindowFullscreenWebView()
     RetainPtr configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration preferences].elementFullscreenEnabled = YES;
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeAudio];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     return webView;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/InspectorBar.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/InspectorBar.mm
@@ -42,7 +42,7 @@ static bool didFinishLoad;
 
 - (NSDictionary *)convertAttributes:(NSDictionary *)dictionary
 {
-    auto newDictionary = adoptNS([dictionary mutableCopy]);
+    RetainPtr newDictionary = adoptNS([dictionary mutableCopy]);
     [newDictionary removeObjectForKey:NSForegroundColorAttributeName];
     return newDictionary.autorelease();
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/JSWrapperForNodeInWebFrame.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/JSWrapperForNodeInWebFrame.mm
@@ -100,8 +100,8 @@ TEST(WebKitLegacy, JSWrapperForNode)
 TEST(WebKitLegacy, JSDOMWindowWrapperBeforeOriginInitialization)
 {
     [WKProcessPool _setLinkedOnOrBeforeEverythingForTesting];
-    auto webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
-    auto frameLoadDelegate = adoptNS([[JSWrapperForNodeFrameLoadDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
+    RetainPtr frameLoadDelegate = adoptNS([[JSWrapperForNodeFrameLoadDelegate alloc] init]);
 
     webView.get().frameLoadDelegate = frameLoadDelegate.get();
     auto *mainFrame = webView.get().mainFrame;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/JavascriptURLNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/JavascriptURLNavigation.mm
@@ -170,11 +170,11 @@ TEST(WKWebView, JavascriptURLNavigation)
 {
     static bool done;
 
-    auto delegate = adoptNS([[JavascriptURLNavigationDelegate alloc] init]);
-    auto handler = adoptNS([[TestURLSchemeHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr delegate = adoptNS([[JavascriptURLNavigationDelegate alloc] init]);
+    RetainPtr handler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"jsurl"];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setUIDelegate:delegate.get()];
 
     [webView performAfterReceivingMessage:@"Passed" action:^() {
@@ -192,7 +192,7 @@ TEST(WKWebView, JavascriptURLNavigation)
             FAIL();
         }
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[NSData dataWithBytes:mainResource length:strlen(mainResource)]];
         [task didFinish];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/KeyboardEventTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/KeyboardEventTests.mm
@@ -95,13 +95,13 @@ static void arrowKeyDownWithKeyRepeat(WKWebView *webView, unsigned keyRepeatCoun
 
 TEST(KeyboardEventTests, FunctionKeyCommand)
 {
-    auto menu = adoptNS([[KeyboardTestMenu alloc] initWithTitle:@"Test menu"]);
-    auto menuItem = adoptNS([[KeyboardTestMenuItem alloc] initWithTitle:@"Emojis & Symbols" action:@selector(description) keyEquivalent:@"e"]);
+    RetainPtr menu = adoptNS([[KeyboardTestMenu alloc] initWithTitle:@"Test menu"]);
+    RetainPtr menuItem = adoptNS([[KeyboardTestMenuItem alloc] initWithTitle:@"Emojis & Symbols" action:@selector(description) keyEquivalent:@"e"]);
     [menuItem setKeyEquivalentModifierMask:NSEventModifierFlagFunction];
     [menu setItemArray:@[ menuItem.get() ]];
     NSApp.mainMenu = menu.get();
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"<script>addEventListener('load', () => document.body.focus())</script><body contenteditable></body>"];
     [webView typeCharacter:'e' modifiers:NSEventModifierFlagFunction];
     [webView waitForNextPresentationUpdate];
@@ -111,10 +111,10 @@ TEST(KeyboardEventTests, FunctionKeyCommand)
 
 TEST(KeyboardEventTests, SmoothKeyboardScrolling)
 {
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 400, 400) styleMask:(NSWindowStyleMaskTitled | NSWindowStyleMaskFullSizeContentView) backing:NSBackingStoreBuffered defer:NO]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 400, 400) styleMask:(NSWindowStyleMaskTitled | NSWindowStyleMaskFullSizeContentView) backing:NSBackingStoreBuffered defer:NO]);
 
-    auto view = adoptNS([[NSViewWithKeyDownOverride alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr view = adoptNS([[NSViewWithKeyDownOverride alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
 
     [view addSubview:webView.get()];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/LimitTitleSize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/LimitTitleSize.mm
@@ -85,10 +85,10 @@ TEST(WebKitLegacy, LimitTitleSize)
 
 TEST(WebKit, LimitTitleSize)
 {
-    auto webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"set-long-title" withExtension:@"html"]]];
     
-    auto observer = adoptNS([LimitTitleSizeTestObserver new]);
+    RetainPtr observer = adoptNS([LimitTitleSizeTestObserver new]);
     [webView addObserver:observer.get() forKeyPath:@"title" options:NSKeyValueObservingOptionNew context:nil];
     
     TestWebKitAPI::Util::run(&waitUntilLongTitleReceived);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/LoadWebArchive.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/LoadWebArchive.mm
@@ -85,15 +85,15 @@ TEST(LoadWebArchive, FailNavigation1)
     // Using `document.location.href = 'helloworld.webarchive';`.
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"load-web-archive-1" withExtension:@"html"];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     for (_WKFeature *feature in WKPreferences._features) {
         NSString *key = feature.key;
         if ([key isEqualToString:@"LoadWebArchiveWithEphemeralStorageEnabled"])
             [[configuration preferences] _setEnabled:YES forFeature:feature];
     }
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     navigationFail = false;
@@ -108,17 +108,17 @@ TEST(LoadWebArchive, FailNavigation2)
     // Using `window.open('helloworld.webarchive');`.
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"load-web-archive-2" withExtension:@"html"];
 
-    auto delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
     gDelegate = delegate.get();
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     for (_WKFeature *feature in WKPreferences._features) {
         NSString *key = feature.key;
         if ([key isEqualToString:@"LoadWebArchiveWithEphemeralStorageEnabled"])
             [[configuration preferences] _setEnabled:YES forFeature:feature];
     }
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:delegate.get()];
     [webView setUIDelegate:delegate.get()];
 
@@ -133,8 +133,8 @@ TEST(LoadWebArchive, ClientNavigationSucceed)
 {
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"helloworld" withExtension:@"webarchive"];
 
-    auto webView = adoptNS([[WKWebView alloc] init]);
-    auto delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
+    RetainPtr delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     navigationComplete = false;
@@ -149,10 +149,10 @@ TEST(LoadWebArchive, ClientNavigationSucceedWithCookie)
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"helloworld" withExtension:@"webarchive"];
 
     RetainPtr<WKWebsiteDataStore> dataStore = WKWebsiteDataStore.nonPersistentDataStore;
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     __block bool doneSettingCookie { false };
@@ -181,16 +181,16 @@ TEST(LoadWebArchive, ClientNavigationReload)
 {
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"helloworld" withExtension:@"webarchive"];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     for (_WKFeature *feature in WKPreferences._features) {
         NSString *key = feature.key;
         if ([key isEqualToString:@"LoadWebArchiveWithEphemeralStorageEnabled"])
             [[configuration preferences] _setEnabled:YES forFeature:feature];
     }
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     navigationComplete = false;
@@ -208,15 +208,15 @@ TEST(LoadWebArchive, ClientNavigationWithStorageReload)
 {
     RetainPtr<NSURL> testURL = [NSBundle.test_resourcesBundle URLForResource:@"helloworld" withExtension:@"webarchive"];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     for (_WKFeature *feature in WKPreferences._features) {
         NSString *key = feature.key;
         if ([key isEqualToString:@"LoadWebArchiveWithEphemeralStorageEnabled"])
             [[configuration preferences] _setEnabled:YES forFeature:feature];
     }
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
-    auto delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     navigationComplete = false;
@@ -263,19 +263,19 @@ TEST(LoadWebArchive, DragNavigationSucceed)
     [pasteboard declareTypes:@[NSFilenamesPboardType] owner:nil];
     [pasteboard setPropertyList:@[webArchiveURL.get().path] forType:NSFilenamesPboardType];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     for (_WKFeature *feature in WKPreferences._features) {
         NSString *key = feature.key;
         if ([key isEqualToString:@"LoadWebArchiveWithEphemeralStorageEnabled"])
             [[configuration preferences] _setEnabled:YES forFeature:feature];
     }
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
     [simulator setExternalDragPasteboard:pasteboard];
     [simulator setDragDestinationAction:WKDragDestinationActionAny];
 
     auto webView = [simulator webView];
-    auto delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     navigationComplete = false;
@@ -299,19 +299,19 @@ TEST(LoadWebArchive, DragNavigationReload)
     [pasteboard declareTypes:@[NSFilenamesPboardType] owner:nil];
     [pasteboard setPropertyList:@[webArchiveURL.get().path] forType:NSFilenamesPboardType];
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     for (_WKFeature *feature in WKPreferences._features) {
         NSString *key = feature.key;
         if ([key isEqualToString:@"LoadWebArchiveWithEphemeralStorageEnabled"])
             [[configuration preferences] _setEnabled:YES forFeature:feature];
     }
 
-    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
     [simulator setExternalDragPasteboard:pasteboard];
     [simulator setDragDestinationAction:WKDragDestinationActionAny];
 
     auto webView = [simulator webView];
-    auto delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     navigationComplete = false;
@@ -333,8 +333,8 @@ TEST(LoadWebArchive, DragNavigationReload)
 static NSData* constructArchive()
 {
     NSString *js = @"alert('loaded http subresource successfully')";
-    auto response = adoptNS([[NSURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://download.example/script.js"] MIMEType:@"application/javascript" expectedContentLength:js.length textEncodingName:@"utf-8"]);
-    auto responseArchiver = adoptNS([[NSKeyedArchiver alloc] initRequiringSecureCoding:YES]);
+    RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://download.example/script.js"] MIMEType:@"application/javascript" expectedContentLength:js.length textEncodingName:@"utf-8"]);
+    RetainPtr responseArchiver = adoptNS([[NSKeyedArchiver alloc] initRequiringSecureCoding:YES]);
     [responseArchiver encodeObject:response.get() forKey:@"WebResourceResponse"];
     NSDictionary *archive = @{
         @"WebMainResource": @{
@@ -359,14 +359,14 @@ TEST(LoadWebArchive, HTTPSUpgrade)
 {
     NSData *data = constructArchive();
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     for (_WKFeature *feature in WKPreferences._features) {
         NSString *key = feature.key;
         if ([key isEqualToString:@"LoadWebArchiveWithEphemeralStorageEnabled"])
             [[configuration preferences] _setEnabled:YES forFeature:feature];
     }
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
 
     [webView loadData:data MIMEType:@"application/x-webarchive" characterEncodingName:@"utf-8" baseURL:[NSURL URLWithString:@"http://download.example/"]];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "loaded http subresource successfully");
@@ -376,7 +376,7 @@ TEST(LoadWebArchive, DisallowedNetworkHosts)
 {
     NSData *data = constructArchive();
 
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get()._allowedNetworkHosts = [NSSet set];
 
     for (_WKFeature *feature in WKPreferences._features) {
@@ -385,7 +385,7 @@ TEST(LoadWebArchive, DisallowedNetworkHosts)
             [[configuration preferences] _setEnabled:YES forFeature:feature];
     }
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadData:data MIMEType:@"application/x-webarchive" characterEncodingName:@"utf-8" baseURL:[NSURL URLWithString:@"http://download.example/"]];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "loaded http subresource successfully");
 }
@@ -398,13 +398,13 @@ TEST(LoadWebArchive, SiteToWebArchiveAndBack)
         { "http://download.example/page1.html"_s, { "<body>page1</body>"_s } },
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(server.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
 
     for (_WKFeature *feature in WKPreferences._features) {
@@ -413,9 +413,9 @@ TEST(LoadWebArchive, SiteToWebArchiveAndBack)
             [[configuration preferences] _setEnabled:YES forFeature:feature];
     }
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     navigationComplete = false;
@@ -491,13 +491,13 @@ TEST(LoadWebArchive, WebArchiveToSiteAndBack)
         { "http://download.example/page1.html"_s, { "<body>page1</body>"_s } },
     }, HTTPServer::Protocol::Http);
 
-    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
     [storeConfiguration setProxyConfiguration:@{
         (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
         (NSString *)kCFStreamPropertyHTTPProxyPort: @(server.port())
     }];
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
 
     for (_WKFeature *feature in WKPreferences._features) {
@@ -506,9 +506,9 @@ TEST(LoadWebArchive, WebArchiveToSiteAndBack)
             [[configuration preferences] _setEnabled:YES forFeature:feature];
     }
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     navigationComplete = false;
@@ -596,16 +596,16 @@ TEST(LoadWebArchive, WebArchiveToSiteAndBack)
 
 TEST(LoadWebArchive, FileWebArchiveToDataWebArchiveAndBack)
 {
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     for (_WKFeature *feature in WKPreferences._features) {
         NSString *key = feature.key;
         if ([key isEqualToString:@"LoadWebArchiveWithEphemeralStorageEnabled"])
             [[configuration preferences] _setEnabled:YES forFeature:feature];
     }
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
-    auto delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[TestLoadWebArchiveNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
     navigationComplete = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/LoadWebViewWithEmptyAppName.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/LoadWebViewWithEmptyAppName.mm
@@ -41,7 +41,7 @@ TEST(WebKit2, LoadWithEmptyAppName)
 {
     InstanceMethodSwizzler appNameSwizzler { NSRunningApplication.class, @selector(localizedName), reinterpret_cast<IMP>(swizzledAppName) };
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 300)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 300)]);
     [webView synchronouslyLoadHTMLString:@"<body>Hello world</body>"];
     EXPECT_TRUE(!![webView _webProcessIdentifier]);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/MediaPlaybackSleepAssertion.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/MediaPlaybackSleepAssertion.mm
@@ -153,11 +153,11 @@ TEST(WebKitLegacy, DISABLED_MediaPlaybackSleepAssertion)
     didEndRemotePlayback = false;
 
     @autoreleasepool {
-        auto webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
-        auto frameLoadDelegate = adoptNS([[MediaPlaybackSleepAssertionLoadDelegate alloc] init]);
-        auto policyDelegate = adoptNS([[MediaPlaybackSleepAssertionPolicyDelegate alloc] init]);
+        RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
+        RetainPtr frameLoadDelegate = adoptNS([[MediaPlaybackSleepAssertionLoadDelegate alloc] init]);
+        RetainPtr policyDelegate = adoptNS([[MediaPlaybackSleepAssertionPolicyDelegate alloc] init]);
 
-        auto window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
+        RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
         [[window contentView] addSubview:webView.get()];
         [window makeKeyAndOrderFront:nil];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/MemoryCachePruneWithinResourceLoadDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/MemoryCachePruneWithinResourceLoadDelegate.mm
@@ -78,13 +78,13 @@ namespace TestWebKitAPI {
 TEST(WebKitLegacy, DISABLED_MemoryCachePruneWithinResourceLoadDelegate)
 {
     @autoreleasepool {
-        auto webView1 = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
-        auto webView2 = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
+        RetainPtr webView1 = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
+        RetainPtr webView2 = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
 
-        auto window = adoptNS([[NSWindow alloc] initWithContentRect:webView2.get().frame styleMask:NSBorderlessWindowMask backing:NSBackingStoreBuffered defer:YES]);
+        RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:webView2.get().frame styleMask:NSBorderlessWindowMask backing:NSBackingStoreBuffered defer:YES]);
         [[window contentView] addSubview:webView2.get()];
 
-        auto resourceLoadDelegate = adoptNS([[MemoryCachePruneTestResourceLoadDelegate alloc] init]);
+        RetainPtr resourceLoadDelegate = adoptNS([[MemoryCachePruneTestResourceLoadDelegate alloc] init]);
         resourceLoadDelegate.get()->_window = window.get();
         webView1.get().resourceLoadDelegate = resourceLoadDelegate.get();
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/MemoryPressureHandler.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/MemoryPressureHandler.mm
@@ -32,7 +32,7 @@ namespace TestWebKitAPI {
 TEST(WebKitLegacy, MemoryPressureHandler)
 {
     WebInstallMemoryPressureHandler();
-    auto webView = adoptNS([[WebView alloc] initWithFrame:NSZeroRect frameName:nil groupName:nil]);
+    RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:NSZeroRect frameName:nil groupName:nil]);
     // This test passes if it does not assert.
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/MenuTypesForMouseEvents.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/MenuTypesForMouseEvents.mm
@@ -42,7 +42,7 @@ static bool canCallMenuTypeForEvent()
 static void buildAndPerformTest(NSEventType buttonEvent, NSEventModifierFlags modifierFlags, WebCore::MouseButton expectedButton, NSMenuType expectedMenu)
 {
     @autoreleasepool {
-        auto webView = adoptNS([[WebView alloc] init]);
+        RetainPtr webView = adoptNS([[WebView alloc] init]);
         NSEvent *event = [NSEvent mouseEventWithType:buttonEvent
                                             location:NSMakePoint(100, 100)
                                        modifierFlags:modifierFlags

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/MouseEventTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/MouseEventTests.mm
@@ -61,7 +61,7 @@ namespace TestWebKitAPI {
 
 TEST(MouseEventTests, SendMouseMoveEventStream)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
         "<html>"
         "<head>"
@@ -94,7 +94,7 @@ TEST(MouseEventTests, SendMouseMoveEventStream)
 
 TEST(MouseEventTests, CoalesceMouseMoveEvents)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
         "<html>"
         "<head>"
@@ -148,17 +148,17 @@ TEST(MouseEventTests, CoalesceMouseMoveEvents)
 
 TEST(MouseEventTests, ProcessSwapWithDeferredMouseMoveEventCompletion)
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     [processPoolConfiguration setProcessSwapsOnNavigation:YES];
     [processPoolConfiguration setUsesWebProcessCache:YES];
     [processPoolConfiguration setPrewarmsProcessesAutomatically:YES];
     [processPoolConfiguration setProcessSwapsOnNavigationWithinSameNonHTTPFamilyProtocol:YES];
 
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setProcessPool:processPool.get()];
 
-    auto handler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr handler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
         auto host = task.request.URL.host;
         if ([host isEqualToString:@"www.apple.com"])
@@ -176,8 +176,8 @@ TEST(MouseEventTests, ProcessSwapWithDeferredMouseMoveEventCompletion)
     }];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://webkit.org/index.html"]]];
@@ -404,7 +404,7 @@ TEST(MouseEventTests, WindowChangeShouldNotCauseMouseLeaveEvent)
 
 TEST(MouseEventTests, AutoscrollOnMouseDragBelowWindow)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
         "<html>"
         "<head>"

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/NSResponderTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/NSResponderTests.mm
@@ -34,7 +34,7 @@ namespace TestWebKitAPI {
 
 TEST(NSResponderTests, ValidRequestorForSendAndReturnTypes)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] init]);
     [webView _setEditable:YES];
     [webView synchronouslyLoadTestPageNamed:@"simple"];
     [webView selectAll:nil];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/NoPolicyDelegateResponse.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/NoPolicyDelegateResponse.mm
@@ -75,8 +75,8 @@ namespace TestWebKitAPI {
 
 TEST(WebKitLegacy, NoDecidePolicyForMIMETypeDecision)
 {
-    auto webView = adoptNS([[WebView alloc] initWithFrame:NSZeroRect frameName:nil groupName:nil]);
-    auto delegate = adoptNS([NoDecidePolicyForMIMETypeDecisionDelegate new]);
+    RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:NSZeroRect frameName:nil groupName:nil]);
+    RetainPtr delegate = adoptNS([NoDecidePolicyForMIMETypeDecisionDelegate new]);
 
     webView.get().frameLoadDelegate = delegate.get();
     webView.get().policyDelegate = delegate.get();
@@ -89,8 +89,8 @@ TEST(WebKitLegacy, NoDecidePolicyForMIMETypeDecision)
 
 TEST(WebKitLegacy, NoDecidePolicyForNavigationActionDecision)
 {
-    auto webView = adoptNS([[WebView alloc] initWithFrame:NSZeroRect frameName:nil groupName:nil]);
-    auto delegate = adoptNS([NoDecidePolicyForNavigationActionDecisionDelegate new]);
+    RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:NSZeroRect frameName:nil groupName:nil]);
+    RetainPtr delegate = adoptNS([NoDecidePolicyForNavigationActionDecisionDelegate new]);
 
     webView.get().frameLoadDelegate = delegate.get();
     webView.get().policyDelegate = delegate.get();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ScrollingCoordinatorTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ScrollingCoordinatorTests.mm
@@ -85,7 +85,7 @@ TEST(ScrollingCoordinatorTests, DISABLED_ScrollingTreeAfterDetachReattach)
     [[NSUserDefaults standardUserDefaults] setObject:@"Scrolling" forKey:@"WebKit2Logging"];
 
     WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 500, 500) configuration:configuration addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 500, 500) configuration:configuration addToWindow:YES]);
     
     NSString *documentString = @"<style>body { height: 5000px; }</style>" \
         "<iframe srcdoc=\"<style>body { height: 5000px; }</style><div style='position:fixed; width: 100px; height: 50px; background: blue'></div>\"></iframe>";

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/SkipAdInPictureInPicture.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/SkipAdInPictureInPicture.mm
@@ -66,7 +66,7 @@ static RetainPtr<TestWKWebView> createWebView()
     RetainPtr configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     [configuration preferences]._allowsPictureInPictureMediaPlayback = YES;
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeAudio];
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get() addToWindow:YES]);
     return webView;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/SpellCheckerDocumentTag.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/SpellCheckerDocumentTag.mm
@@ -51,7 +51,7 @@ TEST(SpellCheckerDocumentTag, SpellCheckerDocumentTagWhenCheckingString)
         reinterpret_cast<IMP>(swizzledCheckString)
     };
 
-    auto webView = adoptNS([[TestWKWebView<NSTextInputClient> alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    RetainPtr webView = adoptNS([[TestWKWebView<NSTextInputClient> alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"<body contenteditable>"];
     [webView objectByEvaluatingJavaScript:@"getSelection().setPosition(document.body)"];
     [webView insertText:@"Testing.\n" replacementRange:NSMakeRange(0, 0)];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/StartLoadInDidFailProvisionalLoad.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/StartLoadInDidFailProvisionalLoad.mm
@@ -55,9 +55,9 @@ namespace TestWebKitAPI {
 
 TEST(WebKitLegacy, StartLoadInDidFailProvisionalLoad)
 {
-    auto webView = adoptNS([[WebView alloc] init]);
+    RetainPtr webView = adoptNS([[WebView alloc] init]);
     testView = webView.get();
-    auto frameLoadDelegate = adoptNS([[StartLoadInDidFailProvisionalLoadDelegate alloc] init]);
+    RetainPtr frameLoadDelegate = adoptNS([[StartLoadInDidFailProvisionalLoadDelegate alloc] init]);
     webView.get().frameLoadDelegate = frameLoadDelegate.get();
     [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/StopLoadingFromDidFinishLoading.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/StopLoadingFromDidFinishLoading.mm
@@ -48,8 +48,8 @@ namespace TestWebKitAPI {
 TEST(WebKitLegacy, StopLoadingFromDidFinishLoading)
 {
     @autoreleasepool {
-        auto webView = adoptNS([[WebView alloc] init]);
-        auto resourceLoadDelegate = adoptNS([[StopLoadingFromDidFinishLoadingDelegate alloc] init]);
+        RetainPtr webView = adoptNS([[WebView alloc] init]);
+        RetainPtr resourceLoadDelegate = adoptNS([[StopLoadingFromDidFinishLoadingDelegate alloc] init]);
         webView.get().resourceLoadDelegate = resourceLoadDelegate.get();
         [webView.get().mainFrame loadHTMLString:@"Hello, World!" baseURL:[NSURL URLWithString:@""]];
         Util::run(&finished);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/SubresourceErrorCrash.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/SubresourceErrorCrash.mm
@@ -31,7 +31,7 @@ namespace TestWebKitAPI {
 
 TEST(WebKitLegacy, SubresourceErrorCrash)
 {
-    auto webView = adoptNS([[WebView alloc] initWithFrame:NSZeroRect frameName:@"" groupName:@""]);
+    RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:NSZeroRect frameName:@"" groupName:@""]);
     [[webView mainFrame] loadHTMLString:@"<link rel=stylesheet href='x-error:error'>" baseURL:nil];
     webView = nil;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/TypingStyleCrash.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/TypingStyleCrash.mm
@@ -31,7 +31,7 @@ namespace TestWebKitAPI {
 
 TEST(WebKitLegacy, TypingStyleCrash)
 {
-    auto webView = adoptNS([[WebView alloc] init]);
+    RetainPtr webView = adoptNS([[WebView alloc] init]);
     (void)[webView typingStyle];
     webView = nil;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WKWebViewCoders.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WKWebViewCoders.mm
@@ -30,13 +30,13 @@
 
 TEST(WKWebView, HitTestAfterInitializingFromCoder)
 {
-    auto webViewToEncode = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webViewToEncode = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webViewToEncode synchronouslyLoadTestPageNamed:@"simple"];
 
-    auto archiver = adoptNS([[NSKeyedArchiver alloc] init]);
+    RetainPtr archiver = adoptNS([[NSKeyedArchiver alloc] init]);
     [archiver encodeObject:webViewToEncode.get() forKey:@"WebView"];
 
-    auto unarchiver = adoptNS([[NSKeyedUnarchiver alloc] initForReadingFromData:[archiver encodedData] error:nil]);
+    RetainPtr unarchiver = adoptNS([[NSKeyedUnarchiver alloc] initForReadingFromData:[archiver encodedData] error:nil]);
     [unarchiver setRequiresSecureCoding:NO];
 
     WKWebView *decodedWebView = [unarchiver decodeObjectForKey:@"WebView"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WKWebViewMacEditingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WKWebViewMacEditingTests.mm
@@ -340,7 +340,7 @@ TEST(WKWebViewMacEditingTests, DoNotCrashWhenInterpretingKeyEventWhileDeallocati
     __block bool isDone = false;
 
     @autoreleasepool {
-        auto webView = adoptNS([[SlowInputWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+        RetainPtr webView = adoptNS([[SlowInputWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
         [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<body contenteditable>Hello world</body>"]];
         [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
         [webView waitForNextPresentationUpdate];
@@ -359,15 +359,15 @@ TEST(WKWebViewMacEditingTests, ProcessSwapAfterSettingMarkedText)
 {
     [TestProtocol registerWithScheme:@"https"];
 
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     [processPoolConfiguration setProcessSwapsOnNavigation:YES];
 
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [configuration setProcessPool:processPool.get()];
 
-    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView<NSTextInputClient, NSTextInputClient_Async> alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView<NSTextInputClient, NSTextInputClient_Async> alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     [webView _setEditable:YES];
 
@@ -400,7 +400,7 @@ TEST(WKWebViewMacEditingTests, DoNotRenderInlinePredictionsForRegularMarkedText)
     [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
     [webView waitForNextPresentationUpdate];
 
-    auto string = adoptNS([[NSAttributedString alloc] initWithString:@"xie wen sheng" attributes:@{
+    RetainPtr string = adoptNS([[NSAttributedString alloc] initWithString:@"xie wen sheng" attributes:@{
         NSMarkedClauseSegmentAttributeName: @0,
         NSUnderlineStyleAttributeName: @(NSUnderlineStyleSingle),
         NSUnderlineColorAttributeName: NSColor.controlAccentColor
@@ -424,7 +424,7 @@ TEST(WKWebViewMacEditingTests, DoNotRenderInlinePredictionsForRegularMarkedText)
 TEST(WKWebViewMacEditingTests, InlinePredictionsShouldSuppressAutocorrection)
 {
     auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView<NSTextInputClient, NSTextInputClient_Async> alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView<NSTextInputClient, NSTextInputClient_Async> alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
     [webView _setContinuousSpellCheckingEnabledForTesting:YES];
     [webView synchronouslyLoadHTMLString:@"<body id='p' contenteditable>Is it &nbsp;</body>"];
     [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
@@ -445,12 +445,12 @@ TEST(WKWebViewMacEditingTests, InlinePredictionsShouldSuppressAutocorrection)
 
     [webView stringByEvaluatingJavaScript:modifySelectionJavascript];
 
-    auto typedString = adoptNS([[NSAttributedString alloc] initWithString:@"wedn"]);
-    auto predictedString = adoptNS([[NSAttributedString alloc] initWithString:@"esday" attributes:@{
+    RetainPtr typedString = adoptNS([[NSAttributedString alloc] initWithString:@"wedn"]);
+    RetainPtr predictedString = adoptNS([[NSAttributedString alloc] initWithString:@"esday" attributes:@{
         NSForegroundColorAttributeName : NSColor.grayColor
     }]);
 
-    auto string = adoptNS([[NSMutableAttributedString alloc] init]);
+    RetainPtr string = adoptNS([[NSMutableAttributedString alloc] init]);
     [string appendAttributedString:typedString.get()];
     [string appendAttributedString:predictedString.get()];
 
@@ -463,7 +463,7 @@ TEST(WKWebViewMacEditingTests, InlinePredictionsShouldSuppressAutocorrection)
 TEST(WKWebViewMacEditingTests, SetMarkedTextWithNoAttributedString)
 {
     auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
-    auto webView = adoptNS([[TestWKWebView<NSTextInputClient, NSTextInputClient_Async> alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    RetainPtr webView = adoptNS([[TestWKWebView<NSTextInputClient, NSTextInputClient_Async> alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
     [webView _setContinuousSpellCheckingEnabledForTesting:YES];
     [webView synchronouslyLoadHTMLString:@"<body id='p' contenteditable>Is it &nbsp;</body>"];
     [webView stringByEvaluatingJavaScript:@"document.body.focus()"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WKWebViewTitlebarSeparatorTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WKWebViewTitlebarSeparatorTests.mm
@@ -65,7 +65,7 @@
 
 TEST(WKWebViewTitlebarSeparatorTests, ScrollWithTitlebarAdjacency)
 {
-    auto webView = adoptNS([[TitlebarSeparatorTestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TitlebarSeparatorTestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     auto separatorTrackingAdapter = [webView separatorTrackingAdapter];
     EXPECT_FALSE([separatorTrackingAdapter hasScrolledContentsUnderTitlebar]);
@@ -81,7 +81,7 @@ TEST(WKWebViewTitlebarSeparatorTests, ScrollWithTitlebarAdjacency)
 
 TEST(WKWebViewTitlebarSeparatorTests, NavigationResetsTitlebarAppearance)
 {
-    auto webView = adoptNS([[TitlebarSeparatorTestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TitlebarSeparatorTestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     auto separatorTrackingAdapter = [webView separatorTrackingAdapter];
     EXPECT_FALSE([separatorTrackingAdapter hasScrolledContentsUnderTitlebar]);
@@ -97,7 +97,7 @@ TEST(WKWebViewTitlebarSeparatorTests, NavigationResetsTitlebarAppearance)
 
 TEST(WKWebViewTitlebarSeparatorTests, ScrollWithoutTitlebarAdjacency)
 {
-    auto webView = adoptNS([[TitlebarSeparatorTestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TitlebarSeparatorTestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView setFrameSize:NSMakeSize(800, 500)];
 
     auto separatorTrackingAdapter = [webView separatorTrackingAdapter];
@@ -110,7 +110,7 @@ TEST(WKWebViewTitlebarSeparatorTests, ScrollWithoutTitlebarAdjacency)
 
 TEST(WKWebViewTitlebarSeparatorTests, ChangeTitlebarAdjacency)
 {
-    auto webView = adoptNS([[TitlebarSeparatorTestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TitlebarSeparatorTestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     auto separatorTrackingAdapter = [webView separatorTrackingAdapter];
     EXPECT_FALSE([separatorTrackingAdapter hasScrolledContentsUnderTitlebar]);
@@ -128,7 +128,7 @@ TEST(WKWebViewTitlebarSeparatorTests, ChangeTitlebarAdjacency)
 
 TEST(WKWebViewTitlebarSeparatorTests, ChangeViewVisibility)
 {
-    auto webView = adoptNS([[TitlebarSeparatorTestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TitlebarSeparatorTestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     auto separatorTrackingAdapter = [webView separatorTrackingAdapter];
     EXPECT_FALSE([separatorTrackingAdapter hasScrolledContentsUnderTitlebar]);
@@ -146,7 +146,7 @@ TEST(WKWebViewTitlebarSeparatorTests, ChangeViewVisibility)
 
 TEST(WKWebViewTitlebarSeparatorTests, BackForwardCache)
 {
-    auto webView = adoptNS([[TitlebarSeparatorTestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr webView = adoptNS([[TitlebarSeparatorTestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
     auto separatorTrackingAdapter = [webView separatorTrackingAdapter];
     EXPECT_FALSE([separatorTrackingAdapter hasScrolledContentsUnderTitlebar]);
@@ -170,15 +170,15 @@ TEST(WKWebViewTitlebarSeparatorTests, BackForwardCache)
 
 TEST(WKWebViewTitlebarSeparatorTests, ParentWhileScrolled)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto rect = CGRectMake(0, 0, 800, 600);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:rect configuration:configuration.get() addToWindow:NO]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:rect configuration:configuration.get() addToWindow:NO]);
     [webView synchronouslyLoadTestPageNamed:@"simple-tall"];
     [webView stringByEvaluatingJavaScript:@"scrollTo(0, 1000)"];
     [webView waitForNextPresentationUpdate];
 
-    auto window = adoptNS([[NSWindow alloc] initWithContentRect:rect styleMask:NSWindowStyleMaskTitled backing:NSBackingStoreBuffered defer:YES]);
+    RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:rect styleMask:NSWindowStyleMaskTitled backing:NSBackingStoreBuffered defer:YES]);
     [[window contentView] addSubview:webView.get()];
     [window makeKeyAndOrderFront:nil];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WebScriptObjectDescription.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WebScriptObjectDescription.mm
@@ -62,7 +62,7 @@ TEST(WebKitLegacy, WebScriptObjectDescription)
 {
     RetainPtr<WebView> webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
     RetainPtr<WebScriptDescriptionTest> testController = adoptNS([WebScriptDescriptionTest new]);
-    auto object = adoptNS([[NSObject alloc] init]);
+    RetainPtr object = adoptNS([[NSObject alloc] init]);
 
     webView.get().frameLoadDelegate = testController.get();
     [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WebViewCanPasteURL.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WebViewCanPasteURL.mm
@@ -34,7 +34,7 @@ namespace TestWebKitAPI {
 
 TEST(WebKitLegacy, WebViewCanPasteURL)
 {
-    auto webView = adoptNS([[WebView alloc] initWithFrame:NSZeroRect frameName:nil groupName:nil]);
+    RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:NSZeroRect frameName:nil groupName:nil]);
     [webView setEditable:YES];
 
     [[NSPasteboard generalPasteboard] declareTypes:@[NSURLPboardType] owner:nil];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WebViewCanPasteZeroPng.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WebViewCanPasteZeroPng.mm
@@ -34,7 +34,7 @@ namespace TestWebKitAPI {
 
 TEST(WebKitLegacy, WebViewCanPasteZeroPng)
 {
-    auto webView = adoptNS([[WebView alloc] initWithFrame:NSZeroRect frameName:nil groupName:nil]);
+    RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:NSZeroRect frameName:nil groupName:nil]);
     [webView setEditable:YES];
     
     //pasting a 0x0 image as pdf board type. Referring to <rdar://problem/11141920>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WebViewDidCreateJavaScriptContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WebViewDidCreateJavaScriptContext.mm
@@ -80,7 +80,7 @@ static bool didReportException = false;
 
 - (void)webView:(WebView *)webView didCreateJavaScriptContext:(JSContext *)context forFrame:(WebFrame *)frame
 {
-    auto myConsole = adoptNS([[MyConsole alloc] init]);
+    RetainPtr myConsole = adoptNS([[MyConsole alloc] init]);
     context[@"myConsole"] = myConsole.get();
     context.exceptionHandler = nil;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WebViewIconLoading.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WebViewIconLoading.mm
@@ -63,7 +63,7 @@ static NSData *customFaviconData()
 
 static NSImage *imageFromData(NSData *data)
 {
-    auto image = adoptNS([[NSImage alloc] initWithData:data]);
+    RetainPtr image = adoptNS([[NSImage alloc] initWithData:data]);
     [image setSize:NSMakeSize(16, 16)];
     return image.autorelease();
 }
@@ -156,10 +156,10 @@ TEST(WebKitLegacy, IconLoadingDelegateDefaultFirst)
 
     currentMainHTML = &defaultFaviconHTML;
     @autoreleasepool {
-        auto webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
-        auto frameLoadDelegate = adoptNS([[IconLoadingFrameLoadDelegate alloc] init]);
+        RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
+        RetainPtr frameLoadDelegate = adoptNS([[IconLoadingFrameLoadDelegate alloc] init]);
 
-        auto kvo = adoptNS([[MainFrameIconKVO alloc] init]);
+        RetainPtr kvo = adoptNS([[MainFrameIconKVO alloc] init]);
         kvo->oldImage = webView.get().mainFrameIcon;
         kvo->expectedImage = imageFromData(defaultFaviconData());
         [webView.get() addObserver:kvo.get() forKeyPath:MainFrameIconKeyPath options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:nil];
@@ -197,10 +197,10 @@ TEST(WebKitLegacy, IconLoadingDelegateCustomFirst)
 
     currentMainHTML = &customFaviconHTML;
     @autoreleasepool {
-        auto webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
-        auto frameLoadDelegate = adoptNS([[IconLoadingFrameLoadDelegate alloc] init]);
+        RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
+        RetainPtr frameLoadDelegate = adoptNS([[IconLoadingFrameLoadDelegate alloc] init]);
 
-        auto kvo = adoptNS([[MainFrameIconKVO alloc] init]);
+        RetainPtr kvo = adoptNS([[MainFrameIconKVO alloc] init]);
         kvo->oldImage = webView.get().mainFrameIcon;
         kvo->expectedImage = imageFromData(customFaviconData());
         [webView.get() addObserver:kvo.get() forKeyPath:MainFrameIconKeyPath options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:nil];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WebViewScheduleInRunLoop.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WebViewScheduleInRunLoop.mm
@@ -52,9 +52,9 @@ TEST(WebKitLegacy, ScheduleInRunLoop)
 {
     const size_t webViewCount = 50;
     Vector<RetainPtr<WebView>> webViews;
-    auto delegate = adoptNS([[ScheduleInRunLoopDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[ScheduleInRunLoopDelegate alloc] init]);
     for (size_t i = 0; i < webViewCount; ++i) {
-        auto webView = adoptNS([[WebView alloc] init]);
+        RetainPtr webView = adoptNS([[WebView alloc] init]);
         [webView setFrameLoadDelegate:delegate.get()];
         [webView unscheduleFromRunLoop:[NSRunLoop currentRunLoop] forMode:(NSString *)kCFRunLoopCommonModes];
         [webView scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:@"TestRunLoopMode"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WindowlessWebViewWithMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WindowlessWebViewWithMedia.mm
@@ -64,8 +64,8 @@ static void spinLoop(NSTimeInterval timeout, BOOL (^block)())
 TEST(WebKitLegacy, WindowlessWebViewWithMedia)
 {
     @autoreleasepool {
-        auto webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
-        auto testController = adoptNS([WindowlessWebViewWithMediaFrameLoadDelegate new]);
+        RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 120, 200) frameName:nil groupName:nil]);
+        RetainPtr testController = adoptNS([WindowlessWebViewWithMediaFrameLoadDelegate new]);
         webView.get().frameLoadDelegate = testController.get();
         [[webView.get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"WindowlessWebViewWithMedia" withExtension:@"html"]]];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/DateTimeInputsAccessoryViewTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/DateTimeInputsAccessoryViewTests.mm
@@ -61,13 +61,13 @@ static void runTestWithInputType(NSString *type)
     NSInteger width = 800;
     NSInteger height = 600;
 
-    auto uiWindow = adoptNS([[UIWindow alloc] initWithFrame:NSMakeRect(0, 0, width, height)]);
-    auto uiWebView = adoptNS([[UIWebView alloc] initWithFrame:NSMakeRect(0, 0, width, height)]);
+    RetainPtr uiWindow = adoptNS([[UIWindow alloc] initWithFrame:NSMakeRect(0, 0, width, height)]);
+    RetainPtr uiWebView = adoptNS([[UIWebView alloc] initWithFrame:NSMakeRect(0, 0, width, height)]);
     [uiWindow addSubview:uiWebView.get()];
 
     [uiWebView setKeyboardDisplayRequiresUserAction:NO];
 
-    auto delegate = adoptNS([[DateTimeInputsTestsLoadingDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[DateTimeInputsTestsLoadingDelegate alloc] init]);
     [uiWebView setDelegate:delegate.get()];
 
     NSString *elementString = [NSString stringWithFormat:@"<input type='%@'>", type];

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/ScrollToRevealSelection.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/ScrollToRevealSelection.mm
@@ -56,11 +56,11 @@ IGNORE_WARNINGS_BEGIN("deprecated-implementations")
 
 TEST(WebKitLegacy, ScrollToRevealSelection)
 {
-    auto window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr window = adoptNS([[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [window setHidden:NO];
-    auto webView = adoptNS([[UIWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr webView = adoptNS([[UIWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
     [window addSubview:webView.get()];
-    auto delegate = adoptNS([[LegacyLoadingDelegate alloc] init]);
+    RetainPtr delegate = adoptNS([[LegacyLoadingDelegate alloc] init]);
     [webView setDelegate:delegate.get()];
     [webView loadHTMLString:@"<meta name='viewport' content='width=device-width, initial-scale=1'><body style='font-size: 100px;' contenteditable>" baseURL:nil];
     [delegate waitForDidFinishLoad];

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/SnapshotViaRenderInContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/SnapshotViaRenderInContext.mm
@@ -82,8 +82,8 @@ TEST(WebKitLegacy, RenderInContextSnapshot)
     const NSInteger width = 800;
     const NSInteger height = 600;
     
-    auto uiWindow = adoptNS([[UIWindow alloc] initWithFrame:NSMakeRect(0, 0, width, height)]);
-    auto uiWebView = adoptNS([[UIWebViewWithoutSafeArea alloc] initWithFrame:NSMakeRect(0, 0, width, height)]);
+    RetainPtr uiWindow = adoptNS([[UIWindow alloc] initWithFrame:NSMakeRect(0, 0, width, height)]);
+    RetainPtr uiWebView = adoptNS([[UIWebViewWithoutSafeArea alloc] initWithFrame:NSMakeRect(0, 0, width, height)]);
     [uiWindow addSubview:uiWebView.get()];
     
     RetainPtr<RenderInContextWebViewDelegate> uiDelegate = adoptNS([[RenderInContextWebViewDelegate alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/AccessingPastedImage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/AccessingPastedImage.mm
@@ -82,8 +82,8 @@ namespace TestWebKitAPI {
 
 TEST(WebKitLegacy, AccessingImageInPastedRTFD)
 {
-    auto webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) frameName:nil groupName:nil]);
-    auto delegate = adoptNS([[SubresourceForBlobURLFrameLoadDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) frameName:nil groupName:nil]);
+    RetainPtr delegate = adoptNS([[SubresourceForBlobURLFrameLoadDelegate alloc] init]);
     [webView.get() setFrameLoadDelegate:delegate.get()];
     [webView.get() setUIDelegate:delegate.get()];
 
@@ -93,7 +93,7 @@ TEST(WebKitLegacy, AccessingImageInPastedRTFD)
     [webView.get() setEditable:YES];
 
     auto *pngData = [NSData dataWithContentsOfFile:[NSBundle.test_resourcesBundle pathForResource:@"sunset-in-cupertino-200px" ofType:@"png"]];
-    auto attachment = adoptNS([[NSTextAttachment alloc] initWithData:pngData ofType:UTTypePNG.identifier]);
+    RetainPtr attachment = adoptNS([[NSTextAttachment alloc] initWithData:pngData ofType:UTTypePNG.identifier]);
     NSAttributedString *string = [NSAttributedString attributedStringWithAttachment:attachment.get()];
     NSData *RTFDData = [string RTFDFromRange:NSMakeRange(0, [string length]) documentAttributes:@{ }];
 
@@ -117,9 +117,9 @@ TEST(WebKitLegacy, AccessingImageInPastedRTFD)
 
 TEST(WebKitLegacy, AccessingImageInPastedWebArchive)
 {
-    auto sourceWebView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) frameName:nil groupName:nil]);
-    auto destinationWebView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) frameName:nil groupName:nil]);
-    auto delegate = adoptNS([[SubresourceForBlobURLFrameLoadDelegate alloc] init]);
+    RetainPtr sourceWebView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) frameName:nil groupName:nil]);
+    RetainPtr destinationWebView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) frameName:nil groupName:nil]);
+    RetainPtr delegate = adoptNS([[SubresourceForBlobURLFrameLoadDelegate alloc] init]);
     [sourceWebView.get() setFrameLoadDelegate:delegate.get()];
     [sourceWebView.get() setUIDelegate:delegate.get()];
     [destinationWebView.get() setFrameLoadDelegate:delegate.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/ClosingWebView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/ClosingWebView.mm
@@ -70,7 +70,7 @@ TEST(WebKitLegacy, ClosingWebViewThenSendingItAKeyDownEvent)
     EXPECT_TRUE([webHTMLView respondsToSelector:@selector(keyDown:)]);
     EXPECT_TRUE([webHTMLView respondsToSelector:@selector(keyUp:)]);
 
-    auto loadDelegate = adoptNS([[ClosingWebViewThenSendingItAKeyDownEventLoadDelegate alloc] init]);
+    RetainPtr loadDelegate = adoptNS([[ClosingWebViewThenSendingItAKeyDownEventLoadDelegate alloc] init]);
     webView.get().frameLoadDelegate = loadDelegate.get();
     
     [[webView mainFrame] loadHTMLString:@"<html><body contenteditable><script>function addKeyPressHandler() { document.body.addEventListener('keypress', function(event) { event.preventDefault(); }, true) }; document.body.focus();</script></body></html>" baseURL:nil];
@@ -78,7 +78,7 @@ TEST(WebKitLegacy, ClosingWebViewThenSendingItAKeyDownEvent)
     Util::run(&didFinishLoad);
 
     // First, add a native event listener that closes the WebView.
-    auto listener = adoptNS([[KeyboardEventListener alloc] init]);
+    RetainPtr listener = adoptNS([[KeyboardEventListener alloc] init]);
     [[[webView mainFrameDocument] body] addEventListener:@"keypress" listener:listener.get() useCapture:NO];
 
     // Second, add a JavaScript event handler that consumes the event.

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/CustomProtocolsInvalidScheme.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/CustomProtocolsInvalidScheme.mm
@@ -72,11 +72,11 @@ TEST(WebKit2CustomProtocolsTest, LoadInvalidScheme)
     [WKBrowsingContextController registerSchemeForCustomProtocol:@"custom"];
     WKRetainPtr<WKContextRef> context = adoptWK(Util::createContextForInjectedBundleTest("CustomProtocolInvalidSchemeTest"));
 
-    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     configuration.get().processPool = (WKProcessPool *)context.get();
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
-    auto loadDelegate = adoptNS([[LoadInvalidSchemeDelegate alloc] init]);
+    RetainPtr loadDelegate = adoptNS([[LoadInvalidSchemeDelegate alloc] init]);
     webView.get().navigationDelegate = loadDelegate.get();
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"ht'tp://www.webkit.org"]]];

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/CustomProtocolsTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/CustomProtocolsTest.mm
@@ -157,7 +157,7 @@ TEST(WebKit2CustomProtocolsTest, ProcessPoolDestroyedDuringLoading)
     [ProcessPoolDestroyedDuringLoadingProtocol registerWithScheme:@"custom"];
 
     @autoreleasepool {
-        auto wkView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+        RetainPtr wkView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
 
         [wkView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"custom:///test"]]];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/DeallocWebViewInEventListener.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/DeallocWebViewInEventListener.mm
@@ -71,13 +71,13 @@ TEST(WebKitLegacy, DeallocWebViewInEventListener)
 {
     @autoreleasepool {
         webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) frameName:nil groupName:nil]);
-        auto loadDelegate = adoptNS([[DeallocWebViewInEventListenerLoadDelegate alloc] init]);
+        RetainPtr loadDelegate = adoptNS([[DeallocWebViewInEventListenerLoadDelegate alloc] init]);
         webView.get().frameLoadDelegate = loadDelegate.get();
 
         [[webView mainFrame] loadHTMLString:@"<html><body></body></html>" baseURL:nil];
         Util::run(&didFinishLoad);
 
-        auto listener = adoptNS([[DeallocWebViewInEventListener alloc] init]);
+        RetainPtr listener = adoptNS([[DeallocWebViewInEventListener alloc] init]);
         [[[webView mainFrameDocument] body] addEventListener:@"keypress" listener:listener.get() useCapture:NO];
         [[[webView mainFrameDocument] body] addEventListener:@"keypress" listener:nullptr useCapture:NO];
         listener = nullptr;

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/DownloadThread.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/DownloadThread.mm
@@ -78,8 +78,8 @@ namespace TestWebKitAPI {
 
 TEST(WebKitLegacy, DownloadThread)
 {
-    auto delegate = adoptNS([DownloadThreadChecker new]);
-    auto webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) frameName:nil groupName:nil]);
+    RetainPtr delegate = adoptNS([DownloadThreadChecker new]);
+    RetainPtr webView = adoptNS([[WebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) frameName:nil groupName:nil]);
     [webView setPolicyDelegate:delegate.get()];
     [webView setDownloadDelegate:delegate.get()];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/PreventImageLoadWithAutoResizing.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/PreventImageLoadWithAutoResizing.mm
@@ -44,7 +44,7 @@ TEST(WebKit, PreventImageLoadWithAutoResizingTest)
     PlatformWebView webView(context.get());
 
     [webView.platformView() _setMinimumLayoutWidth:400];
-    auto loadDelegate = adoptNS([[TestBrowsingContextLoadDelegate alloc] initWithBlockToRunOnLoad:^(WKWebView *sender) {
+    RetainPtr loadDelegate = adoptNS([[TestBrowsingContextLoadDelegate alloc] initWithBlockToRunOnLoad:^(WKWebView *sender) {
         testFinished = true;
     }]);
     webView.platformView().navigationDelegate = loadDelegate.get();

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/UserContentTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/UserContentTest.mm
@@ -91,12 +91,12 @@ TEST_F(WebKit2UserContentTest, AddUserStyleSheetBeforeCreatingView)
 {
     testFinished = false;
     
-    auto sheet = adoptNS([[_WKUserStyleSheet alloc] initWithSource:userStyleSheet forMainFrameOnly:YES]);
+    RetainPtr sheet = adoptNS([[_WKUserStyleSheet alloc] initWithSource:userStyleSheet forMainFrameOnly:YES]);
 
-    auto wkView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr wkView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [wkView.get().configuration.userContentController _addUserStyleSheet:sheet.get()];
     auto backgroundColorQuery = adoptWK(WKStringCreateWithUTF8CString(backgroundColorScript));
-    auto loadDelegate = adoptNS([[TestBrowsingContextLoadDelegate alloc] initWithBlockToRunOnLoad:^(WKWebView *sender) {
+    RetainPtr loadDelegate = adoptNS([[TestBrowsingContextLoadDelegate alloc] initWithBlockToRunOnLoad:^(WKWebView *sender) {
         runJavaScriptInMainFrame([wkView _pageRefForTransitionToWKWebView], backgroundColorQuery.get(), ^(WKTypeRef value, WKErrorRef error) {
             expectScriptValueIsString(value, greenInRGB);
             testFinished = true;
@@ -113,9 +113,9 @@ TEST_F(WebKit2UserContentTest, AddUserStyleSheetAfterCreatingView)
 {
     testFinished = false;
     
-    auto wkView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr wkView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     auto backgroundColorQuery = adoptWK(WKStringCreateWithUTF8CString(backgroundColorScript));
-    auto loadDelegate = adoptNS([[TestBrowsingContextLoadDelegate alloc] initWithBlockToRunOnLoad:^(WKWebView *sender) {
+    RetainPtr loadDelegate = adoptNS([[TestBrowsingContextLoadDelegate alloc] initWithBlockToRunOnLoad:^(WKWebView *sender) {
         runJavaScriptInMainFrame([wkView _pageRefForTransitionToWKWebView], backgroundColorQuery.get(), ^(WKTypeRef result, WKErrorRef error) {
             expectScriptValueIsString(result, greenInRGB);
             testFinished = true;
@@ -123,7 +123,7 @@ TEST_F(WebKit2UserContentTest, AddUserStyleSheetAfterCreatingView)
     }]);
     wkView.get().navigationDelegate = loadDelegate.get();
 
-    auto sheet = adoptNS([[_WKUserStyleSheet alloc] initWithSource:userStyleSheet forMainFrameOnly:YES]);
+    RetainPtr sheet = adoptNS([[_WKUserStyleSheet alloc] initWithSource:userStyleSheet forMainFrameOnly:YES]);
     [wkView.get().configuration.userContentController _addUserStyleSheet:sheet.get()];
 
     [wkView loadHTMLString:htmlString baseURL:nil];
@@ -134,12 +134,12 @@ TEST_F(WebKit2UserContentTest, AddUserStyleSheetAfterCreatingView)
 TEST_F(WebKit2UserContentTest, RemoveAllUserStyleSheets)
 {
     testFinished = false;
-    auto sheet = adoptNS([[_WKUserStyleSheet alloc] initWithSource:userStyleSheet forMainFrameOnly:YES]);
+    RetainPtr sheet = adoptNS([[_WKUserStyleSheet alloc] initWithSource:userStyleSheet forMainFrameOnly:YES]);
     
-    auto wkView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr wkView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [wkView.get().configuration.userContentController _addUserStyleSheet:sheet.get()];
     auto backgroundColorQuery = adoptWK(WKStringCreateWithUTF8CString(backgroundColorScript));
-    auto loadDelegate = adoptNS([[TestBrowsingContextLoadDelegate alloc] initWithBlockToRunOnLoad:^(WKWebView *sender) {
+    RetainPtr loadDelegate = adoptNS([[TestBrowsingContextLoadDelegate alloc] initWithBlockToRunOnLoad:^(WKWebView *sender) {
         runJavaScriptInMainFrame([wkView _pageRefForTransitionToWKWebView], backgroundColorQuery.get(), ^(WKTypeRef result, WKErrorRef error) {
             expectScriptValueIsString(result, redInRGB);
             testFinished = true;
@@ -157,12 +157,12 @@ TEST_F(WebKit2UserContentTest, RemoveAllUserStyleSheets)
 TEST_F(WebKit2UserContentTest, AddUserScriptBeforeCreatingView)
 {
     testFinished = false;
-    auto script = adoptNS([[WKUserScript alloc] initWithSource:[NSString stringWithFormat:@"%s = true;", userScriptTestProperty] injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
+    RetainPtr script = adoptNS([[WKUserScript alloc] initWithSource:[NSString stringWithFormat:@"%s = true;", userScriptTestProperty] injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
 
-    auto wkView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr wkView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [wkView.get().configuration.userContentController addUserScript:script.get()];
     auto userScriptTestPropertyString = adoptWK(WKStringCreateWithUTF8CString(userScriptTestProperty));
-    auto loadDelegate = adoptNS([[TestBrowsingContextLoadDelegate alloc] initWithBlockToRunOnLoad:^(WKWebView *sender) {
+    RetainPtr loadDelegate = adoptNS([[TestBrowsingContextLoadDelegate alloc] initWithBlockToRunOnLoad:^(WKWebView *sender) {
         runJavaScriptInMainFrame([wkView _pageRefForTransitionToWKWebView], userScriptTestPropertyString.get(), ^(WKTypeRef result, WKErrorRef error) {
             expectScriptValueIsBoolean(result, true);
             testFinished = true;
@@ -179,9 +179,9 @@ TEST_F(WebKit2UserContentTest, AddUserScriptAfterCreatingView)
 {
     testFinished = false;
     
-    auto wkView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr wkView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     auto userScriptTestPropertyString = adoptWK(WKStringCreateWithUTF8CString(userScriptTestProperty));
-    auto loadDelegate = adoptNS([[TestBrowsingContextLoadDelegate alloc] initWithBlockToRunOnLoad:^(WKWebView *sender) {
+    RetainPtr loadDelegate = adoptNS([[TestBrowsingContextLoadDelegate alloc] initWithBlockToRunOnLoad:^(WKWebView *sender) {
         runJavaScriptInMainFrame([wkView _pageRefForTransitionToWKWebView], userScriptTestPropertyString.get(), ^(WKTypeRef result, WKErrorRef error) {
             expectScriptValueIsBoolean(result, true);
             testFinished = true;
@@ -189,7 +189,7 @@ TEST_F(WebKit2UserContentTest, AddUserScriptAfterCreatingView)
     }]);
     wkView.get().navigationDelegate = loadDelegate.get();
     
-    auto script = adoptNS([[WKUserScript alloc] initWithSource:[NSString stringWithFormat:@"%s = true;", userScriptTestProperty] injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
+    RetainPtr script = adoptNS([[WKUserScript alloc] initWithSource:[NSString stringWithFormat:@"%s = true;", userScriptTestProperty] injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
     [wkView.get().configuration.userContentController addUserScript:script.get()];
     
     [wkView loadHTMLString:@"" baseURL:nil];
@@ -200,12 +200,12 @@ TEST_F(WebKit2UserContentTest, AddUserScriptAfterCreatingView)
 TEST_F(WebKit2UserContentTest, RemoveAllUserScripts)
 {
     testFinished = false;
-    auto script = adoptNS([[WKUserScript alloc] initWithSource:[NSString stringWithFormat:@"%s = true;", userScriptTestProperty] injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
+    RetainPtr script = adoptNS([[WKUserScript alloc] initWithSource:[NSString stringWithFormat:@"%s = true;", userScriptTestProperty] injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
 
-    auto wkView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr wkView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [wkView.get().configuration.userContentController addUserScript:script.get()];
     auto userScriptTestPropertyString = adoptWK(WKStringCreateWithUTF8CString(userScriptTestProperty));
-    auto loadDelegate = adoptNS([[TestBrowsingContextLoadDelegate alloc] initWithBlockToRunOnLoad:^(WKWebView *sender) {
+    RetainPtr loadDelegate = adoptNS([[TestBrowsingContextLoadDelegate alloc] initWithBlockToRunOnLoad:^(WKWebView *sender) {
         runJavaScriptInMainFrame([wkView _pageRefForTransitionToWKWebView], userScriptTestPropertyString.get(), ^(WKTypeRef value, WKErrorRef error) {
             expectScriptValueIsUndefined(value);
             testFinished = true;

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/WKBrowsingContextLoadDelegateTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/WKBrowsingContextLoadDelegateTest.mm
@@ -95,7 +95,7 @@ TEST_F(WKBrowsingContextLoadDelegateTest, SimpleLoad)
     bool simpleLoadDone = false;
 
     // Add the load delegate.
-    auto loadDelegate = adoptNS([[SimpleLoadDelegate alloc] initWithFlag:&simpleLoadDone]);
+    RetainPtr loadDelegate = adoptNS([[SimpleLoadDelegate alloc] initWithFlag:&simpleLoadDone]);
     view.get().navigationDelegate = loadDelegate.get();
 
     // Load the file.
@@ -114,7 +114,7 @@ TEST_F(WKBrowsingContextLoadDelegateTest, SimpleLoadOfHTMLString)
     bool simpleLoadDone = false;
 
     // Add the load delegate.
-    auto loadDelegate = adoptNS([[SimpleLoadDelegate alloc] initWithFlag:&simpleLoadDone]);
+    RetainPtr loadDelegate = adoptNS([[SimpleLoadDelegate alloc] initWithFlag:&simpleLoadDone]);
     view.get().navigationDelegate = loadDelegate.get();
 
     // Load the HTML string.
@@ -132,7 +132,7 @@ TEST_F(WKBrowsingContextLoadDelegateTest, SimpleLoadOfHTMLString_NilBaseURL)
     bool simpleLoadDone = false;
 
     // Add the load delegate.
-    auto loadDelegate = adoptNS([[SimpleLoadDelegate alloc] initWithFlag:&simpleLoadDone]);
+    RetainPtr loadDelegate = adoptNS([[SimpleLoadDelegate alloc] initWithFlag:&simpleLoadDone]);
     view.get().navigationDelegate = loadDelegate.get();
 
     // Load the HTML string, pass nil as the baseURL.
@@ -150,7 +150,7 @@ TEST_F(WKBrowsingContextLoadDelegateTest, SimpleLoadOfHTMLString_NilHTMLStringAn
     bool simpleLoadDone = false;
 
     // Add the load delegate.
-    auto loadDelegate = adoptNS([[SimpleLoadDelegate alloc] initWithFlag:&simpleLoadDone]);
+    RetainPtr loadDelegate = adoptNS([[SimpleLoadDelegate alloc] initWithFlag:&simpleLoadDone]);
     view.get().navigationDelegate = loadDelegate.get();
 
     // Load the HTML string (as nil).
@@ -200,7 +200,7 @@ TEST_F(WKBrowsingContextLoadDelegateTest, SimpleLoadFail)
     bool simpleLoadFailDone = false;
 
     // Add the load delegate.
-    auto loadDelegate = adoptNS([[SimpleLoadFailDelegate alloc] initWithFlag:&simpleLoadFailDone]);
+    RetainPtr loadDelegate = adoptNS([[SimpleLoadFailDelegate alloc] initWithFlag:&simpleLoadFailDone]);
     view.get().navigationDelegate = loadDelegate.get();
 
     // Load a non-existent file.


### PR DESCRIPTION
#### 0b653ddeca520899ada569417632665e1c07d87a
<pre>
Update `auto` to `RetainPtr` in Cocoa API tests
<a href="https://rdar.apple.com/174539731">rdar://174539731</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=311992">https://bugs.webkit.org/show_bug.cgi?id=311992</a>

Reviewed by Richard Robinson.

Over the last few years it&apos;s been clear which way the wind is blowing:
We prefer explicit smart pointer types instead of `auto` when creating variables of a smart ptr type.

There&apos;s a larger style discussion to be had to formalize this, which I&apos;m going to go start on webkit-dev.

But for now - since I&apos;ve been hit with this feedback for RetainPtrs within API tests recently and I&apos;ve
hit others with the same - here&apos;s a full replacement of all the offenders within the Cocoa API tests.

Modifies 435 files in Tools/TestWebKitAPI. Including all of them makes the commit message too long for git.

Canonical link: <a href="https://commits.webkit.org/311010@main">https://commits.webkit.org/311010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01ef304e4393ccc43ee97cec4f409a05d3b4a5eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155777 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164539 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157648 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28885 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120576 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158734 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22765 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139887 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101265 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21851 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19986 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12369 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147825 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131520 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17719 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167019 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16607 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); Passed JSC tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19330 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128695 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28579 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128827 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34903 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28503 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139512 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86337 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23649 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16310 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187660 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28197 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48240 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27774 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28004 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27847 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->