### PR TITLE
[GLIB][JSC] stress/iterator-prototype-includes.js tests are failing since added in 310769@main

### DIFF
--- a/JSTests/stress/iterator-prototype-includes.js
+++ b/JSTests/stress/iterator-prototype-includes.js
@@ -1,4 +1,3 @@
-//@ skip if $architecture == "x86_64" and $hostOS == "linux"
 //@ requireOptions("--useIteratorIncludes=1")
 
 function sameValue(a, b, testname) {

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -45,6 +45,7 @@
 #include <cstdint>
 #include <optional>
 #include <wtf/Assertions.h>
+#include <wtf/MathExtras.h>
 
 namespace JSC {
 
@@ -243,28 +244,20 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncIncludes, (JSGlobalObject* globalObjec
             toSkip = skippedAsInt32;
         } else if (skippedElementsArg.isDouble()) {
             double skippedAsDouble = skippedElementsArg.asDouble();
-            if (isInteger(skippedAsDouble)) {
-                if (skippedAsDouble < 0) {
-                    iteratorClose(globalObject, thisValue);
-                    TRY_CLEAR_EXCEPTION(scope, { });
-                    return throwVMRangeError(globalObject, scope, errorMessage);
-                }
-
-                toSkip = static_cast<uint64_t>(skippedAsDouble);
-            } else if (std::isinf(skippedAsDouble)) {
-                // check -Infinity
-                if (skippedAsDouble < 0) {
-                    iteratorClose(globalObject, thisValue);
-                    TRY_CLEAR_EXCEPTION(scope, { });
-                    return throwVMRangeError(globalObject, scope, errorMessage);
-                }
-
-                // if the 2nd argument is +Infinity, we should consume the iterator to the end.
+            uint64_t skippedAsUInt = truncateDoubleToUint64(skippedAsDouble);
+            if (skippedAsUInt == skippedAsDouble && skippedAsUInt < maxSafeIntegerAsUInt64())
+                toSkip = skippedAsUInt;
+            else if (!isInteger(skippedAsDouble) && !std::isinf(skippedAsDouble)) {
+                iteratorClose(globalObject, thisValue);
+                TRY_CLEAR_EXCEPTION(scope, { });
+                return throwVMTypeError(globalObject, scope, errorMessage);                
+            } else if (skippedAsDouble > 0) {
+                // if the 2nd argument is +Infinity or too big, we should consume the iterator to the end.
                 toSkip = std::numeric_limits<uint64_t>::max();
             } else {
                 iteratorClose(globalObject, thisValue);
                 TRY_CLEAR_EXCEPTION(scope, { });
-                return throwVMTypeError(globalObject, scope, errorMessage);
+                return throwVMRangeError(globalObject, scope, errorMessage);
             }
         } else {
             iteratorClose(globalObject, thisValue);


### PR DESCRIPTION
#### 30298eb4df3cdf0271a2716c1534a5b42d9da8c1
<pre>
[GLIB][JSC] stress/iterator-prototype-includes.js tests are failing since added in 310769@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=311819">https://bugs.webkit.org/show_bug.cgi?id=311819</a>

Reviewed by Keith Miller and Yusuke Suzuki.

Casting Number.MAX_VALUE to uint64_t is UB, and acts strangely on gcc causing some
test failures.

Canonical link: <a href="https://commits.webkit.org/311446@main">https://commits.webkit.org/311446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3108204eb1755fb4f1593544e5ca6a9f8168fc3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156878 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165701 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110960 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30217 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121506 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85322 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140875 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102174 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22789 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21009 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13473 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148928 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132470 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18704 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168186 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17713 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12345 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20324 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129622 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29816 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25087 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129729 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35163 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29739 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140498 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87543 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24561 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17302 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188840 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29449 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93464 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48494 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28972 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29202 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29098 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->