### PR TITLE
Remove LegacyNativeDictionaryRequiredInterfaceNullability from FaceDetectorOptions

### DIFF
--- a/Source/WebCore/Modules/ShapeDetection/FaceDetectorOptions.h
+++ b/Source/WebCore/Modules/ShapeDetection/FaceDetectorOptions.h
@@ -27,7 +27,6 @@
 
 #include "FaceDetectorOptionsInterface.h"
 #include <cstdint>
-#include <limits>
 
 namespace WebCore {
 
@@ -40,8 +39,8 @@ struct FaceDetectorOptions {
         };
     }
 
-    uint16_t maxDetectedFaces { std::numeric_limits<uint16_t>::max() };
-    bool fastMode { true };
+    uint16_t maxDetectedFaces;
+    bool fastMode;
 };
 
 inline FaceDetectorOptions convertFromBacking(const ShapeDetection::FaceDetectorOptions& faceDetectorOptions)

--- a/Source/WebCore/Modules/ShapeDetection/FaceDetectorOptions.idl
+++ b/Source/WebCore/Modules/ShapeDetection/FaceDetectorOptions.idl
@@ -27,8 +27,7 @@
 
 [
     EnabledBySetting=ShapeDetection,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary FaceDetectorOptions {
-    unsigned short maxDetectedFaces;
-    boolean fastMode;
+    [ImplementationDefaultValue=65535] unsigned short maxDetectedFaces;
+    [ImplementationDefaultValue=true] boolean fastMode;
 };


### PR DESCRIPTION
#### 25186fb9e79fb1d919b85ff2def14cd1ec615e8a
<pre>
Remove LegacyNativeDictionaryRequiredInterfaceNullability from FaceDetectorOptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=312004">https://bugs.webkit.org/show_bug.cgi?id=312004</a>

Reviewed by Brent Fulgham.

Move the default hint values from the struct to IDL. The specification
leaves these defaults up to the user agent so
ImplementationDefaultValue is appropriate.

Canonical link: <a href="https://commits.webkit.org/311021@main">https://commits.webkit.org/311021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54bc3ba705f1cce22c6399567f8b2e566e5520a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164470 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e65feabf-a686-44f6-9300-94e6fe34a3e1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157580 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28817 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120516 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0319581b-57ec-4fc4-b207-bdb876aaa149) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139821 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101205 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/681ff94d-3c45-4f46-8879-e498d9cd8c25) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21780 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19920 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12300 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131449 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166951 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11125 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19264 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128634 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28511 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23954 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128766 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139446 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86265 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23725 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23582 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16243 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28129 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92232 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27706 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27936 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27779 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->