### PR TITLE
Resync `html/semantics/tabular-data` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: table
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/col-span-limits-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/col-span-limits-expected.txt
@@ -1,6 +1,9 @@
 
 PASS col span of 1000 must work
 PASS col span of 1001 must be treated as 1000
+PASS colspan must be clamped to [1, 1000] when set via script
+PASS colspan must be clamped to [1, 1000] when parsing attributes
+PASS column span must be clamped to [1, 1000] when set via script
 
 These two must look the same, each having 2 cells in one row:
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/col-span-limits.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/col-span-limits.html
@@ -39,11 +39,20 @@ These two must look the same, each having 2 cells in one row:
 </table>
 <br>
 <table id=table3>
-  <col span=1001>
+  <col id="colspan-3" span=1001>
   <tr>
     <td colspan=1000><div class="square"></div></td>
     <td><div class="square"></div></td>
   </tr>
+</table>
+<table>
+    <tr>
+        <td id="colspan-limit-test1" colspan=5></td>
+        <td id="colspan-limit-test2" colspan=0></td>
+        <td id="colspan-limit-test3" colspan=1000></td>
+        <td id="colspan-limit-test4" colspan=1001></td>
+        <td id="colspan-limit-test5" colspan=5555555></td>
+    </tr>
 </table>
 </main>
 
@@ -56,4 +65,48 @@ test(() => {
     assert_equals(table2.offsetWidth, 51, "table2 width");
     assert_equals(table3.offsetWidth, 51, "table3 width");
 }, "col span of 1001 must be treated as 1000");
+
+test(() => {
+    let td = document.createElement("td");
+    td.colSpan = 5;
+    assert_equals(td.colSpan, 5);
+
+    td.colSpan = 0;
+    assert_equals(td.colSpan, 1);
+
+    td.colSpan = 1000;
+    assert_equals(td.colSpan, 1000);
+
+    td.colSpan = 1001;
+    assert_equals(td.colSpan, 1000);
+
+    td.colSpan = 555555;
+    assert_equals(td.colSpan, 1000);
+}, "colspan must be clamped to [1, 1000] when set via script");
+
+test(() => {
+    assert_equals(document.getElementById("colspan-limit-test1").colSpan, 5);
+    assert_equals(document.getElementById("colspan-limit-test2").colSpan, 1);
+    assert_equals(document.getElementById("colspan-limit-test3").colSpan, 1000);
+    assert_equals(document.getElementById("colspan-limit-test4").colSpan, 1000);
+    assert_equals(document.getElementById("colspan-limit-test5").colSpan, 1000);
+}, "colspan must be clamped to [1, 1000] when parsing attributes");
+
+test(() => {
+    let column = document.getElementById("colspan-3");
+    column.span = 5;
+    assert_equals(column.span, 5);
+
+    column.span = 0;
+    assert_equals(column.span, 1);
+
+    column.span = 1000;
+    assert_equals(column.span, 1000);
+
+    column.span = 1001;
+    assert_equals(column.span, 1000);
+
+    column.span = 555555;
+    assert_equals(column.span, 1000);
+}, "column span must be clamped to [1, 1000] when set via script");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/rowspan-0-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/rowspan-0-expected.txt
@@ -1,0 +1,6 @@
+x	x
+x
+
+PASS clientHeight
+PASS rowSpan
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/rowspan-0-quirks-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/rowspan-0-quirks-expected.txt
@@ -1,0 +1,6 @@
+x	x
+x
+
+PASS clientHeight
+PASS rowSpan
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/rowspan-0-quirks.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/rowspan-0-quirks.html
@@ -1,0 +1,23 @@
+<!--quirks mode-->
+<title>rowspan=0 in quirks mode</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<table>
+ <tr>
+  <td rowspan="0" id="test-cell">x
+  <td id="ref-cell">x
+ <tr>
+  <td>x
+</table>
+<script>
+const testCell = document.getElementById('test-cell');
+const refCell = document.getElementById('ref-cell');
+
+test(() => {
+  assert_greater_than(testCell.clientHeight, refCell.clientHeight);
+}, 'clientHeight');
+
+test(() => {
+  assert_equals(testCell.rowSpan, 0);
+}, 'rowSpan');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/rowspan-0.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/rowspan-0.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>rowspan=0</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<table>
+ <tr>
+  <td rowspan="0" id="test-cell">x
+  <td id="ref-cell">x
+ <tr>
+  <td>x
+</table>
+<script>
+const testCell = document.getElementById('test-cell');
+const refCell = document.getElementById('ref-cell');
+
+test(() => {
+  assert_greater_than(testCell.clientHeight, refCell.clientHeight);
+}, 'clientHeight');
+
+test(() => {
+  assert_equals(testCell.rowSpan, 0);
+}, 'rowSpan');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/span-limits-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/span-limits-expected.txt
@@ -3,6 +3,8 @@ PASS colspan of 1000 must work
 PASS colspan of 1001 must be treated as 1000
 PASS rowspan of 65534 must work
 PASS rowspan of 65535 must be treated as 65534
+PASS rowspan must be clamped to [0, 65534] when set via script
+PASS rowspan must be clamped to [0, 65534] when parsing attributes
 a	a
 a
 a	a
@@ -10,3 +12,4 @@ a
 a	
 a	
 a	
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/span-limits.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/span-limits.html
@@ -29,6 +29,17 @@
   <!-- We'll add another 65534 rows later -->
 </table>
 
+<table>
+    <tr>
+        <td id="rowspan-limit-test1" rowspan=5></td>
+        <td id="rowspan-limit-test2" rowspan=0></td>
+        <td id="rowspan-limit-test3" rowspan=1000></td>
+        <td id="rowspan-limit-test4" rowspan=65534></td>
+        <td id="rowspan-limit-test5" rowspan=65535></td>
+        <td id="rowspan-limit-test6" rowspan=5555555></td>
+    </tr>
+</table>
+
 <script>
 var $ = document.querySelector.bind(document);
 
@@ -63,4 +74,34 @@ test(() => {
     assert_equals($("#d1").getBoundingClientRect().bottom,
                   $("#d2").getBoundingClientRect().bottom);
 }, "rowspan of 65535 must be treated as 65534");
+
+test(() => {
+    let td = document.createElement("td");
+    td.rowSpan = 5;
+    assert_equals(td.rowSpan, 5);
+
+    td.rowSpan = 0;
+    assert_equals(td.rowSpan, 0);
+
+    td.rowSpan = 1000;
+    assert_equals(td.rowSpan, 1000);
+
+    td.rowSpan = 65534;
+    assert_equals(td.rowSpan, 65534);
+
+    td.rowSpan = 65535;
+    assert_equals(td.rowSpan, 65534);
+
+    td.rowSpan = 555555;
+    assert_equals(td.rowSpan, 65534);
+}, "rowspan must be clamped to [0, 65534] when set via script");
+
+test(() => {
+    assert_equals(document.getElementById("rowspan-limit-test1").rowSpan, 5);
+    assert_equals(document.getElementById("rowspan-limit-test2").rowSpan, 0);
+    assert_equals(document.getElementById("rowspan-limit-test3").rowSpan, 1000);
+    assert_equals(document.getElementById("rowspan-limit-test4").rowSpan, 65534);
+    assert_equals(document.getElementById("rowspan-limit-test5").rowSpan, 65534);
+    assert_equals(document.getElementById("rowspan-limit-test6").rowSpan, 65534);
+}, "rowspan must be clamped to [0, 65534] when parsing attributes");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/w3c-import.log
@@ -15,4 +15,6 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/col-span-limits.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/rowspan-0-quirks.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/rowspan-0.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/span-limits.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/w3c-import.log
@@ -15,5 +15,6 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/historical.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/html-table-section-element.js


### PR DESCRIPTION
#### 94ddd6847cd3f94f207f03da4d58da1373227b37
<pre>
Resync `html/semantics/tabular-data` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=312005">https://bugs.webkit.org/show_bug.cgi?id=312005</a>
<a href="https://rdar.apple.com/174545912">rdar://174545912</a>

Reviewed by Brandon Stewart and Vitor Roriz.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/e63beacaa65022582a3a904f35667a6ed8cbd447">https://github.com/web-platform-tests/wpt/commit/e63beacaa65022582a3a904f35667a6ed8cbd447</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/col-span-limits-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/col-span-limits.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/rowspan-0-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/rowspan-0-quirks-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/rowspan-0-quirks.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/rowspan-0.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/span-limits-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/span-limits.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/processing-model-1/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/tabular-data/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/311002@main">https://commits.webkit.org/311002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d2a61bf1f3a035bde772cc8f13a2886dc25f27d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22127 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164471 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28818 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120517 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158667 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139819 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101206 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e72ebe4-d12f-4831-a71b-bd4ad2747c9c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21781 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19919 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12301 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131450 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17651 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166952 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19262 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128635 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28512 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128767 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34899 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139444 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86266 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23583 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16241 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28130 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27707 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27937 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27780 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->