### PR TITLE
Resync `css/CSS2/abspos` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-001-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-001-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-001.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<title>Static position inside inline</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#abs-non-replaced-height">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#inline-formatting">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  If the #abspos would have had `position: static`, then it would split the #inline (§9.2.1.1).
+
+  The line box containing the preceding fragment of the #inline would have no text, padding,
+  border, margin, preserved newline nor any atomic in-flow content. Thus, it would be treated
+  as a zero-height line box (§9.4.2).
+
+  Therefore, the #abspos' static position for `top` is at the top of the #wrapper (§10.6.4).
+  This is despite the fact that when the #abspos is actually taken out of flow, the #inline
+  isn't split, so the line box has content and it's no longer a treated as a zero-height.
+">
+
+<style>
+#wrapper {
+  overflow: hidden;
+  width: 100px;
+  height: 100px;
+}
+#inline {
+  line-height: 100px;
+  color: transparent;
+}
+#abspos {
+  position: absolute;
+  background-color: green;
+  width: 100px;
+  height: 100px;
+}
+#red {
+  position: absolute;
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="red"></div>
+
+<div id="wrapper">
+  <span id="inline">
+    <div id="abspos"></div>
+    X
+  </span>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-002-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-002-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-002.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<title>Static position inside inline</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#abs-non-replaced-height">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#inline-formatting">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  If the #abspos would have had `position: static`, then it would split the #inline (§9.2.1.1).
+
+  The line box containing the preceding fragment of the #inline would have non-zero margin
+  and border. Thus, it wouldn't be treated as a zero-height line box (§9.4.2).
+
+  Therefore, the #abspos' static position for `top` is at 100px from the #wrapper (§10.6.4).
+">
+
+<style>
+#wrapper {
+  overflow: hidden;
+  width: 100px;
+  height: 100px;
+  margin-top: -100px;
+}
+#inline {
+  line-height: 100px;
+  color: transparent;
+  border-left: 100px solid transparent;
+  margin-left: -100px;
+}
+#abspos {
+  position: absolute;
+  background-color: green;
+  width: 100px;
+  height: 100px;
+}
+#red {
+  position: absolute;
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="red"></div>
+
+<div id="wrapper">
+  <span id="inline">
+    <div id="abspos"></div>
+    X
+  </span>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-003-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-003-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-003.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<title>Static position inside inline</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#abs-non-replaced-height">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#anonymous-block-level">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visuren.html#inline-formatting">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  If the #abspos would have had `position: static`, then it would split the #inline (§9.2.1.1).
+
+  The line box containing the preceding fragment of the #inline would have no text, padding,
+  border, margin, preserved newline nor any atomic in-flow content. Thus, it would be treated
+  as a zero-height line box (§9.4.2).
+
+  Therefore, the #abspos' static position for `top` is at the top of the #wrapper (§10.6.4).
+  This is despite the fact that when the #abspos is actually taken out of flow, the #inline
+  isn't split, so the line box has content and it's no longer a treated as a zero-height.
+">
+
+<style>
+#wrapper {
+  overflow: hidden;
+  width: 100px;
+  height: 100px;
+}
+#inline {
+  line-height: 100px;
+  color: transparent;
+  border-right: 100px solid transparent;
+}
+#abspos {
+  position: absolute;
+  background-color: green;
+  width: 100px;
+  height: 100px;
+}
+#red {
+  position: absolute;
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="red"></div>
+
+<div id="wrapper">
+  <span id="inline">
+    <div id="abspos"></div>
+    X
+  </span>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/w3c-import.log
@@ -66,6 +66,12 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/remove-block-between-inline-and-abspos.html
 /LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-fixed-inside-abspos-expected.xht
 /LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-fixed-inside-abspos.html
+/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-001-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-001.html
+/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-002-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-002.html
+/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-003-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-003.html
 /LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-block-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-block-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-block.html


### PR DESCRIPTION
#### 8ff9fd24cd0719760dd9d7fc185671c7d24db18e
<pre>
Resync `css/CSS2/abspos` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=312006">https://bugs.webkit.org/show_bug.cgi?id=312006</a>
<a href="https://rdar.apple.com/174545890">rdar://174545890</a>

Reviewed by Brandon Stewart and Vitor Roriz.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/e63beacaa65022582a3a904f35667a6ed8cbd447">https://github.com/web-platform-tests/wpt/commit/e63beacaa65022582a3a904f35667a6ed8cbd447</a>

* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-001-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-002-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-003-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/static-inside-inline-003.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/abspos/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/311003@main">https://commits.webkit.org/311003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3295bf4a427041060e3e87c537ac9a46bd7ad7f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164472 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc8ff2b4-30b2-4cc5-802e-af17550bb806) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28819 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120519 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158668 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139823 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101208 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21782 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19921 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12302 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131451 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17655 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166953 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19266 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128637 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28513 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23955 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128769 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34900 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28437 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139448 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86267 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23591 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16245 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28131 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27708 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27938 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27781 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->