### PR TITLE
Remove LegacyNativeDictionaryRequiredInterfaceNullability from EME code

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/MediaKeyMessageEventInit.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeyMessageEventInit.h
@@ -37,16 +37,8 @@
 namespace WebCore {
 
 struct MediaKeyMessageEventInit : EventInit {
-    MediaKeyMessageEventInit() = default;
-
-    MediaKeyMessageEventInit(MediaKeyMessageType messageType, RefPtr<JSC::ArrayBuffer>&& message)
-        : EventInit()
-        , messageType(messageType)
-        , message(WTF::move(message))
-    { }
-
     MediaKeyMessageType messageType;
-    RefPtr<JSC::ArrayBuffer> message;
+    Ref<JSC::ArrayBuffer> message;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeyMessageEventInit.idl
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeyMessageEventInit.idl
@@ -26,11 +26,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/encrypted-media/#mediakeymessageeventinit
+
 [
     Conditional=ENCRYPTED_MEDIA,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaKeyMessageEventInit : EventInit {
     required MediaKeyMessageType messageType;
     required ArrayBuffer message;
 };
-

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -705,7 +705,10 @@ void MediaKeySession::enqueueMessage(MediaKeyMessageType messageType, const Shar
     // 2. Queue a task to create an event named message that does not bubble and is not cancellable using the MediaKeyMessageEvent
     //    interface with its type attribute set to message and its isTrusted attribute initialized to true, and dispatch it at the
     //    session.
-    auto messageEvent = MediaKeyMessageEvent::create(eventNames().messageEvent, {messageType, message.tryCreateArrayBuffer()}, Event::IsTrusted::Yes);
+    RefPtr buffer = message.tryCreateArrayBuffer();
+    if (!buffer)
+        return;
+    auto messageEvent = MediaKeyMessageEvent::create(eventNames().messageEvent, MediaKeyMessageEventInit { { }, messageType, buffer.releaseNonNull() }, Event::IsTrusted::Yes);
     queueTaskToDispatchEvent(*this, TaskSource::Networking, WTF::move(messageEvent));
 }
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemConfiguration.idl
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemConfiguration.idl
@@ -31,7 +31,6 @@
     Conditional=ENCRYPTED_MEDIA,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaKeySystemConfiguration {
     DOMString label = "";
     sequence<[AtomString] DOMString> initDataTypes = [];
@@ -39,5 +38,5 @@
     sequence<MediaKeySystemMediaCapability> videoCapabilities = [];
     MediaKeysRequirement distinctiveIdentifier = "optional";
     MediaKeysRequirement persistentState = "optional";
-    sequence<MediaKeySessionType> sessionTypes;
+    [ImplementationDefaultValue=[]] sequence<MediaKeySessionType> sessionTypes;
 };


### PR DESCRIPTION
#### 24fbdfface8a363f620e82ac2b7d76dceb1288bc
<pre>
Remove LegacyNativeDictionaryRequiredInterfaceNullability from EME code
<a href="https://bugs.webkit.org/show_bug.cgi?id=312007">https://bugs.webkit.org/show_bug.cgi?id=312007</a>

Reviewed by Brent Fulgham.

This is mostly a refactoring except that MediaKeyMessageEvent will no
longer be dispatched with a null buffer, but it seems highly unlikely
that scenario will be hit in practice. (And to be clear, when we hit
that we are in violation of the specification whatever we do.)

Canonical link: <a href="https://commits.webkit.org/311022@main">https://commits.webkit.org/311022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87b886e9aa5c6ec086d5b1e4604a5023f80edcc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22129 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164473 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157583 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28820 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120520 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22697 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139824 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101209 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21783 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19922 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12303 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131452 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17656 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166954 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11128 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19267 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128638 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23956 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128770 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139449 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86268 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23727 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23584 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16246 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28132 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92235 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27709 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27939 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27782 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->