### PR TITLE
Remove LegacyNativeDictionaryRequiredInterfaceNullability from RTC code

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.h
@@ -63,11 +63,11 @@ public:
     void deref() const final { RefCounted::deref(); }
     USING_CAN_MAKE_WEAKPTR(EventTarget);
 
-    bool ordered() const { return *m_options.ordered; }
+    bool ordered() const { return m_options.ordered; }
     std::optional<unsigned short> maxPacketLifeTime() const { return m_options.maxPacketLifeTime; }
     std::optional<unsigned short> maxRetransmits() const { return m_options.maxRetransmits; }
     String protocol() const { return m_options.protocol; }
-    bool negotiated() const { return *m_options.negotiated; };
+    bool negotiated() const { return m_options.negotiated; }
     std::optional<unsigned short> id() const;
     RTCPriorityType priority() const { return m_options.priority; };
     const RTCDataChannelInit& options() const LIFETIME_BOUND { return m_options; }

--- a/Source/WebCore/Modules/mediastream/RTCEncodedStreams.idl
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedStreams.idl
@@ -25,7 +25,6 @@
 [
     Conditional=WEB_RTC,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCEncodedStreams {
     ReadableStream readable;
     WritableStream writable;

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -692,7 +692,7 @@ ExceptionOr<Ref<RTCDataChannel>> RTCPeerConnection::createDataChannel(String&& l
     if (options.protocol.utf8().length() > 65535)
         return Exception { ExceptionCode::TypeError, "protocol is too long"_s };
 
-    if (!options.negotiated || !options.negotiated.value())
+    if (!options.negotiated)
         options.id = { };
     else if (!options.id)
         return Exception { ExceptionCode::TypeError, "negotiated is true but id is null or undefined"_s };

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.idl
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.idl
@@ -39,7 +39,6 @@ typedef RTCRtpTransceiverDirection RtpTransceiverDirection;
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCDataChannelInit {
     boolean ordered = true;
     [EnforceRange] unsigned short maxPacketLifeTime;

--- a/Source/WebCore/Modules/mediastream/RTCRtpCodec.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpCodec.idl
@@ -29,7 +29,6 @@
     EnabledBySetting=PeerConnectionEnabled,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCRtpCodec {
     required DOMString mimeType;
     required unsigned long clockRate;

--- a/Source/WebCore/Modules/mediastream/RTCRtpCodecParameters.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpCodecParameters.idl
@@ -29,7 +29,6 @@
     EnabledBySetting=PeerConnectionEnabled,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCRtpCodecParameters : RTCRtpCodec {
     required unsigned short payloadType;
 };

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
@@ -55,16 +55,13 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(GStreamerDataChannelHandler);
 
 GUniquePtr<GstStructure> GStreamerDataChannelHandler::fromRTCDataChannelInit(const RTCDataChannelInit& options)
 {
-    GUniquePtr<GstStructure> init(gst_structure_new("options", "protocol", G_TYPE_STRING, options.protocol.utf8().data(), nullptr));
+    GUniquePtr<GstStructure> init(gst_structure_new("options", "protocol", G_TYPE_STRING, options.protocol.utf8().data(),
+        "ordered", G_TYPE_BOOLEAN, options.ordered, "negotiated", G_TYPE_BOOLEAN, options.negotiated, nullptr));
 
-    if (options.ordered)
-        gst_structure_set(init.get(), "ordered", G_TYPE_BOOLEAN, *options.ordered, nullptr);
     if (options.maxPacketLifeTime)
         gst_structure_set(init.get(), "max-packet-lifetime", G_TYPE_INT, *options.maxPacketLifeTime, nullptr);
     if (options.maxRetransmits)
         gst_structure_set(init.get(), "max-retransmits", G_TYPE_INT, *options.maxRetransmits, nullptr);
-    if (options.negotiated)
-        gst_structure_set(init.get(), "negotiated", G_TYPE_BOOLEAN, *options.negotiated, nullptr);
     if (options.id)
         gst_structure_set(init.get(), "id", G_TYPE_INT, *options.id, nullptr);
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp
@@ -48,15 +48,13 @@ inline std::span<const T> span(const webrtc::DataBuffer& buffer)
 webrtc::DataChannelInit LibWebRTCDataChannelHandler::fromRTCDataChannelInit(const RTCDataChannelInit& options)
 {
     webrtc::DataChannelInit init;
-    if (options.ordered)
-        init.ordered = *options.ordered;
+    init.ordered = options.ordered;
     if (options.maxPacketLifeTime)
         init.maxRetransmitTime = *options.maxPacketLifeTime;
     if (options.maxRetransmits)
         init.maxRetransmits = *options.maxRetransmits;
     init.protocol = options.protocol.utf8().data();
-    if (options.negotiated)
-        init.negotiated = *options.negotiated;
+    init.negotiated = options.negotiated;
     if (options.id)
         init.id = *options.id;
     init.priority = webrtc::PriorityValue(fromRTCPriorityType(options.priority));

--- a/Source/WebCore/platform/mediastream/RTCDataChannelHandler.h
+++ b/Source/WebCore/platform/mediastream/RTCDataChannelHandler.h
@@ -34,11 +34,11 @@
 namespace WebCore {
 
 struct RTCDataChannelInit {
-    std::optional<bool> ordered;
+    bool ordered;
     std::optional<unsigned short> maxPacketLifeTime;
     std::optional<unsigned short> maxRetransmits;
     String protocol;
-    std::optional<bool> negotiated;
+    bool negotiated;
     std::optional<unsigned short> id;
     RTCPriorityType priority { RTCPriorityType::Low };
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5494,11 +5494,11 @@ struct WebCore::PlatformVideoTrackConfiguration : WebCore::PlatformTrackConfigur
 
 header: <WebCore/RTCDataChannelHandler.h>
 [CustomHeader] struct WebCore::RTCDataChannelInit {
-    std::optional<bool> ordered;
+    bool ordered;
     std::optional<unsigned short> maxPacketLifeTime;
     std::optional<unsigned short> maxRetransmits;
     String protocol;
-    std::optional<bool> negotiated;
+    bool negotiated;
     std::optional<unsigned short> id;
     WebCore::RTCPriorityType priority;
 };


### PR DESCRIPTION
#### 6959e3349f2443d6ade722b0672189a92080a624
<pre>
Remove LegacyNativeDictionaryRequiredInterfaceNullability from RTC code
<a href="https://bugs.webkit.org/show_bug.cgi?id=312011">https://bugs.webkit.org/show_bug.cgi?id=312011</a>

Reviewed by Philippe Normand.

Refactor to get rid of the legacy code path.

Canonical link: <a href="https://commits.webkit.org/310993@main">https://commits.webkit.org/310993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd752c922dc73e76cb97c75e8bb9e644d1f623fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155718 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164479 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157589 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28826 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120524 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22702 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139828 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101213 "Passed tests") | | ⏳ 🛠 vision-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/155036 "Build is in progress. Recent messages:") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12309 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131457 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17660 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166960 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/11134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19271 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128643 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28520 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23960 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128775 "Found 1 new API test failure: WebKitGTK/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/ephemeral (failure)") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28444 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139453 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86274 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23715 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23592 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16250 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28138 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92241 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27715 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27945 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27788 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->