### PR TITLE
Validate transferable states after serialization per spec

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transferrable-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transferrable-expected.txt
@@ -1,9 +1,7 @@
 
 PASS Test that offscreenCanvas's size is correct after being transferred to a worker.
 PASS Test that transfer an OffscreenCanvas that already have a 2d context throws exception.
-FAIL Test that transfer an OffscreenCanvas twice throws exception. assert_throws_dom: function "function() {
-        worker.postMessage({offscreenCanvas}, [offscreenCanvas]);
-    }" threw object "InvalidStateError: The object is in an invalid state." that is not a DOMException DataCloneError: property "code" is equal to 11, expected 25
+PASS Test that transfer an OffscreenCanvas twice throws exception.
 PASS Test that calling getContext('2d') on a detached OffscreenCanvas throws exception.
 PASS Test that calling getContext('webgl') on a detached OffscreenCanvas throws exception.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-errors.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-errors.window-expected.txt
@@ -2,18 +2,18 @@
 PASS Cannot transfer all objects
 PASS Cannot transfer the same ArrayBuffer twice
 PASS Serialize should make the ArrayBuffer detached, so it cannot be transferred again
-FAIL Serialize should throw before a detached ArrayBuffer is found assert_throws_exactly: function "() => self.postMessage({ get whatever() { throw customError } }, "*", [transferable])" threw object "DataCloneError: The object can not be cloned." but we expected it to throw object "Error: hi"
-FAIL Cannot transfer ArrayBuffer detached while the message was serialized assert_throws_dom: function "() => self.postMessage(message, "*", [transferable])" threw object "TypeError: Type error" that is not a DOMException DataCloneError: property "code" is equal to undefined, expected 25
+PASS Serialize should throw before a detached ArrayBuffer is found
+PASS Cannot transfer ArrayBuffer detached while the message was serialized
 PASS Cannot transfer the same MessagePort twice
 PASS Serialize should make the MessagePort detached, so it cannot be transferred again
 PASS Serialize should throw before a detached MessagePort is found
 PASS Cannot transfer MessagePort detached while the message was serialized
 PASS Cannot transfer the same ImageBitmap twice
 PASS Serialize should make the ImageBitmap detached, so it cannot be transferred again
-FAIL Serialize should throw before a detached ImageBitmap is found assert_throws_exactly: function "() => self.postMessage({ get whatever() { throw customError } }, "*", [transferable])" threw object "DataCloneError: The object can not be cloned." but we expected it to throw object "Error: hi"
-FAIL Cannot transfer ImageBitmap detached while the message was serialized assert_throws_dom: function "() => self.postMessage(message, "*", [transferable])" did not throw
+PASS Serialize should throw before a detached ImageBitmap is found
+PASS Cannot transfer ImageBitmap detached while the message was serialized
 PASS Cannot transfer the same OffscreenCanvas twice
-FAIL Serialize should make the OffscreenCanvas detached, so it cannot be transferred again assert_throws_dom: function "() => self.postMessage(null, "*", [transferable])" threw object "InvalidStateError: The object is in an invalid state." that is not a DOMException DataCloneError: property "code" is equal to 11, expected 25
-FAIL Serialize should throw before a detached OffscreenCanvas is found assert_throws_exactly: function "() => self.postMessage({ get whatever() { throw customError } }, "*", [transferable])" threw object "InvalidStateError: The object is in an invalid state." but we expected it to throw object "Error: hi"
-FAIL Cannot transfer OffscreenCanvas detached while the message was serialized assert_throws_dom: function "() => self.postMessage(message, "*", [transferable])" did not throw
+PASS Serialize should make the OffscreenCanvas detached, so it cannot be transferred again
+PASS Serialize should throw before a detached OffscreenCanvas is found
+PASS Cannot transfer OffscreenCanvas detached while the message was serialized
 

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -2170,7 +2170,7 @@ private:
             }
             if (RefPtr arrayBuffer = toPossiblySharedArrayBuffer(vm, obj)) {
                 if (arrayBuffer->isDetached()) {
-                    code = SerializationReturnCode::ValidationError;
+                    code = SerializationReturnCode::DataCloneError;
                     return true;
                 }
                 auto index = m_transferredArrayBuffers.find(obj);
@@ -6473,20 +6473,6 @@ static bool containsDuplicates(const Vector<Ref<ImageBitmap>>& imageBitmaps)
     return false;
 }
 
-#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
-static bool canOffscreenCanvasesDetach(const Vector<Ref<OffscreenCanvas>>& offscreenCanvases)
-{
-    HashSet<Ref<OffscreenCanvas>> visited;
-    for (auto& offscreenCanvas : offscreenCanvases) {
-        if (!offscreenCanvas->canDetach())
-            return false;
-        // Check the return value of add, we should not encounter duplicates.
-        if (!visited.add(offscreenCanvas.get()))
-            return false;
-    }
-    return true;
-}
-#endif
 
 #if ENABLE(WEB_RTC)
 static bool canDetachRTCDataChannels(const Vector<Ref<RTCDataChannel>>& channels)
@@ -6605,46 +6591,31 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
     Vector<Ref<MediaStreamTrackHandle>> transferredMediaStreamTrackHandles;
 #endif
 
+    // Step 1: Check for duplicates and classify transferables into their types.
+    // Per spec, detached/validity checks happen AFTER serialization of the message value.
     HashSet<JSC::Strong<JSC::JSObject>> visited;
     for (auto& transferable : transferList) {
         if (!visited.add(JSC::Strong<JSC::JSObject> { vm, transferable.get() }).isNewEntry)
             return Exception { ExceptionCode::DataCloneError, "Duplicate transferable for structured clone"_s };
 
         if (RefPtr arrayBuffer = toPossiblySharedArrayBuffer(vm, transferable.get())) {
-            if (arrayBuffer->isDetached() || arrayBuffer->isShared())
-                return Exception { ExceptionCode::DataCloneError };
-            if (!arrayBuffer->isDetachable()) {
-                auto scope = DECLARE_THROW_SCOPE(vm);
-                throwVMTypeError(&lexicalGlobalObject, scope, errorMessageForTransfer(arrayBuffer.get()));
-                return Exception { ExceptionCode::ExistingExceptionError };
-            }
             arrayBuffers.append(arrayBuffer.releaseNonNull());
             continue;
         }
         if (RefPtr port = JSMessagePort::toWrapped(vm, transferable.get())) {
-            if (port->isDetached())
-                return Exception { ExceptionCode::DataCloneError, "MessagePort is detached"_s };
             messagePorts.append(port.releaseNonNull());
             continue;
         }
-
         if (RefPtr imageBitmap = JSImageBitmap::toWrapped(vm, transferable.get())) {
-            if (imageBitmap->isDetached())
-                return Exception { ExceptionCode::DataCloneError };
-            if (!imageBitmap->originClean())
-                return Exception { ExceptionCode::DataCloneError };
-
             imageBitmaps.append(imageBitmap.releaseNonNull());
             continue;
         }
-
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
         if (RefPtr offscreenCanvas = JSOffscreenCanvas::toWrapped(vm, transferable.get())) {
             offscreenCanvases.append(offscreenCanvas.releaseNonNull());
             continue;
         }
 #endif
-
 #if ENABLE(WEB_RTC)
         if (RefPtr channel = JSRTCDataChannel::toWrapped(vm, transferable.get())) {
             dataChannels.append(channel.releaseNonNull());
@@ -6665,76 +6636,32 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
         }
 #if ENABLE(MEDIA_SOURCE_IN_WORKERS)
         if (RefPtr handle = JSMediaSourceHandle::toWrapped(vm, transferable.get())) {
-            if (handle->isDetached())
-                return Exception { ExceptionCode::DataCloneError };
             mediaSourceHandles.append(handle.releaseNonNull());
             continue;
         }
 #endif
-
 #if ENABLE(WEB_CODECS)
         if (RefPtr videoFrame = JSWebCodecsVideoFrame::toWrapped(vm, transferable.get())) {
-            if (videoFrame->isDetached())
-                return Exception { ExceptionCode::DataCloneError };
             transferredVideoFrames.append(videoFrame.releaseNonNull());
             continue;
         }
         if (RefPtr audioData = JSWebCodecsAudioData::toWrapped(vm, transferable.get())) {
-            if (audioData->isDetached())
-                return Exception { ExceptionCode::DataCloneError };
             transferredAudioData.append(audioData.releaseNonNull());
             continue;
         }
 #endif
-
 #if ENABLE(MEDIA_STREAM)
         if (RefPtr track = JSMediaStreamTrack::toWrapped(vm, transferable.get())) {
-            if (track->isDetached())
-                return Exception { ExceptionCode::DataCloneError };
             transferredMediaStreamTracks.append(track.releaseNonNull());
             continue;
         }
         if (RefPtr handle = JSMediaStreamTrackHandle::toWrapped(vm, transferable.get())) {
-            if (handle->isDetached())
-                return Exception { ExceptionCode::DataCloneError };
             transferredMediaStreamTrackHandles.append(handle.releaseNonNull());
             continue;
         }
 #endif
-
         return Exception { ExceptionCode::DataCloneError };
     }
-
-    if (containsDuplicates(imageBitmaps))
-        return Exception { ExceptionCode::DataCloneError };
-#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
-    if (!canOffscreenCanvasesDetach(offscreenCanvases))
-        return Exception { ExceptionCode::InvalidStateError };
-#endif
-#if ENABLE(WEB_RTC)
-    if (!canDetachRTCDataChannels(dataChannels))
-        return Exception { ExceptionCode::DataCloneError };
-#endif
-    auto readableStreamSet = canTransfer<ReadableStream>(readableStreams);
-    if (!readableStreamSet)
-        return Exception { ExceptionCode::DataCloneError };
-    auto writableStreamSet = canTransfer<WritableStream>(writableStreams);
-    if (!writableStreamSet)
-        return Exception { ExceptionCode::DataCloneError };
-    if (!canTransfer<TransformStream>(transformStreams))
-        return Exception { ExceptionCode::DataCloneError };
-    if (!validateStreams(*readableStreamSet, *writableStreamSet, transformStreams))
-        return Exception { ExceptionCode::DataCloneError };
-#if ENABLE(MEDIA_SOURCE_IN_WORKERS)
-    if (!canDetachMediaSourceHandles(mediaSourceHandles))
-        return Exception { ExceptionCode::DataCloneError };
-#endif
-#if ENABLE(MEDIA_STREAM)
-    if (!canDetachMediaStreamTracks(transferredMediaStreamTracks))
-        return Exception { ExceptionCode::DataCloneError };
-    if (!canDetachMediaStreamTrackHandles(transferredMediaStreamTrackHandles))
-        return Exception { ExceptionCode::DataCloneError };
-#endif
 
     Vector<uint8_t> buffer;
     Vector<URLKeepingBlobAlive> blobHandles;
@@ -6805,6 +6732,72 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
     // other than success, we should exit right now.
     if (code != SerializationReturnCode::SuccessfullyCompleted)
         return exceptionForSerializationFailure(code);
+
+    // Step 2: Now that serialization is done, validate transferable states.
+    // Per spec, detached/validity checks happen after serialization of the message value,
+    // because serialization may run getters that throw or modify transferables.
+    for (auto& arrayBuffer : arrayBuffers) {
+        if (arrayBuffer->isDetached() || arrayBuffer->isShared())
+            return Exception { ExceptionCode::DataCloneError };
+        if (!arrayBuffer->isDetachable()) {
+            throwVMTypeError(&lexicalGlobalObject, scope, errorMessageForTransfer(arrayBuffer.ptr()));
+            return Exception { ExceptionCode::ExistingExceptionError };
+        }
+    }
+    for (size_t i = 0; i < exposedMessagePortsCount; ++i) {
+        if (messagePorts[i]->isDetached())
+            return Exception { ExceptionCode::DataCloneError, "MessagePort is detached"_s };
+    }
+    for (auto& imageBitmap : imageBitmaps) {
+        if (imageBitmap->isDetached())
+            return Exception { ExceptionCode::DataCloneError };
+        if (!imageBitmap->originClean())
+            return Exception { ExceptionCode::DataCloneError };
+    }
+    if (containsDuplicates(imageBitmaps))
+        return Exception { ExceptionCode::DataCloneError };
+#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
+    for (auto& offscreenCanvas : offscreenCanvases) {
+        if (offscreenCanvas->renderingContext())
+            return Exception { ExceptionCode::InvalidStateError };
+        if (offscreenCanvas->isDetached())
+            return Exception { ExceptionCode::DataCloneError };
+    }
+#endif
+#if ENABLE(WEB_RTC)
+    if (!canDetachRTCDataChannels(dataChannels))
+        return Exception { ExceptionCode::DataCloneError };
+#endif
+    auto readableStreamSet = canTransfer<ReadableStream>(readableStreams);
+    if (!readableStreamSet)
+        return Exception { ExceptionCode::DataCloneError };
+    auto writableStreamSet = canTransfer<WritableStream>(writableStreams);
+    if (!writableStreamSet)
+        return Exception { ExceptionCode::DataCloneError };
+    if (!canTransfer<TransformStream>(transformStreams))
+        return Exception { ExceptionCode::DataCloneError };
+    if (!validateStreams(*readableStreamSet, *writableStreamSet, transformStreams))
+        return Exception { ExceptionCode::DataCloneError };
+#if ENABLE(MEDIA_SOURCE_IN_WORKERS)
+    if (!canDetachMediaSourceHandles(mediaSourceHandles))
+        return Exception { ExceptionCode::DataCloneError };
+#endif
+#if ENABLE(WEB_CODECS)
+    for (auto& videoFrame : transferredVideoFrames) {
+        if (videoFrame->isDetached())
+            return Exception { ExceptionCode::DataCloneError };
+    }
+    for (auto& audioData : transferredAudioData) {
+        if (audioData->isDetached())
+            return Exception { ExceptionCode::DataCloneError };
+    }
+#endif
+#if ENABLE(MEDIA_STREAM)
+    if (!canDetachMediaStreamTracks(transferredMediaStreamTracks))
+        return Exception { ExceptionCode::DataCloneError };
+    if (!canDetachMediaStreamTrackHandles(transferredMediaStreamTrackHandles))
+        return Exception { ExceptionCode::DataCloneError };
+#endif
 
     auto arrayBufferContentsArray = transferArrayBuffers(vm, arrayBuffers);
     if (arrayBufferContentsArray.hasException())


### PR DESCRIPTION
#### dcd0fbf65ddb16d537c4e9563769b3a30cd644e8
<pre>
Validate transferable states after serialization per spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=312014">https://bugs.webkit.org/show_bug.cgi?id=312014</a>

Reviewed by Anne van Kesteren.

The structured clone spec (StructuredSerializeWithTransfer) requires that
the message value is serialized before checking whether transferables are
detached or invalid. WebKit was doing these checks in the wrong order:
validating transferable states first, then serializing. This caused
incorrect exceptions when message serialization would throw (e.g., via
a getter) or modify transferable state during serialization.

Three changes:
  1. In SerializedScriptValue::create, split the transfer list processing
     into two phases: classify transferables by type and check for duplicates
     before serialization, then validate detached/validity states after.
  2. In CloneSerializer::dumpIfTerminal, report DataCloneError instead of
     ValidationError when encountering a detached ArrayBuffer, matching the
     spec requirement.
  3. For OffscreenCanvas, distinguish between having a rendering context
     (throws InvalidStateError per spec) and being already detached (throws
     DataCloneError). Previously canOffscreenCanvasesDetach() lumped both
     cases together under a single error code.

No new tests, rebaselined existing tests.

* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transferrable-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/transfer-errors.window-expected.txt:
Chrome and Firefox were already passing those tests.

* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpIfTerminal):
(WebCore::SerializedScriptValue::create):

Canonical link: <a href="https://commits.webkit.org/310996@main">https://commits.webkit.org/310996@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc47f9b88d38bbf0bf435c764c3c6901d4750814

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164491 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4a6efe80-baac-4d95-b703-028381376e3e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157601 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28838 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120534 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fecaa473-931e-42e8-8d67-7d0ab927ff58) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158687 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22714 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139842 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101223 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cec6acba-14f2-45ea-be5f-d20640f493ae) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12321 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131469 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166972 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11146 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19285 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128653 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23974 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128785 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34895 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139467 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86286 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23605 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16264 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28150 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92253 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27727 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27957 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27800 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->