### PR TITLE
Structured clone of SharedArrayBuffer should throw DataCloneError outside of postMessage

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any-expected.txt
@@ -4,6 +4,6 @@ FAIL SharedArrayBuffer constructor does not exist without COOP+COEP assert_equal
 }"
 FAIL SharedArrayBuffer over MessageChannel without COOP+COEP assert_throws_dom: function "() => channel.port1.postMessage(sab)" did not throw
 FAIL SharedArrayBuffer over BroadcastChannel without COOP+COEP assert_throws_dom: function "() => channel.postMessage(sab)" did not throw
-FAIL SharedArrayBuffer over postMessage() without COOP+COEP assert_throws_dom: function "() => self.postMessage(sab)" did not throw
+PASS SharedArrayBuffer over postMessage() without COOP+COEP
 PASS Bonus: self.crossOriginIsolated
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/serialization-via-notifications-api.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/serialization-via-notifications-api.any-expected.txt
@@ -1,14 +1,4 @@
 
-FAIL SharedArrayBuffer cloning via the Notifications API's data member: basic case assert_throws_dom: function "() => {
-    // See https://github.com/whatwg/html/issues/5380 for why not `new SharedArrayBuffer()`
-    const sab = new WebAssembly.Memory({ shared:true, initial:1, maximum:1 }).buffer;
-    new Notification("Bob: Hi", { data: sab });
-  }" did not throw
-FAIL SharedArrayBuffer cloning via the Notifications API's data member: is interleaved correctly assert_throws_dom: function "() => {
-    new Notification("Bob: Hi", { data: [
-      { get x() { getter1Called = true; return 5; } },
-      sab,
-      { get x() { getter2Called = true; return 5; } }
-    ]});
-  }" did not throw
+PASS SharedArrayBuffer cloning via the Notifications API's data member: basic case
+PASS SharedArrayBuffer cloning via the Notifications API's data member: is interleaved correctly
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/serialization-via-notifications-api.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/serialization-via-notifications-api.any.worker-expected.txt
@@ -1,14 +1,4 @@
 
-FAIL SharedArrayBuffer cloning via the Notifications API's data member: basic case assert_throws_dom: function "() => {
-    // See https://github.com/whatwg/html/issues/5380 for why not `new SharedArrayBuffer()`
-    const sab = new WebAssembly.Memory({ shared:true, initial:1, maximum:1 }).buffer;
-    new Notification("Bob: Hi", { data: sab });
-  }" did not throw
-FAIL SharedArrayBuffer cloning via the Notifications API's data member: is interleaved correctly assert_throws_dom: function "() => {
-    new Notification("Bob: Hi", { data: [
-      { get x() { getter1Called = true; return 5; } },
-      sab,
-      { get x() { getter2Called = true; return 5; } }
-    ]});
-  }" did not throw
+PASS SharedArrayBuffer cloning via the Notifications API's data member: basic case
+PASS SharedArrayBuffer cloning via the Notifications API's data member: is interleaved correctly
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window-expected.txt
@@ -132,7 +132,7 @@ PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
 PASS Resizable ArrayBuffer
-FAIL Growable SharedArrayBuffer assert_true: instanceof ArrayBuffer expected true got false
+PASS Growable SharedArrayBuffer
 PASS Length-tracking TypedArray
 PASS Length-tracking DataView
 PASS Serializing OOB TypedArray throws

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any-expected.txt
@@ -132,7 +132,7 @@ PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
 PASS Resizable ArrayBuffer
-FAIL Growable SharedArrayBuffer assert_true: instanceof ArrayBuffer expected true got false
+PASS Growable SharedArrayBuffer
 PASS Length-tracking TypedArray
 PASS Length-tracking DataView
 PASS Serializing OOB TypedArray throws

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.worker-expected.txt
@@ -117,7 +117,7 @@ PASS Serializing a non-serializable platform object fails
 PASS An object whose interface is deleted from the global must still deserialize
 PASS A subclass instance will deserialize as its closest serializable superclass
 PASS Resizable ArrayBuffer
-FAIL Growable SharedArrayBuffer assert_true: instanceof ArrayBuffer expected true got false
+PASS Growable SharedArrayBuffer
 PASS Length-tracking TypedArray
 PASS Length-tracking DataView
 PASS Serializing OOB TypedArray throws

--- a/LayoutTests/js/structuredClone/structured-clone-of-ResizableSharedArrayBuffer.html
+++ b/LayoutTests/js/structuredClone/structured-clone-of-ResizableSharedArrayBuffer.html
@@ -61,7 +61,7 @@
     globalThis.testRunner?.dumpAsText();
 
     main().catch(e => {
-        console.log(e);
+        alert(e instanceof DOMException && e.name === 'DataCloneError' ? 'PASS' : 'FAIL: ' + e);
     }).finally(async () => {
         globalThis.testRunner?.notifyDone();
     });

--- a/LayoutTests/workers/sab/postMessage-clones-growable-expected.txt
+++ b/LayoutTests/workers/sab/postMessage-clones-growable-expected.txt
@@ -1,18 +1,9 @@
-Checks that window.postMessage clones growable SharedArrayBuffers
+Checks that window.postMessage throws DataCloneError for growable SharedArrayBuffers
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS memory[0] is 42
-PASS otherMemory[0] is 0
-PASS memory[0] is 42
-PASS otherMemory[0] is 43
-PASS memory.length is 1
-PASS otherMemory.length is 1
-PASS memory.length is 256
-PASS otherMemory.length is 1
-PASS memory.length is 256
-PASS otherMemory.length is 256
+PASS window.postMessage(memory, '*') threw exception DataCloneError: The object can not be cloned..
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/workers/sab/postMessage-clones-growable.html
+++ b/LayoutTests/workers/sab/postMessage-clones-growable.html
@@ -5,34 +5,12 @@
 </head>
 <body>
 <script>
-description("Checks that window.postMessage clones growable SharedArrayBuffers");
-
-jsTestIsAsync = true;
+description("Checks that window.postMessage throws DataCloneError for growable SharedArrayBuffers");
 
 var sab = new SharedArrayBuffer(4, { maxByteLength: 1024 });
 var memory = new Int32Array(sab);
-var otherMemory;
 
-window.addEventListener("message", function (event) {
-    otherMemory = event.data;
-    memory[0] = 42;
-    shouldBe("memory[0]", "42");
-    shouldBe("otherMemory[0]", "0");
-    otherMemory[0] = 43;
-    shouldBe("memory[0]", "42");
-    shouldBe("otherMemory[0]", "43");
-    shouldBe("memory.length", "1");
-    shouldBe("otherMemory.length", "1");
-    sab.grow(1024);
-    shouldBe("memory.length", "256");
-    shouldBe("otherMemory.length", "1");
-    otherMemory.buffer.resize(1024); // Cloning it as resizable ArrayBuffer.
-    shouldBe("memory.length", "256");
-    shouldBe("otherMemory.length", "256");
-    finishJSTest();
-});
-
-window.postMessage(memory, "*");
+shouldThrow("window.postMessage(memory, '*')", "'DataCloneError: The object can not be cloned.'");
 </script>
 </body>
 </html>

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -29,6 +29,7 @@
 
 #include "BlobRegistry.h"
 #include "ByteArrayPixelBuffer.h"
+#include "CrossOriginMode.h"
 #include "CryptoKeyAES.h"
 #include "CryptoKeyEC.h"
 #include "CryptoKeyHMAC.h"
@@ -2182,21 +2183,27 @@ private:
                 if (!addToObjectPoolIfNotDupe<ArrayBufferTag, ResizableArrayBufferTag, SharedArrayBufferTag>(obj))
                     return true;
                 
-                if (arrayBuffer->isShared() && (m_context == SerializationContext::WorkerPostMessage || m_forStorage == SerializationForStorage::Yes)) {
+                if (arrayBuffer->isShared()) {
                     // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
-                    if (!JSC::Options::useSharedArrayBuffer() || m_forStorage == SerializationForStorage::Yes) {
+                    if (m_context == SerializationContext::WorkerPostMessage) {
+                        if (!JSC::Options::useSharedArrayBuffer() || m_forStorage == SerializationForStorage::Yes) {
+                            code = SerializationReturnCode::DataCloneError;
+                            return true;
+                        }
+                        uint32_t index = m_sharedBuffers.size();
+                        ArrayBufferContents contents;
+                        if (arrayBuffer->shareWith(contents)) {
+                            appendObjectPoolTag(SharedArrayBufferTag);
+                            write(SharedArrayBufferTag);
+                            m_sharedBuffers.append(WTF::move(contents));
+                            write(index);
+                            return true;
+                        }
+                    } else if (m_context != SerializationContext::WindowPostMessage || ScriptExecutionContext::crossOriginMode() != CrossOriginMode::Isolated) {
                         code = SerializationReturnCode::DataCloneError;
                         return true;
                     }
-                    uint32_t index = m_sharedBuffers.size();
-                    ArrayBufferContents contents;
-                    if (arrayBuffer->shareWith(contents)) {
-                        appendObjectPoolTag(SharedArrayBufferTag);
-                        write(SharedArrayBufferTag);
-                        m_sharedBuffers.append(WTF::move(contents));
-                        write(index);
-                        return true;
-                    }
+                    // WindowPostMessage in a cross-origin isolated context: fall through to serialize as a non-shared copy.
                 }
                 
                 if (arrayBuffer->isResizableOrGrowableShared()) {

--- a/Source/WebCore/page/WindowOrWorkerGlobalScope.cpp
+++ b/Source/WebCore/page/WindowOrWorkerGlobalScope.cpp
@@ -79,7 +79,7 @@ void WindowOrWorkerGlobalScope::reportError(JSDOMGlobalObject& globalObject, JSC
 ExceptionOr<JSC::JSValue> WindowOrWorkerGlobalScope::structuredClone(JSDOMGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& relevantGlobalObject, JSC::JSValue value, StructuredSerializeOptions&& options)
 {
     Vector<Ref<MessagePort>> ports;
-    auto messageData = SerializedScriptValue::create(lexicalGlobalObject, value, WTF::move(options.transfer), ports, SerializationForStorage::No, SerializationContext::WindowPostMessage);
+    auto messageData = SerializedScriptValue::create(lexicalGlobalObject, value, WTF::move(options.transfer), ports, SerializationForStorage::No, SerializationContext::Default);
     if (messageData.hasException())
         return messageData.releaseException();
 


### PR DESCRIPTION
#### f4a29be205df24dc1ba1c11a9d1f41f52b06c063
<pre>
Structured clone of SharedArrayBuffer should throw DataCloneError outside of postMessage
<a href="https://bugs.webkit.org/show_bug.cgi?id=312016">https://bugs.webkit.org/show_bug.cgi?id=312016</a>

Reviewed by Anne van Kesteren.

Per <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal</a>,
serializing a SharedArrayBuffer should throw DataCloneError unless the
agent cluster supports sharing (i.e. cross-origin isolated).

Previously, the structured serialization of SharedArrayBuffer only checked
for shared buffers in WorkerPostMessage context. In other contexts
(window.postMessage, structuredClone), a shared buffer would fall through
to the ResizableArrayBufferTag or ArrayBufferTag paths, silently copying
the data as a non-shared ArrayBuffer instead of throwing DataCloneError.

Additionally, WindowOrWorkerGlobalScope::structuredClone() was incorrectly
using SerializationContext::WindowPostMessage instead of
SerializationContext::Default. This meant the structuredClone() API was
treated as a postMessage operation, allowing SharedArrayBuffer to bypass
the DataCloneError check.

The serialization logic now handles SharedArrayBuffer as follows:
- WorkerPostMessage: serialize as shared (unchanged).
- WindowPostMessage without cross-origin isolation: throw DataCloneError.
- WindowPostMessage with cross-origin isolation: fall through to serialize
  as a non-shared copy (preserves existing behavior since the shared buffer
  transport is not yet supported for window.postMessage).
- Default / structuredClone: throw DataCloneError.

No new tests, updated and rebaselined existing tests.

* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/serialization-via-notifications-api.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/serialization-via-notifications-api.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.worker-expected.txt:
Updated expected results: FAIL -&gt; PASS. Aligns our behavior with Chrome
and Firefox.

* LayoutTests/js/structuredClone/structured-clone-of-ResizableSharedArrayBuffer.html:
* LayoutTests/workers/sab/postMessage-clones-growable-expected.txt:
* LayoutTests/workers/sab/postMessage-clones-growable.html:
Updated to expect DataCloneError instead of a successful clone.

* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpIfTerminal):
Restructured the SharedArrayBuffer serialization logic. WorkerPostMessage
serializes as shared. WindowPostMessage throws DataCloneError unless
cross-origin isolated (in which case it falls through to copy as non-shared).
All other contexts (Default, CloneAcrossWorlds) throw DataCloneError.

* Source/WebCore/page/WindowOrWorkerGlobalScope.cpp:
(WebCore::WindowOrWorkerGlobalScope::structuredClone):
Changed from SerializationContext::WindowPostMessage to
SerializationContext::Default, since structuredClone() is not a postMessage
operation and should not allow SharedArrayBuffer serialization.

Canonical link: <a href="https://commits.webkit.org/310998@main">https://commits.webkit.org/310998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/360473edb6ce1702980279f4afefe2f1ef8ba088

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164495 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157605 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120540 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158691 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22720 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101229 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21806 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19943 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12325 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147782 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131475 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166976 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16564 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11150 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19288 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128658 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28536 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23977 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128790 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34896 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28460 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139470 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86292 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23608 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16267 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187617 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28154 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92257 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48226 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27731 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27961 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27804 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->