### PR TITLE
window.open() should consume user activation when creating a new browsing context

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/consume-user-activation/window-open-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/consume-user-activation/window-open-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Opening a new window should consume user activation
+PASS Opening an existing window should not consume user activation
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/consume-user-activation/window-open.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/consume-user-activation/window-open.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<title>window.open() and consuming user activation</title>
+<link rel="help" href="https://html.spec.whatwg.org/#the-rules-for-choosing-a-navigable">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script>
+'use strict';
+
+promise_test(async function(t) {
+  await test_driver.bless("user activation");
+  const testWin = window.open("/resources/blank.html", "_blank");
+  t.add_cleanup(() => {
+    testWin.close();
+  });
+  assert_false(navigator.userActivation.isActive, "User activation should be consumed");
+}, "Opening a new window should consume user activation");
+
+promise_test(async function(t) {
+  await test_driver.bless("user activation");
+  const testWin = window.open("/resources/blank.html", "testWindow");
+  assert_false(navigator.userActivation.isActive, "User activation should be consumed");
+  t.add_cleanup(() => {
+    testWin.close();
+  });
+
+  // Open the existing window again
+  await test_driver.bless("user activation");
+  const testWin2 = window.open("/resources/blank.html", "testWindow");
+  assert_true(navigator.userActivation.isActive, "User activation should not be consumed");
+}, "Opening an existing window should not consume user activation");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/consumption-sameorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/consumption-sameorigin-expected.txt
@@ -10,8 +10,8 @@ PASS Child1 frame initial state
 PASS Child2 frame initial state
 PASS Grandchild frame initial state
 PASS Parent frame initial state
-FAIL Child2 frame final state assert_false: expected false got true
-FAIL Child1 frame final state assert_false: expected false got true
-FAIL Grand child frame final state assert_false: expected false got true
-FAIL Parent frame final state assert_false: expected false got true
+PASS Child2 frame final state
+PASS Child1 frame final state
+PASS Grand child frame final state
+PASS Parent frame final state
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -5549,6 +5549,7 @@ webkit.org/b/141436 fast/loader/subframe-navigate-during-main-frame-load.html [ 
 # FIXME: Broken tests that use window.open (do not timeout on WK1)
 http/tests/cache/history-navigation-no-resource-revalidation.html [ Skip ]
 http/tests/navigation/target-blank-opener-post.html [ Skip ]
+imported/w3c/web-platform-tests/html/browsers/windows/consume-user-activation/window-open.html [ Skip ]
 
 # Unskip otherwise globally-skipped test
 css2.1/20110323/replaced-intrinsic-002.htm [ Pass ]

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2861,6 +2861,11 @@ ExceptionOr<RefPtr<Frame>> LocalDOMWindow::createWindow(const String& urlString,
     if (!newFrame)
         return RefPtr<Frame> { nullptr };
 
+    // https://html.spec.whatwg.org/#the-rules-for-choosing-a-navigable
+    // Consume user activation when a new browsing context is created.
+    if (created == CreatedNewPage::Yes)
+        activeWindow.consumeTransientActivation();
+
     if (!noopener) {
         ASSERT(!newFrame->opener() || newFrame->opener() == &openerFrame);
         if (auto* page = newFrame->page())


### PR DESCRIPTION
#### edd693e4bb6fd680b9a0f7bcf5b5bca14c190038
<pre>
window.open() should consume user activation when creating a new browsing context
<a href="https://bugs.webkit.org/show_bug.cgi?id=312035">https://bugs.webkit.org/show_bug.cgi?id=312035</a>

Reviewed by Darin Adler.

Per the HTML spec &quot;the rules for choosing a navigable&quot;, opening a new window via
window.open() should consume user activation. Opening an existing named window
should not. WebKit was not consuming activation in either case.

Test: imported/w3c/web-platform-tests/html/browsers/windows/consume-user-activation/window-open.html

* LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/consume-user-activation/window-open-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/windows/consume-user-activation/window-open.html: Added.
Pull the relevant WPT test from upstream. This test was failing in
shipping Safari but is passing in Chrome and Firefox.

* LayoutTests/imported/w3c/web-platform-tests/html/user-activation/consumption-sameorigin-expected.txt:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::createWindow):

Canonical link: <a href="https://commits.webkit.org/311026@main">https://commits.webkit.org/311026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb0e8deefb00cd8c70e4ee53e0a77273229787a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22182 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164526 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157636 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28873 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120564 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139876 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101253 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21837 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19973 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12356 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131506 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17708 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167007 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11181 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19319 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128684 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28567 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128816 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34912 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28491 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139501 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86325 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23637 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16299 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28185 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92288 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27762 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27992 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27835 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->