### PR TITLE
Remove LegacyNativeDictionaryRequiredInterfaceNullability from Payment Request API code

### DIFF
--- a/Source/WebCore/Modules/paymentrequest/PaymentCompleteDetails.idl
+++ b/Source/WebCore/Modules/paymentrequest/PaymentCompleteDetails.idl
@@ -23,9 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/payment-request/#paymentcompletedetails-dictionary
+
 [
     Conditional=PAYMENT_REQUEST,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PaymentCompleteDetails {
-    object? data;
+    object? data = null;
 };

--- a/Source/WebCore/Modules/paymentrequest/PaymentDetailsModifier.idl
+++ b/Source/WebCore/Modules/paymentrequest/PaymentDetailsModifier.idl
@@ -23,12 +23,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/payment-request/#paymentdetailsmodifier-dictionary
+
 [
     Conditional=PAYMENT_REQUEST,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PaymentDetailsModifier {
     required DOMString supportedMethods;
     PaymentItem total;
-    sequence<PaymentItem> additionalDisplayItems;
+    [ImplementationDefaultValue=[]] sequence<PaymentItem> additionalDisplayItems;
     object data;
 };

--- a/Source/WebCore/Modules/paymentrequest/PaymentDetailsUpdate.idl
+++ b/Source/WebCore/Modules/paymentrequest/PaymentDetailsUpdate.idl
@@ -23,13 +23,14 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/payment-request/#paymentdetailsupdate-dictionary
+
 [
     Conditional=PAYMENT_REQUEST,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PaymentDetailsUpdate : PaymentDetailsBase {
     DOMString error;
     PaymentItem total;
-    AddressErrors shippingAddressErrors;
-    PayerErrorFields payerErrors;
+    [ImplementationDefaultValue={}] AddressErrors shippingAddressErrors;
+    [ImplementationDefaultValue={}] PayerErrorFields payerErrors;
     object paymentMethodErrors;
 };

--- a/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.idl
+++ b/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.idl
@@ -23,6 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/payment-request/#paymentmethodchangeevent-interface
+
 [
     Conditional=PAYMENT_REQUEST,
     EnabledBySetting=PaymentRequestEnabled,
@@ -38,8 +40,7 @@
 
 [
     Conditional=PAYMENT_REQUEST,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PaymentMethodChangeEventInit : PaymentRequestUpdateEventInit {
     DOMString methodName = "";
-    object? methodDetails;
+    object? methodDetails = null;
 };

--- a/Source/WebCore/Modules/paymentrequest/PaymentValidationErrors.idl
+++ b/Source/WebCore/Modules/paymentrequest/PaymentValidationErrors.idl
@@ -23,12 +23,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/payment-request/#paymentvalidationerrors-dictionary
+
 [
     Conditional=PAYMENT_REQUEST,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PaymentValidationErrors {
-    PayerErrorFields payer;
-    AddressErrors shippingAddress;
+    [ImplementationDefaultValue={}] PayerErrorFields payer;
+    [ImplementationDefaultValue={}] AddressErrors shippingAddress;
     DOMString error;
     object paymentMethod;
 };

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -2723,6 +2723,7 @@ sub GenerateDefaultValue
             my $useAtomString = $type->extendedAttributes->{AtomString};
             return $useAtomString ? "typename Converter<${IDLType}>::ReturnType { nullAtom() }" : "typename Converter<${IDLType}>::ReturnType { String() }";
         }
+        return "typename Converter<${IDLType}>::ReturnType { }" if $type->name eq "object";
         return "typename Converter<${IDLType}>::ReturnType { std::nullopt }";
     }
 


### PR DESCRIPTION
#### 27926b837c7b4edd9daf8f9f85f1bcb07886eb03
<pre>
Remove LegacyNativeDictionaryRequiredInterfaceNullability from Payment Request API code
<a href="https://bugs.webkit.org/show_bug.cgi?id=312039">https://bugs.webkit.org/show_bug.cgi?id=312039</a>

Reviewed by Abrar Rahman Protyasha.

Refactor IDL away from the legacy code path. This required a small
binding layer fix for object? = null as that ended up in the

std::nullopt fallback path.
Canonical link: <a href="https://commits.webkit.org/311127@main">https://commits.webkit.org/311127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61d0f712ef17e00bf76b7b0fd558116d114c1da7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28997 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22156 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164500 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109553 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/03fa8bd4-1233-4edd-9031-08adcab59533) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157610 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28847 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120541 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84950 "2 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f0780951-bbd3-4dde-934a-33fa64defc8f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158696 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22725 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139850 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101230 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/742d1c96-949c-4070-a85b-3b3648cc2250) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21811 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19947 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12330 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131480 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166981 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11155 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19293 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128661 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28541 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23981 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128793 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28465 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139475 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86298 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23763 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23610 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16272 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28159 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92262 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27736 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27966 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27809 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->