### PR TITLE
Remove LegacyNativeDictionaryRequiredInterfaceNullability from WebXR code

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -844,7 +844,7 @@ void WebXRSession::requestHitTestSource(const XRHitTestOptionsInit& init, Reques
             promise.reject(exceptionOrSource.releaseException());
             return;
         }
-        Ref<WebXRHitTestSource> source =  WebXRHitTestSource::create(protectedThis, exceptionOrSource.releaseReturnValue(), *space);
+        Ref source = WebXRHitTestSource::create(protectedThis, exceptionOrSource.releaseReturnValue(), space);
         ASSERT(source->handle());
         protectedThis->m_activeHitTestSources.add(source->handle().value(), source.get());
         promise.resolve(source);

--- a/Source/WebCore/Modules/webxr/XRCubeLayerInit.idl
+++ b/Source/WebCore/Modules/webxr/XRCubeLayerInit.idl
@@ -27,7 +27,6 @@
 [
     Conditional=WEBXR_LAYERS,
     EnabledBySetting=WebXRLayersAPIEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary XRCubeLayerInit : XRLayerInit {
-    DOMPointReadOnly? orientation;
+    [ImplementationDefaultValue=null] DOMPointReadOnly? orientation;
 };

--- a/Source/WebCore/Modules/webxr/XRCylinderLayerInit.idl
+++ b/Source/WebCore/Modules/webxr/XRCylinderLayerInit.idl
@@ -27,9 +27,8 @@
 [
     Conditional=WEBXR_LAYERS,
     EnabledBySetting=WebXRLayersAPIEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary XRCylinderLayerInit : XRLayerInit {
-    WebXRRigidTransform? transform;
+    [ImplementationDefaultValue=null] WebXRRigidTransform? transform;
     float radius = 2.0;
     float centralAngle = 0.78539;
     float aspectRatio = 2.0;

--- a/Source/WebCore/Modules/webxr/XREquirectLayerInit.idl
+++ b/Source/WebCore/Modules/webxr/XREquirectLayerInit.idl
@@ -27,9 +27,8 @@
 [
     Conditional=WEBXR_LAYERS,
     EnabledBySetting=WebXRLayersAPIEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary XREquirectLayerInit : XRLayerInit {
-    WebXRRigidTransform? transform;
+    [ImplementationDefaultValue=null] WebXRRigidTransform? transform;
     float radius = 0;
     float centralHorizontalAngle = 6.28318;
     float upperVerticalAngle = 1.570795;

--- a/Source/WebCore/Modules/webxr/XRGPULayerInit.h
+++ b/Source/WebCore/Modules/webxr/XRGPULayerInit.h
@@ -38,7 +38,7 @@ struct XRGPULayerInit {
     GPUTextureFormat colorFormat;
     std::optional<GPUTextureFormat> depthStencilFormat;
     GPUTextureUsageFlags textureUsage { GPUTextureUsage::RENDER_ATTACHMENT };
-    RefPtr<WebXRSpace> space;
+    Ref<WebXRSpace> space;
     unsigned long mipLevels { 1 };
     unsigned long viewPixelWidth;
     unsigned long viewPixelHeight;

--- a/Source/WebCore/Modules/webxr/XRGPULayerInit.idl
+++ b/Source/WebCore/Modules/webxr/XRGPULayerInit.idl
@@ -28,10 +28,9 @@ typedef [EnforceRange] unsigned long GPUTextureUsageFlags;
 [
     Conditional=WEBXR_LAYERS&WEBGPU,
     EnabledBySetting=WebXRLayersAPIEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary XRGPULayerInit {
     required GPUTextureFormat colorFormat;
-    GPUTextureFormat? depthStencilFormat;
+    [ImplementationDefaultValue=null] GPUTextureFormat? depthStencilFormat;
     GPUTextureUsageFlags textureUsage = 0x10; // GPUTextureUsage.RENDER_ATTACHMENT
     required WebXRSpace space;
     unsigned long mipLevels = 1;

--- a/Source/WebCore/Modules/webxr/XRGPUProjectionLayerInit.idl
+++ b/Source/WebCore/Modules/webxr/XRGPUProjectionLayerInit.idl
@@ -28,10 +28,9 @@ typedef [EnforceRange] unsigned long GPUTextureUsageFlags;
 [
     Conditional=WEBXR_LAYERS&WEBGPU,
     EnabledBySetting=WebXRWebGPUBindingsEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary XRGPUProjectionLayerInit {
     required GPUTextureFormat colorFormat;
-    GPUTextureFormat? depthStencilFormat;
+    [ImplementationDefaultValue=null] GPUTextureFormat? depthStencilFormat;
     GPUTextureUsageFlags textureUsage = 0x10; // GPUTextureUsage.RENDER_ATTACHMENT
     double scaleFactor = 1.0;
 };

--- a/Source/WebCore/Modules/webxr/XRHitTestOptionsInit.h
+++ b/Source/WebCore/Modules/webxr/XRHitTestOptionsInit.h
@@ -37,7 +37,7 @@ namespace WebCore {
 
 // https://immersive-web.github.io/hit-test/#hit-test-options-dictionary
 struct XRHitTestOptionsInit {
-    RefPtr<WebXRSpace> space;
+    Ref<WebXRSpace> space;
     Vector<XRHitTestTrackableType> entityTypes;
     RefPtr<WebXRRay> offsetRay;
 };

--- a/Source/WebCore/Modules/webxr/XRHitTestOptionsInit.idl
+++ b/Source/WebCore/Modules/webxr/XRHitTestOptionsInit.idl
@@ -27,9 +27,8 @@
 [
     Conditional=WEBXR_HIT_TEST,
     EnabledBySetting=WebXREnabled&WebXRHitTestModuleEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary XRHitTestOptionsInit {
     required WebXRSpace space;
-    sequence<XRHitTestTrackableType> entityTypes;
-    WebXRRay offsetRay;
+    [ImplementationDefaultValue=[]] sequence<XRHitTestTrackableType> entityTypes;
+    [ImplementationDefaultValue=null] WebXRRay offsetRay;
 };

--- a/Source/WebCore/Modules/webxr/XRLayerInit.h
+++ b/Source/WebCore/Modules/webxr/XRLayerInit.h
@@ -36,7 +36,7 @@ namespace WebCore {
 
 // https://immersive-web.github.io/layers/#xrlayerinittype
 struct XRLayerInit {
-    RefPtr<WebXRSpace> space;
+    Ref<WebXRSpace> space;
     XRTextureType textureType;
     GCGLenum colorFormat;
     std::optional<GCGLenum> depthFormat;

--- a/Source/WebCore/Modules/webxr/XRLayerInit.idl
+++ b/Source/WebCore/Modules/webxr/XRLayerInit.idl
@@ -29,12 +29,11 @@ typedef unsigned long GLenum;
 [
     Conditional=WEBXR_LAYERS,
     EnabledBySetting=WebXRLayersAPIEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary XRLayerInit {
     required WebXRSpace space;
     XRTextureType textureType = "texture";
     GLenum colorFormat = 0x1908;
-    GLenum? depthFormat;
+    [ImplementationDefaultValue=null] GLenum? depthFormat;
     unsigned long mipLevels = 1;
     required unsigned long viewPixelWidth;
     required unsigned long viewPixelHeight;

--- a/Source/WebCore/Modules/webxr/XRQuadLayerInit.idl
+++ b/Source/WebCore/Modules/webxr/XRQuadLayerInit.idl
@@ -29,9 +29,8 @@
     EnabledBySetting=WebXRLayersAPIEnabled,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary XRQuadLayerInit : XRLayerInit {
-    WebXRRigidTransform? transform;
+    [ImplementationDefaultValue=null] WebXRRigidTransform? transform;
     float width = 1.0;
     float height = 1.0;
 };

--- a/Source/WebCore/Modules/webxr/XRRayDirectionInit.idl
+++ b/Source/WebCore/Modules/webxr/XRRayDirectionInit.idl
@@ -27,7 +27,6 @@
 [
     Conditional=WEBXR_HIT_TEST,
     EnabledBySetting=WebXREnabled&WebXRHitTestModuleEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary XRRayDirectionInit {
     double x = 0;
     double y = 0;

--- a/Source/WebCore/Modules/webxr/XRRenderStateInit.idl
+++ b/Source/WebCore/Modules/webxr/XRRenderStateInit.idl
@@ -27,12 +27,11 @@
 [
     Conditional=WEBXR,
     EnabledBySetting=WebXREnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary XRRenderStateInit {
     double depthNear;
     double depthFar;
     boolean passthroughFullyObscured;
     double inlineVerticalFieldOfView;
     WebXRWebGLLayer? baseLayer;
-    sequence<WebXRLayer>? layers;
+    [ImplementationDefaultValue=null] sequence<WebXRLayer>? layers;
 };

--- a/Source/WebCore/Modules/webxr/XRTransientInputHitTestOptionsInit.idl
+++ b/Source/WebCore/Modules/webxr/XRTransientInputHitTestOptionsInit.idl
@@ -27,9 +27,8 @@
 [
     Conditional=WEBXR_HIT_TEST,
     EnabledBySetting=WebXREnabled&WebXRHitTestModuleEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary XRTransientInputHitTestOptionsInit {
     required DOMString profile;
-    sequence<XRHitTestTrackableType> entityTypes;
-    WebXRRay offsetRay;
+    [ImplementationDefaultValue=[]] sequence<XRHitTestTrackableType> entityTypes;
+    [ImplementationDefaultValue=null] WebXRRay offsetRay;
 };


### PR DESCRIPTION
#### 0a891923c47d02a45eb55b3dafde4f38735391bb
<pre>
Remove LegacyNativeDictionaryRequiredInterfaceNullability from WebXR code
<a href="https://bugs.webkit.org/show_bug.cgi?id=312041">https://bugs.webkit.org/show_bug.cgi?id=312041</a>

Reviewed by Dan Glastonbury and Mike Wyrzykowski.

Refactor to use the modern code path.

Canonical link: <a href="https://commits.webkit.org/311167@main">https://commits.webkit.org/311167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c25d57f7dbb4d9a42819c35415c4f11a83a18d3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164509 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109562 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/252bd2a7-4b26-4ab6-8868-f2f2157db232) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157619 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29153 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120546 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84953 "2 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fb3c426a-4b3a-4c91-9225-2f69d5da5220) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158705 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22727 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139862 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101235 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b3aaf313-d6a9-47e9-856c-b7aebd51e652) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21813 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19956 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12339 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131482 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17694 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166990 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11164 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19305 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128665 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28550 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128797 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139487 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86307 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23781 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23616 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16284 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28168 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92271 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27745 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27975 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27818 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->