### PR TITLE
[JSC] DFG should keep scope OSR-available for ModuleVar resolve_scope

### DIFF
--- a/JSTests/modules/module-var-resolve-scope-osr-availability-in-async-finally.js
+++ b/JSTests/modules/module-var-resolve-scope-osr-availability-in-async-finally.js
@@ -1,0 +1,13 @@
+import { g } from "./module-var-resolve-scope-osr-availability-in-async-finally/h.js";
+
+async function f(a) {
+    try {
+        if (a)
+            return;
+        await 1;
+    } finally {
+        g;
+    }
+}
+for (let i = 0; i < 1e5; i++)
+    await f(0);

--- a/JSTests/modules/module-var-resolve-scope-osr-availability-in-async-finally/h.js
+++ b/JSTests/modules/module-var-resolve-scope-osr-availability-in-async-finally/h.js
@@ -1,0 +1,1 @@
+export const g = 1;

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -9700,10 +9700,11 @@ void ByteCodeParser::parseBlock(unsigned limit)
                 break;
             }
             case ModuleVar: {
-                // Since the value of the "scope" virtual register is not used in LLInt / baseline op_resolve_scope with ModuleVar,
-                // we need not to keep it alive by the Phantom node.
                 // Module environment is already strongly referenced by the CodeBlock.
                 set(bytecode.m_dst, weakJSConstant(lexicalEnvironment));
+                // BytecodeUseDef reports m_scope as a use regardless of resolve type,
+                // so we need to keep it OSR-available even though LLInt won't read it.
+                addToGraph(Phantom, get(bytecode.m_scope));
                 break;
             }
             case ResolvedClosureVar:


### PR DESCRIPTION
#### 44a6ef81be0355f543f632f3b37a27bc2b16c8bc
<pre>
[JSC] DFG should keep scope OSR-available for ModuleVar resolve_scope
<a href="https://bugs.webkit.org/show_bug.cgi?id=312043">https://bugs.webkit.org/show_bug.cgi?id=312043</a>

Reviewed by Yusuke Suzuki.

    // h.mjs
    export const g = 1;

    // m.mjs
    import { g } from &quot;./h.mjs&quot;;
    async function f(a) {
        try {
            if (a) return;
            await 1;
        } finally { g; }
    }
    for (let i = 0; i &lt; 1e6; i++) await f(0);

With --validateGraph=1 this hits &quot;Live bytecode local not available&quot;.

BytecodeUseDef marks m_scope as a use of op_resolve_scope unconditionally,
but the ModuleVar case in ByteCodeParser was the only resolve type that
skipped Phantom(get(m_scope)). In an async function the scope register has
two reaching defs (initial GetScope and post-resume GetClosureVar), so at a
merge point that only sees a ModuleVar resolve_scope, no Phi is inserted and
the scope becomes unavailable for OSR exit.

Tests: JSTests/modules/module-var-resolve-scope-osr-availability-in-async-finally.js
       JSTests/modules/module-var-resolve-scope-osr-availability-in-async-finally/h.js

* JSTests/modules/module-var-resolve-scope-osr-availability-in-async-finally.js: Added.
(async f):
* JSTests/modules/module-var-resolve-scope-osr-availability-in-async-finally/h.js: Added.
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::parseBlock):

Canonical link: <a href="https://commits.webkit.org/311044@main">https://commits.webkit.org/311044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b24b1b5d00164c3ae675de146feab4e0d758feb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164513 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109566 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28860 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120552 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84955 "2 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139859 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101241 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21821 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12343 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147800 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131490 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166994 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16582 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11168 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19302 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128671 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28554 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23994 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; 9 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128803 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34922 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28478 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139484 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86311 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23630 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16281 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187635 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28172 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92275 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48232 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27749 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27979 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27822 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->