### PR TITLE
NavigationDisabler should not block navigations in unrelated frames

### DIFF
--- a/LayoutTests/fast/events/before-unload-sibling-frame-expected.txt
+++ b/LayoutTests/fast/events/before-unload-sibling-frame-expected.txt
@@ -1,4 +1,4 @@
-This tests navigating a sibling iframe during beforeunload. The navigation should be prevented.
+This tests navigating a sibling iframe during beforeunload. The navigation should be allowed since the sibling is not in the ancestor-descendant chain of the frame being unloaded.
 
 PASS
 

--- a/LayoutTests/fast/events/before-unload-sibling-frame.html
+++ b/LayoutTests/fast/events/before-unload-sibling-frame.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <body>
-<p>This tests navigating a sibling iframe during beforeunload. The navigation should be prevented.</p>
+<p>This tests navigating a sibling iframe during beforeunload. The navigation should be allowed since the sibling is not in the ancestor-descendant chain of the frame being unloaded.</p>
 <div id="log"></div>
 <script>
 
@@ -21,17 +21,21 @@ const frame2 = document.createElement('iframe');
 document.body.appendChild(frame2);
 
 window.onmessage = (event) => {
-    if (event.data == 'load')
-        log.textContent = 'FAIL - the navigation succeeded';
+    if (event.data == 'load') {
+        log.textContent = 'PASS';
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
 }
 
 function startTest() {
     frame2.src = 'resources/message-top.html';
     setTimeout(() => {
-        if (log.textContent == '')
-            log.textContent = 'PASS';
-        if (window.testRunner)
-            testRunner.notifyDone();
+        if (log.textContent == '') {
+            log.textContent = 'FAIL - the sibling navigation was blocked';
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
     }, 1000);
 }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/meta/navigation-during-beforeunload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/meta/navigation-during-beforeunload-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Navigating a sibling iframe during another iframe's beforeunload should not be blocked
+PASS Navigating the same frame during its own beforeunload should be blocked
+PASS Navigating the parent frame during a child's beforeunload should be blocked
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/meta/navigation-during-beforeunload.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/meta/navigation-during-beforeunload.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Test that beforeunload in one frame does not block navigation in sibling or parent frames</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+// Test 1: Navigation of a sibling iframe should not be blocked by another iframe's beforeunload.
+promise_test(async test => {
+    const frame1 = document.createElement("iframe");
+    const frame2 = document.createElement("iframe");
+    document.body.appendChild(frame1);
+    document.body.appendChild(frame2);
+
+    // Wait for both frames to load about:blank.
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    // Set up a beforeunload listener on frame1 that tries to navigate frame2.
+    let frame2NavigationStarted = false;
+    frame1.contentWindow.addEventListener("beforeunload", () => {
+        // During frame1's beforeunload, try to navigate frame2.
+        frame2.contentWindow.location.href = "resources/gotRefreshed.html";
+        frame2NavigationStarted = true;
+    });
+
+    // Navigate frame1, which will trigger its beforeunload.
+    const frame2LoadPromise = new Promise(resolve => {
+        frame2.addEventListener("load", resolve);
+    });
+    frame1.contentWindow.location.href = "resources/gotRefreshed.html";
+
+    // frame2 should successfully navigate.
+    await frame2LoadPromise;
+    assert_true(frame2NavigationStarted, "beforeunload handler ran");
+    assert_true(frame2.contentWindow.location.href.includes("gotRefreshed.html"),
+        "Sibling iframe should have navigated to gotRefreshed.html");
+
+    frame1.remove();
+    frame2.remove();
+}, "Navigating a sibling iframe during another iframe's beforeunload should not be blocked");
+
+// Test 2: Navigation of the frame being unloaded should be blocked during its own beforeunload.
+promise_test(async test => {
+    const frame = document.createElement("iframe");
+    document.body.appendChild(frame);
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    frame.contentWindow.addEventListener("beforeunload", () => {
+        // Try to navigate the same frame during its own beforeunload - should be blocked.
+        frame.contentWindow.location.href = "resources/refresh1.html";
+    });
+
+    const loadPromise = new Promise(resolve => {
+        frame.addEventListener("load", resolve);
+    });
+
+    // Navigate frame to gotRefreshed.html - its beforeunload tries to redirect to refresh1.html instead.
+    frame.contentWindow.location.href = "resources/gotRefreshed.html";
+
+    await loadPromise;
+    // The navigation to gotRefreshed.html should have proceeded, not the one to refresh1.html.
+    assert_true(frame.contentWindow.location.href.includes("gotRefreshed.html"),
+        "Frame should have navigated to gotRefreshed.html, not the blocked refresh1.html");
+
+    frame.remove();
+}, "Navigating the same frame during its own beforeunload should be blocked");
+
+// Test 3: Navigation of the parent frame should be blocked during a child's beforeunload.
+promise_test(async test => {
+    const frame = document.createElement("iframe");
+    document.body.appendChild(frame);
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    let triedToNavigateParent = false;
+    frame.contentWindow.addEventListener("beforeunload", () => {
+        // Try to navigate the parent frame during child's beforeunload - should be blocked.
+        triedToNavigateParent = true;
+        window.location.href = "resources/gotRefreshed.html";
+    });
+
+    const loadPromise = new Promise(resolve => {
+        frame.addEventListener("load", resolve);
+    });
+
+    frame.contentWindow.location.href = "resources/gotRefreshed.html";
+
+    await loadPromise;
+    assert_true(triedToNavigateParent, "beforeunload handler ran and tried to navigate parent");
+    // If we're still here, the parent navigation was blocked.
+    assert_true(true, "Parent frame navigation was blocked during child's beforeunload");
+
+    frame.remove();
+}, "Navigating the parent frame during a child's beforeunload should be blocked");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/meta/refresh-time-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/meta/refresh-time-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS Ensure that refresh is observed
+PASS Ensure that non-fractional part in refresh time does not get discarded
+PASS Ensure that multiple periods in refresh time just get ignored
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/meta/refresh-time.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/meta/refresh-time.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Test fractional values in meta http-equiv=refresh</title>
+<link rel="author" title="Psychpsyo"  href="mailto:psychpsyo@gmail.com">
+<link rel="help" href="https://html.spec.whatwg.org/#pragma-directives">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<script>
+  async function measureRefreshTime(src) {
+    const frame = document.createElement("iframe");
+    document.body.appendChild(frame);
+
+    const loadPromise = new Promise(resolve => {
+      frame.addEventListener("load", () => {
+        resolve(performance.now());
+      });
+    });
+    frame.src = src;
+    const startTime = await loadPromise;
+
+    const unloadPromise = new Promise(resolve => {
+      frame.contentWindow.addEventListener("beforeunload", () => {
+        resolve(performance.now());
+      });
+    });
+    const endTime = await unloadPromise;
+    return endTime - startTime;
+  }
+
+  promise_test(async test => {
+    const refreshTime = await measureRefreshTime("resources/refresh1.html");
+    assert_greater_than(refreshTime, 900);
+  }, "Ensure that refresh is observed");
+
+  promise_test(async test => {
+    const refreshTime = await measureRefreshTime("resources/refresh1.99.html");
+    assert_greater_than(refreshTime, 900);
+  }, "Ensure that non-fractional part in refresh time does not get discarded");
+
+  promise_test(async test => {
+    const refreshTime = await measureRefreshTime("resources/refresh1dotdot9dot.html");
+    assert_greater_than(refreshTime, 900);
+  }, "Ensure that multiple periods in refresh time just get ignored");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/gotRefreshed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/gotRefreshed.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>got refreshed</title>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/refresh1.99.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/refresh1.99.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>refresh 1.99</title>
+
+<meta http-equiv="refresh" content="1.99;url=gotRefreshed.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/refresh1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/refresh1.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>refresh 1</title>
+
+<meta http-equiv="refresh" content="1;url=gotRefreshed.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/refresh1dotdot9dot.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/refresh1dotdot9dot.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>refresh 1..9.</title>
+
+<meta http-equiv="refresh" content="1..9.;url=gotRefreshed.html">

--- a/Source/WebCore/loader/NavigationDisabler.h
+++ b/Source/WebCore/loader/NavigationDisabler.h
@@ -36,8 +36,9 @@ public:
         : m_frame(frame)
     {
         if (frame) {
-            if (auto* localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame()))
-                ++localFrame->m_navigationDisableCount;
+            ++frame->m_navigationDisableCount;
+            if (auto* mainFrame = dynamicDowncast<LocalFrame>(frame->mainFrame()))
+                ++mainFrame->m_totalNavigationDisableCount;
         } else // Disable all navigations when destructing a frame-less document.
             ++s_globalNavigationDisableCount;
     }
@@ -45,9 +46,11 @@ public:
     ~NavigationDisabler()
     {
         if (auto* frame = m_frame.get()) {
+            ASSERT(frame->m_navigationDisableCount);
+            --frame->m_navigationDisableCount;
             if (auto* mainFrame = dynamicDowncast<LocalFrame>(frame->mainFrame())) {
-                ASSERT(mainFrame->m_navigationDisableCount);
-                --mainFrame->m_navigationDisableCount;
+                ASSERT(mainFrame->m_totalNavigationDisableCount);
+                --mainFrame->m_totalNavigationDisableCount;
             }
         } else {
             ASSERT(s_globalNavigationDisableCount);
@@ -57,8 +60,26 @@ public:
 
     static bool isNavigationAllowed(Frame& frame)
     {
-        if (auto* localFrame = dynamicDowncast<LocalFrame>(frame.mainFrame()))
-            return !localFrame->m_navigationDisableCount && !s_globalNavigationDisableCount;
+        if (s_globalNavigationDisableCount)
+            return false;
+        auto* localMainFrame = dynamicDowncast<LocalFrame>(frame.mainFrame());
+        if (!localMainFrame || !localMainFrame->m_totalNavigationDisableCount)
+            return true;
+        // Check if the target frame or any of its ancestors has navigation disabled.
+        for (auto* ancestor = &frame; ancestor; ancestor = ancestor->tree().parent()) {
+            if (auto* localAncestor = dynamicDowncast<LocalFrame>(*ancestor)) {
+                if (localAncestor->m_navigationDisableCount)
+                    return false;
+            }
+        }
+        // Check if any descendant of the target frame has navigation disabled,
+        // since navigating an ancestor would disrupt the descendant's beforeunload.
+        for (auto* descendant = frame.tree().firstChild(); descendant; descendant = descendant->tree().traverseNext(&frame)) {
+            if (auto* localDescendant = dynamicDowncast<LocalFrame>(*descendant)) {
+                if (localDescendant->m_navigationDisableCount)
+                    return false;
+            }
+        }
         return true;
     }
 

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -422,6 +422,7 @@ private:
     int m_activeDOMObjectsAndAnimationsSuspendedCount { 0 };
     bool m_documentIsBeingReplaced { false };
     unsigned m_navigationDisableCount { 0 };
+    unsigned m_totalNavigationDisableCount { 0 }; // Sum of m_navigationDisableCount across all frames in the page. Only used on the main frame.
     unsigned m_selfOnlyRefCount { 0 };
     bool m_hasHadUserInteraction { false };
 


### PR DESCRIPTION
#### a3ea192199a9cf6018890cf11cddfe0b442353be
<pre>
NavigationDisabler should not block navigations in unrelated frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=312044">https://bugs.webkit.org/show_bug.cgi?id=312044</a>

Reviewed by Darin Adler.

NavigationDisabler was storing its disable count on the main frame,
making it page-global. This meant that when shouldClose() dispatched
beforeunload for one iframe, its NavigationDisabler would block
navigations in all other iframes on the page. If JavaScript happened
to schedule a navigation on a sibling iframe during this window (e.g.
via promise microtasks from the beforeunload handler, or from setting
frame.src while an async policy check was in flight), the
scheduleLocationChange would be silently dropped.

Fix by storing the disable count on the specific frame rather than
the main frame. isNavigationAllowed() now walks both directions:
up the ancestor chain (a descendant can&apos;t navigate while an ancestor
has beforeunload active) and down the descendant tree (an ancestor
can&apos;t navigate while a descendant has beforeunload active). Sibling
frames that are not in the ancestor-descendant chain are unaffected.

This matches the behavior of Chrome and Firefox, where navigations
of sibling iframes are allowed during another iframe&apos;s beforeunload
dispatch, while navigations of the frame itself, its ancestors, and
its descendants remain blocked.

* LayoutTests/fast/events/before-unload-sibling-frame-expected.txt:
* LayoutTests/fast/events/before-unload-sibling-frame.html:
Updated test expectations to match the correct behavior: navigating a
sibling iframe during beforeunload should be allowed, not blocked.

* LayoutTests/imported/w3c/web-platform-tests/html/meta/navigation-during-beforeunload-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/meta/navigation-during-beforeunload.html: Added.
Add WPT test coverage.

* LayoutTests/imported/w3c/web-platform-tests/html/meta/refresh-time-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/meta/refresh-time.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/gotRefreshed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/refresh1.99.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/refresh1.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/meta/resources/refresh1dotdot9dot.html: Added.
Import WPT test from upstream that was failing due to this bug in shipping
Safari. This test is fully passing in Chrome and Firefox.

* Source/WebCore/loader/NavigationDisabler.h:
(WebCore::NavigationDisabler::NavigationDisabler):
(WebCore::NavigationDisabler::~NavigationDisabler):
(WebCore::NavigationDisabler::isNavigationAllowed):
* Source/WebCore/page/LocalFrame.h:

Canonical link: <a href="https://commits.webkit.org/311030@main">https://commits.webkit.org/311030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4ff8b81b58952e26da52929398a40220d429ec2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164613 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157722 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28959 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120642 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Passed layout tests; 4 flakes 2 failures; Uploaded test results; 1 flakes; Passed layout tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22831 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139959 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101331 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21916 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20057 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12443 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131585 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17791 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167093 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11267 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19402 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128763 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28653 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128896 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34916 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28577 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139584 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86436 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23718 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16383 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28271 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92374 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27848 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28078 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27921 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->