### PR TITLE
[CMake] Fix Mac CMake build for bmalloc

### DIFF
--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -207,6 +207,7 @@ set(bmalloc_C_SOURCES
 )
 
 set(bmalloc_PUBLIC_HEADERS
+    Configurations/module.modulemap
     bmalloc/Algorithm.h
     bmalloc/AllocationCounts.h
     bmalloc/CompactAllocationMode.h
@@ -229,13 +230,12 @@ set(bmalloc_PUBLIC_HEADERS
     bmalloc/Logging.h
     bmalloc/Map.h
     bmalloc/Mutex.h
-    bmalloc/ProcessCheck.h
-    bmalloc/ScopeExit.h
     bmalloc/Sizes.h
     bmalloc/StaticPerProcess.h
     bmalloc/TZoneHeap.h
     bmalloc/TZoneHeapInlines.h
     bmalloc/TZoneHeapManager.h
+    bmalloc/TZoneLog.h
     bmalloc/VMAllocate.h
     bmalloc/Vector.h
     bmalloc/bmalloc.h
@@ -252,11 +252,9 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/bmalloc_type.h
     libpas/src/libpas/hotbit_heap_config.h
     libpas/src/libpas/hotbit_heap.h
-    libpas/src/libpas/hotbit_heap_inlines.h
     libpas/src/libpas/hotbit_heap_innards.h
     libpas/src/libpas/iso_heap_config.h
     libpas/src/libpas/iso_heap.h
-    libpas/src/libpas/iso_heap_inlines.h
     libpas/src/libpas/iso_heap_innards.h
     libpas/src/libpas/iso_heap_ref.h
     libpas/src/libpas/iso_test_heap_config.h
@@ -271,7 +269,6 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_aligned_allocation_result.h
     libpas/src/libpas/pas_aligned_allocator.h
     libpas/src/libpas/pas_alignment.h
-    libpas/src/libpas/pas_all_heap_configs.h
     libpas/src/libpas/pas_all_heaps.h
     libpas/src/libpas/pas_allocation_callbacks.h
     libpas/src/libpas/pas_allocation_config.h
@@ -289,13 +286,11 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_basic_heap_config_root_data.h
     libpas/src/libpas/pas_basic_heap_page_caches.h
     libpas/src/libpas/pas_basic_heap_runtime_config.h
-    libpas/src/libpas/pas_biasing_directory_kind.h
     libpas/src/libpas/pas_bitfield_vector.h
     libpas/src/libpas/pas_bitfit_allocation_result.h
     libpas/src/libpas/pas_bitfit_allocator.h
     libpas/src/libpas/pas_bitfit_allocator_inlines.h
     libpas/src/libpas/pas_bitfit_directory.h
-    libpas/src/libpas/pas_bitfit_directory_inlines.h
     libpas/src/libpas/pas_bitfit_heap.h
     libpas/src/libpas/pas_bitfit_max_free.h
     libpas/src/libpas/pas_bitfit_page_config.h
@@ -310,7 +305,6 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_bitfit_size_class.h
     libpas/src/libpas/pas_bitfit_view_and_index.h
     libpas/src/libpas/pas_bitfit_view.h
-    libpas/src/libpas/pas_bitfit_view_inlines.h
     libpas/src/libpas/pas_bitvector.h
     libpas/src/libpas/pas_bootstrap_free_heap.h
     libpas/src/libpas/pas_bootstrap_heap_page_provider.h
@@ -321,47 +315,31 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_commit_span.h
     libpas/src/libpas/pas_committed_pages_vector.h
     libpas/src/libpas/pas_compact_atomic_allocator_index_ptr.h
-    libpas/src/libpas/pas_compact_atomic_biasing_directory_ptr.h
-    libpas/src/libpas/pas_compact_atomic_bitfit_biasing_directory_ptr.h
-    libpas/src/libpas/pas_compact_atomic_bitfit_global_size_class_ptr.h
     libpas/src/libpas/pas_compact_atomic_bitfit_heap_ptr.h
     libpas/src/libpas/pas_compact_atomic_bitfit_size_class_ptr.h
     libpas/src/libpas/pas_compact_atomic_bitfit_view_ptr.h
     libpas/src/libpas/pas_compact_atomic_enumerable_range_list_chunk_ptr.h
     libpas/src/libpas/pas_compact_atomic_page_sharing_pool_ptr.h
     libpas/src/libpas/pas_compact_atomic_ptr.h
-    libpas/src/libpas/pas_compact_atomic_segregated_exclusive_view_ptr.h
-    libpas/src/libpas/pas_compact_atomic_segregated_heap_page_sharing_pools_ptr.h
     libpas/src/libpas/pas_compact_atomic_segregated_partial_view_ptr.h
     libpas/src/libpas/pas_compact_atomic_segregated_size_directory_ptr.h
     libpas/src/libpas/pas_compact_atomic_segregated_view.h
     libpas/src/libpas/pas_compact_atomic_thread_local_cache_layout_node.h
-    libpas/src/libpas/pas_compact_atomic_unsigned_ptr.h
-    libpas/src/libpas/pas_compact_biasing_directory_ptr.h
     libpas/src/libpas/pas_compact_bitfit_directory_ptr.h
-    libpas/src/libpas/pas_compact_bitfit_global_directory_ptr.h
-    libpas/src/libpas/pas_compact_bitfit_view_ptr.h
     libpas/src/libpas/pas_compact_bootstrap_free_heap.h
     libpas/src/libpas/pas_compact_cartesian_tree_node_ptr.h
     libpas/src/libpas/pas_compact_expendable_memory.h
     libpas/src/libpas/pas_compact_heap_ptr.h
     libpas/src/libpas/pas_compact_heap_reservation.h
-    libpas/src/libpas/pas_compact_large_utility_free_heap.h
-    libpas/src/libpas/pas_compact_page_granule_use_count_ptr.h
     libpas/src/libpas/pas_compact_ptr.h
-    libpas/src/libpas/pas_compact_segregated_biasing_directory_ptr.h
     libpas/src/libpas/pas_compact_segregated_exclusive_view_ptr.h
-    libpas/src/libpas/pas_compact_segregated_heap_ptr.h
-    libpas/src/libpas/pas_compact_segregated_shared_page_directory_ptr.h
     libpas/src/libpas/pas_compact_segregated_shared_view_ptr.h
     libpas/src/libpas/pas_compact_segregated_size_directory_ptr.h
-    libpas/src/libpas/pas_compact_segregated_view.h
     libpas/src/libpas/pas_compact_tagged_atomic_ptr.h
     libpas/src/libpas/pas_compact_tagged_page_granule_use_count_ptr.h
     libpas/src/libpas/pas_compact_tagged_ptr.h
     libpas/src/libpas/pas_compact_tagged_unsigned_ptr.h
     libpas/src/libpas/pas_compact_thread_local_cache_layout_node.h
-    libpas/src/libpas/pas_compact_unsigned_ptr.h
     libpas/src/libpas/pas_compute_summary_object_callbacks.h
     libpas/src/libpas/pas_config.h
     libpas/src/libpas/pas_config_prefix.h
@@ -411,14 +389,8 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_free_range_kind.h
     libpas/src/libpas/pas_full_alloc_bits.h
     libpas/src/libpas/pas_full_alloc_bits_inlines.h
-    libpas/src/libpas/pas_generic_large_free_heap.h
-    libpas/src/libpas/pas_get_allocation_size.h
-    libpas/src/libpas/pas_get_heap.h
-    libpas/src/libpas/pas_get_object_kind.h
-    libpas/src/libpas/pas_get_page_base.h
     libpas/src/libpas/pas_get_page_base_and_kind_for_small_other_in_fast_megapage.h
     libpas/src/libpas/pas_hashtable.h
-    libpas/src/libpas/pas_has_object.h
     libpas/src/libpas/pas_heap_config.h
     libpas/src/libpas/pas_heap_config_inlines.h
     libpas/src/libpas/pas_heap_config_kind.def
@@ -449,7 +421,6 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_large_free_heap_deferred_commit_log.h
     libpas/src/libpas/pas_large_free_heap_definitions.def
     libpas/src/libpas/pas_large_free_heap_helpers.h
-    libpas/src/libpas/pas_large_free_inlines.h
     libpas/src/libpas/pas_large_free_visitor.h
     libpas/src/libpas/pas_large_heap.h
     libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.h
@@ -457,14 +428,10 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_large_map.h
     libpas/src/libpas/pas_large_sharing_pool_epoch_update_mode.h
     libpas/src/libpas/pas_large_sharing_pool.h
-    libpas/src/libpas/pas_large_utility_free_heap.h
     libpas/src/libpas/pas_large_virtual_range.h
     libpas/src/libpas/pas_large_virtual_range_min_heap.h
     libpas/src/libpas/pas_lenient_compact_ptr.h
-    libpas/src/libpas/pas_lenient_compact_ptr_inlines.h
     libpas/src/libpas/pas_lenient_compact_unsigned_ptr.h
-    libpas/src/libpas/pas_line_word_config.h
-    libpas/src/libpas/pas_list_direction.h
     libpas/src/libpas/pas_local_allocator_config_kind.h
     libpas/src/libpas/pas_local_allocator.h
     libpas/src/libpas/pas_local_allocator_inlines.h
@@ -488,10 +455,8 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_mte.h
     libpas/src/libpas/pas_mte_config.h
     libpas/src/libpas/pas_mutation_count.h
-    libpas/src/libpas/pas_object_kind.h
     libpas/src/libpas/pas_page_base_and_kind.h
     libpas/src/libpas/pas_page_base_config.h
-    libpas/src/libpas/pas_page_base_config_inlines.h
     libpas/src/libpas/pas_page_base_config_utils.h
     libpas/src/libpas/pas_page_base_config_utils_inlines.h
     libpas/src/libpas/pas_page_base.h
@@ -515,15 +480,12 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_platform.h
     libpas/src/libpas/pas_primitive_heap_ref.h
     libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
-    libpas/src/libpas/pas_promote_intrinsic_heap.h
     libpas/src/libpas/pas_ptr_hash_map.h
     libpas/src/libpas/pas_ptr_hash_set.h
     libpas/src/libpas/pas_ptr_min_heap.h
     libpas/src/libpas/pas_ptr_worklist.h
     libpas/src/libpas/pas_race_test_hooks.h
     libpas/src/libpas/pas_random.h
-    libpas/src/libpas/pas_range16.h
-    libpas/src/libpas/pas_range_begin_min_heap.h
     libpas/src/libpas/pas_range.h
     libpas/src/libpas/pas_range_locked_mode.h
     libpas/src/libpas/pas_range_min_heap.h
@@ -559,7 +521,6 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_segregated_page_config_utils.h
     libpas/src/libpas/pas_segregated_page_config_utils_inlines.h
     libpas/src/libpas/pas_segregated_page_config_variant.h
-    libpas/src/libpas/pas_segregated_page_emptiness_kind.h
     libpas/src/libpas/pas_segregated_page.h
     libpas/src/libpas/pas_segregated_page_inlines.h
     libpas/src/libpas/pas_segregated_page_role.h
@@ -585,12 +546,9 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_simple_large_free_heap.h
     libpas/src/libpas/pas_simple_type.h
     libpas/src/libpas/pas_size_lookup_mode.h
-    libpas/src/libpas/pas_slow_path_mode.h
-    libpas/src/libpas/pas_slow_path_mode_prefix.h
     libpas/src/libpas/pas_small_large_map_entry.h
     libpas/src/libpas/pas_small_medium_bootstrap_free_heap.h
     libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.h
-    libpas/src/libpas/pas_snprintf.h
     libpas/src/libpas/pas_stats.h
     libpas/src/libpas/pas_status_reporter.h
     libpas/src/libpas/pas_stream.h
@@ -612,7 +570,6 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_try_allocate_intrinsic.h
     libpas/src/libpas/pas_try_allocate_primitive.h
     libpas/src/libpas/pas_try_reallocate.h
-    libpas/src/libpas/pas_try_shrink.h
     libpas/src/libpas/pas_utility_heap_config.h
     libpas/src/libpas/pas_utility_heap.h
     libpas/src/libpas/pas_utility_heap_support.h
@@ -624,6 +581,55 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_zero_memory.h
     libpas/src/libpas/pas_zero_mode.h
     libpas/src/libpas/thingy_heap_config.h
+)
+
+set(bmalloc_PRIVATE_HEADERS
+    bmalloc/ProcessCheck.h
+    bmalloc/ScopeExit.h
+
+    libpas/src/libpas/hotbit_heap_inlines.h
+    libpas/src/libpas/iso_heap_inlines.h
+    libpas/src/libpas/pas_all_heap_configs.h
+    libpas/src/libpas/pas_biasing_directory_kind.h
+    libpas/src/libpas/pas_bitfit_directory_inlines.h
+    libpas/src/libpas/pas_bitfit_view_inlines.h
+    libpas/src/libpas/pas_compact_atomic_biasing_directory_ptr.h
+    libpas/src/libpas/pas_compact_atomic_bitfit_biasing_directory_ptr.h
+    libpas/src/libpas/pas_compact_atomic_bitfit_global_size_class_ptr.h
+    libpas/src/libpas/pas_compact_atomic_segregated_exclusive_view_ptr.h
+    libpas/src/libpas/pas_compact_atomic_segregated_heap_page_sharing_pools_ptr.h
+    libpas/src/libpas/pas_compact_atomic_unsigned_ptr.h
+    libpas/src/libpas/pas_compact_biasing_directory_ptr.h
+    libpas/src/libpas/pas_compact_bitfit_global_directory_ptr.h
+    libpas/src/libpas/pas_compact_bitfit_view_ptr.h
+    libpas/src/libpas/pas_compact_large_utility_free_heap.h
+    libpas/src/libpas/pas_compact_page_granule_use_count_ptr.h
+    libpas/src/libpas/pas_compact_segregated_biasing_directory_ptr.h
+    libpas/src/libpas/pas_compact_segregated_heap_ptr.h
+    libpas/src/libpas/pas_compact_segregated_shared_page_directory_ptr.h
+    libpas/src/libpas/pas_compact_segregated_view.h
+    libpas/src/libpas/pas_compact_unsigned_ptr.h
+    libpas/src/libpas/pas_generic_large_free_heap.h
+    libpas/src/libpas/pas_get_allocation_size.h
+    libpas/src/libpas/pas_get_heap.h
+    libpas/src/libpas/pas_get_object_kind.h
+    libpas/src/libpas/pas_get_page_base.h
+    libpas/src/libpas/pas_has_object.h
+    libpas/src/libpas/pas_large_free_inlines.h
+    libpas/src/libpas/pas_large_utility_free_heap.h
+    libpas/src/libpas/pas_lenient_compact_ptr_inlines.h
+    libpas/src/libpas/pas_line_word_config.h
+    libpas/src/libpas/pas_list_direction.h
+    libpas/src/libpas/pas_object_kind.h
+    libpas/src/libpas/pas_page_base_config_inlines.h
+    libpas/src/libpas/pas_promote_intrinsic_heap.h
+    libpas/src/libpas/pas_range16.h
+    libpas/src/libpas/pas_range_begin_min_heap.h
+    libpas/src/libpas/pas_segregated_page_emptiness_kind.h
+    libpas/src/libpas/pas_slow_path_mode.h
+    libpas/src/libpas/pas_slow_path_mode_prefix.h
+    libpas/src/libpas/pas_snprintf.h
+    libpas/src/libpas/pas_try_shrink.h
     libpas/src/libpas/thingy_heap.h
     libpas/src/libpas/thingy_heap_prefix.h
 )
@@ -679,6 +685,10 @@ set(bmalloc_COMPILE_OPTIONS
 set(bmalloc_INTERFACE_LIBRARIES bmalloc)
 set(bmalloc_INTERFACE_INCLUDE_DIRECTORIES ${bmalloc_FRAMEWORK_HEADERS_DIR})
 set(bmalloc_INTERFACE_DEPENDENCIES bmalloc_CopyHeaders)
+if (bmalloc_PRIVATE_FRAMEWORK_HEADERS_DIR)
+    list(APPEND bmalloc_INTERFACE_INCLUDE_DIRECTORIES ${bmalloc_PRIVATE_FRAMEWORK_HEADERS_DIR})
+    list(APPEND bmalloc_INTERFACE_DEPENDENCIES bmalloc_CopyPrivateHeaders)
+endif ()
 
 add_definitions(-D_GNU_SOURCE)
 add_definitions(-DPAS_BMALLOC=1)
@@ -706,6 +716,14 @@ WEBKIT_COPY_FILES(bmalloc_CopyHeaders
     FILES ${bmalloc_PUBLIC_HEADERS}
     FLATTENED
 )
+
+if (bmalloc_PRIVATE_FRAMEWORK_HEADERS_DIR)
+    WEBKIT_COPY_FILES(bmalloc_CopyPrivateHeaders
+        DESTINATION ${bmalloc_PRIVATE_FRAMEWORK_HEADERS_DIR}/bmalloc
+        FILES ${bmalloc_PRIVATE_HEADERS}
+        FLATTENED
+    )
+endif ()
 
 WEBKIT_FRAMEWORK(bmalloc)
 

--- a/Source/bmalloc/PlatformMac.cmake
+++ b/Source/bmalloc/PlatformMac.cmake
@@ -1,6 +1,10 @@
 add_definitions(-DBPLATFORM_MAC=1)
 
 list(APPEND bmalloc_SOURCES
-    bmalloc/IsoHeap.cpp
     bmalloc/ProcessCheck.mm
 )
+
+# ProcessCheck.mm uses Foundation (NSBundle, NSProcessInfo).
+# bmalloc is an OBJECT library so framework deps must be explicit.
+find_library(FOUNDATION_LIBRARY Foundation)
+list(APPEND bmalloc_LIBRARIES ${FOUNDATION_LIBRARY})

--- a/Source/bmalloc/bmalloc/TZoneHeap.h
+++ b/Source/bmalloc/bmalloc/TZoneHeap.h
@@ -36,6 +36,7 @@
 #endif
 
 #include "Algorithm.h"
+#include "BAssert.h"
 #include "BInline.h"
 #include "CompactAllocationMode.h"
 


### PR DESCRIPTION
#### be740b1129043fcc742a2ff0f8e45415f57d8c56
<pre>
[CMake] Fix Mac CMake build for bmalloc
<a href="https://bugs.webkit.org/show_bug.cgi?id=312019">https://bugs.webkit.org/show_bug.cgi?id=312019</a>
<a href="https://rdar.apple.com/problem/174561810">rdar://problem/174561810</a>

Reviewed by BJ Burg.

Reorganize bmalloc headers into public and private sets so downstream
targets only see the API surface they need. Add missing TZoneLog.h to
the public list. Remove stale IsoHeap.cpp reference and add Foundation
framework linking for ProcessCheck.mm. Add missing BAssert.h include
in TZoneHeap.h.

Based on a base patch by Simon Lewis. Incorporates private header
reorganization from Ian Grunert (PR #62543).

* Source/bmalloc/CMakeLists.txt:
* Source/bmalloc/PlatformMac.cmake:
* Source/bmalloc/bmalloc/TZoneHeap.h:

Canonical link: <a href="https://commits.webkit.org/311104@main">https://commits.webkit.org/311104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33e626c1e1cc0fb7aa9ba4c2fc42e25dc324c5aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164873 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29520 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29388 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120825 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140155 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101509 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12645 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148102 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131779 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/17987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167352 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16886 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19599 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128944 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28988 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129075 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34959 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28910 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139781 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86677 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23905 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187935 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28619 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48322 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28146 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28374 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28270 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->