### PR TITLE
[JSC] Support `DoubleShape` in `ArrayLengthStore` IC

### DIFF
--- a/JSTests/microbenchmarks/array-length-reset-double.js
+++ b/JSTests/microbenchmarks/array-length-reset-double.js
@@ -1,0 +1,13 @@
+function test() {
+    let a = [];
+    for (let i = 0; i < 1e6; ++i) {
+        a.push(1.5);
+        a.push(2.5);
+        a.push(3.5);
+        a.length = 0;
+    }
+    return a.length;
+}
+noInline(test);
+for (let i = 0; i < 5; ++i)
+    test();

--- a/JSTests/stress/array-length-store-ic-double-noncow.js
+++ b/JSTests/stress/array-length-store-ic-double-noncow.js
@@ -1,0 +1,23 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    let a = [1.5];
+    a.push(2.5);
+    a.push(3.5);
+    a.push(4.5);
+    f(a, 1);
+    shouldBe(a.length, 1);
+    shouldBe(a[0], 1.5);
+    shouldBe(a[1], undefined);
+    shouldBe(a[3], undefined);
+    shouldBe(1 in a, false);
+    a.push(9.5);
+    shouldBe(a.length, 2);
+    shouldBe(a[1], 9.5);
+}

--- a/JSTests/stress/array-length-store-ic-double-then-int32.js
+++ b/JSTests/stress/array-length-store-ic-double-then-int32.js
@@ -1,0 +1,25 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("got " + actual + ", expected " + expected);
+}
+
+function f(a, n) { a.length = n; }
+noInline(f);
+
+let doubleArr = [1.5];
+doubleArr.push(2.5);
+let int32Arr = [1];
+int32Arr.push(2);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    doubleArr.push(3.5, 4.5, 5.5);
+    int32Arr.push(3, 4, 5);
+    f(doubleArr, 2);
+    f(int32Arr, 2);
+    shouldBe(doubleArr.length, 2);
+    shouldBe(doubleArr[2], undefined);
+    shouldBe(2 in doubleArr, false);
+    shouldBe(int32Arr.length, 2);
+    shouldBe(int32Arr[2], undefined);
+    shouldBe(2 in int32Arr, false);
+}

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -2032,33 +2032,39 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
     case AccessCase::ArrayLengthStore: {
         ASSERT(!accessCase.viaGlobalProxy());
 
-        // FIXME: Support DoubleShape by clearing with PNaN instead of empty JSValue.
         jit.load8(CCallHelpers::Address(baseGPR, JSCell::indexingTypeAndMiscOffset()), scratchGPR);
         jit.and32(CCallHelpers::TrustedImm32(IndexingModeMask), scratchGPR);
         auto isInt32 = jit.branch32(CCallHelpers::Equal, scratchGPR, CCallHelpers::TrustedImm32(IsArray | Int32Shape));
-        fallThrough.append(jit.branch32(CCallHelpers::NotEqual, scratchGPR, CCallHelpers::TrustedImm32(IsArray | ContiguousShape)));
+        auto isContiguous = jit.branch32(CCallHelpers::Equal, scratchGPR, CCallHelpers::TrustedImm32(IsArray | ContiguousShape));
+        fallThrough.append(jit.branch32(CCallHelpers::NotEqual, scratchGPR, CCallHelpers::TrustedImm32(IsArray | DoubleShape)));
+        jit.move(CCallHelpers::TrustedImm64(std::bit_cast<int64_t>(PNaN)), scratchGPR);
+        auto holeReady = jit.jump();
         isInt32.link(&jit);
+        isContiguous.link(&jit);
+        jit.move(CCallHelpers::TrustedImm64(JSValue::encode(JSValue())), scratchGPR);
+        holeReady.link(&jit);
 
         m_failAndIgnore.append(jit.branchIfNotInt32(valueRegs));
 
         auto allocator = makeDefaultScratchAllocator(scratchGPR);
         GPRReg scratch2GPR = allocator.allocateScratchGPR();
+        GPRReg scratch3GPR = allocator.allocateScratchGPR();
         ScratchRegisterAllocator::PreservedState preservedState = allocator.preserveReusedRegistersByPushing(jit, ScratchRegisterAllocator::ExtraStackSpace::NoExtraSpace);
 
         CCallHelpers::JumpList failAndIgnore;
 
-        jit.loadPtr(CCallHelpers::Address(baseGPR, JSObject::butterflyOffset()), scratchGPR);
-        jit.load32(CCallHelpers::Address(scratchGPR, Butterfly::offsetOfPublicLength()), scratch2GPR);
-        failAndIgnore.append(jit.branch32(CCallHelpers::Above, valueRegs.payloadGPR(), scratch2GPR));
+        jit.loadPtr(CCallHelpers::Address(baseGPR, JSObject::butterflyOffset()), scratch2GPR);
+        jit.load32(CCallHelpers::Address(scratch2GPR, Butterfly::offsetOfPublicLength()), scratch3GPR);
+        failAndIgnore.append(jit.branch32(CCallHelpers::Above, valueRegs.payloadGPR(), scratch3GPR));
 
         auto loopStart = jit.label();
-        auto loopDone = jit.branch32(CCallHelpers::BelowOrEqual, scratch2GPR, valueRegs.payloadGPR());
-        jit.sub32(CCallHelpers::TrustedImm32(1), scratch2GPR);
-        jit.storeTrustedValue(JSValue(), CCallHelpers::BaseIndex(scratchGPR, scratch2GPR, CCallHelpers::TimesEight));
+        auto loopDone = jit.branch32(CCallHelpers::BelowOrEqual, scratch3GPR, valueRegs.payloadGPR());
+        jit.sub32(CCallHelpers::TrustedImm32(1), scratch3GPR);
+        jit.store64(scratchGPR, CCallHelpers::BaseIndex(scratch2GPR, scratch3GPR, CCallHelpers::TimesEight));
         jit.jump().linkTo(loopStart, &jit);
         loopDone.link(&jit);
 
-        jit.store32(valueRegs.payloadGPR(), CCallHelpers::Address(scratchGPR, Butterfly::offsetOfPublicLength()));
+        jit.store32(valueRegs.payloadGPR(), CCallHelpers::Address(scratch2GPR, Butterfly::offsetOfPublicLength()));
 
         allocator.restoreReusedRegistersByPopping(jit, preservedState);
         succeed();


### PR DESCRIPTION
#### a3e4439fb95cefbdcebb8d1fd4739a1db1d6d267
<pre>
[JSC] Support `DoubleShape` in `ArrayLengthStore` IC
<a href="https://bugs.webkit.org/show_bug.cgi?id=312050">https://bugs.webkit.org/show_bug.cgi?id=312050</a>

Reviewed by Yusuke Suzuki.

311326@main added an ArrayLengthStore inline cache that handles
ArrayWithInt32 and ArrayWithContiguous. This patch extends it to
ArrayWithDouble by selecting the hole pattern (encoded empty JSValue
vs PNaN) at the shape guard, the same way FTL initializeArrayElements
does, and using a single store64 clear loop. The Int32/Contiguous
fast path gains only a single `movz #0`.

FTL:
                                   TipOfTree                  Patched

array-length-reset-double       63.4825+-4.1166     ^     13.0505+-0.4404        ^ definitely 4.8644x faster

DFG:
                                   TipOfTree                  Patched

array-length-reset-double       61.7985+-0.9654     ^     15.8700+-0.5495        ^ definitely 3.8940x faster

Baseline:
                                   TipOfTree                  Patched

array-length-reset-double      121.8742+-2.5465     ^     75.3147+-0.3700        ^ definitely 1.6182x faster

Tests: JSTests/microbenchmarks/array-length-reset-double.js
       JSTests/stress/array-length-store-ic-double-noncow.js
       JSTests/stress/array-length-store-ic-double-then-int32.js

* JSTests/microbenchmarks/array-length-reset-double.js: Added.
(test):
* JSTests/stress/array-length-store-ic-double-noncow.js: Added.
(shouldBe):
(f):
* JSTests/stress/array-length-store-ic-double-then-int32.js: Added.
(shouldBe):
(f):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::generateWithGuard):

Canonical link: <a href="https://commits.webkit.org/311181@main">https://commits.webkit.org/311181@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea13ddb11f6604409a3ce4996cfa8cd141753a89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164536 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109588 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28882 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120573 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84963 "1 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22756 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139889 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101262 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21842 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19983 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12366 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147822 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131511 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17721 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167016 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16604 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11190 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19332 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128691 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28576 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24017 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128823 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35014 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28500 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139514 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86334 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23643 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16312 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187657 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28194 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92297 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48239 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27771 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28001 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27844 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->