### PR TITLE
[GStreamer][WebRTC][Rice] Potential infinite loop in agentSourcePrepare

### DIFF
--- a/Source/WebCore/platform/rice/RiceGioBackend.cpp
+++ b/Source/WebCore/platform/rice/RiceGioBackend.cpp
@@ -54,7 +54,7 @@ static gboolean agentSourcePrepare(GSource* base, gint* timeout)
     auto now = WTF::MonotonicTime::now().secondsSinceEpoch();
 
     gboolean result = FALSE;
-    while (true) {
+    {
         RiceAgentPoll ret;
         rice_agent_poll_init(&ret);
         GST_TRACE_OBJECT(iceAgent.get(), "Polling");
@@ -84,19 +84,18 @@ static gboolean agentSourcePrepare(GSource* base, gint* timeout)
             auto delta = Seconds::fromNanoseconds(ret.wait_until_nanos - now.nanoseconds());
             if (delta >= 99998_s) {
                 GST_TRACE_OBJECT(iceAgent.get(), "Nothing special to do.");
-                result = FALSE;
                 break;
             }
             if (timeout) {
                 *timeout = static_cast<int>(delta.milliseconds());
                 GST_TRACE_OBJECT(iceAgent.get(), "Waiting for %d ms", *timeout);
             }
-            result = FALSE;
             break;
         }
         case RICE_AGENT_POLL_GATHERING_COMPLETE:
             GST_TRACE_OBJECT(iceAgent.get(), "Gathering complete");
             webkitGstWebRTCIceAgentGatheringDoneForStream(iceAgent.get(), ret.gathering_complete.stream_id);
+            result = TRUE;
             break;
         case RICE_AGENT_POLL_GATHERED_CANDIDATE:
             GST_TRACE_OBJECT(iceAgent.get(), "Gathered candidate");
@@ -124,8 +123,6 @@ static gboolean agentSourcePrepare(GSource* base, gint* timeout)
             }
         } else
             rice_transmit_clear(&transmit);
-        if (!result)
-            break;
     }
 
     return result;


### PR DESCRIPTION
#### 4cec55e60c80ef19e630c2c87d793fc01150e13c
<pre>
[GStreamer][WebRTC][Rice] Potential infinite loop in agentSourcePrepare
<a href="https://bugs.webkit.org/show_bug.cgi?id=312051">https://bugs.webkit.org/show_bug.cgi?id=312051</a>

Reviewed by Xabier Rodriguez-Calvar.

The only exit cases were when RICE_AGENT_POLL_WAIT_UNTIL_NANOS was returned from the rice_agent_poll()
call and when the ICE agent was reported as closed.

* Source/WebCore/platform/rice/RiceGioBackend.cpp:
(agentSourcePrepare):

Canonical link: <a href="https://commits.webkit.org/311180@main">https://commits.webkit.org/311180@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/445f82e76217fcceb8d5d12714a6bc022636a454

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29040 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22199 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164544 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109596 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28890 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120581 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84960 "2 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139890 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101270 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21850 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19991 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12374 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131519 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17722 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167024 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11198 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19333 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128700 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28584 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24025 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128832 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35012 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139515 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86342 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23652 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16313 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28202 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92305 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27779 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28009 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27852 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->