### PR TITLE
Codify that smart pointers initialized with an `adopt` method should be declared with their smart pointer type, and not `auto`

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3077,6 +3077,33 @@ def check_wtf_xpc_object_ptr(clean_lines, line_number, file_state, error):
         return
 
 
+def check_auto_with_adopt(clean_lines, line_number, file_state, error):
+    """Looks for usage of 'auto' with adopt functions, which should use the explicit smart pointer type.
+
+    Args:
+      clean_lines: A CleansedLines instance containing the file.
+      line_number: The number of the line to check.
+      file_state: A _FileState instance which maintains information about
+                  the state of things in the file.
+      error: The function to call with any errors found.
+    """
+
+    line = clean_lines.elided[line_number]  # Get rid of comments and strings.
+
+    matched = search(r'\bauto\b\s+\w+\s*=\s*adopt(NS|CF|GDIObject|OSObject|Ref)\b', line)
+    if matched:
+        adopt_func = 'adopt' + matched.group(1)
+        type_map = {
+            'adoptNS': 'RetainPtr',
+            'adoptCF': 'RetainPtr',
+            'adoptGDIObject': 'GDIObject',
+            'adoptOSObject': 'OSObjectPtr',
+            'adoptRef': 'Ref/RefPtr',
+        }
+        smart_ptr = type_map.get(adopt_func, 'the appropriate smart pointer type')
+        error(line_number, 'runtime/auto_with_adopt', 4, "Use '%s' instead of 'auto' with '%s()'." % (smart_ptr, adopt_func))
+
+
 def check_lock_guard(clean_lines, line_number, file_state, error):
     """Looks for use of 'std::lock_guard<>' which should be replaced with 'WTF::Locker'.
 
@@ -3897,6 +3924,7 @@ def check_style(clean_lines, line_number, file_extension, class_state, file_stat
     check_wtf_never_destroyed(clean_lines, line_number, file_state, error)
     check_wtf_os_object_ptr(clean_lines, line_number, file_state, error)
     check_wtf_xpc_object_ptr(clean_lines, line_number, file_state, error)
+    check_auto_with_adopt(clean_lines, line_number, file_state, error)
     check_lock_guard(clean_lines, line_number, file_state, error)
     check_log(clean_lines, line_number, file_state, error)
     check_ctype_functions(clean_lines, line_number, file_state, error)
@@ -5176,6 +5204,7 @@ class CppChecker(object):
         'runtime/unsafe_get_ptr',
         'runtime/unsigned',
         'runtime/virtual',
+        'runtime/auto_with_adopt',
         'runtime/wtf_checked_size',
         'runtime/wtf_make_unique',
         'runtime/wtf_move',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6103,6 +6103,45 @@ class WebKitStyleTest(CppStyleTestBase):
             "  [runtime/wtf_checked_size] [5]",
             'foo.cpp')
 
+    def test_auto_with_adopt(self):
+        self.assert_lint(
+            'RetainPtr webView = adoptNS([[TestWKWebView alloc] init]);',
+            '',
+            'foo.mm')
+        self.assert_lint(
+            'auto webView = adoptNS([[TestWKWebView alloc] init]);',
+            "Use 'RetainPtr' instead of 'auto' with 'adoptNS()'."
+            "  [runtime/auto_with_adopt] [4]",
+            'foo.mm')
+        self.assert_lint(
+            'auto context = adoptCF(CGBitmapContextCreate(0, 0, 0, 0, 0, 0, 0));',
+            "Use 'RetainPtr' instead of 'auto' with 'adoptCF()'."
+            "  [runtime/auto_with_adopt] [4]",
+            'foo.cpp')
+        self.assert_lint(
+            'auto obj = adoptRef(*new MyClass);',
+            "Use 'Ref/RefPtr' instead of 'auto' with 'adoptRef()'."
+            "  [runtime/auto_with_adopt] [4]",
+            'foo.cpp')
+        self.assert_lint(
+            'auto queue = adoptOSObject(dispatch_queue_create("foo", DISPATCH_QUEUE_SERIAL));',
+            "Use 'OSObjectPtr' instead of 'auto' with 'adoptOSObject()'."
+            "  [runtime/auto_with_adopt] [4]",
+            'foo.cpp')
+        self.assert_lint(
+            'auto dc = adoptGDIObject(CreateDC());',
+            "Use 'GDIObject' instead of 'auto' with 'adoptGDIObject()'."
+            "  [runtime/auto_with_adopt] [4]",
+            'foo.cpp')
+        self.assert_lint(
+            'Ref obj = adoptRef(*new MyClass);',
+            '',
+            'foo.cpp')
+        self.assert_lint(
+            'auto x = someOtherFunction();',
+            '',
+            'foo.cpp')
+
 
     def test_wtf_make_unique(self):
         self.assert_lint(
@@ -6351,7 +6390,8 @@ class WebKitStyleTest(CppStyleTestBase):
     def test_wtf_os_object_ptr(self):
         self.assert_lint(
             'auto queue = adoptOSObject(dispatch_queue_create("foo", DISPATCH_QUEUE_SERIAL));',
-            '',
+            "Use 'OSObjectPtr' instead of 'auto' with 'adoptOSObject()'."
+            "  [runtime/auto_with_adopt] [4]",
             'foo.cpp')
         self.assert_lint(
             'OSObjectPtr queue = adoptOSObject(dispatch_queue_create("foo", DISPATCH_QUEUE_SERIAL));',
@@ -6363,7 +6403,8 @@ class WebKitStyleTest(CppStyleTestBase):
             'foo.cpp')
         self.assert_lint(
             'auto group = adoptOSObject(dispatch_group_create());',
-            '',
+            "Use 'OSObjectPtr' instead of 'auto' with 'adoptOSObject()'."
+            "  [runtime/auto_with_adopt] [4]",
             'foo.cpp')
         self.assert_lint(
             'RetainPtr<dispatch_queue_t> m_queue;',
@@ -6385,35 +6426,29 @@ class WebKitStyleTest(CppStyleTestBase):
             "Use 'OSObjectPtr' instead of 'RetainPtr' for dispatch objects."
             "  [runtime/wtf_os_object_ptr] [4]",
             'foo.mm')
-        self.assert_lint(
+        self.assert_lint_one_of_many_errors_re(
             'auto queue = adoptNS(dispatch_queue_create("foo", DISPATCH_QUEUE_SERIAL));',
-            "Use 'adoptOSObject()' instead of 'adoptNS()' for dispatch objects."
-            "  [runtime/wtf_os_object_ptr] [4]",
+            r"Use 'adoptOSObject\(\)' instead of 'adoptNS\(\)' for dispatch objects.",
             'foo.mm')
-        self.assert_lint(
+        self.assert_lint_one_of_many_errors_re(
             'auto group = adoptNS(dispatch_group_create());',
-            "Use 'adoptOSObject()' instead of 'adoptNS()' for dispatch objects."
-            "  [runtime/wtf_os_object_ptr] [4]",
+            r"Use 'adoptOSObject\(\)' instead of 'adoptNS\(\)' for dispatch objects.",
             'foo.mm')
-        self.assert_lint(
+        self.assert_lint_one_of_many_errors_re(
             'auto queue = adoptOSObject(dispatch_queue_create("foo", RetainPtr { DISPATCH_QUEUE_CONCURRENT }.get()));',
-            "Use 'OSObjectPtr' instead of 'RetainPtr' for dispatch objects."
-            "  [runtime/wtf_os_object_ptr] [4]",
+            r"Use 'OSObjectPtr' instead of 'RetainPtr' for dispatch objects.",
             'foo.mm')
-        self.assert_lint(
+        self.assert_lint_one_of_many_errors_re(
             'auto queue = adoptOSObject(dispatch_queue_create("foo", RetainPtr { DISPATCH_QUEUE_SERIAL }.get()));',
-            "Use 'OSObjectPtr' instead of 'RetainPtr' for dispatch objects."
-            "  [runtime/wtf_os_object_ptr] [4]",
+            r"Use 'OSObjectPtr' instead of 'RetainPtr' for dispatch objects.",
             'foo.mm')
-        self.assert_lint(
+        self.assert_lint_one_of_many_errors_re(
             'auto queue = adoptOSObject(dispatch_queue_create("foo", retainPtr(DISPATCH_QUEUE_CONCURRENT).get()));',
-            "Use 'OSObjectPtr' instead of 'RetainPtr' for dispatch objects."
-            "  [runtime/wtf_os_object_ptr] [4]",
+            r"Use 'OSObjectPtr' instead of 'RetainPtr' for dispatch objects.",
             'foo.mm')
-        self.assert_lint(
+        self.assert_lint_one_of_many_errors_re(
             'auto queue = adoptOSObject(dispatch_queue_create("foo", retainPtr(DISPATCH_QUEUE_SERIAL).get()));',
-            "Use 'OSObjectPtr' instead of 'RetainPtr' for dispatch objects."
-            "  [runtime/wtf_os_object_ptr] [4]",
+            r"Use 'OSObjectPtr' instead of 'RetainPtr' for dispatch objects.",
             'foo.mm')
 
     def test_wtf_xpc_object_ptr(self):
@@ -6433,15 +6468,15 @@ class WebKitStyleTest(CppStyleTestBase):
             '',
             'foo.mm')
 
-        self.assert_lint(
+        self.assert_lint_one_of_many_errors_re(
             'auto connection = adoptNS(xpc_connection_create_from_endpoint(endpoint));',
-            "Use 'adoptOSObject()' instead of 'adoptNS()' for XPC objects."
-            "  [runtime/wtf_xpc_object_ptr] [4]",
+            r"Use 'adoptOSObject\(\)' instead of 'adoptNS\(\)' for XPC objects.",
             'foo.mm')
 
         self.assert_lint(
             'auto connection = adoptOSObject(xpc_connection_create_from_endpoint(endpoint));',
-            '',
+            "Use 'OSObjectPtr' instead of 'auto' with 'adoptOSObject()'."
+            "  [runtime/auto_with_adopt] [4]",
             'foo.mm')
 
     def test_lock_guard(self):

--- a/Websites/webkit.org/code-style.md
+++ b/Websites/webkit.org/code-style.md
@@ -1623,6 +1623,39 @@ public:
 }
 ```
 
+### Smart Pointer Variable Types
+
+[](#auto-with-adopt) When declaring a local variable that is initialized with an `adopt` method, the variable's type should be explicitly declared as the smart pointer type and not declared using `auto`.
+
+###### Right:
+
+```cpp
+RetainPtr nsDictionary = adoptNS([NSMutableDictionary new]);
+
+RetainPtr cfDictionary = adoptCF(CFDictionaryCreateMutable(
+    kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+		
+Ref origin1 = adoptRef(*new SecurityOrigin);
+
+RefPtr origin2 = adoptRef(new SecurityOrigin);
+
+OSObjectPtr synchronousFileLoadingGroup = adoptOSObject(dispatch_group_create());
+
+```
+
+###### Wrong:
+
+auto nsDictionary = adoptNS([NSMutableDictionary new]);
+
+auto cfDictionary = adoptCF(CFDictionaryCreateMutable(
+    kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+		
+auto origin1 = adoptRef(*new SecurityOrigin);
+
+auto origin2 = adoptRef(new SecurityOrigin);
+
+auto synchronousFileLoadingGroup = adoptOSObject(dispatch_group_create());
+
 ### Python
 
 [](#python) For Python use PEP8 style.


### PR DESCRIPTION
#### 73e0c069df6456dc276e4584d8c86fc2499904e6
<pre>
Codify that smart pointers initialized with an `adopt` method should be declared with their smart pointer type, and not `auto`
<a href="https://rdar.apple.com/174571974">rdar://174571974</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312056">https://bugs.webkit.org/show_bug.cgi?id=312056</a>

Reviewed by Richard Robinson.

This was already suggested by Safer C++ rules, but was not:
1 - Documented with the coding style guidelines
2 - Enforced by `check-webkit-style`

This patch fixes both of those.

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_auto_with_adopt):
(check_style):
(CppChecker):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_auto_with_adopt):
(WebKitStyleTest.test_wtf_os_object_ptr):
(WebKitStyleTest.test_wtf_xpc_object_ptr):
* Websites/webkit.org/code-style.md:

Canonical link: <a href="https://commits.webkit.org/311018@main">https://commits.webkit.org/311018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6bcb7810e8045eba49ee2a548ae1c31089c8560

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164558 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157667 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120594 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22781 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139907 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101283 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/155114 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21867 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20005 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12388 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147844 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131536 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17739 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167038 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19350 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128713 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28598 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24039 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128845 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34907 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28522 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139532 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86364 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23668 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16330 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28216 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27793 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28023 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27866 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->