### PR TITLE
Implement popover=hint

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
@@ -20,7 +20,7 @@ PASS The element <dialog open="">Dialog without popover attribute</dialog> shoul
 PASS IDL attribute reflection
 PASS Popover attribute value should be case insensitive
 PASS Changing attribute values for popover should work
-FAIL Changing attribute values should close open popovers assert_false: expected false got true
+PASS Changing attribute values should close open popovers
 PASS Removing a visible popover=auto element from the document should close the popover
 PASS A showing popover=auto does not match :modal
 PASS A popover=auto never matches :open or :closed
@@ -41,37 +41,37 @@ PASS Changing a popover from auto to auto (via attr), and then invalid during 'b
 PASS Changing a popover from auto to auto (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via attr), and then undefined during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via attr), and then auto during 'beforetoggle' works
-FAIL Changing a popover from auto to hint (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from auto to hint (via attr), and then hint during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via attr), and then undefined during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via attr), and then auto during 'beforetoggle' works
-FAIL Changing a popover from auto to manual (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from auto to manual (via attr), and then hint during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via attr), and then undefined during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via attr), and then auto during 'beforetoggle' works
-FAIL Changing a popover from auto to invalid (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from auto to invalid (via attr), and then hint during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via attr), and then undefined during 'beforetoggle' works
 PASS Changing a popover from auto to null (via attr), and then auto during 'beforetoggle' works
-FAIL Changing a popover from auto to null (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from auto to null (via attr), and then hint during 'beforetoggle' works
 PASS Changing a popover from auto to null (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to null (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to null (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to null (via attr), and then undefined during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via attr), and then auto during 'beforetoggle' works
-FAIL Changing a popover from auto to undefined (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from auto to undefined (via attr), and then hint during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via attr), and then undefined during 'beforetoggle' works
 PASS Changing a popover from hint to auto (via attr), and then auto during 'beforetoggle' works
-FAIL Changing a popover from hint to auto (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from hint to auto (via attr), and then hint during 'beforetoggle' works
 PASS Changing a popover from hint to auto (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from hint to auto (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from hint to auto (via attr), and then null during 'beforetoggle' works
@@ -82,42 +82,42 @@ PASS Changing a popover from hint to hint (via attr), and then manual during 'be
 PASS Changing a popover from hint to hint (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from hint to hint (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from hint to hint (via attr), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from hint to manual (via attr), and then auto during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via attr), and then hint during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via attr), and then manual during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via attr), and then invalid during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via attr), and then null during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via attr), and then undefined during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via attr), and then auto during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via attr), and then hint during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via attr), and then manual during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via attr), and then invalid during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via attr), and then null during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via attr), and then undefined during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to null (via attr), and then auto during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to null (via attr), and then hint during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to null (via attr), and then manual during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to null (via attr), and then invalid during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to null (via attr), and then null during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to null (via attr), and then undefined during 'beforetoggle' works assert_false: expected false got true
+PASS Changing a popover from hint to manual (via attr), and then auto during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via attr), and then hint during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via attr), and then undefined during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via attr), and then auto during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via attr), and then hint during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via attr), and then undefined during 'beforetoggle' works
+PASS Changing a popover from hint to null (via attr), and then auto during 'beforetoggle' works
+PASS Changing a popover from hint to null (via attr), and then hint during 'beforetoggle' works
+PASS Changing a popover from hint to null (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to null (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to null (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to null (via attr), and then undefined during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via attr), and then auto during 'beforetoggle' works
-FAIL Changing a popover from hint to undefined (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from hint to undefined (via attr), and then hint during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via attr), and then undefined during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via attr), and then auto during 'beforetoggle' works
-FAIL Changing a popover from manual to auto (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from manual to auto (via attr), and then hint during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via attr), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from manual to hint (via attr), and then auto during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via attr), and then hint during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via attr), and then manual during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via attr), and then invalid during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via attr), and then null during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via attr), and then undefined during 'beforetoggle' works assert_false: expected false got true
+PASS Changing a popover from manual to hint (via attr), and then auto during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via attr), and then hint during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via attr), and then undefined during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via attr), and then auto during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via attr), and then hint during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via attr), and then manual during 'beforetoggle' works
@@ -137,7 +137,7 @@ PASS Changing a popover from manual to null (via attr), and then invalid during 
 PASS Changing a popover from manual to null (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to null (via attr), and then undefined during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via attr), and then auto during 'beforetoggle' works
-FAIL Changing a popover from manual to undefined (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from manual to undefined (via attr), and then hint during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via attr), and then null during 'beforetoggle' works
@@ -149,37 +149,37 @@ PASS Changing a popover from auto to auto (via idl), and then invalid during 'be
 PASS Changing a popover from auto to auto (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via idl), and then undefined during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via idl), and then auto during 'beforetoggle' works
-FAIL Changing a popover from auto to hint (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from auto to hint (via idl), and then hint during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via idl), and then undefined during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via idl), and then auto during 'beforetoggle' works
-FAIL Changing a popover from auto to manual (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from auto to manual (via idl), and then hint during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via idl), and then undefined during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via idl), and then auto during 'beforetoggle' works
-FAIL Changing a popover from auto to invalid (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from auto to invalid (via idl), and then hint during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via idl), and then undefined during 'beforetoggle' works
 PASS Changing a popover from auto to null (via idl), and then auto during 'beforetoggle' works
-FAIL Changing a popover from auto to null (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from auto to null (via idl), and then hint during 'beforetoggle' works
 PASS Changing a popover from auto to null (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to null (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to null (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to null (via idl), and then undefined during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via idl), and then auto during 'beforetoggle' works
-FAIL Changing a popover from auto to undefined (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from auto to undefined (via idl), and then hint during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via idl), and then undefined during 'beforetoggle' works
 PASS Changing a popover from hint to auto (via idl), and then auto during 'beforetoggle' works
-FAIL Changing a popover from hint to auto (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from hint to auto (via idl), and then hint during 'beforetoggle' works
 PASS Changing a popover from hint to auto (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from hint to auto (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from hint to auto (via idl), and then null during 'beforetoggle' works
@@ -190,42 +190,42 @@ PASS Changing a popover from hint to hint (via idl), and then manual during 'bef
 PASS Changing a popover from hint to hint (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from hint to hint (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from hint to hint (via idl), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from hint to manual (via idl), and then auto during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via idl), and then hint during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via idl), and then manual during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via idl), and then invalid during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via idl), and then null during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via idl), and then undefined during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via idl), and then auto during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via idl), and then hint during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via idl), and then manual during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via idl), and then invalid during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via idl), and then null during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via idl), and then undefined during 'beforetoggle' works assert_false: expected false got true
+PASS Changing a popover from hint to manual (via idl), and then auto during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via idl), and then hint during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via idl), and then undefined during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via idl), and then auto during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via idl), and then hint during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via idl), and then undefined during 'beforetoggle' works
 PASS Changing a popover from hint to null (via idl), and then auto during 'beforetoggle' works
-FAIL Changing a popover from hint to null (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from hint to null (via idl), and then hint during 'beforetoggle' works
 PASS Changing a popover from hint to null (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from hint to null (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from hint to null (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from hint to null (via idl), and then undefined during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via idl), and then auto during 'beforetoggle' works
-FAIL Changing a popover from hint to undefined (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from hint to undefined (via idl), and then hint during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via idl), and then undefined during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via idl), and then auto during 'beforetoggle' works
-FAIL Changing a popover from manual to auto (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from manual to auto (via idl), and then hint during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via idl), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from manual to hint (via idl), and then auto during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via idl), and then hint during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via idl), and then manual during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via idl), and then invalid during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via idl), and then null during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via idl), and then undefined during 'beforetoggle' works assert_false: expected false got true
+PASS Changing a popover from manual to hint (via idl), and then auto during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via idl), and then hint during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via idl), and then undefined during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via idl), and then auto during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via idl), and then hint during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via idl), and then manual during 'beforetoggle' works
@@ -239,13 +239,13 @@ PASS Changing a popover from manual to invalid (via idl), and then invalid durin
 PASS Changing a popover from manual to invalid (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to invalid (via idl), and then undefined during 'beforetoggle' works
 PASS Changing a popover from manual to null (via idl), and then auto during 'beforetoggle' works
-FAIL Changing a popover from manual to null (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from manual to null (via idl), and then hint during 'beforetoggle' works
 PASS Changing a popover from manual to null (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from manual to null (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to null (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to null (via idl), and then undefined during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via idl), and then auto during 'beforetoggle' works
-FAIL Changing a popover from manual to undefined (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+PASS Changing a popover from manual to undefined (via idl), and then hint during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via idl), and then null during 'beforetoggle' works

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-events-expected.txt
@@ -4,5 +4,5 @@ PASS The "beforetoggle" event (attribute) get properly dispatched for popovers
 PASS The "beforetoggle" event is cancelable for the "opening" transition
 PASS The "beforetoggle" event is not fired for element removal
 PASS The "toggle" event is coalesced
-FAIL The toggle event is still fired if the popover is removed during focus/blur assert_array_equals: lengths differ, expected array ["beforetoggle closed -> open", "button blur", "beforetoggle open -> closed", "focusElement focus", "toggle open -> closed", "toggle closed -> open"] length 6, got ["beforetoggle closed -> open", "button blur", "focusElement focus"] length 3
+FAIL The toggle event is still fired if the popover is removed during focus/blur assert_array_equals: lengths differ, expected array ["beforetoggle closed -> open", "button blur", "beforetoggle open -> closed", "focusElement focus", "toggle open -> closed", "toggle closed -> open"] length 6, got ["beforetoggle closed -> open", "button blur", "focusElement focus", "toggle closed -> open"] length 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-dialog-dismisses-unrelated-auto-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-dialog-dismisses-unrelated-auto-expected.txt
@@ -1,0 +1,4 @@
+
+PASS dialog.show() nested in a hint dismisses unrelated auto popovers but keeps the ancestor hint
+PASS dialog.showModal() nested in a hint dismisses unrelated auto popovers but keeps the ancestor hint
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-dialog-dismisses-unrelated-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-dialog-dismisses-unrelated-auto.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Showing a dialog nested in a hint popover dismisses unrelated auto popovers</title>
+<link rel="author" href="mailto:bfulgham@webkit.org">
+<link rel=help href="https://html.spec.whatwg.org/multipage/popover.html#popover-hint">
+<link rel=help href="https://github.com/whatwg/html/issues/12304">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div popover=hint id=hint>Hint
+  <dialog id=dialogInHint>Dialog</dialog>
+</div>
+<div popover id=unrelatedAuto>Unrelated auto</div>
+
+<script>
+  function hintSupported() {
+    const element = document.createElement('div');
+    element.setAttribute('popover', 'hint');
+    return element.popover === 'hint';
+  }
+
+  function closeAll() {
+    if (dialogInHint.open)
+      dialogInHint.close();
+    hint.hidePopover();
+    unrelatedAuto.hidePopover();
+  }
+
+  // A dialog / fullscreen element joining the top layer light-dismisses every popover that is not
+  // one of its ancestors. When the dialog is nested inside a popover=hint, the ancestor hint must
+  // be kept, but an unrelated open popover=auto elsewhere must still be dismissed. These use the
+  // same Document::hidePopoversForTopLayerElement() path, so dialog show() / showModal() cover the
+  // fullscreen case as well.
+  function testDialog(showDialog, description) {
+    promise_test(async t => {
+      assert_implements_optional(hintSupported(), 'popover=hint is not supported');
+      t.add_cleanup(closeAll);
+
+      // Show the auto first: showing an auto closes all hints, so the hint must be shown last.
+      unrelatedAuto.showPopover();
+      hint.showPopover();
+      assert_true(unrelatedAuto.matches(':popover-open'), 'unrelated auto is open');
+      assert_true(hint.matches(':popover-open'), 'ancestor hint is open');
+
+      showDialog();
+      assert_true(dialogInHint.open, 'dialog is open');
+      assert_true(hint.matches(':popover-open'), 'the dialog\'s ancestor hint must stay open');
+      assert_false(unrelatedAuto.matches(':popover-open'), 'the unrelated auto must be dismissed');
+    }, description);
+  }
+
+  testDialog(() => dialogInHint.show(),
+    'dialog.show() nested in a hint dismisses unrelated auto popovers but keeps the ancestor hint');
+  testDialog(() => dialogInHint.showModal(),
+    'dialog.showModal() nested in a hint dismisses unrelated auto popovers but keeps the ancestor hint');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-hierarchy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-hierarchy-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Opening a hint popover will not hide unrelated auto popovers.
-FAIL Opening a hint popover closes only other non-ancestor hint popovers. assert_array_equals: after hint3 show lengths differ, expected array [Element node <div id="auto1" popover="auto">Auto 1</div>, Element node <div id="hint3" popover="hint">Hint 3</div>] length 2, got [Element node <div id="auto1" popover="auto">Auto 1</div>, Element node <div id="hint1" popover="hint">Hint 1</div>, Element node <div id="hint2" popover="hint">Hint 2</div>, Element node <div id="hint3" popover="hint">Hint 3</div>] length 4
-FAIL Clicking outside consistently closes both auto and hint popovers. assert_array_equals: auto reopen hides hint lengths differ, expected array [Element node <div id="auto1" popover="auto">Auto 1</div>] length 1, got [Element node <div id="auto1" popover="auto">Auto 1</div>, Element node <div id="hint1" popover="hint">Hint 1</div>] length 2
-FAIL Hiding an auto popover closes only its child popovers. assert_array_equals: auto reopen hides hint lengths differ, expected array [Element node <div id="auto1" popover="auto">Auto 1</div>] length 1, got [Element node <div id="auto1" popover="auto">Auto 1</div>, Element node <div id="hint1" popover="hint">Hint 1</div>] length 2
+PASS Opening a hint popover closes only other non-ancestor hint popovers.
+PASS Clicking outside consistently closes both auto and hint popovers.
+PASS Hiding an auto popover closes only its child popovers.
 PASS Opening an auto popover inside a hint popover is allowed and it downgrades to hint.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-invoking-attribute-hint-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-invoking-attribute-hint-expected.txt
@@ -1,702 +1,702 @@
 
-FAIL Test <button type="button">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="button">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="reset">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="submit">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <button type="">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="button">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="reset">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="submit">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="image">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="text">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="email">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="password">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="search">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="tel">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="url">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="checkbox">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="radio">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="range">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="file">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="color">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="date">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="datetime-local">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="month">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="time">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="week">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint assert_equals: reflection expected "hint" but got "manual"
-FAIL Test <input type="number">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint assert_equals: reflection expected "hint" but got "manual"
+PASS Test <button type="button">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="button">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="button">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="button">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="button">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="button">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="button">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="button">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="button">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="button">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="button">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="button">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="button">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="button">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="button">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="button">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="button">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="button">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="button">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="button">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="button">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="button">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="button">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="button">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="button">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="button">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="button">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="button">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="reset">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="reset">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="reset">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="reset">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="reset">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="reset">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="reset">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="reset">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="reset">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="reset">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="reset">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="reset">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="reset">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="reset">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="reset">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="reset">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="reset">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="reset">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="reset">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="reset">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="reset">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="reset">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="reset">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="reset">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="reset">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="reset">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="reset">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="reset">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="submit">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="submit">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="submit">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="submit">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="submit">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="submit">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="submit">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="submit">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="submit">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="submit">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="submit">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="submit">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="submit">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="submit">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="submit">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="submit">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="submit">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="submit">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="submit">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="submit">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="submit">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="submit">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="submit">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="submit">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="submit">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="submit">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="submit">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="submit">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <button type="">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <button type="">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <button type="">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="button">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="button">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="button">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="button">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="button">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="button">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="button">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="button">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="button">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="button">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="button">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="button">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="button">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="button">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="button">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="button">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="button">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="button">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="button">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="button">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="button">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="button">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="button">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="button">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="button">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="button">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="button">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="button">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="reset">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="reset">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="reset">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="reset">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="reset">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="reset">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="reset">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="reset">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="reset">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="reset">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="reset">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="reset">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="reset">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="reset">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="reset">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="reset">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="reset">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="reset">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="reset">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="reset">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="reset">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="reset">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="reset">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="reset">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="reset">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="reset">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="reset">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="reset">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="submit">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="submit">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="submit">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="submit">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="submit">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="submit">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="submit">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="submit">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="submit">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="submit">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="submit">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="submit">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="submit">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="submit">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="submit">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="submit">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="submit">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="submit">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="submit">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="submit">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="submit">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="submit">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="submit">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="submit">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="submit">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="submit">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="submit">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="submit">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="image">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="image">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="image">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="image">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="image">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="image">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="image">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="image">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="image">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="image">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="image">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="image">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="image">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="image">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="image">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="image">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="image">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="image">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="image">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="image">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="image">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="image">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="image">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="image">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="image">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="image">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="image">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="image">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="text">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="text">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="text">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="text">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="text">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="text">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="text">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="text">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="text">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="text">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="text">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="text">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="text">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="text">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="text">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="text">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="text">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="text">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="text">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="text">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="text">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="text">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="text">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="text">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="text">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="text">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="text">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="text">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="email">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="email">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="email">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="email">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="email">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="email">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="email">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="email">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="email">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="email">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="email">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="email">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="email">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="email">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="email">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="email">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="email">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="email">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="email">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="email">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="email">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="email">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="email">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="email">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="email">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="email">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="email">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="email">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="password">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="password">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="password">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="password">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="password">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="password">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="password">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="password">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="password">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="password">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="password">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="password">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="password">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="password">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="password">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="password">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="password">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="password">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="password">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="password">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="password">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="password">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="password">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="password">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="password">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="password">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="password">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="password">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="search">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="search">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="search">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="search">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="search">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="search">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="search">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="search">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="search">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="search">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="search">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="search">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="search">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="search">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="search">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="search">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="search">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="search">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="search">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="search">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="search">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="search">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="search">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="search">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="search">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="search">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="search">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="search">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="tel">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="tel">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="tel">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="tel">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="tel">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="tel">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="tel">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="tel">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="tel">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="tel">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="tel">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="tel">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="tel">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="tel">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="tel">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="tel">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="tel">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="tel">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="tel">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="tel">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="tel">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="tel">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="tel">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="tel">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="tel">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="tel">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="tel">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="tel">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="url">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="url">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="url">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="url">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="url">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="url">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="url">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="url">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="url">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="url">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="url">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="url">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="url">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="url">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="url">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="url">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="url">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="url">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="url">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="url">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="url">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="url">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="url">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="url">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="url">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="url">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="url">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="url">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="checkbox">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="checkbox">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="checkbox">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="checkbox">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="checkbox">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="checkbox">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="checkbox">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="checkbox">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="checkbox">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="checkbox">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="checkbox">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="checkbox">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="checkbox">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="checkbox">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="checkbox">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="checkbox">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="checkbox">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="checkbox">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="checkbox">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="checkbox">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="checkbox">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="checkbox">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="checkbox">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="checkbox">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="checkbox">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="checkbox">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="checkbox">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="checkbox">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="radio">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="radio">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="radio">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="radio">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="radio">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="radio">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="radio">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="radio">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="radio">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="radio">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="radio">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="radio">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="radio">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="radio">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="radio">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="radio">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="radio">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="radio">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="radio">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="radio">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="radio">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="radio">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="radio">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="radio">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="radio">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="radio">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="radio">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="radio">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="range">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="range">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="range">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="range">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="range">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="range">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="range">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="range">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="range">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="range">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="range">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="range">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="range">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="range">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="range">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="range">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="range">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="range">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="range">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="range">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="range">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="range">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="range">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="range">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="range">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="range">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="range">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="range">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="file">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="file">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="file">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="file">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="file">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="file">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="file">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="file">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="file">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="file">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="file">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="file">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="file">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="file">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="file">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="file">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="file">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="file">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="file">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="file">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="file">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="file">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="file">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="file">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="file">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="file">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="file">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="file">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="color">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="color">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="color">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="color">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="color">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="color">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="color">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="color">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="color">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="color">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="color">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="color">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="color">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="color">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="color">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="color">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="color">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="color">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="color">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="color">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="color">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="color">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="color">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="color">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="color">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="color">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="color">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="color">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="date">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="date">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="date">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="date">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="date">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="date">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="date">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="date">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="date">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="date">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="date">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="date">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="date">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="date">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="date">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="date">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="date">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="date">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="date">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="date">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="date">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="date">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="date">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="date">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="date">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="date">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="date">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="date">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="datetime-local">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="datetime-local">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="datetime-local">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="datetime-local">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="datetime-local">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="datetime-local">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="datetime-local">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="datetime-local">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="datetime-local">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="datetime-local">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="datetime-local">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="datetime-local">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="datetime-local">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="datetime-local">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="datetime-local">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="datetime-local">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="datetime-local">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="datetime-local">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="datetime-local">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="datetime-local">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="datetime-local">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="datetime-local">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="datetime-local">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="datetime-local">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="datetime-local">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="datetime-local">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="datetime-local">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="datetime-local">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="month">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="month">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="month">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="month">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="month">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="month">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="month">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="month">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="month">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="month">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="month">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="month">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="month">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="month">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="month">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="month">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="month">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="month">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="month">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="month">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="month">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="month">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="month">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="month">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="month">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="month">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="month">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="month">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="time">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="time">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="time">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="time">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="time">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="time">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="time">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="time">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="time">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="time">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="time">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="time">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="time">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="time">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="time">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="time">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="time">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="time">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="time">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="time">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="time">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="time">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="time">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="time">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="time">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="time">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="time">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="time">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="week">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="week">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="week">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="week">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="week">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="week">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="week">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="week">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="week">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="week">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="week">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="week">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="week">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="week">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="week">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="week">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="week">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="week">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="week">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="week">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="week">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="week">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="week">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="week">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="week">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="week">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="week">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="week">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="number">, action=toggle, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="number">, action=toggle, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="number">, action=toggle, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="number">, action=toggle, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="number">, action=hide, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="number">, action=hide, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="number">, action=hide, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="number">, action=hide, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="number">, action=show, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="number">, action=show, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="number">, action=show, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="number">, action=show, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="number">, action=ShOw, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="number">, action=ShOw, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="number">, action=ShOw, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="number">, action=ShOw, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="number">, action=garbage, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="number">, action=garbage, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="number">, action=garbage, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="number">, action=garbage, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="number">, action=null, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="number">, action=null, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="number">, action=null, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="number">, action=null, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="number">, action=undefined, popovertarget attr, popovertargetaction attr, with popover=hint
+PASS Test <input type="number">, action=undefined, popovertarget attr, popoverTargetAction IDL, with popover=hint
+PASS Test <input type="number">, action=undefined, popoverTarget IDL, popovertargetaction attr, with popover=hint
+PASS Test <input type="number">, action=undefined, popoverTarget IDL, popoverTargetAction IDL, with popover=hint
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
@@ -1,7 +1,5 @@
 Popover 1 Popover 1 Outside all popovers  Next control after popover1  Popover 3 - button 3   Popover8 invoker (no action)  Open convoluted popover  Example 2  Open popover 29   Open popover 30 Non-invoker
 
-Harness Error (FAIL), message = Error: assert_throws_dom: function "() => p28.showPopover()" did not throw
-
 PASS Clicking outside a popover will dismiss the popover
 PASS Canceling pointer events should not keep clicks from light dismissing popovers
 PASS Clicking inside a popover does not close that popover
@@ -24,15 +22,15 @@ PASS Moving focus back to the invoker element should not dismiss the popover
 PASS Ensure circular/convoluted ancestral relationships are functional
 PASS Ensure circular/convoluted ancestral relationships are functional, with a direct showPopover()
 PASS Hide the target popover during "hide all popovers until"
-FAIL Show a sibling popover during "hide all popovers until" assert_array_equals: There should not be a hide event for p17 lengths differ, expected array ["hide p18", "hide p16"] length 2, got ["hide p18", "show p17", "hide p16"] length 3
-FAIL Show an unrelated popover during "hide popover" assert_array_equals: There should not be a second hide event for 19 lengths differ, expected array ["hide p19"] length 1, got ["hide p19", "show p20"] length 2
-FAIL Show other auto popover during "hide all popover until" assert_array_equals: hiding p24 does not fire event lengths differ, expected array ["show p23", "hide p22"] length 2, got ["show p23", "hide p22", "show p24"] length 3
-FAIL Nested showPopover assert_array_equals: Nested showPopover should not fire event for its HideAllPopoversUntil lengths differ, expected array ["show p27", "hide p26"] length 2, got ["show p27", "hide p26", "show p28", "show p27"] length 4
+PASS Show a sibling popover during "hide all popovers until"
+PASS Show an unrelated popover during "hide popover"
+PASS Show other auto popover during "hide all popover until"
+PASS Nested showPopover
 PASS Pointer down in one document and pointer up in another document shouldn't dismiss popover
 PASS Pointer down inside invoker and up outside that invoker shouldn't dismiss popover
 PASS Invoker and DOM ancestor relationship - "latest" wins
-FAIL Test "hint stack parent" behavior assert_false: p36 should be closed - p34 is still its hint stack parent expected false got true
-FAIL Opening a new auto popover should hide all hint popovers, even in the nested case assert_false: expected false got true
-FAIL Test "hint stack parent" behavior with deep nested auto popovers - closing grandparent closes hint assert_false: p40 should be closed - closing grandparent auto popover closes child hint popover expected false got true
-FAIL Test "hint stack parent" behavior with deep nested auto popovers - closing parent closes hint assert_false: expected false got true
+PASS Test "hint stack parent" behavior
+PASS Opening a new auto popover should hide all hint popovers, even in the nested case
+PASS Test "hint stack parent" behavior with deep nested auto popovers - closing grandparent closes hint
+PASS Test "hint stack parent" behavior with deep nested auto popovers - closing parent closes hint
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-hint-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-hint-expected.txt
@@ -1,11 +1,11 @@
 
-FAIL Mixed auto/hint light dismiss behavior, click on auto1 assert_equals: Error, index 2 (innerhint1) expected false but got true
-FAIL Mixed auto/hint light dismiss behavior, click on auto2 assert_equals: Error, index 2 (innerhint1) expected false but got true
-FAIL Mixed auto/hint light dismiss behavior, click on innerhint1 assert_equals: Error, index 3 (innerhint2) expected false but got true
+PASS Mixed auto/hint light dismiss behavior, click on auto1
+PASS Mixed auto/hint light dismiss behavior, click on auto2
+PASS Mixed auto/hint light dismiss behavior, click on innerhint1
 PASS Mixed auto/hint light dismiss behavior, click on innerhint2
-FAIL Mixed auto/hint light dismiss behavior, click on hint1 assert_equals: Error, index 1 (hint2) expected false but got true
+PASS Mixed auto/hint light dismiss behavior, click on hint1
 PASS Mixed auto/hint light dismiss behavior, click on hint2
-FAIL Clicking outside closes all setA assert_equals: Error, index 2 (innerhint1) expected false but got true
-FAIL Clicking outside closes all setB assert_equals: Error, index 0 (hint1) expected false but got true
+PASS Clicking outside closes all setA
+PASS Clicking outside closes all setB
 PASS Auto can be nested inside hint (nothing should throw, auto demoted to hint)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-manual-hide-does-not-close-auto-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-manual-hide-does-not-close-auto-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Hiding a manual popover shown after an auto popover does not close the auto popover
+PASS Hiding a manual popover shown before an auto popover does not close the auto popover
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-manual-hide-does-not-close-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-manual-hide-does-not-close-auto.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Hiding a manual popover must not close open auto popovers</title>
+<link rel="author" href="mailto:bfulgham@webkit.org">
+<link rel=help href="https://html.spec.whatwg.org/multipage/popover.html#hide-popover-algorithm">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div popover id=autoPopover>Auto</div>
+<div popover=manual id=manualPopover>Manual</div>
+
+<script>
+  function closeAll() {
+    autoPopover.hidePopover();
+    manualPopover.hidePopover();
+  }
+
+  test(t => {
+    t.add_cleanup(closeAll);
+    autoPopover.showPopover();
+    manualPopover.showPopover();
+    assert_true(autoPopover.matches(':popover-open'), 'auto is open');
+    assert_true(manualPopover.matches(':popover-open'), 'manual is open');
+
+    manualPopover.hidePopover();
+    assert_false(manualPopover.matches(':popover-open'), 'manual is closed after hidePopover()');
+    assert_true(autoPopover.matches(':popover-open'), 'auto must stay open when a manual popover is hidden');
+  }, 'Hiding a manual popover shown after an auto popover does not close the auto popover');
+
+  test(t => {
+    t.add_cleanup(closeAll);
+    manualPopover.showPopover();
+    autoPopover.showPopover();
+    assert_true(autoPopover.matches(':popover-open'), 'auto is open');
+    assert_true(manualPopover.matches(':popover-open'), 'manual is open');
+
+    manualPopover.hidePopover();
+    assert_false(manualPopover.matches(':popover-open'), 'manual is closed after hidePopover()');
+    assert_true(autoPopover.matches(':popover-open'), 'auto must stay open when a manual popover is hidden');
+  }, 'Hiding a manual popover shown before an auto popover does not close the auto popover');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-open-in-beforetoggle-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-open-in-beforetoggle-expected.txt
@@ -1,11 +1,8 @@
 Outside
-p6
 
-Harness Error (FAIL), message = Error: assert_throws_dom: function "() => p6.showPopover()" did not throw
-
-FAIL Open popover from closing beforetoggle event assert_false: expected false got true
-FAIL Open double-nested popovers from closing beforetoggle event assert_false: expected false got true
+PASS Open popover from closing beforetoggle event
+PASS Open double-nested popovers from closing beforetoggle event
 PASS Open double-nested popovers from closing beforetoggle event, dialog open
 PASS Open double-nested popovers from closing beforetoggle event, light dismiss
-FAIL Showing a hint during a showPopover that hides an auto should throw InvalidStateError assert_false: p6 should be closed expected false got true
+PASS Showing a hint during a showPopover that hides an auto should throw InvalidStateError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-remove-attribute-during-focusing-steps-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-remove-attribute-during-focusing-steps-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Remove popover attribute during the popover focusing steps assert_equals: two toggle events should be dispatched expected 2 but got 0
+FAIL Remove popover attribute during the popover focusing steps assert_equals: two toggle events should be dispatched expected 2 but got 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-hints-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-hints-expected.txt
@@ -12,15 +12,15 @@ PASS Nested auto/hint ancestors with dialog
 PASS Nested auto/hint ancestors with dialog, top layer element *is* a popover
 PASS Nested auto/hint ancestors with fullscreen
 PASS Nested auto/hint ancestors with fullscreen, top layer element *is* a popover
-PASS Nested auto/hint ancestors, target is auto with dialog
+FAIL Nested auto/hint ancestors, target is auto with dialog assert_equals: Incorrect behavior expected true but got false
 PASS Nested auto/hint ancestors, target is auto with dialog, top layer element *is* a popover
-PASS Nested auto/hint ancestors, target is auto with fullscreen
+FAIL Nested auto/hint ancestors, target is auto with fullscreen assert_equals: Incorrect behavior expected true but got false
 PASS Nested auto/hint ancestors, target is auto with fullscreen, top layer element *is* a popover
-FAIL Unrelated hint, target=hint with dialog assert_equals: Incorrect behavior expected true but got false
+PASS Unrelated hint, target=hint with dialog
 PASS Unrelated hint, target=hint with dialog, top layer element *is* a popover
-FAIL Unrelated hint, target=hint with fullscreen assert_equals: Incorrect behavior expected true but got false
+PASS Unrelated hint, target=hint with fullscreen
 PASS Unrelated hint, target=hint with fullscreen, top layer element *is* a popover
-PASS Unrelated hint, target=auto with dialog
+FAIL Unrelated hint, target=auto with dialog assert_equals: Incorrect behavior expected true but got false
 PASS Unrelated hint, target=auto with dialog, top layer element *is* a popover
 FAIL Unrelated hint, target=auto with fullscreen assert_equals: Incorrect behavior expected true but got false
 PASS Unrelated hint, target=auto with fullscreen, top layer element *is* a popover

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-types-with-hints-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-types-with-hints-expected.txt
@@ -1,11 +1,10 @@
-HintAsyncAsync
-Auto Hint Auto3
+Auto Auto3
 
 PASS manuals do not close popovers
-FAIL autos close hints but not manuals assert_equals: Error, index 1 (<div popover="hint">Hint</div>) expected false but got true
-FAIL You can nest hint popovers assert_equals: Error, index 1 (<div popover="hint">Nested hint</div>) expected false but got true
-FAIL Opening an auto popover inside a hint popover is allowed and it downgrades to hint. assert_equals: closing the parent hint should close downgraded, nested auto, index 1 (<div popover="">Nested auto (note - never visible, since inside display:none subtree)</div>) expected false but got true
-FAIL If you: a) show a popover=auto (call it D), then b) show a descendent popover=hint of D (call it T), then c) hide D, then T should be hidden. (A popover=hint gets hidden when its ancestral popover=auto is hidden) assert_equals: Error, index 2 (<div popover="hint">Nested hint</div>) expected false but got true
+PASS autos close hints but not manuals
+PASS You can nest hint popovers
+PASS Opening an auto popover inside a hint popover is allowed and it downgrades to hint.
+PASS If you: a) show a popover=auto (call it D), then b) show a descendent popover=hint of D (call it T), then c) hide D, then T should be hidden. (A popover=hint gets hidden when its ancestral popover=auto is hidden)
 PASS If you: a) show a popover=auto (call it D), then b) show a non-descendent popover=hint of D (call it T), then c) hide D, then T should stay open. (Non-nested popover=hint does not get hidden when unrelated popover=autos are hidden)
-FAIL When showing an auto popover, hint popovers should be closed before auto popovers. assert_array_equals: Hint should be hidden before Auto lengths differ, expected array ["hint", "auto"] length 2, got ["auto"] length 1
+PASS When showing an auto popover, hint popovers should be closed before auto popovers.
 

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
@@ -1,7 +1,5 @@
 Popover 1 Popover 1 Outside all popovers  Next control after popover1  Popover 3 - button 3 Popover8 invoker (no action)  Open convoluted popover  Example 2  Open popover 29   Open popover 30 Non-invoker
 
-Harness Error (FAIL), message = Error: assert_throws_dom: function "() => p28.showPopover()" did not throw
-
 PASS Clicking outside a popover will dismiss the popover
 PASS Canceling pointer events should not keep clicks from light dismissing popovers
 PASS Clicking inside a popover does not close that popover
@@ -24,15 +22,15 @@ PASS Moving focus back to the invoker element should not dismiss the popover
 PASS Ensure circular/convoluted ancestral relationships are functional
 PASS Ensure circular/convoluted ancestral relationships are functional, with a direct showPopover()
 PASS Hide the target popover during "hide all popovers until"
-FAIL Show a sibling popover during "hide all popovers until" assert_array_equals: There should not be a hide event for p17 lengths differ, expected array ["hide p18", "hide p16"] length 2, got ["hide p18", "show p17", "hide p16"] length 3
-FAIL Show an unrelated popover during "hide popover" assert_array_equals: There should not be a second hide event for 19 lengths differ, expected array ["hide p19"] length 1, got ["hide p19", "show p20"] length 2
-FAIL Show other auto popover during "hide all popover until" assert_array_equals: hiding p24 does not fire event lengths differ, expected array ["show p23", "hide p22"] length 2, got ["show p23", "hide p22", "show p24"] length 3
-FAIL Nested showPopover assert_array_equals: Nested showPopover should not fire event for its HideAllPopoversUntil lengths differ, expected array ["show p27", "hide p26"] length 2, got ["show p27", "hide p26", "show p28", "show p27"] length 4
+PASS Show a sibling popover during "hide all popovers until"
+PASS Show an unrelated popover during "hide popover"
+PASS Show other auto popover during "hide all popover until"
+PASS Nested showPopover
 PASS Pointer down in one document and pointer up in another document shouldn't dismiss popover
 PASS Pointer down inside invoker and up outside that invoker shouldn't dismiss popover
 PASS Invoker and DOM ancestor relationship - "latest" wins
-FAIL Test "hint stack parent" behavior assert_false: p36 should be closed - p34 is still its hint stack parent expected false got true
-FAIL Opening a new auto popover should hide all hint popovers, even in the nested case assert_false: expected false got true
-FAIL Test "hint stack parent" behavior with deep nested auto popovers - closing grandparent closes hint assert_false: p40 should be closed - closing grandparent auto popover closes child hint popover expected false got true
-FAIL Test "hint stack parent" behavior with deep nested auto popovers - closing parent closes hint assert_false: expected false got true
+PASS Test "hint stack parent" behavior
+PASS Opening a new auto popover should hide all hint popovers, even in the nested case
+PASS Test "hint stack parent" behavior with deep nested auto popovers - closing grandparent closes hint
+PASS Test "hint stack parent" behavior with deep nested auto popovers - closing parent closes hint
 

--- a/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
+++ b/LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
@@ -20,7 +20,7 @@ PASS The element <dialog open="">Dialog without popover attribute</dialog> shoul
 PASS IDL attribute reflection
 PASS Popover attribute value should be case insensitive
 PASS Changing attribute values for popover should work
-FAIL Changing attribute values should close open popovers assert_false: expected false got true
+PASS Changing attribute values should close open popovers
 PASS Removing a visible popover=auto element from the document should close the popover
 PASS A showing popover=auto does not match :modal
 PASS A popover=auto never matches :open or :closed
@@ -41,37 +41,37 @@ PASS Changing a popover from auto to auto (via attr), and then invalid during 'b
 PASS Changing a popover from auto to auto (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via attr), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to hint (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from auto to hint (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from auto to hint (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to hint (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via attr), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to manual (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from auto to manual (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from auto to manual (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to manual (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via attr), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to invalid (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from auto to invalid (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from auto to invalid (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to invalid (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via attr), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to null (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from auto to null (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from auto to null (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to null (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to null (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to null (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to null (via attr), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to undefined (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from auto to undefined (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from auto to undefined (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to undefined (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via attr), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from hint to auto (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from hint to auto (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from hint to auto (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from hint to auto (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from hint to auto (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from hint to auto (via attr), and then null during 'beforetoggle' works
@@ -82,42 +82,42 @@ PASS Changing a popover from hint to hint (via attr), and then manual during 'be
 PASS Changing a popover from hint to hint (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from hint to hint (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from hint to hint (via attr), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from hint to manual (via attr), and then auto during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via attr), and then hint during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via attr), and then manual during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via attr), and then invalid during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via attr), and then null during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via attr), and then undefined during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via attr), and then auto during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via attr), and then hint during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via attr), and then manual during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via attr), and then invalid during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via attr), and then null during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via attr), and then undefined during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to null (via attr), and then auto during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to null (via attr), and then hint during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to null (via attr), and then manual during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to null (via attr), and then invalid during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to null (via attr), and then null during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to null (via attr), and then undefined during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to manual (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from hint to manual (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from hint to manual (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via attr), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from hint to invalid (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from hint to invalid (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from hint to invalid (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via attr), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from hint to null (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from hint to null (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from hint to null (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to null (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to null (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to null (via attr), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from hint to undefined (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from hint to undefined (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from hint to undefined (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from hint to undefined (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via attr), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from manual to auto (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from manual to auto (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from manual to auto (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from manual to auto (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via attr), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from manual to hint (via attr), and then auto during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via attr), and then hint during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via attr), and then manual during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via attr), and then invalid during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via attr), and then null during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via attr), and then undefined during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from manual to hint (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from manual to hint (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from manual to hint (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via attr), and then undefined during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via attr), and then auto during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via attr), and then hint during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via attr), and then manual during 'beforetoggle' works
@@ -137,7 +137,7 @@ PASS Changing a popover from manual to null (via attr), and then invalid during 
 PASS Changing a popover from manual to null (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to null (via attr), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from manual to undefined (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from manual to undefined (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from manual to undefined (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from manual to undefined (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via attr), and then null during 'beforetoggle' works
@@ -149,37 +149,37 @@ PASS Changing a popover from auto to auto (via idl), and then invalid during 'be
 PASS Changing a popover from auto to auto (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to hint (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from auto to hint (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from auto to hint (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to hint (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to manual (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from auto to manual (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from auto to manual (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to manual (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to invalid (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from auto to invalid (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from auto to invalid (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to invalid (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to null (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from auto to null (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from auto to null (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to null (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to null (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to null (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to null (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to undefined (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from auto to undefined (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from auto to undefined (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to undefined (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from hint to auto (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from hint to auto (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from hint to auto (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from hint to auto (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from hint to auto (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from hint to auto (via idl), and then null during 'beforetoggle' works
@@ -190,42 +190,42 @@ PASS Changing a popover from hint to hint (via idl), and then manual during 'bef
 PASS Changing a popover from hint to hint (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from hint to hint (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from hint to hint (via idl), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from hint to manual (via idl), and then auto during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via idl), and then hint during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via idl), and then manual during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via idl), and then invalid during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via idl), and then null during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via idl), and then undefined during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via idl), and then auto during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via idl), and then hint during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via idl), and then manual during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via idl), and then invalid during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via idl), and then null during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via idl), and then undefined during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to manual (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from hint to manual (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from hint to manual (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via idl), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from hint to invalid (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from hint to invalid (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from hint to invalid (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from hint to null (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from hint to null (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from hint to null (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from hint to null (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from hint to null (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from hint to null (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from hint to null (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from hint to undefined (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from hint to undefined (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from hint to undefined (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from hint to undefined (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from manual to auto (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from manual to auto (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from manual to auto (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from manual to auto (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via idl), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from manual to hint (via idl), and then auto during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via idl), and then hint during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via idl), and then manual during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via idl), and then invalid during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via idl), and then null during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via idl), and then undefined during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from manual to hint (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from manual to hint (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from manual to hint (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via idl), and then undefined during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via idl), and then auto during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via idl), and then hint during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via idl), and then manual during 'beforetoggle' works
@@ -239,13 +239,13 @@ PASS Changing a popover from manual to invalid (via idl), and then invalid durin
 PASS Changing a popover from manual to invalid (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to invalid (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from manual to null (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from manual to null (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from manual to null (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from manual to null (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from manual to null (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to null (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to null (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from manual to undefined (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from manual to undefined (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from manual to undefined (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from manual to undefined (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via idl), and then null during 'beforetoggle' works

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt
@@ -20,7 +20,7 @@ PASS The element <dialog open="">Dialog without popover attribute</dialog> shoul
 PASS IDL attribute reflection
 PASS Popover attribute value should be case insensitive
 PASS Changing attribute values for popover should work
-FAIL Changing attribute values should close open popovers assert_false: expected false got true
+PASS Changing attribute values should close open popovers
 PASS Removing a visible popover=auto element from the document should close the popover
 PASS A showing popover=auto does not match :modal
 PASS A popover=auto never matches :open or :closed
@@ -41,37 +41,37 @@ PASS Changing a popover from auto to auto (via attr), and then invalid during 'b
 PASS Changing a popover from auto to auto (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via attr), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to hint (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from auto to hint (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from auto to hint (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to hint (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via attr), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to manual (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from auto to manual (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from auto to manual (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to manual (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via attr), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to invalid (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from auto to invalid (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from auto to invalid (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to invalid (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via attr), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to null (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from auto to null (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from auto to null (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to null (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to null (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to null (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to null (via attr), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to undefined (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from auto to undefined (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from auto to undefined (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to undefined (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via attr), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from hint to auto (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from hint to auto (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from hint to auto (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from hint to auto (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from hint to auto (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from hint to auto (via attr), and then null during 'beforetoggle' works
@@ -82,42 +82,42 @@ PASS Changing a popover from hint to hint (via attr), and then manual during 'be
 PASS Changing a popover from hint to hint (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from hint to hint (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from hint to hint (via attr), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from hint to manual (via attr), and then auto during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via attr), and then hint during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via attr), and then manual during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via attr), and then invalid during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via attr), and then null during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via attr), and then undefined during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via attr), and then auto during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via attr), and then hint during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via attr), and then manual during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via attr), and then invalid during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via attr), and then null during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via attr), and then undefined during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to null (via attr), and then auto during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to null (via attr), and then hint during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to null (via attr), and then manual during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to null (via attr), and then invalid during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to null (via attr), and then null during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to null (via attr), and then undefined during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to manual (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from hint to manual (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from hint to manual (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via attr), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from hint to invalid (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from hint to invalid (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from hint to invalid (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via attr), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from hint to null (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from hint to null (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from hint to null (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to null (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to null (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to null (via attr), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from hint to undefined (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from hint to undefined (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from hint to undefined (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from hint to undefined (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via attr), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from manual to auto (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from manual to auto (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from manual to auto (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from manual to auto (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via attr), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from manual to hint (via attr), and then auto during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via attr), and then hint during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via attr), and then manual during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via attr), and then invalid during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via attr), and then null during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via attr), and then undefined during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from manual to hint (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from manual to hint (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from manual to hint (via attr), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via attr), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via attr), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via attr), and then undefined during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via attr), and then auto during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via attr), and then hint during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via attr), and then manual during 'beforetoggle' works
@@ -137,7 +137,7 @@ PASS Changing a popover from manual to null (via attr), and then invalid during 
 PASS Changing a popover from manual to null (via attr), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to null (via attr), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from manual to undefined (via attr), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from manual to undefined (via attr), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from manual to undefined (via attr), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from manual to undefined (via attr), and then manual during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via attr), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via attr), and then null during 'beforetoggle' works
@@ -149,37 +149,37 @@ PASS Changing a popover from auto to auto (via idl), and then invalid during 'be
 PASS Changing a popover from auto to auto (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to auto (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to hint (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from auto to hint (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from auto to hint (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to hint (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to hint (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to manual (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from auto to manual (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from auto to manual (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to manual (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to manual (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to invalid (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from auto to invalid (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from auto to invalid (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to invalid (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to invalid (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to null (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from auto to null (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from auto to null (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to null (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to null (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to null (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to null (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from auto to undefined (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from auto to undefined (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from auto to undefined (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from auto to undefined (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from auto to undefined (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from hint to auto (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from hint to auto (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from hint to auto (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from hint to auto (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from hint to auto (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from hint to auto (via idl), and then null during 'beforetoggle' works
@@ -190,42 +190,42 @@ PASS Changing a popover from hint to hint (via idl), and then manual during 'bef
 PASS Changing a popover from hint to hint (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from hint to hint (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from hint to hint (via idl), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from hint to manual (via idl), and then auto during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via idl), and then hint during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via idl), and then manual during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via idl), and then invalid during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via idl), and then null during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to manual (via idl), and then undefined during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via idl), and then auto during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via idl), and then hint during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via idl), and then manual during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via idl), and then invalid during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via idl), and then null during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from hint to invalid (via idl), and then undefined during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from hint to manual (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from hint to manual (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from hint to manual (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to manual (via idl), and then undefined during 'beforetoggle' works
+FAIL Changing a popover from hint to invalid (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from hint to invalid (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from hint to invalid (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from hint to invalid (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from hint to null (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from hint to null (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from hint to null (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from hint to null (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from hint to null (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from hint to null (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from hint to null (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from hint to undefined (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from hint to undefined (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from hint to undefined (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from hint to undefined (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from hint to undefined (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from manual to auto (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from manual to auto (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from manual to auto (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from manual to auto (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to auto (via idl), and then undefined during 'beforetoggle' works
-FAIL Changing a popover from manual to hint (via idl), and then auto during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via idl), and then hint during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via idl), and then manual during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via idl), and then invalid during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via idl), and then null during 'beforetoggle' works assert_false: expected false got true
-FAIL Changing a popover from manual to hint (via idl), and then undefined during 'beforetoggle' works assert_false: expected false got true
+FAIL Changing a popover from manual to hint (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+FAIL Changing a popover from manual to hint (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
+PASS Changing a popover from manual to hint (via idl), and then manual during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via idl), and then invalid during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via idl), and then null during 'beforetoggle' works
+PASS Changing a popover from manual to hint (via idl), and then undefined during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via idl), and then auto during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via idl), and then hint during 'beforetoggle' works
 PASS Changing a popover from manual to manual (via idl), and then manual during 'beforetoggle' works
@@ -239,13 +239,13 @@ PASS Changing a popover from manual to invalid (via idl), and then invalid durin
 PASS Changing a popover from manual to invalid (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to invalid (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from manual to null (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from manual to null (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from manual to null (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from manual to null (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from manual to null (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to null (via idl), and then null during 'beforetoggle' works
 PASS Changing a popover from manual to null (via idl), and then undefined during 'beforetoggle' works
 FAIL Changing a popover from manual to undefined (via idl), and then auto during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
-FAIL Changing a popover from manual to undefined (via idl), and then hint during 'beforetoggle' works assert_equals: IDL attribute expected "hint" but got "manual"
+FAIL Changing a popover from manual to undefined (via idl), and then hint during 'beforetoggle' works assert_false: A popover=auto should light-dismiss expected false got true
 PASS Changing a popover from manual to undefined (via idl), and then manual during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via idl), and then invalid during 'beforetoggle' works
 PASS Changing a popover from manual to undefined (via idl), and then null during 'beforetoggle' works

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-hierarchy-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-hierarchy-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Opening a hint popover will not hide unrelated auto popovers.
-FAIL Opening a hint popover closes only other non-ancestor hint popovers. assert_array_equals: after hint3 show lengths differ, expected array [Element node <div id="auto1" popover="auto">Auto 1</div>, Element node <div id="hint3" popover="hint">Hint 3</div>] length 2, got [Element node <div id="auto1" popover="auto">Auto 1</div>, Element node <div id="hint1" popover="hint">Hint 1</div>, Element node <div id="hint2" popover="hint">Hint 2</div>, Element node <div id="hint3" popover="hint">Hint 3</div>] length 4
+PASS Opening a hint popover closes only other non-ancestor hint popovers.
 FAIL Clicking outside consistently closes both auto and hint popovers. assert_array_equals: after hint click lengths differ, expected array [Element node <div id="hint1" popover="hint">Hint 1</div>] length 1, got [Element node <div id="auto1" popover="auto">Auto 1</div>, Element node <div id="hint1" popover="hint">Hint 1</div>] length 2
-FAIL Hiding an auto popover closes only its child popovers. assert_array_equals: auto reopen hides hint lengths differ, expected array [Element node <div id="auto1" popover="auto">Auto 1</div>] length 1, got [Element node <div id="auto1" popover="auto">Auto 1</div>, Element node <div id="hint1" popover="hint">Hint 1</div>] length 2
+PASS Hiding an auto popover closes only its child popovers.
 FAIL Opening an auto popover inside a hint popover is allowed and it downgrades to hint. assert_array_equals: after click lengths differ, expected array [Element node <div id="auto1" popover="auto">Auto 1</div>, Element node <div id="hint1" popover="hint">Hint 1<button popovertarge...] length 2, got [Element node <div id="hint1" popover="hint">Hint 1<button popovertarge...] length 1
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
@@ -1,7 +1,5 @@
 Popover 1 Popover 1 Outside all popovers  Next control after popover1  Popover 3 - button 3   Popover8 invoker (no action)  Open convoluted popover  Example 2  Open popover 29  Open popover 30 Non-invoker
 
-Harness Error (FAIL), message = Error: assert_throws_dom: function "() => p28.showPopover()" did not throw
-
 PASS Clicking outside a popover will dismiss the popover
 PASS Canceling pointer events should not keep clicks from light dismissing popovers
 PASS Clicking inside a popover does not close that popover
@@ -24,15 +22,15 @@ PASS Moving focus back to the invoker element should not dismiss the popover
 PASS Ensure circular/convoluted ancestral relationships are functional
 PASS Ensure circular/convoluted ancestral relationships are functional, with a direct showPopover()
 PASS Hide the target popover during "hide all popovers until"
-FAIL Show a sibling popover during "hide all popovers until" assert_array_equals: There should not be a hide event for p17 lengths differ, expected array ["hide p18", "hide p16"] length 2, got ["hide p18", "show p17", "hide p16"] length 3
-FAIL Show an unrelated popover during "hide popover" assert_array_equals: There should not be a second hide event for 19 lengths differ, expected array ["hide p19"] length 1, got ["hide p19", "show p20"] length 2
-FAIL Show other auto popover during "hide all popover until" assert_array_equals: hiding p24 does not fire event lengths differ, expected array ["show p23", "hide p22"] length 2, got ["show p23", "hide p22", "show p24"] length 3
-FAIL Nested showPopover assert_array_equals: Nested showPopover should not fire event for its HideAllPopoversUntil lengths differ, expected array ["show p27", "hide p26"] length 2, got ["show p27", "hide p26", "show p28", "show p27"] length 4
+PASS Show a sibling popover during "hide all popovers until"
+PASS Show an unrelated popover during "hide popover"
+PASS Show other auto popover during "hide all popover until"
+PASS Nested showPopover
 PASS Pointer down in one document and pointer up in another document shouldn't dismiss popover
 PASS Pointer down inside invoker and up outside that invoker shouldn't dismiss popover
 PASS Invoker and DOM ancestor relationship - "latest" wins
-FAIL Test "hint stack parent" behavior assert_false: p36 should be closed - p34 is still its hint stack parent expected false got true
-FAIL Opening a new auto popover should hide all hint popovers, even in the nested case assert_false: expected false got true
-FAIL Test "hint stack parent" behavior with deep nested auto popovers - closing grandparent closes hint assert_false: p40 should be closed - closing grandparent auto popover closes child hint popover expected false got true
-FAIL Test "hint stack parent" behavior with deep nested auto popovers - closing parent closes hint assert_false: expected false got true
+PASS Test "hint stack parent" behavior
+PASS Opening a new auto popover should hide all hint popovers, even in the nested case
+PASS Test "hint stack parent" behavior with deep nested auto popovers - closing grandparent closes hint
+PASS Test "hint stack parent" behavior with deep nested auto popovers - closing parent closes hint
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6769,6 +6769,20 @@ PopoverAttributeEnabled:
     WebCore:
       default: true
 
+PopoverHintEnabled:
+  type: bool
+  status: preview
+  category: html
+  humanReadableName: "HTML popover hint type"
+  humanReadableDescription: "Enable popover='hint' type support"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 PreferFasterClickOverDoubleTap:
   type: bool
   status: internal

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3,7 +3,7 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
  *           (C) 2006 Alexey Proskuryakov (ap@webkit.org)
- * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2008, 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  * Copyright (C) 2008-2014 Google Inc. All rights reserved.
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)
@@ -11040,30 +11040,55 @@ void Document::keyframesRuleDidChange(const String& name)
     }
 }
 
+void Document::addPopoverToList(PopoverListType listType, HTMLElement& popover)
+{
+    auto& list = listType == PopoverListType::Auto ? m_autoPopoverList : m_hintPopoverList;
+#if ENABLE(IOS_TOUCH_EVENTS)
+    bool neededEventHandling = needsPointerEventHandlingForPopoverOrDialog();
+#endif
+    auto result = list.add(popover);
+#if ENABLE(IOS_TOUCH_EVENTS)
+    if (!neededEventHandling) {
+        invalidateRenderingDependentRegions();
+        invalidateEventListenerRegions();
+    }
+#endif
+    RELEASE_ASSERT(result.isNewEntry);
+}
+
+void Document::removePopoverFromList(PopoverListType listType, HTMLElement& popover)
+{
+    auto& list = listType == PopoverListType::Auto ? m_autoPopoverList : m_hintPopoverList;
+    list.remove(popover);
+#if ENABLE(IOS_TOUCH_EVENTS)
+    if (!needsPointerEventHandlingForPopoverOrDialog()) {
+        invalidateRenderingDependentRegions();
+        invalidateEventListenerRegions();
+    }
+#endif
+}
+
 void Document::addTopLayerElement(Element& element)
 {
     RELEASE_ASSERT(&element.document() == this && !element.isInTopLayer());
     auto result = m_topLayerElements.add(element);
     RELEASE_ASSERT(result.isNewEntry);
-    if (auto* candidatePopover = dynamicDowncast<HTMLElement>(element); candidatePopover && candidatePopover->popoverState() == PopoverState::Auto) {
+    RefPtr candidatePopover = dynamicDowncast<HTMLElement>(element);
+    if (!candidatePopover)
+        return;
+
 #if ENABLE(FULLSCREEN_API)
-        if (candidatePopover->hasFullscreenFlag())
-            return;
+    if (candidatePopover->hasFullscreenFlag())
+        return;
 #endif
-        CheckedPtr dialogElement = dynamicDowncast<HTMLDialogElement>(*candidatePopover);
-        if (dialogElement && dialogElement->isModal())
-            return;
-#if ENABLE(IOS_TOUCH_EVENTS)
-        bool neededEventHandling = needsPointerEventHandlingForPopoverOrDialog();
-#endif
-        auto result = m_autoPopoverList.add(*candidatePopover);
-#if ENABLE(IOS_TOUCH_EVENTS)
-        if (!neededEventHandling) {
-            invalidateRenderingDependentRegions();
-            invalidateEventListenerRegions();
-        }
-#endif
-        RELEASE_ASSERT(result.isNewEntry);
+
+    RefPtr dialogElement = dynamicDowncast<HTMLDialogElement>(*candidatePopover);
+    if (dialogElement && dialogElement->isModal())
+        return;
+
+    if (candidatePopover->popoverState() == PopoverState::Auto || candidatePopover->popoverState() == PopoverState::Hint) {
+        bool asHint = candidatePopover->popoverData() && candidatePopover->popoverData()->showingAsHint();
+        addPopoverToList(asHint ? PopoverListType::Hint : PopoverListType::Auto, *candidatePopover);
     }
 }
 
@@ -11072,14 +11097,11 @@ void Document::removeTopLayerElement(Element& element)
     RELEASE_ASSERT(&element.document() == this && element.isInTopLayer());
     auto didRemove = m_topLayerElements.remove(element);
     RELEASE_ASSERT(didRemove);
-    if (auto* candidatePopover = dynamicDowncast<HTMLElement>(element); candidatePopover && candidatePopover->isPopoverShowing() && candidatePopover->popoverState() == PopoverState::Auto) {
-        m_autoPopoverList.remove(*candidatePopover);
-#if ENABLE(IOS_TOUCH_EVENTS)
-        if (!needsPointerEventHandlingForPopoverOrDialog()) {
-            invalidateRenderingDependentRegions();
-            invalidateEventListenerRegions();
+    if (RefPtr candidatePopover = dynamicDowncast<HTMLElement>(element); candidatePopover && candidatePopover->isPopoverShowing()) {
+        if (candidatePopover->popoverState() == PopoverState::Auto || candidatePopover->popoverState() == PopoverState::Hint) {
+            bool asHint = candidatePopover->popoverData() && candidatePopover->popoverData()->showingAsHint();
+            removePopoverFromList(asHint ? PopoverListType::Hint : PopoverListType::Auto, *candidatePopover);
         }
-#endif
     }
 }
 
@@ -11098,6 +11120,60 @@ HTMLElement* Document::topmostAutoPopover() const
     if (m_autoPopoverList.isEmpty())
         return nullptr;
     return m_autoPopoverList.last().ptr();
+}
+
+HTMLElement* Document::topmostHintPopover() const
+{
+    if (m_hintPopoverList.isEmpty())
+        return nullptr;
+    return m_hintPopoverList.last().ptr();
+}
+
+// Popover ancestor relationships are defined over the flat/composed tree, so a hint popover
+// slotted into shadow content is still considered nested inside its host's popover. See the
+// "nearest inclusive open popover" definition: https://html.spec.whatwg.org/#nearest-inclusive-open-popover
+HTMLElement* Document::nearestOpenHintAncestor(Element& element) const
+{
+    for (Ref ancestor : composedTreeLineage(element)) {
+        auto* htmlElement = dynamicDowncast<HTMLElement>(ancestor.ptr());
+        if (htmlElement && htmlElement->popoverState() == PopoverState::Hint
+            && htmlElement->popoverData()
+            && htmlElement->popoverData()->visibilityState() == PopoverVisibilityState::Showing)
+            return htmlElement;
+    }
+    return nullptr;
+}
+
+void Document::closeAllHintPopovers(FocusPreviousElement focusPreviousElement, FireEvents fireEvents)
+{
+    while (RefPtr popover = topmostHintPopover())
+        popover->hidePopoverInternal(focusPreviousElement, fireEvents);
+    m_popoverHintPointerDownTarget = nullptr;
+}
+
+void Document::closeHintPopoversUntil(const HTMLElement* endpoint, FocusPreviousElement focusPreviousElement, FireEvents fireEvents)
+{
+    if (!endpoint)
+        return closeAllHintPopovers(focusPreviousElement, fireEvents);
+
+    while (RefPtr topHint = topmostHintPopover()) {
+        if (topHint == endpoint)
+            break;
+        topHint->hidePopoverInternal(focusPreviousElement, fireEvents);
+    }
+}
+
+// Used when a dialog is shown or an element enters fullscreen. Such an element joins the top layer
+// and must light-dismiss every popover that is not one of its ancestors: auto popovers up to the
+// nearest ancestor auto, and hint popovers up to the nearest ancestor hint. Both are dismissed
+// unconditionally — an unrelated auto must still be hidden even when the element is nested inside a
+// hint (in which case there is no ancestor auto and every auto is hidden).
+void Document::hidePopoversForTopLayerElement(Element& element, FireEvents fireEvents)
+{
+    RefPtr hideUntil = element.topmostPopoverAncestor(Element::TopLayerElementType::Other);
+    RefPtr hintAncestor = nearestOpenHintAncestor(element);
+    hideAutoPopoversUntil(hideUntil.get(), FocusPreviousElement::No, fireEvents);
+    closeHintPopoversUntil(hintAncestor.get(), FocusPreviousElement::No, fireEvents);
 }
 
 RefPtr<HTMLDialogElement> Document::nearestClickedDialog(const PointerEvent& event, Node& target) const
@@ -11129,14 +11205,17 @@ RefPtr<HTMLDialogElement> Document::nearestClickedDialog(const PointerEvent& eve
 }
 
 // https://html.spec.whatwg.org/#hide-all-popovers-until
-void Document::hideAllPopoversUntil(HTMLElement* endpoint, FocusPreviousElement focusPreviousElement, FireEvents fireEvents)
+void Document::hideAutoPopoversUntil(HTMLElement* endpoint, FocusPreviousElement focusPreviousElement, FireEvents fireEvents)
 {
-    auto closeAllOpenPopovers = [&]() {
+    auto closeAllAutoPopovers = [&]() {
         while (RefPtr popover = topmostAutoPopover())
             popover->hidePopoverInternal(focusPreviousElement, fireEvents);
     };
-    if (!endpoint)
-        return closeAllOpenPopovers();
+
+    if (!endpoint) {
+        closeAllAutoPopovers();
+        return;
+    }
 
     bool repeatingHide = false;
     do {
@@ -11150,8 +11229,10 @@ void Document::hideAllPopoversUntil(HTMLElement* endpoint, FocusPreviousElement 
                 break;
             }
         }
-        if (!foundEndPoint)
-            return closeAllOpenPopovers();
+        if (!foundEndPoint) {
+            closeAllAutoPopovers();
+            return;
+        }
         while (lastToHide && lastToHide->isPopoverShowing()) {
             RefPtr topmostAutoPopover = this->topmostAutoPopover();
             if (!topmostAutoPopover)
@@ -11170,20 +11251,19 @@ void Document::handlePopoverLightDismiss(const PointerEvent& event, Node& target
     ASSERT(event.isTrusted());
 
     RefPtr topmostAutoPopover = this->topmostAutoPopover();
-    if (!topmostAutoPopover)
+    RefPtr topmostHintPopover = this->topmostHintPopover();
+    if (!topmostAutoPopover && !topmostHintPopover)
         return;
 
     RefPtr popoverToAvoidHiding = [&]() -> HTMLElement* {
-        auto* targetElement = dynamicDowncast<Element>(target);
-        RefPtr startElement = targetElement ? targetElement : target.parentElement();
         auto [clickedPopover, invokerPopover] = [&]() {
             RefPtr<HTMLElement> clickedPopover;
             RefPtr<HTMLElement> invokerPopover;
             auto isShowingAutoPopover = [](HTMLElement& element) -> bool {
                 return element.popoverState() == PopoverState::Auto && element.popoverData()->visibilityState() == PopoverVisibilityState::Showing;
             };
-            for (RefPtr element = WTF::move(startElement); element; element = element->parentElementInComposedTree()) {
-                if (RefPtr htmlElement = dynamicDowncast<HTMLElement>(*element)) {
+            auto checkElement = [&](Element& element) {
+                if (RefPtr htmlElement = dynamicDowncast<HTMLElement>(element)) {
                     if (!clickedPopover && isShowingAutoPopover(*htmlElement))
                         clickedPopover = htmlElement;
 
@@ -11203,6 +11283,13 @@ void Document::handlePopoverLightDismiss(const PointerEvent& event, Node& target
                             }
                         }
                     }
+                }
+            };
+            if (auto* targetElement = dynamicDowncast<Element>(target))
+                checkElement(*targetElement);
+            if (!clickedPopover || !invokerPopover) {
+                for (Ref element : composedTreeAncestors(target)) {
+                    checkElement(element);
                     if (clickedPopover && invokerPopover)
                         break;
                 }
@@ -11225,15 +11312,40 @@ void Document::handlePopoverLightDismiss(const PointerEvent& event, Node& target
         return highestInTopLayer(clickedPopover.get(), invokerPopover.get());
     }();
 
+    // Find the showing hint popover (if any) that contains the pointer target.
+    RefPtr<HTMLElement> clickedHintPopover;
+    if (RefPtr targetElement = dynamicDowncast<Element>(target))
+        clickedHintPopover = nearestOpenHintAncestor(*targetElement);
+    else if (RefPtr parent = target.parentElementInComposedTree())
+        clickedHintPopover = nearestOpenHintAncestor(*parent);
+
     if (event.type() == eventNames().pointerdownEvent) {
         m_popoverPointerDownTarget = popoverToAvoidHiding;
+        m_popoverHintPointerDownTarget = clickedHintPopover;
         return;
     }
 
     ASSERT(event.type() == eventNames().pointerupEvent);
-    if (m_popoverPointerDownTarget == popoverToAvoidHiding.get())
-        hideAllPopoversUntil(popoverToAvoidHiding.get(), FocusPreviousElement::No, FireEvents::Yes);
+
+    bool clickedInsideHint = clickedHintPopover || m_popoverHintPointerDownTarget;
+
+    if (clickedInsideHint) {
+        // Click was inside a hint popover — close hints stacked above the clicked one, keep the
+        // clicked hint, but still light-dismiss auto popovers that are not ancestors of the click
+        // (popoverToAvoidHiding is the nearest auto containing the click).
+        if (clickedHintPopover && m_popoverHintPointerDownTarget == clickedHintPopover)
+            closeHintPopoversUntil(clickedHintPopover.get(), FocusPreviousElement::No, FireEvents::Yes);
+        if (m_popoverPointerDownTarget == popoverToAvoidHiding.get())
+            hideAutoPopoversUntil(popoverToAvoidHiding.get(), FocusPreviousElement::No, FireEvents::Yes);
+    } else {
+        // Click was outside all hint popovers — perform auto and hint light dismiss.
+        if (m_popoverPointerDownTarget == popoverToAvoidHiding.get())
+            hideAutoPopoversUntil(popoverToAvoidHiding.get(), FocusPreviousElement::No, FireEvents::Yes);
+        closeAllHintPopovers(FocusPreviousElement::No, FireEvents::Yes);
+    }
+
     m_popoverPointerDownTarget = nullptr;
+    m_popoverHintPointerDownTarget = nullptr;
 }
 
 // https://html.spec.whatwg.org/multipage/interactive-elements.html#dialog-light-dismiss

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -3,7 +3,7 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
  *           (C) 2006 Alexey Proskuryakov (ap@webkit.org)
- * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2008, 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)
  * Copyright (C) 2011 Google Inc. All rights reserved.
@@ -1885,17 +1885,35 @@ public:
     bool hasTopLayerElement() const { return !m_topLayerElements.isEmpty(); }
 
     const OrderedHashSet<Ref<HTMLElement>>& autoPopoverList() const LIFETIME_BOUND { return m_autoPopoverList; }
+    const OrderedHashSet<Ref<HTMLElement>>& hintPopoverList() const LIFETIME_BOUND { return m_hintPopoverList; }
 
     OrderedHashSet<Ref<HTMLDialogElement>>& openDialogsList() { return m_openDialogsList; }
 
     HTMLDialogElement* activeModalDialog() const;
     HTMLElement* NODELETE topmostAutoPopover() const;
+    HTMLElement* NODELETE topmostHintPopover() const;
+    HTMLElement* NODELETE nearestOpenHintAncestor(Element&) const;
     RefPtr<HTMLDialogElement> nearestClickedDialog(const PointerEvent&, Node&) const;
 
-    void hideAllPopoversUntil(HTMLElement*, FocusPreviousElement, FireEvents);
+    void hideAutoPopoversUntil(HTMLElement*, FocusPreviousElement, FireEvents);
+    void closeAllHintPopovers(FocusPreviousElement, FireEvents);
+    void closeHintPopoversUntil(const HTMLElement* endpoint, FocusPreviousElement, FireEvents);
+    void hidePopoversForTopLayerElement(Element&, FireEvents);
     void handlePopoverLightDismiss(const PointerEvent&, Node&);
     void handleDialogLightDismiss(const PointerEvent&, Node&);
-    bool needsPointerEventHandlingForPopoverOrDialog() const { return !m_autoPopoverList.isEmpty() || !m_openDialogsList.isEmpty(); }
+    bool needsPointerEventHandlingForPopoverOrDialog() const { return !m_autoPopoverList.isEmpty() || !m_hintPopoverList.isEmpty() || !m_openDialogsList.isEmpty(); }
+
+    // True while a popover show or hide algorithm is running (including during the beforetoggle
+    // event it dispatches). Showing a popover reentrantly during this window must throw.
+    bool isRunningPopoverShowOrHide() const { return m_popoverShowOrHideDepth; }
+    class PopoverShowOrHideScope {
+    public:
+        explicit PopoverShowOrHideScope(Document& document)
+            : m_document(document) { ++m_document->m_popoverShowOrHideDepth; }
+        ~PopoverShowOrHideScope() { ASSERT(m_document->m_popoverShowOrHideDepth); --m_document->m_popoverShowOrHideDepth; }
+    private:
+        const Ref<Document> m_document;
+    };
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     void registerAttachmentIdentifier(const String&, const AttachmentAssociatedElement&);
@@ -2106,6 +2124,10 @@ protected:
     void clearXMLVersion() { m_xmlVersion = String(); }
 
 private:
+    enum class PopoverListType : bool { Auto, Hint };
+    void addPopoverToList(PopoverListType, HTMLElement&);
+    void removePopoverFromList(PopoverListType, HTMLElement&);
+
     friend class DocumentParserYieldToken;
     friend class DocumentSyncData;
     friend class IgnoreDestructiveWriteCountIncrementer;
@@ -2617,9 +2639,12 @@ private:
 
     OrderedHashSet<Ref<Element>> m_topLayerElements;
     OrderedHashSet<Ref<HTMLElement>> m_autoPopoverList;
+    OrderedHashSet<Ref<HTMLElement>> m_hintPopoverList;
     OrderedHashSet<Ref<HTMLDialogElement>> m_openDialogsList;
+    unsigned m_popoverShowOrHideDepth { 0 };
 
     WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_popoverPointerDownTarget;
+    WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_popoverHintPointerDownTarget;
     WeakPtr<HTMLDialogElement, WeakPtrImplWithEventTargetData> m_dialogPointerDownTarget;
 
 #if ENABLE(WEB_RTC)

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -372,8 +372,7 @@ void DocumentFullscreen::elementEnterFullscreen(Element& element)
     if (&element == protect(document->fullscreen())->fullscreenElement())
         return;
 
-    RefPtr hideUntil = element.topmostPopoverAncestor(Element::TopLayerElementType::Other);
-    document->hideAllPopoversUntil(hideUntil.get(), FocusPreviousElement::No, FireEvents::No);
+    document->hidePopoversForTopLayerElement(element, FireEvents::No);
 
     auto containingBlockBeforeStyleResolution = SingleThreadWeakPtr<RenderBlock> { };
     if (CheckedPtr renderer = element.renderer())

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -6532,11 +6532,22 @@ TextStream& operator<<(TextStream& ts, ContentRelevancy relevancy)
 // Use top layer positions to disambiguate the topmost one when both exist.
 RefPtr<HTMLElement> Element::topmostPopoverAncestor(TopLayerElementType topLayerType)
 {
-    // Store positions to avoid having to do O(n) search for every popover invoker.
+    // Hint popovers only participate in the popover stack when computing the ancestor for another
+    // popover being shown. For dialog/fullscreen top-layer nesting, only auto popovers are
+    // considered (matching the behavior before popover=hint).
+    bool considerHints = topLayerType == TopLayerElementType::Popover;
+
+    // Store positions to avoid having to do O(n) search for every popover invoker, ordered by
+    // position in the top layer.
     HashMap<Ref<const Element>, size_t> topLayerPositions;
     size_t i = 0;
-    for (auto& element : document().autoPopoverList())
-        topLayerPositions.add(element, i++);
+    for (auto& element : document().topLayerElements()) {
+        if (auto* htmlElement = dynamicDowncast<HTMLElement>(element.get())) {
+            if (htmlElement->popoverData() && htmlElement->popoverData()->visibilityState() == PopoverVisibilityState::Showing
+                && (htmlElement->popoverState() == PopoverState::Auto || (considerHints && htmlElement->popoverState() == PopoverState::Hint)))
+                topLayerPositions.add(element, i++);
+        }
+    }
 
     if (topLayerType == TopLayerElementType::Popover)
         topLayerPositions.add(*this, i);
@@ -6550,10 +6561,11 @@ RefPtr<HTMLElement> Element::topmostPopoverAncestor(TopLayerElementType topLayer
             return;
 
         // https://html.spec.whatwg.org/#nearest-inclusive-open-popover
-        auto nearestInclusiveOpenPopover = [](Element& candidate) -> HTMLElement* {
+        auto nearestInclusiveOpenPopover = [&](Element& candidate) -> HTMLElement* {
             for (Ref element : composedTreeLineage(candidate)) {
                 if (auto* htmlElement = dynamicDowncast<HTMLElement>(element.get())) {
-                    if (htmlElement->popoverState() == PopoverState::Auto && htmlElement->popoverData()->visibilityState() == PopoverVisibilityState::Showing)
+                    if ((htmlElement->popoverState() == PopoverState::Auto || (considerHints && htmlElement->popoverState() == PopoverState::Hint))
+                        && htmlElement->popoverData()->visibilityState() == PopoverVisibilityState::Showing)
                         return htmlElement;
                 }
             }

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -105,7 +105,7 @@ enum class FullscreenNavigationUI : uint8_t;
 enum class FullscreenKeyboardLock : uint8_t;
 enum class IsSyntheticClick : bool { No, Yes };
 enum class ParserContentPolicy : uint8_t;
-enum class PopoverState : uint8_t { None, Auto, Manual };
+enum class PopoverState : uint8_t { None, Auto, Manual, Hint };
 enum class ResolveURLs : uint8_t { No, NoExcludingURLsForPrivacy, Yes, YesExcludingURLsForPrivacy };
 enum class SelectionRestorationMode : uint8_t;
 enum class ShadowRootDelegatesFocus : bool { No, Yes };

--- a/Source/WebCore/dom/PopoverData.h
+++ b/Source/WebCore/dom/PopoverData.h
@@ -59,6 +59,12 @@ public:
     HTMLElement* invoker() const { return m_invoker.get(); }
     void setInvoker(const HTMLElement* element) { m_invoker = element; }
 
+    bool showingAsHint() const { return m_showingAsHint; }
+    void setShowingAsHint(bool showingAsHint) { m_showingAsHint = showingAsHint; }
+
+    HTMLElement* hintStackParent() const { return m_hintStackParent.get(); }
+    void setHintStackParent(HTMLElement* element) { m_hintStackParent = element; }
+
     CloseWatcher* closeWatcher() { return m_closeWatcher.get(); };
     void setCloseWatcher(RefPtr<CloseWatcher>&& closeWatcher) { m_closeWatcher = WTF::move(closeWatcher); }
 
@@ -101,7 +107,9 @@ private:
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_previouslyFocusedElement;
     RefPtr<ToggleEventTask> m_toggleEventTask;
     WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_invoker;
+    WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_hintStackParent;
     bool m_isHidingOrShowingPopover = false;
+    bool m_showingAsHint = false;
     RefPtr<CloseWatcher> m_closeWatcher;
 };
 

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -150,9 +150,7 @@ ExceptionOr<void> HTMLDialogElement::show()
     Ref document = this->document();
     m_previouslyFocusedElement = document->focusedElement();
 
-    RefPtr hideUntil = topmostPopoverAncestor(TopLayerElementType::Other);
-
-    document->hideAllPopoversUntil(hideUntil.get(), FocusPreviousElement::No, FireEvents::No);
+    document->hidePopoversForTopLayerElement(*this, FireEvents::No);
 
     runFocusingSteps();
 
@@ -220,9 +218,7 @@ ExceptionOr<void> HTMLDialogElement::showModal(Element* source)
 
     m_previouslyFocusedElement = document->focusedElement();
 
-    RefPtr hideUntil = topmostPopoverAncestor(TopLayerElementType::Other);
-
-    document->hideAllPopoversUntil(hideUntil.get(), FocusPreviousElement::No, FireEvents::No);
+    document->hidePopoversForTopLayerElement(*this, FireEvents::No);
 
     runFocusingSteps();
 

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1170,10 +1170,16 @@ void HTMLElement::queuePopoverToggleEventTask(ToggleState oldState, ToggleState 
 {
     if (auto* popoverData = this->popoverData())
         popoverData->ensureToggleEventTask(*this)->queue(oldState, newState, source);
+    else
+        ToggleEventTask::create(*this)->queue(oldState, newState, source);
 }
 
 ExceptionOr<void> HTMLElement::showPopover(const ShowPopoverOptions& options)
 {
+    // A scripted showPopover() during another popover's show/hide (e.g. from a beforetoggle
+    // handler) is not allowed. See popover-open-in-beforetoggle.html.
+    if (document().isRunningPopoverShowOrHide())
+        return Exception { ExceptionCode::InvalidStateError, "Cannot show a popover while a popover is being shown or hidden"_s };
     return showPopoverInternal(options.source.get());
 }
 
@@ -1185,6 +1191,10 @@ ExceptionOr<void> HTMLElement::showPopoverInternal(HTMLElement* source)
     if (!check.returnValue())
         return { };
 
+    Ref document = this->document();
+
+    Document::PopoverShowOrHideScope popoverShowOrHideScope(document);
+
     if (popoverData())
         setInvoker(source);
 
@@ -1193,7 +1203,6 @@ ExceptionOr<void> HTMLElement::showPopoverInternal(HTMLElement* source)
     PopoverData::ScopedStartShowingOrHiding showOrHidingPopoverScope(*this);
     auto fireEvents = showOrHidingPopoverScope.wasShowingOrHiding() ? FireEvents::No : FireEvents::Yes;
 
-    Ref document = this->document();
     ToggleEvent::Init init;
     init.oldState = "closed"_s;
     init.newState = "open"_s;
@@ -1213,10 +1222,29 @@ ExceptionOr<void> HTMLElement::showPopoverInternal(HTMLElement* source)
 
     bool shouldRestoreFocus = false;
 
-    if (popoverState() == PopoverState::Auto) {
-        auto originalState = popoverState();
-        RefPtr hideUntil = topmostPopoverAncestor(TopLayerElementType::Popover);
-        document->hideAllPopoversUntil(hideUntil.get(), FocusPreviousElement::No, fireEvents);
+    auto originalState = popoverState();
+    if (originalState == PopoverState::Auto || originalState == PopoverState::Hint) {
+        RefPtr ancestor = topmostPopoverAncestor(TopLayerElementType::Popover);
+
+        auto isShowingAsHint = [](const HTMLElement& element) {
+            return element.popoverData() && element.popoverData()->showingAsHint();
+        };
+
+        // A popover=auto shown with a hint ancestor is "demoted" to a hint and joins the hint
+        // stack. See https://github.com/whatwg/html/issues/12304.
+        bool showingAsHint = originalState == PopoverState::Hint || (ancestor && isShowingAsHint(*ancestor));
+
+        if (!showingAsHint) {
+            // Effective auto: close every hint popover first (hints are dismissed before autos),
+            // then hide auto popovers up to the ancestor (all of them when there is no ancestor).
+            document->closeAllHintPopovers(FocusPreviousElement::No, fireEvents);
+            document->hideAutoPopoversUntil(ancestor.get(), FocusPreviousElement::No, fireEvents);
+        } else {
+            // Effective hint: close hints down to the nearest ancestor hint (all hints when the
+            // ancestor is an auto or there is none). Showing a hint never dismisses auto popovers.
+            RefPtr<HTMLElement> nearestAncestorHint = (ancestor && isShowingAsHint(*ancestor)) ? ancestor : nullptr;
+            document->closeHintPopoversUntil(nearestAncestorHint.get(), FocusPreviousElement::No, fireEvents);
+        }
 
         if (popoverState() != originalState)
             return Exception { ExceptionCode::InvalidStateError, "The value of the popover attribute was changed while hiding the popover."_s };
@@ -1227,7 +1255,16 @@ ExceptionOr<void> HTMLElement::showPopoverInternal(HTMLElement* source)
         if (!check.returnValue())
             return { };
 
-        shouldRestoreFocus = !document->topmostAutoPopover();
+        popoverData()->setShowingAsHint(showingAsHint);
+        popoverData()->setHintStackParent(showingAsHint ? ancestor.get() : nullptr);
+
+        if (!showingAsHint) {
+            // Auto popovers restore focus only when no other autos remain.
+            shouldRestoreFocus = !document->topmostAutoPopover();
+        } else {
+            // Hints restore focus only when no auto or hint popovers remain.
+            shouldRestoreFocus = !document->topmostAutoPopover() && !document->topmostHintPopover();
+        }
 
         if (document->settings().closeWatcherEnabled()) {
             if (RefPtr closeWatcher = CloseWatcher::create(document)) {
@@ -1252,11 +1289,9 @@ ExceptionOr<void> HTMLElement::showPopoverInternal(HTMLElement* source)
 
     runPopoverFocusingSteps(*this);
 
-    if (shouldRestoreFocus) {
-        if (auto* popoverData = this->popoverData()) {
-            ASSERT(popoverState() == PopoverState::Auto);
-            popoverData->setPreviouslyFocusedElement(previouslyFocusedElement.get());
-        }
+    if (shouldRestoreFocus && popoverData()) {
+        ASSERT(popoverState() == PopoverState::Auto || popoverState() == PopoverState::Hint);
+        popoverData()->setPreviouslyFocusedElement(previouslyFocusedElement.get());
     }
 
     queuePopoverToggleEventTask(ToggleState::Closed, ToggleState::Open, source);
@@ -1290,14 +1325,39 @@ ExceptionOr<void> HTMLElement::hidePopoverInternal(FocusPreviousElement focusPre
     if (showOrHidingPopoverScope.wasShowingOrHiding())
         fireEvents = FireEvents::No;
 
-    if (popoverState() == PopoverState::Auto) {
-        Ref<Document> { document() }->hideAllPopoversUntil(this, focusPreviousElement, fireEvents);
+    Ref document = this->document();
+
+    Document::PopoverShowOrHideScope popoverShowOrHideScope(document);
+
+    // Only an "effective auto" popover hides other auto popovers when it is hidden. A manual
+    // popover hides nothing, and a hint (including an auto demoted to a hint) only closes the
+    // hints stacked above it, handled below.
+    if (popoverState() == PopoverState::Auto && !popoverData()->showingAsHint()) {
+        document->hideAutoPopoversUntil(this, focusPreviousElement, fireEvents);
 
         check = checkPopoverValidity(*this, PopoverVisibilityState::Showing);
         if (check.hasException())
             return check.releaseException();
         if (!check.returnValue())
             return { };
+    }
+
+    // Hiding any popover also closes every hint whose hint-stack-parent chain reaches it.
+    {
+        Vector<Ref<HTMLElement>> descendantHints;
+        descendantHints.reserveCapacity(document->hintPopoverList().size());
+        for (auto& hint : document->hintPopoverList()) {
+            if (hint.ptr() == this)
+                continue;
+            for (RefPtr parent = hint->popoverData() ? hint->popoverData()->hintStackParent() : nullptr; parent; parent = parent->popoverData() ? parent->popoverData()->hintStackParent() : nullptr) {
+                if (parent == this) {
+                    descendantHints.append(hint);
+                    break;
+                }
+            }
+        }
+        for (auto& hint : descendantHints)
+            hint->hidePopoverInternal(focusPreviousElement, fireEvents);
     }
 
     setInvoker(nullptr);
@@ -1327,11 +1387,12 @@ ExceptionOr<void> HTMLElement::hidePopoverInternal(FocusPreviousElement focusPre
         styleInvalidation.emplace(*this, CSSSelector::PseudoClass::PopoverOpen, false);
     popoverWasHidden();
     popoverData()->setVisibilityState(PopoverVisibilityState::Hidden);
+    popoverData()->setShowingAsHint(false);
+    popoverData()->setHintStackParent(nullptr);
 
     if (fireEvents == FireEvents::Yes)
         queuePopoverToggleEventTask(ToggleState::Open, ToggleState::Closed, source);
 
-    Ref document = this->document();
     if (RefPtr element = popoverData()->previouslyFocusedElement()) {
         if (focusPreviousElement == FocusPreviousElement::Yes && isShadowIncludingInclusiveAncestorOf(document->focusedElement())) {
             FocusOptions options;
@@ -1377,6 +1438,8 @@ ExceptionOr<bool> HTMLElement::togglePopover(Variant<WebCore::HTMLElement::Toggl
         if (returnValue.hasException())
             return returnValue.releaseException();
     } else if (!isPopoverShowing() && force.value_or(true)) {
+        if (document().isRunningPopoverShowOrHide())
+            return Exception { ExceptionCode::InvalidStateError, "Cannot show a popover while a popover is being shown or hidden"_s };
         auto returnValue = showPopoverInternal(source);
         if (returnValue.hasException())
             return returnValue.releaseException();
@@ -1390,12 +1453,15 @@ ExceptionOr<bool> HTMLElement::togglePopover(Variant<WebCore::HTMLElement::Toggl
 
 void HTMLElement::popoverAttributeChanged(const AtomString& value)
 {
-    auto computePopoverState = [](const AtomString& value) -> PopoverState {
+    auto computePopoverState = [hintEnabled = document().settings().popoverHintEnabled()](const AtomString& value) -> PopoverState {
         if (!value || value.isNull())
             return PopoverState::None;
 
         if (value == emptyString() || equalIgnoringASCIICase(value, autoAtom()))
             return PopoverState::Auto;
+
+        if (hintEnabled && equalIgnoringASCIICase(value, hintAtom()))
+            return PopoverState::Hint;
 
         return PopoverState::Manual;
     };
@@ -1455,6 +1521,8 @@ const AtomString& HTMLElement::popover() const
         return autoAtom();
     case PopoverState::Manual:
         return manualAtom();
+    case PopoverState::Hint:
+        return hintAtom();
     }
     return nullAtom();
 }

--- a/Source/WebCore/platform/CommonAtomStrings.h
+++ b/Source/WebCore/platform/CommonAtomStrings.h
@@ -45,6 +45,7 @@ namespace WebCore {
     macro(eager, "eager") \
     macro(email, "email") \
     macro(false, "false") \
+    macro(hint, "hint") \
     macro(imageSVGContentType, "image/svg+xml") \
     macro(lazy, "lazy") \
     macro(main, "main") \


### PR DESCRIPTION
#### f6eeb78cca650f29dd2649798fa25cb2a554928c
<pre>
Implement popover=hint
<a href="https://bugs.webkit.org/show_bug.cgi?id=275048">https://bugs.webkit.org/show_bug.cgi?id=275048</a>
<a href="https://rdar.apple.com/129495028">rdar://129495028</a>

Reviewed by Anne van Kesteren and Ryosuke Niwa.

This change implements the popover=&apos;hint&apos; feature. This is a small addition to the
existing popover feature added in a previous cycle. The implementation matches the
current specification and existing WPT expectations.

<a href="https://github.com/whatwg/html/pull/9778">https://github.com/whatwg/html/pull/9778</a>
<a href="https://open-ui.org/components/popover-hint.research.explainer/">https://open-ui.org/components/popover-hint.research.explainer/</a>

Tested by existing imported/w3c/web-platform-tests/html/semantics/popovers test suite.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-events-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-dialog-dismisses-unrelated-auto-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-dialog-dismisses-unrelated-auto.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-hierarchy-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-invoking-attribute-hint-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-hint-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-manual-hide-does-not-close-auto-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-manual-hide-does-not-close-auto.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-open-in-beforetoggle-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-remove-attribute-during-focusing-steps-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-nesting-hints-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-types-with-hints-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt:
* LayoutTests/platform/ios-18/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/popovers/popover-hint-hierarchy-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::addPopoverToList):
(WebCore::Document::removePopoverFromList):
(WebCore::Document::addTopLayerElement):
(WebCore::Document::removeTopLayerElement):
(WebCore::Document::topmostHintPopover const):
(WebCore::Document::nearestOpenHintAncestor const):
(WebCore::Document::closeAllHintPopovers):
(WebCore::Document::closeHintPopoversUntil):
(WebCore::Document::hidePopoversForTopLayerElement):
(WebCore::Document::hideAutoPopoversUntil):
(WebCore::Document::handlePopoverLightDismiss):
(WebCore::Document::hideAllPopoversUntil):
* Source/WebCore/dom/Document.h:
(WebCore::Document::needsPointerEventHandlingForPopoverOrDialog const):
(WebCore::Document::isRunningPopoverShowOrHide const):
(WebCore::Document::PopoverShowOrHideScope::PopoverShowOrHideScope):
(WebCore::Document::PopoverShowOrHideScope::~PopoverShowOrHideScope):
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::elementEnterFullscreen):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::topmostPopoverAncestor):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/PopoverData.h:
(WebCore::PopoverData::showingAsHint const):
(WebCore::PopoverData::setShowingAsHint):
(WebCore::PopoverData::hintStackParent const):
(WebCore::PopoverData::setHintStackParent):
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::show):
(WebCore::HTMLDialogElement::showModal):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::queuePopoverToggleEventTask):
(WebCore::HTMLElement::showPopover):
(WebCore::HTMLElement::showPopoverInternal):
(WebCore::HTMLElement::hidePopoverInternal):
(WebCore::HTMLElement::togglePopover):
(WebCore::HTMLElement::popoverAttributeChanged):
(WebCore::HTMLElement::popover const):
* Source/WebCore/platform/CommonAtomStrings.h:

Canonical link: <a href="https://commits.webkit.org/317402@main">https://commits.webkit.org/317402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18e5baf70b75ec8c0e5c4df57dc350e19e743c9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184638 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132961 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/38752e5b-7916-443c-b661-c6237f35a6cf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176918 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48669 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136248 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f1d53c8f-d5a5-4714-81cb-b4ce117529ea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178011 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39687 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157039 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116726 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/07c506c6-c9d5-4647-a001-5e2a9089a05c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38328 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36712 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33111 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5548 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148751 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36531 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187059 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36315 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40914 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145192 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48653 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145048 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39114 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49333 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33152 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115156 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39909 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121484 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212145 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47839 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11504 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55340 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47242 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47472 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47299 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->