### PR TITLE
[CMake] Fix Mac CMake build for PAL

### DIFF
--- a/Source/WebCore/PAL/pal/CMakeLists.txt
+++ b/Source/WebCore/PAL/pal/CMakeLists.txt
@@ -62,11 +62,14 @@ set(PAL_SOURCES
 set(PAL_PRIVATE_INCLUDE_DIRECTORIES
     "${CMAKE_BINARY_DIR}"
     "${PAL_DERIVED_SOURCES_DIR}"
-    "${PAL_DIR}"
-    "${PAL_DIR}/pal"
-    "${PAL_DIR}/pal/crypto"
-    "${PAL_DIR}/pal/system"
-    "${PAL_DIR}/pal/text"
+    # Exclude PAL source dirs from Swift -- the source tree contains module.modulemap
+    # which conflicts with the installed copy. Use generator expressions to include
+    # them only for C/C++/ObjC.
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:${PAL_DIR}>"
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:${PAL_DIR}/pal>"
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:${PAL_DIR}/pal/crypto>"
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:${PAL_DIR}/pal/system>"
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:${PAL_DIR}/pal/text>"
 )
 
 set(PAL_FRAMEWORKS
@@ -80,6 +83,46 @@ set(PAL_INTERFACE_DEPENDENCIES PAL_CopyHeaders)
 
 WEBKIT_FRAMEWORK_DECLARE(PAL)
 WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS()
+
+if (SWIFT_REQUIRED)
+    target_sources(PAL PRIVATE
+        ${PAL_DIR}/pal/crypto/CryptoKit+UnsafeOverlays.swift
+        ${PAL_DIR}/pal/crypto/CryptoTypes.swift
+        ${PAL_DIR}/pal/system/cocoa/RegexHelper.swift
+        ${PAL_DIR}/pal/crypto/CryptoKitShim.swift
+    )
+
+    # Use -Xcc -I for ALL include paths (like Xcode does). Plain -I triggers
+    # Swift's own module discovery which causes C++ stdlib module conflicts.
+    set(PAL_SWIFT_INCLUDE_DIRECTORIES "")
+
+    set(PAL_SWIFT_EXTRA_OPTIONS
+        "-import-underlying-module"
+        "-strict-memory-safety"
+        "-swift-version" "6"
+        "-Xcc" "-I${PAL_FRAMEWORK_HEADERS_DIR}"
+        "-Xcc" "-I${CMAKE_BINARY_DIR}/WTF/Headers"
+        "-Xcc" "-I${CMAKE_BINARY_DIR}/ICU/Headers"
+        "-Xcc" "-I${CMAKE_BINARY_DIR}/bmalloc/Headers"
+        "-Xcc" "-I${CMAKE_BINARY_DIR}"
+        "-Xcc" "-I${PAL_DERIVED_SOURCES_DIR}"
+    )
+
+    WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER(PAL pal
+        "${PAL_FRAMEWORK_HEADERS_DIR}/pal"
+        "PALSwift-Generated.h")
+
+    # Also pass these options to CMake's native Swift compilation (the macro
+    # only adds them to the custom typecheck command).
+    target_compile_options(PAL PRIVATE
+        "$<$<COMPILE_LANGUAGE:Swift>:-import-underlying-module>"
+        "$<$<COMPILE_LANGUAGE:Swift>:-swift-version>"
+        "$<$<COMPILE_LANGUAGE:Swift>:6>"
+        "$<$<COMPILE_LANGUAGE:Swift>:-strict-memory-safety>"
+        "$<$<COMPILE_LANGUAGE:Swift>:-Xcc>"
+        "$<$<COMPILE_LANGUAGE:Swift>:-I${PAL_FRAMEWORK_HEADERS_DIR}>"
+    )
+endif ()
 
 if (PORT STREQUAL GTK OR PORT STREQUAL WPE)
     WEBKIT_ADD_TARGET_CXX_FLAGS(PAL
@@ -95,3 +138,11 @@ WEBKIT_COPY_FILES(PAL_CopyHeaders
 )
 
 WEBKIT_FRAMEWORK(PAL)
+
+# PAL's Swift sources need the module.modulemap and headers to be installed
+# before compilation (they import the underlying pal module). The CopyHeaders
+# target is an interface dependency for downstream targets, but PAL itself
+# also needs it.
+if (SWIFT_REQUIRED)
+    add_dependencies(PAL PAL_CopyHeaders WTF_CopyHeaders bmalloc_CopyHeaders)
+endif ()

--- a/Source/WebCore/PAL/pal/PlatformMac.cmake
+++ b/Source/WebCore/PAL/pal/PlatformMac.cmake
@@ -1,9 +1,12 @@
 list(APPEND PAL_PUBLIC_HEADERS
+    module.modulemap
+
     avfoundation/MediaTimeAVFoundation.h
     avfoundation/OutputContext.h
     avfoundation/OutputDevice.h
 
     cf/AudioToolboxSoftLink.h
+    cf/CoreAudioExtras.h
     cf/CoreMediaSoftLink.h
     cf/CoreTextSoftLink.h
     cf/OTSVGTable.h
@@ -11,14 +14,19 @@ list(APPEND PAL_PUBLIC_HEADERS
 
     cg/CoreGraphicsSoftLink.h
 
-    cocoa/AppSSOSoftLink.h
+    cocoa/AVFAudioSoftLink.h
     cocoa/AVFoundationSoftLink.h
+    cocoa/AccessibilitySoftLink.h
+    cocoa/AppSSOSoftLink.h
+    cocoa/ContactsSoftLink.h
     cocoa/CoreMLSoftLink.h
     cocoa/CoreMaterialSoftLink.h
     cocoa/CoreTelephonySoftLink.h
     cocoa/CryptoKitPrivateSoftLink.h
     cocoa/DataDetectorsCoreSoftLink.h
+    cocoa/EnhancedSecurityCocoa.h
     cocoa/LinkPresentationSoftLink.h
+    cocoa/LockdownModeCocoa.h
     cocoa/MediaToolboxSoftLink.h
     cocoa/NaturalLanguageSoftLink.h
     cocoa/OpenGLSoftLinkCocoa.h
@@ -31,12 +39,28 @@ list(APPEND PAL_PUBLIC_HEADERS
     cocoa/UsageTrackingSoftLink.h
     cocoa/VisionKitCoreSoftLink.h
     cocoa/VisionSoftLink.h
+    cocoa/WebContentRestrictionsSoftLink.h
     cocoa/WebPrivacySoftLink.h
     cocoa/WritingToolsUISoftLink.h
+
+    crypto/CryptoAlgorithmAESGCMCocoa.h
+    crypto/CryptoAlgorithmAESKWCocoaBridging.h
+    crypto/CryptoAlgorithmEd25519CocoaBridging.h
+    crypto/CryptoAlgorithmHKDFCocoaBridging.h
+    crypto/CryptoAlgorithmHMACCocoaBridging.h
+    crypto/CryptoAlgorithmX25519CocoaBridging.h
+    crypto/CryptoEDKeyBridging.h
+    crypto/PlatformECKey.h
+
+    graphics/cocoa/WebAVContentKeyGrouping.h
+    graphics/cocoa/WebAVContentKeyReportGroupExtras.h
+
+    ios/UIKitSoftLink.h
 
     mac/DataDetectorsSoftLink.h
     mac/LookupSoftLink.h
     mac/QuickLookUISoftLink.h
+    mac/ScreenCaptureKitSoftLink.h
 
     spi/cf/CFNetworkConnectionCacheSPI.h
     spi/cf/CFNetworkSPI.h
@@ -47,12 +71,14 @@ list(APPEND PAL_PUBLIC_HEADERS
     spi/cf/CoreTextSPI.h
     spi/cf/CoreVideoSPI.h
     spi/cf/MediaAccessibilitySPI.h
+    spi/cf/VideoToolboxSPI.h
 
     spi/cg/CoreGraphicsSPI.h
     spi/cg/ImageIOSPI.h
 
     spi/cocoa/AVAssetWriterSPI.h
     spi/cocoa/AVFoundationSPI.h
+    spi/cocoa/AVStreamDataParserSPI.h
     spi/cocoa/AVKitSPI.h
     spi/cocoa/AXSpeechManagerSPI.h
     spi/cocoa/AccessibilitySupportSPI.h
@@ -61,6 +87,8 @@ list(APPEND PAL_PUBLIC_HEADERS
     spi/cocoa/AuthKitSPI.h
     spi/cocoa/AudioToolboxSPI.h
     spi/cocoa/CommonCryptoSPI.h
+    spi/cocoa/ContactsSPI.h
+    spi/cocoa/CoreCryptoSPI.h
     spi/cocoa/CoreMaterialSPI.h
     spi/cocoa/CoreServicesSPI.h
     spi/cocoa/CoreTelephonySPI.h
@@ -68,6 +96,7 @@ list(APPEND PAL_PUBLIC_HEADERS
     spi/cocoa/DataDetectorsCoreSPI.h
     spi/cocoa/FeatureFlagsSPI.h
     spi/cocoa/FilePortSPI.h
+    spi/cocoa/FoundationSPI.h
     spi/cocoa/IOKitSPI.h
     spi/cocoa/IOPMLibSPI.h
     spi/cocoa/IOPSLibSPI.h
@@ -83,6 +112,7 @@ list(APPEND PAL_PUBLIC_HEADERS
     spi/cocoa/NSExtensionSPI.h
     spi/cocoa/NSFileManagerSPI.h
     spi/cocoa/NSFileSizeFormatterSPI.h
+    spi/cocoa/NSKeyedUnarchiverSPI.h
     spi/cocoa/NSProgressSPI.h
     spi/cocoa/NSStringSPI.h
     spi/cocoa/NSTouchBarSPI.h
@@ -102,13 +132,24 @@ list(APPEND PAL_PUBLIC_HEADERS
     spi/cocoa/ServersSPI.h
     spi/cocoa/SpeechSPI.h
     spi/cocoa/TCCSPI.h
+    spi/cocoa/TranslationUIServicesSPI.h
+    spi/cocoa/UIFoundationSPI.h
     spi/cocoa/URLFormattingSPI.h
+    spi/cocoa/UniformTypeIdentifiersSPI.h
     spi/cocoa/VisionKitCoreSPI.h
+    spi/cocoa/WebContentRestrictionsSPI.h
     spi/cocoa/WebFilterEvaluatorSPI.h
+    spi/cocoa/WebPrivacySPI.h
+    spi/cocoa/WritingToolsSPI.h
+    spi/cocoa/WritingToolsUISPI.h
     spi/cocoa/pthreadSPI.h
 
+    spi/ios/BrowserEngineKitSPI.h
     spi/ios/DataDetectorsUISPI.h
+    spi/ios/DataDetectorsUISoftLink.h
     spi/ios/GraphicsServicesSPI.h
+    spi/ios/MobileGestaltSPI.h
+    spi/ios/UIKitSPI.h
 
     spi/mac/CoreUISPI.h
     spi/mac/DataDetectorsSPI.h
@@ -135,10 +176,12 @@ list(APPEND PAL_PUBLIC_HEADERS
     spi/mac/NSScrollerImpSPI.h
     spi/mac/NSScrollingInputFilterSPI.h
     spi/mac/NSScrollingMomentumCalculatorSPI.h
+    spi/mac/NSSearchFieldCellSPI.h
     spi/mac/NSServicesRolloverButtonCellSPI.h
     spi/mac/NSSharingServicePickerSPI.h
     spi/mac/NSSharingServiceSPI.h
     spi/mac/NSSpellCheckerSPI.h
+    spi/mac/NSTextFieldCellSPI.h
     spi/mac/NSTextFinderSPI.h
     spi/mac/NSTextInputContextSPI.h
     spi/mac/NSTextTableSPI.h
@@ -146,10 +189,15 @@ list(APPEND PAL_PUBLIC_HEADERS
     spi/mac/NSViewSPI.h
     spi/mac/NSWindowSPI.h
     spi/mac/PIPSPI.h
+    spi/mac/PowerLogSPI.h
+    spi/mac/QuarantineSPI.h
     spi/mac/QuickLookMacSPI.h
     spi/mac/TelephonyUtilitiesSPI.h
 
+    system/cocoa/RegexHelper.h
     system/cocoa/SleepDisablerCocoa.h
+
+    system/ios/UserInterfaceIdiom.h
 
     system/mac/DefaultSearchProvider.h
     system/mac/PopupMenu.h
@@ -170,15 +218,20 @@ list(APPEND PAL_SOURCES
 
     cg/CoreGraphicsSoftLink.cpp
 
-    cocoa/AppSSOSoftLink.mm
+    cocoa/AVFAudioSoftLink.mm
     cocoa/AVFoundationSoftLink.mm
+    cocoa/AccessibilitySoftLink.mm
+    cocoa/AppSSOSoftLink.mm
+    cocoa/ContactsSoftLink.mm
     cocoa/CoreMLSoftLink.mm
     cocoa/CoreMaterialSoftLink.mm
     cocoa/CoreTelephonySoftLink.mm
     cocoa/CryptoKitPrivateSoftLink.mm
     cocoa/DataDetectorsCoreSoftLink.mm
+    cocoa/EnhancedSecurityCocoa.mm
     cocoa/FileSizeFormatterCocoa.mm
     cocoa/LinkPresentationSoftLink.mm
+    cocoa/LockdownModeCocoa.mm
     cocoa/MediaToolboxSoftLink.cpp
     cocoa/NaturalLanguageSoftLink.mm
     cocoa/OpenGLSoftLinkCocoa.mm
@@ -190,14 +243,26 @@ list(APPEND PAL_SOURCES
     cocoa/TranslationUIServicesSoftLink.mm
     cocoa/UsageTrackingSoftLink.mm
     cocoa/VisionKitCoreSoftLink.mm
+    cocoa/VisionSoftLink.mm
+    cocoa/WebContentRestrictionsSoftLink.mm
     cocoa/WebPrivacySoftLink.mm
     cocoa/WritingToolsUISoftLink.mm
 
-    crypto/commoncrypto/CryptoDigestCommonCrypto.mm
+    crypto/CryptoAlgorithmAESGCMCocoa.cpp
+    crypto/CryptoAlgorithmAESKWCocoaBridging.cpp
+    crypto/CryptoAlgorithmEd25519CocoaBridging.cpp
+    crypto/CryptoAlgorithmHKDFCocoaBridging.cpp
+    crypto/CryptoAlgorithmHMACCocoaBridging.cpp
+    crypto/CryptoAlgorithmX25519CocoaBridging.cpp
+    crypto/CryptoEDKeyBridging.cpp
+    crypto/PlatformECKey.cpp
+
+    crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
 
     mac/DataDetectorsSoftLink.mm
     mac/LookupSoftLink.mm
     mac/QuickLookUISoftLink.mm
+    mac/ScreenCaptureKitSoftLink.mm
 
     spi/cocoa/AccessibilitySupportSoftLink.cpp
 


### PR DESCRIPTION
#### fcda7e256435deba13c28eacc4bcb00108a34197
<pre>
[CMake] Fix Mac CMake build for PAL
<a href="https://bugs.webkit.org/show_bug.cgi?id=312021">https://bugs.webkit.org/show_bug.cgi?id=312021</a>
<a href="https://rdar.apple.com/problem/174562352">rdar://problem/174562352</a>

Reviewed by Richard Robinson.

Add Mac-specific PAL SPI headers and Cocoa source files for CMake.

Based on a base patch by Simon Lewis. Incorporates Swift CryptoKit
integration from Ian Grunert (PR #62543), folding follow-up bug
#312030.

* Source/WebCore/PAL/pal/CMakeLists.txt:
* Source/WebCore/PAL/pal/PlatformMac.cmake:
* Source/WebCore/PAL/pal/crypto/CryptoKit+UnsafeOverlays.swift:

Canonical link: <a href="https://commits.webkit.org/311109@main">https://commits.webkit.org/311109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f14224168ae32af3d1bf0e248b7f469edfe3fe5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164874 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157924 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29389 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120824 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159011 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140148 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101508 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12646 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131778 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167353 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11469 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19592 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128943 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28989 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24322 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129074 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34962 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28911 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139774 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86678 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23902 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16572 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28620 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92577 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28147 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28375 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28271 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->