### PR TITLE
[CMake] Fix ANGLE for Mac CMake build

### DIFF
--- a/Source/ThirdParty/ANGLE/CMakeLists.txt
+++ b/Source/ThirdParty/ANGLE/CMakeLists.txt
@@ -2,6 +2,9 @@ set_property(DIRECTORY . PROPERTY FOLDER "ANGLE")
 
 if (APPLE)
     set(is_mac TRUE)
+    # GLESv2.cmake:131 (converted from ANGLE's gn) gates system_utils_{apple,posix,mac}.cpp on
+    # is_apple (gn's naming), but this shim only set is_mac. 25 undefined angle::* at link.
+    set(is_apple TRUE)
 elseif (WIN32)
     set(is_win TRUE)
     set(angle_enable_d3d9 TRUE)
@@ -83,8 +86,8 @@ set(ANGLE_SOURCES
     ${angle_translator_essl_symbol_table_sources}
     ${angle_translator_glsl_and_vulkan_base_sources}
     ${angle_translator_glsl_sources}
+    $<$<BOOL:${is_apple}>:${angle_translator_glsl_apple_sources}>
     ${angle_translator_sources}
-    ${angle_system_utils_sources}
     src/common/angle_version_info.cpp
     src/libANGLE/capture/FrameCapture_mock.cpp
     src/libANGLE/capture/serialize_mock.cpp
@@ -224,7 +227,7 @@ if (ENABLE_WEBGL)
     WEBKIT_COPY_FILES(LibGLESv2EntryPointsHeaders
         DESTINATION ${ANGLE_FRAMEWORK_HEADERS_DIR}/ANGLE
         FILES ${libglesv2_entry_points_headers}
-        FLATTENED
+        FLATTENED NO_SYMLINK  # adjust-angle-include-paths.py rewrites these in-place
     )
     if (WIN32 AND TARGET GLESv2)
         # GLESv2 needs to have a direct or indirect dependency to

--- a/Source/ThirdParty/ANGLE/PlatformMac.cmake
+++ b/Source/ThirdParty/ANGLE/PlatformMac.cmake
@@ -9,7 +9,7 @@ find_package(ZLIB REQUIRED)
 list(APPEND ANGLE_SOURCES
     ${metal_backend_sources}
 
-    ${angle_translator_lib_metal_sources}
+    ${angle_translator_lib_msl_sources}
 
     ${libangle_gpu_info_util_mac_sources}
     ${libangle_gpu_info_util_sources}

--- a/Source/ThirdParty/ANGLE/include/CMakeLists.txt
+++ b/Source/ThirdParty/ANGLE/include/CMakeLists.txt
@@ -44,7 +44,7 @@ if (ENABLE_WEBGL)
     WEBKIT_COPY_FILES(ANGLEWebGLHeaders
         DESTINATION ${ANGLE_FRAMEWORK_HEADERS_DIR}/ANGLE
         FILES ${ANGLE_WEBGL_HEADERS}
-        FLATTENED
+        FLATTENED NO_SYMLINK  # adjust-angle-include-paths.py rewrites these in-place
     )
 endif ()
 
@@ -52,7 +52,7 @@ endif ()
 WEBKIT_COPY_FILES(GLSLANGHeaders
     DESTINATION ${ANGLE_FRAMEWORK_HEADERS_DIR}/ANGLE
     FILES ${glslang_headers}
-    FLATTENED
+    FLATTENED NO_SYMLINK  # adjust-angle-include-paths.py rewrites these in-place
 )
 
 WEBKIT_COPY_FILES(ANGLEHeaders


### PR DESCRIPTION
#### 9b5e74e8a8e53f8b3de4d147cef7a60101487c52
<pre>
[CMake] Fix ANGLE for Mac CMake build
<a href="https://bugs.webkit.org/show_bug.cgi?id=312022">https://bugs.webkit.org/show_bug.cgi?id=312022</a>
<a href="https://rdar.apple.com/problem/174562352">rdar://problem/174562352</a>

Reviewed by BJ Burg.

Set is_apple flag, update MSL source variable name, and add NO_SYMLINK
to header copy targets for CMake Mac builds.

Based on a base patch by Simon Lewis.

* Source/ThirdParty/ANGLE/CMakeLists.txt: Add is_apple flag inside
if (APPLE) block so ANGLE&apos;s GN-derived cmake finds Apple sources.
* Source/ThirdParty/ANGLE/PlatformMac.cmake: Rename
angle_translator_lib_metal_sources to angle_translator_lib_msl_sources
to match upstream ANGLE variable rename.
* Source/ThirdParty/ANGLE/include/CMakeLists.txt: Add NO_SYMLINK to
ANGLEWebGLHeaders and GLSLANGHeaders so adjust-angle-include-paths.py
does not rewrite source tree files.

Canonical link: <a href="https://commits.webkit.org/311107@main">https://commits.webkit.org/311107@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/387d1283210d8af00cef4b9b0aba948e45c056c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164875 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29390 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120823 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23038 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140145 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101507 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12647 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131781 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17977 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167354 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19589 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128941 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28990 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24320 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129072 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34960 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28912 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139771 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86679 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23901 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16569 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28621 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28148 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28376 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28272 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->