### PR TITLE
[CMake] Fix Mac CMake build for WebCore

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2819,7 +2819,7 @@ ${WebCore_DERIVED_SOURCES_DIR}/RenderStyleProperties.h ${WebCore_DERIVED_SOURCES
     DEPENDS ${WebCore_CSS_PROPERTY_NAMES}
     WORKING_DIRECTORY ${WebCore_DERIVED_SOURCES_DIR}
     COMMAND ${PERL_EXECUTABLE} -ne "print" ${WebCore_CSS_PROPERTY_NAMES} > ${WebCore_DERIVED_SOURCES_DIR}/CSSProperties.json
-    COMMAND ${PYTHON_EXECUTABLE} ${WEBCORE_DIR}/css/scripts/process-css-properties.py --defines "${FEATURE_DEFINES_WITH_SPACE_SEPARATOR}" --gperf-executable "${GPERF_EXECUTABLE}"
+    COMMAND ${PYTHON_EXECUTABLE} ${WEBCORE_DIR}/css/scripts/process-css-properties.py --defines "${FEATURE_DEFINES_WITH_SPACE_SEPARATOR} ${CSS_VALUE_PLATFORM_DEFINES}" --gperf-executable "${GPERF_EXECUTABLE}"
     VERBATIM)
 list(APPEND WebCore_SOURCES ${WebCore_DERIVED_SOURCES_DIR}/CSSPropertyNames.cpp)
 list(APPEND WebCore_SOURCES ${WebCore_DERIVED_SOURCES_DIR}/CSSPropertyParsing.cpp)
@@ -3108,8 +3108,31 @@ list(APPEND WebCoreTestSupport_INTERFACE_DEPENDENCIES WebCore_CopyPrivateHeaders
 
 WEBKIT_FRAMEWORK(WebCore)
 
+if (DEFINED WebCore_EXTRA_LINK_OPTIONS)
+    target_link_options(WebCore PRIVATE ${WebCore_EXTRA_LINK_OPTIONS})
+endif ()
+
+# WebCore has no Swift sources. When SWIFT_REQUIRED is ON, CMake may select the
+# Swift linker for targets that transitively depend on Swift libraries (PAL).
+# Force CXX linker -- swiftc mishandles -I include paths during linking.
+set_target_properties(WebCore PROPERTIES LINKER_LANGUAGE CXX)
+
 if (APPLE)
-    set_target_properties(WebCore PROPERTIES LINK_FLAGS "-weak-lxslt -sub_library libobjc -umbrella WebKit -allowable_client WebCoreTestSupport -allowable_client WebKit2 -allowable_client WebKitLegacy")
+    # Use target_link_options with LINKER: so CMake translates these for
+    # whichever linker driver is used (clang or swiftc).
+    target_link_options(WebCore PRIVATE
+        "LINKER:-sub_library,libobjc"
+        "LINKER:-umbrella,WebKit"
+        "LINKER:-weak-lxslt"
+        "LINKER:-allowable_client,WebCoreTestSupport"
+        "LINKER:-allowable_client,WebKit2"
+        "LINKER:-allowable_client,WebKitLegacy"
+        "LINKER:-allowable_client,WebKitTestRunner"
+        "LINKER:-allowable_client,WebKitTestRunnerInjectedBundle"
+        "LINKER:-allowable_client,InjectedBundleTestWebKitAPI"
+        "LINKER:-allowable_client,TestWebCore"
+        "LINKER:-allowable_client,TestWebKitLegacy"
+    )
 endif ()
 
 # The -ftree-sra optimization (implicit with -O2) causes crashes when
@@ -3141,6 +3164,12 @@ list(APPEND WebCoreTestSupport_SYSTEM_INCLUDE_DIRECTORIES ${WebCore_SYSTEM_INCLU
 WEBKIT_LIBRARY(WebCoreTestSupport)
 
 if (${WebCore_LIBRARY_TYPE} MATCHES "SHARED")
-    set_target_properties(WebCore PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+    # Unquoted empty PROJECT_VERSION_MAJOR makes CMake parse SOVERSION as VERSION's value
+    # -> Versions/SOVERSION/ instead of Versions/A/. Mac builds set FRAMEWORK_VERSION directly.
+    if (APPLE)
+        set_target_properties(WebCore PROPERTIES FRAMEWORK_VERSION A)
+    elseif (PROJECT_VERSION)
+        set_target_properties(WebCore PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+    endif ()
     install(TARGETS WebCore DESTINATION "${LIB_INSTALL_DIR}")
 endif ()

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3693,4 +3693,5 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     ${WebCore_DERIVED_SOURCES_DIR}/WebCoreLogDefinitions.h
     ${WebCore_DERIVED_SOURCES_DIR}/WebCoreVirtualLogFunctions.h
     ${WebCore_DERIVED_SOURCES_DIR}/WebKitFontFamilyNames.h
+    ${WebCore_DERIVED_SOURCES_DIR}/XMLNSNames.h
 )

--- a/Source/WebCore/PlatformMac.cmake
+++ b/Source/WebCore/PlatformMac.cmake
@@ -1,8 +1,16 @@
+# Required: LocalizedStrings.cpp looks up this bundle by identifier.
+set(MACOSX_FRAMEWORK_IDENTIFIER com.apple.WebCore)
+
+# Localizable.strings for copyLocalizedString(). Xcode copies via CopyFiles build phase.
+# Configure-time -- files rarely change, no build edge needed.
+file(COPY "${WEBCORE_DIR}/en.lproj"
+     DESTINATION "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebCore.framework/Versions/A/Resources")
+
 find_library(ACCELERATE_LIBRARY Accelerate)
 find_library(APPLICATIONSERVICES_LIBRARY ApplicationServices)
-find_library(AVFOUNDATION_LIBRARY AVFoundation)
 find_library(AUDIOTOOLBOX_LIBRARY AudioToolbox)
 find_library(AUDIOUNIT_LIBRARY AudioUnit)
+find_library(AVFOUNDATION_LIBRARY AVFoundation)
 find_library(CARBON_LIBRARY Carbon)
 find_library(CFNETWORK_LIBRARY CFNetwork)
 find_library(COCOA_LIBRARY Cocoa)
@@ -11,8 +19,13 @@ find_library(COREAUDIO_LIBRARY CoreAudio)
 find_library(COREMEDIA_LIBRARY CoreMedia)
 find_library(CORESERVICES_LIBRARY CoreServices)
 find_library(DISKARBITRATION_LIBRARY DiskArbitration)
+# Private library inside FontServices.framework.
+find_library(FONTPARSER_LIBRARY FontParser HINTS ${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks/FontServices.framework)
 find_library(IOKIT_LIBRARY IOKit)
 find_library(IOSURFACE_LIBRARY IOSurface)
+# libAccessibility (/usr/lib) contains _AXS* symbols; Accessibility.framework is different.
+find_library(LIBACCESSIBILITY_LIBRARY Accessibility PATHS ${CMAKE_OSX_SYSROOT}/usr/lib NO_CMAKE_FIND_ROOT_PATH NO_DEFAULT_PATH)
+find_library(ACCESSIBILITYSUPPORT_LIBRARY AccessibilitySupport HINTS ${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks)
 find_library(METAL_LIBRARY Metal)
 find_library(NETWORKEXTENSION_LIBRARY NetworkExtension)
 find_library(OPENGL_LIBRARY OpenGL)
@@ -20,6 +33,7 @@ find_library(QUARTZ_LIBRARY Quartz)
 find_library(QUARTZCORE_LIBRARY QuartzCore)
 find_library(SECURITY_LIBRARY Security)
 find_library(SYSTEMCONFIGURATION_LIBRARY SystemConfiguration)
+find_library(UNIFORMTYPEIDENTIFIERS_LIBRARY UniformTypeIdentifiers)
 find_library(VIDEOTOOLBOX_LIBRARY VideoToolbox)
 find_library(XML2_LIBRARY XML2)
 
@@ -47,8 +61,11 @@ list(APPEND WebCore_LIBRARIES
     ${COREMEDIA_LIBRARY}
     ${CORESERVICES_LIBRARY}
     ${DISKARBITRATION_LIBRARY}
+    ${FONTPARSER_LIBRARY}
     ${IOKIT_LIBRARY}
     ${IOSURFACE_LIBRARY}
+    ${LIBACCESSIBILITY_LIBRARY}
+    ${ACCESSIBILITYSUPPORT_LIBRARY}
     ${METAL_LIBRARY}
     ${NETWORKEXTENSION_LIBRARY}
     ${OPENGL_LIBRARY}
@@ -57,19 +74,48 @@ list(APPEND WebCore_LIBRARIES
     ${SECURITY_LIBRARY}
     ${SQLITE3_LIBRARIES}
     ${SYSTEMCONFIGURATION_LIBRARY}
+    ${UNIFORMTYPEIDENTIFIERS_LIBRARY}
     ${VIDEOTOOLBOX_LIBRARY}
     ${XML2_LIBRARY}
-    opus
-    vpx
-    webm
-    yuv
 )
+# When libwebrtc is built via CMake, link its targets directly.
+# Otherwise build webm_parser as an OBJECT library for ENABLE(MEDIA_SOURCE).
+if (USE_LIBWEBRTC)
+    list(APPEND WebCore_LIBRARIES webrtc opus vpx webm yuv libsrtp)
+else ()
+    set(_webm_parser_dir "${CMAKE_SOURCE_DIR}/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_parser")
+    file(GLOB _webm_parser_srcs "${_webm_parser_dir}/src/*.cc")
+    add_library(WebMParser OBJECT ${_webm_parser_srcs})
+    # -I must point at webm_parser/ not webm_parser/src/ for #include "src/foo.h".
+    target_include_directories(WebMParser PRIVATE "${_webm_parser_dir}/include" "${_webm_parser_dir}")
+    target_compile_definitions(WebMParser PRIVATE WEBRTC_WEBKIT_BUILD)
+    target_compile_options(WebMParser PRIVATE -w)  # third-party: suppress all warnings
+    list(APPEND WebCore_LIBRARIES WebMParser)
+    unset(_webm_parser_dir)
+    unset(_webm_parser_srcs)
+endif ()
 
-add_definitions(-iframework ${APPLICATIONSERVICES_LIBRARY}/Versions/Current/Frameworks)
-add_definitions(-iframework ${AVFOUNDATION_LIBRARY}/Versions/Current/Frameworks)
-add_definitions(-iframework ${CARBON_LIBRARY}/Versions/Current/Frameworks)
-add_definitions(-iframework ${CORESERVICES_LIBRARY}/Versions/Current/Frameworks)
-add_definitions(-iframework ${QUARTZ_LIBRARY}/Frameworks)
+# FIXME: wgpu* symbols are undefined until WebGPU builds via CMake. This flag
+# suppresses ALL undefined symbols -- remove when WebGPU is enabled.
+# https://bugs.webkit.org/show_bug.cgi?id=312031
+if (NOT ENABLE_WEBGPU)
+    list(APPEND WebCore_PRIVATE_LIBRARIES "-Wl,-undefined,dynamic_lookup")
+else ()
+    list(APPEND WebCore_LIBRARIES WebGPU)
+endif ()
+
+# Force-load PAL so that all soft-link symbols (e.g. getCNContactClassSingleton)
+# are exported from WebCore.framework even when only referenced by WebKit.
+# Deferred to after the target is created via WebCore_EXTRA_LINK_OPTIONS.
+set(WebCore_EXTRA_LINK_OPTIONS "SHELL:-Wl,-force_load $<TARGET_FILE:PAL>")
+
+add_compile_options(
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-iframework${APPLICATIONSERVICES_LIBRARY}/Versions/Current/Frameworks>"
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-iframework${AVFOUNDATION_LIBRARY}/Versions/Current/Frameworks>"
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-iframework${CARBON_LIBRARY}/Versions/Current/Frameworks>"
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-iframework${CORESERVICES_LIBRARY}/Versions/Current/Frameworks>"
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-iframework${QUARTZ_LIBRARY}/Frameworks>"
+)
 
 find_library(COREUI_FRAMEWORK CoreUI HINTS ${CMAKE_OSX_SYSROOT}/System/Library/PrivateFrameworks)
 if (NOT COREUI_FRAMEWORK-NOTFOUND)
@@ -86,13 +132,50 @@ if (NOT LOOKUP_FRAMEWORK-NOTFOUND)
     list(APPEND WebCore_LIBRARIES ${LOOKUP_FRAMEWORK})
 endif ()
 
+# FIXME: Symlink opus headers until libwebrtc builds via CMake.
+# https://bugs.webkit.org/show_bug.cgi?id=312029
+set(_libwebrtc_fwd "${CMAKE_BINARY_DIR}/libwebrtc-forwarding")
+file(MAKE_DIRECTORY "${_libwebrtc_fwd}/libwebrtc")
+foreach (_h opus_defines.h opus_types.h)
+    if (NOT EXISTS "${_libwebrtc_fwd}/libwebrtc/${_h}")
+        file(CREATE_LINK
+            "${CMAKE_SOURCE_DIR}/Source/ThirdParty/libwebrtc/Source/third_party/opus/src/include/${_h}"
+            "${_libwebrtc_fwd}/libwebrtc/${_h}"
+            SYMBOLIC)
+    endif ()
+endforeach ()
+# Symlink libwebm -> webm (Xcode's header-copy renames the directory).
+if (NOT EXISTS "${_libwebrtc_fwd}/webm")
+    file(CREATE_LINK
+        "${CMAKE_SOURCE_DIR}/Source/ThirdParty/libwebrtc/Source/third_party/libwebm"
+        "${_libwebrtc_fwd}/webm"
+        SYMBOLIC)
+endif ()
+unset(_libwebrtc_fwd)
+unset(_h)
+
+# SourceBufferParserWebM.h overrides patched OnElementEnd virtual (MEDIA_SOURCE, not LIBWEBRTC).
+list(APPEND WebCore_PRIVATE_DEFINITIONS WEBRTC_WEBKIT_BUILD)
+
 list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
+    "${CMAKE_SOURCE_DIR}/Source/WebCore/accessibility/cocoa"
+    "${CMAKE_SOURCE_DIR}/Source/WebCore/platform/video-codecs/cocoa"
+    "${CMAKE_SOURCE_DIR}/Source/WebCore/platform/mediastream"
+    "${CMAKE_SOURCE_DIR}/Source/WebCore/platform/mediastream/cocoa"
     "${CMAKE_BINARY_DIR}/libwebrtc/PrivateHeaders"
     "${CMAKE_SOURCE_DIR}/Source/ThirdParty/libwebrtc/Source"
+    # libwebm headers for SourceBufferParserWebM (MEDIA_SOURCE, not LIBWEBRTC).
+    # Two roots: webm_parser/include/ for <webm/callback.h>, libwebm/ for <webm/common/*.h>.
+    "${CMAKE_SOURCE_DIR}/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_parser/include"
+    "${CMAKE_SOURCE_DIR}/Source/ThirdParty/libwebrtc/Source/third_party/libwebm"
+    # Forwarding directory for <libwebrtc/opus_defines.h>.
+    "${CMAKE_BINARY_DIR}/libwebrtc-forwarding"
+    "${WEBCORE_DIR}/Modules/applepay-ams-ui"
     "${WEBCORE_DIR}/Modules/webauthn/apdu"
     "${WEBCORE_DIR}/accessibility/isolatedtree/mac"
     "${WEBCORE_DIR}/accessibility/mac"
     "${WEBCORE_DIR}/bridge/objc"
+    "${WEBCORE_DIR}/crypto/cocoa"
     "${WEBCORE_DIR}/crypto/mac"
     "${WEBCORE_DIR}/dom/mac"
     "${WEBCORE_DIR}/editing/cocoa"
@@ -107,6 +190,7 @@ list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/page/mac"
     "${WEBCORE_DIR}/page/scrolling/cocoa"
     "${WEBCORE_DIR}/page/scrolling/mac"
+    "${WEBCORE_DIR}/page/writing-tools"
     "${WEBCORE_DIR}/platform/audio/cocoa"
     "${WEBCORE_DIR}/platform/audio/mac"
     "${WEBCORE_DIR}/platform/cf"
@@ -119,7 +203,9 @@ list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/platform/graphics/ca"
     "${WEBCORE_DIR}/platform/graphics/ca/cocoa"
     "${WEBCORE_DIR}/platform/graphics/cocoa"
+    "${WEBCORE_DIR}/platform/graphics/cocoa/controls"
     "${WEBCORE_DIR}/platform/graphics/coreimage"
+    "${WEBCORE_DIR}/platform/graphics/coretext"
     "${WEBCORE_DIR}/platform/graphics/cg"
     "${WEBCORE_DIR}/platform/graphics/cv"
     "${WEBCORE_DIR}/platform/graphics/gpu"
@@ -128,11 +214,16 @@ list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/platform/graphics/egl"
     "${WEBCORE_DIR}/platform/graphics/opentype"
     "${WEBCORE_DIR}/platform/graphics/opengl"
+    "${WEBCORE_DIR}/platform/graphics/re"
     "${WEBCORE_DIR}/platform/graphics/mac"
+    "${WEBCORE_DIR}/platform/graphics/mac/controls"
+    "${WEBCORE_DIR}/platform/image-decoders"
+    "${WEBCORE_DIR}/platform/ios"
     "${WEBCORE_DIR}/platform/mac"
     "${WEBCORE_DIR}/platform/mediacapabilities"
     "${WEBCORE_DIR}/platform/mediarecorder/cocoa"
     "${WEBCORE_DIR}/platform/mediastream/cocoa"
+    "${WEBCORE_DIR}/platform/mediastream/libwebrtc"
     "${WEBCORE_DIR}/platform/mediastream/mac"
     "${WEBCORE_DIR}/platform/network/cocoa"
     "${WEBCORE_DIR}/platform/network/cf"
@@ -161,6 +252,9 @@ list(APPEND WebCore_SOURCES
 
     Modules/webaudio/MediaStreamAudioSourceCocoa.cpp
 
+    Modules/webauthn/AuthenticationExtensionsClientInputs.cpp
+    Modules/webauthn/AuthenticationExtensionsClientOutputs.cpp
+
     accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
     accessibility/mac/AXObjectCacheMac.mm
     accessibility/mac/AccessibilityObjectMac.mm
@@ -168,6 +262,8 @@ list(APPEND WebCore_SOURCES
 
     dom/DataTransferMac.mm
     dom/SlotAssignment.cpp
+
+    editing/TextListParser.cpp
 
     editing/cocoa/AlternativeTextUIController.mm
     editing/cocoa/AutofillElements.cpp
@@ -183,7 +279,6 @@ list(APPEND WebCore_SOURCES
 
     page/mac/EventHandlerMac.mm
     page/mac/ServicesOverlayController.mm
-    page/mac/TextIndicatorWindow.mm
     page/mac/WheelEventDeltaFilterMac.mm
 
     page/scrolling/mac/ScrollingCoordinatorMac.mm
@@ -191,7 +286,9 @@ list(APPEND WebCore_SOURCES
     page/scrolling/mac/ScrollingTreeMac.mm
 
     platform/CPUMonitor.cpp
+    platform/DictationCaretAnimator.cpp
     platform/LocalizedStrings.cpp
+    platform/OpacityCaretAnimator.cpp
     platform/ScrollableArea.cpp
 
     platform/audio/AudioSession.cpp
@@ -199,6 +296,7 @@ list(APPEND WebCore_SOURCES
     platform/audio/cocoa/AudioBusCocoa.mm
     platform/audio/cocoa/AudioDecoderCocoa.cpp
     platform/audio/cocoa/AudioEncoderCocoa.cpp
+    platform/audio/cocoa/AudioSessionCocoa.mm
     platform/audio/cocoa/FFTFrameCocoa.cpp
     platform/audio/cocoa/WebAudioBufferList.cpp
 
@@ -221,21 +319,26 @@ list(APPEND WebCore_SOURCES
     platform/cocoa/NetworkExtensionContentFilter.mm
     platform/cocoa/ParentalControlsContentFilter.mm
     platform/cocoa/PasteboardCocoa.mm
-    platform/cocoa/RuntimeApplicationChecksCocoa.mm
     platform/cocoa/SearchPopupMenuCocoa.mm
     platform/cocoa/SharedBufferCocoa.mm
     platform/cocoa/SharedMemoryCocoa.mm
+    platform/cocoa/SharedVideoFrameInfo.mm
     platform/cocoa/StringUtilities.mm
     platform/cocoa/SystemBattery.mm
     platform/cocoa/SystemVersion.mm
     platform/cocoa/TelephoneNumberDetectorCocoa.cpp
     platform/cocoa/ThemeCocoa.mm
+    platform/cocoa/VideoFullscreenCaptions.mm
     platform/cocoa/VideoToolboxSoftLink.cpp
+    platform/cocoa/WebAVPlayerLayer.mm
     platform/cocoa/WebCoreNSErrorExtras.mm
     platform/cocoa/WebCoreNSURLExtras.mm
     platform/cocoa/WebCoreObjCExtras.mm
     platform/cocoa/WebNSAttributedStringExtras.mm
 
+    platform/gamepad/cocoa/CoreHapticsSoftLink.mm
+    platform/gamepad/cocoa/GameControllerHapticEffect.mm
+    platform/gamepad/cocoa/GameControllerHapticEngines.mm
     platform/gamepad/cocoa/GameControllerSoftLink.mm
 
     platform/gamepad/mac/HIDGamepad.cpp
@@ -315,10 +418,10 @@ list(APPEND WebCore_SOURCES
     platform/graphics/cg/TransformationMatrixCG.cpp
     platform/graphics/cg/UTIRegistry.mm
 
+    platform/graphics/cocoa/ANGLEUtilitiesCocoa.mm
     platform/graphics/cocoa/CMUtilities.mm
     platform/graphics/cocoa/FloatRectCocoa.mm
     platform/graphics/cocoa/FontCacheCoreText.cpp
-    platform/graphics/cocoa/FontCascadeCocoa.cpp
     platform/graphics/cocoa/FontCocoa.cpp
     platform/graphics/cocoa/FontDatabase.cpp
     platform/graphics/cocoa/FontDescriptionCocoa.cpp
@@ -331,6 +434,8 @@ list(APPEND WebCore_SOURCES
     platform/graphics/cocoa/IOSurface.mm
     platform/graphics/cocoa/IOSurfaceDrawingBuffer.cpp
     platform/graphics/cocoa/IOSurfacePoolCocoa.mm
+    platform/graphics/cocoa/MediaPlayerEnumsCocoa.mm
+    platform/graphics/cocoa/TextTransformCocoa.cpp
     platform/graphics/cocoa/UnrealizedCoreTextFont.cpp
     platform/graphics/cocoa/WebActionDisablingCALayerDelegate.mm
     platform/graphics/cocoa/WebCoreCALayerExtras.mm
@@ -351,15 +456,11 @@ list(APPEND WebCore_SOURCES
     platform/graphics/cv/GraphicsContextGLCVCocoa.mm
     platform/graphics/cv/ImageRotationSessionVT.mm
     platform/graphics/cv/PixelBufferConformerCV.cpp
+    platform/graphics/cv/PixelBufferConformerCV.mm
 
     platform/graphics/mac/ColorMac.mm
-    platform/graphics/mac/FloatPointMac.mm
-    platform/graphics/mac/FloatSizeMac.mm
     platform/graphics/mac/GraphicsChecksMac.cpp
     platform/graphics/mac/IconMac.mm
-    platform/graphics/mac/ImageMac.mm
-    platform/graphics/mac/IntPointMac.mm
-    platform/graphics/mac/IntSizeMac.mm
     platform/graphics/mac/PDFDocumentImageMac.mm
 
     platform/graphics/opentype/OpenTypeCG.cpp
@@ -391,9 +492,11 @@ list(APPEND WebCore_SOURCES
     platform/mac/WebCoreFullScreenWindow.mm
     platform/mac/WidgetMac.mm
 
+    platform/mediarecorder/MediaRecorderPrivateWriter.cpp
+
+    platform/mediastream/cocoa/CoreAudioCaptureUnit.mm
     platform/mediastream/cocoa/MockRealtimeVideoSourceCocoa.mm
     platform/mediastream/cocoa/RealtimeOutgoingVideoSourceCocoa.cpp
-    platform/mediastream/cocoa/RealtimeOutgoingVideoSourceCocoa.mm
 
     platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp
 
@@ -436,6 +539,12 @@ list(APPEND WebCore_SOURCES
     rendering/cocoa/RenderThemeCocoa.mm
 
     rendering/mac/RenderThemeMac.mm
+
+    testing/MockContentFilter.cpp # FIXME: Compiled into WebCore because CMake links WebCoreTestSupport statically (Bug 312062).
+    testing/MockContentFilterManager.cpp
+    testing/MockContentFilterSettings.cpp
+
+    workers/service/ServiceWorkerRoute.mm
 )
 
 list(APPEND WebCore_USER_AGENT_STYLE_SHEETS
@@ -497,6 +606,8 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     accessibility/cocoa/CocoaAccessibilityConstants.h
     accessibility/cocoa/WebAccessibilityObjectWrapperBase.h
 
+    accessibility/ios/AXRemoteTokenIOS.h
+
     accessibility/mac/WebAccessibilityObjectWrapperMac.h
 
     bridge/objc/WebScriptObject.h
@@ -522,13 +633,18 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/EventLoop.h
     dom/WindowEventLoop.h
 
+    editing/ICUSearcher.h
+
     editing/cocoa/AlternativeTextContextController.h
     editing/cocoa/AlternativeTextUIController.h
     editing/cocoa/AttributedString.h
     editing/cocoa/AutofillElements.h
     editing/cocoa/DataDetection.h
     editing/cocoa/DataDetectorType.h
+    editing/cocoa/EditingHTMLConverter.h
     editing/cocoa/HTMLConverter.h
+    editing/cocoa/NodeHTMLConverter.h
+    editing/cocoa/TextAttachmentForSerialization.h
 
     editing/mac/DictionaryLookup.h
     editing/mac/TextAlternativeWithRange.h
@@ -550,11 +666,16 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     page/CaptionUserPreferencesMediaAF.h
 
+    page/cocoa/ContentChangeObserver.h
+    page/cocoa/DOMTimerHoldingTank.h
     page/cocoa/DataDetectionResultsStorage.h
     page/cocoa/DataDetectorElementInfo.h
     page/cocoa/ImageOverlayDataDetectionResultIdentifier.h
+    page/cocoa/WebTextIndicatorLayer.h
 
-    page/mac/TextIndicatorWindow.h
+    page/ios/WebEventRegion.h
+
+    page/mac/CorrectionIndicator.h
     page/mac/WebCoreFrameView.h
 
     page/scrolling/ScrollingStateOverflowScrollProxyNode.h
@@ -564,10 +685,15 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.h
     page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
 
+    page/scrolling/mac/ScrollerMac.h
+    page/scrolling/mac/ScrollerPairMac.h
     page/scrolling/mac/ScrollingCoordinatorMac.h
     page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h
     page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.h
+    page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.h
     page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
+
+    page/writing-tools/TextEffectController.h
 
     platform/CaptionPreferencesDelegate.h
     platform/FrameRateMonitor.h
@@ -581,6 +707,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/SharedTimer.h
     platform/SystemSoundManager.h
     platform/TextRecognitionResult.h
+    platform/WebCoreMainThread.h
 
     platform/audio/cocoa/AudioDecoderCocoa.h
     platform/audio/cocoa/AudioDestinationCocoa.h
@@ -589,33 +716,57 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/audio/cocoa/AudioSampleBufferList.h
     platform/audio/cocoa/AudioSampleDataConverter.h
     platform/audio/cocoa/AudioSampleDataSource.h
+    platform/audio/cocoa/AudioUtilitiesCocoa.h
     platform/audio/cocoa/CAAudioStreamDescription.h
     platform/audio/cocoa/CARingBuffer.h
     platform/audio/cocoa/MediaSessionManagerCocoa.h
+    platform/audio/cocoa/SpatialAudioExperienceHelper.h
     platform/audio/cocoa/WebAudioBufferList.h
+
+    platform/audio/ios/MediaSessionHelperIOS.h
+    platform/audio/ios/MediaSessionManagerIOS.h
 
     platform/audio/mac/SharedRoutingArbitrator.h
 
     platform/cf/MediaAccessibilitySoftLink.h
 
+    platform/cocoa/AppleVisualEffect.h
+    platform/cocoa/CocoaView.h
+    platform/cocoa/CocoaWritingToolsTypes.h
+    platform/cocoa/CoreLocationGeolocationProvider.h
+    platform/cocoa/CoreVideoExtras.h
     platform/cocoa/CoreVideoSoftLink.h
     platform/cocoa/LocalCurrentGraphicsContext.h
+    platform/cocoa/NSURLUtilities.h
     platform/cocoa/NetworkExtensionContentFilter.h
-    platform/cocoa/PlatformView.h
+    platform/cocoa/ParentalControlsContentFilter.h
+    platform/cocoa/ParentalControlsURLFilter.h
+    platform/cocoa/ParentalControlsURLFilterParameters.h
+    platform/cocoa/PlatformTextAlternatives.h
     platform/cocoa/PlatformViewController.h
     platform/cocoa/PlaybackSessionModel.h
+    platform/cocoa/PlaybackSessionModel.serialization.in
     platform/cocoa/PlaybackSessionModelMediaElement.h
     platform/cocoa/PowerSourceNotifier.h
-    platform/cocoa/PublicSuffixCocoa.mm
     platform/cocoa/SearchPopupMenuCocoa.h
     platform/cocoa/SharedVideoFrameInfo.h
     platform/cocoa/StringUtilities.h
     platform/cocoa/SystemBattery.h
     platform/cocoa/SystemVersion.h
+    platform/cocoa/VideoFullscreenCaptions.h
+    platform/cocoa/VideoPresentationLayerProvider.h
+    platform/cocoa/VideoPresentationModel.h
+    platform/cocoa/VideoPresentationModelVideoElement.h
+    platform/cocoa/WebAVPlayerLayer.h
+    platform/cocoa/WebAVPlayerLayerView.h
     platform/cocoa/WebCoreNSURLExtras.h
     platform/cocoa/WebCoreObjCExtras.h
+    platform/cocoa/WebKitAvailability.h
+    platform/cocoa/WebNSAttributedStringExtras.h
 
     platform/gamepad/cocoa/GameControllerGamepadProvider.h
+    platform/gamepad/cocoa/GameControllerSPI.h
+    platform/gamepad/cocoa/GameControllerSoftLink.h
 
     platform/gamepad/mac/HIDGamepad.h
     platform/gamepad/mac/HIDGamepadElement.h
@@ -626,6 +777,8 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/ImageDecoderIdentifier.h
     platform/graphics/ImageUtilities.h
     platform/graphics/MIMETypeCache.h
+    platform/graphics/MediaPlaybackTargetWirelessPlayback.h
+    platform/graphics/MediaSourceTypeSupportedCache.h
     platform/graphics/Model.h
 
     platform/graphics/angle/ANGLEUtilities.h
@@ -633,12 +786,15 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h
     platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
     platform/graphics/avfoundation/MediaPlaybackTargetCocoa.h
+    platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
     platform/graphics/avfoundation/SampleBufferDisplayLayer.h
+    platform/graphics/avfoundation/WebAVSampleBufferListener.h
     platform/graphics/avfoundation/WebMediaSessionManagerMac.h
 
     platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.h
     platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.h
     platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
+    platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
     platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h
     platform/graphics/avfoundation/objc/VideoLayerManagerObjC.h
 
@@ -648,43 +804,63 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/ca/PlatformCAFilters.h
     platform/graphics/ca/PlatformCALayer.h
     platform/graphics/ca/PlatformCALayerClient.h
+    platform/graphics/ca/PlatformCALayerDelegatedContents.h
     platform/graphics/ca/TileController.h
 
+    platform/graphics/ca/cocoa/ContentsFormatCocoa.h
     platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.h
     platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.h
     platform/graphics/ca/cocoa/PlatformCALayerCocoa.h
+    platform/graphics/ca/cocoa/PlatformDynamicRangeLimitCocoa.h
     platform/graphics/ca/cocoa/WebVideoContainerLayer.h
 
     platform/graphics/cg/CGContextStateSaver.h
     platform/graphics/cg/CGUtilities.h
+    platform/graphics/cg/CGWindowUtilities.h
     platform/graphics/cg/ColorSpaceCG.h
     platform/graphics/cg/GradientRendererCG.h
     platform/graphics/cg/GraphicsContextCG.h
     platform/graphics/cg/IOSurfacePool.h
+    platform/graphics/cg/IOSurfacePoolIdentifier.h
     platform/graphics/cg/ImageBufferCGBackend.h
     platform/graphics/cg/ImageBufferCGBitmapBackend.h
+    platform/graphics/cg/ImageBufferCGPDFDocumentBackend.h
     platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+    platform/graphics/cg/ImageDecoderCG.h
     platform/graphics/cg/PDFDocumentImage.h
+    platform/graphics/cg/PathCG.h
     platform/graphics/cg/UTIRegistry.h
 
+    platform/graphics/cocoa/AV1UtilitiesCocoa.h
     platform/graphics/cocoa/CMUtilities.h
     platform/graphics/cocoa/ColorCocoa.h
+    platform/graphics/cocoa/DynamicContentScalingDisplayList.h
     platform/graphics/cocoa/FontCacheCoreText.h
+    platform/graphics/cocoa/FontCascadeCocoaInlines.h
     platform/graphics/cocoa/FontCocoa.h
     platform/graphics/cocoa/FontDatabase.h
     platform/graphics/cocoa/FontFamilySpecificationCoreText.h
     platform/graphics/cocoa/FontFamilySpecificationCoreTextCache.h
     platform/graphics/cocoa/GraphicsContextGLCocoa.h
+    platform/graphics/cocoa/HEVCUtilitiesCocoa.h
     platform/graphics/cocoa/IOSurface.h
-    platform/graphics/cocoa/MediaPlaybackTargetContext.h
+    platform/graphics/cocoa/IOSurfaceDrawingBuffer.h
+    platform/graphics/cocoa/MediaPlayerEnumsCocoa.h
     platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+    platform/graphics/cocoa/NullPlaybackSessionInterface.h
+    platform/graphics/cocoa/NullVideoPresentationInterface.h
     platform/graphics/cocoa/SourceBufferParser.h
     platform/graphics/cocoa/SourceBufferParserWebM.h
+    platform/graphics/cocoa/SystemFontDatabaseCoreText.h
+    platform/graphics/cocoa/TextTrackRepresentationCocoa.h
     platform/graphics/cocoa/VP9UtilitiesCocoa.h
+    platform/graphics/cocoa/VideoTargetFactory.h
     platform/graphics/cocoa/WebActionDisablingCALayerDelegate.h
     platform/graphics/cocoa/WebCoreCALayerExtras.h
     platform/graphics/cocoa/WebLayer.h
     platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h
+
+    platform/graphics/cocoa/controls/ControlFactoryCocoa.h
 
     platform/graphics/cv/CVUtilities.h
     platform/graphics/cv/GraphicsContextGLCV.h
@@ -692,16 +868,57 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/cv/PixelBufferConformerCV.h
     platform/graphics/cv/VideoFrameCV.h
 
+    platform/graphics/mac/AppKitControlSystemImage.h
     platform/graphics/mac/ColorMac.h
     platform/graphics/mac/GraphicsChecksMac.h
-    platform/graphics/mac/SwitchingGPUClient.h
+    platform/graphics/mac/ScrollbarTrackCornerSystemImageMac.h
 
-    platform/ios/PlaybackSessionInterfaceAVKit.h
+    platform/image-decoders/ScalableImageDecoder.h
+
+    platform/ios/DeviceOrientationUpdateProvider.h
+    platform/ios/KeyEventCodesIOS.h
+    platform/ios/LegacyTileCache.h
+    platform/ios/LocalCurrentTraitCollection.h
+    platform/ios/LocalizedDeviceModel.h
+    platform/ios/MotionManagerClient.h
+    platform/ios/PlatformEventFactoryIOS.h
+    platform/ios/PlaybackSessionInterfaceAVKitLegacy.h
+    platform/ios/PlaybackSessionInterfaceIOS.h
+    platform/ios/PlaybackSessionInterfaceTVOS.h
+    platform/ios/QuickLook.h
+    platform/ios/TileControllerMemoryHandlerIOS.h
+    platform/ios/UIViewControllerUtilities.h
+    platform/ios/VideoPresentationInterfaceAVKitLegacy.h
+    platform/ios/VideoPresentationInterfaceIOS.h
+    platform/ios/VideoPresentationInterfaceTVOS.h
     platform/ios/WebAVPlayerController.h
+    platform/ios/WebBackgroundTaskController.h
+    platform/ios/WebCoreMotionManager.h
+    platform/ios/WebEvent.h
+    platform/ios/WebEventPrivate.h
+    platform/ios/WebItemProviderPasteboard.h
+    platform/ios/WebSQLiteDatabaseTrackerClient.h
+    platform/ios/WebVideoFullscreenControllerAVKit.h
 
     platform/ios/wak/FloatingPointEnvironment.h
+    platform/ios/wak/WAKAppKitStubs.h
+    platform/ios/wak/WAKClipView.h
+    platform/ios/wak/WAKResponder.h
+    platform/ios/wak/WAKScrollView.h
+    platform/ios/wak/WAKWindow.h
+    platform/ios/wak/WKContentObservation.h
+    platform/ios/wak/WKGraphics.h
+    platform/ios/wak/WKTypes.h
+    platform/ios/wak/WKUtilities.h
+    platform/ios/wak/WKView.h
+    platform/ios/wak/WKViewPrivate.h
+    platform/ios/wak/WebCoreThread.h
+    platform/ios/wak/WebCoreThreadInternal.h
+    platform/ios/wak/WebCoreThreadMessage.h
     platform/ios/wak/WebCoreThreadRun.h
+    platform/ios/wak/WebCoreThreadSystemInterface.h
 
+    platform/mac/DataDetectorHighlight.h
     platform/mac/HIDDevice.h
     platform/mac/HIDElement.h
     platform/mac/LegacyNSPasteboardTypes.h
@@ -712,14 +929,13 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/mac/PlaybackSessionInterfaceMac.h
     platform/mac/PowerObserverMac.h
     platform/mac/RevealUtilities.h
-    platform/mac/SerializedPlatformDataCueMac.h
     platform/mac/ScrollbarThemeMac.h
-    platform/mac/VideoFullscreenInterfaceMac.h
+    platform/mac/SerializedPlatformDataCueMac.h
+    platform/mac/VideoPresentationInterfaceMac.h
     platform/mac/WebCoreFullScreenPlaceholderView.h
     platform/mac/WebCoreFullScreenWindow.h
     platform/mac/WebCoreNSFontManagerExtras.h
     platform/mac/WebCoreView.h
-    platform/mac/WebNSAttributedStringExtras.h
     platform/mac/WebPlaybackControlsManager.h
 
     platform/mediarecorder/MediaRecorderPrivateEncoder.h
@@ -732,11 +948,22 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/mediastream/RealtimeIncomingVideoSource.h
     platform/mediastream/RealtimeMediaSourceIdentifier.h
 
+    platform/mediastream/cocoa/AVVideoCaptureSource.h
     platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h
     platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h
+    platform/mediastream/cocoa/BaseAudioCaptureUnit.h
+    platform/mediastream/cocoa/BaseAudioMediaStreamTrackRendererUnit.h
+    platform/mediastream/cocoa/CoreAudioCaptureDeviceManager.h
+    platform/mediastream/cocoa/CoreAudioCaptureSource.h
+    platform/mediastream/cocoa/CoreAudioCaptureUnit.h
+    platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
     platform/mediastream/cocoa/RealtimeIncomingVideoSourceCocoa.h
     platform/mediastream/cocoa/RealtimeVideoUtilities.h
+    platform/mediastream/cocoa/ScreenCaptureKitCaptureSource.h
+    platform/mediastream/cocoa/ScreenCaptureKitSharingSessionManager.h
     platform/mediastream/cocoa/WebAudioSourceProviderCocoa.h
+
+    platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.h
 
     platform/mediastream/libwebrtc/LibWebRTCProviderCocoa.h
     platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h
@@ -754,13 +981,24 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/network/cocoa/FormDataStreamCocoa.h
     platform/network/cocoa/HTTPCookieAcceptPolicyCocoa.h
     platform/network/cocoa/ProtectionSpaceCocoa.h
+    platform/network/cocoa/RangeResponseGenerator.h
     platform/network/cocoa/UTIUtilities.h
     platform/network/cocoa/WebCoreNSURLSession.h
     platform/network/cocoa/WebCoreURLResponse.h
 
+    platform/network/ios/LegacyPreviewLoaderClient.h
+    platform/network/ios/WebCoreURLResponseIOS.h
+
+    platform/video-codecs/cocoa/VideoDecoderVTB.h
+    platform/video-codecs/cocoa/WebRTCVideoDecoder.h
+
+    platform/xr/cocoa/PlatformXRPose.h
+
     rendering/cocoa/RenderThemeCocoa.h
 
     rendering/ios/RenderThemeIOS.h
+
+    rendering/mac/RenderThemeMac.h
 
     testing/MockWebAuthenticationConfiguration.h
 
@@ -778,6 +1016,7 @@ list(APPEND WebCore_IDL_FILES
     Modules/applepay/ApplePayDateComponentsRange.idl
     Modules/applepay/ApplePayDeferredPaymentRequest.idl
     Modules/applepay/ApplePayDetailsUpdateBase.idl
+    Modules/applepay/ApplePayDisbursementRequest.idl
     Modules/applepay/ApplePayError.idl
     Modules/applepay/ApplePayErrorCode.idl
     Modules/applepay/ApplePayErrorContactField.idl
@@ -833,7 +1072,10 @@ set(ADDITIONAL_BINDINGS_DEPENDENCIES
     ${WORKERGLOBALSCOPE_CONSTRUCTORS_FILE}
     ${DEDICATEDWORKERGLOBALSCOPE_CONSTRUCTORS_FILE}
 )
-set(CSS_VALUE_PLATFORM_DEFINES "WTF_PLATFORM_MAC=1 WTF_PLATFORM_COCOA=1 ENABLE_APPLE_PAY_NEW_BUTTON_TYPES=1")
+# CSS codegen scripts only see command-line defines, not PlatformHave.h.
+# Bare names only (no =1). FIXME: HAVE_CORE_MATERIAL should be gated for Mac
+# in PlatformHave.h. https://bugs.webkit.org/show_bug.cgi?id=312061
+set(CSS_VALUE_PLATFORM_DEFINES "WTF_PLATFORM_MAC WTF_PLATFORM_COCOA ENABLE_APPLE_PAY_NEW_BUTTON_TYPES HAVE_CORE_MATERIAL HAVE_MATERIAL_HOSTING")
 
 set(WebCore_USER_AGENT_SCRIPTS ${WebCore_DERIVED_SOURCES_DIR}/ModernMediaControls.js)
 
@@ -842,13 +1084,12 @@ list(APPEND WebCoreTestSupport_PRIVATE_HEADERS testing/cocoa/WebArchiveDumpSuppo
 list(APPEND WebCoreTestSupport_SOURCES
     testing/Internals.mm
     testing/MockApplePaySetupFeature.cpp
-    testing/MockContentFilter.cpp
-    testing/MockContentFilterSettings.cpp
     testing/MockMediaSessionCoordinator.cpp
     testing/MockPaymentCoordinator.cpp
     testing/MockPreviewLoaderClient.cpp
     testing/ServiceWorkerInternals.mm
 
+    testing/cocoa/CocoaColorSerialization.mm
     testing/cocoa/WebArchiveDumpSupport.mm
 )
 list(APPEND WebCoreTestSupport_IDL_FILES
@@ -856,7 +1097,6 @@ list(APPEND WebCoreTestSupport_IDL_FILES
     testing/MockPaymentContactFields.idl
     testing/MockPaymentCoordinator.idl
     testing/MockPaymentError.idl
-    testing/MockWebAuthenticationConfiguration.idl
 )
 
 if (NOT EXISTS ${CMAKE_BINARY_DIR}/WebCore/WebKitAvailability.h)

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -208,7 +208,6 @@ editing/mac/TextUndoInsertionMarkupMac.mm @nonARC
 fileapi/FileCocoa.mm @nonARC
 history/mac/HistoryItemMac.mm @nonARC
 html/canvas/GPUCanvasContextCocoa.mm @nonARC
-html/canvas/UsdModelLoader.swift
 html/shadow/YouTubeEmbedShadowElement.cpp
 inspector/LegacyWebSocketInspectorInstrumentation.cpp
 inspector/mac/FrameDebuggerMac.mm @nonARC
@@ -580,7 +579,6 @@ platform/ios/PasteboardIOS.mm @nonARC
 platform/ios/PlatformEventFactoryIOS.mm @nonARC @no-unify
 platform/ios/PlatformPasteboardIOS.mm @nonARC
 platform/ios/PlatformScreenIOS.mm @nonARC
-platform/ios/PlaybackSessionInterfaceAVKit.mm @nonARC @no-unify
 platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm @nonARC @no-unify
 platform/ios/PlaybackSessionInterfaceIOS.mm @nonARC @no-unify
 platform/ios/PlaybackSessionInterfaceTVOS.cpp
@@ -596,7 +594,6 @@ platform/ios/UIFoundationSoftLink.mm @nonARC
 platform/ios/UIViewControllerUtilities.mm @nonARC
 platform/ios/UserAgentIOS.mm @nonARC
 platform/ios/ValidationBubbleIOS.mm @nonARC
-platform/ios/VideoPresentationInterfaceAVKit.mm @nonARC @no-unify
 platform/ios/VideoPresentationInterfaceAVKitLegacy.mm @nonARC @no-unify
 platform/ios/VideoPresentationInterfaceIOS.mm @nonARC @no-unify
 platform/ios/VideoPresentationInterfaceTVOS.mm @nonARC

--- a/Source/WebCore/accessibility/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/AXIsolatedTree.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+// FIXME: Remove this forwarding header once CMake include paths
+// are configured to find isolatedtree/ directly.
+// https://bugs.webkit.org/show_bug.cgi?id=312024
+#include "accessibility/isolatedtree/AXIsolatedTree.h" // NOLINT(build/self_include)

--- a/Source/WebCore/bindings/js/JSWindowProxy.cpp
+++ b/Source/WebCore/bindings/js/JSWindowProxy.cpp
@@ -32,6 +32,7 @@
 #include "CommonVM.h"
 #include "Document.h"
 #include "Frame.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameLoaderTypes.h"
 #include "GarbageCollectionController.h"
 #include "JSDOMWindow.h"

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -63,7 +63,7 @@
 #endif // ENABLE(WEBGL)
 
 #if HAVE(WEBGPU_IMPLEMENTATION)
-#include "LocalDomWindow.h"
+#include "LocalDOMWindow.h"
 #include "Navigator.h"
 #endif
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -792,8 +792,10 @@ void SourceBufferPrivateAVFObjC::configureParser(SourceBufferParser& parser)
             protectedThis->didProvideContentKeyRequestInitializationDataForTrackID(WTF::move(initData), trackID);
     });
 
+#if ENABLE(MEDIA_RECORDER_WEBM)
     if (auto* webmParser = dynamicDowncast<SourceBufferParserWebM>(parser); webmParser && m_configuration.supportsLimitedMatroska)
         webmParser->allowLimitedMatroska();
+#endif
 
 #if !RELEASE_LOG_DISABLED
     parser.setLogger(m_logger.get(), m_logIdentifier);

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
@@ -30,7 +30,9 @@
 
 #import "CMUtilities.h"
 #import "FourCC.h"
+#if USE(LIBWEBRTC)
 #import "LibWebRTCProvider.h"
+#endif
 #import "Logging.h"
 #import "MediaStrategy.h"
 #import "PlatformMediaCapabilitiesInfo.h"
@@ -150,7 +152,9 @@ static ResolutionCategory NODELETE resolutionCategory(const FloatSize& size)
 
 void registerWebKitVP9Decoder()
 {
+#if USE(LIBWEBRTC)
     LibWebRTCProvider::registerWebKitVP9Decoder();
+#endif
 }
 
 static std::optional<bool> s_vp9HardwareDecoderAvailableInProcess = { };

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
@@ -27,6 +27,7 @@
 
 #include "MediaPromiseTypes.h"
 #include "ProcessIdentity.h"
+#include <CoreMedia/CMFormatDescription.h>
 #include <CoreMedia/CMTime.h>
 #include <atomic>
 #include <wtf/Expected.h>

--- a/Source/WebCore/platform/graphics/coreimage/FECompositeCoreImageApplier.h
+++ b/Source/WebCore/platform/graphics/coreimage/FECompositeCoreImageApplier.h
@@ -28,6 +28,7 @@
 #if USE(CORE_IMAGE)
 
 #import "FilterEffectApplier.h"
+#import "FloatRect.h"
 #import <wtf/TZoneMalloc.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/coreimage/FECompositeCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FECompositeCoreImageApplier.mm
@@ -29,6 +29,7 @@
 #if USE(CORE_IMAGE)
 
 #import "FEComposite.h"
+#import "Filter.h"
 #import "FilterImage.h"
 #import <CoreImage/CoreImage.h>
 #import <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/platform/graphics/coreimage/FEMergeCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FEMergeCoreImageApplier.mm
@@ -30,6 +30,7 @@
 
 #import "ColorSpaceCG.h"
 #import "FEMerge.h"
+#import "Filter.h"
 #import "Logging.h"
 #import <CoreImage/CIFilterBuiltins.h>
 #import <CoreImage/CoreImage.h>

--- a/Source/WebCore/platform/graphics/cv/CVUtilities.mm
+++ b/Source/WebCore/platform/graphics/cv/CVUtilities.mm
@@ -31,6 +31,7 @@
 #import "ImageUtilities.h"
 #import "Logging.h"
 #import "RealtimeVideoUtilities.h"
+#import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <wtf/CheckedArithmetic.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/cf/TypeCastsCF.h>

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
@@ -60,7 +60,7 @@ bool MediaRecorderPrivateAVFImpl::isTypeSupported(Document& document, ContentTyp
         for (auto& codec : mimeType.codecs()) {
             // FIXME: We should further validate parameters.
             if (!startsWithLettersIgnoringASCIICase(codec, "avc1"_s)
-#if ENABLE(AV1)
+#if ENABLE(AV1) && ENABLE(WEB_RTC)
                 && !(codec.startsWith("av01."_s) && document.settings().webRTCAV1CodecEnabled())
 #endif
 #if ENABLE(WEB_RTC)


### PR DESCRIPTION
#### 5bbeecb131e59b2284a6367d93c0cc9255ef2308
<pre>
[CMake] Fix Mac CMake build for WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=312024">https://bugs.webkit.org/show_bug.cgi?id=312024</a>
<a href="https://rdar.apple.com/174578979">rdar://174578979</a>

Reviewed by BJ Burg.

Add comprehensive Mac CMake configuration for WebCore including
framework linking, include directories, Cocoa source files, IDL
additions, libwebrtc/WebM handling, private framework headers, and
build guards for USE(LIBWEBRTC).

Based on a base patch by Simon Lewis. Incorporates LINKER: prefix
link options and source file include fixes from Ian Grunert
(PR #62543). Force-load PAL into WebCore via
WebCore_EXTRA_LINK_OPTIONS so soft-link symbols are exported even
under -undefined,dynamic_lookup, thanks to Brandon Stewart.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Headers.cmake: Add private framework headers for
downstream WebKit/WebKitLegacy targets.
* Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp:
* Source/WebCore/PlatformMac.cmake: Add framework linking, include
directories, Cocoa sources, WebM parser OBJECT library, and build
guards.
* Source/WebCore/SourcesCocoa.txt: Remove files that no longer exist.
* Source/WebCore/accessibility/AXIsolatedTree.h: Add forwarding include.
* Source/WebCore/bindings/js/JSWindowProxy.cpp: Add missing include.
* Source/WebCore/html/OffscreenCanvas.cpp: Fix header name case.
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::configureParser):
* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm: Add
USE(LIBWEBRTC) guards.
(WebCore::registerWebKitVP9Decoder):
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h:
Add missing include.
* Source/WebCore/platform/graphics/coreimage/FECompositeCoreImageApplier.h:
Add missing include.
* Source/WebCore/platform/graphics/coreimage/FECompositeCoreImageApplier.mm:
Add missing include.
* Source/WebCore/platform/graphics/coreimage/FEMergeCoreImageApplier.mm:
Add missing include.
* Source/WebCore/platform/graphics/cv/CVUtilities.mm: Add missing include.
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp:
(WebCore::MediaRecorderPrivateAVFImpl::isTypeSupported):

Canonical link: <a href="https://commits.webkit.org/311117@main">https://commits.webkit.org/311117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4b103c2961e9146f48a667031ab39c1daae45d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164877 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157927 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29392 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120830 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23043 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140150 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101512 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20262 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12649 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131785 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17982 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167356 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11472 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19594 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128942 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24324 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129073 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34969 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28914 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139776 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86681 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23904 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16574 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28623 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92580 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28150 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28378 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28274 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->