### PR TITLE
[JSC] Remove IPInt metadata from SIMD instructions

### DIFF
--- a/JSTests/wasm/ipint-tests/ipint-test-simd-memory.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-simd-memory.js
@@ -1,0 +1,141 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Test SIMD memory operations through the fast/slow path memarg parsing.
+
+let wat = `
+(module
+    (memory 1)
+
+    ;; Initialize memory with known pattern
+    (data (i32.const 0) "\\01\\02\\03\\04\\05\\06\\07\\08\\09\\0a\\0b\\0c\\0d\\0e\\0f\\10\\11\\12\\13\\14\\15\\16\\17\\18\\19\\1a\\1b\\1c\\1d\\1e\\1f\\20")
+
+    ;; v128.load + v128.store round-trip
+    (func (export "test_load_store") (result i32)
+        ;; Load v128 from offset 0, store to offset 16
+        (v128.store (i32.const 16) (v128.load (i32.const 0)))
+        ;; Verify by extracting lane 0 from reloaded value
+        (i32x4.extract_lane 0 (v128.load (i32.const 16)))
+    )
+
+    ;; v128.load8_splat
+    (func (export "test_load8_splat") (result i32)
+        ;; Load byte at offset 4 (value 0x05) and splat
+        (i8x16.extract_lane_u 7 (v128.load8_splat (i32.const 4)))
+    )
+
+    ;; v128.load16_splat
+    (func (export "test_load16_splat") (result i32)
+        ;; Load halfword at offset 0 (value 0x0201) and splat
+        (i16x8.extract_lane_u 3 (v128.load16_splat (i32.const 0)))
+    )
+
+    ;; v128.load32_splat
+    (func (export "test_load32_splat") (result i32)
+        ;; Load word at offset 0 (value 0x04030201) and splat
+        (i32x4.extract_lane 2 (v128.load32_splat (i32.const 0)))
+    )
+
+    ;; v128.load64_splat
+    (func (export "test_load64_splat") (result i64)
+        ;; Load doubleword at offset 0 and splat
+        (i64x2.extract_lane 1 (v128.load64_splat (i32.const 0)))
+    )
+
+    ;; v128.load8x8_s (sign extend 8->16)
+    (func (export "test_load8x8s") (result i32)
+        ;; Load 8 bytes from offset 0, sign-extend to i16x8
+        (i16x8.extract_lane_u 0 (v128.load8x8_s (i32.const 0)))
+    )
+
+    ;; v128.load32_zero
+    (func (export "test_load32_zero") (result i32)
+        ;; Load 32-bit from offset 0, zero upper
+        (i32x4.extract_lane 1 (v128.load32_zero (i32.const 0)))
+    )
+
+    ;; v128.load8_lane
+    (func (export "test_load8_lane") (result i32)
+        (v128.load8_lane 3 (i32.const 5) (v128.const i32x4 0 0 0 0))  ;; Load byte at addr 5 (value 0x06), replace lane 3
+        (i8x16.extract_lane_u 3)
+    )
+
+    ;; v128.store8_lane
+    (func (export "test_store8_lane") (result i32)
+        ;; Store lane 2 of a known vector to memory address 31
+        (v128.store8_lane 2 (i32.const 31) (v128.const i8x16 0x41 0x42 0x43 0x44 0 0 0 0 0 0 0 0 0 0 0 0))
+        ;; Read back
+        (i32.load8_u (i32.const 31))
+    )
+
+    ;; v128.load16_lane
+    (func (export "test_load16_lane") (result i32)
+        (v128.load16_lane 1 (i32.const 2) (v128.const i32x4 0 0 0 0))  ;; Load halfword at addr 2 (value 0x0403), replace lane 1
+        (i16x8.extract_lane_u 1)
+    )
+
+    ;; v128.store16_lane
+    (func (export "test_store16_lane") (result i32)
+        (v128.store16_lane 1 (i32.const 30) (v128.const i16x8 0x1234 0x5678 0 0 0 0 0 0))
+        (i32.load16_u (i32.const 30))
+    )
+
+    ;; v128.load32_lane
+    (func (export "test_load32_lane") (result i32)
+        (v128.load32_lane 2 (i32.const 0) (v128.const i32x4 0 0 0 0))  ;; Load word at addr 0 (0x04030201), replace lane 2
+        (i32x4.extract_lane 2)
+    )
+
+    ;; v128.store32_lane
+    (func (export "test_store32_lane") (result i32)
+        (v128.store32_lane 0 (i32.const 28) (v128.const i32x4 0xDEADBEEF 0 0 0))
+        (i32.load (i32.const 28))
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const e = instance.exports
+
+    // v128.load + v128.store: bytes 0-3 are 0x04030201 in little-endian
+    assert.eq(e.test_load_store(), 0x04030201)
+
+    // v128.load8_splat: byte at offset 4 = 0x05
+    assert.eq(e.test_load8_splat(), 5)
+
+    // v128.load16_splat: halfword at offset 0 = 0x0201
+    assert.eq(e.test_load16_splat(), 0x0201)
+
+    // v128.load32_splat: word at offset 0 = 0x04030201
+    assert.eq(e.test_load32_splat(), 0x04030201)
+
+    // v128.load64_splat: dword at offset 0 = 0x0807060504030201
+    assert.eq(e.test_load64_splat(), 0x0807060504030201n)
+
+    // v128.load8x8_s: byte 0x01 sign-extended to i16 = 1
+    assert.eq(e.test_load8x8s(), 1)
+
+    // v128.load32_zero: upper lane should be 0
+    assert.eq(e.test_load32_zero(), 0)
+
+    // v128.load8_lane: byte at addr 5 = 0x06
+    assert.eq(e.test_load8_lane(), 6)
+
+    // v128.store8_lane: lane 2 = 0x43
+    assert.eq(e.test_store8_lane(), 0x43)
+
+    // v128.load16_lane: halfword at addr 2 = 0x0403
+    assert.eq(e.test_load16_lane(), 0x0403)
+
+    // v128.store16_lane: lane 1 = 0x5678
+    assert.eq(e.test_store16_lane(), 0x5678)
+
+    // v128.load32_lane: word at addr 0 = 0x04030201
+    assert.eq(e.test_load32_lane(), 0x04030201)
+
+    // v128.store32_lane: lane 0 = 0xDEADBEEF
+    assert.eq(e.test_store32_lane(), 0xDEADBEEF | 0)
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-test-simd-multi-byte-leb.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-simd-multi-byte-leb.js
@@ -1,0 +1,160 @@
+import * as assert from "../assert.js"
+
+// Test SIMD instructions with padded (non-minimal) LEB128 opcode encoding.
+// The simd_prefix handler decodes the opcode LEB128 into t4, so t4 correctly
+// points past however many bytes the opcode takes. Before this fix, the code
+// used a hardcoded offset from PC (ImmLaneIdxOffset = 2), which assumed
+// a 1-byte opcode. With padded LEB128, the opcode is 2+ bytes, making the
+// hardcoded offset wrong. This test verifies the t4-based approach works.
+
+function buildModule(codeBody) {
+    // Minimal wasm module: 1 type (() -> i32), 1 func, 1 export "f"
+    const header = [0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+    const typeSection = [0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f]; // () -> i32
+    const funcSection = [0x03, 0x02, 0x01, 0x00];
+    const exportSection = [0x07, 0x05, 0x01, 0x01, 0x66, 0x00, 0x00]; // "f"
+
+    const bodyWithLocals = [0x00, ...codeBody, 0x0b]; // 0 locals, body, end
+    const bodyLen = bodyWithLocals.length;
+    const codeSection = [0x0a, ...uleb128(bodyLen + 1 + uleb128(bodyLen).length), 0x01, ...uleb128(bodyLen), ...bodyWithLocals];
+
+    return new Uint8Array([...header, ...typeSection, ...funcSection, ...exportSection, ...codeSection]);
+}
+
+function uleb128(value) {
+    const bytes = [];
+    do {
+        let byte = value & 0x7f;
+        value >>>= 7;
+        if (value !== 0) byte |= 0x80;
+        bytes.push(byte);
+    } while (value !== 0);
+    return bytes;
+}
+
+// Encode a SIMD opcode with padded LEB128 (add continuation byte).
+// Opcode 0x16 -> [0xfd, 0x96, 0x00] instead of [0xfd, 0x16]
+// Opcode 0xAE (already 2-byte: 0xAE,0x01) -> [0xfd, 0xAE, 0x81, 0x00] (3-byte padded)
+function paddedSIMDOp(opcode) {
+    // Normal LEB128 encoding, then pad with one extra continuation byte
+    const lebBytes = uleb128(opcode);
+    // Set continuation bit on the last byte, then add 0x00
+    lebBytes[lebBytes.length - 1] |= 0x80;
+    lebBytes.push(0x00);
+    return [0xfd, ...lebBytes];
+}
+
+// v128.const i32x4 with specified values
+function v128ConstI32x4(a, b, c, d) {
+    const buf = new ArrayBuffer(16);
+    const view = new DataView(buf);
+    view.setInt32(0, a, true);
+    view.setInt32(4, b, true);
+    view.setInt32(8, c, true);
+    view.setInt32(12, d, true);
+    return [0xfd, 0x0c, ...new Uint8Array(buf)];
+}
+
+// v128.const with padded opcode
+function v128ConstI32x4Padded(a, b, c, d) {
+    const buf = new ArrayBuffer(16);
+    const view = new DataView(buf);
+    view.setInt32(0, a, true);
+    view.setInt32(4, b, true);
+    view.setInt32(8, c, true);
+    view.setInt32(12, d, true);
+    return [...paddedSIMDOp(0x0c), ...new Uint8Array(buf)];
+}
+
+// i32.const with correct signed LEB128 encoding
+function i32Const(value) {
+    const bytes = [];
+    let more = true;
+    while (more) {
+        let byte = value & 0x7f;
+        value >>= 7;
+        if ((value === 0 && (byte & 0x40) === 0) || (value === -1 && (byte & 0x40) !== 0))
+            more = false;
+        else
+            byte |= 0x80;
+        bytes.push(byte);
+    }
+    return [0x41, ...bytes];
+}
+
+function instantiateAndRun(bytes) {
+    const mod = new WebAssembly.Module(bytes);
+    const inst = new WebAssembly.Instance(mod);
+    return inst.exports.f();
+}
+
+// Test 1: i8x16.extract_lane_u (opcode 0x16) with padded LEB128
+// Extracts byte at lane 4 from i32x4 [0x04030201, ...]
+// Lane 4 = first byte of second i32 = 0x05
+{
+    const bytes = buildModule([
+        ...v128ConstI32x4(0x04030201, 0x08070605, 0x0c0b0a09, 0x100f0e0d),
+        ...paddedSIMDOp(0x16), 0x04, // i8x16.extract_lane_u 4 (padded opcode)
+    ]);
+    assert.eq(instantiateAndRun(bytes), 5);
+}
+
+// Test 2: i32x4.extract_lane (opcode 0x1b) with padded LEB128
+{
+    const bytes = buildModule([
+        ...v128ConstI32x4(10, 20, 30, 40),
+        ...paddedSIMDOp(0x1b), 0x02, // i32x4.extract_lane 2 (padded opcode)
+    ]);
+    assert.eq(instantiateAndRun(bytes), 30);
+}
+
+// Test 3: v128.const (opcode 0x0c) with padded LEB128
+{
+    const bytes = buildModule([
+        ...v128ConstI32x4Padded(42, 0, 0, 0), // v128.const with padded opcode
+        0xfd, 0x1b, 0x00, // i32x4.extract_lane 0 (normal encoding)
+    ]);
+    assert.eq(instantiateAndRun(bytes), 42);
+}
+
+// Test 4: i8x16.replace_lane (opcode 0x17) with padded LEB128
+{
+    const bytes = buildModule([
+        ...v128ConstI32x4(0, 0, 0, 0),
+        ...i32Const(99),             // i32.const 99 (proper signed LEB128)
+        ...paddedSIMDOp(0x17), 0x02, // i8x16.replace_lane 2 (padded opcode)
+        ...paddedSIMDOp(0x16), 0x02, // i8x16.extract_lane_u 2 (padded opcode)
+    ]);
+    assert.eq(instantiateAndRun(bytes), 99);
+}
+
+// Test 5: Chain of padded ops — v128.const (padded) + i32x4.add (padded, opcode 0xAE)
+// + i32x4.extract_lane (padded)
+{
+    const bytes = buildModule([
+        ...v128ConstI32x4Padded(10, 20, 30, 40),
+        ...v128ConstI32x4Padded(1, 2, 3, 4),
+        ...paddedSIMDOp(0xAE),       // i32x4.add (padded)
+        ...paddedSIMDOp(0x1b), 0x01, // i32x4.extract_lane 1 (padded opcode)
+    ]);
+    assert.eq(instantiateAndRun(bytes), 22);
+}
+
+// Test 6: i8x16.shuffle (opcode 0x0d) with padded LEB128
+// Shuffle: take first 4 bytes from second vector, then first 12 from first.
+{
+    const shuffleImm = [
+        0x10, 0x11, 0x12, 0x13,  // lanes 16-19 (from second vector)
+        0x00, 0x01, 0x02, 0x03,  // lanes 0-3 (from first vector)
+        0x04, 0x05, 0x06, 0x07,  // lanes 4-7 (from first vector)
+        0x08, 0x09, 0x0a, 0x0b,  // lanes 8-11 (from first vector)
+    ];
+    const bytes = buildModule([
+        ...v128ConstI32x4(0x04030201, 0x08070605, 0x0c0b0a09, 0x100f0e0d),
+        ...v128ConstI32x4(0x44434241, 0x48474645, 0x4c4b4a49, 0x504f4e4d),
+        ...paddedSIMDOp(0x0d), ...shuffleImm,  // i8x16.shuffle (padded opcode)
+        0xfd, 0x1b, 0x00, // i32x4.extract_lane 0 (normal encoding)
+    ]);
+    // First 4 bytes of result = bytes 16-19 = first 4 bytes of second vector = 0x44434241
+    assert.eq(instantiateAndRun(bytes), 0x44434241);
+}

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -892,14 +892,10 @@ end)
 
 reservedOpcode(0x27)
 
-macro popMemoryIndex(reg, tmp)
-    loadb JSWebAssemblyInstance::m_cachedIsMemory64[wasmInstance], tmp
-    btiz tmp, .memory32
-    popInt64(reg)
-    jmp .done
-.memory32:
-    popInt32(reg)
-    ori 0, reg
+macro popMemoryIndex(reg)
+    popInt64(reg) # Note that popInt32 and popInt64 are same implementation.
+    btbnz JSWebAssemblyInstance::m_cachedIsMemory64[wasmInstance], .done
+    zxi2q reg, reg
 .done:
 end
 
@@ -909,16 +905,14 @@ macro baddpc(src, dst, label)
     bpb dst, src, label # unsigned overflow check
 end
 
-macro metadataMemoryMakePointer(offsetField, memoryIndexField, wasmAddrReg, size, scratch, scratch2)
-    # Loads 64-bit offset from metadata, adds to wasmAddr, does bounds check + multi-memory.
-    # After return: wasmAddrReg points to the resolved host address.
-    loadq offsetField[MC], scratch2
+macro atomicMemoryMakePointerAndAdvanceMC(instrLenReg, wasmAddrReg, size, scratch, scratch2)
+    loadq IPInt::AtomicMemoryAccessMetadata::offset[MC], scratch2
     baddpc(scratch2, wasmAddrReg, .outOfBounds)
 
     move size - 1, scratch2
     baddpc(wasmAddrReg, scratch2, .outOfBounds)
 
-    loadb memoryIndexField[MC], scratch
+    loadb IPInt::AtomicMemoryAccessMetadata::memoryIndex[MC], scratch
     btinz scratch, .memoryIsNotZero
     bpaeq scratch2, boundsCheckingSize, .outOfBounds # scratch2 contains wasm address + size - 1
     addp memoryBase, wasmAddrReg
@@ -937,24 +931,21 @@ macro metadataMemoryMakePointer(offsetField, memoryIndexField, wasmAddrReg, size
 .outOfBounds:
     handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsMemoryAccess)
 .done:
-end
-
-macro atomicMemoryMakePointerAndAdvanceMC(instrLenReg, wasmAddrReg, size, scratch, scratch2)
-    metadataMemoryMakePointer(IPInt::AtomicMemoryAccessMetadata::offset, IPInt::AtomicMemoryAccessMetadata::memoryIndex, wasmAddrReg, size, scratch, scratch2)
     loadb IPInt::AtomicMemoryAccessMetadata::instructionLength[MC], instrLenReg
     advanceMC(constexpr (sizeof(IPInt::AtomicMemoryAccessMetadata)))
 end
 
-macro loadStoreMakePointerFast(wasmAddrReg, size, scratch, scratch2, slowLabel)
+macro loadStoreMakePointerFast(alignAccess, offsetAccess, wasmAddrReg, size, scratch, scratch2, slowLabel)
     # overwrites wasmAddrReg with computed pointer.
     # Fast path: alignment byte < 0x40 (single-byte, no multi-memory),
     # and offset byte < 0x80 (single-byte). Memory index is 0.
-    # Instruction is always 3 bytes: opcode + 1-byte align + 1-byte offset.
+    # alignAccess/offsetAccess are memory access patterns for the memarg bytes.
+    # For non-SIMD: pass (1[PC], 2[PC]). For SIMD: pass ([t4], 1[t4]).
 
     # Check alignment byte: if >= 0x40, it's multi-memory or unusual alignment
-    loadb 1[PC], scratch2        # alignment/flags byte
+    loadb alignAccess, scratch2          # alignment/flags byte
     bbaeq scratch2, 0x40, slowLabel
-    loadb 2[PC], scratch         # offset byte
+    loadb offsetAccess, scratch          # offset byte
     bbaeq scratch, 0x80, slowLabel
 
     # Both single-byte, memory index = 0. scratch = offset value.
@@ -998,9 +989,10 @@ macro loadStoreMakePointerSlow(cursor, wasmAddrReg, size, scratch, scratch2, dec
     jmp .done
 
 .memoryIsNotZero:
-    # FIXME: it's probably worth trying to use a loadpair here, but that requires a separate x86 codepath
     mulp constexpr (sizeof(JSWebAssemblyInstance::WasmMemoryBaseAndSize)), scratch
+    # FIXME: it's probably worth trying to use a loadpair here, but that requires a separate x86 codepath
     loadp (constexpr (JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0) + sizeof(void*))) [wasmInstance, scratch], scratch2 # bounds checking size
+    subp size - 1, scratch2 # wasmAddrReg + (size-1) >= scratch2 is equivalent to wasmAddrReg >= scratch2 - (size-1)
     bpaeq wasmAddrReg, scratch2, .outOfBounds
     loadp (constexpr (JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0))) [wasmInstance, scratch], scratch2 # memory base
     addp scratch2, wasmAddrReg
@@ -1014,8 +1006,8 @@ end
 ipintOp(_i32_load_mem, macro()
     # i32.load
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 4, t1, t2, .ipint_i32_load_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 4, t1, t2, .ipint_i32_load_mem_slow_path)
     # load memory location
     loadi [t0], t1
     pushInt32(t1)
@@ -1027,8 +1019,8 @@ end)
 ipintOp(_i64_load_mem, macro()
     # i32.load
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 8, t1, t2, .ipint_i64_load_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 8, t1, t2, .ipint_i64_load_mem_slow_path)
     # load memory location
     loadq [t0], t1
     pushInt64(t1)
@@ -1040,8 +1032,8 @@ end)
 ipintOp(_f32_load_mem, macro()
     # f32.load
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 4, t1, t2, .ipint_f32_load_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 4, t1, t2, .ipint_f32_load_mem_slow_path)
     # load memory location
     loadf [t0], ft0
     pushFloat32(ft0)
@@ -1053,8 +1045,8 @@ end)
 ipintOp(_f64_load_mem, macro()
     # f64.load
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 8, t1, t2, .ipint_f64_load_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 8, t1, t2, .ipint_f64_load_mem_slow_path)
     # load memory location
     loadd [t0], ft0
     pushFloat64(ft0)
@@ -1066,8 +1058,8 @@ end)
 ipintOp(_i32_load8s_mem, macro()
     # i32.load8_s
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 1, t1, t2, .ipint_i32_load8s_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 1, t1, t2, .ipint_i32_load8s_mem_slow_path)
     loadbsi [t0], t1
     pushInt32(t1)
 
@@ -1078,8 +1070,8 @@ end)
 ipintOp(_i32_load8u_mem, macro()
     # i32.load8_u
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 1, t1, t2, .ipint_i32_load8u_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 1, t1, t2, .ipint_i32_load8u_mem_slow_path)
     loadb [t0], t1
     pushInt32(t1)
 
@@ -1090,8 +1082,8 @@ end)
 ipintOp(_i32_load16s_mem, macro()
     # i32.load16_s
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 2, t1, t2, .ipint_i32_load16s_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 2, t1, t2, .ipint_i32_load16s_mem_slow_path)
     loadhsi [t0], t1
     pushInt32(t1)
 
@@ -1102,8 +1094,8 @@ end)
 ipintOp(_i32_load16u_mem, macro()
     # i32.load16_u
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 2, t1, t2, .ipint_i32_load16u_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 2, t1, t2, .ipint_i32_load16u_mem_slow_path)
     loadh [t0], t1
     pushInt32(t1)
 
@@ -1114,8 +1106,8 @@ end)
 ipintOp(_i64_load8s_mem, macro()
     # i64.load8_s
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 1, t1, t2, .ipint_i64_load8s_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 1, t1, t2, .ipint_i64_load8s_mem_slow_path)
     loadbsq [t0], t1
     pushInt64(t1)
 
@@ -1126,8 +1118,8 @@ end)
 ipintOp(_i64_load8u_mem, macro()
     # i64.load8_u
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 1, t1, t2, .ipint_i64_load8u_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 1, t1, t2, .ipint_i64_load8u_mem_slow_path)
     loadb [t0], t1
     pushInt64(t1)
 
@@ -1138,8 +1130,8 @@ end)
 ipintOp(_i64_load16s_mem, macro()
     # i64.load16_s
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 2, t1, t2, .ipint_i64_load16s_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 2, t1, t2, .ipint_i64_load16s_mem_slow_path)
     loadhsq [t0], t1
     pushInt64(t1)
 
@@ -1150,8 +1142,8 @@ end)
 ipintOp(_i64_load16u_mem, macro()
     # i64.load16_u
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 2, t1, t2, .ipint_i64_load16u_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 2, t1, t2, .ipint_i64_load16u_mem_slow_path)
     loadh [t0], t1
     pushInt64(t1)
 
@@ -1162,8 +1154,8 @@ end)
 ipintOp(_i64_load32s_mem, macro()
     # i64.load32_s
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 4, t1, t2, .ipint_i64_load32s_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 4, t1, t2, .ipint_i64_load32s_mem_slow_path)
     loadi [t0], t1
     sxi2q t1, t1
     pushInt64(t1)
@@ -1175,8 +1167,8 @@ end)
 ipintOp(_i64_load32u_mem, macro()
     # i64.load8_s
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 4, t1, t2, .ipint_i64_load32u_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 4, t1, t2, .ipint_i64_load32u_mem_slow_path)
     loadi [t0], t1
     pushInt64(t1)
 
@@ -1189,8 +1181,8 @@ ipintOp(_i32_store_mem, macro()
     # pop data
     popInt32(t3)
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 4, t1, t2, .ipint_i32_store_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 4, t1, t2, .ipint_i32_store_mem_slow_path)
     storei t3, [t0]
     advancePC(3)
     nextIPIntInstruction()
@@ -1201,8 +1193,8 @@ ipintOp(_i64_store_mem, macro()
     # pop data
     popInt64(t3)
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 8, t1, t2, .ipint_i64_store_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 8, t1, t2, .ipint_i64_store_mem_slow_path)
     storeq t3, [t0]
     advancePC(3)
     nextIPIntInstruction()
@@ -1213,8 +1205,8 @@ ipintOp(_f32_store_mem, macro()
     # pop data
     popFloat32(ft0)
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 4, t1, t2, .ipint_f32_store_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 4, t1, t2, .ipint_f32_store_mem_slow_path)
     storef ft0, [t0]
     advancePC(3)
     nextIPIntInstruction()
@@ -1225,8 +1217,8 @@ ipintOp(_f64_store_mem, macro()
     # pop data
     popFloat64(ft0)
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 8, t1, t2, .ipint_f64_store_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 8, t1, t2, .ipint_f64_store_mem_slow_path)
     stored ft0, [t0]
     advancePC(3)
     nextIPIntInstruction()
@@ -1237,8 +1229,8 @@ ipintOp(_i32_store8_mem, macro()
     # pop data
     popInt32(t3)
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 1, t1, t2, .ipint_i32_store8_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 1, t1, t2, .ipint_i32_store8_mem_slow_path)
     storeb t3, [t0]
     advancePC(3)
     nextIPIntInstruction()
@@ -1249,8 +1241,8 @@ ipintOp(_i32_store16_mem, macro()
     # pop data
     popInt32(t3)
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 2, t1, t2, .ipint_i32_store16_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 2, t1, t2, .ipint_i32_store16_mem_slow_path)
     storeh t3, [t0]
     advancePC(3)
     nextIPIntInstruction()
@@ -1261,8 +1253,8 @@ ipintOp(_i64_store8_mem, macro()
     # pop data
     popInt64(t3)
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 1, t1, t2, .ipint_i64_store8_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 1, t1, t2, .ipint_i64_store8_mem_slow_path)
     storeb t3, [t0]
     advancePC(3)
     nextIPIntInstruction()
@@ -1273,8 +1265,8 @@ ipintOp(_i64_store16_mem, macro()
     # pop data
     popInt64(t3)
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 2, t1, t2, .ipint_i64_store16_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 2, t1, t2, .ipint_i64_store16_mem_slow_path)
     storeh t3, [t0]
     advancePC(3)
     nextIPIntInstruction()
@@ -1285,8 +1277,8 @@ ipintOp(_i64_store32_mem, macro()
     # pop data
     popInt64(t3)
     # pop index
-    popMemoryIndex(t0, t2)
-    loadStoreMakePointerFast(t0, 4, t1, t2, .ipint_i64_store32_mem_slow_path)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast(1[PC], 2[PC], t0, 4, t1, t2, .ipint_i64_store32_mem_slow_path)
     storei t3, [t0]
     advancePC(3)
     nextIPIntInstruction()
@@ -4058,230 +4050,258 @@ end)
     ## SIMD Instructions ##
     #######################
 
-const ImmLaneIdxOffset = 2 # Offset in bytecode
+const ImmLaneIdxOffset = 0 # Offset from t4 (points past the decoded SIMD opcode)
 const ImmLaneIdx16Mask = 0xf
 const ImmLaneIdx8Mask = 0x7
 const ImmLaneIdx4Mask = 0x3
 const ImmLaneIdx2Mask = 0x1
 
-# 0xFD 0x00 - 0xFD 0x0B: memory
+# Platform-specific SIMD load macros (shared between fast and slow paths).
+# Input: t0 = host pointer (rax on x86_64). Output: v0 = loaded vector.
+# Clobbers: ft0 (ARM64), t1 (splat ops on ARM64).
 
-# Wrapper for SIMD load/store operations. Places linear address in t0 for memOp()
-macro simdMemoryOp(accessSize, memOp)
-    popMemoryIndex(t0, t2)
-    metadataMemoryMakePointer(IPInt::SIMDMemoryAccessMetadata::offset, IPInt::SIMDMemoryAccessMetadata::memoryIndex, t0, accessSize, t2, t1)
-
-    # memOp must not clobber t4
-    memOp()
-
-    loadb IPInt::SIMDMemoryAccessMetadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::SIMDMemoryAccessMetadata)))
-    nextIPIntInstruction()
+macro simdLoad8x8s()
+    if ARM64 or ARM64E
+        loadd [t0], ft0
+        emit "sxtl v16.8h, v0.8b"
+    elsif X86_64
+        emit "pmovsxbw (%rax), %xmm0"
+    else
+        break
+    end
 end
+
+macro simdLoad8x8u()
+    if ARM64 or ARM64E
+        loadd [t0], ft0
+        emit "uxtl v16.8h, v0.8b"
+    elsif X86_64
+        emit "pmovzxbw (%rax), %xmm0"
+    else
+        break
+    end
+end
+
+macro simdLoad16x4s()
+    if ARM64 or ARM64E
+        loadd [t0], ft0
+        emit "sxtl v16.4s, v0.4h"
+    elsif X86_64
+        emit "pmovsxwd (%rax), %xmm0"
+    else
+        break
+    end
+end
+
+macro simdLoad16x4u()
+    if ARM64 or ARM64E
+        loadd [t0], ft0
+        emit "uxtl v16.4s, v0.4h"
+    elsif X86_64
+        emit "pmovzxwd (%rax), %xmm0"
+    else
+        break
+    end
+end
+
+macro simdLoad32x2s()
+    if ARM64 or ARM64E
+        loadd [t0], ft0
+        emit "sxtl v16.2d, v0.2s"
+    elsif X86_64
+        emit "pmovsxdq (%rax), %xmm0"
+    else
+        break
+    end
+end
+
+macro simdLoad32x2u()
+    if ARM64 or ARM64E
+        loadd [t0], ft0
+        emit "uxtl v16.2d, v0.2s"
+    elsif X86_64
+        emit "pmovzxdq (%rax), %xmm0"
+    else
+        break
+    end
+end
+
+macro simdLoadSplat8()
+    if ARM64 or ARM64E
+        loadb [t0], t1
+        emit "dup v16.16b, w1"
+    elsif X86_64
+        emit "vpinsrb $0, (%rax), %xmm0, %xmm0"
+        emit "vpxor %xmm1, %xmm1, %xmm1"
+        emit "vpshufb %xmm1, %xmm0, %xmm0"
+    else
+        break
+    end
+end
+
+macro simdLoadSplat16()
+    if ARM64 or ARM64E
+        loadh [t0], t1
+        emit "dup v16.8h, w1"
+    elsif X86_64
+        emit "vpinsrw $0, (%rax), %xmm0, %xmm0"
+        emit "vpshuflw $0, %xmm0, %xmm0"
+        emit "vpunpcklqdq %xmm0, %xmm0, %xmm0"
+    else
+        break
+    end
+end
+
+macro simdLoadSplat32()
+    if ARM64 or ARM64E
+        loadi [t0], t1
+        emit "dup v16.4s, w1"
+    elsif X86_64
+        emit "vbroadcastss (%rax), %xmm0"
+    else
+        break
+    end
+end
+
+macro simdLoadSplat64()
+    if ARM64 or ARM64E
+        loadq [t0], t1
+        emit "dup v16.2d, x1"
+    elsif X86_64
+        emit "vmovddup (%rax), %xmm0"
+    else
+        break
+    end
+end
+
+# 0xFD 0x00 - 0xFD 0x0B: memory
 
 ipintOp(_simd_v128_load_mem, macro()
     # v128.load
-    simdMemoryOp(16, macro()
-        loadv [t0], v0
-        pushVec(v0)
-    end)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 16, t1, t2, .simd_v128_load_slow_path)
+    loadv [t0], v0
+    pushVec(v0)
+    leap 2[t4], PC
+    nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_load_8x8s_mem, macro()
-    # v128.load8x8_s - load 8 8-bit values, sign-extend each to i16
-    simdMemoryOp(8, macro()
-        if ARM64 or ARM64E
-            loadd [t0], ft0
-            # offlineasm ft0 = ARM v0
-            # offlineasm v0 = ARM v16
-            emit "sxtl v16.8h, v0.8b"
-        elsif X86_64
-            # t0 is eax
-            emit "pmovsxbw (%rax), %xmm0"
-        else
-            break # Not implemented
-        end
-        pushVec(v0)
-    end)
+    # v128.load8x8_s
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 8, t1, t2, .simd_v128_load_8x8s_slow_path)
+    simdLoad8x8s()
+    pushVec(v0)
+    leap 2[t4], PC
+    nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_load_8x8u_mem, macro()
-    # v128.load8x8_u - load 8 8-bit values, zero-extend each to i16
-    simdMemoryOp(8, macro()
-        if ARM64 or ARM64E
-            loadd [t0], ft0
-            # offlineasm ft0 = ARM v0
-            # offlineasm v0 = ARM v16
-            emit "uxtl v16.8h, v0.8b"
-        elsif X86_64
-            # t0 is eax
-            emit "pmovzxbw (%rax), %xmm0"
-        else
-            break # Not implemented
-        end
-        pushVec(v0)
-    end)
+    # v128.load8x8_u
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 8, t1, t2, .simd_v128_load_8x8u_slow_path)
+    simdLoad8x8u()
+    pushVec(v0)
+    leap 2[t4], PC
+    nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_load_16x4s_mem, macro()
-    # v128.load16x4_s - load 4 16-bit values, sign-extend each to i32
-    simdMemoryOp(8, macro()
-        if ARM64 or ARM64E
-            loadd [t0], ft0
-            # offlineasm ft0 = ARM v0
-            # offlineasm v0 = ARM v16
-            emit "sxtl v16.4s, v0.4h"
-        elsif X86_64
-            # t0 is eax
-            emit "pmovsxwd (%rax), %xmm0"
-        else
-            break # Not implemented
-        end
-        pushVec(v0)
-    end)
+    # v128.load16x4_s
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 8, t1, t2, .simd_v128_load_16x4s_slow_path)
+    simdLoad16x4s()
+    pushVec(v0)
+    leap 2[t4], PC
+    nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_load_16x4u_mem, macro()
-    # v128.load16x4_u - load 4 16-bit values, zero-extend each to i32
-    simdMemoryOp(8, macro()
-        if ARM64 or ARM64E
-            loadd [t0], ft0
-            # offlineasm ft0 = ARM v0
-            # offlineasm v0 = ARM v16
-            emit "uxtl v16.4s, v0.4h"
-        elsif X86_64
-            # t0 is eax
-            emit "pmovzxwd (%rax), %xmm0"
-        else
-            break # Not implemented
-        end
-        pushVec(v0)
-    end)
+    # v128.load16x4_u
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 8, t1, t2, .simd_v128_load_16x4u_slow_path)
+    simdLoad16x4u()
+    pushVec(v0)
+    leap 2[t4], PC
+    nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_load_32x2s_mem, macro()
-    # v128.load32x2_s - load 2 32-bit values, sign-extend each to i64
-    simdMemoryOp(8, macro()
-        if ARM64 or ARM64E
-            loadd [t0], ft0
-            # offlineasm ft0 = ARM v0
-            # offlineasm v0 = ARM v16
-            emit "sxtl v16.2d, v0.2s"
-        elsif X86_64
-            # t0 is eax
-            emit "pmovsxdq (%rax), %xmm0"
-        else
-            break # Not implemented
-        end
-        pushVec(v0)
-    end)
+    # v128.load32x2_s
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 8, t1, t2, .simd_v128_load_32x2s_slow_path)
+    simdLoad32x2s()
+    pushVec(v0)
+    leap 2[t4], PC
+    nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_load_32x2u_mem, macro()
-    # v128.load32x2_u - load 2 32-bit values, zero-extend each to i64
-    simdMemoryOp(8, macro()
-        if ARM64 or ARM64E
-            loadd [t0], ft0
-            # offlineasm ft0 = ARM v0
-            # offlineasm v0 = ARM v16
-            emit "uxtl v16.2d, v0.2s"
-        elsif X86_64
-            # t0 is eax
-            emit "pmovzxdq (%rax), %xmm0"
-        else
-            break # Not implemented
-        end
-        pushVec(v0)
-    end)
+    # v128.load32x2_u
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 8, t1, t2, .simd_v128_load_32x2u_slow_path)
+    simdLoad32x2u()
+    pushVec(v0)
+    leap 2[t4], PC
+    nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_load8_splat_mem, macro()
-    # v128.load8_splat - load 1 8-bit value and splat to all 16 lanes
-    simdMemoryOp(1, macro()
-        if ARM64 or ARM64E
-            loadb [t0], t1
-            emit "dup v16.16b, w1"
-        elsif X86_64
-            # t0 is eax
-            emit "vpinsrb $0, (%rax), %xmm0, %xmm0"
-            emit "vpxor %xmm1, %xmm1, %xmm1"
-            emit "vpshufb %xmm1, %xmm0, %xmm0"
-        else
-            break # Not implemented
-        end
-        pushVec(v0)
-    end)
+    # v128.load8_splat
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 1, t1, t2, .simd_v128_load8_splat_slow_path)
+    simdLoadSplat8()
+    pushVec(v0)
+    leap 2[t4], PC
+    nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_load16_splat_mem, macro()
-    # v128.load16_splat - load 1 16-bit value and splat to all 8 lanes
-    simdMemoryOp(2, macro()
-        if ARM64 or ARM64E
-            loadh [t0], t1
-            emit "dup v16.8h, w1"
-        elsif X86_64
-            # t0 is eax
-            emit "vpinsrw $0, (%rax), %xmm0, %xmm0"
-            emit "vpshuflw $0, %xmm0, %xmm0"
-            emit "vpunpcklqdq %xmm0, %xmm0, %xmm0"
-        else
-            break # Not implemented
-        end
-        pushVec(v0)
-    end)
+    # v128.load16_splat
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 2, t1, t2, .simd_v128_load16_splat_slow_path)
+    simdLoadSplat16()
+    pushVec(v0)
+    leap 2[t4], PC
+    nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_load32_splat_mem, macro()
-    # v128.load32_splat - load 1 32-bit value and splat to all 4 lanes
-    simdMemoryOp(4, macro()
-        if ARM64 or ARM64E
-            loadi [t0], t1
-            emit "dup v16.4s, w1"
-        elsif X86_64
-            # Load and broadcast 32-bit value directly from memory to all 4 dwords
-            # t0 is eax
-            emit "vbroadcastss (%rax), %xmm0"
-        else
-            break # Not implemented
-        end
-        pushVec(v0)
-    end)
+    # v128.load32_splat
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .simd_v128_load32_splat_slow_path)
+    simdLoadSplat32()
+    pushVec(v0)
+    leap 2[t4], PC
+    nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_load64_splat_mem, macro()
-    # v128.load64_splat - load 1 64-bit value and splat to all 2 lanes
-    simdMemoryOp(8, macro()
-        if ARM64 or ARM64E
-            loadq [t0], t1
-            emit "dup v16.2d, x1"
-        elsif X86_64
-            # Load and broadcast 64-bit value directly from memory to both qwords
-            # t0 is eax
-            emit "vmovddup (%rax), %xmm0"
-        else
-            break # Not implemented
-        end
-        pushVec(v0)
-    end)
+    # v128.load64_splat
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 8, t1, t2, .simd_v128_load64_splat_slow_path)
+    simdLoadSplat64()
+    pushVec(v0)
+    leap 2[t4], PC
+    nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_store_mem, macro()
     # v128.store
     popVec(v0)
-    simdMemoryOp(16, macro()
-        storev v0, [t0]
-    end)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 16, t1, t2, .simd_v128_store_slow_path)
+    storev v0, [t0]
+    leap 2[t4], PC
+    nextIPIntInstruction()
 end)
 
 # 0xFD 0x0C: v128.const
 ipintOp(_simd_v128_const, macro()
     # v128.const
-    loadv 2[PC], v0
+    loadv [t4], v0
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    leap 16[t4], PC
     nextIPIntInstruction()
 end)
 
@@ -4292,7 +4312,7 @@ ipintOp(_simd_i8x16_shuffle, macro()
     if ARM64 or ARM64E
         popVec(v1)
         popVec(v0)
-        loadv ImmLaneIdxOffset[PC], v2
+        loadv [t4], v2
         emit "tbl v16.16b, {v16.16b, v17.16b}, v18.16b"
         pushVec(v0)
     else
@@ -4303,7 +4323,7 @@ ipintOp(_simd_i8x16_shuffle, macro()
         move 0, t0
 
     .shuffleLoop:
-        loadb ImmLaneIdxOffset[PC, t0, 1], t1
+        loadb [t4, t0, 1], t1
 
         bigt t1, 31, .outOfBounds
         bigt t1, 15, .useRightVector
@@ -4334,9 +4354,7 @@ ipintOp(_simd_i8x16_shuffle, macro()
         addp 2 * V128ISize, sp            # Pop temp result and right vector
     end
 
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    leap 16[t4], PC
     nextIPIntInstruction()
 end)
 
@@ -4363,9 +4381,7 @@ ipintOp(_simd_i8x16_swizzle, macro()
     end
 
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -4386,9 +4402,7 @@ ipintOp(_simd_i8x16_splat, macro()
     end
 
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -4408,9 +4422,7 @@ ipintOp(_simd_i16x8_splat, macro()
     end
 
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -4429,9 +4441,7 @@ ipintOp(_simd_i32x4_splat, macro()
     end
 
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -4450,9 +4460,7 @@ ipintOp(_simd_i64x2_splat, macro()
     end
 
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -4470,9 +4478,7 @@ ipintOp(_simd_f32x4_splat, macro()
     end
 
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -4490,186 +4496,156 @@ ipintOp(_simd_f64x2_splat, macro()
     end
 
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
 # 0xFD 0x15 - 0xFD 0x22: extract and replace lanes
 ipintOp(_simd_i8x16_extract_lane_s, macro()
     # i8x16.extract_lane_s (lane)
-    loadb ImmLaneIdxOffset[PC], t0
+    loadb ImmLaneIdxOffset[t4], t0
     andi ImmLaneIdx16Mask, t0
     loadbsi [sp, t0], t0
     addp V128ISize, sp
     pushInt32(t0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    leap 1[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_i8x16_extract_lane_u, macro()
     # i8x16.extract_lane_u (lane)
-    loadb ImmLaneIdxOffset[PC], t0
+    loadb ImmLaneIdxOffset[t4], t0
     andi ImmLaneIdx16Mask, t0
     loadb [sp, t0], t0
     addp V128ISize, sp
     pushInt32(t0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    leap 1[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_i8x16_replace_lane, macro()
     # i8x16.replace_lane (lane)
-    loadb ImmLaneIdxOffset[PC], t0
+    loadb ImmLaneIdxOffset[t4], t0
     andi ImmLaneIdx16Mask, t0
     popInt32(t1)  # value to replace with
     storeb t1, [sp, t0]  # replace the byte at lane index
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    leap 1[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_i16x8_extract_lane_s, macro()
     # i16x8.extract_lane_s (lane)
-    loadb ImmLaneIdxOffset[PC], t0
+    loadb ImmLaneIdxOffset[t4], t0
     andi ImmLaneIdx8Mask, t0
     loadhsi [sp, t0, 2], t0
     addp V128ISize, sp
     pushInt32(t0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    leap 1[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_i16x8_extract_lane_u, macro()
     # i16x8.extract_lane_u (lane)
-    loadb ImmLaneIdxOffset[PC], t0
+    loadb ImmLaneIdxOffset[t4], t0
     andi ImmLaneIdx8Mask, t0
     loadh [sp, t0, 2], t0
     addp V128ISize, sp
     pushInt32(t0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    leap 1[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_i16x8_replace_lane, macro()
     # i16x8.replace_lane (lane)
-    loadb ImmLaneIdxOffset[PC], t0
+    loadb ImmLaneIdxOffset[t4], t0
     andi ImmLaneIdx8Mask, t0
     popInt32(t1)  # value to replace with
     storeh t1, [sp, t0, 2]  # replace the 16-bit value at lane index
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    leap 1[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_i32x4_extract_lane, macro()
     # i32x4.extract_lane (lane)
-    loadb ImmLaneIdxOffset[PC], t0
+    loadb ImmLaneIdxOffset[t4], t0
     andi ImmLaneIdx4Mask, t0
     loadi [sp, t0, 4], t0
     addp V128ISize, sp
     pushInt32(t0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    leap 1[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_i32x4_replace_lane, macro()
     # i32x4.replace_lane (lane)
-    loadb ImmLaneIdxOffset[PC], t0
+    loadb ImmLaneIdxOffset[t4], t0
     andi ImmLaneIdx4Mask, t0
     popInt32(t1)  # value to replace with
     storei t1, [sp, t0, 4]  # replace the 32-bit value at lane index
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    leap 1[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_i64x2_extract_lane, macro()
     # i64x2.extract_lane (lane)
-    loadb ImmLaneIdxOffset[PC], t0
+    loadb ImmLaneIdxOffset[t4], t0
     andi ImmLaneIdx2Mask, t0
     loadq [sp, t0, 8], t0
     addp V128ISize, sp
     pushInt64(t0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    leap 1[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_i64x2_replace_lane, macro()
     # i64x2.replace_lane (lane)
-    loadb ImmLaneIdxOffset[PC], t0
+    loadb ImmLaneIdxOffset[t4], t0
     andi ImmLaneIdx2Mask, t0
     popInt64(t1)  # value to replace with
     storeq t1, [sp, t0, 8]  # replace the 64-bit value at lane index
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    leap 1[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_f32x4_extract_lane, macro()
     # f32x4.extract_lane (lane)
-    loadb ImmLaneIdxOffset[PC], t0
+    loadb ImmLaneIdxOffset[t4], t0
     andi ImmLaneIdx4Mask, t0
     loadf [sp, t0, 4], ft0
     addp V128ISize, sp
     pushFloat32(ft0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    leap 1[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_f32x4_replace_lane, macro()
     # f32x4.replace_lane (lane)
-    loadb ImmLaneIdxOffset[PC], t0
+    loadb ImmLaneIdxOffset[t4], t0
     andi ImmLaneIdx4Mask, t0
     popFloat32(ft0)  # value to replace with
     storef ft0, [sp, t0, 4]  # replace the 32-bit float at lane index
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    leap 1[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_f64x2_extract_lane, macro()
     # f64x2.extract_lane (lane)
-    loadb ImmLaneIdxOffset[PC], t0
+    loadb ImmLaneIdxOffset[t4], t0
     andi ImmLaneIdx2Mask, t0
     loadd [sp, t0, 8], ft0
     addp V128ISize, sp
     pushFloat64(ft0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    leap 1[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_f64x2_replace_lane, macro()
     # f64x2.replace_lane (lane)
-    loadb ImmLaneIdxOffset[PC], t0
+    loadb ImmLaneIdxOffset[t4], t0
     andi ImmLaneIdx2Mask, t0
     popFloat64(ft0)  # value to replace with
     stored ft0, [sp, t0, 8]  # replace the 64-bit float at lane index
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    leap 1[t4], PC
     nextIPIntInstruction()
 end)
 
@@ -4686,9 +4662,7 @@ ipintOp(_simd_i8x16_eq, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -4709,9 +4683,7 @@ ipintOp(_simd_i8x16_ne, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -4729,9 +4701,7 @@ ipintOp(_simd_i8x16_lt_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -4752,9 +4722,7 @@ ipintOp(_simd_i8x16_lt_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -4770,9 +4738,7 @@ ipintOp(_simd_i8x16_gt_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -4792,9 +4758,7 @@ ipintOp(_simd_i8x16_gt_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -4814,9 +4778,7 @@ ipintOp(_simd_i8x16_le_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -4835,9 +4797,7 @@ ipintOp(_simd_i8x16_le_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -4856,9 +4816,7 @@ ipintOp(_simd_i8x16_ge_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -4876,9 +4834,7 @@ ipintOp(_simd_i8x16_ge_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -4896,9 +4852,7 @@ ipintOp(_simd_i16x8_eq, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -4918,9 +4872,7 @@ ipintOp(_simd_i16x8_ne, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -4938,9 +4890,7 @@ ipintOp(_simd_i16x8_lt_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -4961,9 +4911,7 @@ ipintOp(_simd_i16x8_lt_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -4979,9 +4927,7 @@ ipintOp(_simd_i16x8_gt_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5001,9 +4947,7 @@ ipintOp(_simd_i16x8_gt_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5023,9 +4967,7 @@ ipintOp(_simd_i16x8_le_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5044,9 +4986,7 @@ ipintOp(_simd_i16x8_le_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5065,9 +5005,7 @@ ipintOp(_simd_i16x8_ge_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5085,9 +5023,7 @@ ipintOp(_simd_i16x8_ge_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5104,9 +5040,7 @@ ipintOp(_simd_i32x4_eq, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5126,9 +5060,7 @@ ipintOp(_simd_i32x4_ne, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5146,9 +5078,7 @@ ipintOp(_simd_i32x4_lt_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5169,9 +5099,7 @@ ipintOp(_simd_i32x4_lt_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5187,9 +5115,7 @@ ipintOp(_simd_i32x4_gt_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5209,9 +5135,7 @@ ipintOp(_simd_i32x4_gt_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5231,9 +5155,7 @@ ipintOp(_simd_i32x4_le_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5252,9 +5174,7 @@ ipintOp(_simd_i32x4_le_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5273,9 +5193,7 @@ ipintOp(_simd_i32x4_ge_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5293,9 +5211,7 @@ ipintOp(_simd_i32x4_ge_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5312,9 +5228,7 @@ ipintOp(_simd_f32x4_eq, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5331,9 +5245,7 @@ ipintOp(_simd_f32x4_ne, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5350,9 +5262,7 @@ ipintOp(_simd_f32x4_lt, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5368,9 +5278,7 @@ ipintOp(_simd_f32x4_gt, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5387,9 +5295,7 @@ ipintOp(_simd_f32x4_le, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5405,9 +5311,7 @@ ipintOp(_simd_f32x4_ge, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5424,9 +5328,7 @@ ipintOp(_simd_f64x2_eq, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5443,9 +5345,7 @@ ipintOp(_simd_f64x2_ne, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5462,9 +5362,7 @@ ipintOp(_simd_f64x2_lt, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5480,9 +5378,7 @@ ipintOp(_simd_f64x2_gt, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5499,9 +5395,7 @@ ipintOp(_simd_f64x2_le, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5517,9 +5411,7 @@ ipintOp(_simd_f64x2_ge, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5537,9 +5429,7 @@ ipintOp(_simd_v128_not, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5555,9 +5445,7 @@ ipintOp(_simd_v128_and, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5573,9 +5461,7 @@ ipintOp(_simd_v128_andnot, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5591,9 +5477,7 @@ ipintOp(_simd_v128_or, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5609,9 +5493,7 @@ ipintOp(_simd_v128_xor, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5636,9 +5518,7 @@ ipintOp(_simd_v128_bitselect, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5661,274 +5541,150 @@ ipintOp(_simd_v128_any_true, macro()
         break # Not implemented
     end
     pushInt32(t0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
 # 0xFD 0x54 - 0xFD 0x5D: v128 load/store lane
-
-# If simd ops used memoryOpAdvanceMCAndMakePointer the macro would read
-# memory index and advance MC and then the handler would read the constant
-# and advance MC, so there is a performance optimization here to only
-# advance MC once
-
-macro ipintCheckMemoryBoundAndMakePointer(whichMemory, mem, scratch, size)
-    # overwrites mem with computed pointer
-    btiz whichMemory, .checkBounds
-    # overwrites whichMemory
-    mulp (constexpr (sizeof(JSWebAssemblyInstance::WasmMemoryBaseAndSize))), whichMemory
-    addp (constexpr (JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0))), whichMemory
-    addp wasmInstance, whichMemory
-    loadp [whichMemory], memoryBase
-    loadp (constexpr (sizeof(void*)))[whichMemory], boundsCheckingSize
-    move 1, whichMemory # restore base and size registers afterward if using nonzero memory
-.checkBounds:
-    # Memory indices are 32 bit
-    leap size - 1[mem], scratch
-    bpb scratch, boundsCheckingSize, .continuation
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsMemoryAccess)
-.continuation:
-    addp memoryBase, mem
-    btiz whichMemory, .done
-    loadp (constexpr (JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0))) [wasmInstance], memoryBase
-    loadp (constexpr (JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0) + sizeof(void*))) [wasmInstance], boundsCheckingSize
-.done:
-end
+# For load_lane: stack is [v128, i32_addr]. Pop addr, do memarg, load from memory,
+# read lane index, replace lane in the v128 still on stack.
+# For store_lane: stack is [v128, i32_addr]. Pop addr, do memarg, read lane index,
+# extract value from v128 on stack, pop v128, store to memory.
+# Lane index is the last byte of the instruction, right after the memarg.
 
 ipintOp(_simd_v128_load8_lane_mem, macro()
-    # v128.load8_lane - load 8-bit value from memory and replace lane in existing vector
-
     popVec(v0)
-    popMemoryIndex(t0, t2)
-
-    loadq IPInt::SIMDMemoryAccessMetadata::offset[MC], t2
-    addp t2, t0
-    loadb IPInt::SIMDMemoryAccessMetadata::memoryIndex[MC], t3
-    ipintCheckMemoryBoundAndMakePointer(t3, t0, t2, 1)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 1, t1, t2, .simd_v128_load8_lane_slow_path)
     loadb [t0], t0
-
-    # The lane index comes after the variable length memory offset, so find it by
-    # advancing the PC and loading the byte before the next instruction.
-    loadb IPInt::SIMDMemoryAccessMetadata::instructionLength[MC], t1
-    advancePCByReg(t1)
-    loadb -1[PC], t1
+    loadb 2[t4], t1
     andi ImmLaneIdx16Mask, t1
-
-    # Push the result and then replace one lane of the result with the loaded value
     pushVec(v0)
     storeb t0, [sp, t1]
-
-    advanceMC(constexpr (sizeof(IPInt::SIMDMemoryAccessMetadata)))
+    leap 3[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_load16_lane_mem, macro()
-    # v128.load16_lane - load 16-bit value from memory and replace lane in existing vector
-
     popVec(v0)
-    popMemoryIndex(t0, t2)
-
-    loadq IPInt::SIMDMemoryAccessMetadata::offset[MC], t2
-    addp t2, t0
-    loadb IPInt::SIMDMemoryAccessMetadata::memoryIndex[MC], t3
-    ipintCheckMemoryBoundAndMakePointer(t3, t0, t2, 2)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 2, t1, t2, .simd_v128_load16_lane_slow_path)
     loadh [t0], t0
-
-    # The lane index comes after the variable length memory offset, so find it by
-    # advancing the PC and loading the byte before the next instruction.
-    loadb IPInt::SIMDMemoryAccessMetadata::instructionLength[MC], t1
-    advancePCByReg(t1)
-    loadb -1[PC], t1
+    loadb 2[t4], t1
     andi ImmLaneIdx8Mask, t1
-
-    # Push the result and then replace one lane of the result with the loaded value
     pushVec(v0)
     storeh t0, [sp, t1, 2]
-
-    advanceMC(constexpr (sizeof(IPInt::SIMDMemoryAccessMetadata)))
+    leap 3[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_load32_lane_mem, macro()
-    # v128.load32_lane - load 32-bit value from memory and replace lane in existing vector
-
     popVec(v0)
-    popMemoryIndex(t0, t2)
-
-    loadq IPInt::SIMDMemoryAccessMetadata::offset[MC], t2
-    addp t2, t0
-    loadb IPInt::SIMDMemoryAccessMetadata::memoryIndex[MC], t3
-    ipintCheckMemoryBoundAndMakePointer(t3, t0, t2, 4)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .simd_v128_load32_lane_slow_path)
     loadi [t0], t0
-
-    # The lane index comes after the variable length memory offset, so find it by
-    # advancing the PC and loading the byte before the next instruction.
-    loadb IPInt::SIMDMemoryAccessMetadata::instructionLength[MC], t1
-    advancePCByReg(t1)
-    loadb -1[PC], t1
+    loadb 2[t4], t1
     andi ImmLaneIdx4Mask, t1
-
-    # Push the result and then replace one lane of the result with the loaded value
     pushVec(v0)
     storei t0, [sp, t1, 4]
-
-    advanceMC(constexpr (sizeof(IPInt::SIMDMemoryAccessMetadata)))
+    leap 3[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_load64_lane_mem, macro()
-    # v128.load64_lane - load 64-bit value from memory and replace lane in existing vector
-
     popVec(v0)
-    popMemoryIndex(t0, t2)
-
-    loadq IPInt::SIMDMemoryAccessMetadata::offset[MC], t2
-    addp t2, t0
-    loadb IPInt::SIMDMemoryAccessMetadata::memoryIndex[MC], t3
-    ipintCheckMemoryBoundAndMakePointer(t3, t0, t2, 8)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 8, t1, t2, .simd_v128_load64_lane_slow_path)
     loadq [t0], t0
-
-    # The lane index comes after the variable length memory offset, so find it by
-    # advancing the PC and loading the byte before the next instruction.
-    loadb IPInt::SIMDMemoryAccessMetadata::instructionLength[MC], t1
-    advancePCByReg(t1)
-    loadb -1[PC], t1
+    loadb 2[t4], t1
     andi ImmLaneIdx2Mask, t1
-
-    # Push the result and then replace one lane of the result with the loaded value
     pushVec(v0)
     storeq t0, [sp, t1, 8]
-
-    advanceMC(constexpr (sizeof(IPInt::SIMDMemoryAccessMetadata)))
+    leap 3[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_store8_lane_mem, macro()
-    # v128.store8_lane - extract 8-bit value from lane and store to memory
-
-    # The lane index comes after the variable length memory offset, so find it by
-    # advancing the PC and loading the byte before the next instruction.
-    loadb IPInt::SIMDMemoryAccessMetadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    loadb -1[PC], t1
+    # Stack: [addr, v128] with v128 on top. Pop both, parse memarg, extract lane, store.
+    popVec(v0)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 1, t1, t2, .simd_v128_store8_lane_slow_path)
+    loadb 2[t4], t1
     andi ImmLaneIdx16Mask, t1
-
-    loadb [sp, t1], t1  # Load value from lane in vector on stack
-    addp V128ISize, sp  # Pop the vector
-
-    popMemoryIndex(t0, t2)
-
-    loadq IPInt::SIMDMemoryAccessMetadata::offset[MC], t2
-    addp t2, t0
-    loadb IPInt::SIMDMemoryAccessMetadata::memoryIndex[MC], t3
-    ipintCheckMemoryBoundAndMakePointer(t3, t0, t2, 1)
-
+    # Extract byte from v0 via temp push
+    pushVec(v0)
+    loadb [sp, t1], t1
+    addp V128ISize, sp
     storeb t1, [t0]
-
-    advanceMC(constexpr (sizeof(IPInt::SIMDMemoryAccessMetadata)))
+    leap 3[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_store16_lane_mem, macro()
-    # v128.store16_lane - extract 16-bit value from lane and store to memory
-
-    # The lane index comes after the variable length memory offset, so find it by
-    # advancing the PC and loading the byte before the next instruction.
-    loadb IPInt::SIMDMemoryAccessMetadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    loadb -1[PC], t1
+    popVec(v0)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 2, t1, t2, .simd_v128_store16_lane_slow_path)
+    loadb 2[t4], t1
     andi ImmLaneIdx8Mask, t1
-
-    loadh [sp, t1, 2], t1   # Load value from lane in vector on stack
-    addp V128ISize, sp      # Pop the vector
-
-    popMemoryIndex(t0, t2)
-
-    loadq IPInt::SIMDMemoryAccessMetadata::offset[MC], t2
-    addp t2, t0
-    loadb IPInt::SIMDMemoryAccessMetadata::memoryIndex[MC], t3
-    ipintCheckMemoryBoundAndMakePointer(t3, t0, t2, 2)
-
+    pushVec(v0)
+    loadh [sp, t1, 2], t1
+    addp V128ISize, sp
     storeh t1, [t0]
-
-    advanceMC(constexpr (sizeof(IPInt::SIMDMemoryAccessMetadata)))
+    leap 3[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_store32_lane_mem, macro()
-    # v128.store32_lane - extract 32-bit value from lane and store to memory
-
-    # The lane index comes after the variable length memory offset, so find it by
-    # advancing the PC and loading the byte before the next instruction.
-    loadb IPInt::SIMDMemoryAccessMetadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    loadb -1[PC], t1
+    popVec(v0)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .simd_v128_store32_lane_slow_path)
+    loadb 2[t4], t1
     andi ImmLaneIdx4Mask, t1
-
-    loadi [sp, t1, 4], t1   # Load value from lane in vector on stack
-    addp V128ISize, sp      # Pop the vector
-
-    popMemoryIndex(t0, t2)
-
-    loadq IPInt::SIMDMemoryAccessMetadata::offset[MC], t2
-    addp t2, t0
-    loadb IPInt::SIMDMemoryAccessMetadata::memoryIndex[MC], t3
-    ipintCheckMemoryBoundAndMakePointer(t3, t0, t2, 4)
-
+    pushVec(v0)
+    loadi [sp, t1, 4], t1
+    addp V128ISize, sp
     storei t1, [t0]
-
-    advanceMC(constexpr (sizeof(IPInt::SIMDMemoryAccessMetadata)))
+    leap 3[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_store64_lane_mem, macro()
-    # v128.store64_lane - extract 64-bit value from lane and store to memory
-
-    # The lane index comes after the variable length memory offset, so find it by
-    # advancing the PC and loading the byte before the next instruction.
-    loadb IPInt::SIMDMemoryAccessMetadata::instructionLength[MC], t0
-    advancePCByReg(t0)
-    loadb -1[PC], t1
+    popVec(v0)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 8, t1, t2, .simd_v128_store64_lane_slow_path)
+    loadb 2[t4], t1
     andi ImmLaneIdx2Mask, t1
-
-    loadq [sp, t1, 8], t1   # Load value from lane in vector on stack
-    addp V128ISize, sp      # Pop the vector
-
-    popMemoryIndex(t0, t2)
-    loadq IPInt::SIMDMemoryAccessMetadata::offset[MC], t2
-    addp t2, t0
-    loadb IPInt::SIMDMemoryAccessMetadata::memoryIndex[MC], t3
-    ipintCheckMemoryBoundAndMakePointer(t3, t0, t2, 8)
-
+    pushVec(v0)
+    loadq [sp, t1, 8], t1
+    addp V128ISize, sp
     storeq t1, [t0]
-
-    advanceMC(constexpr (sizeof(IPInt::SIMDMemoryAccessMetadata)))
+    leap 3[t4], PC
     nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_load32_zero_mem, macro()
     # v128.load32_zero - load 32-bit value from memory and zero-pad to 128 bits
-    simdMemoryOp(4, macro()
-        loadi [t0], t0
-
-        subp V128ISize, sp
-        storei t0, [sp]
-        storei 0, 4[sp]
-        storeq 0, 8[sp]
-    end)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 4, t1, t2, .simd_v128_load32_zero_slow_path)
+    loadi [t0], t0
+    subp V128ISize, sp
+    storei t0, [sp]
+    storei 0, 4[sp]
+    storeq 0, 8[sp]
+    leap 2[t4], PC
+    nextIPIntInstruction()
 end)
 
 ipintOp(_simd_v128_load64_zero_mem, macro()
     # v128.load64_zero - load 64-bit value from memory and zero-pad to 128 bits
-    simdMemoryOp(8, macro()
-        loadq [t0], t0
-
-        subp V128ISize, sp
-        storeq t0, [sp]
-        storeq 0, 8[sp]
-    end)
+    popMemoryIndex(t0)
+    loadStoreMakePointerFast([t4], 1[t4], t0, 8, t1, t2, .simd_v128_load64_zero_slow_path)
+    loadq [t0], t0
+    subp V128ISize, sp
+    storeq t0, [sp]
+    storeq 0, 8[sp]
+    leap 2[t4], PC
+    nextIPIntInstruction()
 end)
 
 # 0xFD 0x5E - 0xFD 0x5F: f32x4/f64x2 conversion
@@ -5947,9 +5703,7 @@ ipintOp(_simd_f32x4_demote_f64x2_zero, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5964,9 +5718,7 @@ ipintOp(_simd_f64x2_promote_low_f32x4, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -5983,9 +5735,7 @@ ipintOp(_simd_i8x16_abs, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6002,9 +5752,7 @@ ipintOp(_simd_i8x16_neg, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6046,9 +5794,7 @@ ipintOp(_simd_i8x16_popcnt, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6073,9 +5819,7 @@ ipintOp(_simd_i8x16_all_true, macro()
         break # Not implemented
     end
     pushInt32(t0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6103,9 +5847,7 @@ ipintOp(_simd_i8x16_bitmask, macro()
 
     addp V128ISize, sp  # Pop the vector
     pushInt32(t0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6123,9 +5865,7 @@ ipintOp(_simd_i8x16_narrow_i16x8_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6143,9 +5883,7 @@ ipintOp(_simd_i8x16_narrow_i16x8_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6162,9 +5900,7 @@ ipintOp(_simd_f32x4_ceil, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6179,9 +5915,7 @@ ipintOp(_simd_f32x4_floor, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6196,9 +5930,7 @@ ipintOp(_simd_f32x4_trunc, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6213,9 +5945,7 @@ ipintOp(_simd_f32x4_nearest, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6263,9 +5993,7 @@ ipintOp(_simd_i8x16_shl, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6307,9 +6035,7 @@ ipintOp(_simd_i8x16_shr_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6351,9 +6077,7 @@ ipintOp(_simd_i8x16_shr_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6369,9 +6093,7 @@ ipintOp(_simd_i8x16_add, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6387,9 +6109,7 @@ ipintOp(_simd_i8x16_add_sat_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6405,9 +6125,7 @@ ipintOp(_simd_i8x16_add_sat_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6423,9 +6141,7 @@ ipintOp(_simd_i8x16_sub, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6441,9 +6157,7 @@ ipintOp(_simd_i8x16_sub_sat_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6459,9 +6173,7 @@ ipintOp(_simd_i8x16_sub_sat_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6478,9 +6190,7 @@ ipintOp(_simd_f64x2_ceil, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6495,9 +6205,7 @@ ipintOp(_simd_f64x2_floor, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6514,9 +6222,7 @@ ipintOp(_simd_i8x16_min_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6532,9 +6238,7 @@ ipintOp(_simd_i8x16_min_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6550,9 +6254,7 @@ ipintOp(_simd_i8x16_max_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6568,9 +6270,7 @@ ipintOp(_simd_i8x16_max_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6587,9 +6287,7 @@ ipintOp(_simd_f64x2_trunc, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6607,9 +6305,7 @@ ipintOp(_simd_i8x16_avgr_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6629,9 +6325,7 @@ ipintOp(_simd_i16x8_extadd_pairwise_i8x16_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6649,9 +6343,7 @@ ipintOp(_simd_i16x8_extadd_pairwise_i8x16_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6669,9 +6361,7 @@ ipintOp(_simd_i32x4_extadd_pairwise_i16x8_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6688,9 +6378,7 @@ ipintOp(_simd_i32x4_extadd_pairwise_i16x8_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6707,9 +6395,7 @@ ipintOp(_simd_i16x8_abs, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6726,9 +6412,7 @@ ipintOp(_simd_i16x8_neg, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6752,9 +6436,7 @@ ipintOp(_simd_i16x8_q15mulr_sat_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6781,9 +6463,7 @@ ipintOp(_simd_i16x8_all_true, macro()
         break # Not implemented
     end
     pushInt32(t0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6811,9 +6491,7 @@ ipintOp(_simd_i16x8_bitmask, macro()
 
     addp V128ISize, sp  # Pop the vector
     pushInt32(t0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6831,9 +6509,7 @@ ipintOp(_simd_i16x8_narrow_i32x4_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6851,9 +6527,7 @@ ipintOp(_simd_i16x8_narrow_i32x4_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6868,9 +6542,7 @@ ipintOp(_simd_i16x8_extend_low_i8x16_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6887,9 +6559,7 @@ ipintOp(_simd_i16x8_extend_high_i8x16_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6904,9 +6574,7 @@ ipintOp(_simd_i16x8_extend_low_i8x16_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6923,9 +6591,7 @@ ipintOp(_simd_i16x8_extend_high_i8x16_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6950,9 +6616,7 @@ ipintOp(_simd_i16x8_shl, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -6979,9 +6643,7 @@ ipintOp(_simd_i16x8_shr_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7006,9 +6668,7 @@ ipintOp(_simd_i16x8_shr_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7024,9 +6684,7 @@ ipintOp(_simd_i16x8_add, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7042,9 +6700,7 @@ ipintOp(_simd_i16x8_add_sat_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7060,9 +6716,7 @@ ipintOp(_simd_i16x8_add_sat_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7078,9 +6732,7 @@ ipintOp(_simd_i16x8_sub, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7096,9 +6748,7 @@ ipintOp(_simd_i16x8_sub_sat_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7114,9 +6764,7 @@ ipintOp(_simd_i16x8_sub_sat_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7133,9 +6781,7 @@ ipintOp(_simd_f64x2_nearest, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7153,9 +6799,7 @@ ipintOp(_simd_i16x8_mul, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7171,9 +6815,7 @@ ipintOp(_simd_i16x8_min_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7189,9 +6831,7 @@ ipintOp(_simd_i16x8_min_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7207,9 +6847,7 @@ ipintOp(_simd_i16x8_max_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7225,13 +6863,12 @@ ipintOp(_simd_i16x8_max_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
 reservedOpcode(0xfd9a01)
+
 ipintOp(_simd_i16x8_avgr_u, macro()
     # i16x8.avgr_u - average of 8 16-bit unsigned integers with rounding
     popVec(v1)
@@ -7244,9 +6881,7 @@ ipintOp(_simd_i16x8_avgr_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7265,9 +6900,7 @@ ipintOp(_simd_i16x8_extmul_low_i8x16_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7288,9 +6921,7 @@ ipintOp(_simd_i16x8_extmul_high_i8x16_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7309,9 +6940,7 @@ ipintOp(_simd_i16x8_extmul_low_i8x16_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7331,9 +6960,7 @@ ipintOp(_simd_i16x8_extmul_high_i8x16_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7350,9 +6977,7 @@ ipintOp(_simd_i32x4_abs, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7369,9 +6994,7 @@ ipintOp(_simd_i32x4_neg, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7400,9 +7023,7 @@ ipintOp(_simd_i32x4_all_true, macro()
         break # Not implemented
     end
     pushInt32(t0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7430,9 +7051,7 @@ ipintOp(_simd_i32x4_bitmask, macro()
 
     addp V128ISize, sp  # Pop the vector
     pushInt32(t0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7450,9 +7069,7 @@ ipintOp(_simd_i32x4_extend_low_i16x8_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7469,9 +7086,7 @@ ipintOp(_simd_i32x4_extend_high_i16x8_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7486,9 +7101,7 @@ ipintOp(_simd_i32x4_extend_low_i16x8_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7505,9 +7118,7 @@ ipintOp(_simd_i32x4_extend_high_i16x8_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7530,9 +7141,7 @@ ipintOp(_simd_i32x4_shl, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7557,9 +7166,7 @@ ipintOp(_simd_i32x4_shr_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7584,9 +7191,7 @@ ipintOp(_simd_i32x4_shr_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7602,9 +7207,7 @@ ipintOp(_simd_i32x4_add, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7623,9 +7226,7 @@ ipintOp(_simd_i32x4_sub, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7645,9 +7246,7 @@ ipintOp(_simd_i32x4_mul, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7663,9 +7262,7 @@ ipintOp(_simd_i32x4_min_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7681,9 +7278,7 @@ ipintOp(_simd_i32x4_min_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7699,9 +7294,7 @@ ipintOp(_simd_i32x4_max_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7717,9 +7310,7 @@ ipintOp(_simd_i32x4_max_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7740,9 +7331,7 @@ ipintOp(_simd_i32x4_dot_i16x8_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 reservedOpcode(0xfdbb01)
@@ -7762,9 +7351,7 @@ ipintOp(_simd_i32x4_extmul_low_i16x8_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7783,9 +7370,7 @@ ipintOp(_simd_i32x4_extmul_high_i16x8_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7804,9 +7389,7 @@ ipintOp(_simd_i32x4_extmul_low_i16x8_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7825,9 +7408,7 @@ ipintOp(_simd_i32x4_extmul_high_i16x8_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7849,9 +7430,7 @@ ipintOp(_simd_i64x2_abs, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7868,9 +7447,7 @@ ipintOp(_simd_i64x2_neg, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7899,9 +7476,7 @@ ipintOp(_simd_i64x2_all_true, macro()
         break # Not implemented
     end
     pushInt32(t0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7931,9 +7506,7 @@ ipintOp(_simd_i64x2_bitmask, macro()
 
 .bitmask_i64x2_done:
     pushInt32(t2)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7951,9 +7524,7 @@ ipintOp(_simd_i64x2_extend_low_i32x4_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7970,9 +7541,7 @@ ipintOp(_simd_i64x2_extend_high_i32x4_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -7987,9 +7556,7 @@ ipintOp(_simd_i64x2_extend_low_i32x4_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8006,9 +7573,7 @@ ipintOp(_simd_i64x2_extend_high_i32x4_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8031,9 +7596,7 @@ ipintOp(_simd_i64x2_shl, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8051,9 +7614,7 @@ ipintOp(_simd_i64x2_shr_s, macro()
     rshiftq t0, t1
     storeq t1, [sp]
 
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8078,9 +7639,7 @@ ipintOp(_simd_i64x2_shr_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8096,9 +7655,7 @@ ipintOp(_simd_i64x2_add, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8117,9 +7674,7 @@ ipintOp(_simd_i64x2_sub, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8144,9 +7699,7 @@ ipintOp(_simd_i64x2_mul, macro()
 
     # Pop vector1, result in vector0
     addp V128ISize, sp        # Remove first vector from stack, leaving result
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8162,9 +7715,7 @@ ipintOp(_simd_i64x2_eq, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8184,9 +7735,7 @@ ipintOp(_simd_i64x2_ne, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8204,9 +7753,7 @@ ipintOp(_simd_i64x2_lt_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8222,9 +7769,7 @@ ipintOp(_simd_i64x2_gt_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8244,9 +7789,7 @@ ipintOp(_simd_i64x2_le_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8265,9 +7808,7 @@ ipintOp(_simd_i64x2_ge_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8286,9 +7827,7 @@ ipintOp(_simd_i64x2_extmul_low_i32x4_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8307,9 +7846,7 @@ ipintOp(_simd_i64x2_extmul_high_i32x4_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8328,9 +7865,7 @@ ipintOp(_simd_i64x2_extmul_low_i32x4_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8349,9 +7884,7 @@ ipintOp(_simd_i64x2_extmul_high_i32x4_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8372,9 +7905,7 @@ ipintOp(_simd_f32x4_abs, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8393,9 +7924,7 @@ ipintOp(_simd_f32x4_neg, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8412,9 +7941,7 @@ ipintOp(_simd_f32x4_sqrt, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8430,9 +7957,7 @@ ipintOp(_simd_f32x4_add, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8448,9 +7973,7 @@ ipintOp(_simd_f32x4_sub, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8466,9 +7989,7 @@ ipintOp(_simd_f32x4_mul, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8484,9 +8005,7 @@ ipintOp(_simd_f32x4_div, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8515,9 +8034,7 @@ ipintOp(_simd_f32x4_min, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8551,9 +8068,7 @@ ipintOp(_simd_f32x4_max, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8573,9 +8088,7 @@ ipintOp(_simd_f32x4_pmin, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8595,9 +8108,7 @@ ipintOp(_simd_f32x4_pmax, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8618,9 +8129,7 @@ ipintOp(_simd_f64x2_abs, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8639,9 +8148,7 @@ ipintOp(_simd_f64x2_neg, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8658,9 +8165,7 @@ ipintOp(_simd_f64x2_sqrt, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8676,9 +8181,7 @@ ipintOp(_simd_f64x2_add, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8694,9 +8197,7 @@ ipintOp(_simd_f64x2_sub, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8712,9 +8213,7 @@ ipintOp(_simd_f64x2_mul, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8730,9 +8229,7 @@ ipintOp(_simd_f64x2_div, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8761,9 +8258,7 @@ ipintOp(_simd_f64x2_min, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8797,9 +8292,7 @@ ipintOp(_simd_f64x2_max, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8819,9 +8312,7 @@ ipintOp(_simd_f64x2_pmin, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8841,9 +8332,7 @@ ipintOp(_simd_f64x2_pmax, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8872,9 +8361,7 @@ ipintOp(_simd_i32x4_trunc_sat_f32x4_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8908,9 +8395,7 @@ ipintOp(_simd_i32x4_trunc_sat_f32x4_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8925,9 +8410,7 @@ ipintOp(_simd_f32x4_convert_i32x4_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8950,9 +8433,7 @@ ipintOp(_simd_f32x4_convert_i32x4_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -8981,9 +8462,7 @@ ipintOp(_simd_i32x4_trunc_sat_f64x2_s_zero, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -9018,9 +8497,7 @@ ipintOp(_simd_i32x4_trunc_sat_f64x2_u_zero, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -9037,9 +8514,7 @@ ipintOp(_simd_f64x2_convert_low_i32x4_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -9071,9 +8546,7 @@ ipintOp(_simd_f64x2_convert_low_i32x4_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    loadb IPInt::InstructionLengthMetadata::length[MC], t0
-    advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
+    move t4, PC
     nextIPIntInstruction()
 end)
 
@@ -9195,7 +8668,7 @@ reservedAtomicOpcode(atomic_0xe)
 reservedAtomicOpcode(atomic_0xf)
 
 ipintAtomicOp(_i32_atomic_load, macro()
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
     checkAlignment4(t0, .throwUnaligned)
     if ARM64 or ARM64E or X86_64
@@ -9211,7 +8684,7 @@ ipintAtomicOp(_i32_atomic_load, macro()
 end)
 
 ipintAtomicOp(_i64_atomic_load, macro()
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
     checkAlignment8(t0, .throwUnaligned)
     if ARM64 or ARM64E or X86_64
@@ -9227,7 +8700,7 @@ ipintAtomicOp(_i64_atomic_load, macro()
 end)
 
 ipintAtomicOp(_i32_atomic_load8_u, macro()
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
     noAlignmentCheck(t0, .throwUnaligned)
     if ARM64 or ARM64E or X86_64
@@ -9243,7 +8716,7 @@ ipintAtomicOp(_i32_atomic_load8_u, macro()
 end)
 
 ipintAtomicOp(_i32_atomic_load16_u, macro()
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
     checkAlignment2(t0, .throwUnaligned)
     if ARM64 or ARM64E or X86_64
@@ -9259,7 +8732,7 @@ ipintAtomicOp(_i32_atomic_load16_u, macro()
 end)
 
 ipintAtomicOp(_i64_atomic_load8_u, macro()
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
     noAlignmentCheck(t0, .throwUnaligned)
     if ARM64 or ARM64E or X86_64
@@ -9275,7 +8748,7 @@ ipintAtomicOp(_i64_atomic_load8_u, macro()
 end)
 
 ipintAtomicOp(_i64_atomic_load16_u, macro()
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
     checkAlignment2(t0, .throwUnaligned)
     if ARM64 or ARM64E or X86_64
@@ -9291,7 +8764,7 @@ ipintAtomicOp(_i64_atomic_load16_u, macro()
 end)
 
 ipintAtomicOp(_i64_atomic_load32_u, macro()
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
     checkAlignment4(t0, .throwUnaligned)
     if ARM64 or ARM64E or X86_64
@@ -9377,7 +8850,7 @@ end
 
 ipintAtomicOp(_i32_atomic_store, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
     checkAlignment4(t0, .throwUnaligned)
     move t0, t2
@@ -9400,7 +8873,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_store, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
     checkAlignment8(t0, .throwUnaligned)
     move t0, t2
@@ -9423,7 +8896,7 @@ end)
 
 ipintAtomicOp(_i32_atomic_store8_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
     noAlignmentCheck(t0, .throwUnaligned)
     move t0, t2
@@ -9446,7 +8919,7 @@ end)
 
 ipintAtomicOp(_i32_atomic_store16_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
     checkAlignment2(t0, .throwUnaligned)
     move t0, t2
@@ -9469,7 +8942,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_store8_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
     noAlignmentCheck(t0, .throwUnaligned)
     move t0, t2
@@ -9492,7 +8965,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_store16_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
     checkAlignment2(t0, .throwUnaligned)
     move t0, t2
@@ -9515,7 +8988,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_store32_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
     checkAlignment4(t0, .throwUnaligned)
     move t0, t2
@@ -9538,7 +9011,7 @@ end)
 
 ipintAtomicOp(_i32_atomic_rmw_add, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
     checkAlignment4(t0, .throwUnaligned)
     move t0, t2
@@ -9563,7 +9036,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw_add, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
     checkAlignment8(t0, .throwUnaligned)
     move t0, t2
@@ -9588,7 +9061,7 @@ end)
 
 ipintAtomicOp(_i32_atomic_rmw8_add_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
     noAlignmentCheck(t0, .throwUnaligned)
     move t0, t2
@@ -9614,7 +9087,7 @@ end)
 
 ipintAtomicOp(_i32_atomic_rmw16_add_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
     checkAlignment2(t0, .throwUnaligned)
     move t0, t2
@@ -9640,7 +9113,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw8_add_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
     noAlignmentCheck(t0, .throwUnaligned)
     move t0, t2
@@ -9666,7 +9139,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw16_add_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
     checkAlignment2(t0, .throwUnaligned)
     move t0, t2
@@ -9692,7 +9165,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw32_add_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
     checkAlignment4(t0, .throwUnaligned)
     move t0, t2
@@ -9718,7 +9191,7 @@ end)
 
 ipintAtomicOp(_i32_atomic_rmw_sub, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
     checkAlignment4(t0, .throwUnaligned)
     move t0, t2
@@ -9745,7 +9218,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw_sub, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
     checkAlignment8(t0, .throwUnaligned)
     move t0, t2
@@ -9772,7 +9245,7 @@ end)
 
 ipintAtomicOp(_i32_atomic_rmw8_sub_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
     noAlignmentCheck(t0, .throwUnaligned)
     move t0, t2
@@ -9800,7 +9273,7 @@ end)
 
 ipintAtomicOp(_i32_atomic_rmw16_sub_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
     checkAlignment2(t0, .throwUnaligned)
     move t0, t2
@@ -9828,7 +9301,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw8_sub_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
     noAlignmentCheck(t0, .throwUnaligned)
     move t0, t2
@@ -9856,7 +9329,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw16_sub_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
     checkAlignment2(t0, .throwUnaligned)
     move t0, t2
@@ -9884,7 +9357,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw32_sub_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
     checkAlignment4(t0, .throwUnaligned)
     move t0, t2
@@ -9912,7 +9385,7 @@ end)
 
 ipintAtomicOp(_i32_atomic_rmw_and, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
     checkAlignment4(t0, .throwUnaligned)
     move t0, t2
@@ -9939,7 +9412,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw_and, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
     checkAlignment8(t0, .throwUnaligned)
     move t0, t2
@@ -9966,7 +9439,7 @@ end)
 
 ipintAtomicOp(_i32_atomic_rmw8_and_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
     noAlignmentCheck(t0, .throwUnaligned)
     move t0, t2
@@ -9993,7 +9466,7 @@ end)
 
 ipintAtomicOp(_i32_atomic_rmw16_and_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
     checkAlignment2(t0, .throwUnaligned)
     move t0, t2
@@ -10020,7 +9493,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw8_and_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
     noAlignmentCheck(t0, .throwUnaligned)
     move t0, t2
@@ -10047,7 +9520,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw16_and_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
     checkAlignment2(t0, .throwUnaligned)
     move t0, t2
@@ -10074,7 +9547,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw32_and_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
     checkAlignment4(t0, .throwUnaligned)
     move t0, t2
@@ -10101,7 +9574,7 @@ end)
 
 ipintAtomicOp(_i32_atomic_rmw_or, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
     checkAlignment4(t0, .throwUnaligned)
     move t0, t2
@@ -10127,7 +9600,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw_or, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
     checkAlignment8(t0, .throwUnaligned)
     move t0, t2
@@ -10153,7 +9626,7 @@ end)
 
 ipintAtomicOp(_i32_atomic_rmw8_or_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
     noAlignmentCheck(t0, .throwUnaligned)
     move t0, t2
@@ -10179,7 +9652,7 @@ end)
 
 ipintAtomicOp(_i32_atomic_rmw16_or_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
     checkAlignment2(t0, .throwUnaligned)
     move t0, t2
@@ -10205,7 +9678,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw8_or_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
     noAlignmentCheck(t0, .throwUnaligned)
     move t0, t2
@@ -10231,7 +9704,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw16_or_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
     checkAlignment2(t0, .throwUnaligned)
     move t0, t2
@@ -10257,7 +9730,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw32_or_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
     checkAlignment4(t0, .throwUnaligned)
     move t0, t2
@@ -10283,7 +9756,7 @@ end)
 
 ipintAtomicOp(_i32_atomic_rmw_xor, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
     checkAlignment4(t0, .throwUnaligned)
     move t0, t2
@@ -10309,7 +9782,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw_xor, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
     checkAlignment8(t0, .throwUnaligned)
     move t0, t2
@@ -10335,7 +9808,7 @@ end)
 
 ipintAtomicOp(_i32_atomic_rmw8_xor_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
     noAlignmentCheck(t0, .throwUnaligned)
     move t0, t2
@@ -10361,7 +9834,7 @@ end)
 
 ipintAtomicOp(_i32_atomic_rmw16_xor_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
     checkAlignment2(t0, .throwUnaligned)
     move t0, t2
@@ -10387,7 +9860,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw8_xor_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
     noAlignmentCheck(t0, .throwUnaligned)
     move t0, t2
@@ -10413,7 +9886,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw16_xor_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
     checkAlignment2(t0, .throwUnaligned)
     move t0, t2
@@ -10439,7 +9912,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw32_xor_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
     checkAlignment4(t0, .throwUnaligned)
     move t0, t2
@@ -10465,7 +9938,7 @@ end)
 
 ipintAtomicOp(_i32_atomic_rmw_xchg, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
     checkAlignment4(t0, .throwUnaligned)
     move t0, t2
@@ -10491,7 +9964,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw_xchg, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
     checkAlignment8(t0, .throwUnaligned)
     move t0, t2
@@ -10517,7 +9990,7 @@ end)
 
 ipintAtomicOp(_i32_atomic_rmw8_xchg_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
     noAlignmentCheck(t0, .throwUnaligned)
     move t0, t2
@@ -10543,7 +10016,7 @@ end)
 
 ipintAtomicOp(_i32_atomic_rmw16_xchg_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
     checkAlignment2(t0, .throwUnaligned)
     move t0, t2
@@ -10569,7 +10042,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw8_xchg_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
     noAlignmentCheck(t0, .throwUnaligned)
     move t0, t2
@@ -10595,7 +10068,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw16_xchg_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
     checkAlignment2(t0, .throwUnaligned)
     move t0, t2
@@ -10621,7 +10094,7 @@ end)
 
 ipintAtomicOp(_i64_atomic_rmw32_xchg_u, macro()
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
     checkAlignment4(t0, .throwUnaligned)
     move t0, t2
@@ -10730,7 +10203,7 @@ ipintAtomicOp(_i32_atomic_rmw_cmpxchg, macro()
     # ARMv7 (where PL=t7) does not run 64-bit atomic instructions.
     popInt64(t7)
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
     checkAlignment4(t0, .throwUnaligned)
     move t0, t2
@@ -10755,7 +10228,7 @@ ipintAtomicOp(_i64_atomic_rmw_cmpxchg, macro()
     # ARMv7 (where PL=t7) does not run 64-bit atomic instructions.
     popInt64(t7)
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
     checkAlignment8(t0, .throwUnaligned)
     move t0, t2
@@ -10779,7 +10252,7 @@ ipintAtomicOp(_i32_atomic_rmw8_cmpxchg_u, macro()
     # ARMv7 (where PL=t7) does not run 64-bit atomic instructions.
     popInt64(t7)
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
     noAlignmentCheck(t0, .throwUnaligned)
     move t0, t2
@@ -10804,7 +10277,7 @@ ipintAtomicOp(_i32_atomic_rmw16_cmpxchg_u, macro()
     # ARMv7 (where PL=t7) does not run 64-bit atomic instructions.
     popInt64(t7)
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
     checkAlignment2(t0, .throwUnaligned)
     move t0, t2
@@ -10829,7 +10302,7 @@ ipintAtomicOp(_i64_atomic_rmw8_cmpxchg_u, macro()
     # ARMv7 (where PL=t7) does not run 64-bit atomic instructions.
     popInt64(t7)
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
     noAlignmentCheck(t0, .throwUnaligned)
     move t0, t2
@@ -10854,7 +10327,7 @@ ipintAtomicOp(_i64_atomic_rmw16_cmpxchg_u, macro()
     # ARMv7 (where PL=t7) does not run 64-bit atomic instructions.
     popInt64(t7)
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
     checkAlignment2(t0, .throwUnaligned)
     move t0, t2
@@ -10879,7 +10352,7 @@ ipintAtomicOp(_i64_atomic_rmw32_cmpxchg_u, macro()
     # ARMv7 (where PL=t7) does not run 64-bit atomic instructions.
     popInt64(t7)
     popInt64(t3)
-    popMemoryIndex(t0, t2)
+    popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
     checkAlignment4(t0, .throwUnaligned)
     move t0, t2
@@ -11131,6 +10604,206 @@ end
     loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
     storei t3, [t0]
     move t4, PC
+    nextIPIntInstruction()
+
+###################################################
+## Out-of-line slow paths for SIMD memory access ##
+###################################################
+
+# t0 = wasm address (from popMemoryIndex before branching).
+# t4 = cursor pointing to start of memarg (past SIMD opcode, set by simd_prefix).
+# After loadStoreMakePointerSlow, t4 points past the memarg.
+
+.simd_v128_load_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 16, t1, t2, notPL, t7)
+    loadv [t0], v0
+    pushVec(v0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.simd_v128_load_8x8s_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    simdLoad8x8s()
+    pushVec(v0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.simd_v128_load_8x8u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    simdLoad8x8u()
+    pushVec(v0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.simd_v128_load_16x4s_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    simdLoad16x4s()
+    pushVec(v0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.simd_v128_load_16x4u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    simdLoad16x4u()
+    pushVec(v0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.simd_v128_load_32x2s_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    simdLoad32x2s()
+    pushVec(v0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.simd_v128_load_32x2u_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    simdLoad32x2u()
+    pushVec(v0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.simd_v128_load8_splat_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    simdLoadSplat8()
+    pushVec(v0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.simd_v128_load16_splat_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    simdLoadSplat16()
+    pushVec(v0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.simd_v128_load32_splat_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    simdLoadSplat32()
+    pushVec(v0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.simd_v128_load64_splat_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    simdLoadSplat64()
+    pushVec(v0)
+    move t4, PC
+    nextIPIntInstruction()
+
+.simd_v128_store_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 16, t1, t2, notPL, t7)
+    storev v0, [t0]
+    move t4, PC
+    nextIPIntInstruction()
+
+.simd_v128_load32_zero_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadi [t0], t0
+    subp V128ISize, sp
+    storei t0, [sp]
+    storei 0, 4[sp]
+    storeq 0, 8[sp]
+    move t4, PC
+    nextIPIntInstruction()
+
+.simd_v128_load64_zero_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadq [t0], t0
+    subp V128ISize, sp
+    storeq t0, [sp]
+    storeq 0, 8[sp]
+    move t4, PC
+    nextIPIntInstruction()
+
+# Load lane slow paths: v0 = vector (already popped), t0 = wasm addr.
+# t4 points past memarg after loadStoreMakePointerSlow. Lane index is at [t4].
+
+.simd_v128_load8_lane_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadb [t0], t0
+    loadb [t4], t1
+    andi ImmLaneIdx16Mask, t1
+    pushVec(v0)
+    storeb t0, [sp, t1]
+    leap 1[t4], PC
+    nextIPIntInstruction()
+
+.simd_v128_load16_lane_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadh [t0], t0
+    loadb [t4], t1
+    andi ImmLaneIdx8Mask, t1
+    pushVec(v0)
+    storeh t0, [sp, t1, 2]
+    leap 1[t4], PC
+    nextIPIntInstruction()
+
+.simd_v128_load32_lane_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadi [t0], t0
+    loadb [t4], t1
+    andi ImmLaneIdx4Mask, t1
+    pushVec(v0)
+    storei t0, [sp, t1, 4]
+    leap 1[t4], PC
+    nextIPIntInstruction()
+
+.simd_v128_load64_lane_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadq [t0], t0
+    loadb [t4], t1
+    andi ImmLaneIdx2Mask, t1
+    pushVec(v0)
+    storeq t0, [sp, t1, 8]
+    leap 1[t4], PC
+    nextIPIntInstruction()
+
+# Store lane slow paths: v0 = vector (already popped), t0 = wasm addr.
+# t4 points past memarg. Lane index is at [t4].
+
+.simd_v128_store8_lane_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 1, t1, t2, notPL, t7)
+    loadb [t4], t1
+    andi ImmLaneIdx16Mask, t1
+    pushVec(v0)
+    loadb [sp, t1], t1
+    addp V128ISize, sp
+    storeb t1, [t0]
+    leap 1[t4], PC
+    nextIPIntInstruction()
+
+.simd_v128_store16_lane_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 2, t1, t2, notPL, t7)
+    loadb [t4], t1
+    andi ImmLaneIdx8Mask, t1
+    pushVec(v0)
+    loadh [sp, t1, 2], t1
+    addp V128ISize, sp
+    storeh t1, [t0]
+    leap 1[t4], PC
+    nextIPIntInstruction()
+
+.simd_v128_store32_lane_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 4, t1, t2, notPL, t7)
+    loadb [t4], t1
+    andi ImmLaneIdx4Mask, t1
+    pushVec(v0)
+    loadi [sp, t1, 4], t1
+    addp V128ISize, sp
+    storei t1, [t0]
+    leap 1[t4], PC
+    nextIPIntInstruction()
+
+.simd_v128_store64_lane_slow_path:
+    loadStoreMakePointerSlow(t4, t0, 8, t1, t2, notPL, t7)
+    loadb [t4], t1
+    andi ImmLaneIdx2Mask, t1
+    pushVec(v0)
+    loadq [sp, t1, 8], t1
+    addp V128ISize, sp
+    storeq t1, [t0]
+    leap 1[t4], PC
     nextIPIntInstruction()
 
 ##################################

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
@@ -149,16 +149,6 @@ void FunctionIPIntMetadataGenerator::addAtomicMemoryAccess(uint8_t memoryIndex, 
     appendMetadata(md);
 }
 
-void FunctionIPIntMetadataGenerator::addSIMDMemoryAccess(uint8_t memoryIndex, uint64_t offset, size_t length)
-{
-    IPInt::SIMDMemoryAccessMetadata md {
-        .memoryIndex = memoryIndex,
-        .offset = offset,
-        .instructionLength = { .length = safeCast<uint8_t>(length) }
-    };
-    appendMetadata(md);
-}
-
 void FunctionIPIntMetadataGenerator::addReturnData(const FunctionSignature& sig, const CallInformation& returnCC)
 {
     m_uINTBytecode.reserveInitialCapacity(sig.returnCount() + 1);

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -127,7 +127,6 @@ private:
     void addMemoryFill(uint8_t memoryIndex, size_t length);
     void addMemoryCopy(uint8_t dstMemoryIndex, uint8_t srcMemoryIndex, size_t length);
     void addAtomicMemoryAccess(uint8_t memoryIndex, uint64_t offset, size_t length);
-    void addSIMDMemoryAccess(uint8_t memoryIndex, uint64_t offset, size_t length);
     void addReturnData(const FunctionSignature&, const CallInformation&);
 
     FunctionCodeIndex m_functionIndex;

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -702,44 +702,38 @@ Value IPIntGenerator::addConstant(Type, uint64_t)
 
 // SIMD
 
-[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoad(ExpressionType, uint32_t offset, ExpressionType&, uint8_t memoryIndex)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoad(ExpressionType, uint32_t, ExpressionType&, uint8_t)
 {
     changeStackSize(0); // Pop address, push v128 value (net change = 0)
-    m_metadata->addSIMDMemoryAccess(memoryIndex, offset, getCurrentInstructionLength());
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addSIMDStore(ExpressionType, ExpressionType, uint32_t offset, uint8_t memoryIndex)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDStore(ExpressionType, ExpressionType, uint32_t, uint8_t)
 {
     changeStackSize(-2); // Pop address and v128 value
-    m_metadata->addSIMDMemoryAccess(memoryIndex, offset, getCurrentInstructionLength());
     return { };
 }
 
 [[nodiscard]] PartialResult IPIntGenerator::addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&)
 {
-    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
 [[nodiscard]] PartialResult IPIntGenerator::addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
-    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
 [[nodiscard]] PartialResult IPIntGenerator::addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
-    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
 [[nodiscard]] PartialResult IPIntGenerator::addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
-    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
@@ -748,17 +742,15 @@ Value IPIntGenerator::addConstant(Type, uint64_t)
     return addSIMDLoad(pointer, offset, result, memoryIndex);
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t offset, uint8_t, ExpressionType&, uint8_t memoryIndex)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, ExpressionType&, uint8_t)
 {
     changeStackSize(-1);
-    m_metadata->addSIMDMemoryAccess(memoryIndex, offset, getCurrentInstructionLength());
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t offset, uint8_t, uint8_t memoryIndex)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, uint8_t)
 {
     changeStackSize(-2);
-    m_metadata->addSIMDMemoryAccess(memoryIndex, offset, getCurrentInstructionLength());
     return { };
 }
 
@@ -775,39 +767,33 @@ Value IPIntGenerator::addConstant(Type, uint64_t)
 IPIntGenerator::ExpressionType IPIntGenerator::addSIMDConstant(v128_t)
 {
     changeStackSize(1);
-    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
 [[nodiscard]] PartialResult IPIntGenerator::addSIMDExtractLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType&)
 {
-    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
 [[nodiscard]] PartialResult IPIntGenerator::addSIMDReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
-    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
 [[nodiscard]] PartialResult IPIntGenerator::addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
 {
-    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
 [[nodiscard]] PartialResult IPIntGenerator::addSIMDV_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
 {
-    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
 [[nodiscard]] PartialResult IPIntGenerator::addSIMDBitwiseSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-2); // 3 operands, 1 result
-    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
@@ -815,7 +801,6 @@ IPIntGenerator::ExpressionType IPIntGenerator::addSIMDConstant(v128_t)
 [[nodiscard]] PartialResult IPIntGenerator::addSIMDRelOp(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, B3::Air::Arg, ExpressionType&)
 {
     changeStackSize(-1);
-    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 #endif
@@ -823,7 +808,6 @@ IPIntGenerator::ExpressionType IPIntGenerator::addSIMDConstant(v128_t)
 [[nodiscard]] PartialResult IPIntGenerator::addSIMDV_VV(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1); // Pop two v128 values, push one v128 value
-    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
@@ -179,12 +179,6 @@ struct AtomicMemoryAccessMetadata {
     InstructionLengthMetadata instructionLength;
 };
 
-struct SIMDMemoryAccessMetadata {
-    uint8_t memoryIndex;
-    uint64_t offset;
-    InstructionLengthMetadata instructionLength;
-};
-
 struct MemorySizeMetadata {
     uint8_t memoryIndex;
 };


### PR DESCRIPTION
#### 32161b38e4240ea9cb156663b61eb4924f3984a8
<pre>
[JSC] Remove IPInt metadata from SIMD instructions
<a href="https://bugs.webkit.org/show_bug.cgi?id=312068">https://bugs.webkit.org/show_bug.cgi?id=312068</a>
<a href="https://rdar.apple.com/174580874">rdar://174580874</a>

Reviewed by Marcus Plutowski.

This patch removes IPInt metadata from all SIMD instructions. This also
fixes some semantic bugs in SIMD instructions in IPInt.

1. As we use `t4` consistently as a cursor in PC, we can continue using
   this in SIMD instructions and we do not need to have a metadata for
   skipping to the next PC.
2. Previously we had some SIMD instructions using PC, but this was
   wrong, because SIMD ext opcode is VarUInt32, thus size is variable
   and we cannot get information from the fixed offset with PC. We can
   just use `t4` offered from simd_prefix dispatch, and then issue gets
   fixed. We add tests for these patterns.
3. We drop SIMDMemoryAccessMetadata and use the pattern similar to what
   we have in normal memory load / store.
4. Clean up popMemoryIndex to shrink its size.

Tests: JSTests/wasm/ipint-tests/ipint-test-simd-memory.js
       JSTests/wasm/ipint-tests/ipint-test-simd-multi-byte-leb.js

* JSTests/wasm/ipint-tests/ipint-test-simd-memory.js: Added.
(v128.store32_lane.func.export.string_appeared_here.result.i32.v128.store32_lane.0.i32.const.28.v128.const.i32x4.0xDEADBEEF.0.0.0.i32.load.i32.const.28.async test):
* JSTests/wasm/ipint-tests/ipint-test-simd-multi-byte-leb.js: Added.
(import.as.assert.from.string_appeared_here.buildModule):
(uleb128):
(paddedSIMDOp):
(v128ConstI32x4):
(v128ConstI32x4Padded):
(i32Const):
(instantiateAndRun):
(return.inst.exports.f):
(assert.eq):
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addSIMDMemoryAccess): Deleted.
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h:
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::addSIMDLoad):
(JSC::Wasm::IPIntGenerator::addSIMDStore):
(JSC::Wasm::IPIntGenerator::addSIMDSplat):
(JSC::Wasm::IPIntGenerator::addSIMDShuffle):
(JSC::Wasm::IPIntGenerator::addSIMDShift):
(JSC::Wasm::IPIntGenerator::addSIMDExtmul):
(JSC::Wasm::IPIntGenerator::addSIMDLoadLane):
(JSC::Wasm::IPIntGenerator::addSIMDStoreLane):
(JSC::Wasm::IPIntGenerator::addSIMDConstant):
(JSC::Wasm::IPIntGenerator::addSIMDExtractLane):
(JSC::Wasm::IPIntGenerator::addSIMDReplaceLane):
(JSC::Wasm::IPIntGenerator::addSIMDI_V):
(JSC::Wasm::IPIntGenerator::addSIMDV_V):
(JSC::Wasm::IPIntGenerator::addSIMDBitwiseSelect):
(JSC::Wasm::IPIntGenerator::addSIMDRelOp):
(JSC::Wasm::IPIntGenerator::addSIMDV_VV):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.h:

Canonical link: <a href="https://commits.webkit.org/311143@main">https://commits.webkit.org/311143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c89d54d3063b631cc9aef63b9523cdd115fe55b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29494 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/22676 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164980 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/29627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29495 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/120920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159117 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/29627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/101597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/29627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12752 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/148209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/29627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/18067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167459 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/16993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/11575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/19679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/129162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/29017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/139861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23771 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/29017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188042 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28726 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/92683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/48342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/28481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28377 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->