### PR TITLE
[JSC] Consolidate error throwing code in IPInt to reduce code size in each handler

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -235,7 +235,7 @@ end
     #############################
 
 ipintOp(_unreachable, macro()
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(Unreachable)
+    jmp _ipint_throw_Unreachable
 end)
 
 ipintOp(_nop, macro()
@@ -364,7 +364,7 @@ end)
 
 ipintOp(_throw_ref, macro()
     popQuad(a2)
-    bieq a2, ValueNull, .throw_null_ref
+    bieq a2, ValueNull, _ipint_throw_NullExnrefReference
 
     saveCallSiteIndex()
 
@@ -375,9 +375,6 @@ ipintOp(_throw_ref, macro()
     move cfr, a1
     operationCall(macro() cCall3(_ipint_extern_throw_ref) end)
     jumpToException()
-
-.throw_null_ref:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(NullExnrefReference)
 end)
 
 macro uintDispatch()
@@ -907,14 +904,14 @@ end
 
 macro atomicMemoryMakePointerAndAdvanceMC(instrLenReg, wasmAddrReg, size, scratch, scratch2)
     loadq IPInt::AtomicMemoryAccessMetadata::offset[MC], scratch2
-    baddpc(scratch2, wasmAddrReg, .outOfBounds)
+    baddpc(scratch2, wasmAddrReg, _ipint_throw_OutOfBoundsMemoryAccess)
 
     move size - 1, scratch2
-    baddpc(wasmAddrReg, scratch2, .outOfBounds)
+    baddpc(wasmAddrReg, scratch2, _ipint_throw_OutOfBoundsMemoryAccess)
 
     loadb IPInt::AtomicMemoryAccessMetadata::memoryIndex[MC], scratch
     btinz scratch, .memoryIsNotZero
-    bpaeq scratch2, boundsCheckingSize, .outOfBounds # scratch2 contains wasm address + size - 1
+    bpaeq scratch2, boundsCheckingSize, _ipint_throw_OutOfBoundsMemoryAccess # scratch2 contains wasm address + size - 1
     addp memoryBase, wasmAddrReg
     jmp .done
 
@@ -923,13 +920,9 @@ macro atomicMemoryMakePointerAndAdvanceMC(instrLenReg, wasmAddrReg, size, scratc
     # FIXME: it's probably worth trying to use a loadpair here, but that requires a separate x86 codepath
     loadp (constexpr (JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0) + sizeof(void*))) [wasmInstance, scratch], scratch2 # bounds checking size
     subp size - 1, scratch2 # wasmAddrReg + (size-1) >= scratch2 is equivalent to wasmAddrReg >= scratch2 - (size-1)
-    bpaeq wasmAddrReg, scratch2, .outOfBounds
+    bpaeq wasmAddrReg, scratch2, _ipint_throw_OutOfBoundsMemoryAccess
     loadp (constexpr (JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0))) [wasmInstance, scratch], scratch2 # memory base
     addp scratch2, wasmAddrReg
-    jmp .done
-
-.outOfBounds:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsMemoryAccess)
 .done:
     loadb IPInt::AtomicMemoryAccessMetadata::instructionLength[MC], instrLenReg
     advanceMC(constexpr (sizeof(IPInt::AtomicMemoryAccessMetadata)))
@@ -949,17 +942,12 @@ macro loadStoreMakePointerFast(alignAccess, offsetAccess, wasmAddrReg, size, scr
     bbaeq scratch, 0x80, slowLabel
 
     # Both single-byte, memory index = 0. scratch = offset value.
-    baddpc(scratch, wasmAddrReg, .outOfBounds)
+    baddpc(scratch, wasmAddrReg, _ipint_throw_OutOfBoundsMemoryAccess)
     move size - 1, scratch2
-    baddpc(wasmAddrReg, scratch2, .outOfBounds)
+    baddpc(wasmAddrReg, scratch2, _ipint_throw_OutOfBoundsMemoryAccess)
 
-    bpaeq scratch2, boundsCheckingSize, .outOfBounds # scratch2 contains wasm address + size - 1
+    bpaeq scratch2, boundsCheckingSize, _ipint_throw_OutOfBoundsMemoryAccess # scratch2 contains wasm address + size - 1
     addp memoryBase, wasmAddrReg
-    jmp .done
-
-.outOfBounds:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsMemoryAccess)
-.done:
 end
 
 # Note: wasmAddrReg (t0) is set by the handler's popMemoryIndex before branching here.
@@ -979,12 +967,12 @@ macro loadStoreMakePointerSlow(cursor, wasmAddrReg, size, scratch, scratch2, dec
     # 3. Decode offset
     decodeLEBVarUInt(scratch2, cursor, decodeScratch1, decodeScratch2)
 
-    baddpc(scratch2, wasmAddrReg, .outOfBounds)
+    baddpc(scratch2, wasmAddrReg, _ipint_throw_OutOfBoundsMemoryAccess)
     move size - 1, scratch2
-    baddpc(wasmAddrReg, scratch2, .outOfBounds)
+    baddpc(wasmAddrReg, scratch2, _ipint_throw_OutOfBoundsMemoryAccess)
 
     btinz scratch, .memoryIsNotZero
-    bpaeq scratch2, boundsCheckingSize, .outOfBounds # scratch2 contains wasm address + size - 1
+    bpaeq scratch2, boundsCheckingSize, _ipint_throw_OutOfBoundsMemoryAccess # scratch2 contains wasm address + size - 1
     addp memoryBase, wasmAddrReg
     jmp .done
 
@@ -993,13 +981,9 @@ macro loadStoreMakePointerSlow(cursor, wasmAddrReg, size, scratch, scratch2, dec
     # FIXME: it's probably worth trying to use a loadpair here, but that requires a separate x86 codepath
     loadp (constexpr (JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0) + sizeof(void*))) [wasmInstance, scratch], scratch2 # bounds checking size
     subp size - 1, scratch2 # wasmAddrReg + (size-1) >= scratch2 is equivalent to wasmAddrReg >= scratch2 - (size-1)
-    bpaeq wasmAddrReg, scratch2, .outOfBounds
+    bpaeq wasmAddrReg, scratch2, _ipint_throw_OutOfBoundsMemoryAccess
     loadp (constexpr (JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0))) [wasmInstance, scratch], scratch2 # memory base
     addp scratch2, wasmAddrReg
-    jmp .done
-
-.outOfBounds:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsMemoryAccess)
 .done:
 end
 
@@ -1786,10 +1770,10 @@ ipintOp(_i32_div_s, macro()
     # i32.div_s
     popInt32(t1)
     popInt32(t0)
-    btiz t1, .ipint_i32_div_s_throwDivisionByZero
+    btiz t1, _ipint_throw_DivisionByZero
 
     bineq t1, -1, .ipint_i32_div_s_safe
-    bieq t0, constexpr INT32_MIN, .ipint_i32_div_s_throwIntegerOverflow
+    bieq t0, constexpr INT32_MIN, _ipint_throw_IntegerOverflow
 
 .ipint_i32_div_s_safe:
     if X86_64
@@ -1805,19 +1789,13 @@ ipintOp(_i32_div_s, macro()
     pushInt32(t0)
     advancePC(1)
     nextIPIntInstruction()
-
-.ipint_i32_div_s_throwDivisionByZero:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(DivisionByZero)
-
-.ipint_i32_div_s_throwIntegerOverflow:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(IntegerOverflow)
 end)
 
 ipintOp(_i32_div_u, macro()
     # i32.div_u
     popInt32(t1)
     popInt32(t0)
-    btiz t1, .ipint_i32_div_u_throwDivisionByZero
+    btiz t1, _ipint_throw_DivisionByZero
 
     if X86_64
         xori t2, t2
@@ -1830,9 +1808,6 @@ ipintOp(_i32_div_u, macro()
     pushInt32(t0)
     advancePC(1)
     nextIPIntInstruction()
-
-.ipint_i32_div_u_throwDivisionByZero:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(DivisionByZero)
 end)
 
 ipintOp(_i32_rem_s, macro()
@@ -1840,7 +1815,7 @@ ipintOp(_i32_rem_s, macro()
     popInt32(t1)
     popInt32(t0)
 
-    btiz t1, .ipint_i32_rem_s_throwDivisionByZero
+    btiz t1, _ipint_throw_DivisionByZero
 
     bineq t1, -1, .ipint_i32_rem_s_safe
     bineq t0, constexpr INT32_MIN, .ipint_i32_rem_s_safe
@@ -1868,16 +1843,13 @@ ipintOp(_i32_rem_s, macro()
     pushInt32(t2)
     advancePC(1)
     nextIPIntInstruction()
-
-.ipint_i32_rem_s_throwDivisionByZero:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(DivisionByZero)
 end)
 
 ipintOp(_i32_rem_u, macro()
     # i32.rem_u
     popInt32(t1)
     popInt32(t0)
-    btiz t1, .ipint_i32_rem_u_throwDivisionByZero
+    btiz t1, _ipint_throw_DivisionByZero
 
     if X86_64
         xori t2, t2
@@ -1894,9 +1866,6 @@ ipintOp(_i32_rem_u, macro()
     pushInt32(t2)
     advancePC(1)
     nextIPIntInstruction()
-
-.ipint_i32_rem_u_throwDivisionByZero:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(DivisionByZero)
 end)
 
 ipintOp(_i32_and, macro()
@@ -2058,10 +2027,10 @@ ipintOp(_i64_div_s, macro()
     # i64.div_s
     popInt64(t1)
     popInt64(t0)
-    btqz t1, .ipint_i64_div_s_throwDivisionByZero
+    btqz t1, _ipint_throw_DivisionByZero
 
     bqneq t1, -1, .ipint_i64_div_s_safe
-    bqeq t0, constexpr INT64_MIN, .ipint_i64_div_s_throwIntegerOverflow
+    bqeq t0, constexpr INT64_MIN, _ipint_throw_IntegerOverflow
 
 .ipint_i64_div_s_safe:
     if X86_64
@@ -2077,19 +2046,13 @@ ipintOp(_i64_div_s, macro()
     pushInt64(t0)
     advancePC(1)
     nextIPIntInstruction()
-
-.ipint_i64_div_s_throwDivisionByZero:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(DivisionByZero)
-
-.ipint_i64_div_s_throwIntegerOverflow:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(IntegerOverflow)
 end)
 
 ipintOp(_i64_div_u, macro()
     # i64.div_u
     popInt64(t1)
     popInt64(t0)
-    btqz t1, .ipint_i64_div_u_throwDivisionByZero
+    btqz t1, _ipint_throw_DivisionByZero
 
     if X86_64
         xorq t2, t2
@@ -2102,9 +2065,6 @@ ipintOp(_i64_div_u, macro()
     pushInt64(t0)
     advancePC(1)
     nextIPIntInstruction()
-
-.ipint_i64_div_u_throwDivisionByZero:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(DivisionByZero)
 end)
 
 ipintOp(_i64_rem_s, macro()
@@ -2112,7 +2072,7 @@ ipintOp(_i64_rem_s, macro()
     popInt64(t1)
     popInt64(t0)
 
-    btqz t1, .ipint_i64_rem_s_throwDivisionByZero
+    btqz t1, _ipint_throw_DivisionByZero
 
     bqneq t1, -1, .ipint_i64_rem_s_safe
     bqneq t0, constexpr INT64_MIN, .ipint_i64_rem_s_safe
@@ -2140,16 +2100,13 @@ ipintOp(_i64_rem_s, macro()
     pushInt64(t2)
     advancePC(1)
     nextIPIntInstruction()
-
-.ipint_i64_rem_s_throwDivisionByZero:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(DivisionByZero)
 end)
 
 ipintOp(_i64_rem_u, macro()
     # i64.rem_u
     popInt64(t1)
     popInt64(t0)
-    btqz t1, .ipint_i64_rem_u_throwDivisionByZero
+    btqz t1, _ipint_throw_DivisionByZero
 
     if X86_64
         xorq t2, t2
@@ -2166,9 +2123,6 @@ ipintOp(_i64_rem_u, macro()
     pushInt64(t2)
     advancePC(1)
     nextIPIntInstruction()
-
-.ipint_i64_rem_u_throwDivisionByZero:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(DivisionByZero)
 end)
 
 ipintOp(_i64_and, macro()
@@ -2684,76 +2638,67 @@ ipintOp(_i32_trunc_f32_s, macro()
     popFloat32(ft0)
     move 0xcf000000, t0 # INT32_MIN (Note that INT32_MIN - 1.0 in float is the same as INT32_MIN in float).
     fi2f t0, ft1
-    bfltun ft0, ft1, .ipint_trunc_i32_f32_s_outOfBoundsTrunc
+    bfltun ft0, ft1, _ipint_throw_OutOfBoundsTrunc
 
     move 0x4f000000, t0 # -INT32_MIN
     fi2f t0, ft1
-    bfgtequn ft0, ft1, .ipint_trunc_i32_f32_s_outOfBoundsTrunc
+    bfgtequn ft0, ft1, _ipint_throw_OutOfBoundsTrunc
 
     truncatef2is ft0, t0
     pushInt32(t0)
     advancePC(1)
     nextIPIntInstruction()
 
-.ipint_trunc_i32_f32_s_outOfBoundsTrunc:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsTrunc)
 end)
 
 ipintOp(_i32_trunc_f32_u, macro()
     popFloat32(ft0)
     move 0xbf800000, t0 # -1.0
     fi2f t0, ft1
-    bfltequn ft0, ft1, .ipint_trunc_i32_f32_u_outOfBoundsTrunc
+    bfltequn ft0, ft1, _ipint_throw_OutOfBoundsTrunc
 
     move 0x4f800000, t0 # INT32_MIN * -2.0
     fi2f t0, ft1
-    bfgtequn ft0, ft1, .ipint_trunc_i32_f32_u_outOfBoundsTrunc
+    bfgtequn ft0, ft1, _ipint_throw_OutOfBoundsTrunc
 
     truncatef2i ft0, t0
     pushInt32(t0)
     advancePC(1)
     nextIPIntInstruction()
 
-.ipint_trunc_i32_f32_u_outOfBoundsTrunc:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsTrunc)
 end)
 
 ipintOp(_i32_trunc_f64_s, macro()
     popFloat64(ft0)
     move 0xc1e0000000200000, t0 # INT32_MIN - 1.0
     fq2d t0, ft1
-    bdltequn ft0, ft1, .ipint_trunc_i32_f64_s_outOfBoundsTrunc
+    bdltequn ft0, ft1, _ipint_throw_OutOfBoundsTrunc
 
     move 0x41e0000000000000, t0 # -INT32_MIN
     fq2d t0, ft1
-    bdgtequn ft0, ft1, .ipint_trunc_i32_f64_s_outOfBoundsTrunc
+    bdgtequn ft0, ft1, _ipint_throw_OutOfBoundsTrunc
 
     truncated2is ft0, t0
     pushInt32(t0)
     advancePC(1)
     nextIPIntInstruction()
 
-.ipint_trunc_i32_f64_s_outOfBoundsTrunc:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsTrunc)
 end)
 
 ipintOp(_i32_trunc_f64_u, macro()
     popFloat64(ft0)
     move 0xbff0000000000000, t0 # -1.0
     fq2d t0, ft1
-    bdltequn ft0, ft1, .ipint_trunc_i32_f64_u_outOfBoundsTrunc
+    bdltequn ft0, ft1, _ipint_throw_OutOfBoundsTrunc
 
     move 0x41f0000000000000, t0 # INT32_MIN * -2.0
     fq2d t0, ft1
-    bdgtequn ft0, ft1, .ipint_trunc_i32_f64_u_outOfBoundsTrunc
+    bdgtequn ft0, ft1, _ipint_throw_OutOfBoundsTrunc
 
     truncated2i ft0, t0
     pushInt32(t0)
     advancePC(1)
     nextIPIntInstruction()
-
-.ipint_trunc_i32_f64_u_outOfBoundsTrunc:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsTrunc)
 end)
 
 ipintOp(_i64_extend_i32_s, macro()
@@ -2778,76 +2723,68 @@ ipintOp(_i64_trunc_f32_s, macro()
     popFloat32(ft0)
     move 0xdf000000, t0 # INT64_MIN
     fi2f t0, ft1
-    bfltun ft0, ft1, .ipint_trunc_i64_f32_s_outOfBoundsTrunc
+    bfltun ft0, ft1, _ipint_throw_OutOfBoundsTrunc
 
     move 0x5f000000, t0 # -INT64_MIN
     fi2f t0, ft1
-    bfgtequn ft0, ft1, .ipint_trunc_i64_f32_s_outOfBoundsTrunc
+    bfgtequn ft0, ft1, _ipint_throw_OutOfBoundsTrunc
 
     truncatef2qs ft0, t0
     pushInt64(t0)
     advancePC(1)
     nextIPIntInstruction()
 
-.ipint_trunc_i64_f32_s_outOfBoundsTrunc:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsTrunc)
 end)
 
 ipintOp(_i64_trunc_f32_u, macro()
     popFloat32(ft0)
     move 0xbf800000, t0 # -1.0
     fi2f t0, ft1
-    bfltequn ft0, ft1, .ipint_i64_f32_u_outOfBoundsTrunc
+    bfltequn ft0, ft1, _ipint_throw_OutOfBoundsTrunc
 
     move 0x5f800000, t0 # INT64_MIN * -2.0
     fi2f t0, ft1
-    bfgtequn ft0, ft1, .ipint_i64_f32_u_outOfBoundsTrunc
+    bfgtequn ft0, ft1, _ipint_throw_OutOfBoundsTrunc
 
     truncatef2q ft0, t0
     pushInt64(t0)
     advancePC(1)
     nextIPIntInstruction()
 
-.ipint_i64_f32_u_outOfBoundsTrunc:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsTrunc)
 end)
 
 ipintOp(_i64_trunc_f64_s, macro()
     popFloat64(ft0)
     move 0xc3e0000000000000, t0 # INT64_MIN
     fq2d t0, ft1
-    bdltun ft0, ft1, .ipint_i64_f64_s_outOfBoundsTrunc
+    bdltun ft0, ft1, _ipint_throw_OutOfBoundsTrunc
 
     move 0x43e0000000000000, t0 # -INT64_MIN
     fq2d t0, ft1
-    bdgtequn ft0, ft1, .ipint_i64_f64_s_outOfBoundsTrunc
+    bdgtequn ft0, ft1, _ipint_throw_OutOfBoundsTrunc
 
     truncated2qs ft0, t0
     pushInt64(t0)
     advancePC(1)
     nextIPIntInstruction()
 
-.ipint_i64_f64_s_outOfBoundsTrunc:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsTrunc)
 end)
 
 ipintOp(_i64_trunc_f64_u, macro()
     popFloat64(ft0)
     move 0xbff0000000000000, t0 # -1.0
     fq2d t0, ft1
-    bdltequn ft0, ft1, .ipint_i64_f64_u_outOfBoundsTrunc
+    bdltequn ft0, ft1, _ipint_throw_OutOfBoundsTrunc
 
     move 0x43f0000000000000, t0 # INT64_MIN * -2.0
     fq2d t0, ft1
-    bdgtequn ft0, ft1, .ipint_i64_f64_u_outOfBoundsTrunc
+    bdgtequn ft0, ft1, _ipint_throw_OutOfBoundsTrunc
 
     truncated2q ft0, t0
     pushInt64(t0)
     advancePC(1)
     nextIPIntInstruction()
 
-.ipint_i64_f64_u_outOfBoundsTrunc:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsTrunc)
 end)
 
 ipintOp(_f32_convert_i32_s, macro()
@@ -3069,11 +3006,9 @@ end)
 
 ipintOp(_ref_as_non_null, macro()
     loadq [sp], t0
-    bqeq t0, ValueNull, .ref_as_non_null_nullRef
+    bqeq t0, ValueNull, _ipint_throw_NullRefAsNonNull
     advancePC(1)
     nextIPIntInstruction()
-.ref_as_non_null_nullRef:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(NullRefAsNonNull)
 end)
 
 ipintOp(_br_on_null, macro()
@@ -3434,16 +3369,13 @@ end)
 
 ipintOp(_array_len, macro()
     popQuad(t0)  # array into t0
-    bqeq t0, ValueNull, .nullArray
+    bqeq t0, ValueNull, _ipint_throw_NullAccess
     loadi JSWebAssemblyArray::m_size[t0], t0
     pushInt32(t0)
     loadb IPInt::InstructionLengthMetadata::length[MC], t0
     advancePCByReg(t0)
     advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
-
-.nullArray:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(NullAccess)
 end)
 
 ipintOp(_array_fill, macro()
@@ -3621,20 +3553,18 @@ end)
 
 ipintOp(_i31_get_s, macro()
     popQuad(t0)
-    bqeq t0, ValueNull, .i31_get_throw
+    bqeq t0, ValueNull, _ipint_throw_NullI31Get
     pushInt32(t0)
 
     loadb IPInt::InstructionLengthMetadata::length[MC], t0
     advancePCByReg(t0)
     advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
-.i31_get_throw:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(NullI31Get)
 end)
 
 ipintOp(_i31_get_u, macro()
     popQuad(t0)
-    bqeq t0, ValueNull, .i31_get_throw
+    bqeq t0, ValueNull, _ipint_throw_NullI31Get
     andq 0x7fffffff, t0
     pushInt32(t0)
 
@@ -3642,8 +3572,6 @@ ipintOp(_i31_get_u, macro()
     advancePCByReg(t0)
     advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
-.i31_get_throw:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(NullI31Get)
 end)
 
     #############################
@@ -8579,7 +8507,7 @@ ipintAtomicOp(_memory_atomic_notify, macro()
     move sp, a1
 
     operationCall(macro() cCall2(_ipint_extern_memory_atomic_notify) end)
-    bilt r0, 0, .atomic_notify_throw
+    bilt r0, 0, _ipint_throw_OutOfBoundsMemoryAccess
 
     addq (StackValueSize * 4), sp
 
@@ -8588,9 +8516,6 @@ ipintAtomicOp(_memory_atomic_notify, macro()
     advancePCByReg(t0)
     advanceMC(constexpr (sizeof(IPInt::AtomicMemoryAccessMetadata)))
     nextIPIntInstruction()
-
-.atomic_notify_throw:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsMemoryAccess)
 end)
 
 ipintAtomicOp(_memory_atomic_wait32, macro()
@@ -8605,7 +8530,7 @@ ipintAtomicOp(_memory_atomic_wait32, macro()
     move sp, a1
 
     operationCall(macro() cCall2(_ipint_extern_memory_atomic_wait32) end)
-    bilt r0, 0, .atomic_wait32_throw
+    bilt r0, 0, _ipint_throw_OutOfBoundsMemoryAccess
 
     addq (StackValueSize * 4), sp
 
@@ -8614,9 +8539,6 @@ ipintAtomicOp(_memory_atomic_wait32, macro()
     advancePCByReg(t0)
     advanceMC(constexpr (sizeof(IPInt::AtomicMemoryAccessMetadata)))
     nextIPIntInstruction()
-
-.atomic_wait32_throw:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsMemoryAccess)
 end)
 
 ipintAtomicOp(_memory_atomic_wait64, macro()
@@ -8631,7 +8553,7 @@ ipintAtomicOp(_memory_atomic_wait64, macro()
     move sp, a1
 
     operationCall(macro() cCall2(_ipint_extern_memory_atomic_wait64) end)
-    bilt r0, 0, .atomic_wait64_throw
+    bilt r0, 0, _ipint_throw_OutOfBoundsMemoryAccess
 
     addq (StackValueSize * 4), sp
 
@@ -8640,9 +8562,6 @@ ipintAtomicOp(_memory_atomic_wait64, macro()
     advancePCByReg(t0)
     advanceMC(constexpr (sizeof(IPInt::AtomicMemoryAccessMetadata)))
     nextIPIntInstruction()
-
-.atomic_wait64_throw:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsMemoryAccess)
 end)
 
 ipintAtomicOp(_atomic_fence, macro()
@@ -8670,7 +8589,7 @@ reservedAtomicOpcode(atomic_0xf)
 ipintAtomicOp(_i32_atomic_load, macro()
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, .throwUnaligned)
+    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
     if ARM64 or ARM64E or X86_64
         atomicloadi [t0], t2
     else
@@ -8679,14 +8598,12 @@ ipintAtomicOp(_i32_atomic_load, macro()
     pushInt32(t2)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_load, macro()
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
-    checkAlignment8(t0, .throwUnaligned)
+    checkAlignment8(t0, _ipint_throw_UnalignedMemoryAccess)
     if ARM64 or ARM64E or X86_64
         atomicloadq [t0], t2
     else
@@ -8695,14 +8612,12 @@ ipintAtomicOp(_i64_atomic_load, macro()
     pushInt64(t2)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_load8_u, macro()
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, .throwUnaligned)
+    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
     if ARM64 or ARM64E or X86_64
         atomicloadb [t0], t2
     else
@@ -8711,14 +8626,12 @@ ipintAtomicOp(_i32_atomic_load8_u, macro()
     pushInt32(t2)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_load16_u, macro()
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, .throwUnaligned)
+    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
     if ARM64 or ARM64E or X86_64
         atomicloadh [t0], t2
     else
@@ -8727,14 +8640,12 @@ ipintAtomicOp(_i32_atomic_load16_u, macro()
     pushInt32(t2)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_load8_u, macro()
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, .throwUnaligned)
+    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
     if ARM64 or ARM64E or X86_64
         atomicloadb [t0], t2
     else
@@ -8743,14 +8654,12 @@ ipintAtomicOp(_i64_atomic_load8_u, macro()
     pushInt64(t2)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_load16_u, macro()
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, .throwUnaligned)
+    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
     if ARM64 or ARM64E or X86_64
         atomicloadh [t0], t2
     else
@@ -8759,14 +8668,12 @@ ipintAtomicOp(_i64_atomic_load16_u, macro()
     pushInt64(t2)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_load32_u, macro()
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, .throwUnaligned)
+    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
     if ARM64 or ARM64E or X86_64
         atomicloadi [t0], t2
     else
@@ -8775,8 +8682,6 @@ ipintAtomicOp(_i64_atomic_load32_u, macro()
     pushInt64(t2)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 macro weakCASLoopByte(mem, value, scratch1AndOldValue, scratch2, fn)
@@ -8852,7 +8757,7 @@ ipintAtomicOp(_i32_atomic_store, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, .throwUnaligned)
+    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgi t3, [t2], t3
@@ -8867,15 +8772,13 @@ ipintAtomicOp(_i32_atomic_store, macro()
     end
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_store, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
-    checkAlignment8(t0, .throwUnaligned)
+    checkAlignment8(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgq t3, [t2], t3
@@ -8890,15 +8793,13 @@ ipintAtomicOp(_i64_atomic_store, macro()
     end
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_store8_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, .throwUnaligned)
+    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgb t3, [t2], t3
@@ -8913,15 +8814,13 @@ ipintAtomicOp(_i32_atomic_store8_u, macro()
     end
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_store16_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, .throwUnaligned)
+    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgh t3, [t2], t3
@@ -8936,15 +8835,13 @@ ipintAtomicOp(_i32_atomic_store16_u, macro()
     end
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_store8_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, .throwUnaligned)
+    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgb t3, [t2], t3
@@ -8959,15 +8856,13 @@ ipintAtomicOp(_i64_atomic_store8_u, macro()
     end
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_store16_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, .throwUnaligned)
+    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgh t3, [t2], t3
@@ -8982,15 +8877,13 @@ ipintAtomicOp(_i64_atomic_store16_u, macro()
     end
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_store32_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, .throwUnaligned)
+    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgi t3, [t2], t3
@@ -9005,15 +8898,13 @@ ipintAtomicOp(_i64_atomic_store32_u, macro()
     end
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_rmw_add, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, .throwUnaligned)
+    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgaddi t3, [t2], t0
@@ -9030,15 +8921,13 @@ ipintAtomicOp(_i32_atomic_rmw_add, macro()
     pushInt32(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw_add, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
-    checkAlignment8(t0, .throwUnaligned)
+    checkAlignment8(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgaddq t3, [t2], t0
@@ -9055,15 +8944,13 @@ ipintAtomicOp(_i64_atomic_rmw_add, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_rmw8_add_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, .throwUnaligned)
+    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgaddb t3, [t2], t0
@@ -9081,15 +8968,13 @@ ipintAtomicOp(_i32_atomic_rmw8_add_u, macro()
     pushInt32(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_rmw16_add_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, .throwUnaligned)
+    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgaddh t3, [t2], t0
@@ -9107,15 +8992,13 @@ ipintAtomicOp(_i32_atomic_rmw16_add_u, macro()
     pushInt32(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw8_add_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, .throwUnaligned)
+    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgaddb t3, [t2], t0
@@ -9133,15 +9016,13 @@ ipintAtomicOp(_i64_atomic_rmw8_add_u, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw16_add_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, .throwUnaligned)
+    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgaddh t3, [t2], t0
@@ -9159,15 +9040,13 @@ ipintAtomicOp(_i64_atomic_rmw16_add_u, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw32_add_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, .throwUnaligned)
+    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgaddi t3, [t2], t0
@@ -9185,15 +9064,13 @@ ipintAtomicOp(_i64_atomic_rmw32_add_u, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_rmw_sub, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, .throwUnaligned)
+    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         negi t3
@@ -9212,15 +9089,13 @@ ipintAtomicOp(_i32_atomic_rmw_sub, macro()
     pushInt32(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw_sub, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
-    checkAlignment8(t0, .throwUnaligned)
+    checkAlignment8(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         negq t3
@@ -9239,15 +9114,13 @@ ipintAtomicOp(_i64_atomic_rmw_sub, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_rmw8_sub_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, .throwUnaligned)
+    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         negi t3
@@ -9267,15 +9140,13 @@ ipintAtomicOp(_i32_atomic_rmw8_sub_u, macro()
     pushInt32(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_rmw16_sub_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, .throwUnaligned)
+    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         negi t3
@@ -9295,15 +9166,13 @@ ipintAtomicOp(_i32_atomic_rmw16_sub_u, macro()
     pushInt32(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw8_sub_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, .throwUnaligned)
+    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         negq t3
@@ -9323,15 +9192,13 @@ ipintAtomicOp(_i64_atomic_rmw8_sub_u, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw16_sub_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, .throwUnaligned)
+    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         negq t3
@@ -9351,15 +9218,13 @@ ipintAtomicOp(_i64_atomic_rmw16_sub_u, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw32_sub_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, .throwUnaligned)
+    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         negq t3
@@ -9379,15 +9244,13 @@ ipintAtomicOp(_i64_atomic_rmw32_sub_u, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_rmw_and, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, .throwUnaligned)
+    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         noti t3
@@ -9406,15 +9269,13 @@ ipintAtomicOp(_i32_atomic_rmw_and, macro()
     pushInt32(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw_and, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
-    checkAlignment8(t0, .throwUnaligned)
+    checkAlignment8(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         notq t3
@@ -9433,15 +9294,13 @@ ipintAtomicOp(_i64_atomic_rmw_and, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_rmw8_and_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, .throwUnaligned)
+    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         noti t3
@@ -9460,15 +9319,13 @@ ipintAtomicOp(_i32_atomic_rmw8_and_u, macro()
     pushInt32(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_rmw16_and_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, .throwUnaligned)
+    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         noti t3
@@ -9487,15 +9344,13 @@ ipintAtomicOp(_i32_atomic_rmw16_and_u, macro()
     pushInt32(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw8_and_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, .throwUnaligned)
+    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         notq t3
@@ -9514,15 +9369,13 @@ ipintAtomicOp(_i64_atomic_rmw8_and_u, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw16_and_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, .throwUnaligned)
+    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         notq t3
@@ -9541,15 +9394,13 @@ ipintAtomicOp(_i64_atomic_rmw16_and_u, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw32_and_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, .throwUnaligned)
+    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         notq t3
@@ -9568,15 +9419,13 @@ ipintAtomicOp(_i64_atomic_rmw32_and_u, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_rmw_or, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, .throwUnaligned)
+    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgori t3, [t2], t0
@@ -9594,15 +9443,13 @@ ipintAtomicOp(_i32_atomic_rmw_or, macro()
     pushInt32(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw_or, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
-    checkAlignment8(t0, .throwUnaligned)
+    checkAlignment8(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgorq t3, [t2], t0
@@ -9620,15 +9467,13 @@ ipintAtomicOp(_i64_atomic_rmw_or, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_rmw8_or_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, .throwUnaligned)
+    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgorb t3, [t2], t0
@@ -9646,15 +9491,13 @@ ipintAtomicOp(_i32_atomic_rmw8_or_u, macro()
     pushInt32(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_rmw16_or_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, .throwUnaligned)
+    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgorh t3, [t2], t0
@@ -9672,15 +9515,13 @@ ipintAtomicOp(_i32_atomic_rmw16_or_u, macro()
     pushInt32(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw8_or_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, .throwUnaligned)
+    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgorb t3, [t2], t0
@@ -9698,15 +9539,13 @@ ipintAtomicOp(_i64_atomic_rmw8_or_u, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw16_or_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, .throwUnaligned)
+    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgorh t3, [t2], t0
@@ -9724,15 +9563,13 @@ ipintAtomicOp(_i64_atomic_rmw16_or_u, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw32_or_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, .throwUnaligned)
+    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgori t3, [t2], t0
@@ -9750,15 +9587,13 @@ ipintAtomicOp(_i64_atomic_rmw32_or_u, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_rmw_xor, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, .throwUnaligned)
+    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgxori t3, [t2], t0
@@ -9776,15 +9611,13 @@ ipintAtomicOp(_i32_atomic_rmw_xor, macro()
     pushInt32(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw_xor, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
-    checkAlignment8(t0, .throwUnaligned)
+    checkAlignment8(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgxorq t3, [t2], t0
@@ -9802,15 +9635,13 @@ ipintAtomicOp(_i64_atomic_rmw_xor, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_rmw8_xor_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, .throwUnaligned)
+    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgxorb t3, [t2], t0
@@ -9828,15 +9659,13 @@ ipintAtomicOp(_i32_atomic_rmw8_xor_u, macro()
     pushInt32(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_rmw16_xor_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, .throwUnaligned)
+    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgxorh t3, [t2], t0
@@ -9854,15 +9683,13 @@ ipintAtomicOp(_i32_atomic_rmw16_xor_u, macro()
     pushInt32(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw8_xor_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, .throwUnaligned)
+    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgxorb t3, [t2], t0
@@ -9880,15 +9707,13 @@ ipintAtomicOp(_i64_atomic_rmw8_xor_u, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw16_xor_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, .throwUnaligned)
+    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgxorh t3, [t2], t0
@@ -9906,15 +9731,13 @@ ipintAtomicOp(_i64_atomic_rmw16_xor_u, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw32_xor_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, .throwUnaligned)
+    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgxori t3, [t2], t0
@@ -9932,15 +9755,13 @@ ipintAtomicOp(_i64_atomic_rmw32_xor_u, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_rmw_xchg, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, .throwUnaligned)
+    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgi t3, [t2], t0
@@ -9958,15 +9779,13 @@ ipintAtomicOp(_i32_atomic_rmw_xchg, macro()
     pushInt32(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw_xchg, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
-    checkAlignment8(t0, .throwUnaligned)
+    checkAlignment8(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgq t3, [t2], t0
@@ -9984,15 +9803,13 @@ ipintAtomicOp(_i64_atomic_rmw_xchg, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_rmw8_xchg_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, .throwUnaligned)
+    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgb t3, [t2], t0
@@ -10010,15 +9827,13 @@ ipintAtomicOp(_i32_atomic_rmw8_xchg_u, macro()
     pushInt32(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_rmw16_xchg_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, .throwUnaligned)
+    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgh t3, [t2], t0
@@ -10036,15 +9851,13 @@ ipintAtomicOp(_i32_atomic_rmw16_xchg_u, macro()
     pushInt32(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw8_xchg_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, .throwUnaligned)
+    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgb t3, [t2], t0
@@ -10062,15 +9875,13 @@ ipintAtomicOp(_i64_atomic_rmw8_xchg_u, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw16_xchg_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, .throwUnaligned)
+    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgh t3, [t2], t0
@@ -10088,15 +9899,13 @@ ipintAtomicOp(_i64_atomic_rmw16_xchg_u, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw32_xchg_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, .throwUnaligned)
+    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     if ARM64E
         atomicxchgi t3, [t2], t0
@@ -10114,8 +9923,6 @@ ipintAtomicOp(_i64_atomic_rmw32_xchg_u, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 macro weakCASExchangeByte(mem, value, expected, scratch, scratch2)
@@ -10205,7 +10012,7 @@ ipintAtomicOp(_i32_atomic_rmw_cmpxchg, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, .throwUnaligned)
+    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     move t3, t0
     andq 0xffffffff, t0
@@ -10219,8 +10026,6 @@ ipintAtomicOp(_i32_atomic_rmw_cmpxchg, macro()
     pushInt32(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw_cmpxchg, macro()
@@ -10230,7 +10035,7 @@ ipintAtomicOp(_i64_atomic_rmw_cmpxchg, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 8, t1, t2)
-    checkAlignment8(t0, .throwUnaligned)
+    checkAlignment8(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     move t3, t0
     if ARM64E or X86_64
@@ -10243,8 +10048,6 @@ ipintAtomicOp(_i64_atomic_rmw_cmpxchg, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_rmw8_cmpxchg_u, macro()
@@ -10254,7 +10057,7 @@ ipintAtomicOp(_i32_atomic_rmw8_cmpxchg_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, .throwUnaligned)
+    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     move t3, t0
     andq 0xff, t0
@@ -10268,8 +10071,6 @@ ipintAtomicOp(_i32_atomic_rmw8_cmpxchg_u, macro()
     pushInt32(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i32_atomic_rmw16_cmpxchg_u, macro()
@@ -10279,7 +10080,7 @@ ipintAtomicOp(_i32_atomic_rmw16_cmpxchg_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, .throwUnaligned)
+    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     move t3, t0
     andq 0xffff, t0
@@ -10293,8 +10094,6 @@ ipintAtomicOp(_i32_atomic_rmw16_cmpxchg_u, macro()
     pushInt32(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw8_cmpxchg_u, macro()
@@ -10304,7 +10103,7 @@ ipintAtomicOp(_i64_atomic_rmw8_cmpxchg_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 1, t1, t2)
-    noAlignmentCheck(t0, .throwUnaligned)
+    noAlignmentCheck(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     move t3, t0
     andq 0xff, t0
@@ -10318,8 +10117,6 @@ ipintAtomicOp(_i64_atomic_rmw8_cmpxchg_u, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw16_cmpxchg_u, macro()
@@ -10329,7 +10126,7 @@ ipintAtomicOp(_i64_atomic_rmw16_cmpxchg_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 2, t1, t2)
-    checkAlignment2(t0, .throwUnaligned)
+    checkAlignment2(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     move t3, t0
     andq 0xffff, t0
@@ -10343,8 +10140,6 @@ ipintAtomicOp(_i64_atomic_rmw16_cmpxchg_u, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 ipintAtomicOp(_i64_atomic_rmw32_cmpxchg_u, macro()
@@ -10354,7 +10149,7 @@ ipintAtomicOp(_i64_atomic_rmw32_cmpxchg_u, macro()
     popInt64(t3)
     popMemoryIndex(t0)
     atomicMemoryMakePointerAndAdvanceMC(t4, t0, 4, t1, t2)
-    checkAlignment4(t0, .throwUnaligned)
+    checkAlignment4(t0, _ipint_throw_UnalignedMemoryAccess)
     move t0, t2
     move t3, t0
     andq 0xffffffff, t0
@@ -10368,8 +10163,6 @@ ipintAtomicOp(_i64_atomic_rmw32_cmpxchg_u, macro()
     pushInt64(t0)
     advancePCByReg(t4)
     nextIPIntInstruction()
-.throwUnaligned:
-    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 end)
 
 #######################################
@@ -11608,6 +11401,36 @@ _ipint_mint_arg_dispatch_err:
 _ipint_mint_ret_dispatch_err:
     move 0x88, a0
     break
+
+_ipint_throw_Unreachable:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(Unreachable)
+
+_ipint_throw_NullExnrefReference:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(NullExnrefReference)
+
+_ipint_throw_OutOfBoundsMemoryAccess:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsMemoryAccess)
+
+_ipint_throw_DivisionByZero:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(DivisionByZero)
+
+_ipint_throw_IntegerOverflow:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(IntegerOverflow)
+
+_ipint_throw_OutOfBoundsTrunc:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(OutOfBoundsTrunc)
+
+_ipint_throw_NullRefAsNonNull:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(NullRefAsNonNull)
+
+_ipint_throw_NullAccess:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(NullAccess)
+
+_ipint_throw_NullI31Get:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(NullI31Get)
+
+_ipint_throw_UnalignedMemoryAccess:
+    handleDebuggerTrapIfNeededAndThrowWasmTrap(UnalignedMemoryAccess)
 
 ###########################################
 # uINT: function return value interpreter #


### PR DESCRIPTION
#### 723bdacf3bed4568822c50a02226c7fb115a487b
<pre>
[JSC] Consolidate error throwing code in IPInt to reduce code size in each handler
<a href="https://bugs.webkit.org/show_bug.cgi?id=312073">https://bugs.webkit.org/show_bug.cgi?id=312073</a>
<a href="https://rdar.apple.com/174582904">rdar://174582904</a>

Reviewed by Keith Miller.

This patch consolidates error throwing code in IPInt. We are observing larger
size in atomics related IPInt code, but we would like to reduce code size in
to fit it into 256 size again.

* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:

Canonical link: <a href="https://commits.webkit.org/311147@main">https://commits.webkit.org/311147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/578d3afc3114600067ab823cefd9355b19a0c40c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156173 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164994 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29511 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/120929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159131 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/23129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101605 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12766 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/148223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/18076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167473 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17007 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/11589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19689 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/29109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129169 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29031 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139870 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23772 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23991 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188056 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28740 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/92697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/48347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/28495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28391 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->