### PR TITLE
document.styleSheets and shadowRoot.styleSheets incorrectly include adopted style sheets

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL document.styleSheets does not include adopted style sheets assert_equals: expected 1 but got 2
+PASS document.styleSheets does not include adopted style sheets
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-shadow-expected.txt
@@ -1,0 +1,3 @@
+
+PASS shadowRoot.styleSheets does not include adopted style sheets
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-shadow-with-style-recalc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-shadow-with-style-recalc-expected.txt
@@ -1,0 +1,3 @@
+
+PASS shadowRoot.styleSheets does not include adopted style sheets
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-shadow-with-style-recalc.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-shadow-with-style-recalc.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSSOM - StyleSheetList does not include adopted style sheets in shadow roots even after style recalc</title>
+    <link rel="help" href="https://drafts.csswg.org/cssom/#css-style-sheet-collections">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+      test(() => {
+        const host = document.createElement('div');
+        document.body.appendChild(host);
+        const shadow = host.attachShadow({mode: 'open'});
+
+        const style = document.createElement('style');
+        style.textContent = ':host { color: red }';
+        shadow.appendChild(style);
+
+        const sheet = new CSSStyleSheet();
+        shadow.adoptedStyleSheets = [sheet];
+
+        host.offsetTop;
+
+        var styleSheets = shadow.styleSheets;
+        assert_equals(styleSheets.length, 1);
+        assert_equals(styleSheets[0], style.sheet);
+      }, 'shadowRoot.styleSheets does not include adopted style sheets');
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-shadow.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSSOM - StyleSheetList does not include adopted style sheets in shadow roots</title>
+    <link rel="help" href="https://drafts.csswg.org/cssom/#css-style-sheet-collections">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+      test(() => {
+        const host = document.createElement('div');
+        document.body.appendChild(host);
+        const shadow = host.attachShadow({mode: 'open'});
+
+        const style = document.createElement('style');
+        style.textContent = ':host { color: red }';
+        shadow.appendChild(style);
+
+        const sheet = new CSSStyleSheet();
+        shadow.adoptedStyleSheets = [sheet];
+
+        var styleSheets = shadow.styleSheets;
+        assert_equals(styleSheets.length, 1);
+        assert_equals(styleSheets[0], style.sheet);
+      }, 'shadowRoot.styleSheets does not include adopted style sheets');
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-with-style-recalc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-with-style-recalc-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL document.styleSheets does not include adopted style sheets assert_equals: expected 1 but got 2
+PASS document.styleSheets does not include adopted style sheets
 

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -499,7 +499,6 @@ auto Scope::collectActiveStyleSheets() -> ActiveStyleSheetCollection
     for (auto& adoptedStyleSheet : treeScope().adoptedStyleSheets()) {
         if (!canActivateAdoptedStyleSheet(adoptedStyleSheet.get()))
             continue;
-        styleSheetsForStyleSheetsList.append(adoptedStyleSheet.get());
         sheets.append(adoptedStyleSheet.get());
     }
 


### PR DESCRIPTION
#### 2dd7e967bacc31172fcf228e24af776f1e2546b0
<pre>
document.styleSheets and shadowRoot.styleSheets incorrectly include adopted style sheets
<a href="https://bugs.webkit.org/show_bug.cgi?id=312074">https://bugs.webkit.org/show_bug.cgi?id=312074</a>
<a href="https://rdar.apple.com/174583340">rdar://174583340</a>

Reviewed by Antti Koivisto.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Per CSSOM §6.2 [1], the spec defines two separate lists:

&quot;document or shadow root CSS style sheets&quot; — which contains:
  &quot;Any CSS style sheets created from HTTP Link headers, in header order&quot;
  &quot;Any CSS style sheets associated with the DocumentOrShadowRoot, in
    tree order&quot;

&quot;final CSS style sheets&quot; — which contains:
  &quot;The document or shadow root CSS style sheets.&quot;
  &quot;The contents of DocumentOrShadowRoot&apos;s adoptedStyleSheets&apos; backing
    list, in array order.&quot;

The styleSheets attribute (StyleSheetList) should reflect the &quot;document
or shadow root CSS style sheets&quot;, not the &quot;final CSS style sheets&quot;.

StyleScope::collectActiveStyleSheets() was appending adopted sheets to
both the style resolution list and the StyleSheetList backing store.
Remove the erroneous append to styleSheetsForStyleSheetsList.

[1] <a href="https://drafts.csswg.org/cssom/#css-style-sheet-collections">https://drafts.csswg.org/cssom/#css-style-sheet-collections</a>

This patch also add new test cases in context of ShadowRoot to ensure that
we don&apos;t regress anything.

Tests: imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-shadow-with-style-recalc.html
       imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-shadow.html

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-shadow-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-shadow-with-style-recalc-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-shadow-with-style-recalc.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-shadow.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-with-style-recalc-expected.txt:
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::collectActiveStyleSheets):

Canonical link: <a href="https://commits.webkit.org/311074@main">https://commits.webkit.org/311074@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d77cd11abc767e2d9a6bae79d061f29381f09659

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164595 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109647 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157704 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120625 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84981 "3 flakes 3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158790 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139941 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101314 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21898 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20039 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12425 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131567 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17773 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167075 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11249 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19384 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128745 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28635 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128878 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34942 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28559 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139566 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86415 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23701 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; Passed layout tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16365 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28253 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92356 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27830 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28060 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27903 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->