### PR TITLE
checkUTF8 should use SIMDUTF

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmParser.h
+++ b/Source/JavaScriptCore/wasm/WasmParser.h
@@ -185,13 +185,12 @@ ALWAYS_INLINE bool ParserBase::consumeUTF8String(Name& result, size_t stringLeng
         return false;
 
     auto string = byteCast<char8_t>(m_source.subspan(m_offset, stringLength));
-    if (auto checkResult = WTF::Unicode::checkUTF8(string); checkResult.characters.size() != string.size())
+    if (auto checkResult = WTF::Unicode::checkUTF8WithoutUTF16Length(string); checkResult.size() != string.size())
         return false;
 
-    result.grow(stringLength);
-    // FIXME: Adopt memcpySpan().
-    memcpy(result.mutableSpan().data(), string.data(), stringLength);
-    m_offset += stringLength;
+    result.grow(string.size());
+    memcpySpan(result.mutableSpan().last(string.size()), string);
+    m_offset += string.size();
     return true;
 }
 

--- a/Source/WTF/wtf/unicode/UTF8Conversion.cpp
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.cpp
@@ -159,21 +159,20 @@ ConversionResult<char16_t> convertReplacingInvalidSequences(std::span<const char
     return convertInternal<Replacement::ReplaceInvalidSequences>(source, buffer);
 }
 
+std::span<const char8_t> checkUTF8WithoutUTF16Length(std::span<const char8_t> source)
+{
+    auto result = simdutf::validate_utf8_with_errors(reinterpret_cast<const char*>(source.data()), source.size());
+    size_t validLength = result.error == simdutf::error_code::SUCCESS ? source.size() : result.count;
+    return source.first(validLength);
+}
+
 CheckedUTF8 checkUTF8(std::span<const char8_t> source)
 {
-    size_t lengthUTF16 = 0;
-    char32_t orAllData = 0;
-    size_t sourceOffset;
-    for (sourceOffset = 0; sourceOffset < source.size(); ) {
-        size_t nextSourceOffset = sourceOffset;
-        char32_t character = next(source, nextSourceOffset);
-        if (character == sentinelCodePoint)
-            break;
-        sourceOffset = nextSourceOffset;
-        lengthUTF16 += U16_LENGTH(character);
-        orAllData |= character;
-    }
-    return { source.first(sourceOffset), lengthUTF16, isASCII(orAllData) };
+    auto result = simdutf::validate_utf8_with_errors(reinterpret_cast<const char*>(source.data()), source.size());
+    size_t validLength = result.error == simdutf::error_code::SUCCESS ? source.size() : result.count;
+    auto validSpan = source.first(validLength);
+    size_t lengthUTF16 = simdutf::utf16_length_from_utf8(reinterpret_cast<const char*>(validSpan.data()), validSpan.size());
+    return { validSpan, lengthUTF16, validLength == lengthUTF16 };
 }
 
 template<typename CharacterTypeA, typename CharacterTypeB> bool equalInternal(std::span<CharacterTypeA> a, std::span<CharacterTypeB> b)

--- a/Source/WTF/wtf/unicode/UTF8Conversion.h
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.h
@@ -65,6 +65,7 @@ struct CheckedUTF8 {
     bool isAllASCII { };
 };
 WTF_EXPORT_PRIVATE CheckedUTF8 checkUTF8(std::span<const char8_t>);
+WTF_EXPORT_PRIVATE std::span<const char8_t> checkUTF8WithoutUTF16Length(std::span<const char8_t>);
 
 } // namespace Unicode
 } // namespace WTF


### PR DESCRIPTION
#### cfed70b0995468ec5afc297a754339943a352cbd
<pre>
checkUTF8 should use SIMDUTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=312076">https://bugs.webkit.org/show_bug.cgi?id=312076</a>
<a href="https://rdar.apple.com/174585782">rdar://174585782</a>

Reviewed by Sosuke Suzuki.

Use SIMDUTF in checkUTF8. Also adding WTF::Unicode::checkUTF8WithoutUTF16Length,
which only validates UTF-8. We use this in wasm name parsing.

* Source/JavaScriptCore/wasm/WasmParser.h:
(JSC::Wasm::ParserBase::consumeUTF8String):
* Source/WTF/wtf/unicode/UTF8Conversion.cpp:
(WTF::Unicode::checkUTF8WithoutUTF16Length):
(WTF::Unicode::checkUTF8):
* Source/WTF/wtf/unicode/UTF8Conversion.h:

Canonical link: <a href="https://commits.webkit.org/311031@main">https://commits.webkit.org/311031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad9c70a3a4f73e5faed35155ca3a3768efff9dfe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164603 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29246 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120638 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158798 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101327 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21911 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20051 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIAlarms.DelaySingleShot (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12433 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147889 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131580 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17785 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167083 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16671 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11257 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19396 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128758 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28643 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24085 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128891 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28567 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139578 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86425 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23729 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23713 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16377 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187724 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28261 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92364 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48262 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27838 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28068 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27911 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->