### PR TITLE
CSSOM "add a CSS style sheet" should establish preferred style sheet set name at creation time

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/preferred-stylesheet-reversed-order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/preferred-stylesheet-reversed-order-expected.txt
@@ -1,4 +1,4 @@
 This text should be green
 
-FAIL Preferred stylesheet where insertion order is tree order assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS Preferred stylesheet where insertion order is tree order
 

--- a/Source/WebCore/dom/InlineStyleSheetOwner.cpp
+++ b/Source/WebCore/dom/InlineStyleSheetOwner.cpp
@@ -166,6 +166,9 @@ void InlineStyleSheetOwner::createSheet(Element& element, const String& text)
         if (!element.isInShadowTree())
             sheet->setTitle(element.title());
 
+        if (CheckedPtr scope = m_styleScope.get())
+            scope->establishPreferredStylesheetSetName(element, sheet.get());
+
         sheetLoaded(element);
         element.notifyLoadedSheetAndAllCriticalSubresources(false);
         return;
@@ -180,6 +183,9 @@ void InlineStyleSheetOwner::createSheet(Element& element, const String& text)
     sheet->setMediaQueries(WTF::move(mediaQueries));
     if (!element.isInShadowTree())
         sheet->setTitle(element.title());
+
+    if (CheckedPtr scope = m_styleScope.get())
+        scope->establishPreferredStylesheetSetName(element, sheet.get());
 
     contents->parseString(text);
 

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -584,6 +584,9 @@ void HTMLLinkElement::initializeStyleSheet(Ref<StyleSheetContents>&& styleSheet,
     if (!isInShadowTree())
         m_sheet->setTitle(title());
 
+    if (CheckedPtr styleScope = m_styleScope)
+        styleScope->establishPreferredStylesheetSetName(*this, *m_sheet);
+
     if (!m_sheet->canAccessRules())
         m_sheet->contents().setAsLoadedFromOpaqueSource();
 }

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -391,6 +391,31 @@ void Scope::addStyleSheetCandidateNode(Node& node, bool createdByParser)
     m_styleSheetCandidateNodes.insertBefore(*followingNode, node);
 }
 
+void Scope::establishPreferredStylesheetSetName(const Element& element, const CSSStyleSheet& sheet)
+{
+    // Per CSSOM spec "add a CSS style sheet", the preferred CSS style sheet set
+    // name is established when a sheet is added, based on insertion order — not
+    // tree order. This is called at sheet-creation time so that a later-inserted
+    // stylesheet placed earlier in tree order does not override the name.
+    // https://drafts.csswg.org/cssom/#add-a-css-style-sheet
+    if (!m_preferredStylesheetSetName.isEmpty())
+        return;
+
+    if (element.isInShadowTree())
+        return;
+
+    auto title = sheet.title();
+    if (title.isNull() || title.isEmpty())
+        return;
+
+    if (is<HTMLStyleElement>(element))
+        m_preferredStylesheetSetName = title;
+    else if (auto* linkElement = dynamicDowncast<HTMLLinkElement>(element)) {
+        if (!linkElement->isEnabledViaScript() && !linkElement->attributeWithoutSynchronization(HTMLNames::relAttr).contains("alternate"_s))
+            m_preferredStylesheetSetName = title;
+    }
+}
+
 void Scope::removeStyleSheetCandidateNode(Node& node)
 {
     if (m_styleSheetCandidateNodes.remove(node))

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -93,6 +93,7 @@ public:
     void removeStyleSheetCandidateNode(Node&);
 
     void setPreferredStylesheetSetName(const String&);
+    void establishPreferredStylesheetSetName(const Element&, const CSSStyleSheet&);
 
     void addPendingSheet(const Element&);
     void removePendingSheet(const Element&);


### PR DESCRIPTION
#### 8fb1ba555ff603c2016ec4c9f70f3310052040ad
<pre>
CSSOM &quot;add a CSS style sheet&quot; should establish preferred style sheet set name at creation time
<a href="https://bugs.webkit.org/show_bug.cgi?id=312077">https://bugs.webkit.org/show_bug.cgi?id=312077</a>
<a href="https://rdar.apple.com/174586058">rdar://174586058</a>

Reviewed by Antti Koivisto.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Per [1], the preferred CSS style sheet set name is set when a sheet is
added: &quot;If the title is not the empty string, the alternate flag is unset,
and preferred CSS style sheet set name is the empty string change the
preferred CSS style sheet set name to the title.&quot;

WebKit was determining the preferred name during collectActiveStyleSheets()
by iterating candidate nodes in tree order, so a dynamically inserted
stylesheet placed before the first-added one would incorrectly override
the preferred name.

Fix this by calling establishPreferredStylesheetSetName() at sheet-creation
time in InlineStyleSheetOwner::createSheet and
HTMLLinkElement::initializeStyleSheet, preserving insertion-order semantics.
The existing tree-order determination in collectActiveStyleSheets() is
retained as a fallback for cases where the name was not established at
creation time (e.g. still-loading link elements).

[1] <a href="https://drafts.csswg.org/cssom/#add-a-css-style-sheet">https://drafts.csswg.org/cssom/#add-a-css-style-sheet</a>

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/preferred-stylesheet-reversed-order-expected.txt: Progression
* Source/WebCore/dom/InlineStyleSheetOwner.cpp:
(WebCore::InlineStyleSheetOwner::createSheet):
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::initializeStyleSheet):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::establishPreferredStylesheetSetName):
* Source/WebCore/style/StyleScope.h:

Canonical link: <a href="https://commits.webkit.org/311077@main">https://commits.webkit.org/311077@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e2740fcc0066a21091f0071c82dfa9ebf2b4796

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155845 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29103 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164607 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109659 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157716 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28953 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120636 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84989 "1 flakes 3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139950 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101325 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21909 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20050 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12437 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131578 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17782 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167087 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11261 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128756 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28647 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128889 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34943 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28571 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139575 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86429 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23709 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16374 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28265 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92368 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27842 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28072 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27915 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->