### PR TITLE
[JSC] Avoid repeated lock contension due to NativeCalleeRegistry registration

### DIFF
--- a/Source/JavaScriptCore/runtime/NativeCalleeRegistry.h
+++ b/Source/JavaScriptCore/runtime/NativeCalleeRegistry.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <JavaScriptCore/PCToCodeOriginMap.h>
-#include <wtf/Box.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/TZoneMalloc.h>
@@ -51,13 +49,20 @@ public:
         ASSERT_UNUSED(addResult, addResult.isNewEntry);
     }
 
+    template<typename CalleeContainer>
+    void registerCallees(const CalleeContainer& callees)
+    {
+        Locker locker { m_lock };
+        for (auto& callee : callees) {
+            auto addResult = m_calleeSet.add(callee.ptr());
+            ASSERT_UNUSED(addResult, addResult.isNewEntry);
+        }
+    }
+
     void unregisterCallee(NativeCallee* callee)
     {
         Locker locker { m_lock };
         m_calleeSet.remove(callee);
-#if ENABLE(JIT)
-        m_pcToCodeOriginMaps.remove(callee);
-#endif
     }
 
     const UncheckedKeyHashSet<NativeCallee*>& allCallees() WTF_REQUIRES_LOCK(m_lock)
@@ -72,33 +77,11 @@ public:
         return m_calleeSet.contains(callee);
     }
 
-#if ENABLE(JIT)
-    void addPCToCodeOriginMap(NativeCallee* callee, Box<PCToCodeOriginMap> originMap)
-    {
-        Locker locker { m_lock };
-        ASSERT(isValidCallee(callee));
-        auto addResult = m_pcToCodeOriginMaps.add(callee, WTF::move(originMap));
-        RELEASE_ASSERT(addResult.isNewEntry);
-    }
-
-    Box<PCToCodeOriginMap> codeOriginMap(NativeCallee* callee)  WTF_REQUIRES_LOCK(m_lock)
-    {
-        ASSERT(isValidCallee(callee));
-        auto iter = m_pcToCodeOriginMaps.find(callee);
-        if (iter != m_pcToCodeOriginMaps.end())
-            return iter->value;
-        return nullptr;
-    }
-#endif
-
     NativeCalleeRegistry() = default;
 
 private:
     Lock m_lock;
     UncheckedKeyHashSet<NativeCallee*> m_calleeSet WTF_GUARDED_BY_LOCK(m_lock);
-#if ENABLE(JIT)
-    UncheckedKeyHashMap<NativeCallee*, Box<PCToCodeOriginMap>> m_pcToCodeOriginMaps WTF_GUARDED_BY_LOCK(m_lock);
-#endif
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -152,7 +152,7 @@ protected:
                         if (isInlined)
                             stackTrace[m_depth].wasmIndexOrName = origin;
                     }
-                    stackTrace[m_depth].wasmPCMap = NativeCalleeRegistry::singleton().codeOriginMap(wasmCallee);
+                    stackTrace[m_depth].wasmPCMap = wasmCallee->pcToCodeOriginMap();
 #endif
 #endif
                     break;

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -31,7 +31,6 @@
 #include "JITCompilation.h"
 #include "JSToWasm.h"
 #include "LinkBuffer.h"
-#include "NativeCalleeRegistry.h"
 #include "WasmBBQJIT.h"
 #include "WasmCallee.h"
 #include "WasmCalleeGroup.h"
@@ -126,8 +125,10 @@ void BBQPlan::work()
         callee->setEntrypoint(WTF::move(function->entrypoint), WTF::move(unlinkedWasmToWasmCalls), WTF::move(function->stackmaps), WTF::move(function->exceptionHandlers), WTF::move(exceptionHandlerLocations), WTF::move(loopEntrypointLocations), sharedLoopEntrypoint, function->osrEntryScratchBufferSize);
         entrypoint = callee->entrypoint();
 
-        if (context.pcToCodeOriginMap)
-            NativeCalleeRegistry::singleton().addPCToCodeOriginMap(callee.ptr(), WTF::move(context.pcToCodeOriginMap));
+        if (context.pcToCodeOriginMap) {
+            WTF::storeStoreFence();
+            callee->setPCToCodeOriginMap(WTF::move(context.pcToCodeOriginMap));
+        }
 
         {
             Locker locker { m_calleeGroup->m_lock };

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -183,6 +183,17 @@ std::tuple<void*, void*> Callee::range() const
     return result;
 }
 
+#if ENABLE(JIT)
+Box<PCToCodeOriginMap> Callee::pcToCodeOriginMap() const
+{
+    Box<PCToCodeOriginMap> result;
+    runWithDowncast([&](auto* derived) {
+        result = derived->pcToCodeOriginMapImpl();
+    });
+    return result;
+}
+#endif
+
 const RegisterAtOffsetList* Callee::calleeSaveRegisters()
 {
     const RegisterAtOffsetList* result = nullptr;
@@ -302,6 +313,12 @@ void IPIntCallee::setEntrypoint(CodePtr<WasmEntryPtrTag> entrypoint)
     ASSERT(!m_entrypoint);
     m_entrypoint = entrypoint;
     NativeCalleeRegistry::singleton().registerCallee(this);
+}
+
+void IPIntCallee::setEntrypointWithoutRegistration(CodePtr<WasmEntryPtrTag> entrypoint)
+{
+    ASSERT(!m_entrypoint);
+    m_entrypoint = entrypoint;
 }
 
 const RegisterAtOffsetList* IPIntCallee::calleeSaveRegistersImpl()

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -76,6 +76,10 @@ public:
     // Used by Wasm's fault signal handler to determine if the fault came from Wasm.
     std::tuple<void*, void*> range() const;
 
+#if ENABLE(JIT)
+    Box<PCToCodeOriginMap> pcToCodeOriginMap() const;
+#endif
+
     const HandlerInfo* handlerForIndex(JSWebAssemblyInstance&, unsigned, const Tag*);
 
     bool hasExceptionHandlers() const { return !m_exceptionHandlers.isEmpty(); }
@@ -92,6 +96,10 @@ public:
     {
         return 0;
     }
+
+#if ENABLE(JIT)
+    Box<PCToCodeOriginMap> pcToCodeOriginMapImpl() const { return nullptr; }
+#endif
 
 protected:
     JS_EXPORT_PRIVATE Callee(Wasm::CompilationMode);
@@ -258,6 +266,9 @@ public:
 
     Box<PCToCodeOriginMap> materializePCToOriginMap(B3::PCToOriginMap&&, LinkBuffer&);
 
+    Box<PCToCodeOriginMap> pcToCodeOriginMapImpl() const { return m_pcToCodeOriginMap; }
+    void setPCToCodeOriginMap(Box<PCToCodeOriginMap>&& map) { m_pcToCodeOriginMap = WTF::move(map); }
+
     unsigned computeCodeHashImpl() const;
 
 protected:
@@ -283,6 +294,7 @@ private:
     Vector<WasmCodeOrigin, 0> codeOrigins;
     Vector<Ref<NameSection>, 0> nameSections;
     Box<PCToCodeOriginMap> m_callSiteIndexMap;
+    Box<PCToCodeOriginMap> m_pcToCodeOriginMap;
     const Ref<IPIntCallee> m_profiledCallee;
 };
 
@@ -445,6 +457,7 @@ public:
 
     FunctionCodeIndex functionIndex() const { return m_functionIndex; }
     void setEntrypoint(CodePtr<WasmEntryPtrTag>);
+    void setEntrypointWithoutRegistration(CodePtr<WasmEntryPtrTag>);
     const uint8_t* bytecode() const { return m_bytecode; }
     const uint8_t* bytecodeEnd() const { return m_bytecodeEnd; }
     const uint8_t* metadata() const LIFETIME_BOUND { return m_metadata.span().data(); }

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -36,6 +36,7 @@
 #include "LLIntData.h"
 #include "LLIntThunks.h"
 #include "LinkBuffer.h"
+#include "NativeCalleeRegistry.h"
 #include "WasmCallee.h"
 #include "WasmFunctionIPIntMetadataGenerator.h"
 #include "WasmIPIntGenerator.h"
@@ -149,7 +150,7 @@ void IPIntPlan::compileFunction(FunctionCodeIndex functionIndex)
         if (!entrypoint)
             entrypoint = LLInt::getCodeFunctionPtr<CFunctionPtrTag>(ipint_trampoline);
 
-        callee->setEntrypoint(entrypoint);
+        callee->setEntrypointWithoutRegistration(entrypoint);
         ipintCallee = callee.ptr();
         m_calleesVector[functionIndex] = WTF::move(callee);
     } else
@@ -184,6 +185,7 @@ void IPIntPlan::didCompleteCompilation()
     unsigned functionCount = m_wasmInternalFunctions.size();
     if (!m_callees && functionCount) {
         m_callees = m_calleesVector.span().data();
+        NativeCalleeRegistry::singleton().registerCallees(m_calleesVector);
         if (!m_moduleInformation->clobberingTailCalls().isEmpty())
             computeTransitiveTailCalls();
     }

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -31,7 +31,6 @@
 
 #include "JITCompilation.h"
 #include "LinkBuffer.h"
-#include "NativeCalleeRegistry.h"
 #include "WasmCallee.h"
 #include "WasmFaultSignalHandler.h"
 #include "WasmIRGeneratorHelpers.h"
@@ -175,8 +174,10 @@ void OMGPlan::work()
         callee->setEntrypoint(WTF::move(omgEntrypoint), WTF::move(unlinkedCalls), WTF::move(internalFunction->stackmaps), WTF::move(internalFunction->exceptionHandlers), WTF::move(exceptionHandlerLocations));
         entrypoint = callee->entrypoint();
 
-        if (samplingProfilerMap)
-            NativeCalleeRegistry::singleton().addPCToCodeOriginMap(callee.ptr(), WTF::move(samplingProfilerMap));
+        if (samplingProfilerMap) {
+            WTF::storeStoreFence();
+            callee->setPCToCodeOriginMap(WTF::move(samplingProfilerMap));
+        }
 
         Locker locker { m_calleeGroup->m_lock };
         newlyInstalled = m_calleeGroup->installOptimizedCallee(locker, m_moduleInformation, m_functionIndex, callee.copyRef(), internalFunction->outgoingJITDirectCallees);

--- a/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
@@ -30,7 +30,6 @@
 
 #include "JITCompilation.h"
 #include "LinkBuffer.h"
-#include "NativeCalleeRegistry.h"
 #include "WasmCallee.h"
 #include "WasmFaultSignalHandler.h"
 #include "WasmIRGeneratorHelpers.h"
@@ -144,8 +143,10 @@ void OSREntryPlan::work()
     ASSERT(m_calleeGroup.ptr() == m_module->calleeGroupFor(mode()));
     callee->setEntrypoint(WTF::move(omgEntrypoint), internalFunction->osrEntryScratchBufferSize, WTF::move(unlinkedCalls), WTF::move(internalFunction->stackmaps), WTF::move(internalFunction->exceptionHandlers), WTF::move(exceptionHandlerLocations));
 
-    if (samplingProfilerMap)
-        NativeCalleeRegistry::singleton().addPCToCodeOriginMap(callee.ptr(), WTF::move(samplingProfilerMap));
+    if (samplingProfilerMap) {
+        WTF::storeStoreFence();
+        callee->setPCToCodeOriginMap(WTF::move(samplingProfilerMap));
+    }
 
     {
         Locker locker { m_calleeGroup->m_lock };


### PR DESCRIPTION
#### 52a97217691976f5ac23bdb1236caf0878bc6f3d
<pre>
[JSC] Avoid repeated lock contension due to NativeCalleeRegistry registration
<a href="https://bugs.webkit.org/show_bug.cgi?id=312082">https://bugs.webkit.org/show_bug.cgi?id=312082</a>
<a href="https://rdar.apple.com/174588184">rdar://174588184</a>

Reviewed by Keith Miller.

We found that IPIntCallee&apos;s registration is taking huge lock contension.
But its entrypoint generation is no longer costly as we use the shared
thunk. We should avoid doing these registration from the multiple thread
concurrently, and do them in a batched style when finalizing all callees
at the end. Also we should have Box&lt;PCToCodeOriginMap&gt; in
OptimizingJITCallee instead of having it in NativeCalleeRegistry.

* Source/JavaScriptCore/runtime/NativeCalleeRegistry.h:
(JSC::NativeCalleeRegistry::registerCallees):
(JSC::NativeCalleeRegistry::unregisterCallee):
(JSC::NativeCalleeRegistry::addPCToCodeOriginMap): Deleted.
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::FrameWalker::recordJITFrame):
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::work):
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::Callee::pcToCodeOriginMap const):
(JSC::Wasm::IPIntCallee::setEntrypointWithoutRegistration):
* Source/JavaScriptCore/wasm/WasmCallee.h:
(JSC::Wasm::Callee::pcToCodeOriginMapImpl const):
(JSC::Wasm::OptimizingJITCallee::pcToCodeOriginMapImpl const):
(JSC::Wasm::OptimizingJITCallee::setPCToCodeOriginMap):
* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
(JSC::Wasm::IPIntPlan::compileFunction):
(JSC::Wasm::IPIntPlan::didCompleteCompilation):
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:
(JSC::Wasm::OMGPlan::work):
* Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp:
(JSC::Wasm::OSREntryPlan::work):

Canonical link: <a href="https://commits.webkit.org/311037@main">https://commits.webkit.org/311037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae8ef5ea4396d3b611b28a665bf27b298ead976b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22273 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164618 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28964 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120649 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158813 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22834 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139963 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101338 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21919 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20061 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12448 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147904 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131588 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17795 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167098 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16686 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11272 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19406 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128769 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28658 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128902 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139588 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86441 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23733 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23722 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16387 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187739 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28276 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92379 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48270 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27853 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28083 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27926 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->