### PR TITLE
-webkit-box-pack should account for box-direction and handle overflow repositioning

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -871,8 +871,6 @@ imported/w3c/web-platform-tests/compat/webkit-box-fieldset.html [ ImageOnlyFailu
 imported/w3c/web-platform-tests/compat/webkit-box-rtl-flex.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/compat/webkit-text-fill-color-property-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/compat/webkit-text-fill-color-property-005.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/compat/webkit-box-horizontal-rtl-variants.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/compat/webkit-box-horizontal-reverse-variants.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/encoding/eof-utf-8-one.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/encoding/eof-utf-8-three.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/encoding/eof-utf-8-two.html [ ImageOnlyFailure ]

--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -878,8 +878,6 @@ imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-
 
 # Newly imported WPT ref tests failures.
 imported/w3c/web-platform-tests/compat/webkit-box-rtl-flex.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/compat/webkit-box-horizontal-rtl-variants.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/compat/webkit-box-horizontal-reverse-variants.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/browsers/windows/iframe-cross-origin-scaled-print.sub.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/browsers/windows/iframe-cross-origin-print.sub.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/fieldset-border-gap-negative-margin.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/glib/fast/flexbox/017-expected.txt
+++ b/LayoutTests/platform/glib/fast/flexbox/017-expected.txt
@@ -42,19 +42,19 @@ layer at (0,0) size 800x600
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "1"
         RenderDeprecatedFlexibleBox {DIV} at (0,76) size 784x38
-          RenderBlock {DIV} at (4,4) size 20x30 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (648,4) size 20x30 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "1"
-          RenderBlock {DIV} at (32,4) size 20x30 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (676,4) size 20x30 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "2"
-          RenderBlock {DIV} at (60,4) size 20x30 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (704,4) size 20x30 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "3"
-          RenderBlock {DIV} at (88,4) size 20x30 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (732,4) size 20x30 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "4"
-          RenderBlock {DIV} at (116,4) size 20x30 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (760,4) size 20x30 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "5"
         RenderDeprecatedFlexibleBox {DIV} at (0,114) size 784x38
@@ -74,18 +74,18 @@ layer at (0,0) size 800x600
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "5"
         RenderDeprecatedFlexibleBox {DIV} at (0,152) size 784x38
-          RenderBlock {DIV} at (60,4) size 20x30 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (704,4) size 20x30 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "3"
-          RenderBlock {DIV} at (4,4) size 20x30 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (648,4) size 20x30 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "1"
-          RenderBlock {DIV} at (88,4) size 20x30 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (732,4) size 20x30 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "4"
-          RenderBlock {DIV} at (32,4) size 20x30 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (676,4) size 20x30 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "2"
-          RenderBlock {DIV} at (116,4) size 20x30 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (760,4) size 20x30 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "5"

--- a/LayoutTests/platform/ios/fast/flexbox/017-expected.txt
+++ b/LayoutTests/platform/ios/fast/flexbox/017-expected.txt
@@ -42,19 +42,19 @@ layer at (0,0) size 800x600
             RenderText {#text} at (6,6) size 8x20
               text run at (6,6) width 8: "1"
         RenderDeprecatedFlexibleBox {DIV} at (0,80) size 784x40
-          RenderBlock {DIV} at (4,4) size 20x32 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (648,4) size 20x32 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x20
               text run at (6,6) width 8: "1"
-          RenderBlock {DIV} at (32,4) size 20x32 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (676,4) size 20x32 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x20
               text run at (6,6) width 8: "2"
-          RenderBlock {DIV} at (60,4) size 20x32 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (704,4) size 20x32 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x20
               text run at (6,6) width 8: "3"
-          RenderBlock {DIV} at (88,4) size 20x32 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (732,4) size 20x32 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x20
               text run at (6,6) width 8: "4"
-          RenderBlock {DIV} at (116,4) size 20x32 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (760,4) size 20x32 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x20
               text run at (6,6) width 8: "5"
         RenderDeprecatedFlexibleBox {DIV} at (0,120) size 784x40
@@ -74,18 +74,18 @@ layer at (0,0) size 800x600
             RenderText {#text} at (6,6) size 8x20
               text run at (6,6) width 8: "5"
         RenderDeprecatedFlexibleBox {DIV} at (0,160) size 784x40
-          RenderBlock {DIV} at (60,4) size 20x32 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (704,4) size 20x32 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x20
               text run at (6,6) width 8: "3"
-          RenderBlock {DIV} at (4,4) size 20x32 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (648,4) size 20x32 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x20
               text run at (6,6) width 8: "1"
-          RenderBlock {DIV} at (88,4) size 20x32 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (732,4) size 20x32 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x20
               text run at (6,6) width 8: "4"
-          RenderBlock {DIV} at (32,4) size 20x32 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (676,4) size 20x32 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x20
               text run at (6,6) width 8: "2"
-          RenderBlock {DIV} at (116,4) size 20x32 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (760,4) size 20x32 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x20
               text run at (6,6) width 8: "5"

--- a/LayoutTests/platform/mac/fast/flexbox/017-expected.txt
+++ b/LayoutTests/platform/mac/fast/flexbox/017-expected.txt
@@ -42,19 +42,19 @@ layer at (0,0) size 800x600
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "1"
         RenderDeprecatedFlexibleBox {DIV} at (0,76) size 784x38
-          RenderBlock {DIV} at (4,4) size 20x30 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (648,4) size 20x30 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "1"
-          RenderBlock {DIV} at (32,4) size 20x30 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (676,4) size 20x30 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "2"
-          RenderBlock {DIV} at (60,4) size 20x30 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (704,4) size 20x30 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "3"
-          RenderBlock {DIV} at (88,4) size 20x30 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (732,4) size 20x30 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "4"
-          RenderBlock {DIV} at (116,4) size 20x30 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (760,4) size 20x30 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "5"
         RenderDeprecatedFlexibleBox {DIV} at (0,114) size 784x38
@@ -74,18 +74,18 @@ layer at (0,0) size 800x600
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "5"
         RenderDeprecatedFlexibleBox {DIV} at (0,152) size 784x38
-          RenderBlock {DIV} at (60,4) size 20x30 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (704,4) size 20x30 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "3"
-          RenderBlock {DIV} at (4,4) size 20x30 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (648,4) size 20x30 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "1"
-          RenderBlock {DIV} at (88,4) size 20x30 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (732,4) size 20x30 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "4"
-          RenderBlock {DIV} at (32,4) size 20x30 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (676,4) size 20x30 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "2"
-          RenderBlock {DIV} at (116,4) size 20x30 [border: (2px solid #000000)]
+          RenderBlock {DIV} at (760,4) size 20x30 [border: (2px solid #000000)]
             RenderText {#text} at (6,6) size 8x18
               text run at (6,6) width 8: "5"

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -670,52 +670,57 @@ void RenderDeprecatedFlexibleBox::layoutHorizontalBox(RelayoutChildren relayoutC
 
     endAndCommitUpdateScrollInfoAfterLayoutTransaction();
 
-    if (remainingSpace > 0 && ((style().writingMode().deprecatedIsLeftToRightDirection() && style().boxPack() != BoxPack::Start)
-        || (!style().writingMode().deprecatedIsLeftToRightDirection() && style().boxPack() != BoxPack::End))) {
-        // Children must be repositioned.
-        LayoutUnit offset;
-        if (style().boxPack() == BoxPack::Justify) {
-            // Determine the total number of children.
-            int totalChildren = 0;
-            for (RenderBox* child = iterator.first(); child; child = iterator.next()) {
-                if (childDoesNotAffectWidthOrFlexing(child))
-                    continue;
-                ++totalChildren;
-            }
+    // Account for box-direction: reverse flipping the effective main-axis direction.
+    bool isEffectiveLTR = style().writingMode().deprecatedIsLeftToRightDirection();
+    if (style().boxOrient() == BoxOrient::Horizontal && style().boxDirection() == BoxDirection::Reverse)
+        isEffectiveLTR = !isEffectiveLTR;
 
-            // Iterate over the children and space them out according to the
-            // justification level.
-            if (totalChildren > 1) {
-                --totalChildren;
-                bool firstChild = true;
-                for (RenderBox* child = iterator.first(); child; child = iterator.next()) {
-                    if (childDoesNotAffectWidthOrFlexing(child))
-                        continue;
-
-                    if (firstChild) {
-                        firstChild = false;
-                        continue;
-                    }
-
-                    offset += remainingSpace/totalChildren;
-                    remainingSpace -= (remainingSpace/totalChildren);
-                    --totalChildren;
-
-                    placeChild(child, child->location() + LayoutSize(offset, 0_lu));
-                }
-            }
-        } else {
-            if (style().boxPack() == BoxPack::Center)
-                offset += remainingSpace / 2;
-            else // BoxPack::End for LTR, BoxPack::Start for RTL
-                offset += remainingSpace;
-            for (RenderBox* child = iterator.first(); child; child = iterator.next()) {
-                if (childDoesNotAffectWidthOrFlexing(child))
-                    continue;
-
-                placeChild(child, child->location() + LayoutSize(offset, 0_lu));
-            }
+    auto forEachFlexChild = [&](auto callback) {
+        for (auto* child = iterator.first(); child; child = iterator.next()) {
+            if (!childDoesNotAffectWidthOrFlexing(child))
+                callback(*child);
         }
+    };
+
+    auto offsetChildren = [&](LayoutUnit offset) {
+        if (!offset)
+            return;
+        forEachFlexChild([&](RenderBox& child) {
+            placeChild(&child, child.location() + LayoutSize(offset, 0_lu));
+        });
+    };
+
+    if (style().boxPack() == BoxPack::Justify && remainingSpace > 0) {
+        // Children must be repositioned.
+        // Determine the total number of children.
+        int totalChildren = 0;
+        forEachFlexChild([&](auto&) { ++totalChildren; });
+
+        // Iterate over the children and space them out according to the
+        // justification level.
+        if (totalChildren > 1) {
+            --totalChildren;
+            LayoutUnit offset;
+            bool firstChild = true;
+            forEachFlexChild([&](RenderBox& child) {
+                if (firstChild) {
+                    firstChild = false;
+                    return;
+                }
+                offset += remainingSpace / totalChildren;
+                remainingSpace -= (remainingSpace / totalChildren);
+                --totalChildren;
+                placeChild(&child, child.location() + LayoutSize(offset, 0_lu));
+            });
+        }
+    } else {
+        LayoutUnit offset;
+        if (style().boxPack() == BoxPack::Center)
+            offset += remainingSpace / 2;
+        else if ((isEffectiveLTR && style().boxPack() == BoxPack::End)
+            || (!isEffectiveLTR && style().boxPack() != BoxPack::End))
+            offset += remainingSpace;
+        offsetChildren(offset);
     }
 
     // So that the computeLogicalHeight in layoutBlock() knows to relayout positioned objects because of

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -693,52 +693,57 @@ void RenderDeprecatedFlexibleBox::layoutHorizontalBox(RelayoutChildren relayoutC
 
     endAndCommitUpdateScrollInfoAfterLayoutTransaction();
 
-    if (remainingSpace > 0 && ((style().writingMode().deprecatedIsLeftToRightDirection() && style().boxPack() != BoxPack::Start)
-        || (!style().writingMode().deprecatedIsLeftToRightDirection() && style().boxPack() != BoxPack::End))) {
-        // Children must be repositioned.
-        LayoutUnit offset;
-        if (style().boxPack() == BoxPack::Justify) {
-            // Determine the total number of children.
-            int totalChildren = 0;
-            for (RenderBox* child = iterator.first(); child; child = iterator.next()) {
-                if (childDoesNotAffectWidthOrFlexing(child))
-                    continue;
-                ++totalChildren;
-            }
+    // Account for box-direction: reverse flipping the effective main-axis direction.
+    bool isEffectiveLTR = style().writingMode().deprecatedIsLeftToRightDirection();
+    if (style().boxOrient() == BoxOrient::Horizontal && style().boxDirection() == BoxDirection::Reverse)
+        isEffectiveLTR = !isEffectiveLTR;
 
-            // Iterate over the children and space them out according to the
-            // justification level.
-            if (totalChildren > 1) {
-                --totalChildren;
-                bool firstChild = true;
-                for (RenderBox* child = iterator.first(); child; child = iterator.next()) {
-                    if (childDoesNotAffectWidthOrFlexing(child))
-                        continue;
-
-                    if (firstChild) {
-                        firstChild = false;
-                        continue;
-                    }
-
-                    offset += remainingSpace/totalChildren;
-                    remainingSpace -= (remainingSpace/totalChildren);
-                    --totalChildren;
-
-                    placeChild(child, child->location() + LayoutSize(offset, 0_lu));
-                }
-            }
-        } else {
-            if (style().boxPack() == BoxPack::Center)
-                offset += remainingSpace / 2;
-            else // BoxPack::End for LTR, BoxPack::Start for RTL
-                offset += remainingSpace;
-            for (RenderBox* child = iterator.first(); child; child = iterator.next()) {
-                if (childDoesNotAffectWidthOrFlexing(child))
-                    continue;
-
-                placeChild(child, child->location() + LayoutSize(offset, 0_lu));
-            }
+    auto forEachFlexChild = [&](auto callback) {
+        for (auto* child = iterator.first(); child; child = iterator.next()) {
+            if (!childDoesNotAffectWidthOrFlexing(child))
+                callback(*child);
         }
+    };
+
+    auto offsetChildren = [&](LayoutUnit offset) {
+        if (!offset)
+            return;
+        forEachFlexChild([&](RenderBox& child) {
+            placeChild(&child, child.location() + LayoutSize(offset, 0_lu));
+        });
+    };
+
+    if (style().boxPack() == BoxPack::Justify && remainingSpace > 0) {
+        // Children must be repositioned.
+        // Determine the total number of children.
+        int totalChildren = 0;
+        forEachFlexChild([&](auto&) { ++totalChildren; });
+
+        // Iterate over the children and space them out according to the
+        // justification level.
+        if (totalChildren > 1) {
+            --totalChildren;
+            LayoutUnit offset;
+            bool firstChild = true;
+            forEachFlexChild([&](RenderBox& child) {
+                if (firstChild) {
+                    firstChild = false;
+                    return;
+                }
+                offset += remainingSpace / totalChildren;
+                remainingSpace -= (remainingSpace / totalChildren);
+                --totalChildren;
+                placeChild(&child, child.location() + LayoutSize(offset, 0_lu));
+            });
+        }
+    } else {
+        LayoutUnit offset;
+        if (style().boxPack() == BoxPack::Center)
+            offset += remainingSpace / 2;
+        else if ((isEffectiveLTR && style().boxPack() == BoxPack::End)
+            || (!isEffectiveLTR && style().boxPack() != BoxPack::End))
+            offset += remainingSpace;
+        offsetChildren(offset);
     }
 
     // So that the computeLogicalHeight in layoutBlock() knows to relayout positioned objects because of


### PR DESCRIPTION
#### f6303b938e85b46bd48834bea4f78396fdf12225
<pre>
-webkit-box-pack should account for box-direction and handle overflow repositioning
<a href="https://bugs.webkit.org/show_bug.cgi?id=312084">https://bugs.webkit.org/show_bug.cgi?id=312084</a>
<a href="https://rdar.apple.com/174588996">rdar://174588996</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

The box-pack alignment logic in layoutHorizontalBox() used the writing
direction directly without considering box-direction: reverse, causing
start/end to resolve to the wrong side. It also gated all repositioning
on remainingSpace &gt; 0, so overflowing content in RTL or reversed boxes
was never shifted to the correct edge or centered.

Compute an effective LTR flag that flips when box-direction is reverse,
and allow center/end offsets to apply with negative remainingSpace so
overflow content is positioned correctly.

* LayoutTests/TestExpectations: Progressions
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp:
(WebCore::RenderDeprecatedFlexibleBox::layoutHorizontalBox):

&gt; Rebaselines (now match other browsers):
* LayoutTests/platform/glib/fast/flexbox/017-expected.txt:
* LayoutTests/platform/ios/fast/flexbox/017-expected.txt:
* LayoutTests/platform/mac/fast/flexbox/017-expected.txt:

Canonical link: <a href="https://commits.webkit.org/313862@main">https://commits.webkit.org/313862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce123232deb7d61a32e115bab047ed86249fdb7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171407 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118914 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f356f9c2-cb6e-4acd-a744-d06c449cc44e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36049 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126085 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88831 "1 flakes 18 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28430 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146037 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106663 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27476 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26002 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19107 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137180 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173911 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21224 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134392 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35619 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30093 "Found 1 new test failure: http/tests/ssl/applepay/ApplePayButton.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134391 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36633 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35603 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145563 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97862 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28929 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22397 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35112 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102864 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34614 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/420 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34859 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34762 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->