### PR TITLE
Disallow vendor-prefixed and allow other properties in highlight pseudo-elements

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -869,7 +869,6 @@ imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-to-prefetch-
 # Newly imported WPT ref tests failures.
 imported/w3c/web-platform-tests/compat/webkit-box-fieldset.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/compat/webkit-box-rtl-flex.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/compat/webkit-text-fill-color-property-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/compat/webkit-text-fill-color-property-005.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/compat/webkit-box-horizontal-rtl-variants.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/compat/webkit-box-horizontal-reverse-variants.html [ ImageOnlyFailure ]
@@ -3739,7 +3738,6 @@ imported/w3c/web-platform-tests/css/css-pseudo/target-text-004.html [ ImageOnlyF
 imported/w3c/web-platform-tests/css/css-pseudo/target-text-005.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/target-text-009.html [ ImageOnlyFailure ]
 # Incorrect test, needs WPT resync (webkit.org/b/277692)
-imported/w3c/web-platform-tests/css/css-pseudo/target-text-dynamic-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/selection-background-painting-order.html [ ImageOnlyFailure ]
 
 # We failed to text-decorate for pseudo selectors (This has always failed, we were just not able to render the expected correctly)
@@ -7983,7 +7981,6 @@ imported/w3c/web-platform-tests/svg/shapes/rect-03.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-003.svg [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/css/css-pseudo/first-line-line-height-003.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-pseudo/highlight-styling-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/relative-box-order-of-pseudo-elements.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/css/css-break/background-image-004.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-cascade-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-cascade-007-expected.txt
@@ -2,16 +2,16 @@ M
 W
 U
 
-FAIL M::selection’s font-size is the same as in M assert_equals: expected "12px" but got "42px"
-FAIL M span::selection’s font-size is the same as in M span assert_equals: expected "18px" but got "42px"
-FAIL M::selection’s own text-shadow respects M’s font-size assert_equals: expected "rgb(0, 128, 0) 12px 0px 0px" but got "rgb(0, 128, 0) 42px 0px 0px"
+PASS M::selection’s font-size is the same as in M
+PASS M span::selection’s font-size is the same as in M span
+PASS M::selection’s own text-shadow respects M’s font-size
 FAIL M span::selection’s inherited text-shadow respects M’s font-size assert_equals: expected "rgb(0, 128, 0) 12px 0px 0px" but got "none"
-FAIL W::selection’s line-height is the same as in W assert_equals: expected "13px" but got "43px"
-FAIL W span::selection’s line-height is the same as in W span assert_equals: expected "19px" but got "43px"
-FAIL W::selection’s own text-shadow respects W’s line-height assert_equals: expected "rgb(0, 128, 0) 0px 13px 0px" but got "rgb(0, 128, 0) 0px 43px 0px"
+PASS W::selection’s line-height is the same as in W
+PASS W span::selection’s line-height is the same as in W span
+PASS W::selection’s own text-shadow respects W’s line-height
 FAIL W span::selection’s inherited text-shadow respects W’s line-height assert_equals: expected "rgb(0, 128, 0) 0px 13px 0px" but got "none"
-FAIL U::selection’s font-size is the same as in U assert_equals: expected "12px" but got "42px"
-FAIL U span::selection’s font-size is the same as in U span assert_equals: expected "18px" but got "42px"
-FAIL U::selection’s own text-decoration-thickness respects U’s font-size assert_equals: expected "12px" but got "42px"
-FAIL U span::selection’s own text-decoration-thickness respects U span’s font-size assert_equals: expected "18px" but got "42px"
+PASS U::selection’s font-size is the same as in U
+PASS U span::selection’s font-size is the same as in U span
+PASS U::selection’s own text-decoration-thickness respects U’s font-size
+PASS U span::selection’s own text-decoration-thickness respects U span’s font-size
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3872,6 +3872,7 @@ webkit.org/b/243690 imported/w3c/web-platform-tests/html/cross-origin-opener-pol
 imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-paired-cascade-005.html [ Pass ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-cascade-008.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-pseudo/highlight-styling-001.html [ Pass ]
+imported/w3c/web-platform-tests/css/css-pseudo/highlight-styling-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/highlight-styling-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/highlight-custom-properties-dynamic-001.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-pseudo/input-element-pseudo-open-click.optional.html [ Skip ]

--- a/Source/WebCore/style/PropertyAllowlist.cpp
+++ b/Source/WebCore/style/PropertyAllowlist.cpp
@@ -31,9 +31,46 @@ namespace Style {
 
 PropertyAllowlist propertyAllowlistForPseudoElement(PseudoElementType type)
 {
-    if (type == PseudoElementType::Marker)
+    switch (type) {
+    case PseudoElementType::GrammarError:
+    case PseudoElementType::Highlight:
+    case PseudoElementType::Selection:
+    case PseudoElementType::SpellingError:
+    case PseudoElementType::TargetText:
+        return PropertyAllowlist::Highlight;
+    case PseudoElementType::Marker:
         return PropertyAllowlist::Marker;
-    return PropertyAllowlist::None;
+    default:
+        return PropertyAllowlist::None;
+    }
+}
+
+// https://drafts.csswg.org/css-pseudo-4/#highlight-styling
+bool isValidHighlightStyleProperty(CSSPropertyID id)
+{
+    switch (id) {
+    case CSSPropertyBackgroundColor:
+    case CSSPropertyColor:
+    case CSSPropertyCustom:
+    case CSSPropertyFill:
+    case CSSPropertyStroke:
+    case CSSPropertyStrokeColor:
+    case CSSPropertyStrokeWidth:
+    case CSSPropertyTextDecoration:
+    case CSSPropertyTextDecorationColor:
+    case CSSPropertyTextDecorationLine:
+    case CSSPropertyTextDecorationSkip:
+    case CSSPropertyTextDecorationSkipInk:
+    case CSSPropertyTextDecorationStyle:
+    case CSSPropertyTextDecorationThickness:
+    case CSSPropertyTextShadow:
+    case CSSPropertyTextUnderlineOffset:
+    case CSSPropertyTextUnderlinePosition:
+        return true;
+    default:
+        break;
+    }
+    return false;
 }
 
 // https://drafts.csswg.org/css-lists-3/#marker-properties (Editor's Draft, 14 July 2021)

--- a/Source/WebCore/style/PropertyAllowlist.h
+++ b/Source/WebCore/style/PropertyAllowlist.h
@@ -40,10 +40,12 @@ enum class PropertyAllowlist : uint8_t {
     CueSelector,
     CueBackground,
 #endif
+    Highlight,
 };
 
 PropertyAllowlist NODELETE propertyAllowlistForPseudoElement(PseudoElementType);
 
+bool NODELETE isValidHighlightStyleProperty(CSSPropertyID);
 bool NODELETE isValidMarkerStyleProperty(CSSPropertyID);
 #if ENABLE(VIDEO)
 bool NODELETE isValidCueStyleProperty(CSSPropertyID);

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -295,6 +295,8 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Origi
 #endif
             if (propertyAllowlist == PropertyAllowlist::Marker && !isValidMarkerStyleProperty(propertyID))
                 return false;
+            if (propertyAllowlist == PropertyAllowlist::Highlight && !isValidHighlightStyleProperty(propertyID))
+                return false;
 
             if (m_includedProperties.types.containsAll(normalPropertyTypes()))
                 return true;

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -88,19 +88,31 @@ static inline MatchBasedOnRuleHash NODELETE computeMatchBasedOnRuleHash(const CS
 static inline PropertyAllowlist determinePropertyAllowlist(const CSSSelector& selector)
 {
     for (const CSSSelector* component = &selector; component; component = component->precedingInComplexSelector()) {
+        if (component->match() == CSSSelector::Match::PseudoElement) {
+            switch (component->pseudoElement()) {
+            case CSSSelector::PseudoElement::GrammarError:
+            case CSSSelector::PseudoElement::Highlight:
+            case CSSSelector::PseudoElement::Selection:
+            case CSSSelector::PseudoElement::SpellingError:
+            case CSSSelector::PseudoElement::TargetText:
+                return PropertyAllowlist::Highlight;
+            case CSSSelector::PseudoElement::Marker:
+                return PropertyAllowlist::Marker;
 #if ENABLE(VIDEO)
-        // Property allow-list for `::cue`:
-        if (component->match() == CSSSelector::Match::PseudoElement && component->pseudoElement() == CSSSelector::PseudoElement::UserAgentPart && component->value() == UserAgentParts::cue())
-            return PropertyAllowlist::Cue;
-        // Property allow-list for `::cue(selector)`:
-        if (component->match() == CSSSelector::Match::PseudoElement && component->pseudoElement() == CSSSelector::PseudoElement::Cue)
-            return PropertyAllowlist::CueSelector;
-        // Property allow-list for '::-internal-cue-background':
-        if (component->match() == CSSSelector::Match::PseudoElement && component->pseudoElement() == CSSSelector::PseudoElement::UserAgentPart && component->value() == UserAgentParts::internalCueBackground())
-            return PropertyAllowlist::CueBackground;
+            case CSSSelector::PseudoElement::UserAgentPart:
+                if (component->value() == UserAgentParts::cue())
+                    return PropertyAllowlist::Cue;
+                // Property allow-list for '::-internal-cue-background':
+                if (component->value() == UserAgentParts::internalCueBackground())
+                    return PropertyAllowlist::CueBackground;
+                break;
+            case CSSSelector::PseudoElement::Cue:
+                return PropertyAllowlist::CueSelector;
 #endif
-        if (component->match() == CSSSelector::Match::PseudoElement && component->pseudoElement() == CSSSelector::PseudoElement::Marker)
-            return propertyAllowlistForPseudoElement(PseudoElementType::Marker);
+            default:
+                break;
+            }
+        }
 
         if (const auto* selectorList = selector.selectorList()) {
             for (auto& subSelector : *selectorList) {

--- a/Source/WebCore/style/RuleData.h
+++ b/Source/WebCore/style/RuleData.h
@@ -81,7 +81,7 @@ private:
     unsigned m_matchBasedOnRuleHash : 3;
     unsigned m_canMatchPseudoElement : 1;
     unsigned m_linkMatchType : 2; //  SelectorChecker::LinkMatchMask
-    unsigned m_propertyAllowlist : 2;
+    unsigned m_propertyAllowlist : 3;
     unsigned m_isStartingStyle : 1;
     unsigned m_isEnabled : 1;
     // If we have more rules than 2^bitcount here we'll get confused about rule order.


### PR DESCRIPTION
#### a30d9c11bed7b232815b694f5a1867c97abcc9b8
<pre>
Disallow vendor-prefixed and allow other properties in highlight pseudo-elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=312085">https://bugs.webkit.org/show_bug.cgi?id=312085</a>
<a href="https://rdar.apple.com/174590593">rdar://174590593</a>

Reviewed by Antti Koivisto.

The CSS Pseudo 4 spec [1] states that vendor-prefixed properties such as
-webkit-text-fill-color are not applicable to highlight pseudo-elements.

This adds a PropertyAllowlist for highlight pseudos (::selection,
::highlight(), ::spelling-error, ::grammar-error, ::target-text) with
the spec-defined set of applicable properties: color, background-color,
text-decoration and sub-properties, text-shadow, stroke-color,
stroke-width, and custom properties.

Also consolidates propertyAllowlistForPseudoElement() and
determinePropertyAllowlist() to use switch statements instead of
repeated if-chains.

[1] <a href="https://drafts.csswg.org/css-pseudo-4/#highlight-styling">https://drafts.csswg.org/css-pseudo-4/#highlight-styling</a>

* LayoutTests/TestExpectations: Progressions
* LayoutTests/platform/ios/TestExpectations: Skip Test on iOS
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-cascade/highlight-cascade-007-expected.txt: Ditto
* Source/WebCore/style/PropertyAllowlist.cpp:
(WebCore::Style::propertyAllowlistForPseudoElement):
(WebCore::Style::isValidHighlightStyleProperty):
* Source/WebCore/style/PropertyAllowlist.h:
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::addMatch):
* Source/WebCore/style/RuleData.cpp:
(WebCore::Style::determinePropertyAllowlist):
* Source/WebCore/style/RuleData.h:

Canonical link: <a href="https://commits.webkit.org/311073@main">https://commits.webkit.org/311073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c63fccb41aa6309e312f0492e97bebdf186bd9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22437 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164682 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109734 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120703 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85028 "2 flakes 3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22900 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140022 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101392 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21980 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20120 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12512 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131649 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17854 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167162 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11336 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19465 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128824 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28856 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24163 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128956 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34941 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28778 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139648 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86521 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23777 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16446 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28487 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92443 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28014 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28242 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28138 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->