### PR TITLE
Element.blur() on iframe should reset document.activeElement to body

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/focus/activeelement-after-focusing-different-site-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/focus/activeelement-after-focusing-different-site-iframe-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Check trailing events
-FAIL Check result assert_equals: Check log expected "outeronload,activeElement:BODY,willfocusiframe,didfocusiframe,activeElement:IFRAME,willbluriframe,didbluriframe,activeElement:BODY,willspineventloop,innerbodyfocus,innerbodyblur," but got "outeronload,activeElement:BODY,willfocusiframe,didfocusiframe,activeElement:IFRAME,willbluriframe,didbluriframe,activeElement:IFRAME,willspineventloop,innerbodyfocus,"
+PASS Check result
 

--- a/LayoutTests/imported/w3c/web-platform-tests/focus/activeelement-after-focusing-same-site-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/focus/activeelement-after-focusing-same-site-iframe-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Check trailing events
-FAIL Check result assert_equals: Check log expected "outeronload,activeElement:BODY,willfocusiframe,didfocusiframe,activeElement:IFRAME,willbluriframe,didbluriframe,activeElement:BODY,willspineventloop,innerbodyfocus,innerbodyblur," but got "outeronload,activeElement:BODY,willfocusiframe,didfocusiframe,activeElement:IFRAME,willbluriframe,didbluriframe,activeElement:IFRAME,willspineventloop,innerbodyfocus,"
+PASS Check result
 

--- a/LayoutTests/imported/w3c/web-platform-tests/focus/activeelement-after-immediately-focusing-different-site-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/focus/activeelement-after-immediately-focusing-different-site-iframe-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Check result assert_equals: Check log expected "outerparser,activeElement:BODY,willfocusiframe,didfocusiframe,activeElement:IFRAME,willbluriframe,didbluriframe,activeElement:BODY,willspineventloop," but got "outerparser,activeElement:BODY,willfocusiframe,didfocusiframe,activeElement:IFRAME,willbluriframe,didbluriframe,activeElement:IFRAME,willspineventloop,"
+PASS Check result
 

--- a/LayoutTests/imported/w3c/web-platform-tests/focus/activeelement-after-immediately-focusing-same-site-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/focus/activeelement-after-immediately-focusing-same-site-iframe-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Check result assert_equals: Check log expected "outerparse,activeElement:BODY,willfocusiframe,didfocusiframe,activeElement:IFRAME,willbluriframe,didbluriframe,activeElement:BODY,willspineventloop," but got "outerparse,activeElement:BODY,willfocusiframe,didfocusiframe,activeElement:IFRAME,willbluriframe,didbluriframe,activeElement:IFRAME,willspineventloop,"
+PASS Check result
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/focus/activeelement-after-focusing-different-site-iframe-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/focus/activeelement-after-focusing-different-site-iframe-expected.txt
@@ -1,4 +1,0 @@
-
-PASS Check trailing events
-FAIL Check result assert_equals: Check log expected "outeronload,activeElement:BODY,willfocusiframe,didfocusiframe,activeElement:IFRAME,willbluriframe,didbluriframe,activeElement:BODY,willspineventloop,innerbodyfocus,innerbodyblur," but got "outeronload,activeElement:BODY,willfocusiframe,didfocusiframe,activeElement:IFRAME,willbluriframe,didbluriframe,activeElement:IFRAME,willspineventloop,innerbodyfocus,"
-

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -1144,8 +1144,15 @@ bool FocusController::setFocusedElement(Element* element, Frame* newFocusedFrame
     RefPtr oldFocusedElement = oldDocument ? oldDocument->focusedElement() : nullptr;
     Ref page = m_page.get();
     if (oldFocusedElement == element) {
-        if (element)
+        if (element) {
             page->chrome().client().elementDidRefocus(*element, options);
+            return true;
+        }
+        if (newFocusedLocalFrame) {
+            RefPtr newFocusedDocument = newFocusedLocalFrame->document();
+            if (newFocusedDocument && newFocusedDocument != oldDocument)
+                newFocusedDocument->setFocusedElement(nullptr, broadcast);
+        }
         return true;
     }
 
@@ -1159,6 +1166,11 @@ bool FocusController::setFocusedElement(Element* element, Frame* newFocusedFrame
     if (!element) {
         if (oldDocument)
             oldDocument->setFocusedElement(nullptr, broadcast);
+        if (newFocusedLocalFrame) {
+            RefPtr newFocusedDocument = newFocusedLocalFrame->document();
+            if (newFocusedDocument && newFocusedDocument != oldDocument)
+                newFocusedDocument->setFocusedElement(nullptr, broadcast);
+        }
         page->editorClient().setInputMethodState(nullptr);
         return true;
     }


### PR DESCRIPTION
#### 2a93792734affd5f05cf3ac27009fcac80a3934d
<pre>
Element.blur() on iframe should reset document.activeElement to body
<a href="https://bugs.webkit.org/show_bug.cgi?id=312086">https://bugs.webkit.org/show_bug.cgi?id=312086</a>
<a href="https://rdar.apple.com/174591529">rdar://174591529</a>

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

When calling blur() on a focused iframe element, document.activeElement
should revert to the document body. Instead, it incorrectly remained as
the iframe element.

The bug was in FocusController::setFocusedElement(). When called with
nullptr to clear focus, it used focusedLocalFrame() to find the &quot;old&quot;
document. But after iframe.focus(), the focused frame is the iframe&apos;s
content frame, not the parent frame containing the iframe element. This
caused two problems:

1. An early return when both old and new focused elements were nullptr
 (the content frame&apos;s document had no focused element either), so
 nothing was cleared at all.

2. Even past the early return, the wrong document (inner, not parent)
 would have its focused element cleared.

The fix ensures that when clearing focus, we always clear the focused
element in the old (focused frame&apos;s) document, and additionally clear
it in the new focused frame&apos;s document when it differs. This handles
the iframe blur case — where the new focused frame (parent) differs
from the old focused frame (iframe&apos;s content frame) — while still
correctly clearing focus for elements like PDF annotation dropdowns
in the inner document.

* LayoutTests/imported/w3c/web-platform-tests/focus/activeelement-after-focusing-different-site-iframe-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/focus/activeelement-after-focusing-same-site-iframe-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/focus/activeelement-after-immediately-focusing-different-site-iframe-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/focus/activeelement-after-immediately-focusing-same-site-iframe-expected.txt: Ditto
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/focus/activeelement-after-focusing-different-site-iframe-expected.txt: Removed.
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setFocusedElement):

Canonical link: <a href="https://commits.webkit.org/311452@main">https://commits.webkit.org/311452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a844af6ddd25e66163485c0cfa313437a8d97661

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165793 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111052 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b1cfd457-8f40-4049-818d-b11a4de37c64) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158841 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30309 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121562 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85358 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4a86a118-491f-47d1-a311-ac5d2a24af90) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140957 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102230 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22852 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21087 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13565 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132533 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18785 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168278 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12437 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20405 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129685 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29908 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129793 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35168 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29831 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140579 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87635 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24617 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17383 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29542 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93556 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29064 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29294 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29190 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->