### PR TITLE
[JSC] Always use call-ret based IC

### DIFF
--- a/JSTests/stress/polymorphic-ic-call-ret-exception.js
+++ b/JSTests/stress/polymorphic-ic-call-ret-exception.js
@@ -1,0 +1,69 @@
+// Test that exceptions from getter/setter calls inside polymorphic IC stubs
+// are handled correctly with call/ret dispatch. The makeshiftCatchHandler must
+// properly unwind the call/ret stack overhead before jumping to the FTL exception handler.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("Expected: " + expected + " but got: " + actual);
+}
+
+function shouldThrow(fn, expectedMessage) {
+    let threw = false;
+    try {
+        fn();
+    } catch (e) {
+        threw = true;
+        if (expectedMessage && e.message !== expectedMessage)
+            throw new Error("Expected message: " + expectedMessage + " but got: " + e.message);
+    }
+    if (!threw)
+        throw new Error("Expected to throw but didn't");
+}
+
+// -- Exception from getter in polymorphic IC --
+function getX(o) { return o.x; }
+noInline(getX);
+
+let plain = { x: 1 };
+let plain2 = { x: 2, y: 1 };
+let thrower = { get x() { throw new Error("getter-boom"); } };
+
+for (let iter = 0; iter < 1e5; iter++) {
+    shouldBe(getX(plain), 1);
+    shouldBe(getX(plain2), 2);
+    shouldThrow(() => getX(thrower), "getter-boom");
+}
+
+// Verify state is not corrupted after many exceptions
+shouldBe(getX(plain), 1);
+shouldBe(getX(plain2), 2);
+
+// -- Exception from setter in polymorphic IC --
+function setX(o, v) { o.x = v; }
+noInline(setX);
+
+let setPlain = { x: 0 };
+let setPlain2 = { x: 0, y: 1 };
+let setThrower = { set x(v) { throw new Error("setter-boom"); } };
+
+for (let iter = 0; iter < 1e5; iter++) {
+    setX(setPlain, iter);
+    shouldBe(setPlain.x, iter);
+    setX(setPlain2, iter);
+    shouldBe(setPlain2.x, iter);
+    shouldThrow(() => setX(setThrower, 42), "setter-boom");
+}
+
+// -- Exception from proxy in polymorphic IC --
+function hasKey(o) { return "x" in o; }
+noInline(hasKey);
+
+let hasPlain = { x: 1 };
+let hasPlain2 = { x: 2, y: 1 };
+let proxyThrower = new Proxy({}, { has() { throw new Error("proxy-boom"); } });
+
+for (let iter = 0; iter < 1e5; iter++) {
+    shouldBe(hasKey(hasPlain), true);
+    shouldBe(hasKey(hasPlain2), true);
+    shouldThrow(() => hasKey(proxyThrower), "proxy-boom");
+}

--- a/JSTests/stress/polymorphic-ic-call-ret-getter-setter.js
+++ b/JSTests/stress/polymorphic-ic-call-ret-getter-setter.js
@@ -1,0 +1,56 @@
+// Test that polymorphic IC stubs with getter/setter sub-calls work correctly
+// with call/ret dispatch. The stub must preserve the return address across
+// the getter/setter JS call (via emitDataICPrepareForCall/RestoreAfterCall).
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("Expected: " + expected + " but got: " + actual);
+}
+
+// -- GetById with getter (JS call inside IC stub) --
+function getX(o) { return o.x; }
+noInline(getX);
+
+let plain1 = { x: 100 };
+let plain2 = { x: 200, y: 1 };
+let withGetter = { get x() { return 300; } };
+let proto = { get x() { return 400; } };
+let inheriting = Object.create(proto);
+
+for (let iter = 0; iter < 1e5; iter++) {
+    shouldBe(getX(plain1), 100);
+    shouldBe(getX(plain2), 200);
+    shouldBe(getX(withGetter), 300);
+    shouldBe(getX(inheriting), 400);
+}
+
+// -- PutById with setter (JS call inside IC stub) --
+function setX(o, v) { o.x = v; }
+noInline(setX);
+
+let withSetter = { _x: 0, set x(v) { this._x = v; } };
+let plainSet = { x: 0 };
+let plainSet2 = { x: 0, y: 1 };
+
+for (let iter = 0; iter < 1e5; iter++) {
+    setX(withSetter, iter);
+    shouldBe(withSetter._x, iter);
+    setX(plainSet, iter);
+    shouldBe(plainSet.x, iter);
+    setX(plainSet2, iter);
+    shouldBe(plainSet2.x, iter);
+}
+
+// -- Custom getter (C++ call inside IC stub) --
+function getByteLen(o) { return o.byteLength; }
+noInline(getByteLen);
+
+let ab1 = new ArrayBuffer(10);
+let ab2 = new ArrayBuffer(20);
+let u8 = new Uint8Array(30);
+
+for (let iter = 0; iter < 1e5; iter++) {
+    shouldBe(getByteLen(ab1), 10);
+    shouldBe(getByteLen(ab2), 20);
+    shouldBe(getByteLen(u8), 30);
+}

--- a/JSTests/stress/polymorphic-ic-call-ret.js
+++ b/JSTests/stress/polymorphic-ic-call-ret.js
@@ -1,0 +1,75 @@
+// Test that polymorphic inline cache stubs work correctly with call/ret dispatch.
+// When the IC becomes polymorphic, the slab is rewritten with a call to the compiled stub
+// which returns via ret. This tests the basic get/put/in/delete/instanceof paths.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("Expected: " + expected + " but got: " + actual);
+}
+
+// -- GetById polymorphic --
+function getX(o) { return o.x; }
+noInline(getX);
+
+let shapes = [];
+for (let i = 0; i < 5; i++) {
+    let o = {};
+    for (let j = 0; j < i; j++)
+        o["p" + j] = j;
+    o.x = i * 100;
+    shapes.push(o);
+}
+
+for (let iter = 0; iter < 1e5; iter++) {
+    for (let s of shapes)
+        shouldBe(getX(s), s.x);
+}
+
+// -- PutById polymorphic --
+function putX(o, v) { o.x = v; }
+noInline(putX);
+
+for (let iter = 0; iter < 1e5; iter++) {
+    for (let s of shapes) {
+        putX(s, iter);
+        shouldBe(s.x, iter);
+    }
+}
+
+// -- InById polymorphic --
+function hasX(o) { return "x" in o; }
+noInline(hasX);
+
+let hasShapes = [{ x: 1 }, { x: 2, y: 1 }, { x: 3, y: 1, z: 1 }, { a: 1 }];
+for (let iter = 0; iter < 1e5; iter++) {
+    shouldBe(hasX(hasShapes[0]), true);
+    shouldBe(hasX(hasShapes[1]), true);
+    shouldBe(hasX(hasShapes[2]), true);
+    shouldBe(hasX(hasShapes[3]), false);
+}
+
+// -- DeleteById polymorphic --
+function delX(o) { delete o.x; }
+noInline(delX);
+
+for (let iter = 0; iter < 1e5; iter++) {
+    let o1 = { x: 1 };
+    let o2 = { x: 2, y: 1 };
+    let o3 = { x: 3, y: 1, z: 1 };
+    delX(o1);
+    delX(o2);
+    delX(o3);
+    shouldBe(o1.x, undefined);
+    shouldBe(o2.x, undefined);
+    shouldBe(o3.x, undefined);
+}
+
+// -- InstanceOf polymorphic --
+function isArray(o) { return o instanceof Array; }
+noInline(isArray);
+
+for (let iter = 0; iter < 1e5; iter++) {
+    shouldBe(isArray([]), true);
+    shouldBe(isArray({}), false);
+    shouldBe(isArray(""), false);
+}

--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -3890,6 +3890,26 @@ public:
         cacheFlush(where, sizeof(int));
     }
 
+    static void replaceWithCall(void* where, void* to)
+    {
+        intptr_t offset = (reinterpret_cast<intptr_t>(to) - reinterpret_cast<intptr_t>(where)) >> 2;
+        ASSERT(static_cast<int>(offset) == offset);
+
+#if ENABLE(JUMP_ISLANDS)
+        if (!isInt<26>(offset)) {
+            to = ExecutableAllocator::singleton().getJumpIslandToUsingJITMemcpy(where, to);
+            offset = (std::bit_cast<intptr_t>(to) - std::bit_cast<intptr_t>(where)) >> 2;
+            RELEASE_ASSERT(isInt<26>(offset));
+        }
+#endif
+
+        // BL imm26 — same as B but with link bit set (saves return address in LR).
+        int insn = unconditionalBranchImmediate(true, static_cast<int>(offset));
+        RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(where) == where);
+        performJITMemcpy<jitMemcpyRepatchAtomic>(where, &insn, sizeof(int));
+        cacheFlush(where, sizeof(int));
+    }
+
     static void replaceWithNops(void* where, size_t memoryToFillWithNopsInBytes)
     {
         fillNops<jitMemcpyRepatch>(where, memoryToFillWithNopsInBytes);
@@ -3902,6 +3922,11 @@ public:
     }
 
     static constexpr ptrdiff_t patchableJumpSize()
+    {
+        return 4;
+    }
+
+    static constexpr ptrdiff_t patchableCallSize()
     {
         return 4;
     }

--- a/Source/JavaScriptCore/assembler/ARMv7Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARMv7Assembler.h
@@ -2845,6 +2845,11 @@ public:
         return 10;
     }
 
+    static constexpr ptrdiff_t patchableCallSize()
+    {
+        return 10;
+    }
+
     unsigned debugOffset() { return m_formatter.debugOffset(); }
 
 #if OS(LINUX)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -7414,6 +7414,12 @@ public:
         Assembler::replaceWithJump(instructionStart.dataLocation(), destination.dataLocation());
     }
 
+    template<PtrTag startTag, PtrTag destTag>
+    static void replaceWithCall(CodeLocationLabel<startTag> instructionStart, CodeLocationLabel<destTag> destination)
+    {
+        Assembler::replaceWithCall(instructionStart.dataLocation(), destination.dataLocation());
+    }
+
     template<PtrTag startTag>
     static void replaceWithNops(CodeLocationLabel<startTag> instructionStart, size_t memoryToFillWithNopsInBytes)
     {
@@ -7428,6 +7434,11 @@ public:
     static ptrdiff_t patchableJumpSize()
     {
         return Assembler::patchableJumpSize();
+    }
+
+    static ptrdiff_t patchableCallSize()
+    {
+        return Assembler::patchableCallSize();
     }
 
     RegisterID scratchRegisterForBlinding()

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
@@ -2816,6 +2816,11 @@ public:
         return ARMv7Assembler::patchableJumpSize();
     }
 
+    static ptrdiff_t patchableCallSize()
+    {
+        return ARMv7Assembler::patchableCallSize();
+    }
+
     // Forwards / external control flow operations:
     //
     // This set of jump and conditional branch operations return a Jump

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -4555,6 +4555,12 @@ public:
         X86Assembler::replaceWithJump(instructionStart.taggedPtr(), destination.taggedPtr());
     }
 
+    template<PtrTag startTag, PtrTag destTag>
+    static void replaceWithCall(CodeLocationLabel<startTag> instructionStart, CodeLocationLabel<destTag> destination)
+    {
+        X86Assembler::replaceWithCall(instructionStart.taggedPtr(), destination.taggedPtr());
+    }
+
     template<PtrTag startTag>
     static void replaceWithNops(CodeLocationLabel<startTag> instructionStart, size_t memoryToFillWithNopsInBytes)
     {
@@ -4569,6 +4575,11 @@ public:
     static ptrdiff_t patchableJumpSize()
     {
         return X86Assembler::patchableJumpSize();
+    }
+
+    static ptrdiff_t patchableCallSize()
+    {
+        return X86Assembler::patchableCallSize();
     }
 
     static bool supportsSSE4_1()

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -6458,6 +6458,24 @@ public:
 #endif
     }
 
+    // Same as replaceWithJump but emits CALL rel32 (0xE8) instead of JMP rel32 (0xE9).
+    // After the callee returns, execution resumes at instructionStart + 5 (the instruction after the call).
+    static void replaceWithCall(void* instructionStart, void* to)
+    {
+        uint8_t* ptr = std::bit_cast<uint8_t*>(instructionStart);
+        uint8_t* dstPtr = std::bit_cast<uint8_t*>(to);
+        intptr_t distance = (intptr_t)(dstPtr - (ptr + 5));
+#if ENABLE(MPROTECT_RX_TO_RWX)
+        uint8_t buffer[5];
+        buffer[0] = static_cast<uint8_t>(OP_CALL_rel32);
+        WTF::unalignedStore<int32_t>(buffer + 1, static_cast<int32_t>(distance));
+        performJITMemcpy<jitMemcpyRepatch>(ptr, buffer, 5);
+#else
+        WTF::unalignedStore<uint8_t>(ptr, static_cast<uint8_t>(OP_CALL_rel32));
+        WTF::unalignedStore<int32_t>(ptr + 1, static_cast<int32_t>(distance));
+#endif
+    }
+
     static void replaceWithNops(void* instructionStart, size_t memoryToFillWithNopsInBytes)
     {
         fillNops(instructionStart, memoryToFillWithNopsInBytes);
@@ -6469,6 +6487,11 @@ public:
     }
 
     static constexpr ptrdiff_t patchableJumpSize()
+    {
+        return 5;
+    }
+
+    static constexpr ptrdiff_t patchableCallSize()
     {
         return 5;
     }

--- a/Source/JavaScriptCore/bytecode/AccessCaseSnippetParams.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCaseSnippetParams.cpp
@@ -53,8 +53,7 @@ public:
         // We spill (1) the used registers by IC and (2) the used registers by Snippet.
         InlineCacheCompiler::SpillState spillState = compiler.preserveLiveRegistersToStackForCall(usedRegistersBySnippet);
 
-        if (compiler.useHandlerIC())
-            InlineCacheCompiler::emitDataICPrepareForCall(jit);
+        InlineCacheCompiler::emitDataICPrepareForCall(jit);
         jit.makeSpaceOnStackForCCall();
 
         jit.setupArguments<FunctionType>(std::get<ArgumentsIndex>(m_arguments)...);
@@ -62,8 +61,7 @@ public:
         jit.callOperation<OperationPtrTag>(m_function);
         jit.setupResults(m_result);
         jit.reclaimSpaceOnStackForCCall();
-        if (compiler.useHandlerIC())
-            InlineCacheCompiler::emitDataICRestoreAfterCall(jit);
+        InlineCacheCompiler::emitDataICRestoreAfterCall(jit);
 
         CCallHelpers::Jump noException = jit.emitExceptionCheck(compiler.vm(), CCallHelpers::InvertedExceptionCheck);
 

--- a/Source/JavaScriptCore/bytecode/InlineAccess.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineAccess.cpp
@@ -158,19 +158,12 @@ ALWAYS_INLINE static bool linkCodeInline(const char* name, CCallHelpers& jit, Re
         FINALIZE_CODE(linkBuffer, NoPtrTag, ASCIILiteral::fromLiteralUnsafe(name), "InlineAccessType: '%s'", name);
         return true;
     }
-
-    // This is helpful when determining the size for inline ICs on various
-    // platforms. You want to choose a size that usually succeeds, but sometimes
-    // there may be variability in the length of the code we generate just because
-    // of randomness. It's helpful to flip this on when running tests or browsing
-    // the web just to see how often it fails. You don't want an IC size that always fails.
     constexpr bool failIfCantInline = false;
     if (failIfCantInline) {
         dataLog("Failure for: ", name, "\n");
         dataLog("real size: ", jit.m_assembler.buffer().codeSize(), " inline size:", propertyCache.inlineCodeSize(), "\n");
         CRASH();
     }
-
     return false;
 }
 

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -1138,16 +1138,8 @@ bool InlineCacheCompiler::useHandlerIC() const
 void InlineCacheCompiler::succeed()
 {
     restoreScratch();
-    if (useHandlerIC()) {
-        emitDataICEpilogue(*m_jit);
-        m_jit->ret();
-        return;
-    }
-    if (m_propertyCache.isHandlerIC()) {
-        m_jit->farJump(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfDoneLocation()), JSInternalPtrTag);
-        return;
-    }
-    m_success.append(m_jit->jump());
+    emitDataICEpilogue(*m_jit);
+    m_jit->ret();
 }
 
 const ScalarRegisterSet& InlineCacheCompiler::liveRegistersForCall()
@@ -1185,7 +1177,7 @@ const ScalarRegisterSet& InlineCacheCompiler::calculateLiveRegistersForCallAndEx
         }
 
         auto liveRegistersForCall = RegisterSet(m_liveRegistersToPreserveAtExceptionHandlingCallSite.toRegisterSet(), m_allocator->usedRegisters());
-        if (m_propertyCache.isHandlerIC())
+        if (useHandlerIC())
             liveRegistersForCall.add(m_propertyCache.m_propertyCacheGPR, IgnoreVectors);
         liveRegistersForCall.exclude(calleeSaveRegisters().includeWholeRegisterWidth());
         m_liveRegistersForCall = liveRegistersForCall.toScalarRegisterSet();
@@ -1216,7 +1208,7 @@ auto InlineCacheCompiler::preserveLiveRegistersToStackForCall(const RegisterSet&
 auto InlineCacheCompiler::preserveLiveRegistersToStackForCallWithoutExceptions() -> SpillState
 {
     RegisterSet liveRegisters = m_allocator->usedRegisters();
-    if (m_propertyCache.isHandlerIC())
+    if (useHandlerIC())
         liveRegisters.add(m_propertyCache.m_propertyCacheGPR, IgnoreVectors);
     liveRegisters.exclude(calleeSaveRegisters().includeWholeRegisterWidth());
     liveRegisters.filter(RegisterSet::allScalarRegisters());
@@ -1300,6 +1292,15 @@ CallSiteIndex InlineCacheCompiler::originalCallSiteIndex() const { return m_prop
 void InlineCacheCompiler::emitExplicitExceptionHandler()
 {
     restoreScratch();
+    // For RepatchingIC with call/ret: undo the call/prologue overhead.
+    // At this point, all sub-call pushes (emitDataICPrepareForCall) and spilled
+    // registers have been restored by the caller. Only the call entry overhead remains.
+    if (!useHandlerIC()) {
+        emitDataICEpilogue(*m_jit);
+#if CPU(X86_64)
+        m_jit->addPtr(CCallHelpers::TrustedImm32(sizeof(CPURegister)), CCallHelpers::stackPointerRegister);
+#endif
+    }
     m_jit->pushToSave(GPRInfo::regT0);
     m_jit->loadPtr(&m_vm.topEntryFrame, GPRInfo::regT0);
     m_jit->copyCalleeSavesToEntryFrameCalleeSavesBuffer(GPRInfo::regT0);
@@ -3100,20 +3101,18 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
         {
             // Handle the case where we are allocating out-of-line using an operation.
             InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall();
-            if (m_propertyCache.isHandlerIC()) {
+            if (useHandlerIC()) {
                 callSiteIndexForExceptionHandlingOrOriginal();
                 jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
             } else
                 jit.store32(CCallHelpers::TrustedImm32(callSiteIndexForExceptionHandlingOrOriginal().bits()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
-            if (m_propertyCache.isHandlerIC())
-                InlineCacheCompiler::emitDataICPrepareForCall(jit);
+            InlineCacheCompiler::emitDataICPrepareForCall(jit);
             jit.makeSpaceOnStackForCCall();
             jit.setupArguments<decltype(operationPutByMegamorphicReallocating)>(CCallHelpers::TrustedImmPtr(&vm), baseGPR, valueRegs.payloadGPR(), scratch3GPR);
             jit.prepareCallOperation(vm);
             jit.callOperation<OperationPtrTag>(operationPutByMegamorphicReallocating);
             jit.reclaimSpaceOnStackForCCall();
-            if (m_propertyCache.isHandlerIC())
-                InlineCacheCompiler::emitDataICRestoreAfterCall(jit);
+            InlineCacheCompiler::emitDataICRestoreAfterCall(jit);
             restoreLiveRegistersFromStackForCall(spillState, { });
             jit.jump().linkTo(doneLabel, &jit);
         }
@@ -3235,20 +3234,18 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
         {
             // Handle the case where we are allocating out-of-line using an operation.
             InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall();
-            if (m_propertyCache.isHandlerIC()) {
+            if (useHandlerIC()) {
                 callSiteIndexForExceptionHandlingOrOriginal();
                 jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
             } else
                 jit.store32(CCallHelpers::TrustedImm32(callSiteIndexForExceptionHandlingOrOriginal().bits()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
-            if (m_propertyCache.isHandlerIC())
-                InlineCacheCompiler::emitDataICPrepareForCall(jit);
+            InlineCacheCompiler::emitDataICPrepareForCall(jit);
             jit.makeSpaceOnStackForCCall();
             jit.setupArguments<decltype(operationPutByMegamorphicReallocating)>(CCallHelpers::TrustedImmPtr(&vm), baseGPR, valueRegs.payloadGPR(), scratch3GPR);
             jit.prepareCallOperation(vm);
             jit.callOperation<OperationPtrTag>(operationPutByMegamorphicReallocating);
             jit.reclaimSpaceOnStackForCCall();
-            if (m_propertyCache.isHandlerIC())
-                InlineCacheCompiler::emitDataICRestoreAfterCall(jit);
+            InlineCacheCompiler::emitDataICRestoreAfterCall(jit);
             restoreLiveRegistersFromStackForCall(spillState, { });
             jit.jump().linkTo(doneLabel, &jit);
         }
@@ -3446,7 +3443,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
         // exception handling call site.
         InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall();
 
-        if (m_propertyCache.isHandlerIC()) {
+        if (useHandlerIC()) {
             callSiteIndexForExceptionHandlingOrOriginal();
             jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
         } else
@@ -3460,8 +3457,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
         // Need to make room for the C call so any of our stack spillage isn't overwritten. It's
         // hard to track if someone did spillage or not, so we just assume that we always need
         // to make some space here.
-        if (m_propertyCache.isHandlerIC())
-            InlineCacheCompiler::emitDataICPrepareForCall(jit);
+        InlineCacheCompiler::emitDataICPrepareForCall(jit);
         jit.makeSpaceOnStackForCCall();
 
         jit.storePtr(GPRInfo::callFrameRegister, &vm.topCallFrame);
@@ -3510,8 +3506,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
         }
 
         jit.reclaimSpaceOnStackForCCall();
-        if (m_propertyCache.isHandlerIC())
-            InlineCacheCompiler::emitDataICRestoreAfterCall(jit);
+        InlineCacheCompiler::emitDataICRestoreAfterCall(jit);
 
         CCallHelpers::Jump noException = jit.emitExceptionCheck(vm, CCallHelpers::InvertedExceptionCheck);
 
@@ -3586,8 +3581,8 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
         // exception handling call site.
         InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall();
 
-        if (m_propertyCache.isHandlerIC()) {
-            emitDataICPrepareForCall(jit);
+        emitDataICPrepareForCall(jit);
+        if (useHandlerIC()) {
             callSiteIndexForExceptionHandlingOrOriginal();
             jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
         } else
@@ -3678,20 +3673,19 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
         if (isGetter)
             jit.setupResults(valueRegs);
 
-        if (m_propertyCache.isHandlerIC()) {
+        if (useHandlerIC()) {
             jit.loadPtr(CCallHelpers::Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfStackOffset()), scratchGPR);
-            if (useHandlerIC())
-                jit.addPtr(CCallHelpers::TrustedImm32(-(sizeof(CallerFrameAndPC) + maxFrameExtentForSlowPathCall + m_preservedReusedRegisterState.numberOfBytesPreserved + spillState.numberOfStackBytesUsedForRegisterPreservation)), scratchGPR);
-            else
-                jit.addPtr(CCallHelpers::TrustedImm32(-(m_preservedReusedRegisterState.numberOfBytesPreserved + spillState.numberOfStackBytesUsedForRegisterPreservation)), scratchGPR);
+            jit.addPtr(CCallHelpers::TrustedImm32(-(sizeof(CallerFrameAndPC) + maxFrameExtentForSlowPathCall + m_preservedReusedRegisterState.numberOfBytesPreserved + spillState.numberOfStackBytesUsedForRegisterPreservation)), scratchGPR);
             jit.addPtr(scratchGPR, GPRInfo::callFrameRegister, CCallHelpers::stackPointerRegister);
         } else {
-            int stackPointerOffset = (jit.codeBlock()->stackPointerOffset() * sizeof(Register)) - m_preservedReusedRegisterState.numberOfBytesPreserved - spillState.numberOfStackBytesUsedForRegisterPreservation;
+            // Account for the saved FP and return address (PC) on the stack.
+            // On x86_64: call pushes return address + prologue pushes FP.
+            // On ARM64: emitDataICPrepareForCall pushes FP+LR pair.
+            int stackPointerOffset = (jit.codeBlock()->stackPointerOffset() * sizeof(Register)) - static_cast<int>(sizeof(CallerFrameAndPC)) - m_preservedReusedRegisterState.numberOfBytesPreserved - spillState.numberOfStackBytesUsedForRegisterPreservation;
             jit.addPtr(CCallHelpers::TrustedImm32(stackPointerOffset), GPRInfo::callFrameRegister, CCallHelpers::stackPointerRegister);
         }
 
-        if (m_propertyCache.isHandlerIC())
-            emitDataICRestoreAfterCall(jit);
+        emitDataICRestoreAfterCall(jit);
 
         RegisterSet dontRestore;
         if (isGetter) {
@@ -3743,13 +3737,11 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
 
             auto spillState = preserveLiveRegistersToStackForCallWithoutExceptions();
 
-            if (m_propertyCache.isHandlerIC())
-                InlineCacheCompiler::emitDataICPrepareForCall(jit);
+            InlineCacheCompiler::emitDataICPrepareForCall(jit);
             jit.setupArguments<decltype(operationWriteBarrierSlowPath)>(CCallHelpers::TrustedImmPtr(&vm), scratchGPR);
             jit.prepareCallOperation(vm);
             jit.callOperation<OperationPtrTag>(operationWriteBarrierSlowPath);
-            if (m_propertyCache.isHandlerIC())
-                InlineCacheCompiler::emitDataICRestoreAfterCall(jit);
+            InlineCacheCompiler::emitDataICRestoreAfterCall(jit);
             restoreLiveRegistersFromStackForCall(spillState);
 
             skipBarrier.link(&jit);
@@ -3834,15 +3826,14 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
                 extraRegistersToPreserve.add(valueRegs, IgnoreVectors);
                 InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall(extraRegistersToPreserve);
 
-                if (m_propertyCache.isHandlerIC()) {
+                if (useHandlerIC()) {
                     callSiteIndexForExceptionHandlingOrOriginal();
                     jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
                 } else
                     jit.store32(CCallHelpers::TrustedImm32(callSiteIndexForExceptionHandlingOrOriginal().bits()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
 
                 jit.makeSpaceOnStackForCCall();
-                if (m_propertyCache.isHandlerIC())
-                    InlineCacheCompiler::emitDataICPrepareForCall(jit);
+                InlineCacheCompiler::emitDataICPrepareForCall(jit);
 
                 if (!reallocating) {
                     jit.setupArguments<decltype(operationReallocateButterflyToHavePropertyStorageWithInitialCapacity)>(CCallHelpers::TrustedImmPtr(&vm), baseGPR);
@@ -3856,8 +3847,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
                     jit.callOperation<OperationPtrTag>(operationReallocateButterflyToGrowPropertyStorage);
                 }
 
-                if (m_propertyCache.isHandlerIC())
-                    InlineCacheCompiler::emitDataICRestoreAfterCall(jit);
+                InlineCacheCompiler::emitDataICRestoreAfterCall(jit);
                 jit.reclaimSpaceOnStackForCCall();
                 jit.move(GPRInfo::returnValueGPR, scratchGPR);
 
@@ -4110,7 +4100,7 @@ void InlineCacheCompiler::emitDOMJITGetter(JSGlobalObject* globalObjectForDOMJIT
     GPRReg baseGPR = m_propertyCache.m_baseGPR;
     GPRReg scratchGPR = m_scratchGPR;
 
-    if (m_propertyCache.isHandlerIC()) {
+    if (useHandlerIC()) {
         callSiteIndexForExceptionHandlingOrOriginal();
         jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
     } else
@@ -4213,7 +4203,7 @@ void InlineCacheCompiler::emitDOMJITGetter(JSGlobalObject* globalObjectForDOMJIT
         usedRegisters.add(reg, IgnoreVectors);
     for (FPRReg reg : fpScratch)
         usedRegisters.add(reg, IgnoreVectors);
-    if (m_propertyCache.isHandlerIC())
+    if (useHandlerIC())
         usedRegisters.add(m_propertyCache.m_propertyCacheGPR, IgnoreVectors);
     auto registersToSpillForCCall = RegisterSet::registersToSaveForCCall(usedRegisters);
 
@@ -4269,8 +4259,8 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
 
     InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall();
 
-    if (m_propertyCache.isHandlerIC()) {
-        emitDataICPrepareForCall(jit);
+    emitDataICPrepareForCall(jit);
+    if (useHandlerIC()) {
         callSiteIndexForExceptionHandlingOrOriginal();
         jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
     } else
@@ -4428,15 +4418,15 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
         jit.setupResults(valueRegs);
 
 
-    if (m_propertyCache.isHandlerIC()) {
+    if (useHandlerIC()) {
         jit.loadPtr(CCallHelpers::Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfStackOffset()), m_scratchGPR);
         jit.addPtr(CCallHelpers::TrustedImm32(-(sizeof(CallerFrameAndPC) + maxFrameExtentForSlowPathCall + m_preservedReusedRegisterState.numberOfBytesPreserved + spillState.numberOfStackBytesUsedForRegisterPreservation)), m_scratchGPR);
         jit.addPtr(m_scratchGPR, GPRInfo::callFrameRegister, CCallHelpers::stackPointerRegister);
-        InlineCacheCompiler::emitDataICRestoreAfterCall(jit);
     } else {
-        int stackPointerOffset = (jit.codeBlock()->stackPointerOffset() * sizeof(Register)) - m_preservedReusedRegisterState.numberOfBytesPreserved - spillState.numberOfStackBytesUsedForRegisterPreservation;
+        int stackPointerOffset = (jit.codeBlock()->stackPointerOffset() * sizeof(Register)) - static_cast<int>(sizeof(CallerFrameAndPC)) - m_preservedReusedRegisterState.numberOfBytesPreserved - spillState.numberOfStackBytesUsedForRegisterPreservation;
         jit.addPtr(CCallHelpers::TrustedImm32(stackPointerOffset), GPRInfo::callFrameRegister, CCallHelpers::stackPointerRegister);
     }
+    InlineCacheCompiler::emitDataICRestoreAfterCall(jit);
 
     RegisterSet dontRestore;
     if (accessCase.m_type != AccessCase::ProxyObjectStore && accessCase.m_type != AccessCase::IndexedProxyObjectStore) {
@@ -5151,12 +5141,26 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
     CCallHelpers jit(codeBlock);
     m_jit = &jit;
 
+    // All IC stubs are now entered via call (not jump), so emit the DataIC prologue.
+    // On x86_64 this pushes FP; on ARM64 it tags the return address.
+    emitDataICPrologue(jit);
+
     if (ASSERT_ENABLED) {
-        if (m_propertyCache.isHandlerIC()) {
+        if (useHandlerIC()) {
             jit.loadPtr(CCallHelpers::Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfStackOffset()), jit.scratchRegister());
             jit.addPtr(jit.scratchRegister(), GPRInfo::callFrameRegister, jit.scratchRegister());
-        } else
-            jit.addPtr(CCallHelpers::TrustedImm32(codeBlock->stackPointerOffset() * sizeof(Register)), GPRInfo::callFrameRegister, jit.scratchRegister());
+        } else {
+            // Account for the return address and prologue push on the stack.
+            // On x86_64: call pushes 8 bytes (return addr) + prologue pushes 8 bytes (FP) = 16 extra bytes below expected SP.
+            // On ARM64: no SP change from call/prologue.
+            constexpr int callAndPrologueStackUsage =
+#if CPU(X86_64)
+                static_cast<int>(sizeof(CallerFrameAndPC)); // return address + pushed FP
+#else
+                0;
+#endif
+            jit.addPtr(CCallHelpers::TrustedImm32(codeBlock->stackPointerOffset() * sizeof(Register) - callAndPrologueStackUsage), GPRInfo::callFrameRegister, jit.scratchRegister());
+        }
         auto ok = jit.branchPtr(CCallHelpers::Equal, CCallHelpers::stackPointerRegister, jit.scratchRegister());
         jit.breakpoint();
         ok.link(&jit);
@@ -5306,7 +5310,7 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
         // of something that isn't patchable. The slow path will decrement "countdown" and will only
         // patch things if the countdown reaches zero. We increment the slow path count here to ensure
         // that the slow path does not try to patch.
-        if (m_propertyCache.isHandlerIC())
+        if (useHandlerIC())
             jit.add8(CCallHelpers::TrustedImm32(1), CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCountdown()));
         else {
             jit.move(CCallHelpers::TrustedImmPtr(&m_propertyCache.countdown), m_scratchGPR);
@@ -5335,18 +5339,32 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
         InlineCacheCompiler::SpillState spillState = this->spillStateForJSCall();
         ASSERT(!spillState.isEmpty());
         jit.loadPtr(vm().addressOfCallFrameForCatch(), GPRInfo::callFrameRegister);
-        if (m_propertyCache.isHandlerIC()) {
+        if (useHandlerIC()) {
             ASSERT(!JITCode::isBaselineCode(m_jitType));
             jit.loadPtr(CCallHelpers::Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfStackOffset()), m_scratchGPR);
             jit.addPtr(CCallHelpers::TrustedImm32(-(m_preservedReusedRegisterState.numberOfBytesPreserved + spillState.numberOfStackBytesUsedForRegisterPreservation)), m_scratchGPR);
             jit.addPtr(m_scratchGPR, GPRInfo::callFrameRegister, CCallHelpers::stackPointerRegister);
         } else {
-            int stackPointerOffset = (codeBlock->stackPointerOffset() * sizeof(Register)) - m_preservedReusedRegisterState.numberOfBytesPreserved - spillState.numberOfStackBytesUsedForRegisterPreservation;
+            // Set SP to point at the bottom of the prepareForCall push.
+            // The stack (high to low) is:
+            //   [FTL frame] [ret addr + FP (x86_64)] [preserved reused regs] [spilled live regs] [FP+LR (ARM64)]
+            // We must unwind in reverse push order: prepareForCall first, then spilled, then preserved.
+            int stackPointerOffset = (codeBlock->stackPointerOffset() * sizeof(Register)) - static_cast<int>(sizeof(CallerFrameAndPC)) - m_preservedReusedRegisterState.numberOfBytesPreserved - spillState.numberOfStackBytesUsedForRegisterPreservation;
             jit.addPtr(CCallHelpers::TrustedImm32(stackPointerOffset), GPRInfo::callFrameRegister, CCallHelpers::stackPointerRegister);
+            // Pop the FP+LR saved by emitDataICPrepareForCall (ARM64) — no-op on x86_64.
+            emitDataICRestoreAfterCall(jit);
         }
 
         restoreLiveRegistersFromStackForCallWithThrownException(spillState);
         restoreScratch();
+        // Undo the call/ret entry overhead so the original handler sees the correct SP.
+        if (!useHandlerIC()) {
+            emitDataICEpilogue(jit);
+#if CPU(X86_64)
+            // Pop the return address pushed by the call instruction.
+            jit.addPtr(CCallHelpers::TrustedImm32(sizeof(CPURegister)), CCallHelpers::stackPointerRegister);
+#endif
+        }
         HandlerInfo oldHandler = originalExceptionHandler();
         jit.jumpThunk(oldHandler.nativeCode);
         DisposableCallSiteIndex newExceptionHandlingCallSite = this->callSiteIndexForExceptionHandling();
@@ -5367,13 +5385,27 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
     }
 
     CodeLocationLabel<JSInternalPtrTag> successLabel = m_propertyCache.doneLocation;
-    if (m_propertyCache.isHandlerIC()) {
+    if (useHandlerIC()) {
         JIT_COMMENT(jit, "failure far jump");
         failure.link(&jit);
         jit.farJump(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfSlowPathStartLocation()), JITStubRoutinePtrTag);
     } else {
-        m_success.linkThunk(successLabel, &jit);
-        failure.linkThunk(m_propertyCache.slowPathStartLocation, &jit);
+        JIT_COMMENT(jit, "failure ret to slow path");
+        failure.link(&jit);
+        emitDataICEpilogue(jit);
+#if CPU(X86_64)
+        // After epilogue (pop FP), the return address from the call is on top of stack.
+        // Overwrite it with the slow path address and ret.
+        jit.move(CCallHelpers::TrustedImmPtr(m_propertyCache.slowPathStartLocation.retagged<NoPtrTag>().dataLocation()), jit.scratchRegister());
+        jit.storePtr(jit.scratchRegister(), CCallHelpers::Address(CCallHelpers::stackPointerRegister));
+#elif CPU(ARM64)
+        // LR holds the (possibly PAC-signed) return address from bl.
+        // Replace it with the slow path address, re-sign for ret.
+        jit.untagReturnAddress();
+        jit.move(CCallHelpers::TrustedImmPtr(m_propertyCache.slowPathStartLocation.retagged<NoPtrTag>().dataLocation()), CCallHelpers::linkRegister);
+        jit.tagReturnAddress();
+#endif
+        jit.ret();
     }
 
     LinkBuffer linkBuffer(jit, codeBlock, LinkBuffer::Profile::InlineCache, JITCompilationCanFail);
@@ -5382,13 +5414,9 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
         return AccessGenerationResult::GaveUp;
     }
 
-
-    if (m_propertyCache.isHandlerIC())
-        ASSERT(m_success.empty());
-
     dataLogLnIf(InlineCacheCompilerInternal::verbose, FullCodeOrigin(codeBlock, m_propertyCache.codeOrigin), ": Generating polymorphic access stub for ", listDump(keys));
 
-    MacroAssemblerCodeRef<JITStubRoutinePtrTag> code = FINALIZE_CODE_FOR(codeBlock, linkBuffer, JITStubRoutinePtrTag, categoryName(m_propertyCache.accessType), "%s", toCString("Access stub for ", *codeBlock, " ", m_propertyCache.codeOrigin, " with start: ", downcast<RepatchingPropertyInlineCache>(m_propertyCache).startLocation, " with return point ", successLabel, ": ", listDump(keys)).data());
+    MacroAssemblerCodeRef<JITStubRoutinePtrTag> code = FINALIZE_CODE_FOR(codeBlock, linkBuffer, JITStubRoutinePtrTag, categoryName(m_propertyCache.accessType), "%s", toCString("Access stub for ", *codeBlock, " ", m_propertyCache.codeOrigin, " with return point ", successLabel, ": ", listDump(keys)).data());
 
     CodeBlock* owner = codeBlock;
     FixedVector<StructureID> weakStructures(WTF::move(m_weakStructures));
@@ -7320,7 +7348,7 @@ AccessGenerationResult InlineCacheCompiler::compileHandler(const GCSafeConcurren
         return compileOneAccessCaseHandler(poly, codeBlock, *megamorphicCase, WTF::move(additionalWatchpointSets));
 
     additionalWatchpointSets.appendVector(WTF::move(sets));
-    ASSERT(m_propertyCache.isHandlerIC());
+    ASSERT(useHandlerIC());
     return compileOneAccessCaseHandler(poly, codeBlock, accessCase, WTF::move(additionalWatchpointSets));
 }
 
@@ -8221,8 +8249,6 @@ AccessGenerationResult InlineCacheCompiler::compileOneAccessCaseHandler(const Ve
         dataLogLnIf(InlineCacheCompilerInternal::verbose, "Did fail to allocate.");
         return AccessGenerationResult::GaveUp;
     }
-
-    ASSERT(m_success.empty());
 
     auto keys = FixedVector<Ref<AccessCase>> { Ref { accessCase } };
     dataLogLnIf(InlineCacheCompilerInternal::verbose, FullCodeOrigin(codeBlock, m_propertyCache.codeOrigin), ": Generating polymorphic access stub handler for ", listDump(keys));

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -307,7 +307,6 @@ private:
 #endif
     CCallHelpers* m_jit { nullptr };
     ScratchRegisterAllocator* m_allocator { nullptr };
-    MacroAssembler::JumpList m_success;
     MacroAssembler::JumpList m_failAndRepatch;
     MacroAssembler::JumpList m_failAndIgnore;
     ScratchRegisterAllocator::PreservedState m_preservedReusedRegisterState;

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp
@@ -937,9 +937,8 @@ void PropertyInlineCache::initializeWithUnitHandler(CodeBlock* codeBlock, Ref<In
             m_handler->removeOwner(codeBlock);
         m_handler = WTF::move(handler);
         m_handler->addOwner(codeBlock);
-    } else {
+    } else
         m_handler = WTF::move(handler);
-    }
 }
 
 void PropertyInlineCache::prependHandler(CodeBlock* codeBlock, Ref<InlineCacheHandler>&& handler, bool isMegamorphic)
@@ -967,7 +966,25 @@ void PropertyInlineCache::rewireStubAsJumpInAccess(CodeBlock* codeBlock, Ref<Inl
     ASSERT(!isHandlerIC());
     CodeLocationLabel label { handler->callTarget() };
     initializeWithUnitHandler(codeBlock, WTF::move(handler));
-    CCallHelpers::replaceWithJump(downcast<RepatchingPropertyInlineCache>(*this).startLocation.retagged<JSInternalPtrTag>(), label);
+    auto& repatchingIC = downcast<RepatchingPropertyInlineCache>(*this);
+    // Use call instead of jump so the stub is visible to sampling profilers.
+    // Layout the slab as [CALL at start][JUMP to done][NOP fill]. On entry the CALL
+    // enters the stub; the stub's ret lands on the JUMP, which skips the NOP fill
+    // to doneLocation, avoiding NOP execution on the hot path.
+    uint32_t slabSize = repatchingIC.inlineCodeSize();
+    CCallHelpers::replaceWithNops(repatchingIC.startLocation.retagged<JSInternalPtrTag>(), slabSize);
+#if CPU(ARM64) || CPU(X86_64)
+    size_t callSize = CCallHelpers::patchableCallSize();
+    size_t jumpSize = CCallHelpers::patchableJumpSize();
+    if (slabSize >= callSize + jumpSize) {
+        char* startPtr = repatchingIC.startLocation.dataLocation<char*>();
+        CodeLocationLabel<JSInternalPtrTag> jumpLocation { CodePtr<JSInternalPtrTag>::fromUntaggedPtr(startPtr + callSize) };
+        CCallHelpers::replaceWithJump(jumpLocation, doneLocation);
+        CCallHelpers::replaceWithCall(repatchingIC.startLocation.retagged<JSInternalPtrTag>(), label);
+        return;
+    }
+#endif
+    CCallHelpers::replaceWithCall(repatchingIC.startLocation.retagged<JSInternalPtrTag>(), label);
 }
 
 void PropertyInlineCache::resetStubAsJumpInAccess(CodeBlock* codeBlock)
@@ -984,7 +1001,9 @@ void PropertyInlineCache::resetStubAsJumpInAccess(CodeBlock* codeBlock)
         return;
     }
 
-    rewireStubAsJumpInAccess(codeBlock, InlineCacheHandler::createNonHandlerSlowPath(slowPathStartLocation));
+    auto& repatchingIC = downcast<RepatchingPropertyInlineCache>(*this);
+    initializeWithUnitHandler(codeBlock, InlineCacheHandler::createNonHandlerSlowPath(slowPathStartLocation));
+    CCallHelpers::replaceWithJump(repatchingIC.startLocation.retagged<JSInternalPtrTag>(), slowPathStartLocation);
 }
 
 Vector<AccessCase*, 16> PropertyInlineCache::listedAccessCases(const AbstractLocker&) const

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCache.h
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCache.h
@@ -692,7 +692,7 @@ public:
         : PropertyInlineCache(PropertyInlineCacheType::Repatching, accessType, codeOrigin)
     { }
 
-    // This is either the start of the inline IC for *byId caches, or the location of patchable jump for 'instanceof' caches.
+    // Start of the out-of-line slab code (used by InlineAccess for in-place patching).
     CodeLocationLabel<JITStubRoutinePtrTag> startLocation;
     CodeLocationCall<JSInternalPtrTag> m_slowPathCallLocation;
     std::unique_ptr<PolymorphicAccess> m_stub;

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1659,11 +1659,6 @@ private:
             if (m_graph.m_plan.isUnlinked())
                 break;
 
-            if (m_graph.m_plan.isFTL()) {
-                if (Options::useHandlerICInFTL())
-                    break;
-            }
-
 #if ENABLE(WEBASSEMBLY)
             // FIXME: Support wasm IC.
             // DirectCall to wasm function has suboptimal implementation. We avoid using DirectCall if we know that function is a wasm function.

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -4690,7 +4690,7 @@ private:
         patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-        patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 1 : 0;
+        patchpoint->numGPScratchRegisters = 0;
 
         RefPtr<PatchpointExceptionHandle> exceptionHandle = preparePatchpointForExceptions(patchpoint);
 
@@ -4714,12 +4714,11 @@ private:
             GPRReg baseGPR = params[1].gpr();
             GPRReg thisValueGPR = params[2].gpr();
             GPRReg propertyGPR = params[3].gpr();
-            GPRReg propertyCacheGPR = Options::useHandlerICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
 
             auto* propertyCache = state->addPropertyInlineCache();
             auto generator = Box<JITGetByValWithThisGenerator>::create(
                 jit.codeBlock(), propertyCache, JITType::FTLJIT, nodeSemanticOrigin, callSiteIndex, AccessType::GetByValWithThis,
-                params.unavailableRegisters(), JSValueRegs(baseGPR), JSValueRegs(propertyGPR), JSValueRegs(thisValueGPR), JSValueRegs(resultGPR), InvalidGPRReg, propertyCacheGPR);
+                params.unavailableRegisters(), JSValueRegs(baseGPR), JSValueRegs(propertyGPR), JSValueRegs(thisValueGPR), JSValueRegs(resultGPR), InvalidGPRReg, InvalidGPRReg);
 
             generator->propertyCache()->propertyIsString = propertyIsString;
             generator->propertyCache()->propertyIsInt32 = propertyIsInt32;
@@ -4737,23 +4736,13 @@ private:
 
                 if (notCell.isSet())
                     notCell.link(&jit);
-                if (!Options::useHandlerICInFTL())
-                    generator->slowPathJump().link(&jit);
+                generator->slowPathJump().link(&jit);
                 CCallHelpers::Label slowPathBegin = jit.label();
                 CCallHelpers::Call slowPathCall;
-                if (Options::useHandlerICInFTL()) {
-                    jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                    downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = operationGetByValWithThisOptimize;
-                    slowPathCall = callOperation(
-                        *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                        exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), resultGPR,
-                        baseGPR, propertyGPR, thisValueGPR, propertyCacheGPR, CCallHelpers::TrustedImmPtr(nullptr)).call();
-                } else {
-                    slowPathCall = callOperation(
-                        *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                        exceptions.get(), operationGetByValWithThisOptimize, resultGPR,
-                        baseGPR, propertyGPR, thisValueGPR, CCallHelpers::TrustedImmPtr(generator->propertyCache()), CCallHelpers::TrustedImmPtr(nullptr)).call();
-                }
+                slowPathCall = callOperation(
+                    *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
+                    exceptions.get(), operationGetByValWithThisOptimize, resultGPR,
+                    baseGPR, propertyGPR, thisValueGPR, CCallHelpers::TrustedImmPtr(generator->propertyCache()), CCallHelpers::TrustedImmPtr(nullptr)).call();
                 jit.jump().linkTo(done, &jit);
 
                 generator->reportSlowPathCall(slowPathBegin, slowPathCall);
@@ -4846,7 +4835,7 @@ private:
         patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-        patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 1 : 0;
+        patchpoint->numGPScratchRegisters = 0;
 
         RefPtr<PatchpointExceptionHandle> exceptionHandle = preparePatchpointForExceptions(patchpoint);
 
@@ -4870,12 +4859,11 @@ private:
                 GPRReg resultGPR = params[0].gpr();
                 GPRReg baseGPR = params[1].gpr();
                 GPRReg propertyGPR = params[2].gpr();
-                GPRReg propertyCacheGPR = Options::useHandlerICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
 
                 auto* propertyCache = state->addPropertyInlineCache();
                 auto generator = Box<JITGetByValGenerator>::create(
                     jit.codeBlock(), propertyCache, JITType::FTLJIT, nodeSemanticOrigin, callSiteIndex, AccessType::GetPrivateName,
-                    params.unavailableRegisters(), JSValueRegs(baseGPR), JSValueRegs(propertyGPR), JSValueRegs(resultGPR), InvalidGPRReg, propertyCacheGPR);
+                    params.unavailableRegisters(), JSValueRegs(baseGPR), JSValueRegs(propertyGPR), JSValueRegs(resultGPR), InvalidGPRReg, InvalidGPRReg);
 
                 CCallHelpers::Jump notCell;
                 if (!baseIsCell)
@@ -4889,23 +4877,13 @@ private:
 
                     if (notCell.isSet())
                         notCell.link(&jit);
-                    if (!Options::useHandlerICInFTL())
-                        generator->slowPathJump().link(&jit);
+                    generator->slowPathJump().link(&jit);
                     CCallHelpers::Label slowPathBegin = jit.label();
                     CCallHelpers::Call slowPathCall;
-                    if (Options::useHandlerICInFTL()) {
-                        jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                        downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = operationGetPrivateNameOptimize;
-                        slowPathCall = callOperation(
-                            *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                            exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), resultGPR,
-                            baseGPR, propertyGPR, propertyCacheGPR).call();
-                    } else {
-                        slowPathCall = callOperation(
-                            *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                            exceptions.get(), operationGetPrivateNameOptimize, resultGPR,
-                            baseGPR, propertyGPR, CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
-                    }
+                    slowPathCall = callOperation(
+                        *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
+                        exceptions.get(), operationGetPrivateNameOptimize, resultGPR,
+                        baseGPR, propertyGPR, CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
                     jit.jump().linkTo(done, &jit);
 
                     generator->reportSlowPathCall(slowPathBegin, slowPathCall);
@@ -4990,7 +4968,7 @@ private:
         patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-        patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 1 : 0;
+        patchpoint->numGPScratchRegisters = 0;
 
         RefPtr<PatchpointExceptionHandle> exceptionHandle = preparePatchpointForExceptions(patchpoint);
 
@@ -5013,12 +4991,11 @@ private:
 
             GPRReg baseGPR = params[0].gpr();
             GPRReg brandGPR = params[1].gpr();
-            GPRReg propertyCacheGPR = Options::useHandlerICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
 
             auto* propertyCache = state->addPropertyInlineCache();
             auto generator = Box<JITPrivateBrandAccessGenerator>::create(
                 jit.codeBlock(), propertyCache, JITType::FTLJIT, nodeSemanticOrigin, callSiteIndex, accessType,
-                params.unavailableRegisters(), JSValueRegs(baseGPR), JSValueRegs(brandGPR), propertyCacheGPR);
+                params.unavailableRegisters(), JSValueRegs(baseGPR), JSValueRegs(brandGPR), InvalidGPRReg);
 
             CCallHelpers::Jump notCell;
             if (!baseIsCell)
@@ -5044,23 +5021,13 @@ private:
 
                 if (notCell.isSet())
                     notCell.link(&jit);
-                if (!Options::useHandlerICInFTL())
-                    generator->slowPathJump().link(&jit);
+                generator->slowPathJump().link(&jit);
                 CCallHelpers::Label slowPathBegin = jit.label();
                 CCallHelpers::Call slowPathCall;
-                if (Options::useHandlerICInFTL()) {
-                    jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                    downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = appropriatePrivateAccessFunction(accessType);
-                    slowPathCall = callOperation(
-                        *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                        exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), InvalidGPRReg,
-                        baseGPR, brandGPR, propertyCacheGPR).call();
-                } else {
-                    slowPathCall = callOperation(
-                        *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                        exceptions.get(), appropriatePrivateAccessFunction(accessType), InvalidGPRReg,
-                        baseGPR, brandGPR, CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
-                }
+                slowPathCall = callOperation(
+                    *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
+                    exceptions.get(), appropriatePrivateAccessFunction(accessType), InvalidGPRReg,
+                    baseGPR, brandGPR, CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
                 jit.jump().linkTo(done, &jit);
 
                 generator->reportSlowPathCall(slowPathBegin, slowPathCall);
@@ -5224,7 +5191,7 @@ private:
         patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-        patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 1 : 0;
+        patchpoint->numGPScratchRegisters = 0;
 
         RefPtr<PatchpointExceptionHandle> exceptionHandle = preparePatchpointForExceptions(patchpoint);
 
@@ -5249,12 +5216,11 @@ private:
             GPRReg baseGPR = params[0].gpr();
             GPRReg propertyGPR = params[1].gpr();
             GPRReg valueGPR = params[2].gpr();
-            GPRReg propertyCacheGPR = Options::useHandlerICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
 
             auto* propertyCache = state->addPropertyInlineCache();
             auto generator = Box<JITPutByValGenerator>::create(
                 jit.codeBlock(), propertyCache, JITType::FTLJIT, nodeSemanticOrigin, callSiteIndex, privateFieldPutKind.isDefine() ? AccessType::DefinePrivateNameByVal : AccessType::SetPrivateNameByVal,
-                params.unavailableRegisters(), JSValueRegs(baseGPR), JSValueRegs(propertyGPR), JSValueRegs(valueGPR), InvalidGPRReg, propertyCacheGPR);
+                params.unavailableRegisters(), JSValueRegs(baseGPR), JSValueRegs(propertyGPR), JSValueRegs(valueGPR), InvalidGPRReg, InvalidGPRReg);
 
             generator->propertyCache()->propertyIsSymbol = true;
 
@@ -5264,23 +5230,13 @@ private:
             params.addLatePath([=] (CCallHelpers& jit) {
                 AllowMacroScratchRegisterUsage allowScratch(jit);
 
-                if (!Options::useHandlerICInFTL())
-                    generator->slowPathJump().link(&jit);
+                generator->slowPathJump().link(&jit);
                 CCallHelpers::Label slowPathBegin = jit.label();
                 CCallHelpers::Call slowPathCall;
-                if (Options::useHandlerICInFTL()) {
-                    jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                    downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = operation;
-                    slowPathCall = callOperation(
-                        *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                        exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), InvalidGPRReg,
-                        baseGPR, propertyGPR, valueGPR, propertyCacheGPR, CCallHelpers::TrustedImmPtr(nullptr)).call();
-                } else {
-                    slowPathCall = callOperation(
-                        *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                        exceptions.get(), operation, InvalidGPRReg,
-                        baseGPR, propertyGPR, valueGPR, CCallHelpers::TrustedImmPtr(generator->propertyCache()), CCallHelpers::TrustedImmPtr(nullptr)).call();
-                }
+                slowPathCall = callOperation(
+                    *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
+                    exceptions.get(), operation, InvalidGPRReg,
+                    baseGPR, propertyGPR, valueGPR, CCallHelpers::TrustedImmPtr(generator->propertyCache()), CCallHelpers::TrustedImmPtr(nullptr)).call();
                 jit.jump().linkTo(done, &jit);
 
                 generator->reportSlowPathCall(slowPathBegin, slowPathCall);
@@ -5580,7 +5536,7 @@ private:
         patchpoint->append(m_notCellMask, ValueRep::reg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::reg(GPRInfo::numberTagRegister));
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-        patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 3 : 0;
+        patchpoint->numGPScratchRegisters = 0;
 
         // FIXME: If this is a PutByIdFlush, we might want to late-clobber volatile registers.
         // https://bugs.webkit.org/show_bug.cgi?id=152848
@@ -5604,23 +5560,11 @@ private:
                 // JS setter call ICs generated by the PutById IC will need this.
                 exceptionHandle->scheduleExitCreationForUnwind(params, callSiteIndex);
 
-                GPRReg propertyCacheGPR = InvalidGPRReg;
-                GPRReg scratchGPR = InvalidGPRReg;
-                GPRReg scratch2GPR = InvalidGPRReg;
-                if (Options::useHandlerICInFTL()) {
-                    propertyCacheGPR = params.gpScratch(0);
-                    scratchGPR = params.gpScratch(1);
-                    scratch2GPR = params.gpScratch(2);
-                }
-                UNUSED_PARAM(propertyCacheGPR);
-                UNUSED_PARAM(scratchGPR);
-                UNUSED_PARAM(scratch2GPR);
-
                 auto* propertyCache = state->addPropertyInlineCache();
                 auto generator = Box<JITPutByIdGenerator>::create(
                     jit.codeBlock(), propertyCache, JITType::FTLJIT, nodeSemanticOrigin, callSiteIndex,
                     params.unavailableRegisters(), identifier, JSValueRegs(params[0].gpr()),
-                    JSValueRegs(params[1].gpr()), propertyCacheGPR, GPRInfo::patchpointScratchRegister,
+                    JSValueRegs(params[1].gpr()), InvalidGPRReg, GPRInfo::patchpointScratchRegister,
                     accessType);
 
                 generator->generateFastPath(jit);
@@ -5630,24 +5574,14 @@ private:
                     [=] (CCallHelpers& jit) {
                         AllowMacroScratchRegisterUsage allowScratch(jit);
 
-                        if (!Options::useHandlerICInFTL())
-                            generator->slowPathJump().link(&jit);
+                        generator->slowPathJump().link(&jit);
                         CCallHelpers::Label slowPathBegin = jit.label();
                         CCallHelpers::Call slowPathCall;
                         auto* operation = appropriatePutByIdOptimizeFunction(accessType);
-                        if (Options::useHandlerICInFTL()) {
-                            jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                            downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = operation;
-                            slowPathCall = callOperation(
-                                *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                                exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), InvalidGPRReg,
-                                params[1].gpr(), params[0].gpr(), propertyCacheGPR).call();
-                        } else {
-                            slowPathCall = callOperation(
-                                *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                                exceptions.get(), operation, InvalidGPRReg,
-                                params[1].gpr(), params[0].gpr(), CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
-                        }
+                        slowPathCall = callOperation(
+                            *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
+                            exceptions.get(), operation, InvalidGPRReg,
+                            params[1].gpr(), params[0].gpr(), CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
                         jit.jump().linkTo(done, &jit);
 
                         generator->reportSlowPathCall(slowPathBegin, slowPathCall);
@@ -6544,7 +6478,7 @@ IGNORE_CLANG_WARNINGS_END
             patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
             patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
             patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-            patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 1 : 0;
+            patchpoint->numGPScratchRegisters = 0;
 
             RefPtr<PatchpointExceptionHandle> exceptionHandle = preparePatchpointForExceptions(patchpoint);
 
@@ -6567,12 +6501,11 @@ IGNORE_CLANG_WARNINGS_END
                 GPRReg resultGPR = params[0].gpr();
                 GPRReg baseGPR = params[1].gpr();
                 GPRReg propertyGPR = params[2].gpr();
-                GPRReg propertyCacheGPR = Options::useHandlerICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
 
                 auto* propertyCache = state->addPropertyInlineCache();
                 auto generator = Box<JITGetByValGenerator>::create(
                     jit.codeBlock(), propertyCache, JITType::FTLJIT, nodeSemanticOrigin, callSiteIndex, AccessType::GetByVal,
-                    params.unavailableRegisters(), JSValueRegs(baseGPR), JSValueRegs(propertyGPR), JSValueRegs(resultGPR), InvalidGPRReg, propertyCacheGPR);
+                    params.unavailableRegisters(), JSValueRegs(baseGPR), JSValueRegs(propertyGPR), JSValueRegs(resultGPR), InvalidGPRReg, InvalidGPRReg);
 
                 generator->propertyCache()->propertyIsString = propertyIsString;
                 generator->propertyCache()->propertyIsInt32 = propertyIsInt32;
@@ -6590,23 +6523,13 @@ IGNORE_CLANG_WARNINGS_END
 
                     if (notCell.isSet())
                         notCell.link(&jit);
-                    if (!Options::useHandlerICInFTL())
-                        generator->slowPathJump().link(&jit);
+                    generator->slowPathJump().link(&jit);
                     CCallHelpers::Label slowPathBegin = jit.label();
                     CCallHelpers::Call slowPathCall;
-                    if (Options::useHandlerICInFTL()) {
-                        jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                        downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = operationGetByValOptimize;
-                        slowPathCall = callOperation(
-                            *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                            exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), resultGPR,
-                            baseGPR, propertyGPR, propertyCacheGPR, CCallHelpers::TrustedImmPtr(nullptr)).call();
-                    } else {
-                        slowPathCall = callOperation(
-                            *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                            exceptions.get(), operationGetByValOptimize, resultGPR,
-                            baseGPR, propertyGPR, CCallHelpers::TrustedImmPtr(generator->propertyCache()), CCallHelpers::TrustedImmPtr(nullptr)).call();
-                    }
+                    slowPathCall = callOperation(
+                        *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
+                        exceptions.get(), operationGetByValOptimize, resultGPR,
+                        baseGPR, propertyGPR, CCallHelpers::TrustedImmPtr(generator->propertyCache()), CCallHelpers::TrustedImmPtr(nullptr)).call();
                     jit.jump().linkTo(done, &jit);
 
                     generator->reportSlowPathCall(slowPathBegin, slowPathCall);
@@ -7274,7 +7197,7 @@ IGNORE_CLANG_WARNINGS_END
             patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
             patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
             patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-            patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 1 : 0;
+            patchpoint->numGPScratchRegisters = 0;
 
             RefPtr<PatchpointExceptionHandle> exceptionHandle = preparePatchpointForExceptions(patchpoint);
 
@@ -7299,12 +7222,11 @@ IGNORE_CLANG_WARNINGS_END
                 GPRReg baseGPR = params[0].gpr();
                 GPRReg propertyGPR = params[1].gpr();
                 GPRReg valueGPR = params[2].gpr();
-                GPRReg propertyCacheGPR = Options::useHandlerICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
 
                 auto* propertyCache = state->addPropertyInlineCache();
                 auto generator = Box<JITPutByValGenerator>::create(
                     jit.codeBlock(), propertyCache, JITType::FTLJIT, nodeSemanticOrigin, callSiteIndex, isDirect ? (ecmaMode.isStrict() ? AccessType::PutByValDirectStrict : AccessType::PutByValDirectSloppy) : (ecmaMode.isStrict() ? AccessType::PutByValStrict : AccessType::PutByValSloppy),
-                    params.unavailableRegisters(), JSValueRegs(baseGPR), JSValueRegs(propertyGPR), JSValueRegs(valueGPR), InvalidGPRReg, propertyCacheGPR);
+                    params.unavailableRegisters(), JSValueRegs(baseGPR), JSValueRegs(propertyGPR), JSValueRegs(valueGPR), InvalidGPRReg, InvalidGPRReg);
 
                 generator->propertyCache()->propertyIsString = propertyIsString;
                 generator->propertyCache()->propertyIsInt32 = propertyIsInt32;
@@ -7316,24 +7238,14 @@ IGNORE_CLANG_WARNINGS_END
                 params.addLatePath([=] (CCallHelpers& jit) {
                     AllowMacroScratchRegisterUsage allowScratch(jit);
 
-                    if (!Options::useHandlerICInFTL())
-                        generator->slowPathJump().link(&jit);
+                    generator->slowPathJump().link(&jit);
                     CCallHelpers::Label slowPathBegin = jit.label();
                     CCallHelpers::Call slowPathCall;
                     auto operation = isDirect ? (ecmaMode.isStrict() ? operationDirectPutByValStrictOptimize : operationDirectPutByValSloppyOptimize) : (ecmaMode.isStrict() ? operationPutByValStrictOptimize : operationPutByValSloppyOptimize);
-                    if (Options::useHandlerICInFTL()) {
-                        jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                        downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = operation;
-                        slowPathCall = callOperation(
-                            *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                            exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), InvalidGPRReg,
-                            baseGPR, propertyGPR, valueGPR, propertyCacheGPR, CCallHelpers::TrustedImmPtr(nullptr)).call();
-                    } else {
-                        slowPathCall = callOperation(
-                            *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                            exceptions.get(), operation, InvalidGPRReg,
-                            baseGPR, propertyGPR, valueGPR, CCallHelpers::TrustedImmPtr(generator->propertyCache()), CCallHelpers::TrustedImmPtr(nullptr)).call();
-                    }
+                    slowPathCall = callOperation(
+                        *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
+                        exceptions.get(), operation, InvalidGPRReg,
+                        baseGPR, propertyGPR, valueGPR, CCallHelpers::TrustedImmPtr(generator->propertyCache()), CCallHelpers::TrustedImmPtr(nullptr)).call();
                     jit.jump().linkTo(done, &jit);
 
                     generator->reportSlowPathCall(slowPathBegin, slowPathCall);
@@ -7898,7 +7810,7 @@ IGNORE_CLANG_WARNINGS_END
         patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-        patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 1 : 0;
+        patchpoint->numGPScratchRegisters = 0;
 
         RefPtr<PatchpointExceptionHandle> exceptionHandle =
             preparePatchpointForExceptions(patchpoint);
@@ -7931,7 +7843,6 @@ IGNORE_CLANG_WARNINGS_END
 
                 auto base = JSValueRegs(params[1].gpr());
                 auto returnGPR = params[0].gpr();
-                GPRReg propertyCacheGPR = Options::useHandlerICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
                 ASSERT(base.gpr() != returnGPR);
 
                 if (child1UseKind)
@@ -7965,20 +7876,18 @@ IGNORE_CLANG_WARNINGS_END
                             jit.codeBlock(), propertyCache, JITType::FTLJIT, nodeSemanticOrigin, callSiteIndex,
                             kind == DelByKind::ByIdSloppy ? AccessType::DeleteByIdSloppy : AccessType::DeleteByIdStrict,
                             params.unavailableRegisters(), subscriptValue, base,
-                            JSValueRegs(returnGPR), propertyCacheGPR);
+                            JSValueRegs(returnGPR), InvalidGPRReg);
                     } else {
                         auto* propertyCache = state->addPropertyInlineCache();
                         return Box<JITDelByValGenerator>::create(
                             jit.codeBlock(), propertyCache, JITType::FTLJIT, nodeSemanticOrigin, callSiteIndex,
                             kind == DelByKind::ByValSloppy ? AccessType::DeleteByValSloppy : AccessType::DeleteByValStrict,
                             params.unavailableRegisters(), base,
-                            subscript, JSValueRegs(returnGPR), propertyCacheGPR);
+                            subscript, JSValueRegs(returnGPR), InvalidGPRReg);
                     }
                 }();
 
                 generator->generateFastPath(jit);
-                if (!Options::useHandlerICInFTL())
-                    slowCases.append(generator->slowPathJump());
                 CCallHelpers::Label done = jit.label();
 
                 params.addLatePath(
@@ -7986,37 +7895,20 @@ IGNORE_CLANG_WARNINGS_END
                         AllowMacroScratchRegisterUsage allowScratch(jit);
 
                         slowCases.link(&jit);
+                        generator->slowPathJump().link(&jit);
                         CCallHelpers::Label slowPathBegin = jit.label();
                         CCallHelpers::Call slowPathCall;
 
                         if constexpr (kind == DelByKind::ByIdStrict || kind == DelByKind::ByIdSloppy) {
-                            if (Options::useHandlerICInFTL()) {
-                                jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                                downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = optimizationFunction;
-                                slowPathCall = callOperation(
-                                    *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                                    exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), returnGPR,
-                                    base, propertyCacheGPR).call();
-                            } else {
-                                slowPathCall = callOperation(
-                                    *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                                    exceptions.get(), optimizationFunction, returnGPR,
-                                    base, CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
-                            }
+                            slowPathCall = callOperation(
+                                *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
+                                exceptions.get(), optimizationFunction, returnGPR,
+                                base, CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
                         } else {
-                            if (Options::useHandlerICInFTL()) {
-                                jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                                downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = optimizationFunction;
-                                slowPathCall = callOperation(
-                                    *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                                    exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), returnGPR,
-                                    base, subscript, propertyCacheGPR).call();
-                            } else {
-                                slowPathCall = callOperation(
-                                    *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                                    exceptions.get(), optimizationFunction, returnGPR,
-                                    base, subscript, CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
-                            }
+                            slowPathCall = callOperation(
+                                *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
+                                exceptions.get(), optimizationFunction, returnGPR,
+                                base, subscript, CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
                         }
                         jit.jump().linkTo(done, &jit);
 
@@ -16517,10 +16409,7 @@ IGNORE_CLANG_WARNINGS_END
         patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-        if constexpr (type == AccessType::InById)
-            patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 2 : 0;
-        else
-            patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 1 : 0;
+        patchpoint->numGPScratchRegisters = 0;
 
         RefPtr<PatchpointExceptionHandle> exceptionHandle = preparePatchpointForExceptions(patchpoint);
 
@@ -16539,15 +16428,6 @@ IGNORE_CLANG_WARNINGS_END
 
                 exceptionHandle->scheduleExitCreationForUnwind(params, callSiteIndex);
 
-                GPRReg propertyCacheGPR = InvalidGPRReg;
-                GPRReg scratchGPR = InvalidGPRReg;
-                if (Options::useHandlerICInFTL()) {
-                    propertyCacheGPR = params.gpScratch(0);
-                    if constexpr (type == AccessType::InById)
-                        scratchGPR = params.gpScratch(1);
-                }
-                UNUSED_PARAM(propertyCacheGPR);
-                UNUSED_PARAM(scratchGPR);
                 auto returnGPR = params[0].gpr();
                 auto base = JSValueRegs(params[1].gpr());
 
@@ -16577,20 +16457,18 @@ IGNORE_CLANG_WARNINGS_END
                         return Box<JITInByIdGenerator>::create(
                             jit.codeBlock(), propertyCache, JITType::FTLJIT, semanticNodeOrigin, callSiteIndex,
                             params.unavailableRegisters(), subscriptValue, base,
-                            JSValueRegs(returnGPR), propertyCacheGPR);
+                            JSValueRegs(returnGPR), InvalidGPRReg);
                     } else {
                         auto* propertyCache = state->addPropertyInlineCache();
                         return Box<JITInByValGenerator>::create(
                             jit.codeBlock(), propertyCache, JITType::FTLJIT, semanticNodeOrigin, callSiteIndex,
                             type, params.unavailableRegisters(), base, subscript,
-                            JSValueRegs(returnGPR), InvalidGPRReg, propertyCacheGPR);
+                            JSValueRegs(returnGPR), InvalidGPRReg, InvalidGPRReg);
                     }
                 }();
 
                 CCallHelpers::JumpList slowCases;
                 generator->generateFastPath(jit);
-                if (!Options::useHandlerICInFTL())
-                    slowCases.append(generator->slowPathJump());
                 CCallHelpers::Label done = jit.label();
 
                 params.addLatePath(
@@ -16598,50 +16476,24 @@ IGNORE_CLANG_WARNINGS_END
                         AllowMacroScratchRegisterUsage allowScratch(jit);
 
                         slowCases.link(&jit);
+                        generator->slowPathJump().link(&jit);
                         CCallHelpers::Label slowPathBegin = jit.label();
                         CCallHelpers::Call slowPathCall;
                         if constexpr (type == AccessType::InById) {
-                            if (Options::useHandlerICInFTL()) {
-                                jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                                downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = optimizationFunction;
-                                slowPathCall = callOperation(
-                                    *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
-                                    exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), returnGPR,
-                                    base, propertyCacheGPR).call();
-                            } else {
-                                slowPathCall = callOperation(
-                                    *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
-                                    exceptions.get(), optimizationFunction, returnGPR,
-                                    base, CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
-                            }
+                            slowPathCall = callOperation(
+                                *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
+                                exceptions.get(), optimizationFunction, returnGPR,
+                                base, CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
                         } else if constexpr (type == AccessType::InByVal) {
-                            if (Options::useHandlerICInFTL()) {
-                                jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                                downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = optimizationFunction;
-                                slowPathCall = callOperation(
-                                    *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
-                                    exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), returnGPR,
-                                    base, subscript, propertyCacheGPR, CCallHelpers::TrustedImmPtr(nullptr)).call();
-                            } else {
-                                slowPathCall = callOperation(
-                                    *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
-                                    exceptions.get(), optimizationFunction, returnGPR,
-                                    base, subscript, CCallHelpers::TrustedImmPtr(generator->propertyCache()), CCallHelpers::TrustedImmPtr(nullptr)).call();
-                            }
+                            slowPathCall = callOperation(
+                                *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
+                                exceptions.get(), optimizationFunction, returnGPR,
+                                base, subscript, CCallHelpers::TrustedImmPtr(generator->propertyCache()), CCallHelpers::TrustedImmPtr(nullptr)).call();
                         } else {
-                            if (Options::useHandlerICInFTL()) {
-                                jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                                downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = optimizationFunction;
-                                slowPathCall = callOperation(
-                                    *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
-                                    exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), returnGPR,
-                                    base, subscript, propertyCacheGPR).call();
-                            } else {
-                                slowPathCall = callOperation(
-                                    *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
-                                    exceptions.get(), optimizationFunction, returnGPR,
-                                    base, subscript, CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
-                            }
+                            slowPathCall = callOperation(
+                                *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
+                                exceptions.get(), optimizationFunction, returnGPR,
+                                base, subscript, CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
                         }
                         jit.jump().linkTo(done, &jit);
 
@@ -17102,7 +16954,7 @@ IGNORE_CLANG_WARNINGS_END
         patchpoint->appendSomeRegister(prototype);
         patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
-        patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 1 : 0;
+        patchpoint->numGPScratchRegisters = 0;
         patchpoint->resultConstraints = { ValueRep::SomeEarlyRegister };
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
 
@@ -17118,7 +16970,6 @@ IGNORE_CLANG_WARNINGS_END
                 GPRReg resultGPR = params[0].gpr();
                 GPRReg valueGPR = params[1].gpr();
                 GPRReg prototypeGPR = params[2].gpr();
-                GPRReg propertyCacheGPR = Options::useHandlerICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
 
                 CCallHelpers::Jump doneJump;
                 if (!valueIsCell) {
@@ -17142,10 +16993,8 @@ IGNORE_CLANG_WARNINGS_END
                 auto* propertyCache = state->addPropertyInlineCache();
                 auto generator = Box<JITInstanceOfGenerator>::create(
                     jit.codeBlock(), propertyCache, JITType::FTLJIT, semanticNodeOrigin, callSiteIndex,
-                    params.unavailableRegisters(), resultGPR, valueGPR, prototypeGPR, propertyCacheGPR, prototypeIsObject);
+                    params.unavailableRegisters(), resultGPR, valueGPR, prototypeGPR, InvalidGPRReg, prototypeIsObject);
                 generator->generateFastPath(jit);
-                if (!Options::useHandlerICInFTL())
-                    slowCases.append(generator->slowPathJump());
                 CCallHelpers::Label done = jit.label();
 
                 params.addLatePath(
@@ -17155,21 +17004,13 @@ IGNORE_CLANG_WARNINGS_END
                         auto optimizationFunction = operationInstanceOfOptimize;
 
                         slowCases.link(&jit);
+                        generator->slowPathJump().link(&jit);
                         CCallHelpers::Label slowPathBegin = jit.label();
                         CCallHelpers::Call slowPathCall;
-                        if (Options::useHandlerICInFTL()) {
-                            jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                            downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = optimizationFunction;
-                            slowPathCall = callOperation(
-                                *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
-                                exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), resultGPR,
-                                valueGPR, prototypeGPR, propertyCacheGPR).call();
-                        } else {
-                            slowPathCall = callOperation(
-                                *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
-                                exceptions.get(), optimizationFunction, resultGPR,
-                                valueGPR, prototypeGPR, CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
-                        }
+                        slowPathCall = callOperation(
+                            *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
+                            exceptions.get(), optimizationFunction, resultGPR,
+                            valueGPR, prototypeGPR, CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
                         jit.jump().linkTo(done, &jit);
 
                         generator->reportSlowPathCall(slowPathBegin, slowPathCall);
@@ -17962,7 +17803,7 @@ IGNORE_CLANG_WARNINGS_END
         patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-        patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 1 : 0;
+        patchpoint->numGPScratchRegisters = 0;
 
         RefPtr<PatchpointExceptionHandle> exceptionHandle = preparePatchpointForExceptions(patchpoint);
 
@@ -17986,12 +17827,11 @@ IGNORE_CLANG_WARNINGS_END
             GPRReg baseGPR = params[0].gpr();
             GPRReg propertyGPR = params[1].gpr();
             GPRReg valueGPR = params[2].gpr();
-            GPRReg propertyCacheGPR = Options::useHandlerICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
 
             auto* propertyCache = state->addPropertyInlineCache();
             auto generator = Box<JITPutByValGenerator>::create(
                 jit.codeBlock(), propertyCache, JITType::FTLJIT, nodeSemanticOrigin, callSiteIndex, ecmaMode.isStrict() ? AccessType::PutByValStrict : AccessType::PutByValSloppy,
-                params.unavailableRegisters(), JSValueRegs(baseGPR), JSValueRegs(propertyGPR), JSValueRegs(valueGPR), InvalidGPRReg, propertyCacheGPR);
+                params.unavailableRegisters(), JSValueRegs(baseGPR), JSValueRegs(propertyGPR), JSValueRegs(valueGPR), InvalidGPRReg, InvalidGPRReg);
 
             generator->generateFastPath(jit);
             CCallHelpers::Label done = jit.label();
@@ -17999,24 +17839,14 @@ IGNORE_CLANG_WARNINGS_END
             params.addLatePath([=] (CCallHelpers& jit) {
                 AllowMacroScratchRegisterUsage allowScratch(jit);
 
-                if (!Options::useHandlerICInFTL())
-                    generator->slowPathJump().link(&jit);
+                generator->slowPathJump().link(&jit);
                 CCallHelpers::Label slowPathBegin = jit.label();
                 CCallHelpers::Call slowPathCall;
                 auto operation = ecmaMode.isStrict() ? operationPutByValStrictOptimize : operationPutByValSloppyOptimize;
-                if (Options::useHandlerICInFTL()) {
-                    jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                    downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = operation;
-                    slowPathCall = callOperation(
-                        *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                        exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), InvalidGPRReg,
-                        baseGPR, propertyGPR, valueGPR, propertyCacheGPR, CCallHelpers::TrustedImmPtr(nullptr)).call();
-                } else {
-                    slowPathCall = callOperation(
-                        *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                        exceptions.get(), operation, InvalidGPRReg,
-                        baseGPR, propertyGPR, valueGPR, CCallHelpers::TrustedImmPtr(generator->propertyCache()), CCallHelpers::TrustedImmPtr(nullptr)).call();
-                }
+                slowPathCall = callOperation(
+                    *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
+                    exceptions.get(), operation, InvalidGPRReg,
+                    baseGPR, propertyGPR, valueGPR, CCallHelpers::TrustedImmPtr(generator->propertyCache()), CCallHelpers::TrustedImmPtr(nullptr)).call();
                 jit.jump().linkTo(done, &jit);
 
                 generator->reportSlowPathCall(slowPathBegin, slowPathCall);
@@ -19473,7 +19303,7 @@ IGNORE_CLANG_WARNINGS_END
         patchpoint->appendSomeRegister(base);
         patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
-        patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 2 : 0;
+        patchpoint->numGPScratchRegisters = 0;
 
         // FIXME: If this is a GetByIdFlush/GetByIdDirectFlush, we might get some performance boost if we claim that it
         // clobbers volatile registers late. It's not necessary for correctness, though, since the
@@ -19504,20 +19334,11 @@ IGNORE_CLANG_WARNINGS_END
                 // the callsite index.
                 exceptionHandle->scheduleExitCreationForUnwind(params, callSiteIndex);
 
-                GPRReg propertyCacheGPR = InvalidGPRReg;
-                GPRReg scratchGPR = InvalidGPRReg;
-                if (Options::useHandlerICInFTL()) {
-                    propertyCacheGPR = params.gpScratch(0);
-                    scratchGPR = params.gpScratch(1);
-                }
-                UNUSED_PARAM(propertyCacheGPR);
-                UNUSED_PARAM(scratchGPR);
-
                 auto* propertyCache = state->addPropertyInlineCache();
                 auto generator = Box<JITGetByIdGenerator>::create(
                     jit.codeBlock(), propertyCache, JITType::FTLJIT, semanticNodeOrigin, callSiteIndex,
                     params.unavailableRegisters(), identifier, JSValueRegs(params[1].gpr()),
-                    JSValueRegs(params[0].gpr()), propertyCacheGPR, type, CacheType::GetByIdSelf);
+                    JSValueRegs(params[0].gpr()), InvalidGPRReg, type, CacheType::GetByIdSelf);
 
                 generator->generateFastPath(jit);
                 CCallHelpers::Label done = jit.label();
@@ -19528,23 +19349,13 @@ IGNORE_CLANG_WARNINGS_END
 
                         auto optimizationFunction = appropriateGetByIdOptimizeFunction(type);
 
-                        if (!Options::useHandlerICInFTL())
-                            generator->slowPathJump().link(&jit);
+                        generator->slowPathJump().link(&jit);
                         CCallHelpers::Label slowPathBegin = jit.label();
                         CCallHelpers::Call slowPathCall;
-                        if (Options::useHandlerICInFTL()) {
-                            jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                            downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = optimizationFunction;
-                            slowPathCall = callOperation(
-                                *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
-                                exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), params[0].gpr(),
-                                params[1].gpr(), propertyCacheGPR).call();
-                        } else {
-                            slowPathCall = callOperation(
-                                *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
-                                exceptions.get(), optimizationFunction, params[0].gpr(),
-                                params[1].gpr(), CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
-                        }
+                        slowPathCall = callOperation(
+                            *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
+                            exceptions.get(), optimizationFunction, params[0].gpr(),
+                            params[1].gpr(), CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
                         jit.jump().linkTo(done, &jit);
 
                         generator->reportSlowPathCall(slowPathBegin, slowPathCall);
@@ -19570,7 +19381,7 @@ IGNORE_CLANG_WARNINGS_END
         patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-        patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 2 : 0;
+        patchpoint->numGPScratchRegisters = 0;
 
         RefPtr<PatchpointExceptionHandle> exceptionHandle =
             preparePatchpointForExceptions(patchpoint);
@@ -19594,20 +19405,11 @@ IGNORE_CLANG_WARNINGS_END
                 // the callsite index.
                 exceptionHandle->scheduleExitCreationForUnwind(params, callSiteIndex);
 
-                GPRReg propertyCacheGPR = InvalidGPRReg;
-                GPRReg scratchGPR = InvalidGPRReg;
-                if (Options::useHandlerICInFTL()) {
-                    propertyCacheGPR = params.gpScratch(0);
-                    scratchGPR = params.gpScratch(1);
-                }
-                UNUSED_PARAM(propertyCacheGPR);
-                UNUSED_PARAM(scratchGPR);
-
                 auto* propertyCache = state->addPropertyInlineCache();
                 auto generator = Box<JITGetByIdWithThisGenerator>::create(
                     jit.codeBlock(), propertyCache, JITType::FTLJIT, semanticNodeOrigin, callSiteIndex,
                     params.unavailableRegisters(), identifier, JSValueRegs(params[0].gpr()),
-                    JSValueRegs(params[1].gpr()), JSValueRegs(params[2].gpr()), propertyCacheGPR);
+                    JSValueRegs(params[1].gpr()), JSValueRegs(params[2].gpr()), InvalidGPRReg);
 
                 generator->generateFastPath(jit);
                 CCallHelpers::Label done = jit.label();
@@ -19618,23 +19420,13 @@ IGNORE_CLANG_WARNINGS_END
 
                         auto optimizationFunction = operationGetByIdWithThisOptimize;
 
-                        if (!Options::useHandlerICInFTL())
-                            generator->slowPathJump().link(&jit);
+                        generator->slowPathJump().link(&jit);
                         CCallHelpers::Label slowPathBegin = jit.label();
                         CCallHelpers::Call slowPathCall;
-                        if (Options::useHandlerICInFTL()) {
-                            jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                            downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = optimizationFunction;
-                            slowPathCall = callOperation(
-                                *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
-                                exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), params[0].gpr(),
-                                params[1].gpr(), params[2].gpr(), propertyCacheGPR).call();
-                        } else {
-                            slowPathCall = callOperation(
-                                *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
-                                exceptions.get(), optimizationFunction, params[0].gpr(),
-                                params[1].gpr(), params[2].gpr(), CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
-                        }
+                        slowPathCall = callOperation(
+                            *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
+                            exceptions.get(), optimizationFunction, params[0].gpr(),
+                            params[1].gpr(), params[2].gpr(), CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
                         jit.jump().linkTo(done, &jit);
 
                         generator->reportSlowPathCall(slowPathBegin, slowPathCall);

--- a/Source/JavaScriptCore/ftl/FTLState.cpp
+++ b/Source/JavaScriptCore/ftl/FTLState.cpp
@@ -172,8 +172,6 @@ State::~State() = default;
 PropertyInlineCache* State::addPropertyInlineCache()
 {
     ASSERT(!graph.m_plan.isUnlinked());
-    if (Options::useHandlerICInFTL())
-        return jitCode->common.m_handlerPropertyInlineCaches.add();
     return jitCode->common.m_repatchingPropertyInlineCaches.add();
 }
 

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -811,7 +811,6 @@ void Options::notifyOptionsChanged()
     Options::useRandomizingExecutableIslandAllocation() = false;
 #endif
 
-    Options::useHandlerICInFTL() = false; // Currently, it is not completed. Disable forcefully.
     Options::forceUnlinkedDFG() = false; // Currently, IC is rapidly changing. We disable this until we get the final form of Data IC.
 
     if (!Options::allowDoubleShape())

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -630,7 +630,6 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, maxNumericHotLoopSize, 225, Normal, nullptr) \
     v(Bool, printEachUnrolledLoop, false, Normal, nullptr) \
     v(Bool, verboseExecutablePoolAllocation, false, Normal, nullptr) \
-    v(Bool, useHandlerICInFTL, false, Normal, nullptr) \
     v(Bool, useLLIntICs, true, Normal, "Use property and call ICs in LLInt code."_s) \
     v(Bool, useBaselineJITCodeSharing, is64Bit(), Normal, nullptr) \
     v(Bool, libpasScavengeContinuously, false, Normal, nullptr) \

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -696,7 +696,7 @@ BASE_OPTIONS = ["--validateOptions=true", "--useFTLJIT=false", "--useFunctionDot
 EAGER_OPTIONS = ["--validateOptions=true", "--thresholdForJITAfterWarmUp=10", "--thresholdForJITSoon=10", "--thresholdForOptimizeAfterWarmUp=20", "--thresholdForOptimizeAfterLongWarmUp=20", "--thresholdForOptimizeSoon=20", "--thresholdForFTLOptimizeAfterWarmUp=20", "--thresholdForFTLOptimizeSoon=20", "--thresholdForOMGOptimizeAfterWarmUp=20", "--thresholdForOMGOptimizeSoon=20", "--maximumEvalCacheableSourceLength=150000", "--useEagerCodeBlockJettisonTiming=true", "--repatchBufferingCountdown=0"]
 # NOTE: Tests rely on this using scribbleFreeCells.
 NO_CJIT_OPTIONS = ["--validateOptions=true", "--useConcurrentJIT=false", "--thresholdForJITAfterWarmUp=100", "--scribbleFreeCells=true"]
-B3O1_OPTIONS = ["--defaultB3OptLevel=1", "--useHandlerICInFTL=1", "--forceUnlinkedDFG=1"]
+B3O1_OPTIONS = ["--defaultB3OptLevel=1", "--forceUnlinkedDFG=1"]
 B3O0_OPTIONS = ["--maxDFGNodesInBasicBlockForPreciseAnalysis=100", "--defaultB3OptLevel=0"]
 FTL_OPTIONS = ["--validateOptions=true", "--useFTLJIT=true"]
 FORCE_LLINT_EXIT_OPTIONS = ["--forceOSRExitToLLInt=true"]
@@ -1187,7 +1187,6 @@ BASE_MODES = [
         "FTLNoCJIT",
         "misc-ftl-no-cjit",
         [
-            "--useHandlerICInFTL=true",
             "--allowNonSPTagging=false",
             "--libpasForcePGMWithRate=#{10 + rand(10)}",
         ] +
@@ -1216,7 +1215,6 @@ BASE_MODES = [
             "--useSamplingProfiler=true",
             "--airForceIRCAllocator=true",
             "--airUseGreedyRegAlloc=false", # FIXME: remove with rdar://144792585
-            "--useHandlerICInFTL=true",
             "--forceUnlinkedDFG=true",
             "--allowNonSPTagging=false",
         ] +
@@ -1279,7 +1277,6 @@ BASE_MODES = [
             "--airForceBriggsAllocator=true",
             "--useRandomizingExecutableIslandAllocation=true",
             "--forcePolyProto=true",
-            "--useHandlerICInFTL=true",
             "--allowNonSPTagging=false",
         ] +
         FTL_OPTIONS +


### PR DESCRIPTION
#### 2aca18b1adc729917c85b28b9341775b97912127
<pre>
[JSC] Always use call-ret based IC
<a href="https://bugs.webkit.org/show_bug.cgi?id=312087">https://bugs.webkit.org/show_bug.cgi?id=312087</a>
<a href="https://rdar.apple.com/174592376">rdar://174592376</a>

Reviewed by NOBODY (OOPS!).

WIP

Tests: JSTests/stress/polymorphic-ic-call-ret-exception.js
       JSTests/stress/polymorphic-ic-call-ret-getter-setter.js
       JSTests/stress/polymorphic-ic-call-ret.js

* JSTests/stress/polymorphic-ic-call-ret-exception.js: Added.
(shouldBe):
(shouldThrow):
(getX):
(let.thrower.get x):
(setX):
(let.setThrower.set x):
(hasKey):
(has):
* JSTests/stress/polymorphic-ic-call-ret-getter-setter.js: Added.
(shouldBe):
(getX):
(let.withGetter.get x):
(let.proto.get x):
(setX):
(let.withSetter.set x):
(getByteLen):
* JSTests/stress/polymorphic-ic-call-ret.js: Added.
(shouldBe):
(getX):
(putX):
(hasX):
(delX):
(isArray):
* Source/JavaScriptCore/assembler/ARM64Assembler.h:
* Source/JavaScriptCore/assembler/ARMv7Assembler.h:
(JSC::ARMv7Assembler::patchableCallSize):
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::replaceWithCall):
(JSC::MacroAssemblerARM64::patchableCallSize):
* Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h:
(JSC::MacroAssemblerARMv7::patchableCallSize):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::replaceWithCall):
(JSC::MacroAssemblerX86_64::patchableCallSize):
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::replaceWithCall):
(JSC::X86Assembler::patchableCallSize):
* Source/JavaScriptCore/bytecode/AccessCaseSnippetParams.cpp:
* Source/JavaScriptCore/bytecode/InlineAccess.cpp:
(JSC::linkCodeInline):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::succeed):
(JSC::InlineCacheCompiler::calculateLiveRegistersForCallAndExceptionHandling):
(JSC::InlineCacheCompiler::preserveLiveRegistersToStackForCallWithoutExceptions):
(JSC::InlineCacheCompiler::emitExplicitExceptionHandler):
(JSC::InlineCacheCompiler::generateWithGuard):
(JSC::InlineCacheCompiler::generateAccessCase):
(JSC::InlineCacheCompiler::emitDOMJITGetter):
(JSC::InlineCacheCompiler::emitProxyObjectAccess):
(JSC::InlineCacheCompiler::compile):
(JSC::InlineCacheCompiler::compileHandler):
(JSC::InlineCacheCompiler::compileOneAccessCaseHandler):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.h:
* Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp:
(JSC::PropertyInlineCache::initializeWithUnitHandler):
(JSC::PropertyInlineCache::rewireStubAsJumpInAccess):
(JSC::PropertyInlineCache::resetStubAsJumpInAccess):
* Source/JavaScriptCore/bytecode/PropertyInlineCache.h:
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileGetByValWithThis):
(JSC::FTL::DFG::LowerDFGToB3::getPrivateName):
(JSC::FTL::DFG::LowerDFGToB3::compilePrivateBrandAccess):
(JSC::FTL::DFG::LowerDFGToB3::compilePutPrivateName):
(JSC::FTL::DFG::LowerDFGToB3::cachedPutById):
(JSC::FTL::DFG::LowerDFGToB3::compileGetByValImpl):
(JSC::FTL::DFG::LowerDFGToB3::compilePutByVal):
(JSC::FTL::DFG::LowerDFGToB3::compileDelBy):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/ftl/FTLState.cpp:
(JSC::FTL::State::addPropertyInlineCache):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::notifyOptionsChanged):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Tools/Scripts/run-jsc-stress-tests:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2aca18b1adc729917c85b28b9341775b97912127

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161331 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170234 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117702 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125150 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88190 "1 flakes 1 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cc0bdb84-2ed2-4ca0-8dfe-92d9bb7ae387) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27437 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144916 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105747 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26485 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24995 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17954 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153388 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136179 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172717 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22169 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19738 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24317 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133432 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34478 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29087 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133440 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34463 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144471 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96328 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27977 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21290 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/193730 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33973 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101398 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49913 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33472 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33716 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33621 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->