### PR TITLE
Add strong CSS/Style types for CSS string values

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -110,6 +110,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/css/values/counter-styles"
     "${WEBCORE_DIR}/css/values/easing"
     "${WEBCORE_DIR}/css/values/filter-effects"
+    "${WEBCORE_DIR}/css/values/fonts"
     "${WEBCORE_DIR}/css/values/grid"
     "${WEBCORE_DIR}/css/values/images"
     "${WEBCORE_DIR}/css/values/motion"

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1060,7 +1060,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     crypto/parameters/CryptoAlgorithmRsaPssParamsInit.h
     crypto/parameters/CryptoAlgorithmX25519ParamsInit.h
 
-    css/CSSAttrValue.h
     css/CSSColorValue.h
     css/CSSComputedStyleDeclaration.h
     css/CSSConditionRule.h
@@ -1202,6 +1201,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/values/primitives/CSSPrimitiveNumericTypes.h
     css/values/primitives/CSSPrimitiveNumericUnits.h
     css/values/primitives/CSSRatio.h
+    css/values/primitives/CSSString.h
     css/values/primitives/CSSSymbol.h
     css/values/primitives/CSSURL.h
     css/values/primitives/CSSURLModifiers.h
@@ -3365,6 +3365,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/primitives/StylePrimitiveNumericTypes.h
     style/values/primitives/StylePropertyIdentifier.h
     style/values/primitives/StyleRatio.h
+    style/values/primitives/StyleString.h
     style/values/primitives/StyleURL.h
     style/values/primitives/StyleUnevaluatedCalculation.h
 

--- a/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -6,9 +6,11 @@ Modules/webauthn/cbor/CBORValue.cpp
 Modules/websockets/WebSocketChannelInspector.cpp
 Modules/webtransport/WebTransportDatagramsWritable.cpp
 css/CSSComputedStyleDeclaration.cpp
-css/DOMMatrixReadOnly.cpp
+css/CSSPrimitiveValue.cpp
+css/CSSPropertyInitialValues.cpp
 css/PropertySetCSSDescriptors.cpp
 css/StyleSheetList.cpp
+css/parser/CSSPropertyParserConsumer+String.cpp
 dom/ChildNodeList.cpp
 dom/Document.cpp
 dom/Node.cpp

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -35,6 +35,7 @@ rendering/RenderLayerBacking.cpp
 rendering/RenderLayerBacking.h
 rendering/RenderLayerCompositor.cpp
 rendering/RenderLayerScrollableArea.h
+rendering/RenderQuote.cpp
 rendering/updating/RenderTreeUpdater.h
 style/ClassChangeInvalidation.cpp
 style/ElementRuleCollector.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -152,7 +152,6 @@ css/CSSFontFace.cpp
 css/CSSFontFaceRule.cpp
 css/CSSFontValue.cpp
 css/CSSGroupingRule.cpp
-css/CSSImageSetOptionValue.cpp
 css/CSSImageValue.h
 css/CSSKeyframeRule.cpp
 css/CSSKeyframesRule.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -912,6 +912,7 @@ css/CSSFontFaceRule.cpp
 css/CSSFontFaceSet.cpp
 css/CSSFontFaceSource.cpp
 css/CSSFontFaceSrcValue.cpp
+css/CSSFontFamilyNameValue.cpp
 css/CSSFontFeatureValue.cpp
 css/CSSFontFeatureValuesRule.cpp
 css/CSSFontPaletteValuesRule.cpp
@@ -974,6 +975,7 @@ css/CSSSegmentedFontFace.cpp
 css/CSSSelector.cpp
 css/CSSSelectorList.cpp
 css/CSSStartingStyleRule.cpp
+css/CSSStringValue.cpp
 css/CSSStyleDeclaration.cpp
 css/CSSStyleProperties.cpp
 css/CSSStyleRule.cpp
@@ -1176,6 +1178,7 @@ css/values/color/CSSKeywordColor.cpp
 css/values/color/CSSLightDarkColor.cpp
 css/values/color/CSSPlatformColorResolutionState.cpp
 css/values/color/CSSResolvedColor.cpp
+css/values/fonts/CSSFontFamilyName.cpp
 css/values/grid/CSSGridNamedAreaMap.cpp
 css/values/images/CSSGradient.cpp
 css/values/motion/CSSRayFunction.cpp
@@ -1189,6 +1192,7 @@ css/values/primitives/CSSPrimitiveNumericTypes+SymbolReplacement.cpp
 css/values/primitives/CSSPrimitiveNumericUnits.cpp
 css/values/primitives/CSSPropertyIdentifier.cpp
 css/values/primitives/CSSRatio.cpp
+css/values/primitives/CSSString.cpp
 css/values/primitives/CSSSymbol.cpp
 css/values/primitives/CSSURL.cpp
 css/values/primitives/CSSURLModifiers.cpp
@@ -3387,6 +3391,7 @@ style/values/primitives/StylePosition.cpp
 style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp
 style/values/primitives/StylePropertyIdentifier.cpp
 style/values/primitives/StyleRatio.cpp
+style/values/primitives/StyleString.cpp
 style/values/primitives/StyleURL.cpp
 style/values/primitives/StyleUnevaluatedCalculation.cpp
 style/values/rhythm/StyleBlockStepSize.cpp

--- a/Source/WebCore/css/CSSAttrValue.cpp
+++ b/Source/WebCore/css/CSSAttrValue.cpp
@@ -27,35 +27,34 @@
 #include "CSSAttrValue.h"
 
 #include <wtf/text/MakeString.h>
-#include "CSSPrimitiveValue.h"
 
 namespace WebCore {
 
-Ref<CSSAttrValue> CSSAttrValue::create(String attributeName, RefPtr<CSSValue>&& fallback)
+Ref<CSSAttrValue> CSSAttrValue::create(AtomString&& attributeName, std::optional<CSS::String>&& fallback)
 {
     return adoptRef(*new CSSAttrValue(WTF::move(attributeName), WTF::move(fallback)));
 }
 
+CSSAttrValue::CSSAttrValue(AtomString&& attributeName, std::optional<CSS::String>&& fallback)
+    : CSSValue(ClassType::Attr)
+    , m_attributeName(WTF::move(attributeName))
+    , m_fallback(WTF::move(fallback))
+{
+}
+
 bool CSSAttrValue::equals(const CSSAttrValue& other) const
 {
-    RefPtr fallback = dynamicDowncast<CSSPrimitiveValue>(m_fallback);
-    RefPtr otherFallback = dynamicDowncast<CSSPrimitiveValue>(other.m_fallback);
-
-    if (fallback && otherFallback)
-        return m_attributeName == other.m_attributeName && fallback->stringValue() == otherFallback->stringValue();
-    if (fallback || otherFallback)
-        return false;
-    return m_attributeName == other.m_attributeName;
+    return m_attributeName == other.m_attributeName
+        && m_fallback == other.m_fallback;
 }
 
 String CSSAttrValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    RefPtr fallback = dynamicDowncast<CSSPrimitiveValue>(m_fallback);
     return makeString(
         "attr("_s,
         m_attributeName.impl(),
-        fallback && !fallback->stringValue().isEmpty() ? ", "_s : ""_s,
-        fallback && !fallback->stringValue().isEmpty() ? fallback->cssText(context) : ""_s,
+        m_fallback && !m_fallback->value.isEmpty() ? ", "_s : ""_s,
+        m_fallback && !m_fallback->value.isEmpty() ? CSS::serializationForCSS(context, *m_fallback) : ""_s,
         ')'
     );
 }

--- a/Source/WebCore/css/CSSAttrValue.h
+++ b/Source/WebCore/css/CSSAttrValue.h
@@ -25,32 +25,28 @@
 
 #pragma once
 
-#include <WebCore/CSSValue.h>
-
-#include <wtf/text/WTFString.h>
+#include "CSSString.h"
+#include "CSSValue.h"
+#include <optional>
+#include <wtf/text/AtomString.h>
 
 namespace WebCore {
 
-class Element;
-
 class CSSAttrValue final : public CSSValue {
 public:
-    static Ref<CSSAttrValue> create(String attributeName, RefPtr<CSSValue>&& fallback = nullptr);
-    const String attributeName() const { return m_attributeName; }
-    const CSSValue* fallback() const { return m_fallback.get(); }
+    static Ref<CSSAttrValue> create(AtomString&& attributeName, std::optional<CSS::String>&& fallback);
+
+    const AtomString& attributeName() const LIFETIME_BOUND { return m_attributeName; }
+    const std::optional<CSS::String>& fallback() const LIFETIME_BOUND { return m_fallback; }
+
     bool equals(const CSSAttrValue& other) const;
     String customCSSText(const CSS::SerializationContext&) const;
 
 private:
-    explicit CSSAttrValue(String&& attributeName, RefPtr<CSSValue>&& fallback)
-        : CSSValue(ClassType::Attr)
-        , m_attributeName(WTF::move(attributeName))
-        , m_fallback(WTF::move(fallback))
-    {
-    }
+    explicit CSSAttrValue(AtomString&&, std::optional<CSS::String>&&);
 
-    String m_attributeName;
-    const RefPtr<CSSValue> m_fallback;
+    AtomString m_attributeName;
+    const std::optional<CSS::String> m_fallback;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSCanvasValue.cpp
+++ b/Source/WebCore/css/CSSCanvasValue.cpp
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-CSSCanvasValue::CSSCanvasValue(String&& name)
+CSSCanvasValue::CSSCanvasValue(CSS::CustomIdent&& name)
     : CSSValue { ClassType::Canvas }
     , m_name { WTF::move(name) }
 {
@@ -39,9 +39,13 @@ CSSCanvasValue::CSSCanvasValue(String&& name)
 
 CSSCanvasValue::~CSSCanvasValue() = default;
 
-String CSSCanvasValue::customCSSText(const CSS::SerializationContext&) const
+String CSSCanvasValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    return makeString("-webkit-canvas("_s, m_name, ')');
+    StringBuilder builder;
+    builder.append("-webkit-canvas("_s);
+    CSS::serializationForCSS(builder, context, m_name);
+    builder.append(')');
+    return builder.toString();
 }
 
 bool CSSCanvasValue::equals(const CSSCanvasValue& other) const
@@ -49,12 +53,12 @@ bool CSSCanvasValue::equals(const CSSCanvasValue& other) const
     return m_name == other.m_name;
 }
 
-RefPtr<Style::Image> CSSCanvasValue::createStyleImage(const Style::BuilderState&) const
+RefPtr<Style::Image> CSSCanvasValue::createStyleImage(const Style::BuilderState& state) const
 {
     if (m_cachedStyleImage)
         return m_cachedStyleImage;
 
-    m_cachedStyleImage = Style::CanvasImage::create(m_name);
+    m_cachedStyleImage = Style::CanvasImage::create(Style::toStyle(m_name, state));
     return m_cachedStyleImage;
 }
 

--- a/Source/WebCore/css/CSSCanvasValue.h
+++ b/Source/WebCore/css/CSSCanvasValue.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
+#include "CSSCustomIdent.h"
 #include "CSSValue.h"
-#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
@@ -37,7 +37,7 @@ class Image;
 
 class CSSCanvasValue final : public CSSValue {
 public:
-    static Ref<CSSCanvasValue> create(String name) { return adoptRef(*new CSSCanvasValue(WTF::move(name))); }
+    static Ref<CSSCanvasValue> create(CSS::CustomIdent&& name) { return adoptRef(*new CSSCanvasValue(WTF::move(name))); }
     ~CSSCanvasValue();
 
     String customCSSText(const CSS::SerializationContext&) const;
@@ -46,9 +46,9 @@ public:
     RefPtr<Style::Image> createStyleImage(const Style::BuilderState&) const;
 
 private:
-    explicit CSSCanvasValue(String&&);
+    explicit CSSCanvasValue(CSS::CustomIdent&&);
 
-    String m_name;
+    CSS::CustomIdent m_name;
     mutable RefPtr<Style::Image> m_cachedStyleImage;
 };
 

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
@@ -30,6 +30,7 @@
 #include "CSSCustomIdentValue.h"
 #include "CSSMarkup.h"
 #include "CSSPrimitiveValue.h"
+#include "CSSStringValue.h"
 #include "CSSValueList.h"
 #include "CSSValuePair.h"
 #include <utility>
@@ -74,8 +75,8 @@ CSSCounterStyleDescriptors::Symbol symbolFromCSSValue(const CSSValue* value)
     if (RefPtr customIdentValue = dynamicDowncast<CSSCustomIdentValue>(value))
         return { .isCustomIdent = true, .text = customIdentValue->customIdent().value };
 
-    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value))
-        return { .isCustomIdent = false, .text = primitiveValue->stringValue() };
+    if (RefPtr stringValue = dynamicDowncast<CSSStringValue>(value))
+        return { .isCustomIdent = false, .text = stringValue->string().value };
 
     return { };
 }

--- a/Source/WebCore/css/CSSCounterValue.cpp
+++ b/Source/WebCore/css/CSSCounterValue.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,7 +31,7 @@
 
 namespace WebCore {
 
-CSSCounterValue::CSSCounterValue(CSS::CustomIdent&& identifier, AtomString&& separator, CSS::CounterStyle&& counterStyle)
+CSSCounterValue::CSSCounterValue(CSS::CustomIdent&& identifier, CSS::String&& separator, CSS::CounterStyle&& counterStyle)
     : CSSValue(ClassType::Counter)
     , m_identifier(WTF::move(identifier))
     , m_separator(WTF::move(separator))
@@ -38,7 +39,7 @@ CSSCounterValue::CSSCounterValue(CSS::CustomIdent&& identifier, AtomString&& sep
 {
 }
 
-Ref<CSSCounterValue> CSSCounterValue::create(CSS::CustomIdent&& identifier, AtomString&& separator, CSS::CounterStyle&& counterStyle)
+Ref<CSSCounterValue> CSSCounterValue::create(CSS::CustomIdent&& identifier, CSS::String&& separator, CSS::CounterStyle&& counterStyle)
 {
     return adoptRef(*new CSSCounterValue(WTF::move(identifier), WTF::move(separator), WTF::move(counterStyle)));
 }
@@ -61,7 +62,7 @@ String CSSCounterValue::customCSSText(const CSS::SerializationContext& context) 
         }
     );
 
-    if (m_separator.isEmpty()) {
+    if (m_separator.value.isEmpty()) {
         StringBuilder builder;
         builder.append("counter("_s);
         CSS::serializationForCSS(builder, context, m_identifier);

--- a/Source/WebCore/css/CSSCounterValue.h
+++ b/Source/WebCore/css/CSSCounterValue.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,19 +28,18 @@
 
 #include "CSSCounterStyle.h"
 #include "CSSCustomIdent.h"
+#include "CSSString.h"
 #include "CSSValue.h"
-#include <wtf/Function.h>
-#include <wtf/text/AtomString.h>
 
 namespace WebCore {
 
 class CSSCounterValue final : public CSSValue {
 public:
-    static Ref<CSSCounterValue> create(CSS::CustomIdent&&, AtomString&& separator, CSS::CounterStyle&&);
+    static Ref<CSSCounterValue> create(CSS::CustomIdent&&, CSS::String&& separator, CSS::CounterStyle&&);
 
     const CSS::CustomIdent& identifier() const LIFETIME_BOUND { return m_identifier; }
-    const AtomString& separator() const LIFETIME_BOUND { return m_separator; }
-    const CSS::CounterStyle& counterStyle() const { return m_counterStyle; }
+    const CSS::String& separator() const LIFETIME_BOUND { return m_separator; }
+    const CSS::CounterStyle& counterStyle() const LIFETIME_BOUND { return m_counterStyle; }
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSCounterValue&) const;
@@ -50,10 +50,10 @@ public:
     }
 
 private:
-    CSSCounterValue(CSS::CustomIdent&& identifier, AtomString&& separator, CSS::CounterStyle&&);
+    CSSCounterValue(CSS::CustomIdent&& identifier, CSS::String&& separator, CSS::CounterStyle&&);
 
     CSS::CustomIdent m_identifier;
-    AtomString m_separator;
+    CSS::String m_separator;
     CSS::CounterStyle m_counterStyle;
 };
 

--- a/Source/WebCore/css/CSSCustomIdentValue.h
+++ b/Source/WebCore/css/CSSCustomIdentValue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -28,6 +28,7 @@
 
 #include "CSSFontFaceSource.h"
 #include "CSSFontFaceSrcValue.h"
+#include "CSSFontFamilyNameValue.h"
 #include "CSSFontFeatureValue.h"
 #include "CSSFontSelector.h"
 #include "CSSFontStyleRangeValue.h"
@@ -363,13 +364,12 @@ void CSSFontFace::setDisplay(CSSValue& loadingBehaviorValue)
     });
 }
 
-String CSSFontFace::family() const
+AtomString CSSFontFace::family() const
 {
-    RefPtr value = dynamicDowncast<CSSPrimitiveValue>(properties().getPropertyCSSValue(CSSPropertyFontFamily));
+    RefPtr value = dynamicDowncast<CSSFontFamilyNameValue>(properties().getPropertyCSSValue(CSSPropertyFontFamily));
     if (!value)
         return { };
-    ASSERT(value->isFontFamily());
-    return value->stringValue();
+    return value->fontFamilyName().value;
 }
 
 String CSSFontFace::style() const

--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -76,7 +76,7 @@ public:
     void setFeatureSettings(CSSValue&);
     void setDisplay(CSSValue&);
 
-    String family() const;
+    AtomString family() const;
     String style() const;
     String weight() const;
     String width() const;

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -28,6 +28,7 @@
 #include "CSSFontFaceSet.h"
 
 #include "CSSFontFaceSource.h"
+#include "CSSFontFamilyNameValue.h"
 #include "CSSFontSelector.h"
 #include "CSSParser.h"
 #include "CSSPrimitiveValue.h"
@@ -130,7 +131,7 @@ void CSSFontFaceSet::ensureLocalFontFacesForFamilyRegistered(const AtomString& f
         auto face = CSSFontFace::create(owningFontSelector, nullptr, nullptr, true);
 
         auto& pool = protect(owningFontSelector->scriptExecutionContext())->cssValuePool();
-        face->setFamily(pool.createFontFamilyValue(familyName));
+        face->setFamily(pool.createFontFamilyNameValue(familyName));
         face->setFontSelectionCapabilities(item);
         face->adoptSource(makeUniqueWithoutRefCountedCheck<CSSFontFaceSource>(face.get(), familyName));
         ASSERT(!face->computeFailureState());
@@ -139,10 +140,10 @@ void CSSFontFaceSet::ensureLocalFontFacesForFamilyRegistered(const AtomString& f
     m_locallyInstalledFacesLookupTable.add(familyName, WTF::move(faces));
 }
 
-String CSSFontFaceSet::familyNameFromPrimitive(const CSSPrimitiveValue& value)
+AtomString CSSFontFaceSet::familyName(const CSSValue& value)
 {
-    if (value.isFontFamily())
-        return value.stringValue();
+    if (RefPtr fontFamilyNameValue = dynamicDowncast<CSSFontFamilyNameValue>(value))
+        return fontFamilyNameValue->fontFamilyName().value;
 
     // We need to use the raw text for all the generic family types, since @font-face is a way of actually
     // defining what font to use for those types.
@@ -177,7 +178,7 @@ void CSSFontFaceSet::addToFacesLookupTable(CSSFontFace& face)
         return;
     }
 
-    auto familyName = AtomString { CSSFontFaceSet::familyNameFromPrimitive(downcast<CSSPrimitiveValue>(*family)) };
+    auto familyName = CSSFontFaceSet::familyName(*family);
     if (familyName.isNull())
         return;
 
@@ -223,7 +224,7 @@ void CSSFontFaceSet::add(CSSFontFace& face)
 
 void CSSFontFaceSet::removeFromFacesLookupTable(const CSSFontFace& face, const CSSValue& familyToSearchFor)
 {
-    auto familyName = CSSFontFaceSet::familyNameFromPrimitive(downcast<CSSPrimitiveValue>(familyToSearchFor));
+    auto familyName = CSSFontFaceSet::familyName(familyToSearchFor);
     if (familyName.isNull())
         return;
 

--- a/Source/WebCore/css/CSSFontFaceSet.h
+++ b/Source/WebCore/css/CSSFontFaceSet.h
@@ -35,8 +35,8 @@
 
 namespace WebCore {
 
-class CSSPrimitiveValue;
 class CSSSegmentedFontFace;
+class CSSValue;
 class FontFaceSet;
 
 template<typename> class ExceptionOr;
@@ -108,7 +108,7 @@ private:
 
     void ensureLocalFontFacesForFamilyRegistered(const AtomString&);
 
-    static String familyNameFromPrimitive(const CSSPrimitiveValue&);
+    static AtomString familyName(const CSSValue&);
 
     using FontSelectionKey = std::optional<FontSelectionRequest>;
     struct FontSelectionKeyHash : WTF::HasherBasedHash<FontSelectionKey> {

--- a/Source/WebCore/css/CSSFontFamilyNameValue.cpp
+++ b/Source/WebCore/css/CSSFontFamilyNameValue.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSFontFamilyNameValue.h"
+
+namespace WebCore {
+
+Ref<CSSFontFamilyNameValue> CSSFontFamilyNameValue::create(CSS::FontFamilyName fontFamilyName)
+{
+    return adoptRef(*new CSSFontFamilyNameValue(WTF::move(fontFamilyName)));
+}
+
+CSSFontFamilyNameValue::CSSFontFamilyNameValue(CSS::FontFamilyName&& fontFamilyName)
+    : CSSValue(ClassType::FontFamilyName)
+    , m_fontFamilyName(WTF::move(fontFamilyName))
+{
+}
+
+String CSSFontFamilyNameValue::customCSSText(const CSS::SerializationContext& context) const
+{
+    return CSS::serializationForCSS(context, m_fontFamilyName);
+}
+
+bool CSSFontFamilyNameValue::equals(const CSSFontFamilyNameValue& other) const
+{
+    return m_fontFamilyName == other.m_fontFamilyName;
+}
+
+IterationStatus CSSFontFamilyNameValue::customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+{
+    return CSS::visitCSSValueChildren(func, m_fontFamilyName);
+}
+
+String CSSFontFamilyNameValue::stringValue() const
+{
+    return m_fontFamilyName.value;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/CSSFontFamilyNameValue.h
+++ b/Source/WebCore/css/CSSFontFamilyNameValue.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSFontFamilyName.h"
+#include "CSSValue.h"
+
+namespace WebCore {
+
+class CSSFontFamilyNameValue final : public CSSValue {
+public:
+    static Ref<CSSFontFamilyNameValue> create(CSS::FontFamilyName);
+
+    const CSS::FontFamilyName& fontFamilyName() const LIFETIME_BOUND { return m_fontFamilyName; }
+
+    String customCSSText(const CSS::SerializationContext&) const;
+    bool equals(const CSSFontFamilyNameValue&) const;
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>&) const;
+
+    String stringValue() const;
+
+private:
+    CSSFontFamilyNameValue(CSS::FontFamilyName&&);
+
+    CSS::FontFamilyName m_fontFamilyName;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSFontFamilyNameValue, isFontFamilyNameValue())

--- a/Source/WebCore/css/CSSFontFeatureValuesRule.cpp
+++ b/Source/WebCore/css/CSSFontFeatureValuesRule.cpp
@@ -45,7 +45,7 @@ String CSSFontFeatureValuesRule::cssText() const
         for (auto element : elements) {
             if (!first)
                 builder.append(separator);
-            builder.append(serializeFontFamily(element));
+            serializeFontFamily(builder, element);
             first = false;
         }
     };

--- a/Source/WebCore/css/CSSImageSetOptionValue.cpp
+++ b/Source/WebCore/css/CSSImageSetOptionValue.cpp
@@ -27,80 +27,69 @@
 #include "CSSImageSetOptionValue.h"
 
 #include "CSSImageValue.h"
+#include "CSSPrimitiveNumericTypes+CSSValueVisitation.h"
+#include "CSSPrimitiveNumericTypes+Serialization.h"
 
 namespace WebCore {
 
-CSSImageSetOptionValue::CSSImageSetOptionValue(Ref<CSSValue>&& image, Ref<CSSPrimitiveValue>&& resolution)
+CSSImageSetOptionValue::CSSImageSetOptionValue(Ref<CSSValue>&& image, std::optional<CSS::Resolution<>>&& resolution, std::optional<FunctionNotation<CSSValueType, CSS::String>>&& mimeType)
     : CSSValue(ClassType::ImageSetOption)
     , m_image(WTF::move(image))
-    , m_resolution(WTF::move(resolution))
+    , m_resolution(resolution.value_or(CSS::Literals::x(1)))
+    , m_mimeType(WTF::move(mimeType))
 {
 }
 
-CSSImageSetOptionValue::CSSImageSetOptionValue(Ref<CSSValue>&& image, Ref<CSSPrimitiveValue>&& resolution, String&& type)
-    : CSSValue(ClassType::ImageSetOption)
-    , m_image(WTF::move(image))
-    , m_resolution(WTF::move(resolution))
-    , m_mimeType(WTF::move(type))
-{
-}
-
-Ref<CSSImageSetOptionValue> CSSImageSetOptionValue::create(Ref<CSSValue>&& image)
+Ref<CSSImageSetOptionValue> CSSImageSetOptionValue::create(Ref<CSSValue>&& image, std::optional<CSS::Resolution<>>&& resolution, std::optional<FunctionNotation<CSSValueType, CSS::String>>&& mimeType)
 {
     ASSERT(is<CSSImageValue>(image) || image->isImageGeneratorValue());
-    return adoptRef(*new CSSImageSetOptionValue(WTF::move(image), CSSPrimitiveValue::create(1.0, CSSUnitType::CSS_X)));
-}
-
-Ref<CSSImageSetOptionValue> CSSImageSetOptionValue::create(Ref<CSSValue>&& image, Ref<CSSPrimitiveValue>&& resolution)
-{
-    ASSERT(is<CSSImageValue>(image) || image->isImageGeneratorValue());
-    return adoptRef(*new CSSImageSetOptionValue(WTF::move(image), WTF::move(resolution)));
-}
-
-Ref<CSSImageSetOptionValue> CSSImageSetOptionValue::create(Ref<CSSValue>&& image, Ref<CSSPrimitiveValue>&& resolution, String type)
-{
-    ASSERT(is<CSSImageValue>(image) || image->isImageGeneratorValue());
-    return adoptRef(*new CSSImageSetOptionValue(WTF::move(image), WTF::move(resolution), WTF::move(type)));
+    return adoptRef(*new CSSImageSetOptionValue( WTF::move(image), WTF::move(resolution), WTF::move(mimeType)));
 }
 
 bool CSSImageSetOptionValue::equals(const CSSImageSetOptionValue& other) const
 {
     if (!m_image->equals(other.m_image))
         return false;
-
-    if (!m_resolution->equals(other.m_resolution))
+    if (m_resolution != other.m_resolution)
         return false;
-
     if (m_mimeType != other.m_mimeType)
         return false;
-
     return true;
 }
 
 String CSSImageSetOptionValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    StringBuilder result;
-    result.append(m_image->cssText(context));
-    result.append(' ', m_resolution->cssText(context));
-    if (!m_mimeType.isNull())
-        result.append(" type(\""_s, m_mimeType, "\")"_s);
+    using namespace CSS::Literals;
 
-    return result.toString();
+    StringBuilder builder;
+    builder.append(m_image->cssText(context));
+
+    // FIXME: The resolution should probably not be serialized when m_resolution is the default value to comply with the shortest serialization principle.
+    builder.append(' ');
+    CSS::serializationForCSS(builder, context, m_resolution);
+
+    if (m_mimeType) {
+        builder.append(' ');
+        CSS::serializationForCSS(builder, context, *m_mimeType);
+    }
+
+    return builder.toString();
 }
 
-void CSSImageSetOptionValue::setResolution(Ref<CSSPrimitiveValue>&& resolution)
+IterationStatus CSSImageSetOptionValue::customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const
 {
-    m_resolution = WTF::move(resolution);
-}
-
-void CSSImageSetOptionValue::setType(String type)
-{
-    m_mimeType = WTF::move(type);
+    if (func(m_image.get()) == IterationStatus::Done)
+        return IterationStatus::Done;
+    if (CSS::visitCSSValueChildren(func, m_resolution) == IterationStatus::Done)
+        return IterationStatus::Done;
+    if (CSS::visitCSSValueChildren(func, m_mimeType) == IterationStatus::Done)
+        return IterationStatus::Done;
+    return IterationStatus::Continue;
 }
 
 bool CSSImageSetOptionValue::customTraverseSubresources(NOESCAPE const Function<bool(const CachedResource&)>& handler) const
 {
-    return m_resolution->traverseSubresources(handler) || m_image->traverseSubresources(handler);
+    return m_image->traverseSubresources(handler);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSImageSetOptionValue.h
+++ b/Source/WebCore/css/CSSImageSetOptionValue.h
@@ -25,47 +25,36 @@
 
 #pragma once
 
-#include "CSSPrimitiveValue.h"
+#include "CSSPrimitiveNumeric.h"
+#include "CSSString.h"
 #include "CSSValue.h"
 #include <wtf/Function.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
+// <image-set-option> = [ <image> | <string> ] [ <resolution> || type(<string>) ]?
+// https://drafts.csswg.org/css-images-4/#typedef-image-set-option
 class CSSImageSetOptionValue final : public CSSValue {
 public:
-    static Ref<CSSImageSetOptionValue> create(Ref<CSSValue>&&);
-    static Ref<CSSImageSetOptionValue> NODELETE create(Ref<CSSValue>&&, Ref<CSSPrimitiveValue>&&);
-    static Ref<CSSImageSetOptionValue> create(Ref<CSSValue>&&, Ref<CSSPrimitiveValue>&&, String);
+    static Ref<CSSImageSetOptionValue> create(Ref<CSSValue>&&, std::optional<CSS::Resolution<>>&&, std::optional<FunctionNotation<CSSValueType, CSS::String>>&&);
 
     bool equals(const CSSImageSetOptionValue&) const;
     String customCSSText(const CSS::SerializationContext&) const;
 
-    CSSValue& image() const { return m_image; }
+    const CSSValue& image() const LIFETIME_BOUND { return m_image; }
+    const CSS::Resolution<>& resolution() const LIFETIME_BOUND { return m_resolution; }
+    const std::optional<FunctionNotation<CSSValueType, CSS::String>>& type() const LIFETIME_BOUND { return m_mimeType; }
 
-    CSSPrimitiveValue& resolution() const { return m_resolution; }
-    void NODELETE setResolution(Ref<CSSPrimitiveValue>&&);
-
-    String type() const { return m_mimeType; }
-    void setType(String);
-
-    IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const
-    {
-        if (func(m_image.get()) == IterationStatus::Done)
-            return IterationStatus::Done;
-        if (func(m_resolution.get()) == IterationStatus::Done)
-            return IterationStatus::Done;
-        return IterationStatus::Continue;
-    }
+    IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;
     bool customTraverseSubresources(NOESCAPE const Function<bool(const CachedResource&)>&) const;
 
 private:
-    CSSImageSetOptionValue(Ref<CSSValue>&&, Ref<CSSPrimitiveValue>&&);
-    CSSImageSetOptionValue(Ref<CSSValue>&&, Ref<CSSPrimitiveValue>&&, String&&);
+    CSSImageSetOptionValue(Ref<CSSValue>&&, std::optional<CSS::Resolution<>>&&, std::optional<FunctionNotation<CSSValueType, CSS::String>>&&);
 
     const Ref<CSSValue> m_image;
-    Ref<CSSPrimitiveValue> m_resolution;
-    String m_mimeType;
+    const CSS::Resolution<> m_resolution;
+    const std::optional<FunctionNotation<CSSValueType, CSS::String>> m_mimeType;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSImageSetValue.cpp
+++ b/Source/WebCore/css/CSSImageSetValue.cpp
@@ -31,6 +31,8 @@
 #include "CSSPrimitiveValue.h"
 #include "StyleBuilderState.h"
 #include "StyleImageSet.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
+#include "StyleString.h"
 #include <numeric>
 #include <wtf/text/StringBuilder.h>
 
@@ -68,8 +70,8 @@ RefPtr<Style::Image> CSSImageSetValue::createStyleImage(const Style::BuilderStat
         RefPtr<const CSSImageSetOptionValue> option = downcast<CSSImageSetOptionValue>(item(i));
         return Style::ImageWithScale {
             .image = state.createStyleImage(option->image()),
-            .scaleFactor = protect(option->resolution())->resolveAsResolution<float>(state.cssToLengthConversionData()),
-            .mimeType = option->type(),
+            .scaleFactor = Style::toStyle(option->resolution(), state),
+            .mimeType = Style::toStyle(option->type(), state),
         };
     });
 
@@ -79,7 +81,7 @@ RefPtr<Style::Image> CSSImageSetValue::createStyleImage(const Style::BuilderStat
     std::iota(sortedIndices.begin(), sortedIndices.end(), 0);
 
     std::stable_sort(sortedIndices.begin(), sortedIndices.end(), [&images](size_t lhs, size_t rhs) {
-        return images[lhs].scaleFactor < images[rhs].scaleFactor;
+        return images[lhs].scaleFactor.value < images[rhs].scaleFactor.value;
     });
 
     return Style::ImageSet::create(WTF::move(images), WTF::move(sortedIndices));

--- a/Source/WebCore/css/CSSMarkup.cpp
+++ b/Source/WebCore/css/CSSMarkup.cpp
@@ -152,10 +152,10 @@ String serializeString(StringView string)
     return builder.toString();
 }
 
-String serializeFontFamily(const String& string)
+static bool shouldQuoteFontFamily(StringView string)
 {
     if (!isCSSTokenizerIdentifier(string))
-        return serializeString(string);
+        return true;
 
     // Font family names that match CSS-wide keywords, 'default', or generic
     // family keywords must be quoted to prevent confusion with the keywords
@@ -168,9 +168,23 @@ String serializeFontFamily(const String& string)
     // keyword from a quoted family name at this point, and the generic
     // keyword is the common case, we leave it unquoted.
     auto valueID = cssValueKeywordID(string);
-    if (valueID != CSSValueSystemUi && (!isValidCustomIdentifier(valueID) || isGenericFontFamilyKeyword(valueID)))
-        return serializeString(string);
+    return valueID != CSSValueSystemUi && (!isValidCustomIdentifier(valueID) || isGenericFontFamilyKeyword(valueID));
+}
 
+void serializeFontFamily(StringBuilder& builder, StringView string)
+{
+    if (shouldQuoteFontFamily(string)) {
+        serializeString(builder, string);
+        return;
+    }
+
+    builder.append(string);
+}
+
+String serializeFontFamily(const String& string)
+{
+    if (shouldQuoteFontFamily(string))
+        return serializeString(string);
     return string;
 }
 

--- a/Source/WebCore/css/CSSMarkup.h
+++ b/Source/WebCore/css/CSSMarkup.h
@@ -31,10 +31,14 @@ namespace WebCore {
 
 // Common serializing methods. See: http://dev.w3.org/csswg/cssom/#common-serializing-idioms
 enum class ShouldSkipStartChecks : bool { No, Yes };
-void serializeIdentifier(StringBuilder& appendTo, StringView identifier, ShouldSkipStartChecks = ShouldSkipStartChecks::No);
-void serializeString(StringBuilder& appendTo, StringView);
+void serializeIdentifier(StringBuilder&, StringView identifier, ShouldSkipStartChecks = ShouldSkipStartChecks::No);
+
+void serializeString(StringBuilder&, StringView);
 String serializeString(StringView);
-void serializeURLTokenValue(StringBuilder& appendTo, StringView);
+
+void serializeURLTokenValue(StringBuilder&, StringView);
+
+void serializeFontFamily(StringBuilder&, StringView);
 String serializeFontFamily(const String&);
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSNamedImageValue.cpp
+++ b/Source/WebCore/css/CSSNamedImageValue.cpp
@@ -27,11 +27,11 @@
 #include "CSSNamedImageValue.h"
 
 #include "StyleNamedImage.h"
-#include <wtf/text/MakeString.h>
+#include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
-CSSNamedImageValue::CSSNamedImageValue(String&& name)
+CSSNamedImageValue::CSSNamedImageValue(CSS::CustomIdent&& name)
     : CSSValue { ClassType::NamedImage }
     , m_name { WTF::move(name) }
 {
@@ -39,9 +39,13 @@ CSSNamedImageValue::CSSNamedImageValue(String&& name)
 
 CSSNamedImageValue::~CSSNamedImageValue() = default;
 
-String CSSNamedImageValue::customCSSText(const CSS::SerializationContext&) const
+String CSSNamedImageValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    return makeString("-webkit-named-image("_s, m_name, ')');
+    StringBuilder builder;
+    builder.append("-webkit-named-image("_s);
+    CSS::serializationForCSS(builder, context, m_name);
+    builder.append(')');
+    return builder.toString();
 }
 
 bool CSSNamedImageValue::equals(const CSSNamedImageValue& other) const
@@ -49,12 +53,12 @@ bool CSSNamedImageValue::equals(const CSSNamedImageValue& other) const
     return m_name == other.m_name;
 }
 
-RefPtr<Style::Image> CSSNamedImageValue::createStyleImage(const Style::BuilderState&) const
+RefPtr<Style::Image> CSSNamedImageValue::createStyleImage(const Style::BuilderState& state) const
 {
     if (m_cachedStyleImage)
         return m_cachedStyleImage;
 
-    m_cachedStyleImage = Style::NamedImage::create(m_name);
+    m_cachedStyleImage = Style::NamedImage::create(Style::toStyle(m_name, state));
     return m_cachedStyleImage;
 }
 

--- a/Source/WebCore/css/CSSNamedImageValue.h
+++ b/Source/WebCore/css/CSSNamedImageValue.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
+#include "CSSCustomIdent.h"
 #include "CSSValue.h"
-#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
@@ -37,7 +37,7 @@ class Image;
 
 class CSSNamedImageValue final : public CSSValue {
 public:
-    static Ref<CSSNamedImageValue> create(String name)
+    static Ref<CSSNamedImageValue> create(CSS::CustomIdent&& name)
     {
         return adoptRef(*new CSSNamedImageValue(WTF::move(name)));
     }
@@ -49,9 +49,9 @@ public:
     RefPtr<Style::Image> createStyleImage(const Style::BuilderState&) const;
 
 private:
-    explicit CSSNamedImageValue(String&&);
+    explicit CSSNamedImageValue(CSS::CustomIdent&&);
 
-    String m_name;
+    CSS::CustomIdent m_name;
     mutable RefPtr<Style::Image> m_cachedStyleImage;
 };
 

--- a/Source/WebCore/css/CSSPaintImageValue.cpp
+++ b/Source/WebCore/css/CSSPaintImageValue.cpp
@@ -29,12 +29,11 @@
 
 #include "CSSVariableData.h"
 #include "StylePaintImage.h"
-#include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
-CSSPaintImageValue::CSSPaintImageValue(String&& name, Ref<CSSVariableData>&& arguments)
+CSSPaintImageValue::CSSPaintImageValue(CSS::CustomIdent&& name, Ref<CSSVariableData>&& arguments)
     : CSSValue { ClassType::PaintImage }
     , m_name { WTF::move(name) }
     , m_arguments { WTF::move(arguments) }
@@ -43,15 +42,20 @@ CSSPaintImageValue::CSSPaintImageValue(String&& name, Ref<CSSVariableData>&& arg
 
 CSSPaintImageValue::~CSSPaintImageValue() = default;
 
-String CSSPaintImageValue::customCSSText(const CSS::SerializationContext&) const
+String CSSPaintImageValue::customCSSText(const CSS::SerializationContext& context) const
 {
     // FIXME: This should include the arguments too.
-    return makeString("paint("_s, m_name, ')');
+
+    StringBuilder builder;
+    builder.append("paint("_s);
+    CSS::serializationForCSS(builder, context, m_name);
+    builder.append(')');
+    return builder.toString();
 }
 
-RefPtr<Style::Image> CSSPaintImageValue::createStyleImage(const Style::BuilderState&) const
+RefPtr<Style::Image> CSSPaintImageValue::createStyleImage(const Style::BuilderState& state) const
 {
-    return Style::PaintImage::create(m_name, m_arguments);
+    return Style::PaintImage::create(Style::toStyle(m_name, state), m_arguments);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSPaintImageValue.h
+++ b/Source/WebCore/css/CSSPaintImageValue.h
@@ -26,8 +26,8 @@
 
 #pragma once
 
+#include "CSSCustomIdent.h"
 #include "CSSValue.h"
-#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
@@ -40,13 +40,13 @@ class Image;
 
 class CSSPaintImageValue final : public CSSValue {
 public:
-    static Ref<CSSPaintImageValue> create(String name, Ref<CSSVariableData> arguments)
+    static Ref<CSSPaintImageValue> create(CSS::CustomIdent&& name, Ref<CSSVariableData> arguments)
     {
         return adoptRef(*new CSSPaintImageValue(WTF::move(name), WTF::move(arguments)));
     }
     ~CSSPaintImageValue();
 
-    const String& name() const LIFETIME_BOUND { return m_name; }
+    const CSS::CustomIdent& name() const LIFETIME_BOUND { return m_name; }
 
     bool equals(const CSSPaintImageValue& other) const { return m_name == other.m_name; }
     String customCSSText(const CSS::SerializationContext&) const;
@@ -54,9 +54,9 @@ public:
     RefPtr<Style::Image> createStyleImage(const Style::BuilderState&) const;
 
 private:
-    explicit CSSPaintImageValue(String&&, Ref<CSSVariableData>&&);
+    explicit CSSPaintImageValue(CSS::CustomIdent&&, Ref<CSSVariableData>&&);
 
-    String m_name;
+    CSS::CustomIdent m_name;
     const Ref<CSSVariableData> m_arguments;
 };
 

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -126,110 +126,14 @@ static inline bool NODELETE isValidCSSUnitTypeForDoubleConversion(CSSUnitType un
     case CSSUnitType::CSS_CQMIN:
     case CSSUnitType::CSS_CQMAX:
         return true;
-    case CSSUnitType::CSS_ATTR:
-    case CSSUnitType::CSS_FONT_FAMILY:
-    case CSSUnitType::CSS_STRING:
     case CSSUnitType::CSS_UNKNOWN:
     case CSSUnitType::CSS_VALUE_ID:
-        return false;
-    case CSSUnitType::CSS_IDENT:
-        break;
-    }
-
-    ASSERT_NOT_REACHED();
-    return false;
-}
-
-#if ASSERT_ENABLED
-
-static inline bool isStringType(CSSUnitType type)
-{
-    switch (type) {
-    case CSSUnitType::CSS_STRING:
-    case CSSUnitType::CSS_ATTR:
-    case CSSUnitType::CSS_FONT_FAMILY:
-        return true;
-    case CSSUnitType::CSS_CALC:
-    case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
-    case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:
-    case CSSUnitType::CSS_CAP:
-    case CSSUnitType::CSS_CH:
-    case CSSUnitType::CSS_IC:
-    case CSSUnitType::CSS_CM:
-    case CSSUnitType::CSS_DEG:
-    case CSSUnitType::CSS_DIMENSION:
-    case CSSUnitType::CSS_DPCM:
-    case CSSUnitType::CSS_DPI:
-    case CSSUnitType::CSS_DPPX:
-    case CSSUnitType::CSS_DVB:
-    case CSSUnitType::CSS_DVH:
-    case CSSUnitType::CSS_DVI:
-    case CSSUnitType::CSS_DVMAX:
-    case CSSUnitType::CSS_DVMIN:
-    case CSSUnitType::CSS_DVW:
-    case CSSUnitType::CSS_X:
-    case CSSUnitType::CSS_EM:
-    case CSSUnitType::CSS_EX:
-    case CSSUnitType::CSS_FR:
-    case CSSUnitType::CSS_GRAD:
-    case CSSUnitType::CSS_HZ:
-    case CSSUnitType::CSS_IDENT:
-    case CSSUnitType::CSS_IN:
-    case CSSUnitType::CSS_KHZ:
-    case CSSUnitType::CSS_LVB:
-    case CSSUnitType::CSS_LVH:
-    case CSSUnitType::CSS_LVI:
-    case CSSUnitType::CSS_LVMAX:
-    case CSSUnitType::CSS_LVMIN:
-    case CSSUnitType::CSS_LVW:
-    case CSSUnitType::CSS_MM:
-    case CSSUnitType::CSS_MS:
-    case CSSUnitType::CSS_NUMBER:
-    case CSSUnitType::CSS_INTEGER:
-    case CSSUnitType::CSS_PC:
-    case CSSUnitType::CSS_PERCENTAGE:
-    case CSSUnitType::CSS_PT:
-    case CSSUnitType::CSS_PX:
-    case CSSUnitType::CSS_Q:
-    case CSSUnitType::CSS_LH:
-    case CSSUnitType::CSS_RLH:
-    case CSSUnitType::CSS_QUIRKY_EM:
-    case CSSUnitType::CSS_RAD:
-    case CSSUnitType::CSS_RCAP:
-    case CSSUnitType::CSS_RCH:
-    case CSSUnitType::CSS_REM:
-    case CSSUnitType::CSS_REX:
-    case CSSUnitType::CSS_RIC:
-    case CSSUnitType::CSS_S:
-    case CSSUnitType::CSS_SVB:
-    case CSSUnitType::CSS_SVH:
-    case CSSUnitType::CSS_SVI:
-    case CSSUnitType::CSS_SVMAX:
-    case CSSUnitType::CSS_SVMIN:
-    case CSSUnitType::CSS_SVW:
-    case CSSUnitType::CSS_TURN:
-    case CSSUnitType::CSS_UNKNOWN:
-    case CSSUnitType::CSS_VALUE_ID:
-    case CSSUnitType::CSS_VB:
-    case CSSUnitType::CSS_VH:
-    case CSSUnitType::CSS_VI:
-    case CSSUnitType::CSS_VMAX:
-    case CSSUnitType::CSS_VMIN:
-    case CSSUnitType::CSS_VW:
-    case CSSUnitType::CSS_CQW:
-    case CSSUnitType::CSS_CQH:
-    case CSSUnitType::CSS_CQI:
-    case CSSUnitType::CSS_CQB:
-    case CSSUnitType::CSS_CQMIN:
-    case CSSUnitType::CSS_CQMAX:
         return false;
     }
 
     ASSERT_NOT_REACHED();
     return false;
 }
-
-#endif // ASSERT_ENABLED
 
 static HashMap<const CSSPrimitiveValue*, String>& NODELETE serializedPrimitiveValues()
 {
@@ -239,20 +143,9 @@ static HashMap<const CSSPrimitiveValue*, String>& NODELETE serializedPrimitiveVa
 
 CSSUnitType CSSPrimitiveValue::primitiveType() const
 {
-    auto type = primitiveUnitType();
-    switch (type) {
-    case CSSUnitType::CSS_VALUE_ID:
-        return CSSUnitType::CSS_IDENT;
-    case CSSUnitType::CSS_FONT_FAMILY:
-        // Web-exposed content expects font family values to have CSSUnitType::CSS_STRING primitive type
-        // so we need to map our internal CSSUnitType::CSS_FONT_FAMILY type here.
-        return CSSUnitType::CSS_STRING;
-    default:
-        if (auto* calcValue = cssCalcValue())
-            return calcValue->primitiveType();
-
-        return type;
-    }
+    if (RefPtr calcValue = cssCalcValue())
+        return calcValue->primitiveType();
+    return primitiveUnitType();
 }
 
 CSSPrimitiveValue::CSSPrimitiveValue(double number, CSSUnitType type)
@@ -260,15 +153,6 @@ CSSPrimitiveValue::CSSPrimitiveValue(double number, CSSUnitType type)
 {
     setPrimitiveUnitType(type);
     m_value.number = number;
-}
-
-CSSPrimitiveValue::CSSPrimitiveValue(const String& string, CSSUnitType type)
-    : CSSValue(ClassType::Primitive)
-{
-    ASSERT(isStringType(type));
-    setPrimitiveUnitType(type);
-    if ((m_value.string = string.impl()))
-        m_value.string->ref();
 }
 
 CSSPrimitiveValue::CSSPrimitiveValue(StaticCSSValueTag, CSSValueID valueID)
@@ -298,25 +182,10 @@ CSSPrimitiveValue::CSSPrimitiveValue(Ref<CSSCalc::Value> value)
     m_value.calc = &value.leakRef();
 }
 
-CSSPrimitiveValue::CSSPrimitiveValue(Ref<CSSAttrValue> value)
-    : CSSValue(ClassType::Primitive)
-{
-    setPrimitiveUnitType(CSSUnitType::CSS_ATTR);
-    m_value.attr = &value.leakRef();
-}
-
 CSSPrimitiveValue::~CSSPrimitiveValue()
 {
     auto type = primitiveUnitType();
     switch (type) {
-    case CSSUnitType::CSS_STRING:
-    case CSSUnitType::CSS_FONT_FAMILY:
-        if (m_value.string)
-            m_value.string->deref();
-        break;
-    case CSSUnitType::CSS_ATTR:
-        m_value.attr->deref();
-        break;
     case CSSUnitType::CSS_CALC:
         m_value.calc->deref();
         break;
@@ -385,7 +254,6 @@ CSSPrimitiveValue::~CSSPrimitiveValue()
     case CSSUnitType::CSS_Q:
     case CSSUnitType::CSS_LH:
     case CSSUnitType::CSS_RLH:
-    case CSSUnitType::CSS_IDENT:
     case CSSUnitType::CSS_UNKNOWN:
     case CSSUnitType::CSS_VALUE_ID:
     case CSSUnitType::CSS_CQW:
@@ -394,7 +262,6 @@ CSSPrimitiveValue::~CSSPrimitiveValue()
     case CSSUnitType::CSS_CQB:
     case CSSUnitType::CSS_CQMIN:
     case CSSUnitType::CSS_CQMAX:
-        ASSERT(!isStringType(type));
         break;
     }
     if (m_hasCachedCSSText) {
@@ -442,24 +309,9 @@ Ref<CSSPrimitiveValue> CSSPrimitiveValue::create(double value, CSSUnitType type)
     return adoptRef(*new CSSPrimitiveValue(value, type));
 }
 
-Ref<CSSPrimitiveValue> CSSPrimitiveValue::create(String value)
-{
-    return adoptRef(*new CSSPrimitiveValue(WTF::move(value), CSSUnitType::CSS_STRING));
-}
-
 Ref<CSSPrimitiveValue> CSSPrimitiveValue::create(Ref<CSSCalc::Value> value)
 {
     return adoptRef(*new CSSPrimitiveValue(WTF::move(value)));
-}
-
-Ref<CSSPrimitiveValue> CSSPrimitiveValue::create(Ref<CSSAttrValue> value)
-{
-    return adoptRef(*new CSSPrimitiveValue(WTF::move(value)));
-}
-
-Ref<CSSPrimitiveValue> CSSPrimitiveValue::createFontFamily(String value)
-{
-    return adoptRef(*new CSSPrimitiveValue(WTF::move(value), CSSUnitType::CSS_FONT_FAMILY));
 }
 
 Ref<CSSPrimitiveValue> CSSPrimitiveValue::createInteger(double value)
@@ -799,13 +651,8 @@ std::optional<double> CSSPrimitiveValue::doubleValueInternalDeprecated(CSSUnitTy
 String CSSPrimitiveValue::stringValue() const
 {
     switch (primitiveUnitType()) {
-    case CSSUnitType::CSS_STRING:
-    case CSSUnitType::CSS_FONT_FAMILY:
-        return m_value.string;
     case CSSUnitType::CSS_VALUE_ID:
         return nameString(m_value.valueID);
-    case CSSUnitType::CSS_ATTR:
-        return protect(cssAttrValue())->cssText(CSS::defaultSerializationContext());
     default:
         return String();
     }
@@ -890,17 +737,13 @@ ASCIILiteral CSSPrimitiveValue::unitTypeString(CSSUnitType unitType)
     case CSSUnitType::CSS_VW: return "vw"_s;
     case CSSUnitType::CSS_X: return "x"_s;
 
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_CALC:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:
     case CSSUnitType::CSS_DIMENSION:
-    case CSSUnitType::CSS_FONT_FAMILY:
-    case CSSUnitType::CSS_IDENT:
     case CSSUnitType::CSS_INTEGER:
     case CSSUnitType::CSS_NUMBER:
     case CSSUnitType::CSS_QUIRKY_EM:
-    case CSSUnitType::CSS_STRING:
     case CSSUnitType::CSS_UNKNOWN:
     case CSSUnitType::CSS_VALUE_ID:
         return ""_s;
@@ -978,24 +821,17 @@ ALWAYS_INLINE String CSSPrimitiveValue::serializeInternal(const CSS::Serializati
     case CSSUnitType::CSS_VW:
     case CSSUnitType::CSS_X:
         return formatNumberValue(unitTypeString(type));
-    case CSSUnitType::CSS_ATTR:
-        return protect(cssAttrValue())->cssText(context);
     case CSSUnitType::CSS_CALC:
         return protect(cssCalcValue())->cssText(context);
     case CSSUnitType::CSS_DIMENSION:
         // FIXME: This isn't correct.
         return formatNumberValue(""_s);
-    case CSSUnitType::CSS_FONT_FAMILY:
-        return serializeFontFamily(m_value.string);
     case CSSUnitType::CSS_INTEGER:
         return formatIntegerValue(""_s);
     case CSSUnitType::CSS_QUIRKY_EM:
         return formatNumberValue("em"_s);
-    case CSSUnitType::CSS_STRING:
-        return serializeString(m_value.string);
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:
-    case CSSUnitType::CSS_IDENT:
     case CSSUnitType::CSS_UNKNOWN:
     case CSSUnitType::CSS_VALUE_ID:
         break;
@@ -1101,14 +937,8 @@ bool CSSPrimitiveValue::equals(const CSSPrimitiveValue& other) const
         return m_value.number == other.m_value.number;
     case CSSUnitType::CSS_VALUE_ID:
         return m_value.valueID == other.m_value.valueID;
-    case CSSUnitType::CSS_STRING:
-    case CSSUnitType::CSS_FONT_FAMILY:
-        return equal(m_value.string, other.m_value.string);
-    case CSSUnitType::CSS_ATTR:
-        return protect(cssAttrValue())->equals(*protect(other.cssAttrValue()));
     case CSSUnitType::CSS_CALC:
         return protect(cssCalcValue())->equals(*protect(other.cssCalcValue()));
-    case CSSUnitType::CSS_IDENT:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:
         // FIXME: seems like these should be handled.
@@ -1197,17 +1027,9 @@ bool CSSPrimitiveValue::addDerivedHash(Hasher& hasher) const
     case CSSUnitType::CSS_VALUE_ID:
         add(hasher, m_value.valueID);
         break;
-    case CSSUnitType::CSS_STRING:
-    case CSSUnitType::CSS_FONT_FAMILY:
-        add(hasher, String { m_value.string });
-        break;
-    case CSSUnitType::CSS_ATTR:
-        add(hasher, m_value.attr);
-        break;
     case CSSUnitType::CSS_CALC:
         add(hasher, m_value.calc);
         break;
-    case CSSUnitType::CSS_IDENT:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -22,7 +22,6 @@
 
 #pragma once
 
-#include <WebCore/CSSAttrValue.h>
 #include <WebCore/CSSCalcValue.h>
 #include <WebCore/CSSPrimitiveNumericUnits.h>
 #include <WebCore/CSSValue.h>
@@ -57,7 +56,6 @@ public:
 
     // FIXME: Some of these use primitiveUnitType() and some use NODELETE primitiveType(). Many that use primitiveUnitType() are likely broken with calc().
     bool isAngle() const { return unitCategory(primitiveType()) == CSSUnitCategory::Angle; }
-    bool isAttr() const { return primitiveUnitType() == CSSUnitType::CSS_ATTR; }
     bool isFontIndependentLength() const { return isFontIndependentLength(primitiveUnitType()); }
     bool isFontRelativeLength() const { return isFontRelativeLength(primitiveUnitType()); }
     bool isParentFontRelativeLength() const { return isPercentage() || (isFontRelativeLength() && !isRootFontRelativeLength()); }
@@ -88,17 +86,10 @@ public:
     static Ref<CSSPrimitiveValue> create(double, CSSUnitType);
     static Ref<CSSPrimitiveValue> NODELETE createInteger(double);
     static Ref<CSSPrimitiveValue> create(Ref<CSSCalc::Value>);
-    static Ref<CSSPrimitiveValue> NODELETE create(Ref<CSSAttrValue>);
 
     static inline Ref<CSSPrimitiveValue> create(CSSValueID);
     bool isValueID() const { return primitiveUnitType() == CSSUnitType::CSS_VALUE_ID; }
     CSSValueID valueID() const { return isValueID() ? m_value.valueID : CSSValueInvalid; }
-
-    bool isString() const { return primitiveUnitType() == CSSUnitType::CSS_STRING; }
-    static Ref<CSSPrimitiveValue> create(String);
-
-    static Ref<CSSPrimitiveValue> createFontFamily(String);
-    bool isFontFamily() const { return primitiveUnitType() == CSSUnitType::CSS_FONT_FAMILY; }
 
     static inline CSSPrimitiveValue& implicitInitialValue();
 
@@ -168,7 +159,6 @@ public:
 
     WEBCORE_EXPORT String stringValue() const;
     const CSSCalc::Value* cssCalcValue() const { return isCalculated() ? m_value.calc : nullptr; }
-    const CSSAttrValue* cssAttrValue() const { return isAttr() ? m_value.attr : nullptr; }
 
     String customCSSText(const CSS::SerializationContext&) const;
 
@@ -187,7 +177,6 @@ private:
     CSSPrimitiveValue(const String&, CSSUnitType);
     CSSPrimitiveValue(double, CSSUnitType);
     explicit CSSPrimitiveValue(Ref<CSSCalc::Value>);
-    explicit CSSPrimitiveValue(Ref<CSSAttrValue>);
 
     CSSPrimitiveValue(StaticCSSValueTag, CSSValueID);
     CSSPrimitiveValue(StaticCSSValueTag, double, CSSUnitType);
@@ -241,9 +230,7 @@ private:
     union {
         CSSValueID valueID;
         double number;
-        StringImpl* string;
         const CSSCalc::Value* calc;
-        const CSSAttrValue* attr;
     } m_value;
 };
 
@@ -727,18 +714,6 @@ inline CSSValueID CSSValue::valueID() const
 {
     auto* value = dynamicDowncast<CSSPrimitiveValue>(*this);
     return value ? value->valueID() : CSSValueInvalid;
-}
-
-inline bool CSSValue::isString() const
-{
-    auto* value = dynamicDowncast<CSSPrimitiveValue>(*this);
-    return value && value->isString();
-}
-
-inline String CSSValue::string() const
-{
-    ASSERT(isString());
-    return downcast<CSSPrimitiveValue>(*this).stringValue();
 }
 
 inline bool CSSValue::isInteger() const

--- a/Source/WebCore/css/CSSStringValue.cpp
+++ b/Source/WebCore/css/CSSStringValue.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSStringValue.h"
+
+namespace WebCore {
+
+Ref<CSSStringValue> CSSStringValue::create(CSS::String string)
+{
+    return adoptRef(*new CSSStringValue(WTF::move(string)));
+}
+
+CSSStringValue::CSSStringValue(CSS::String&& string)
+    : CSSValue(ClassType::String)
+    , m_string(WTF::move(string))
+{
+}
+
+String CSSStringValue::customCSSText(const CSS::SerializationContext& context) const
+{
+    return CSS::serializationForCSS(context, m_string);
+}
+
+bool CSSStringValue::equals(const CSSStringValue& other) const
+{
+    return m_string == other.m_string;
+}
+
+IterationStatus CSSStringValue::customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
+{
+    return CSS::visitCSSValueChildren(func, m_string);
+}
+
+String CSSStringValue::stringValue() const
+{
+    return m_string.value;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/CSSStringValue.h
+++ b/Source/WebCore/css/CSSStringValue.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSString.h"
+#include "CSSValue.h"
+
+namespace WebCore {
+
+class CSSStringValue final : public CSSValue {
+public:
+    static Ref<CSSStringValue> create(CSS::String);
+
+    const CSS::String& string() const LIFETIME_BOUND { return m_string; }
+
+    String customCSSText(const CSS::SerializationContext&) const;
+    bool equals(const CSSStringValue&) const;
+    IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>&) const;
+
+    String stringValue() const;
+
+private:
+    CSSStringValue(CSS::String&&);
+
+    CSS::String m_string;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSStringValue, isStringValue())

--- a/Source/WebCore/css/CSSURLValue.h
+++ b/Source/WebCore/css/CSSURLValue.h
@@ -42,7 +42,7 @@ public:
     }
 
     const CSS::URL& url() const LIFETIME_BOUND { return m_url; }
-    String stringValue() const { return m_url.specified; }
+    WTF::String stringValue() const { return m_url.specified; }
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSURLValue&) const;

--- a/Source/WebCore/css/CSSUnits.cpp
+++ b/Source/WebCore/css/CSSUnits.cpp
@@ -111,15 +111,11 @@ CSSUnitCategory unitCategory(CSSUnitType type)
     case CSSUnitType::CSS_CQB:
     case CSSUnitType::CSS_CQMIN:
     case CSSUnitType::CSS_CQMAX:
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_CALC:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:
     case CSSUnitType::CSS_DIMENSION:
-    case CSSUnitType::CSS_FONT_FAMILY:
-    case CSSUnitType::CSS_IDENT:
     case CSSUnitType::CSS_QUIRKY_EM:
-    case CSSUnitType::CSS_STRING:
     case CSSUnitType::CSS_UNKNOWN:
     case CSSUnitType::CSS_VALUE_ID:
         return CSSUnitCategory::Other;
@@ -202,9 +198,6 @@ TextStream& operator<<(TextStream& ts, CSSUnitType unitType)
     case CSSUnitType::CSS_HZ: ts << "hz"_s; break;
     case CSSUnitType::CSS_KHZ: ts << "khz"_s; break;
     case CSSUnitType::CSS_DIMENSION: ts << "dimension"_s; break;
-    case CSSUnitType::CSS_STRING: ts << "string"_s; break;
-    case CSSUnitType::CSS_IDENT: ts << "ident"_s; break;
-    case CSSUnitType::CSS_ATTR: ts << "attr"_s; break;
     case CSSUnitType::CSS_VW: ts << "vw"_s; break;
     case CSSUnitType::CSS_VH: ts << "vh"_s; break;
     case CSSUnitType::CSS_VMIN: ts << "vmin"_s; break;
@@ -255,7 +248,6 @@ TextStream& operator<<(TextStream& ts, CSSUnitType unitType)
     case CSSUnitType::CSS_CALC: ts << "calc"_s; break;
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE: ts << "calc_percentage_with_angle"_s; break;
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH: ts << "calc_percentage_with_length"_s; break;
-    case CSSUnitType::CSS_FONT_FAMILY: ts << "font_family"_s; break;
     case CSSUnitType::CSS_VALUE_ID: ts << "value_id"_s; break;
     case CSSUnitType::CSS_QUIRKY_EM: ts << "quirky_em"_s; break;
     }
@@ -366,15 +358,11 @@ bool conversionToCanonicalUnitRequiresConversionData(CSSUnitType unit)
     case CSSUnitType::CSS_DPI:
     case CSSUnitType::CSS_DPCM:
     case CSSUnitType::CSS_FR:
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_CALC:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:
     case CSSUnitType::CSS_DIMENSION:
-    case CSSUnitType::CSS_FONT_FAMILY:
-    case CSSUnitType::CSS_IDENT:
     case CSSUnitType::CSS_QUIRKY_EM:
-    case CSSUnitType::CSS_STRING:
     case CSSUnitType::CSS_UNKNOWN:
     case CSSUnitType::CSS_VALUE_ID:
         break;

--- a/Source/WebCore/css/CSSUnits.h
+++ b/Source/WebCore/css/CSSUnits.h
@@ -76,9 +76,6 @@ enum class CSSUnitType : uint8_t {
     CSS_HZ,
     CSS_KHZ,
     CSS_DIMENSION,
-    CSS_STRING,
-    CSS_IDENT,
-    CSS_ATTR,
 
     CSS_VW,
     CSS_VH,
@@ -136,8 +133,6 @@ enum class CSSUnitType : uint8_t {
     CSS_CALC,
     CSS_CALC_PERCENTAGE_WITH_ANGLE,
     CSS_CALC_PERCENTAGE_WITH_LENGTH,
-
-    CSS_FONT_FAMILY,
 
     CSS_VALUE_ID,
     

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -50,6 +50,7 @@
 #include "CSSFilterImageValue.h"
 #include "CSSFilterValue.h"
 #include "CSSFontFaceSrcValue.h"
+#include "CSSFontFamilyNameValue.h"
 #include "CSSFontFeatureValue.h"
 #include "CSSFontStyleRangeValue.h"
 #include "CSSFontStyleWithAngleValue.h"
@@ -81,6 +82,7 @@
 #include "CSSScrollValue.h"
 #include "CSSSerializationContext.h"
 #include "CSSShorthandSubstitutionValue.h"
+#include "CSSStringValue.h"
 #include "CSSSubgridValue.h"
 #include "CSSSubstitutionValue.h"
 #include "CSSTextShadowPropertyValue.h"
@@ -158,6 +160,8 @@ template<typename Visitor> constexpr decltype(auto) CSSValue::visitDerived(Visit
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontFaceSrcLocalValue>(*this));
     case FontFaceSrcResource:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontFaceSrcResourceValue>(*this));
+    case FontFamilyName:
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontFamilyNameValue>(*this));
     case FontFeature:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSFontFeatureValue>(*this));
     case FontStyleWithAngle:
@@ -216,6 +220,8 @@ template<typename Visitor> constexpr decltype(auto) CSSValue::visitDerived(Visit
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSReflectValue>(*this));
     case Scroll:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSScrollValue>(*this));
+    case String:
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSStringValue>(*this));
     case Subgrid:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSSubgridValue>(*this));
     case TextShadowProperty:
@@ -378,10 +384,12 @@ Ref<DeprecatedCSSOMValue> CSSValue::createDeprecatedCSSOMWrapper(CSSStyleDeclara
     case Color:
     case Counter:
     case CustomIdent:
+    case FontFamilyName:
     case PropertyIdentifier:
     case Quad:
     case Rect:
     case URL:
+    case String:
     case ValuePair:
         return DeprecatedCSSOMPrimitiveValue::create(*this, styleDeclaration);
     case ValueList:

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -93,6 +93,7 @@ public:
     bool isFilterValue() const { return m_classType == ClassType::Filter; }
     bool isFontFaceSrcLocalValue() const { return m_classType == ClassType::FontFaceSrcLocal; }
     bool isFontFaceSrcResourceValue() const { return m_classType == ClassType::FontFaceSrcResource; }
+    bool isFontFamilyNameValue() const { return m_classType == ClassType::FontFamilyName; }
     bool isFontFeatureValue() const { return m_classType == ClassType::FontFeature; }
     bool isFontStyleRangeValue() const { return m_classType == ClassType::FontStyleRange; }
     bool isFontStyleWithAngleValue() const { return m_classType == ClassType::FontStyleWithAngle; }
@@ -124,6 +125,7 @@ public:
     bool isRect() const { return m_classType == ClassType::Rect; }
     bool isReflectValue() const { return m_classType == ClassType::Reflect; }
     bool isScrollValue() const { return m_classType == ClassType::Scroll; }
+    bool isStringValue() const { return m_classType == ClassType::String; }
     bool isSubgridValue() const { return m_classType == ClassType::Subgrid; }
     bool isTextShadowPropertyValue() const { return m_classType == ClassType::TextShadowProperty; }
     bool isTransformListValue() const { return m_classType == ClassType::TransformList; }
@@ -173,9 +175,6 @@ public:
 
     static constexpr size_t ValueSeparatorBits = 2;
     enum ValueSeparator : uint8_t { SpaceSeparator, CommaSeparator, SlashSeparator };
-
-    inline bool isString() const;
-    inline String string() const;
 
     inline bool isInteger() const;
     inline int integer(const CSSToLengthConversionData&) const;
@@ -234,6 +233,7 @@ protected:
         Font,
         FontFaceSrcLocal,
         FontFaceSrcResource,
+        FontFamilyName,
         FontFeature,
         FontStyleRange,
         FontStyleWithAngle,
@@ -258,6 +258,7 @@ protected:
         URL,
         UnicodeRange,
         ValuePair,
+        String,
         Substitution,
         View,
 

--- a/Source/WebCore/css/CSSValuePool.cpp
+++ b/Source/WebCore/css/CSSValuePool.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CSSValuePool.h"
 
+#include "CSSFontFamilyNameValue.h"
 #include "CSSPrimitiveValueMappings.h"
 #include "CSSPropertyParser.h"
 #include "CSSValueKeywords.h"
@@ -92,16 +93,16 @@ Ref<CSSColorValue> CSSValuePool::createColorValue(const WebCore::Color& color)
     }).iterator->value;
 }
 
-Ref<CSSPrimitiveValue> CSSValuePool::createFontFamilyValue(const AtomString& familyName)
+Ref<CSSValue> CSSValuePool::createFontFamilyNameValue(const AtomString& familyName)
 {
     // Remove one entry at random if the cache grows too large.
     // FIXME: Use TinyLRUCache instead?
     const int maximumFontFamilyCacheSize = 128;
-    if (m_fontFamilyValueCache.size() >= maximumFontFamilyCacheSize)
-        m_fontFamilyValueCache.remove(m_fontFamilyValueCache.random());
+    if (m_fontFamilyNameValueCache.size() >= maximumFontFamilyCacheSize)
+        m_fontFamilyNameValueCache.remove(m_fontFamilyNameValueCache.random());
 
-    return m_fontFamilyValueCache.ensure(familyName, [&familyName] {
-        return CSSPrimitiveValue::createFontFamily(familyName);
+    return m_fontFamilyNameValueCache.ensure(familyName, [&familyName] {
+        return CSSFontFamilyNameValue::create(CSS::FontFamilyName { familyName });
     }).iterator->value;
 }
 
@@ -123,7 +124,7 @@ void CSSValuePool::drain()
 {
     m_colorValueCache.clear();
     m_fontFaceValueCache.clear();
-    m_fontFamilyValueCache.clear();
+    m_fontFamilyNameValueCache.clear();
 }
 
-}
+} // namespace WebCore

--- a/Source/WebCore/css/CSSValuePool.h
+++ b/Source/WebCore/css/CSSValuePool.h
@@ -75,12 +75,12 @@ public:
 
     Ref<CSSColorValue> createColorValue(const WebCore::Color&);
     RefPtr<CSSValueList> createFontFaceValue(const AtomString&);
-    Ref<CSSPrimitiveValue> createFontFamilyValue(const AtomString&);
+    Ref<CSSValue> createFontFamilyNameValue(const AtomString&);
 
 private:
     HashMap<WebCore::Color, Ref<CSSColorValue>> m_colorValueCache;
     HashMap<AtomString, RefPtr<CSSValueList>> m_fontFaceValueCache;
-    HashMap<AtomString, Ref<CSSPrimitiveValue>> m_fontFamilyValueCache;
+    HashMap<AtomString, Ref<CSSValue>> m_fontFamilyNameValueCache;
 };
 
 inline CSSPrimitiveValue& CSSPrimitiveValue::implicitInitialValue()

--- a/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
+++ b/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
@@ -43,8 +43,6 @@
 namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DOMCSSRegisterCustomProperty);
 
-using namespace Style;
-
 ExceptionOr<void> DOMCSSRegisterCustomProperty::registerProperty(Document& document, const DOMCSSCustomPropertyDescriptor& descriptor)
 {
     if (!isCustomPropertyName(descriptor.name))
@@ -63,18 +61,18 @@ ExceptionOr<void> DOMCSSRegisterCustomProperty::registerProperty(Document& docum
     if (!descriptor.initialValue.isNull()) {
         CSSTokenizer tokenizer(descriptor.initialValue);
 
-        auto parsedInitialValue = CustomPropertyRegistry::parseInitialValue(document, descriptor.name, *syntax, tokenizer.tokenRange());
+        auto parsedInitialValue = Style::CustomPropertyRegistry::parseInitialValue(document, descriptor.name, *syntax, tokenizer.tokenRange());
 
         if (!parsedInitialValue) {
-            if (parsedInitialValue.error() == CustomPropertyRegistry::ParseInitialValueError::NotComputationallyIndependent)
+            if (parsedInitialValue.error() == Style::CustomPropertyRegistry::ParseInitialValueError::NotComputationallyIndependent)
                 return Exception { ExceptionCode::SyntaxError, "The given initial value must be computationally independent."_s };
 
-            ASSERT(parsedInitialValue.error() == CustomPropertyRegistry::ParseInitialValueError::DidNotParse);
+            ASSERT(parsedInitialValue.error() == Style::CustomPropertyRegistry::ParseInitialValueError::DidNotParse);
             return Exception { ExceptionCode::SyntaxError, "The given initial value does not parse for the given syntax."_s };
         }
 
         initialValue = parsedInitialValue->first;
-        if (parsedInitialValue->second == CustomPropertyRegistry::ViewportUnitDependency::Yes) {
+        if (parsedInitialValue->second == Style::CustomPropertyRegistry::ViewportUnitDependency::Yes) {
             initialValueTokensForViewportUnits = CSSVariableData::create(tokenizer.tokenRange());
             document.setHasStyleWithViewportUnits();
         }

--- a/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp
+++ b/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp
@@ -27,12 +27,15 @@
 #include "config.h"
 #include "DeprecatedCSSOMPrimitiveValue.h"
 
+#include "CSSAttrValue.h"
 #include "CSSColorValue.h"
 #include "CSSCounterValue.h"
 #include "CSSCustomIdentValue.h"
+#include "CSSFontFamilyNameValue.h"
 #include "CSSPropertyIdentifierValue.h"
 #include "CSSRectValue.h"
 #include "CSSSerializationContext.h"
+#include "CSSStringValue.h"
 #include "CSSURLValue.h"
 #include "DeprecatedCSSOMCounter.h"
 #include "DeprecatedCSSOMRGBColor.h"
@@ -55,26 +58,25 @@ unsigned short DeprecatedCSSOMPrimitiveValue::primitiveType() const
         return CSS_RGBCOLOR;
     if (m_value->isURL())
         return CSS_URI;
-    if (m_value->isCustomIdentValue())
+    if (m_value->isCustomIdentValue() || m_value->isPropertyIdentifierValue())
         return CSS_IDENT;
-    if (m_value->isPropertyIdentifierValue())
-        return CSS_IDENT;
+    if (m_value->isStringValue() || m_value->isFontFamilyNameValue())
+        return CSS_STRING;
+    if (m_value->isAttrValue())
+        return CSS_ATTR;
 
     RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(m_value.get());
     if (!primitiveValue)
         return CSS_UNKNOWN;
 
     switch (primitiveValue->primitiveType()) {
-    case CSSUnitType::CSS_ATTR:                         return CSS_ATTR;
     case CSSUnitType::CSS_CM:                           return CSS_CM;
     case CSSUnitType::CSS_DEG:                          return CSS_DEG;
     case CSSUnitType::CSS_DIMENSION:                    return CSS_DIMENSION;
     case CSSUnitType::CSS_EM:                           return CSS_EMS;
     case CSSUnitType::CSS_EX:                           return CSS_EXS;
-    case CSSUnitType::CSS_FONT_FAMILY:                  return CSS_STRING;
     case CSSUnitType::CSS_GRAD:                         return CSS_GRAD;
     case CSSUnitType::CSS_HZ:                           return CSS_HZ;
-    case CSSUnitType::CSS_IDENT:                        return CSS_IDENT;
     case CSSUnitType::CSS_INTEGER:                      return CSS_NUMBER;
     case CSSUnitType::CSS_IN:                           return CSS_IN;
     case CSSUnitType::CSS_KHZ:                          return CSS_KHZ;
@@ -87,7 +89,6 @@ unsigned short DeprecatedCSSOMPrimitiveValue::primitiveType() const
     case CSSUnitType::CSS_PX:                           return CSS_PX;
     case CSSUnitType::CSS_RAD:                          return CSS_RAD;
     case CSSUnitType::CSS_S:                            return CSS_S;
-    case CSSUnitType::CSS_STRING:                       return CSS_STRING;
     case CSSUnitType::CSS_VALUE_ID:                     return CSS_IDENT;
 
     // All other, including newer types, should return UNKNOWN.
@@ -131,7 +132,7 @@ ExceptionOr<String> DeprecatedCSSOMPrimitiveValue::getStringValue() const
 {
     switch (primitiveType()) {
     case CSS_ATTR:
-        return downcast<CSSPrimitiveValue>(m_value.get()).stringValue();
+        return downcast<CSSAttrValue>(m_value.get()).cssText(CSS::defaultSerializationContext());
     case CSS_IDENT:
         if (RefPtr customIdentValue = dynamicDowncast<CSSCustomIdentValue>(m_value))
             return customIdentValue->stringValue();
@@ -139,7 +140,9 @@ ExceptionOr<String> DeprecatedCSSOMPrimitiveValue::getStringValue() const
             return propertyIdentifierValue->stringValue();
         return downcast<CSSPrimitiveValue>(m_value.get()).stringValue();
     case CSS_STRING:
-        return downcast<CSSPrimitiveValue>(m_value.get()).stringValue();
+        if (RefPtr fontFamilyNameValue = dynamicDowncast<CSSFontFamilyNameValue>(m_value))
+            return fontFamilyNameValue->stringValue();
+        return downcast<CSSStringValue>(m_value.get()).stringValue();
     case CSS_URI:
         return downcast<CSSURLValue>(m_value.get()).stringValue();
 
@@ -160,11 +163,11 @@ ExceptionOr<Ref<DeprecatedCSSOMCounter>> DeprecatedCSSOMPrimitiveValue::getCount
                 return customIdent.value.string();
             }
         );
-        return DeprecatedCSSOMCounter::create(value->identifier().value, value->separator(), WTF::move(counterStyle));
+        return DeprecatedCSSOMCounter::create(value->identifier().value, value->separator().value, WTF::move(counterStyle));
     }
     return Exception { ExceptionCode::InvalidAccessError };
 }
-    
+
 ExceptionOr<Ref<DeprecatedCSSOMRect>> DeprecatedCSSOMPrimitiveValue::getRectValue() const
 {
     if (RefPtr rectValue = dynamicDowncast<CSSRectValue>(m_value.get()))

--- a/Source/WebCore/css/FontFace.cpp
+++ b/Source/WebCore/css/FontFace.cpp
@@ -56,7 +56,7 @@ void FontFace::setErrorState()
     m_backing->setErrorState();
 }
 
-Ref<FontFace> FontFace::create(ScriptExecutionContext& context, const String& family, Source&& source, const Descriptors& descriptors)
+Ref<FontFace> FontFace::create(ScriptExecutionContext& context, const AtomString& family, Source&& source, const Descriptors& descriptors)
 {
     ASSERT(context.cssFontSelector());
     auto result = adoptRef(*new FontFace(*context.cssFontSelector()));
@@ -69,7 +69,7 @@ Ref<FontFace> FontFace::create(ScriptExecutionContext& context, const String& fa
 #endif
     bool dataRequiresAsynchronousLoading = true;
 
-    auto setFamilyResult = result->setFamily(family);
+    auto setFamilyResult = result->setFamily(context, family);
     if (setFamilyResult.hasException()) {
         result->setErrorState();
         return result;
@@ -183,11 +183,11 @@ FontFace::~FontFace()
     m_backing->removeClient(*this);
 }
 
-ExceptionOr<void> FontFace::setFamily(const String& family)
+ExceptionOr<void> FontFace::setFamily(ScriptExecutionContext& context, const AtomString& family)
 {
     if (family.isEmpty())
         return Exception { ExceptionCode::SyntaxError };
-    m_backing->setFamily(CSSPrimitiveValue::createFontFamily(family));
+    m_backing->setFamily(context.cssValuePool().createFontFamilyNameValue(family));
     return { };
 }
 
@@ -254,7 +254,7 @@ ExceptionOr<void> FontFace::setSizeAdjust(ScriptExecutionContext& context, const
     return Exception { ExceptionCode::SyntaxError };
 }
 
-String FontFace::family() const
+AtomString FontFace::family() const
 {
     if (auto value = m_backing->family(); !value.isNull())
         return value;

--- a/Source/WebCore/css/FontFace.h
+++ b/Source/WebCore/css/FontFace.h
@@ -55,7 +55,7 @@ public:
     };
     
     using Source = Variant<String, Ref<JSC::ArrayBuffer>, Ref<JSC::ArrayBufferView>>;
-    static Ref<FontFace> create(ScriptExecutionContext&, const String& family, Source&&, const Descriptors&);
+    static Ref<FontFace> create(ScriptExecutionContext&, const AtomString& family, Source&&, const Descriptors&);
     static Ref<FontFace> create(ScriptExecutionContext*, CSSFontFace&);
     virtual ~FontFace();
 
@@ -64,7 +64,7 @@ public:
     void deref() const final { RefCounted::deref(); }
     USING_CAN_MAKE_WEAKPTR(CSSFontFaceClient);
 
-    ExceptionOr<void> setFamily(const String&);
+    ExceptionOr<void> setFamily(ScriptExecutionContext&, const AtomString&);
     ExceptionOr<void> setStyle(ScriptExecutionContext&, const String&);
     ExceptionOr<void> setWeight(ScriptExecutionContext&, const String&);
     ExceptionOr<void> setWidth(ScriptExecutionContext&, const String&);
@@ -73,7 +73,7 @@ public:
     ExceptionOr<void> setDisplay(ScriptExecutionContext&, const String&);
     ExceptionOr<void> setSizeAdjust(ScriptExecutionContext&, const String&);
 
-    String family() const;
+    AtomString family() const;
     String style() const;
     String weight() const;
     String width() const;

--- a/Source/WebCore/css/FontFace.idl
+++ b/Source/WebCore/css/FontFace.idl
@@ -64,9 +64,9 @@ dictionary FontFaceDescriptors {
     ActiveDOMObject,
     Exposed=(Window,Worker)
 ] interface FontFace {
-    [CallWith=CurrentScriptExecutionContext] constructor(DOMString family, (DOMString or BinaryData) source, optional FontFaceDescriptors descriptors = {});
+    [CallWith=CurrentScriptExecutionContext] constructor([AtomString] DOMString family, (DOMString or BinaryData) source, optional FontFaceDescriptors descriptors = {});
 
-    attribute DOMString family;
+    [SetterCallWith=CurrentScriptExecutionContext] attribute [AtomString] DOMString family;
     [SetterCallWith=CurrentScriptExecutionContext] attribute DOMString style;
     [SetterCallWith=CurrentScriptExecutionContext] attribute DOMString weight;
     [SetterCallWith=CurrentScriptExecutionContext] attribute DOMString width;

--- a/Source/WebCore/css/calc/CSSCalcTree+NumericIdentity.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+NumericIdentity.h
@@ -200,15 +200,11 @@ constexpr NumericIdentity toNumericIdentity(const NonCanonicalDimension& dimensi
     case CSSUnitType::CSS_HZ:
     case CSSUnitType::CSS_DPPX:
     case CSSUnitType::CSS_FR:
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_CALC:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:
     case CSSUnitType::CSS_DIMENSION:
-    case CSSUnitType::CSS_FONT_FAMILY:
-    case CSSUnitType::CSS_IDENT:
     case CSSUnitType::CSS_QUIRKY_EM:
-    case CSSUnitType::CSS_STRING:
     case CSSUnitType::CSS_UNKNOWN:
     case CSSUnitType::CSS_VALUE_ID:
         break;

--- a/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
@@ -189,15 +189,11 @@ static unsigned NODELETE sortPriority(CSSUnitType unit)
     case CSSUnitType::CSS_X:            return 63;
 
     // Non-numeric types are not supported.
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_CALC:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:
     case CSSUnitType::CSS_DIMENSION:
-    case CSSUnitType::CSS_FONT_FAMILY:
-    case CSSUnitType::CSS_IDENT:
     case CSSUnitType::CSS_QUIRKY_EM:
-    case CSSUnitType::CSS_STRING:
     case CSSUnitType::CSS_UNKNOWN:
     case CSSUnitType::CSS_VALUE_ID:
         break;

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -273,15 +273,11 @@ std::optional<CanonicalDimension> canonicalize(NonCanonicalDimension root, const
     case CSSUnitType::CSS_INTEGER:
     case CSSUnitType::CSS_PERCENTAGE:
     // Non-numeric types should never be stored in a NonCanonicalDimension.
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_CALC:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:
     case CSSUnitType::CSS_DIMENSION:
-    case CSSUnitType::CSS_FONT_FAMILY:
-    case CSSUnitType::CSS_IDENT:
     case CSSUnitType::CSS_QUIRKY_EM:
-    case CSSUnitType::CSS_STRING:
     case CSSUnitType::CSS_UNKNOWN:
     case CSSUnitType::CSS_VALUE_ID:
         break;
@@ -1332,6 +1328,7 @@ std::optional<Child> simplify(Random& root, const SimplificationOptions& options
             auto randomBaseValue = WTF::switchOn(root.sharing,
                 [&](const Random::SharingOptions& sharingOptions) -> std::optional<double> {
                     CheckedPtr builderState = options.conversionData->styleBuilderState();
+
                     if (sharingOptions.elementScoped.has_value() && !builderState->element())
                         return { };
 

--- a/Source/WebCore/css/calc/CSSCalcTree.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree.cpp
@@ -165,15 +165,11 @@ Child makeNumeric(double value, CSSUnitType unit)
         return makeChild(NonCanonicalDimension { .value = value, .unit = unit });
 
     // Non-numeric types are not supported.
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_CALC:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:
     case CSSUnitType::CSS_DIMENSION:
-    case CSSUnitType::CSS_FONT_FAMILY:
-    case CSSUnitType::CSS_IDENT:
     case CSSUnitType::CSS_QUIRKY_EM:
-    case CSSUnitType::CSS_STRING:
     case CSSUnitType::CSS_UNKNOWN:
     case CSSUnitType::CSS_VALUE_ID:
         break;

--- a/Source/WebCore/css/calc/CSSCalcTree.h
+++ b/Source/WebCore/css/calc/CSSCalcTree.h
@@ -745,7 +745,7 @@ struct Random {
     WTF_MAKE_STRUCT_TZONE_ALLOCATED(Random);
     static constexpr auto id = CSSValueRandom;
 
-    // <random-value-sharing> = [ auto | <dashed-ident> ] || element-scoped | fixed <number [0,1]>
+    // <random-value-sharing> = [ [ auto | <dashed-ident> ] || element-scoped ] | fixed <number [0,1]>
     struct SharingOptions {
         struct Auto {
             CSSPropertyID property;

--- a/Source/WebCore/css/calc/CSSCalcType.cpp
+++ b/Source/WebCore/css/calc/CSSCalcType.cpp
@@ -293,15 +293,11 @@ Type Type::determineType(CSSUnitType unitType)
         // the type is «[ "percent" → 1 ]».
         return Type { .percent = 1 };
 
-    case CSSUnitType::CSS_ATTR:
     case CSSUnitType::CSS_CALC:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:
     case CSSUnitType::CSS_DIMENSION:
-    case CSSUnitType::CSS_FONT_FAMILY:
-    case CSSUnitType::CSS_IDENT:
     case CSSUnitType::CSS_QUIRKY_EM:
-    case CSSUnitType::CSS_STRING:
     case CSSUnitType::CSS_UNKNOWN:
     case CSSUnitType::CSS_VALUE_ID:
         break;

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -35,6 +35,7 @@
 #include "CSSCounterStyleRule.h"
 #include "CSSCustomPropertySyntax.h"
 #include "CSSCustomPropertyValue.h"
+#include "CSSFontFamilyNameValue.h"
 #include "CSSFontFeatureValuesRule.h"
 #include "CSSKeyframeRule.h"
 #include "CSSKeyframesRule.h"
@@ -55,6 +56,7 @@
 #include "CSSPropertyParserConsumer+Primitives.h"
 #include "CSSPropertyParserConsumer+Timeline.h"
 #include "CSSSelectorParser.h"
+#include "CSSStringValue.h"
 #include "CSSStyleSheet.h"
 #include "CSSSubstitutionParser.h"
 #include "CSSSupportsParser.h"
@@ -937,19 +939,18 @@ RefPtr<StyleRuleFontPaletteValues> CSSParser::consumeFontPaletteValuesRule(CSSPa
     auto fontFamilies = [&] {
         Vector<AtomString> fontFamilies;
         auto append = [&](auto& value) {
-            if (value.isFontFamily())
-                fontFamilies.append(AtomString { value.stringValue() });
+            if (RefPtr fontFamilyNameValue = dynamicDowncast<CSSFontFamilyNameValue>(value))
+                fontFamilies.append(fontFamilyNameValue->fontFamilyName().value);
         };
         RefPtr cssFontFamily = properties->getPropertyCSSValue(CSSPropertyFontFamily);
         if (!cssFontFamily)
             return fontFamilies;
         if (RefPtr families = dynamicDowncast<CSSValueList>(*cssFontFamily)) {
             for (Ref item : *families)
-                append(downcast<CSSPrimitiveValue>(item.get()));
+                append(item.get());
             return fontFamilies;
         }
-        if (RefPtr family = dynamicDowncast<CSSPrimitiveValue>(cssFontFamily.releaseNonNull()))
-            append(*family);
+        append(*cssFontFamily);
         return fontFamilies;
     }();
 
@@ -1386,7 +1387,7 @@ RefPtr<StyleRuleProperty> CSSParser::consumePropertyRule(CSSParserTokenRange pre
     for (auto& property : declarations) {
         switch (property.id()) {
         case CSSPropertySyntax:
-            descriptor.syntax = Ref { downcast<CSSPrimitiveValue>(*property.value()) }->stringValue();
+            descriptor.syntax = Ref { downcast<CSSStringValue>(*property.value()) }->string().value;
             continue;
         case CSSPropertyInherits:
             descriptor.inherits = property.value()->valueID() == CSSValueTrue;

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -60,6 +60,7 @@
 #include "CSSPropertyParserState.h"
 #include "CSSPropertyParsing.h"
 #include "CSSShorthandSubstitutionValue.h"
+#include "CSSStringValue.h"
 #include "CSSSubstitutionParser.h"
 #include "CSSSubstitutionValue.h"
 #include "CSSTokenizer.h"
@@ -579,19 +580,17 @@ std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> consume
             return Style::toStyleFromCSSValue<Style::Resolution<>>(builderState, downcast<CSSPrimitiveValue>(value));
         case CSSCustomPropertySyntax::Type::Color:
             return Style::toStyleFromCSSValue<Style::Color>(builderState, value, Style::ForVisitedLink::No);
-        case CSSCustomPropertySyntax::Type::Image: {
-            auto styleImage = builderState.createStyleImage(value);
-            if (!styleImage)
-                return { };
-            return Style::ImageWrapper { styleImage.releaseNonNull() };
-        }
+        case CSSCustomPropertySyntax::Type::Image:
+            if (RefPtr styleImage = builderState.createStyleImage(value))
+                return Style::ImageWrapper { styleImage.releaseNonNull() };
+            return { };
         case CSSCustomPropertySyntax::Type::URL:
-            return Style::toStyle(downcast<CSSURLValue>(value).url(), builderState);
+            return Style::toStyleFromCSSValue<Style::URL>(builderState, downcast<CSSURLValue>(value));
         case CSSCustomPropertySyntax::Type::Ident:
         case CSSCustomPropertySyntax::Type::CustomIdent:
-            return Style::toStyleFromCSSValue<Style::CustomIdent>(builderState, value);
+            return Style::toStyleFromCSSValue<Style::CustomIdent>(builderState, downcast<CSSCustomIdentValue>(value));
         case CSSCustomPropertySyntax::Type::String:
-            return downcast<CSSPrimitiveValue>(value).stringValue();
+            return Style::toStyleFromCSSValue<Style::String>(builderState, downcast<CSSStringValue>(value));
         case CSSCustomPropertySyntax::Type::TransformFunction:
         case CSSCustomPropertySyntax::Type::TransformList:
             return Style::toStyleFromCSSValue<Style::TransformFunction>(builderState, value);

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp
@@ -38,6 +38,7 @@
 #include "CSSPropertyParserConsumer+PercentageDefinitions.h"
 #include "CSSPropertyParserConsumer+Timeline.h"
 #include "CSSPropertyParserState.h"
+#include "CSSStringValue.h"
 
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
@@ -137,7 +138,7 @@ RefPtr<CSSValue> consumeKeyframesName(CSSParserTokenRange& range, CSS::PropertyP
         auto valueId = cssValueKeywordID(token.value());
         if (isValidCustomIdentifier(valueId) && valueId != CSSValueNone)
             return CSSCustomIdentValue::create(CSS::CustomIdent { token.value().toAtomString() });
-        return CSSPrimitiveValue::create(token.value().toString());
+        return CSSStringValue::create(CSS::String { token.value().toString() });
     }
 
     return consumeCustomIdent(range, state);

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Attr.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Attr.cpp
@@ -32,6 +32,7 @@
 #include "CSSPrimitiveValue.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
 #include "CSSPropertyParserState.h"
+#include "CSSString.h"
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
@@ -63,19 +64,16 @@ RefPtr<CSSValue> consumeAttr(CSSParserTokenRange args, CSS::PropertyParserState&
     if (!args.atEnd() && !consumeCommaIncludingWhitespace(args))
         return nullptr;
 
-    RefPtr<CSSValue> fallback;
+    std::optional<CSS::String> fallback;
     if (args.peek().type() == StringToken) {
         token = args.consumeIncludingWhitespace();
-        fallback = CSSPrimitiveValue::create(token.value().toString());
+        fallback = CSS::String { token.value().toString() };
     }
 
     if (!args.atEnd())
         return nullptr;
 
-    auto attr = CSSAttrValue::create(WTF::move(attrName), WTF::move(fallback));
-    // FIXME: Consider moving to a CSSFunctionValue with a custom-ident rather than a special CSS_ATTR primitive value.
-
-    return CSSPrimitiveValue::create(WTF::move(attr));
+    return CSSAttrValue::create(WTF::move(attrName), WTF::move(fallback));
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Content.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Content.cpp
@@ -88,7 +88,7 @@ static RefPtr<CSSValue> consumeCounterContent(CSSParserTokenRange args, CSS::Pro
     if (!args.atEnd())
         return nullptr;
 
-    return CSSCounterValue::create(WTF::move(*customIdent), AtomString { nullAtom() }, WTF::move(*counterStyle));
+    return CSSCounterValue::create(WTF::move(*customIdent), CSS::String { nullString() }, WTF::move(*counterStyle));
 }
 
 static RefPtr<CSSValue> consumeCountersContent(CSSParserTokenRange args, CSS::PropertyParserState& state)
@@ -100,9 +100,12 @@ static RefPtr<CSSValue> consumeCountersContent(CSSParserTokenRange args, CSS::Pr
     if (!customIdent)
         return nullptr;
 
-    if (!consumeCommaIncludingWhitespace(args) || args.peek().type() != StringToken)
+    if (!consumeCommaIncludingWhitespace(args))
         return nullptr;
-    auto separator = args.consumeIncludingWhitespace().value().toAtomString();
+
+    auto separator = consumeUnresolvedString(args);
+    if (!separator)
+        return nullptr;
 
     std::optional<CSS::CounterStyle> counterStyle;
     if (consumeCommaIncludingWhitespace(args)) {
@@ -110,12 +113,12 @@ static RefPtr<CSSValue> consumeCountersContent(CSSParserTokenRange args, CSS::Pr
         if (!counterStyle)
             return nullptr;
     } else
-        counterStyle = CSS::CounterStyle { CSS::CustomIdent { AtomString { nameLiteral(CSSValueDecimal) } } };
+        counterStyle = CSS::CounterStyle { CSSValueDecimal };
 
     if (!args.atEnd())
         return nullptr;
 
-    return CSSCounterValue::create(WTF::move(*customIdent), WTF::move(separator), WTF::move(*counterStyle));
+    return CSSCounterValue::create(WTF::move(*customIdent), WTF::move(*separator), WTF::move(*counterStyle));
 }
 
 RefPtr<CSSValue> consumeContent(CSSParserTokenRange& range, CSS::PropertyParserState& state)
@@ -132,7 +135,7 @@ RefPtr<CSSValue> consumeContent(CSSParserTokenRange& range, CSS::PropertyParserS
     auto consumeContentList = [&](CSSValueListBuilder& values, ContentListType type) -> bool {
         bool shouldEnd = false;
         do {
-            RefPtr<CSSValue> parsedValue = consumeString(range);
+            RefPtr parsedValue = consumeString(range);
             if (type == ContentListType::VisibleContent) {
                 if (!parsedValue)
                     parsedValue = consumeImage(range, state);

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -298,7 +298,7 @@ static RefPtr<CSSValue> consumeGenericFamily(CSSParserTokenRange& range, CSS::Pr
     if (auto familyName = consumeGenericFamilyUnresolved(range)) {
         // FIXME: Remove special case for system-ui.
         if (*familyName == CSSValueSystemUi)
-            return state.pool.createFontFamilyValue(nameString(*familyName));
+            return state.pool.createFontFamilyNameValue(nameLiteral(*familyName));
         return CSSPrimitiveValue::create(*familyName);
     }
     return nullptr;
@@ -330,7 +330,7 @@ RefPtr<CSSValue> consumeFamilyName(CSSParserTokenRange& range, CSS::PropertyPars
     auto familyName = consumeFamilyNameUnresolved(range);
     if (familyName.isNull())
         return nullptr;
-    return state.pool.createFontFamilyValue(familyName);
+    return state.pool.createFontFamilyNameValue(familyName);
 }
 
 RefPtr<CSSValue> consumeFontFamily(CSSParserTokenRange& range, CSS::PropertyParserState& state)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
@@ -60,6 +60,7 @@
 #include "CSSPropertyParserConsumer+URL.h"
 #include "CSSPropertyParserOptions.h"
 #include "CSSPropertyParserState.h"
+#include "CSSStringValue.h"
 #include "CSSValue.h"
 #include "CSSValueList.h"
 #include "CSSValuePool.h"
@@ -1006,7 +1007,7 @@ static RefPtr<CSSValue> consumeWebkitCanvas(CSSParserTokenRange& args)
 {
     if (args.peek().type() != IdentToken)
         return nullptr;
-    return CSSCanvasValue::create(args.consumeIncludingWhitespace().value().toString());
+    return CSSCanvasValue::create(CSS::CustomIdent { args.consumeIncludingWhitespace().value().toAtomString() });
 }
 
 // MARK: <-webkit-named-image()>
@@ -1015,7 +1016,7 @@ static RefPtr<CSSValue> consumeWebkitNamedImage(CSSParserTokenRange& args)
 {
     if (args.peek().type() != IdentToken)
         return nullptr;
-    return CSSNamedImageValue::create(args.consumeIncludingWhitespace().value().toString());
+    return CSSNamedImageValue::create(CSS::CustomIdent { args.consumeIncludingWhitespace().value().toAtomString() });
 }
 
 // MARK: <filter()>
@@ -1048,7 +1049,7 @@ static RefPtr<CSSValue> consumeCustomPaint(CSSParserTokenRange& args, CSS::Prope
         return nullptr;
     if (args.peek().type() != IdentToken)
         return nullptr;
-    auto name = args.consumeIncludingWhitespace().value().toString();
+    auto name = args.consumeIncludingWhitespace().value().toAtomString();
 
     if (!args.atEnd() && args.peek() != CommaToken)
         return nullptr;
@@ -1056,13 +1057,14 @@ static RefPtr<CSSValue> consumeCustomPaint(CSSParserTokenRange& args, CSS::Prope
         args.consume();
 
     auto argumentList = CSSVariableData::create(args.consumeAll());
-    return CSSPaintImageValue::create(name, WTF::move(argumentList));
+    return CSSPaintImageValue::create(CSS::CustomIdent { WTF::move(name) }, WTF::move(argumentList));
 }
 
 // MARK: <image-set()>
+// https://w3c.github.io/csswg-drafts/css-images-4/#image-set-notation
 
 struct ImageSetTypeFunctionRaw {
-    String value;
+    FunctionNotation<CSSValueType, CSS::String> value;
 
     bool operator==(const ImageSetTypeFunctionRaw&) const = default;
 };
@@ -1079,13 +1081,13 @@ struct ImageSetTypeFunctionRawKnownTokenTypeFunctionConsumer {
 
         auto rangeCopy = range;
         auto typeArg = consumeFunction(rangeCopy);
-        auto result = consumeStringRaw(typeArg);
+        auto result = consumeUnresolvedString(typeArg);
 
-        if (result.isNull() || !typeArg.atEnd())
+        if (!result || !typeArg.atEnd())
             return { };
 
         range = rangeCopy;
-        return { { result.toString() } };
+        return ImageSetTypeFunctionRaw { FunctionNotation<CSSValueType, CSS::String> { WTF::move(*result) } };
     }
 };
 
@@ -1095,61 +1097,47 @@ template<> struct ConsumerDefinition<ImageSetTypeFunction> {
 
 // MARK: Image Set Resolution + Type Function
 
-static RefPtr<CSSPrimitiveValue> consumeImageSetResolutionOrTypeFunction(CSSParserTokenRange& range, CSS::PropertyParserState& state)
-{
-    // [ <resolution> || type(<string>) ]
-    //
-    //   as part of
-    //
-    // <image-set()> = image-set( <image-set-option># )
-    // <image-set-option> = [ <image> | <string> ] [ <resolution> || type(<string>) ]?
-
-    return MetaConsumer<CSS::Resolution<>, ImageSetTypeFunction>::consume(range, state,
-        [&](const ImageSetTypeFunction& typeFunction) -> RefPtr<CSSPrimitiveValue> {
-            return CSSPrimitiveValue::create(typeFunction.value);
-        },
-        [&](const CSS::Resolution<>& resolution) -> RefPtr<CSSPrimitiveValue> {
-            return CSSPrimitiveValueResolverBase::resolve(resolution);
-        }
-    ).value_or(nullptr);
-}
-
-// https://w3c.github.io/csswg-drafts/css-images-4/#image-set-notation
 static RefPtr<CSSImageSetOptionValue> consumeImageSetOption(CSSParserTokenRange& range, CSS::PropertyParserState& state, OptionSet<AllowedImageType> allowedImageTypes)
 {
+    // <image-set()> = image-set( <image-set-option># )
+    // <image-set-option> = [ <image> | <string> ] [ <resolution> || type(<string>) ]?
+    // https://w3c.github.io/csswg-drafts/css-images-4/#image-set-notation
+
     auto image = consumeImage(range, state, allowedImageTypes);
     if (!image)
         return nullptr;
 
-    auto result = CSSImageSetOptionValue::create(image.releaseNonNull());
-
-    RefPtr<CSSPrimitiveValue> resolution;
-    RefPtr<CSSPrimitiveValue> type;
+    std::optional<CSS::Resolution<>> resolution;
+    std::optional<FunctionNotation<CSSValueType, CSS::String>> type;
 
     // Optional resolution and type in any order.
     for (size_t i = 0; i < 2 && !range.atEnd(); ++i) {
-        if (auto optionalArgument = consumeImageSetResolutionOrTypeFunction(range, state)) {
-            if ((resolution && optionalArgument->isResolution()) || (type && optionalArgument->isString()))
+        if (auto optionalArgument = MetaConsumer<CSS::Resolution<>, ImageSetTypeFunction>::consume(range, state)) {
+            bool success = WTF::switchOn(WTF::move(*optionalArgument),
+                [&](CSS::Resolution<>&& parsedResolution) {
+                    if (resolution)
+                        return false;
+                    resolution = WTF::move(parsedResolution);
+                    return true;
+                },
+                [&](ImageSetTypeFunction&& parsedType) {
+                    if (type)
+                        return false;
+                    type = WTF::move(parsedType.value);
+                    return true;
+                }
+            );
+            if (!success)
                 return nullptr;
-
-            if (optionalArgument->isResolution()) {
-                resolution = optionalArgument;
-                result->setResolution(optionalArgument.releaseNonNull());
-                continue;
-            }
-
-            if (optionalArgument->isString()) {
-                type = optionalArgument;
-                result->setType(type->stringValue());
-                continue;
-            }
+            continue;
         }
         break;
     }
 
     if (!range.atEnd() && range.peek().type() != CommaToken)
         return nullptr;
-    return result;
+
+    return CSSImageSetOptionValue::create(image.releaseNonNull(), WTF::move(resolution), WTF::move(type));
 }
 
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumer.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumer.h
@@ -160,7 +160,7 @@ struct MetaConsumerUnroller<T, Ts...> {
 };
 
 // The `MetaConsumer` is the main driver of token consumption, dispatching
-// to a `MetaConsumerUnroller` based on token type. Caller use this directly.
+// to a `MetaConsumerUnroller` based on token type. Callers use this directly.
 // An example use that attempts to consumer either a <number> or <percentage>
 // looks like (argument list elided for brevity):
 //

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+String.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+String.cpp
@@ -26,7 +26,7 @@
 #include "CSSPropertyParserConsumer+String.h"
 
 #include "CSSParserTokenRange.h"
-#include "CSSPrimitiveValue.h"
+#include "CSSStringValue.h"
 #include "CSSValueKeywords.h"
 #include <wtf/text/StringView.h>
 
@@ -43,11 +43,18 @@ StringView consumeStringRaw(CSSParserTokenRange& range)
     return range.consumeIncludingWhitespace().value();
 }
 
-RefPtr<CSSPrimitiveValue> consumeString(CSSParserTokenRange& range)
+std::optional<CSS::String> consumeUnresolvedString(CSSParserTokenRange& range)
+{
+    if (range.peek().type() != StringToken)
+        return { };
+    return CSS::String { range.consumeIncludingWhitespace().value().toString() };
+}
+
+RefPtr<CSSValue> consumeString(CSSParserTokenRange& range)
 {
     if (range.peek().type() != StringToken)
         return nullptr;
-    return CSSPrimitiveValue::create(range.consumeIncludingWhitespace().value().toString());
+    return CSSStringValue::create(CSS::String { range.consumeIncludingWhitespace().value().toString() });
 }
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+String.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+String.h
@@ -29,7 +29,11 @@
 namespace WebCore {
 
 class CSSParserTokenRange;
-class CSSPrimitiveValue;
+class CSSValue;
+
+namespace CSS {
+struct String;
+}
 
 namespace CSSPropertyParserHelpers {
 
@@ -37,7 +41,8 @@ namespace CSSPropertyParserHelpers {
 // https://drafts.csswg.org/css-values/#strings
 
 StringView NODELETE consumeStringRaw(CSSParserTokenRange&);
-RefPtr<CSSPrimitiveValue> consumeString(CSSParserTokenRange&);
+std::optional<CSS::String> NODELETE consumeUnresolvedString(CSSParserTokenRange&);
+RefPtr<CSSValue> consumeString(CSSParserTokenRange&);
 
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.cpp
@@ -29,6 +29,7 @@
 #include "CSSCustomIdentValue.h"
 #include "CSSParserTokenRange.h"
 #include "CSSPropertyParserConsumer+Ident.h"
+#include "CSSPropertyParserConsumer+List.h"
 #include "CSSValueKeywords.h"
 #include "CSSValueList.h"
 

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -283,7 +283,7 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Document& docum
             return Ref<CSSStyleValue> { CSSNumericFactory::cqmin(primitiveValue->valueNoConversionDataRequired<double>()) };
         case CSSUnitType::CSS_CQMAX:
             return Ref<CSSStyleValue> { CSSNumericFactory::cqmax(primitiveValue->valueNoConversionDataRequired<double>()) };
-        case CSSUnitType::CSS_IDENT:
+        case CSSUnitType::CSS_VALUE_ID:
             // Per the specification, the CSSKeywordValue's value slot should be set to the serialization
             // of the identifier. As a result, the identifier will be lowercase:
             // https://drafts.css-houdini.org/css-typed-om-1/#reify-ident
@@ -297,11 +297,11 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Document& docum
         return upcast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(propertyIdentifierValue->cssText(CSS::defaultSerializationContext())));
     else if (auto* imageValue = dynamicDowncast<CSSImageValue>(cssValue))
         return Ref<CSSStyleValue> { CSSStyleImageValue::create(const_cast<CSSImageValue&>(*imageValue), document) };
-    else if (auto* referenceValue = dynamicDowncast<CSSSubstitutionValue>(cssValue)) {
+    else if (auto* referenceValue = dynamicDowncast<CSSSubstitutionValue>(cssValue))
         return Ref<CSSStyleValue> { CSSUnparsedValue::create(referenceValue->data().tokenRange()) };
-    } else if (auto* substitutionValue = dynamicDowncast<CSSShorthandSubstitutionValue>(cssValue)) {
+    else if (auto* substitutionValue = dynamicDowncast<CSSShorthandSubstitutionValue>(cssValue))
         return Ref<CSSStyleValue> { CSSUnparsedValue::create(substitutionValue->shorthandValue().data().tokenRange()) };
-    } else if (auto* customPropertyValue = dynamicDowncast<CSSCustomPropertyValue>(cssValue)) {
+    else if (auto* customPropertyValue = dynamicDowncast<CSSCustomPropertyValue>(cssValue)) {
         // FIXME: remove CSSStyleValue::create(WTF::move(cssValue)), add reification control flow
         return WTF::switchOn(customPropertyValue->value(),
             [&](const Ref<CSSSubstitutionValue>& value) {

--- a/Source/WebCore/css/values/CSSSerializationContext.cpp
+++ b/Source/WebCore/css/values/CSSSerializationContext.cpp
@@ -33,7 +33,7 @@ namespace CSS {
 SerializationContext::SerializationContext() = default;
 SerializationContext::~SerializationContext() = default;
 
-SerializationContext::SerializationContext(HashMap<String, String>&& replacementURLStrings, HashMap<Ref<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet, bool shouldUseResolvedURLInCSSText)
+SerializationContext::SerializationContext(HashMap<WTF::String, WTF::String>&& replacementURLStrings, HashMap<Ref<CSSStyleSheet>, WTF::String>&& replacementURLStringsForCSSStyleSheet, bool shouldUseResolvedURLInCSSText)
     : replacementURLStrings { WTF::move(replacementURLStrings) }
     , replacementURLStringsForCSSStyleSheet { WTF::move(replacementURLStringsForCSSStyleSheet) }
     , shouldUseResolvedURLInCSSText { shouldUseResolvedURLInCSSText }

--- a/Source/WebCore/css/values/CSSSerializationContext.h
+++ b/Source/WebCore/css/values/CSSSerializationContext.h
@@ -35,11 +35,11 @@ namespace CSS {
 
 struct SerializationContext {
     SerializationContext();
-    SerializationContext(HashMap<String, String>&&, HashMap<Ref<CSSStyleSheet>, String>&&, bool);
+    SerializationContext(HashMap<WTF::String, WTF::String>&&, HashMap<Ref<CSSStyleSheet>, WTF::String>&&, bool);
     ~SerializationContext();
 
-    HashMap<String, String> replacementURLStrings;
-    HashMap<Ref<CSSStyleSheet>, String> replacementURLStringsForCSSStyleSheet;
+    HashMap<WTF::String, WTF::String> replacementURLStrings;
+    HashMap<Ref<CSSStyleSheet>, WTF::String> replacementURLStringsForCSSStyleSheet;
     bool shouldUseResolvedURLInCSSText = false;
 };
 

--- a/Source/WebCore/css/values/CSSValueTypes.cpp
+++ b/Source/WebCore/css/values/CSSValueTypes.cpp
@@ -26,7 +26,6 @@
 #include "CSSValueTypes.h"
 
 #include "CSSFunctionValue.h"
-#include "CSSMarkup.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSQuadValue.h"
 #include "CSSValueList.h"
@@ -36,27 +35,7 @@
 namespace WebCore {
 namespace CSS {
 
-void serializationForCSSString(StringBuilder& builder, const SerializationContext&, const WTF::AtomString& value)
-{
-    WebCore::serializeString(builder, value);
-}
-
-void serializationForCSSString(StringBuilder& builder, const SerializationContext&, const WTF::String& value)
-{
-    WebCore::serializeString(builder, value);
-}
-
 Ref<CSSValue> makePrimitiveCSSValue(CSSValueID value)
-{
-    return CSSPrimitiveValue::create(value);
-}
-
-Ref<CSSValue> makePrimitiveCSSValue(const WTF::AtomString& value)
-{
-    return CSSPrimitiveValue::create(value);
-}
-
-Ref<CSSValue> makePrimitiveCSSValue(const WTF::String& value)
 {
     return CSSPrimitiveValue::create(value);
 }

--- a/Source/WebCore/css/values/CSSValueTypes.h
+++ b/Source/WebCore/css/values/CSSValueTypes.h
@@ -54,7 +54,7 @@ struct SerializeInvoker {
         Serialize<CSSType>{}(builder, context, value, std::forward<Rest>(rest)...);
    }
 
-    template<typename CSSType, typename... Rest> [[nodiscard]] String operator()(const SerializationContext& context, const CSSType& value, Rest&&... rest) const
+    template<typename CSSType, typename... Rest> [[nodiscard]] WTF::String operator()(const SerializationContext& context, const CSSType& value, Rest&&... rest) const
     {
         StringBuilder builder;
         this->operator()(builder, context, value, std::forward<Rest>(rest)...);
@@ -62,9 +62,6 @@ struct SerializeInvoker {
     }
 };
 inline constexpr SerializeInvoker serializationForCSS{};
-
-void serializationForCSSString(StringBuilder&, const SerializationContext&, const WTF::AtomString&);
-void serializationForCSSString(StringBuilder&, const SerializationContext&, const WTF::String&);
 
 template<typename CSSType, typename... Rest> void serializationForCSSOnOptionalLike(StringBuilder& builder, const SerializationContext& context, const CSSType& value, Rest&&... rest)
 {
@@ -181,22 +178,6 @@ template<CSSValueID C> struct Serialize<Constant<C>> {
     }
 };
 
-// Specialization for `WTF::AtomString`.
-template<> struct Serialize<WTF::AtomString> {
-    template<typename... Rest> void operator()(StringBuilder& builder, const SerializationContext& context, const WTF::AtomString& value, Rest&&...)
-    {
-        serializationForCSSString(builder, context, value);
-    }
-};
-
-// Specialization for `WTF::String`.
-template<> struct Serialize<WTF::String> {
-    template<typename... Rest> void operator()(StringBuilder& builder, const SerializationContext& context, const WTF::String& value, Rest&&...)
-    {
-        serializationForCSSString(builder, context, value);
-    }
-};
-
 // Specialization for `FunctionNotation`.
 template<CSSValueID Name, typename CSSType> struct Serialize<FunctionNotation<Name, CSSType>> {
     template<typename... Rest> void operator()(StringBuilder& builder, const SerializationContext& context, const FunctionNotation<Name, CSSType>& value, Rest&&... rest)
@@ -305,21 +286,6 @@ template<CSSValueID C> struct ComputedStyleDependenciesCollector<Constant<C>> {
     }
 };
 
-// Specialization for `WTF::AtomString`.
-template<> struct ComputedStyleDependenciesCollector<WTF::AtomString> {
-    constexpr void operator()(ComputedStyleDependencies&, const WTF::AtomString&)
-    {
-        // Nothing to do.
-    }
-};
-
-// Specialization for `WTF::String`.
-template<> struct ComputedStyleDependenciesCollector<WTF::String> {
-    constexpr void operator()(ComputedStyleDependencies&, const WTF::String&)
-    {
-        // Nothing to do.
-    }
-};
 
 // Specialization for `WTF::URL`.
 template<> struct ComputedStyleDependenciesCollector<WTF::URL> {
@@ -430,22 +396,6 @@ template<CSSValueID C> struct CSSValueChildrenVisitor<Constant<C>> {
     }
 };
 
-// Specialization for `WTF::AtomString`.
-template<> struct CSSValueChildrenVisitor<WTF::AtomString> {
-    constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const WTF::AtomString&)
-    {
-        return IterationStatus::Continue;
-    }
-};
-
-// Specialization for `WTF::String`.
-template<> struct CSSValueChildrenVisitor<WTF::String> {
-    constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const WTF::String&)
-    {
-        return IterationStatus::Continue;
-    }
-};
-
 // Specialization for `WTF::URL`.
 template<> struct CSSValueChildrenVisitor<WTF::URL> {
     constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const WTF::URL&)
@@ -467,8 +417,6 @@ struct CSSValueCreationInvoker {
 inline constexpr CSSValueCreationInvoker createCSSValue{};
 
 Ref<CSSValue> NODELETE makePrimitiveCSSValue(CSSValueID);
-Ref<CSSValue> makePrimitiveCSSValue(const WTF::AtomString&);
-Ref<CSSValue> makePrimitiveCSSValue(const WTF::String&);
 Ref<CSSValue> makeFunctionCSSValue(CSSValueID, Ref<CSSValue>&&);
 
 template<SerializationSeparatorType> Ref<CSSValue> NODELETE makeCoalescingPairCSSValue(Ref<CSSValue>&&, Ref<CSSValue>&&);
@@ -537,22 +485,6 @@ template<CSSValueID Id> struct CSSValueCreation<Constant<Id>> {
     template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool&, const Constant<Id>&, Rest&&...)
     {
         return makePrimitiveCSSValue(Id);
-    }
-};
-
-// Specialization for `WTF::AtomString`.
-template<> struct CSSValueCreation<WTF::AtomString> {
-    template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool&, const WTF::AtomString& string, Rest&&...)
-    {
-        return makePrimitiveCSSValue(string);
-    }
-};
-
-// Specialization for `WTF::String`.
-template<> struct CSSValueCreation<WTF::String> {
-    template<typename... Rest> Ref<CSSValue> operator()(CSSValuePool&, const WTF::String& string, Rest&&...)
-    {
-        return makePrimitiveCSSValue(string);
     }
 };
 

--- a/Source/WebCore/css/values/fonts/CSSFontFamilyName.cpp
+++ b/Source/WebCore/css/values/fonts/CSSFontFamilyName.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSFontFamilyName.h"
+
+#include "CSSFontFamilyNameValue.h"
+#include "CSSMarkup.h"
+#include "CSSValuePool.h"
+#include <wtf/Hasher.h>
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+namespace CSS {
+
+void Serialize<FontFamilyName>::operator()(StringBuilder& builder, const SerializationContext&, const FontFamilyName& value)
+{
+    WebCore::serializeFontFamily(builder, value.value);
+}
+
+Ref<CSSValue> CSSValueCreation<FontFamilyName>::operator()(CSSValuePool& pool, const FontFamilyName& value)
+{
+    return pool.createFontFamilyNameValue(value.value);
+}
+
+// MARK: - Logging
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, const FontFamilyName& value)
+{
+    return ts << value.value;
+}
+
+// MARK: - Hashing
+
+void add(Hasher& hasher, const FontFamilyName& value)
+{
+    add(hasher, value.value);
+}
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/css/values/fonts/CSSFontFamilyName.h
+++ b/Source/WebCore/css/values/fonts/CSSFontFamilyName.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/CSSValueTypes.h>
+#include <wtf/text/AtomString.h>
+
+namespace WebCore {
+namespace CSS {
+
+struct FontFamilyName {
+    WTF::AtomString value;
+
+    bool operator==(const FontFamilyName&) const = default;
+};
+
+template<> struct Serialize<FontFamilyName> { void operator()(StringBuilder&, const SerializationContext&, const FontFamilyName&); };
+template<> struct ComputedStyleDependenciesCollector<FontFamilyName> { constexpr void operator()(ComputedStyleDependencies&, const FontFamilyName&) { } };
+template<> struct CSSValueChildrenVisitor<FontFamilyName> { constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const FontFamilyName&) { return IterationStatus::Continue; } };
+template<> struct CSSValueCreation<FontFamilyName> { Ref<CSSValue> operator()(CSSValuePool&, const FontFamilyName&); };
+
+// MARK: - Logging
+
+WTF::TextStream& operator<<(WTF::TextStream&, const FontFamilyName&);
+
+// MARK: - Hashing
+
+void NODELETE add(Hasher&, const FontFamilyName&);
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/css/values/grid/CSSGridNamedAreaMap.cpp
+++ b/Source/WebCore/css/values/grid/CSSGridNamedAreaMap.cpp
@@ -89,7 +89,7 @@ bool addRow(GridNamedAreaMap& gridAreaMap, const GridNamedAreaMapRow& row)
 
 static void serializeGridNamedAreaMapPosition(StringBuilder& builder, const GridNamedAreaMap::Map& map, size_t row, size_t column)
 {
-    HashSet<String> candidates;
+    HashSet<WTF::String> candidates;
     for (auto& [name, area] : map) {
         if (row >= area.rows.startLine() && row < area.rows.endLine())
             candidates.add(name);

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.cpp
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.cpp
@@ -46,7 +46,7 @@ NEVER_INLINE void formatNonfiniteCSSNumberValue(StringBuilder& builder, const Se
     return builder.append(formatNonfiniteCSSNumberValuePrefix(number.value), number.suffix.isEmpty() ? ""_s : " * 1"_s, number.suffix);
 }
 
-NEVER_INLINE String formatNonfiniteCSSNumberValue(const SerializableNumber& number)
+NEVER_INLINE WTF::String formatNonfiniteCSSNumberValue(const SerializableNumber& number)
 {
     return makeString(formatNonfiniteCSSNumberValuePrefix(number.value), number.suffix.isEmpty() ? ""_s : " * 1"_s, number.suffix);
 }
@@ -58,7 +58,7 @@ NEVER_INLINE void formatCSSNumberValue(StringBuilder& builder, const Serializabl
     return builder.append(FormattedCSSNumber::create(number.value), number.suffix);
 }
 
-NEVER_INLINE String formatCSSNumberValue(const SerializableNumber& number)
+NEVER_INLINE WTF::String formatCSSNumberValue(const SerializableNumber& number)
 {
     if (!std::isfinite(number.value))
         return formatNonfiniteCSSNumberValue(number);

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.h
@@ -37,10 +37,10 @@ struct SerializableNumber {
 };
 
 void formatNonfiniteCSSNumberValue(StringBuilder&, const SerializableNumber&);
-String formatNonfiniteCSSNumberValue(const SerializableNumber&);
+WTF::String formatNonfiniteCSSNumberValue(const SerializableNumber&);
 
 void formatCSSNumberValue(StringBuilder&, const SerializableNumber&);
-String formatCSSNumberValue(const SerializableNumber&);
+WTF::String formatCSSNumberValue(const SerializableNumber&);
 
 template<> struct Serialize<SerializableNumber> {
     void operator()(StringBuilder&, const SerializationContext&, const SerializableNumber&);

--- a/Source/WebCore/css/values/primitives/CSSString.cpp
+++ b/Source/WebCore/css/values/primitives/CSSString.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSString.h"
+
+#include "CSSMarkup.h"
+#include "CSSStringValue.h"
+#include <wtf/Hasher.h>
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+namespace CSS {
+
+void Serialize<String>::operator()(StringBuilder& builder, const SerializationContext&, const String& value)
+{
+    WebCore::serializeString(builder, value.value);
+}
+
+Ref<CSSValue> CSSValueCreation<String>::operator()(CSSValuePool&, const String& value)
+{
+    return CSSStringValue::create(value);
+}
+
+// MARK: - Logging
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, const String& value)
+{
+    return ts << value.value;
+}
+
+// MARK: - Hashing
+
+void add(Hasher& hasher, const String& value)
+{
+    add(hasher, value.value);
+}
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSString.h
+++ b/Source/WebCore/css/values/primitives/CSSString.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/CSSValueTypes.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+namespace CSS {
+
+// https://drafts.csswg.org/css-values-4/#strings
+struct String {
+    WTF::String value;
+
+    bool operator==(const String&) const = default;
+    bool operator==(const WTF::String& other) const { return value == other; }
+};
+
+template<> struct Serialize<String> { void operator()(StringBuilder&, const SerializationContext&, const String&); };
+template<> struct ComputedStyleDependenciesCollector<String> { constexpr void operator()(ComputedStyleDependencies&, const String&) { } };
+template<> struct CSSValueChildrenVisitor<String> { constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const String&) { return IterationStatus::Continue; } };
+template<> struct CSSValueCreation<String> { Ref<CSSValue> operator()(CSSValuePool&, const String&); };
+
+// MARK: - Logging
+
+WTF::TextStream& operator<<(WTF::TextStream&, const String&);
+
+// MARK: - Hashing
+
+void NODELETE add(Hasher&, const String&);
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSURL.cpp
+++ b/Source/WebCore/css/values/primitives/CSSURL.cpp
@@ -28,6 +28,7 @@
 #include "CSSMarkup.h"
 #include "CSSParserContext.h"
 #include "CSSSerializationContext.h"
+#include "CSSURLValue.h"
 #include "Document.h"
 
 namespace WebCore {
@@ -67,9 +68,16 @@ void Serialize<URL>::operator()(StringBuilder& builder, const SerializationConte
     builder.append(')');
 }
 
+// MARK: - CSSValueCreation
+
+Ref<CSSValue> CSSValueCreation<URL>::operator()(CSSValuePool&, const URL& value)
+{
+    return CSSURLValue::create(value);
+}
+
 // MARK: Operations
 
-static URL completeURL(const String& string, const WTF::URL& baseURL)
+static URL completeURL(const WTF::String& string, const WTF::URL& baseURL)
 {
     if (string.isEmpty() || string.startsWith('#'))
         return URL { .specified = string, .resolved = WTF::URL { string }, .modifiers = { } };
@@ -78,7 +86,7 @@ static URL completeURL(const String& string, const WTF::URL& baseURL)
     return URL { .specified = string, .resolved = WTF::URL { baseURL, string }, .modifiers = { } };
 }
 
-std::optional<URL> completeURL(const String& string, const CSSParserContext& context)
+std::optional<URL> completeURL(const WTF::String& string, const CSSParserContext& context)
 {
     if (string.isNull())
         return { };
@@ -92,7 +100,7 @@ std::optional<URL> completeURL(const String& string, const CSSParserContext& con
     return result;
 }
 
-std::optional<URL> completeURL(const String& string, const Document& document)
+std::optional<URL> completeURL(const WTF::String& string, const Document& document)
 {
     if (string.isNull())
         return { };

--- a/Source/WebCore/css/values/primitives/CSSURL.h
+++ b/Source/WebCore/css/values/primitives/CSSURL.h
@@ -56,10 +56,14 @@ template<size_t I> const auto& get(const URL& value)
         return value.modifiers;
 }
 
-template<> struct Serialize<URL> { void operator()(StringBuilder&, const SerializationContext&, const URL&); };
+template<> struct ComputedStyleDependenciesCollector<URL> { constexpr void operator()(ComputedStyleDependencies&, const URL&) { } };
+template<> struct CSSValueChildrenVisitor<URL> { constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const URL&) { return IterationStatus::Continue; } };
 
-std::optional<URL> completeURL(const String&, const CSSParserContext&);
-std::optional<URL> completeURL(const String&, const Document&);
+template<> struct Serialize<URL> { void operator()(StringBuilder&, const SerializationContext&, const URL&); };
+template<> struct CSSValueCreation<URL> { Ref<CSSValue> operator()(CSSValuePool&, const URL&); };
+
+std::optional<URL> completeURL(const WTF::String&, const CSSParserContext&);
+std::optional<URL> completeURL(const WTF::String&, const Document&);
 
 URL resolve(URL&&);
 

--- a/Source/WebCore/css/values/primitives/CSSURLModifiers.cpp
+++ b/Source/WebCore/css/values/primitives/CSSURLModifiers.cpp
@@ -51,7 +51,7 @@ void applyModifiersToLoaderOptions(const URLModifiers& modifiers, ResourceLoader
         //
         // The URL request modifier steps for this modifier given request req are to set
         // request's integrity metadata to the given <string>.
-        loaderOptions.integrity = modifiers.integrity->parameters;
+        loaderOptions.integrity = modifiers.integrity->parameters.value;
     }
 
     if (modifiers.referrerPolicy) {

--- a/Source/WebCore/css/values/primitives/CSSURLModifiers.h
+++ b/Source/WebCore/css/values/primitives/CSSURLModifiers.h
@@ -24,9 +24,9 @@
 
 #pragma once
 
+#include <WebCore/CSSString.h>
 #include <WebCore/CSSValueTypes.h>
 #include <WebCore/LoadedFromOpaqueSource.h>
-#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/css/values/shapes/CSSPathFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSPathFunction.cpp
@@ -44,7 +44,7 @@ void Serialize<Path>::operator()(StringBuilder& builder, const SerializationCont
     }
 
     // FIXME: Add version of `buildStringFromByteStream` that takes a `StringBuilder`.
-    String pathString;
+    WTF::String pathString;
     buildStringFromByteStream(value.data.byteStream, pathString, UnalteredParsing);
     serializeString(builder, pathString);
 }

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -31,6 +31,7 @@
 #include "ContainerNodeInlines.h"
 #include "CSSColorValue.h"
 #include "CSSComputedStyleDeclaration.h"
+#include "CSSFontFamilyNameValue.h"
 #include "CSSFontStyleWithAngleValue.h"
 #include "CSSParserIdioms.h"
 #include "CSSPropertyParserConsumer+Font.h"
@@ -1443,15 +1444,15 @@ void EditingStyle::mergeStyleFromRules(StyledElement& element)
     m_mutableStyle = WTF::move(styleFromMatchedRules);
 }
 
-static String loneFontFamilyName(const CSSValue& value)
+static AtomString loneFontFamilyName(const CSSValue& value)
 {
-    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value))
-        return primitiveValue->stringValue();
+    if (RefPtr fontFamilyNameValue = dynamicDowncast<CSSFontFamilyNameValue>(value))
+        return fontFamilyNameValue->fontFamilyName().value;
     RefPtr list = dynamicDowncast<CSSValueList>(value);
     if (!list || list->length() != 1)
-        return { };
-    RefPtr item = dynamicDowncast<CSSPrimitiveValue>(list->item(0));
-    return item ? item->stringValue() : String();
+        return nullAtom();
+    RefPtr item = dynamicDowncast<CSSFontFamilyNameValue>(list->item(0));
+    return item ? item->fontFamilyName().value : nullAtom();
 }
 
 void EditingStyle::mergeStyleFromRulesForSerialization(StyledElement& element, StandardFontFamilySerializationMode standardFontFamilySerializationMode)

--- a/Source/WebCore/editing/FontAttributeChanges.cpp
+++ b/Source/WebCore/editing/FontAttributeChanges.cpp
@@ -70,7 +70,7 @@ Ref<MutableStyleProperties> FontChanges::createStyleProperties() const
     if (!m_fontFamily.isNull()) {
         AtomString familyNameForCSS { platformFontFamilyNameForCSS() };
         if (!familyNameForCSS.isNull())
-            style->setProperty(CSSPropertyFontFamily, CSSValuePool::singleton().createFontFamilyValue(familyNameForCSS));
+            style->setProperty(CSSPropertyFontFamily, CSSValuePool::singleton().createFontFamilyNameValue(familyNameForCSS));
     }
 
     if (m_italic)

--- a/Source/WebCore/editing/TextListParser.cpp
+++ b/Source/WebCore/editing/TextListParser.cpp
@@ -102,7 +102,7 @@ std::optional<TextList> tryConsumeUnorderedDashTextList(StringParsingBuffer<Char
 
     if (WTF::skipExactly(input, WTF::Unicode::hyphenMinus)) {
         if (input.atEnd())
-            return { { Style::ListStyleType { AtomString { std::span { marker } } }, 0, false } };
+            return { { Style::ListStyleType { Style::String { WTF::String { std::span { marker } } } }, 0, false } };
 
         skipToEnd(input);
     }

--- a/Source/WebCore/editing/cocoa/FontAttributesCocoa.mm
+++ b/Source/WebCore/editing/cocoa/FontAttributesCocoa.mm
@@ -91,10 +91,10 @@ static RetainPtr<NSString> cocoaTextListMarkerName(const Style::ListStyleType& s
         [&](const CSS::Keyword::None&) {
             return retainPtr(ordered ? NSTextListMarkerDecimal : NSTextListMarkerDisc);
         },
-        [&](const AtomString& identifier) {
+        [&](const Style::String& identifier) {
             // The marker for the marker format `{<identifier>}` is `n` where `n` is the item ordinal, and the list is considered ordered.
             // The marker for the marker format `<identifier>` is `<identifier>`, and the list is considered unordered.
-            auto format = ordered ? makeString("{"_s, identifier, "}"_s) : identifier;
+            auto format = ordered ? makeString("{"_s, identifier.value, "}"_s) : identifier.value;
             return format.createNSString();
         }
     );

--- a/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
@@ -476,17 +476,17 @@ RefPtr<CSSValue> HTMLConverterCaches::inlineStylePropertyForElement(Element& ele
 
 static bool stringFromCSSValue(CSSValue& value, String& result)
 {
-    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         // FIXME: Use isStringType(CSSUnitType)?
         auto primitiveType = primitiveValue->primitiveType();
-        if (primitiveType == CSSUnitType::CSS_STRING || primitiveType == CSSUnitType::CSS_IDENT || primitiveType == CSSUnitType::CSS_ATTR) {
+        if (primitiveType == CSSUnitType::CSS_VALUE_ID) {
             auto stringValue = value.cssText(CSS::defaultSerializationContext());
             if (stringValue.length()) {
                 result = stringValue;
                 return true;
             }
         }
-    } else if (value.isValueList() || value.isAppleColorFilterValue() || value.isFilterValue() || value.isTextShadowPropertyValue() || value.isBoxShadowPropertyValue() || value.isURL() || value.isPropertyIdentifierValue()) {
+    } else if (value.isValueList() || value.isAppleColorFilterValue() || value.isFilterValue() || value.isTextShadowPropertyValue() || value.isBoxShadowPropertyValue() || value.isURL() || value.isPropertyIdentifierValue() || value.isStringValue() || value.isAttrValue()) {
         result = value.cssText(CSS::defaultSerializationContext());
         return true;
     }

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -409,8 +409,10 @@ String CanvasRenderingContext2DBase::State::fontString() const
         auto separator = i ? ", "_s : " "_s;
         if (fontFamily.isGeneric())
             serializedFont.append(separator, family);
-        else
-            serializedFont.append(separator, serializeFontFamily(family.toString()));
+        else {
+            serializedFont.append(separator);
+            serializeFontFamily(serializedFont, family);
+        }
     }
 
     return serializedFont.toString();

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp
@@ -492,7 +492,7 @@ std::optional<InlineDisplay::Line::Ellipsis> InlineDisplayLineBuilder::applyElli
     if (truncationPolicy == LineEndingTruncationPolicy::NoTruncation || !displayBoxes.size())
         return { };
 
-    auto ellipsisText = [&] {
+    auto ellipsisText = [&] -> AtomString {
         if (truncationPolicy == LineEndingTruncationPolicy::WhenContentOverflowsInInlineDirection || isLegacyLineClamp) {
             // Legacy line clamp always uses ...
             return TextUtil::ellipsisTextInInlineDirection(displayLine.isHorizontal());
@@ -504,8 +504,8 @@ std::optional<InlineDisplay::Line::Ellipsis> InlineDisplayLineBuilder::applyElli
             [&](const CSS::Keyword::Auto&) -> AtomString {
                 return TextUtil::ellipsisTextInInlineDirection(displayLine.isHorizontal());
             },
-            [&](const AtomString& string) -> AtomString {
-                return string;
+            [&](const Style::String& string) -> AtomString {
+                return AtomString { string.value };
             }
         );
     }();

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -181,7 +181,7 @@ TextUtil::FallbackFontList TextUtil::fallbackFontsForText(StringView textContent
     };
 
     if (includeHyphen == IncludeHyphen::Yes)
-        collectFallbackFonts(TextRun { StringView(style.hyphenString().string()), { }, { }, ExpansionBehavior::defaultBehavior(), style.writingMode().bidiDirection() });
+        collectFallbackFonts(TextRun { StringView(style.hyphenString()), { }, { }, ExpansionBehavior::defaultBehavior(), style.writingMode().bidiDirection() });
     collectFallbackFonts(TextRun { textContent, { }, { }, ExpansionBehavior::defaultBehavior(), style.writingMode().bidiDirection() });
     return fallbackFonts;
 }

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -148,7 +148,7 @@ static bool hasValidColumnEnd(const Style::GridPositionExplicit& explicitColumnS
             return false;
         },
         [&](const Style::GridPositionExplicit&) {
-            if (!columnEnd.namedGridLine().isEmpty() || columnEnd.explicitPosition() < 0 || columnEnd.explicitPosition() > static_cast<int>(linesFromGridTemplateColumnsCount))
+            if (!columnEnd.namedGridLine().value.isEmpty() || columnEnd.explicitPosition() < 0 || columnEnd.explicitPosition() > static_cast<int>(linesFromGridTemplateColumnsCount))
                 return false;
 
             // FIXME: Multi-span items are not yet supported in intrinsic sizing
@@ -198,7 +198,7 @@ static bool hasValidRowEnd(const Style::GridPositionExplicit& explicitRowStart, 
             return false;
         },
         [&](const Style::GridPositionExplicit&) {
-            if (!rowEnd.namedGridLine().isEmpty() || rowEnd.explicitPosition() < 0 || rowEnd.explicitPosition() > static_cast<int>(linesFromGridTemplateRowsCount))
+            if (!rowEnd.namedGridLine().value.isEmpty() || rowEnd.explicitPosition() < 0 || rowEnd.explicitPosition() > static_cast<int>(linesFromGridTemplateRowsCount))
                 return false;
 
             // FIXME: Multi-span items are not yet supported in intrinsic sizing
@@ -477,7 +477,7 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
             },
             [&](const Style::GridPositionExplicit& explicitPosition) -> std::optional<GridAvoidanceReason> {
                 auto columnStartLineNumber = explicitPosition.position.value;
-                if (!columnStart.namedGridLine().isEmpty())
+                if (!columnStart.namedGridLine().value.isEmpty())
                     return GridAvoidanceReason::GridItemColumnStartHasLineName;
                 if (columnStartLineNumber < 0)
                     return GridAvoidanceReason::GridItemColumnStartHasNegativeLineNumber;
@@ -507,7 +507,7 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
             },
             [&](const Style::GridPositionExplicit& explicitPosition) -> std::optional<GridAvoidanceReason> {
                 auto rowStartLineNumber = explicitPosition.position.value;
-                if (!rowStart.namedGridLine().isEmpty())
+                if (!rowStart.namedGridLine().value.isEmpty())
                     return GridAvoidanceReason::GridItemRowStartHasLineName;
                 if (rowStartLineNumber < 0)
                     return GridAvoidanceReason::GridItemRowStartHasNegativeLineNumber;

--- a/Source/WebCore/rendering/RenderCounter.cpp
+++ b/Source/WebCore/rendering/RenderCounter.cpp
@@ -447,11 +447,11 @@ String RenderCounter::originalText() const
         return counterStyle()->text(value, writingMode());
     };
     auto text = counterText(value);
-    if (!m_counter.separator.isNull()) {
+    if (!m_counter.separator.value.isNull()) {
         if (!counterNode->actsAsReset())
             counterNode = counterNode->parent();
         while (RefPtr parent = counterNode->parent()) {
-            text = makeString(counterText(counterNode->countInParent()), m_counter.separator, text);
+            text = makeString(counterText(counterNode->countInParent()), m_counter.separator.value, text);
             counterNode = parent;
         }
     }

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -415,11 +415,11 @@ void RenderListMarker::updateContent()
                 .textDirection = TextDirection::LTR,
             };
         },
-        [&](const AtomString& identifier) {
+        [&](const Style::String& identifier) {
             m_textContent = {
-                .textWithSuffix = identifier,
-                .textWithoutSuffixLength = identifier.length(),
-                .textDirection = contentTextDirection(StringView { identifier }),
+                .textWithSuffix = identifier.value,
+                .textWithoutSuffixLength = identifier.value.length(),
+                .textDirection = contentTextDirection(StringView { identifier.value }),
             };
         },
         [&](const Style::CounterStyle&) {

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1183,7 +1183,7 @@ void RenderText::computePreferredLogicalWidths(float leadWidth, bool forcedMinMa
 static inline float hyphenWidth(RenderText& renderer, const FontCascade& font)
 {
     const RenderStyle& style = renderer.style();
-    auto textRun = RenderBlock::constructTextRun(style.hyphenString().string(), style);
+    auto textRun = RenderBlock::constructTextRun(style.hyphenString(), style);
     return font.width(textRun);
 }
 

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -486,7 +486,7 @@ static inline void writeTextRuns(TextStream& ts, auto& textRenderer)
         ts << ": "_s
             << quoteAndEscapeNonPrintables(textRun.originalText());
         if (textRun.hasHyphen())
-            ts << " + hyphen string "_s << quoteAndEscapeNonPrintables(textRenderer.style().hyphenString().string());
+            ts << " + hyphen string "_s << quoteAndEscapeNonPrintables(textRenderer.style().hyphenString());
         ts << '\n';
     };
 

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -216,20 +216,20 @@ bool RenderStyle::outOfFlowPositionStyleDidChange(const RenderStyle* other) cons
 
 // MARK: - Used Values
 
-const AtomString& RenderStyle::hyphenString() const
+const String& RenderStyle::hyphenString() const
 {
     ASSERT(hyphens() != Hyphens::None);
 
     return WTF::switchOn(hyphenateCharacter(),
-        [&](const CSS::Keyword::Auto&) -> const AtomString& {
+        [&](const CSS::Keyword::Auto&) -> const String& {
             // FIXME: This should depend on locale.
-            static MainThreadNeverDestroyed<const AtomString> hyphenMinusString(span(hyphenMinus));
-            static MainThreadNeverDestroyed<const AtomString> hyphenString(span(hyphen));
+            static MainThreadNeverDestroyed<const String> hyphenMinusString(span(hyphenMinus));
+            static MainThreadNeverDestroyed<const String> hyphenString(span(hyphen));
 
             return protect(fontCascade().primaryFont())->glyphForCharacter(hyphen) ? hyphenString : hyphenMinusString;
         },
-        [](const AtomString& string) -> const AtomString& {
-            return string;
+        [](const Style::String& string) -> const String& {
+            return string.value;
         }
     );
 }

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -392,7 +392,7 @@ public:
 
     // MARK: - Used Values
 
-    const AtomString& hyphenString() const LIFETIME_BOUND;
+    const String& hyphenString() const LIFETIME_BOUND;
     float usedStrokeWidth(const IntSize& viewportSize) const;
     Color usedStrokeColor() const;
     Color usedStrokeColorApplyingColorFilter() const;

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -112,10 +112,10 @@ static bool needsPseudoElementForAnimation(const Element& element, PseudoElement
 
 static RenderPtr<RenderObject> createContentRenderer(const Style::Content::Text& value, const String& altText, Document& document, const RenderStyle&)
 {
-    if (value.text.isEmpty() && altText.isEmpty())
+    if (value.text.value.isEmpty() && altText.isEmpty())
         return { };
 
-    auto contentRenderer = createRenderer<RenderTextFragment>(document, value.text);
+    auto contentRenderer = createRenderer<RenderTextFragment>(document, value.text.value);
     contentRenderer->setAltText(altText);
     return contentRenderer;
 }
@@ -143,11 +143,11 @@ static RenderPtr<RenderObject> createContentRenderer(const Style::Content::Quote
 void RenderTreeUpdater::GeneratedContent::createContentRenderers(RenderTreeBuilder& builder, RenderElement& pseudoRenderer, const RenderStyle& style, PseudoElementType pseudoElementType)
 {
     if (auto* contentData = style.content().tryData()) {
-        auto altText = contentData->altText.value_or(String { });
+        auto altText = contentData->altText.value_or(String { nullString() });
         for (auto& contentItem : contentData->list) {
             WTF::switchOn(contentItem,
                 [&](const auto& item) {
-                    if (auto child = createContentRenderer(item, altText, pseudoRenderer.document(), style); child && pseudoRenderer.isChildAllowed(*child, style))
+                    if (auto child = createContentRenderer(item, altText.value, pseudoRenderer.document(), style); child && pseudoRenderer.isChildAllowed(*child, style))
                         builder.attach(pseudoRenderer, WTF::move(child));
                 }
             );

--- a/Source/WebCore/style/ContainerQueryEvaluator.cpp
+++ b/Source/WebCore/style/ContainerQueryEvaluator.cpp
@@ -107,7 +107,7 @@ auto ContainerQueryEvaluator::featureEvaluationContextForQuery(const CQ::Contain
     };
 }
 
-RefPtr<const Element> ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axis> requiredAxes, const String& name, const Element& element, SelectionMode selectionMode, ScopeOrdinal scopeOrdinal, const ContainerQueryEvaluationState* evaluationState)
+RefPtr<const Element> ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axis> requiredAxes, const WTF::String& name, const Element& element, SelectionMode selectionMode, ScopeOrdinal scopeOrdinal, const ContainerQueryEvaluationState* evaluationState)
 {
     // "For each element, the query container to be queried is selected from among the element’s
     // ancestor query containers that have a valid container-type for all the container features

--- a/Source/WebCore/style/ContainerQueryEvaluator.h
+++ b/Source/WebCore/style/ContainerQueryEvaluator.h
@@ -48,7 +48,7 @@ public:
 
     bool evaluate(const CQ::ContainerQuery&) const;
 
-    static RefPtr<const Element> selectContainer(OptionSet<CQ::Axis>, const String& name, const Element&, SelectionMode = SelectionMode::Element, ScopeOrdinal = ScopeOrdinal::Element, const ContainerQueryEvaluationState* = nullptr);
+    static RefPtr<const Element> selectContainer(OptionSet<CQ::Axis>, const WTF::String& name, const Element&, SelectionMode = SelectionMode::Element, ScopeOrdinal = ScopeOrdinal::Element, const ContainerQueryEvaluationState* = nullptr);
 
 private:
     std::optional<MQ::FeatureEvaluationContext> featureEvaluationContextForQuery(const CQ::ContainerQuery&) const;

--- a/Source/WebCore/style/PageRuleCollector.cpp
+++ b/Source/WebCore/style/PageRuleCollector.cpp
@@ -55,7 +55,7 @@ bool PageRuleCollector::isFirstPage(int pageIndex) const
     return (!pageIndex);
 }
 
-String PageRuleCollector::pageName(int /* pageIndex */) const
+WTF::String PageRuleCollector::pageName(int /* pageIndex */) const
 {
     // FIXME: Implement page index to page name mapping.
     return emptyString();
@@ -63,9 +63,9 @@ String PageRuleCollector::pageName(int /* pageIndex */) const
 
 void PageRuleCollector::matchAllPageRules(int pageIndex)
 {
-    const bool isLeft = isLeftPage(pageIndex);
-    const bool isFirst = isFirstPage(pageIndex);
-    const String page = pageName(pageIndex);
+    auto isLeft = isLeftPage(pageIndex);
+    auto isFirst = isFirstPage(pageIndex);
+    auto page = pageName(pageIndex);
 
     matchPageRules(UserAgentStyle::defaultPrintStyle, isLeft, isFirst, page);
     matchPageRules(m_ruleSets.userStyle(), isLeft, isFirst, page);
@@ -74,7 +74,7 @@ void PageRuleCollector::matchAllPageRules(int pageIndex)
         matchPageRules(&m_ruleSets.authorStyle(), isLeft, isFirst, page);
 }
 
-void PageRuleCollector::matchPageRules(RuleSet* rules, bool isLeftPage, bool isFirstPage, const String& pageName)
+void PageRuleCollector::matchPageRules(RuleSet* rules, bool isLeftPage, bool isFirstPage, const WTF::String& pageName)
 {
     if (!rules)
         return;
@@ -91,7 +91,7 @@ void PageRuleCollector::matchPageRules(RuleSet* rules, bool isLeftPage, bool isF
     });
 }
 
-static bool NODELETE checkPageSelectorComponents(const CSSSelector& selector, bool isLeftPage, bool isFirstPage, const String& pageName)
+static bool NODELETE checkPageSelectorComponents(const CSSSelector& selector, bool isLeftPage, bool isFirstPage, const WTF::String& pageName)
 {
     for (const CSSSelector* component = &selector; component; component = component->precedingInComplexSelector()) {
         if (component->match() == CSSSelector::Match::Tag) {
@@ -111,7 +111,7 @@ static bool NODELETE checkPageSelectorComponents(const CSSSelector& selector, bo
     return true;
 }
 
-void PageRuleCollector::matchPageRulesForList(Vector<StyleRulePage*>& matchedRules, const Vector<StyleRulePage*>& rules, bool isLeftPage, bool isFirstPage, const String& pageName)
+void PageRuleCollector::matchPageRulesForList(Vector<StyleRulePage*>& matchedRules, const Vector<StyleRulePage*>& rules, bool isLeftPage, bool isFirstPage, const WTF::String& pageName)
 {
     for (unsigned i = 0; i < rules.size(); ++i) {
         StyleRulePage* rule = rules[i];

--- a/Source/WebCore/style/PageRuleCollector.h
+++ b/Source/WebCore/style/PageRuleCollector.h
@@ -46,10 +46,10 @@ private:
     bool NODELETE isLeftPage(int pageIndex) const;
     bool isRightPage(int pageIndex) const { return !isLeftPage(pageIndex); }
     bool NODELETE isFirstPage(int pageIndex) const;
-    String NODELETE pageName(int pageIndex) const;
+    WTF::String NODELETE pageName(int pageIndex) const;
 
-    void matchPageRules(RuleSet* rules, bool isLeftPage, bool isFirstPage, const String& pageName);
-    void matchPageRulesForList(Vector<StyleRulePage*>& matchedRules, const Vector<StyleRulePage*>& rules, bool isLeftPage, bool isFirstPage, const String& pageName);
+    void matchPageRules(RuleSet* rules, bool isLeftPage, bool isFirstPage, const WTF::String& pageName);
+    void matchPageRulesForList(Vector<StyleRulePage*>& matchedRules, const Vector<StyleRulePage*>& rules, bool isLeftPage, bool isFirstPage, const WTF::String& pageName);
 
     ScopeRuleSets& m_ruleSets;
     WritingMode m_rootWritingMode;

--- a/Source/WebCore/style/PseudoElementUtilities.cpp
+++ b/Source/WebCore/style/PseudoElementUtilities.cpp
@@ -46,7 +46,7 @@ static RefPtr<Element> findElementForUserAgentPart(Element& host, const AtomStri
     return nullptr;
 }
 
-ResolvedComputedPseudoElement resolveComputedPseudoElement(Element& element, const String& pseudoElement)
+ResolvedComputedPseudoElement resolveComputedPseudoElement(Element& element, const WTF::String& pseudoElement)
 {
     auto identifier = CSSSelectorParser::parsePseudoElement(pseudoElement, CSSSelectorParserContext { protect(element.document()) });
     if (!identifier)

--- a/Source/WebCore/style/PseudoElementUtilities.h
+++ b/Source/WebCore/style/PseudoElementUtilities.h
@@ -42,7 +42,7 @@ struct ResolvedComputedPseudoElement {
     std::optional<PseudoElementIdentifier> identifier;
 };
 
-ResolvedComputedPseudoElement resolveComputedPseudoElement(Element&, const String& pseudoElement);
+ResolvedComputedPseudoElement resolveComputedPseudoElement(Element&, const WTF::String& pseudoElement);
 
 bool pseudoElementRendererIsNeeded(const RenderStyle&);
 

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -702,7 +702,7 @@ const RefPtr<const StyleRulePositionTry> RuleSet::positionTryRuleForName(const A
     return m_positionTryRules.get(name);
 }
 
-String RuleSet::selectorsForDebugging() const
+WTF::String RuleSet::selectorsForDebugging() const
 {
     TextStream ts;
     ts << "RuleSet size " << ruleCount();

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -144,7 +144,7 @@ public:
 
     const RefPtr<const StyleRulePositionTry> NODELETE positionTryRuleForName(const AtomString&) const;
 
-    String selectorsForDebugging() const;
+    WTF::String selectorsForDebugging() const;
 
 private:
     friend class RuleSetBuilder;

--- a/Source/WebCore/style/ScopedName.cpp
+++ b/Source/WebCore/style/ScopedName.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ScopedName.h"
 
+#include "CSSStringValue.h"
 #include "StyleBuilderChecking.h"
 #include <wtf/text/TextStream.h>
 
@@ -36,17 +37,12 @@ namespace Style {
 
 auto CSSValueConversion<ScopedName>::operator()(BuilderState& state, const CSSValue& value) -> ScopedName
 {
-    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
-        if (primitiveValue->isString()) {
-            return ScopedName {
-                .name = AtomString { primitiveValue->string() },
-                .scopeOrdinal = state.styleScopeOrdinal(),
-                .isIdentifier = false,
-            };
-        }
-
-        state.setCurrentPropertyInvalidAtComputedValueTime();
-        return ScopedName { nullAtom() };
+    if (RefPtr stringValue = dynamicDowncast<CSSStringValue>(value)) {
+        return ScopedName {
+            .name = AtomString { toStyleFromCSSValue<String>(state, value).value },
+            .scopeOrdinal = state.styleScopeOrdinal(),
+            .isIdentifier = false,
+        };
     }
 
     return ScopedName {

--- a/Source/WebCore/style/ScopedName.h
+++ b/Source/WebCore/style/ScopedName.h
@@ -26,6 +26,7 @@
 
 #include <WebCore/StyleCustomIdent.h>
 #include <WebCore/StyleScopeOrdinal.h>
+#include <WebCore/StyleString.h>
 #include <WebCore/StyleValueTypes.h>
 #include <wtf/text/AtomString.h>
 
@@ -42,7 +43,7 @@ struct ScopedName {
         auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
         if (isIdentifier)
             return visitor(CustomIdent { name });
-        return visitor(name);
+        return visitor(String { name });
     }
 
     bool operator==(const ScopedName&) const = default;

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -406,7 +406,7 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
         style.setHasExplicitlyInheritedProperties();
 
     if (auto* paintImageValue = dynamicDowncast<CSSPaintImageValue>(valueToApply.get())) {
-        auto& name = paintImageValue->name();
+        auto& name = paintImageValue->name().value;
         if (auto* paintWorklet = const_cast<Document&>(m_state->document()).paintWorkletGlobalScopeForName(name)) {
             Locker locker { paintWorklet->paintDefinitionLock() };
             if (auto* registration = paintWorklet->paintDefinitionMap().get(name)) {

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -34,6 +34,7 @@
 #include "CSSPrimitiveValueMappings.h"
 #include "CSSPropertyParserConsumer+Font.h"
 #include "CSSRegisteredCustomProperty.h"
+#include "CSSStringValue.h"
 #include "CSSValuePair.h"
 #include "CSSValuePool.h"
 #include "DocumentQuirks.h"
@@ -514,14 +515,7 @@ inline void BuilderCustom::applyValueLineHeight(BuilderState& builderState, CSSV
 
 inline void BuilderCustom::applyValueWebkitLocale(BuilderState& builderState, CSSValue& value)
 {
-    auto primitiveValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-    if (!primitiveValue)
-        return;
-
-    if (primitiveValue->valueID() == CSSValueAuto)
-        builderState.setFontDescriptionSpecifiedLocale(nullAtom());
-    else
-        builderState.setFontDescriptionSpecifiedLocale(AtomString { primitiveValue->stringValue() });
+    builderState.setFontDescriptionSpecifiedLocale(toStyleFromCSSValue<WebkitLocale>(builderState, value));
 }
 
 inline void BuilderCustom::applyValueWritingMode(BuilderState& builderState, CSSValue& value)

--- a/Source/WebCore/style/StyleCustomProperty.cpp
+++ b/Source/WebCore/style/StyleCustomProperty.cpp
@@ -28,6 +28,7 @@
 #include "CSSCalcValue.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSSerializationContext.h"
+#include "CSSStringValue.h"
 #include "CSSSubstitutionValue.h"
 #include "CSSTokenizer.h"
 #include "CSSValueList.h"
@@ -82,7 +83,7 @@ Ref<CSSValue> CustomProperty::propertyValue(CSSValuePool& pool, const RenderStyl
 
     return WTF::switchOn(m_value,
         [&](const GuaranteedInvalid&) -> Ref<CSSValue> {
-            return CSSPrimitiveValue::create(""_s);
+            return CSSStringValue::create(CSS::String { emptyString() });
         },
         [&](const Ref<CSSVariableData>& variableData) -> Ref<CSSValue> {
             return CSSSubstitutionValue::create(variableData.copyRef());
@@ -107,7 +108,7 @@ Ref<CSSValue> CustomProperty::propertyValue(CSSValuePool& pool, const RenderStyl
     );
 }
 
-String CustomProperty::propertyValueSerialization(const CSS::SerializationContext& context, const RenderStyle& style) const
+WTF::String CustomProperty::propertyValueSerialization(const CSS::SerializationContext& context, const RenderStyle& style) const
 {
     StringBuilder builder;
     propertyValueSerialization(builder, context, style);
@@ -119,7 +120,7 @@ void CustomProperty::propertyValueSerialization(StringBuilder& builder, const CS
     auto serializeValue = [&](StringBuilder& builder, const Value& value) {
         WTF::switchOn(value,
             [&](const auto& value) {
-                Style::serializationForCSS(builder, context, style, value);
+                serializationForCSS(builder, context, style, value);
             }
         );
     };
@@ -144,7 +145,7 @@ void CustomProperty::propertyValueSerialization(StringBuilder& builder, const CS
     );
 }
 
-String CustomProperty::propertyValueSerializationForTokenization(const CSS::SerializationContext& context, const RenderStyle& style) const
+WTF::String CustomProperty::propertyValueSerializationForTokenization(const CSS::SerializationContext& context, const RenderStyle& style) const
 {
     StringBuilder builder;
     propertyValueSerializationForTokenization(builder, context, style);
@@ -162,10 +163,10 @@ void CustomProperty::propertyValueSerializationForTokenization(StringBuilder& bu
     auto serializeValue = [&](StringBuilder& builder, const Value& value) {
         WTF::switchOn(value,
             [&](const Color& value) {
-                Style::serializationForCSSTokenization(builder, context, value);
+                serializationForCSSTokenization(builder, context, value);
             },
             [&](const auto& value) {
-                Style::serializationForCSS(builder, context, style, value);
+                serializationForCSS(builder, context, style, value);
             }
         );
     };

--- a/Source/WebCore/style/StyleCustomProperty.h
+++ b/Source/WebCore/style/StyleCustomProperty.h
@@ -31,6 +31,7 @@
 #include <WebCore/StyleCustomIdent.h>
 #include <WebCore/StyleImageWrapper.h>
 #include <WebCore/StylePrimitiveNumeric.h>
+#include <WebCore/StyleString.h>
 #include <WebCore/StyleTransformFunction.h>
 #include <WebCore/StyleURL.h>
 #include <wtf/RefCounted.h>
@@ -105,7 +106,7 @@ public:
     bool valueEquals(const CustomProperty&) const;
 
     Ref<CSSValue> propertyValue(CSSValuePool&, const RenderStyle&) const;
-    String propertyValueSerialization(const CSS::SerializationContext&, const RenderStyle&) const;
+    WTF::String propertyValueSerialization(const CSS::SerializationContext&, const RenderStyle&) const;
     void propertyValueSerialization(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&) const;
 
 private:
@@ -116,7 +117,7 @@ private:
     {
     }
 
-    String propertyValueSerializationForTokenization(const CSS::SerializationContext&, const RenderStyle&) const;
+    WTF::String propertyValueSerializationForTokenization(const CSS::SerializationContext&, const RenderStyle&) const;
     void propertyValueSerializationForTokenization(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&) const;
 
     const AtomString m_name;

--- a/Source/WebCore/style/StyleExtractor.cpp
+++ b/Source/WebCore/style/StyleExtractor.cpp
@@ -256,7 +256,7 @@ RefPtr<CSSValue> Extractor::customPropertyValue(const AtomString& propertyName) 
     return value->propertyValue(CSSValuePool::singleton(), *style);
 }
 
-String Extractor::customPropertyValueSerialization(const AtomString& propertyName, const CSS::SerializationContext& serializationContext) const
+WTF::String Extractor::customPropertyValueSerialization(const AtomString& propertyName, const CSS::SerializationContext& serializationContext) const
 {
     std::unique_ptr<RenderStyle> ownedStyle;
     if (auto* style = computeStyleForCustomProperty(ownedStyle))
@@ -264,7 +264,7 @@ String Extractor::customPropertyValueSerialization(const AtomString& propertyNam
     return emptyString();
 }
 
-String Extractor::customPropertyValueSerializationInStyle(const RenderStyle& style, const AtomString& propertyName, const CSS::SerializationContext& serializationContext) const
+WTF::String Extractor::customPropertyValueSerializationInStyle(const RenderStyle& style, const AtomString& propertyName, const CSS::SerializationContext& serializationContext) const
 {
     if (RefPtr value = style.customPropertyValue(propertyName))
         return value->propertyValueSerialization(serializationContext, style);
@@ -456,7 +456,7 @@ RefPtr<CSSValue> Extractor::propertyValue(CSSPropertyID propertyID, UpdateLayout
     );
 }
 
-String Extractor::propertyValueSerialization(CSSPropertyID propertyID, const CSS::SerializationContext& serializationContext, UpdateLayout updateLayout, ExtractorState::PropertyValueType valueType) const
+WTF::String Extractor::propertyValueSerialization(CSSPropertyID propertyID, const CSS::SerializationContext& serializationContext, UpdateLayout updateLayout, ExtractorState::PropertyValueType valueType) const
 {
     std::unique_ptr<RenderStyle> ownedStyle;
     auto style = computeStyle(propertyID, updateLayout, ownedStyle);
@@ -504,7 +504,7 @@ RefPtr<CSSValue> Extractor::propertyValueInStyle(const RenderStyle& style, CSSPr
     return ExtractorGenerated::extractValue(state, propertyID);
 }
 
-String Extractor::propertyValueSerializationInStyle(const RenderStyle& style, CSSPropertyID propertyID, const CSS::SerializationContext& serializationContext, CSSValuePool& cssValuePool, const RenderElement* renderer, ExtractorState::PropertyValueType valueType) const
+WTF::String Extractor::propertyValueSerializationInStyle(const RenderStyle& style, CSSPropertyID propertyID, const CSS::SerializationContext& serializationContext, CSSValuePool& cssValuePool, const RenderElement* renderer, ExtractorState::PropertyValueType valueType) const
 {
     ASSERT(isExposed(propertyID, m_element->document().settings()));
 

--- a/Source/WebCore/style/StyleExtractor.h
+++ b/Source/WebCore/style/StyleExtractor.h
@@ -66,22 +66,22 @@ public:
     RefPtr<CSSValue> propertyValue(CSSPropertyID, UpdateLayout = UpdateLayout::Yes, ExtractorState::PropertyValueType = ExtractorState::PropertyValueType::Resolved) const;
 
     // Extract a serialized value for the specified property.
-    String propertyValueSerialization(CSSPropertyID, const CSS::SerializationContext&, UpdateLayout = UpdateLayout::Yes, ExtractorState::PropertyValueType = ExtractorState::PropertyValueType::Resolved) const;
+    WTF::String propertyValueSerialization(CSSPropertyID, const CSS::SerializationContext&, UpdateLayout = UpdateLayout::Yes, ExtractorState::PropertyValueType = ExtractorState::PropertyValueType::Resolved) const;
 
     // Extract a CSSValue for the specified property using the provided RenderStyle and RenderElement.
     RefPtr<CSSValue> propertyValueInStyle(const RenderStyle&, CSSPropertyID, CSSValuePool&, const RenderElement* = nullptr, ExtractorState::PropertyValueType = ExtractorState::PropertyValueType::Resolved) const;
 
     // Extract a serialized value for the specified property using the provided RenderStyle and RenderElement.
-    String propertyValueSerializationInStyle(const RenderStyle&, CSSPropertyID, const CSS::SerializationContext&, CSSValuePool&, const RenderElement* = nullptr, ExtractorState::PropertyValueType = ExtractorState::PropertyValueType::Resolved) const;
+    WTF::String propertyValueSerializationInStyle(const RenderStyle&, CSSPropertyID, const CSS::SerializationContext&, CSSValuePool&, const RenderElement* = nullptr, ExtractorState::PropertyValueType = ExtractorState::PropertyValueType::Resolved) const;
 
     // Extract a CSSValue for the specified custom property.
     RefPtr<CSSValue> customPropertyValue(const AtomString& propertyName) const;
 
     // Extract a serialized value for the specified custom property.
-    String customPropertyValueSerialization(const AtomString& propertyName, const CSS::SerializationContext&) const;
+    WTF::String customPropertyValueSerialization(const AtomString& propertyName, const CSS::SerializationContext&) const;
 
     // Extract a serialized value for the specified custom property using the provided RenderStyle and RenderElement.
-    String customPropertyValueSerializationInStyle(const RenderStyle&, const AtomString& propertyName, const CSS::SerializationContext&) const;
+    WTF::String customPropertyValueSerializationInStyle(const RenderStyle&, const AtomString& propertyName, const CSS::SerializationContext&) const;
 
     // Helper methods for HTML editing.
     Ref<MutableStyleProperties> copyProperties(std::span<const CSSPropertyID>) const;

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -2442,23 +2442,23 @@ inline void ExtractorCustom::extractOutlineOffsetSerialization(ExtractorState& s
 inline Ref<CSSValue> convertSingleAnimation(ExtractorState& state, const Animation& animation, const Animations& animations)
 {
     static NeverDestroyed<EasingFunction> initialTimingFunction(Animation::initialTimingFunction());
-    static NeverDestroyed<String> alternate { "alternate"_s };
-    static NeverDestroyed<String> alternateReverse { "alternate-reverse"_s };
-    static NeverDestroyed<String> backwards { "backwards"_s };
-    static NeverDestroyed<String> both { "both"_s };
-    static NeverDestroyed<String> ease { "ease"_s };
-    static NeverDestroyed<String> easeIn { "ease-in"_s };
-    static NeverDestroyed<String> easeInOut { "ease-in-out"_s };
-    static NeverDestroyed<String> easeOut { "ease-out"_s };
-    static NeverDestroyed<String> forwards { "forwards"_s };
-    static NeverDestroyed<String> infinite { "infinite"_s };
-    static NeverDestroyed<String> linear { "linear"_s };
-    static NeverDestroyed<String> normal { "normal"_s };
-    static NeverDestroyed<String> paused { "paused"_s };
-    static NeverDestroyed<String> reverse { "reverse"_s };
-    static NeverDestroyed<String> running { "running"_s };
-    static NeverDestroyed<String> stepEnd { "step-end"_s };
-    static NeverDestroyed<String> stepStart { "step-start"_s };
+    static NeverDestroyed<WTF::String> alternate { "alternate"_s };
+    static NeverDestroyed<WTF::String> alternateReverse { "alternate-reverse"_s };
+    static NeverDestroyed<WTF::String> backwards { "backwards"_s };
+    static NeverDestroyed<WTF::String> both { "both"_s };
+    static NeverDestroyed<WTF::String> ease { "ease"_s };
+    static NeverDestroyed<WTF::String> easeIn { "ease-in"_s };
+    static NeverDestroyed<WTF::String> easeInOut { "ease-in-out"_s };
+    static NeverDestroyed<WTF::String> easeOut { "ease-out"_s };
+    static NeverDestroyed<WTF::String> forwards { "forwards"_s };
+    static NeverDestroyed<WTF::String> infinite { "infinite"_s };
+    static NeverDestroyed<WTF::String> linear { "linear"_s };
+    static NeverDestroyed<WTF::String> normal { "normal"_s };
+    static NeverDestroyed<WTF::String> paused { "paused"_s };
+    static NeverDestroyed<WTF::String> reverse { "reverse"_s };
+    static NeverDestroyed<WTF::String> running { "running"_s };
+    static NeverDestroyed<WTF::String> stepEnd { "step-end"_s };
+    static NeverDestroyed<WTF::String> stepStart { "step-start"_s };
 
     // If we have an animation-delay but no animation-duration set, we must serialize
     // the animation-duration because they're both <time> values and animation-delay
@@ -2466,7 +2466,7 @@ inline Ref<CSSValue> convertSingleAnimation(ExtractorState& state, const Animati
     auto showsDelay = animation.delay() != Animation::initialDelay();
     auto showsDuration = showsDelay || animation.duration() != Animation::initialDuration();
 
-    auto name = [&] -> String {
+    auto name = [&] -> WTF::String {
         if (auto keyframesName = animation.name().tryKeyframesName())
             return keyframesName->name;
         return nullString();

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -451,10 +451,10 @@ std::unique_ptr<RenderStyle> Resolver::styleForKeyframe(Element& element, const 
     return state.takeStyle();
 }
 
-bool Resolver::isAnimationNameValid(const String& name) const
+bool Resolver::isAnimationNameValid(const AtomString& name) const
 {
-    return m_keyframesRuleMap.find(AtomString(name)) != m_keyframesRuleMap.end()
-        || userAgentKeyframes().find(AtomString(name)) != userAgentKeyframes().end();
+    return m_keyframesRuleMap.find(name) != m_keyframesRuleMap.end()
+        || userAgentKeyframes().find(name) != userAgentKeyframes().end();
 }
 
 Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& animationName, const TimingFunction* defaultTimingFunction) const

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -128,7 +128,7 @@ public:
     void addCurrentSVGFontFaceRules();
 
     std::unique_ptr<RenderStyle> styleForKeyframe(Element&, const RenderStyle& elementStyle, const ResolutionContext&, const StyleRuleKeyframe&, BlendingKeyframe&) const;
-    bool isAnimationNameValid(const String&) const;
+    bool isAnimationNameValid(const AtomString&) const;
 
     void setViewTransitionStyles(CSSSelector::PseudoElement, const AtomString&, Ref<MutableStyleProperties>);
 

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -263,7 +263,7 @@ const Scope* Scope::forOrdinal(const Element& element, ScopeOrdinal ordinal)
     return forOrdinal(const_cast<Element&>(element), ordinal);
 }
 
-void Scope::setPreferredStylesheetSetName(const String& name)
+void Scope::setPreferredStylesheetSetName(const WTF::String& name)
 {
     if (m_preferredStylesheetSetName == name)
         return;

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -92,7 +92,7 @@ public:
     void addStyleSheetCandidateNode(Node&, bool createdByParser);
     void removeStyleSheetCandidateNode(Node&);
 
-    void setPreferredStylesheetSetName(const String&);
+    void setPreferredStylesheetSetName(const WTF::String&);
     void establishPreferredStylesheetSetName(const Element&, const CSSStyleSheet&);
 
     void addPendingSheet(const Element&);
@@ -262,7 +262,7 @@ private:
 
     WeakListHashSet<Node, WeakPtrImplWithEventTargetData> m_styleSheetCandidateNodes;
 
-    String m_preferredStylesheetSetName;
+    WTF::String m_preferredStylesheetSetName;
 
     std::optional<UpdateType> m_pendingUpdate;
 

--- a/Source/WebCore/style/UserAgentStyle.cpp
+++ b/Source/WebCore/style/UserAgentStyle.cpp
@@ -111,7 +111,7 @@ static const MQ::MediaQueryEvaluator& printEval()
     return staticPrintEval;
 }
 
-static StyleSheetContents* parseUASheet(const String& str)
+static StyleSheetContents* parseUASheet(const WTF::String& str)
 {
     Ref sheet = StyleSheetContents::create(CSSParserContext(UASheetMode));
     sheet->parseString(str);
@@ -171,7 +171,7 @@ void UserAgentStyle::initDefaultStyleSheet()
     defaultQuirksStyle = &RuleSet::create().leakRef();
     mediaQueryStyleSheet = &StyleSheetContents::create(CSSParserContext(UASheetMode)).leakRef();
 
-    String defaultRules;
+    WTF::String defaultRules;
     auto extraDefaultStyleSheet = RenderTheme::singleton().extraDefaultStyleSheet();
     if (extraDefaultStyleSheet.isEmpty())
         defaultRules = StringImpl::createWithoutCopying(htmlUserAgentStyleSheet);

--- a/Source/WebCore/style/values/StyleValueTypes+CSSValueConversion.h
+++ b/Source/WebCore/style/values/StyleValueTypes+CSSValueConversion.h
@@ -32,44 +32,6 @@
 namespace WebCore {
 namespace Style {
 
-// Specialization for `String`.
-template<> struct CSSValueConversion<String> {
-    String operator()(BuilderState& state, const CSSPrimitiveValue& value)
-    {
-        if (!value.isString()) [[unlikely]] {
-            state.setCurrentPropertyInvalidAtComputedValueTime();
-            return emptyString();
-        }
-        return value.string();
-    }
-    String operator()(BuilderState& state, const CSSValue& value)
-    {
-        RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
-        if (!primitiveValue) [[unlikely]]
-            return emptyString();
-        return this->operator()(state, *primitiveValue);
-    }
-};
-
-// Specialization for `AtomString`.
-template<> struct CSSValueConversion<AtomString> {
-    AtomString operator()(BuilderState& state, const CSSPrimitiveValue& value)
-    {
-        if (!value.isString()) [[unlikely]] {
-            state.setCurrentPropertyInvalidAtComputedValueTime();
-            return emptyAtom();
-        }
-        return AtomString { value.string() };
-    }
-    AtomString operator()(BuilderState& state, const CSSValue& value)
-    {
-        RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
-        if (!primitiveValue) [[unlikely]]
-            return emptyAtom();
-        return this->operator()(state, *primitiveValue);
-    }
-};
-
 // Specialization for `TupleLike` (wrapper).
 template<TupleLike StyleType>
     requires(std::tuple_size_v<StyleType> == 1)

--- a/Source/WebCore/style/values/StyleValueTypes.h
+++ b/Source/WebCore/style/values/StyleValueTypes.h
@@ -106,13 +106,6 @@ template<typename> struct ToStyle;
 // Specialize `TreatAsNonConverting` for `Constant<C>`, to indicate that its type does not change from the CSS representation.
 template<CSSValueID C> inline constexpr bool TreatAsNonConverting<Constant<C>> = true;
 
-// Specialize `TreatAsNonConverting` for `WTF::AtomString`, to indicate that its type does not change from the CSS representation.
-template<> inline constexpr bool TreatAsNonConverting<WTF::AtomString> = true;
-
-// Specialize `TreatAsNonConverting` for `WTF::String`, to indicate that its type does not change from the CSS representation.
-template<> inline constexpr bool TreatAsNonConverting<WTF::String> = true;
-
-
 // MARK: - Conversion from "Style to "CSS"
 
 struct ToCSSInvoker {
@@ -571,7 +564,7 @@ struct SerializeInvoker {
         Serialize<StyleType>{}(builder, context, style, value, std::forward<Rest>(rest)...);
     }
 
-    template<typename StyleType, typename... Rest> [[nodiscard]] String operator()(const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value, Rest&&... rest) const
+    template<typename StyleType, typename... Rest> [[nodiscard]] WTF::String operator()(const CSS::SerializationContext& context, const RenderStyle& style, const StyleType& value, Rest&&... rest) const
     {
         StringBuilder builder;
         this->operator()(builder, context, style, value, std::forward<Rest>(rest)...);

--- a/Source/WebCore/style/values/animations/StyleSingleAnimationName.cpp
+++ b/Source/WebCore/style/values/animations/StyleSingleAnimationName.cpp
@@ -42,13 +42,11 @@ auto CSSValueConversion<SingleAnimationName>::operator()(BuilderState& state, co
         if (primitiveValue->valueID() == CSSValueNone)
             return SingleAnimationName { CSS::Keyword::None { } };
 
-        return SingleAnimationName { ScopedName { AtomString { primitiveValue->stringValue() }, state.styleScopeOrdinal(), false } };
+        state.setCurrentPropertyInvalidAtComputedValueTime();
+        return SingleAnimationName { CSS::Keyword::None { } };
     }
 
-    auto customIdent = toStyleFromCSSValue<CustomIdent>(state, value);
-    if (customIdent.value.isNull())
-        return SingleAnimationName { CSS::Keyword::None { } };
-    return SingleAnimationName { ScopedName { WTF::move(customIdent.value), state.styleScopeOrdinal(), true } };
+    return toStyleFromCSSValue<ScopedName>(state, value);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/animations/StyleSingleAnimationRangeName.cpp
+++ b/Source/WebCore/style/values/animations/StyleSingleAnimationRangeName.cpp
@@ -83,7 +83,7 @@ CSSValueID convertSingleAnimationRangeNameToCSSValueID(SingleAnimationRangeName 
     return CSSValueNormal;
 }
 
-String convertSingleAnimationRangeNameToRangeString(SingleAnimationRangeName rangeName)
+WTF::String convertSingleAnimationRangeNameToRangeString(SingleAnimationRangeName rangeName)
 {
     switch (rangeName) {
     case SingleAnimationRangeName::Normal:
@@ -110,7 +110,7 @@ String convertSingleAnimationRangeNameToRangeString(SingleAnimationRangeName ran
 }
 
 
-SingleAnimationRangeName convertRangeStringToSingleTimelineRangeName(const String& rangeString)
+SingleAnimationRangeName convertRangeStringToSingleTimelineRangeName(const WTF::String& rangeString)
 {
     if (rangeString == "cover"_s)
         return Style::SingleAnimationRangeName::Cover;

--- a/Source/WebCore/style/values/animations/StyleSingleAnimationRangeName.h
+++ b/Source/WebCore/style/values/animations/StyleSingleAnimationRangeName.h
@@ -46,8 +46,8 @@ enum class SingleAnimationRangeName : uint8_t { Normal, Omitted, Cover, Contain,
 CSSValueID NODELETE convertSingleAnimationRangeNameToCSSValueID(SingleAnimationRangeName);
 SingleAnimationRangeName NODELETE convertCSSValueIDToSingleAnimationRangeName(CSSValueID);
 
-String convertSingleAnimationRangeNameToRangeString(SingleAnimationRangeName);
-SingleAnimationRangeName convertRangeStringToSingleTimelineRangeName(const String&);
+WTF::String convertSingleAnimationRangeNameToRangeString(SingleAnimationRangeName);
+SingleAnimationRangeName convertRangeStringToSingleTimelineRangeName(const WTF::String&);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/color/StyleColor.cpp
+++ b/Source/WebCore/style/values/color/StyleColor.cpp
@@ -242,7 +242,7 @@ Color::ColorKind Color::copy(const Color::ColorKind& other)
     );
 }
 
-String Color::debugDescription() const
+WTF::String Color::debugDescription() const
 {
     TextStream ts;
     ts << *this;
@@ -327,7 +327,7 @@ bool containsCurrentColor(const Color& value)
 
 // MARK: - Serialization
 
-String serializationForCSSTokenization(const CSS::SerializationContext& context, const Color& value)
+WTF::String serializationForCSSTokenization(const CSS::SerializationContext& context, const Color& value)
 {
     return WTF::switchOn(value, [&](const auto& kind) { return WebCore::Style::serializationForCSSTokenization(context, kind); });
 }

--- a/Source/WebCore/style/values/color/StyleColor.h
+++ b/Source/WebCore/style/values/color/StyleColor.h
@@ -161,7 +161,7 @@ public:
     // as const references, pretending the UniqueRefs don't exist.
     template<typename... F> decltype(auto) switchOn(F&&...) const;
 
-    String debugDescription() const;
+    WTF::String debugDescription() const;
 
 private:
     template<typename T>
@@ -175,7 +175,7 @@ WebCore::Color resolveColor(const Color&, const WebCore::Color& currentColor);
 bool containsCurrentColor(const Color&);
 
 void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const Color&);
-String serializationForCSSTokenization(const CSS::SerializationContext&, const Color&);
+WTF::String serializationForCSSTokenization(const CSS::SerializationContext&, const Color&);
 
 template<> struct Serialize<Color> {
     void operator()(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&, const Color&);

--- a/Source/WebCore/style/values/color/StyleColorLayers.cpp
+++ b/Source/WebCore/style/values/color/StyleColorLayers.cpp
@@ -108,7 +108,7 @@ void serializationForCSSTokenization(StringBuilder& builder, const CSS::Serializ
     builder.append(')');
 }
 
-String serializationForCSSTokenization(const CSS::SerializationContext& context, const ColorLayers& colorLayers)
+WTF::String serializationForCSSTokenization(const CSS::SerializationContext& context, const ColorLayers& colorLayers)
 {
     StringBuilder builder;
     serializationForCSSTokenization(builder, context, colorLayers);

--- a/Source/WebCore/style/values/color/StyleColorLayers.h
+++ b/Source/WebCore/style/values/color/StyleColorLayers.h
@@ -58,7 +58,7 @@ WebCore::Color resolveColor(const ColorLayers&, const WebCore::Color& currentCol
 bool containsCurrentColor(const ColorLayers&);
 
 void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const ColorLayers&);
-String serializationForCSSTokenization(const CSS::SerializationContext&, const ColorLayers&);
+WTF::String serializationForCSSTokenization(const CSS::SerializationContext&, const ColorLayers&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, const ColorLayers&);
 

--- a/Source/WebCore/style/values/color/StyleColorMix.cpp
+++ b/Source/WebCore/style/values/color/StyleColorMix.cpp
@@ -186,7 +186,7 @@ void serializationForCSSTokenization(StringBuilder& builder, const CSS::Serializ
     builder.append(')');
 }
 
-String serializationForCSSTokenization(const CSS::SerializationContext& context, const ColorMix& colorMix)
+WTF::String serializationForCSSTokenization(const CSS::SerializationContext& context, const ColorMix& colorMix)
 {
     StringBuilder builder;
     serializationForCSSTokenization(builder, context, colorMix);

--- a/Source/WebCore/style/values/color/StyleColorMix.h
+++ b/Source/WebCore/style/values/color/StyleColorMix.h
@@ -69,7 +69,7 @@ WebCore::Color resolveColor(const ColorMix&, const WebCore::Color& currentColor)
 bool containsCurrentColor(const ColorMix&);
 
 void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const ColorMix&);
-String serializationForCSSTokenization(const CSS::SerializationContext&, const ColorMix&);
+WTF::String serializationForCSSTokenization(const CSS::SerializationContext&, const ColorMix&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, const ColorMix&);
 

--- a/Source/WebCore/style/values/color/StyleContrastColor.cpp
+++ b/Source/WebCore/style/values/color/StyleContrastColor.cpp
@@ -85,7 +85,7 @@ void serializationForCSSTokenization(StringBuilder& builder, const CSS::Serializ
     builder.append(')');
 }
 
-String serializationForCSSTokenization(const CSS::SerializationContext& context, const ContrastColor& contrastColor)
+WTF::String serializationForCSSTokenization(const CSS::SerializationContext& context, const ContrastColor& contrastColor)
 {
     StringBuilder builder;
     serializationForCSSTokenization(builder, context, contrastColor);

--- a/Source/WebCore/style/values/color/StyleContrastColor.h
+++ b/Source/WebCore/style/values/color/StyleContrastColor.h
@@ -54,7 +54,7 @@ WebCore::Color resolveColor(const ContrastColor&, const WebCore::Color& currentC
 bool containsCurrentColor(const ContrastColor&);
 
 void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const ContrastColor&);
-String serializationForCSSTokenization(const CSS::SerializationContext&, const ContrastColor&);
+WTF::String serializationForCSSTokenization(const CSS::SerializationContext&, const ContrastColor&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, const ContrastColor&);
 

--- a/Source/WebCore/style/values/color/StyleCurrentColor.cpp
+++ b/Source/WebCore/style/values/color/StyleCurrentColor.cpp
@@ -39,7 +39,7 @@ void serializationForCSSTokenization(StringBuilder& builder, const CSS::Serializ
     builder.append("currentcolor"_s);
 }
 
-String serializationForCSSTokenization(const CSS::SerializationContext&, const CurrentColor&)
+WTF::String serializationForCSSTokenization(const CSS::SerializationContext&, const CurrentColor&)
 {
     return "currentcolor"_s;
 }

--- a/Source/WebCore/style/values/color/StyleCurrentColor.h
+++ b/Source/WebCore/style/values/color/StyleCurrentColor.h
@@ -52,7 +52,7 @@ constexpr bool containsCurrentColor(const CurrentColor&)
 }
 
 void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const CurrentColor&);
-String serializationForCSSTokenization(const CSS::SerializationContext&, const CurrentColor&);
+WTF::String serializationForCSSTokenization(const CSS::SerializationContext&, const CurrentColor&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, const CurrentColor&);
 

--- a/Source/WebCore/style/values/color/StyleRelativeColor.h
+++ b/Source/WebCore/style/values/color/StyleRelativeColor.h
@@ -135,7 +135,7 @@ template<typename D> void serializationForCSSTokenization(StringBuilder& builder
     builder.append(')');
 }
 
-template<typename D> String serializationForCSSTokenization(const CSS::SerializationContext& context, const RelativeColor<D>& relative)
+template<typename D> WTF::String serializationForCSSTokenization(const CSS::SerializationContext& context, const RelativeColor<D>& relative)
 {
     StringBuilder builder;
     serializationForCSSTokenization(builder, context, relative);

--- a/Source/WebCore/style/values/color/StyleResolvedColor.cpp
+++ b/Source/WebCore/style/values/color/StyleResolvedColor.cpp
@@ -48,7 +48,7 @@ void serializationForCSSTokenization(StringBuilder& builder, const CSS::Serializ
     builder.append(WebCore::serializationForCSS(absoluteColor.color));
 }
 
-String serializationForCSSTokenization(const CSS::SerializationContext&, const ResolvedColor& absoluteColor)
+WTF::String serializationForCSSTokenization(const CSS::SerializationContext&, const ResolvedColor& absoluteColor)
 {
     return WebCore::serializationForCSS(absoluteColor.color);
 }

--- a/Source/WebCore/style/values/color/StyleResolvedColor.h
+++ b/Source/WebCore/style/values/color/StyleResolvedColor.h
@@ -57,7 +57,7 @@ constexpr bool containsCurrentColor(const ResolvedColor&)
 }
 
 void serializationForCSSTokenization(StringBuilder&, const CSS::SerializationContext&, const ResolvedColor&);
-String serializationForCSSTokenization(const CSS::SerializationContext&, const ResolvedColor&);
+WTF::String serializationForCSSTokenization(const CSS::SerializationContext&, const ResolvedColor&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, const ResolvedColor&);
 

--- a/Source/WebCore/style/values/content/StyleContent.cpp
+++ b/Source/WebCore/style/values/content/StyleContent.cpp
@@ -29,6 +29,7 @@
 #include "CSSAttrValue.h"
 #include "CSSCounterValue.h"
 #include "CSSPrimitiveValue.h"
+#include "CSSStringValue.h"
 #include "CSSValueList.h"
 #include "RenderStyle+GettersInlines.h"
 #include "RenderStyle+SettersInlines.h"
@@ -38,10 +39,10 @@
 namespace WebCore {
 namespace Style {
 
-String Content::altText() const
+WTF::String Content::altText() const
 {
     if (auto* contentData = tryData())
-        return contentData->altText.value_or(nullString());
+        return contentData->altText.value_or(String { nullString() }).value;
     return { };
 }
 
@@ -83,8 +84,9 @@ auto CSSValueConversion<Content>::operator()(BuilderState& state, const CSSValue
         state.registerSubstitutionAttribute(attr.localName());
 
         if (attributeValue.isNull()) {
-            RefPtr fallback = dynamicDowncast<CSSPrimitiveValue>(value.fallback());
-            return fallback && fallback->isString() ? fallback->stringValue().impl() : emptyAtom();
+            if (auto fallback = value.fallback())
+                return AtomString { fallback->value };
+            return emptyAtom();
         }
         return attributeValue.impl();
     };
@@ -96,7 +98,7 @@ auto CSSValueConversion<Content>::operator()(BuilderState& state, const CSSValue
                     return Content::Image { ImageWrapper { image.releaseNonNull() } };
 
                 state.setCurrentPropertyInvalidAtComputedValueTime();
-                return Content::Text { emptyString() };
+                return Content::Text { String { emptyString() } };
             }
 
             if (RefPtr primitive = dynamicDowncast<CSSPrimitiveValue>(item)) {
@@ -112,14 +114,15 @@ auto CSSValueConversion<Content>::operator()(BuilderState& state, const CSSValue
                 default:
                     break;
                 }
-                if (primitive->isString())
-                    return Content::Text { primitive->stringValue() };
-                if (RefPtr attr = primitive->cssAttrValue())
-                    return Content::Text { processAttrContent(*attr) };
-
                 state.setCurrentPropertyInvalidAtComputedValueTime();
-                return Content::Text { emptyString() };
+                return Content::Text { String { emptyString() } };
             }
+
+            if (RefPtr stringValue = dynamicDowncast<CSSStringValue>(item))
+                return Content::Text { toStyleFromCSSValue<String>(state, *stringValue) };
+
+            if (RefPtr attrValue = dynamicDowncast<CSSAttrValue>(item))
+                return Content::Text { String { processAttrContent(*attrValue) } };
 
             if (RefPtr counter = dynamicDowncast<CSSCounterValue>(item)) {
                 return Content::Counter {
@@ -130,7 +133,7 @@ auto CSSValueConversion<Content>::operator()(BuilderState& state, const CSSValue
             }
 
             state.setCurrentPropertyInvalidAtComputedValueTime();
-            return Content::Text { emptyString() };
+            return Content::Text { String { emptyString() } };
         });
     };
 
@@ -138,18 +141,22 @@ auto CSSValueConversion<Content>::operator()(BuilderState& state, const CSSValue
         if (!contentListAltTextPair)
             return { };
 
-        auto altTextList = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(state, contentListAltTextPair->second());
+        auto altTextList = requiredListDowncast<CSSValueList, CSSValue>(state, contentListAltTextPair->second());
         if (!altTextList)
             return { };
 
         StringBuilder altTextBuilder;
         for (Ref item : *altTextList) {
-            if (item->isString())
-                altTextBuilder.append(item->stringValue());
-            else if (RefPtr attr = item->cssAttrValue())
-                altTextBuilder.append(processAttrContent(*attr));
+            if (RefPtr stringValue = dynamicDowncast<CSSStringValue>(item))
+                altTextBuilder.append(toStyleFromCSSValue<String>(state, *stringValue).value);
+            else if (RefPtr attrValue = dynamicDowncast<CSSAttrValue>(item))
+                altTextBuilder.append(processAttrContent(*attrValue));
+            else {
+                state.setCurrentPropertyInvalidAtComputedValueTime();
+                return { };
+            }
         }
-        return altTextBuilder.toString();
+        return String { altTextBuilder.toString() };
     };
 
     return Content::Data { computeContentList(), computeAltText() };
@@ -159,7 +166,7 @@ Ref<CSSValue> CSSValueCreation<Content::Counter>::operator()(CSSValuePool&, cons
 {
     return CSSCounterValue::create(
         toCSS(value.identifier, style),
-        AtomString { value.separator },
+        toCSS(value.separator, style),
         toCSS(value.style, style)
     );
 }

--- a/Source/WebCore/style/values/content/StyleContent.h
+++ b/Source/WebCore/style/values/content/StyleContent.h
@@ -28,6 +28,7 @@
 #include <WebCore/RenderStyleConstants.h>
 #include <WebCore/StyleCounterStyle.h>
 #include <WebCore/StyleImageWrapper.h>
+#include <WebCore/StyleString.h>
 #include <WebCore/StyleValueTypes.h>
 
 namespace WebCore {
@@ -65,7 +66,7 @@ struct Content {
     };
     struct Counter {
         CustomIdent identifier;
-        AtomString separator;
+        String separator;
         CounterStyle style;
 
         template<typename... F> decltype(auto) switchOn(F&&...) const;
@@ -117,7 +118,7 @@ struct Content {
         return WTF::switchOn(m_value, std::forward<F>(f)...);
     }
 
-    String altText() const;
+    WTF::String altText() const;
 
     bool operator==(const Content&) const = default;
 
@@ -143,15 +144,22 @@ template<typename... F> decltype(auto) Content::Counter::switchOn(F&&... f) cons
     auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
 
     using CounterFunction = FunctionNotation<CSSValueCounter, CommaSeparatedTuple<CustomIdent, std::optional<CounterStyle>>>;
-    using CountersFunction = FunctionNotation<CSSValueCounters, CommaSeparatedTuple<CustomIdent, AtomString, std::optional<CounterStyle>>>;
+    using CountersFunction = FunctionNotation<CSSValueCounters, CommaSeparatedTuple<CustomIdent, String, std::optional<CounterStyle>>>;
 
-    if (separator.isEmpty()) {
+    if (separator.value.isEmpty()) {
         return visitor(CounterFunction {
-            .parameters = { CustomIdent { identifier }, style != nameString(CSSValueDecimal) ? std::make_optional(style) : std::nullopt }
+            .parameters = {
+                identifier,
+                style != CSSValueDecimal ? std::make_optional(style) : std::nullopt
+            }
         });
     } else {
         return visitor(CountersFunction {
-            .parameters = { CustomIdent { identifier }, separator, style != nameString(CSSValueDecimal) ? std::make_optional(style) : std::nullopt }
+            .parameters = {
+                identifier,
+                separator,
+                style != CSSValueDecimal ? std::make_optional(style) : std::nullopt
+            }
         });
     }
 }

--- a/Source/WebCore/style/values/content/StyleQuotes.cpp
+++ b/Source/WebCore/style/values/content/StyleQuotes.cpp
@@ -23,39 +23,39 @@
 #include "config.h"
 #include "StyleQuotes.h"
 
-#include "CSSPrimitiveValue.h"
+#include "CSSStringValue.h"
 #include "StyleBuilderChecking.h"
 
 namespace WebCore {
 namespace Style {
 
-const String& Quotes::openQuote(unsigned index) const
+const WTF::String& Quotes::openQuote(unsigned index) const
 {
     return WTF::switchOn(m_value,
-        [&](const Data& data) -> const String& {
+        [&](const Data& data) -> const WTF::String& {
             auto i = index * 2;
 
             if (i < data.size())
-                return data[i];
-            return data[data.size() - 2];
+                return data[i].value;
+            return data[data.size() - 2].value;
         },
-        [&](const auto&) -> const String& {
+        [&](const auto&) -> const WTF::String& {
             return emptyString();
         }
     );
 }
 
-const String& Quotes::closeQuote(unsigned index) const
+const WTF::String& Quotes::closeQuote(unsigned index) const
 {
     return WTF::switchOn(m_value,
-        [&](const Data& data) -> const String& {
+        [&](const Data& data) -> const WTF::String& {
             auto i = (index * 2) + 1;
 
             if (i < data.size())
-                return data[i];
-            return data[data.size() - 1];
+                return data[i].value;
+            return data[data.size() - 1].value;
         },
-        [&](const auto&) -> const String& {
+        [&](const auto&) -> const WTF::String& {
             return emptyString();
         }
     );
@@ -79,7 +79,7 @@ auto CSSValueConversion<Quotes>::operator()(BuilderState& state, const CSSValue&
         return CSS::Keyword::Auto { };
     }
 
-    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue, 2>(state, value);
+    auto list = requiredListDowncast<CSSValueList, CSSStringValue, 2>(state, value);
     if (!list)
         return CSS::Keyword::Auto { };
 
@@ -88,8 +88,8 @@ auto CSSValueConversion<Quotes>::operator()(BuilderState& state, const CSSValue&
         return CSS::Keyword::Auto { };
     }
 
-    return Quotes::Data::map(*list, [](const CSSPrimitiveValue& item) {
-        return item.stringValue();
+    return Quotes::Data::map(*list, [&](const CSSStringValue& item) {
+        return toStyle(item.string(), state);
     });
 }
 

--- a/Source/WebCore/style/values/content/StyleQuotes.h
+++ b/Source/WebCore/style/values/content/StyleQuotes.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <WebCore/StyleString.h>
 #include <WebCore/StyleValueTypes.h>
 
 namespace WebCore {
@@ -51,8 +52,8 @@ struct Quotes {
     bool isNone() const { return WTF::holdsAlternative<CSS::Keyword::None>(m_value); }
     bool isQuotes() const { return WTF::holdsAlternative<Data>(m_value); }
 
-    const String& openQuote(unsigned index) const;
-    const String& closeQuote(unsigned index) const;
+    const WTF::String& openQuote(unsigned index) const;
+    const WTF::String& closeQuote(unsigned index) const;
 
     template<typename... F> decltype(auto) switchOn(F&&... f) const
     {

--- a/Source/WebCore/style/values/fonts/StyleFontFamily.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontFamily.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "StyleFontFamily.h"
 
+#include "CSSFontFamilyNameValue.h"
 #include "CSSPropertyParserConsumer+Font.h"
 #include "Document.h"
 #include "Settings.h"
@@ -43,13 +44,6 @@ auto CSSValueConversion<FontFamilies>::operator()(BuilderState& state, const CSS
     using namespace CSSPropertyParserHelpers;
 
     if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
-        if (primitiveValue->isFontFamily()) {
-            return {
-                AtomString { primitiveValue->stringValue() },
-                FontFamilyKind::Specified
-            };
-        }
-
         auto valueID = primitiveValue->valueID();
         if (valueID == CSSValueWebkitBody) {
             return {
@@ -79,17 +73,32 @@ auto CSSValueConversion<FontFamilies>::operator()(BuilderState& state, const CSS
         return { nullAtom(), FontFamilyKind::Generic };
     }
 
-    auto valueList = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(state, value);
+    if (RefPtr fontFamilyNameValue = dynamicDowncast<CSSFontFamilyNameValue>(value)) {
+        return {
+            toStyleFromCSSValue<FontFamilyName>(state, *fontFamilyNameValue).value,
+            FontFamilyKind::Specified
+        };
+    }
+
+    auto valueList = requiredListDowncast<CSSValueList, CSSValue>(state, value);
     if (!valueList)
         return { nullAtom(), FontFamilyKind::Generic };
 
     std::optional<FontFamilyKind> firstFontKind;
     auto families = WTF::compactMap(*valueList, [&](auto& contentValue) -> std::optional<WebCore::FontFamily> {
         auto [family, kind] = [&] -> std::pair<AtomString, FontFamilyKind> {
-            if (contentValue.isFontFamily())
-                return { AtomString { contentValue.stringValue() }, FontFamilyKind::Specified };
+            if (RefPtr fontFamilyNameContentValue = dynamicDowncast<CSSFontFamilyNameValue>(contentValue)) {
+                return {
+                    toStyleFromCSSValue<FontFamilyName>(state, *fontFamilyNameContentValue).value,
+                    FontFamilyKind::Specified
+                };
+            }
 
-            auto valueID = contentValue.valueID();
+            RefPtr primitiveContentValue = requiredDowncast<CSSPrimitiveValue>(state, contentValue);
+            if (!primitiveContentValue)
+                return { nullAtom(), FontFamilyKind::Generic };
+
+            auto valueID = primitiveContentValue->valueID();
             if (valueID == CSSValueWebkitBody)
                 return { AtomString { state.document().settings().standardFontFamily() }, FontFamilyKind::Specified };
 

--- a/Source/WebCore/style/values/fonts/StyleFontFamilyName.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontFamilyName.cpp
@@ -26,9 +26,9 @@
 #include "config.h"
 #include "StyleFontFamilyName.h"
 
+#include "CSSFontFamilyNameValue.h"
 #include "CSSMarkup.h"
-#include "CSSPrimitiveValue.h"
-#include "CSSValuePool.h"
+#include "StyleBuilderChecking.h"
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
@@ -36,23 +36,46 @@ namespace Style {
 
 // MARK: - Conversion
 
-Ref<CSSValue> CSSValueCreation<FontFamilyName>::operator()(CSSValuePool& pool, const RenderStyle&, const FontFamilyName& value)
+auto ToCSS<FontFamilyName>::operator()(const FontFamilyName& value, const RenderStyle&) -> CSS::FontFamilyName
 {
-    return pool.createFontFamilyValue(value.value);
+    return { .value = value.value };
+}
+
+auto ToStyle<CSS::FontFamilyName>::operator()(const CSS::FontFamilyName& value, const BuilderState&) -> FontFamilyName
+{
+    return { .value = value.value };
+}
+
+Ref<CSSValue> CSSValueCreation<FontFamilyName>::operator()(CSSValuePool& pool, const RenderStyle& style, const FontFamilyName& value)
+{
+    return CSS::createCSSValue(pool, toCSS(value, style));
+}
+
+auto CSSValueConversion<FontFamilyName>::operator()(BuilderState& state, const CSSFontFamilyNameValue& value) -> FontFamilyName
+{
+    return toStyle(value.fontFamilyName(), state);
+}
+
+auto CSSValueConversion<FontFamilyName>::operator()(BuilderState& state, const CSSValue& value) -> FontFamilyName
+{
+    RefPtr fontFamilyNameValue = requiredDowncast<CSSFontFamilyNameValue>(state, value);
+    if (!fontFamilyNameValue) [[unlikely]]
+        return { .value = nullAtom() };
+    return toStyle(fontFamilyNameValue->fontFamilyName(), state);
 }
 
 // MARK: - Serialization
 
 void Serialize<FontFamilyName>::operator()(StringBuilder& builder, const CSS::SerializationContext&, const RenderStyle&, const FontFamilyName& value)
 {
-    builder.append(WebCore::serializeFontFamily(value.value));
+    WebCore::serializeFontFamily(builder, value.value);
 }
 
 // MARK: - Logging
 
 TextStream& operator<<(TextStream& ts, const FontFamilyName& value)
 {
-    return ts << WebCore::serializeFontFamily(value.value);
+    return ts << value.value;
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/fonts/StyleFontFamilyName.h
+++ b/Source/WebCore/style/values/fonts/StyleFontFamilyName.h
@@ -28,6 +28,13 @@
 #include <WebCore/StyleValueTypes.h>
 
 namespace WebCore {
+
+namespace CSS {
+struct FontFamilyName;
+}
+
+class CSSFontFamilyNameValue;
+
 namespace Style {
 
 // <family-name> = <string> | <custom-ident>+
@@ -41,7 +48,16 @@ struct FontFamilyName {
 
 // MARK: - Conversion
 
-template<> struct CSSValueCreation<FontFamilyName> { auto operator()(CSSValuePool&, const RenderStyle&, const FontFamilyName&) -> Ref<CSSValue>; };
+template<> struct ToCSS<FontFamilyName> { auto operator()(const FontFamilyName&, const RenderStyle&) -> CSS::FontFamilyName; };
+template<> struct ToStyle<CSS::FontFamilyName> { auto operator()(const CSS::FontFamilyName&, const BuilderState&) -> FontFamilyName; };
+
+template<> struct CSSValueCreation<FontFamilyName> {
+    auto operator()(CSSValuePool&, const RenderStyle&, const FontFamilyName&) -> Ref<CSSValue>;
+};
+template<> struct CSSValueConversion<FontFamilyName> {
+    auto operator()(BuilderState&, const CSSFontFamilyNameValue&) -> FontFamilyName;
+    auto operator()(BuilderState&, const CSSValue&) -> FontFamilyName;
+};
 
 // MARK: - Serialization
 

--- a/Source/WebCore/style/values/fonts/StyleFontVariantAlternates.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontVariantAlternates.cpp
@@ -39,7 +39,7 @@ namespace Style {
 
 auto CSSValueConversion<FontVariantAlternates>::operator()(BuilderState& state, const CSSValue& value) -> FontVariantAlternates
 {
-    auto processSingleItemFunction = [&](const CSSFunctionValue& function, String& parameterToSet) -> bool {
+    auto processSingleItemFunction = [&](const CSSFunctionValue& function, WTF::String& parameterToSet) -> bool {
         if (function.size() != 1) {
             state.setCurrentPropertyInvalidAtComputedValueTime();
             return false;
@@ -51,7 +51,7 @@ auto CSSValueConversion<FontVariantAlternates>::operator()(BuilderState& state, 
         return true;
     };
 
-    auto processListFunction = [&](const CSSFunctionValue& function, Vector<String>& parameterToSet) -> bool {
+    auto processListFunction = [&](const CSSFunctionValue& function, Vector<WTF::String>& parameterToSet) -> bool {
         if (!function.size()) {
             state.setCurrentPropertyInvalidAtComputedValueTime();
             return false;

--- a/Source/WebCore/style/values/grid/StyleGridPosition.cpp
+++ b/Source/WebCore/style/values/grid/StyleGridPosition.cpp
@@ -89,10 +89,10 @@ int GridPosition::spanPosition() const
     return m_integerPosition;
 }
 
-String GridPosition::namedGridLine() const
+const CustomIdent& GridPosition::namedGridLine() const
 {
     ASSERT(m_type == GridPositionType::Explicit || m_type == GridPositionType::Span || m_type == GridPositionType::NamedGridArea);
-    return m_namedGridLine.value;
+    return m_namedGridLine;
 }
 
 int GridPosition::max()

--- a/Source/WebCore/style/values/grid/StyleGridPosition.h
+++ b/Source/WebCore/style/values/grid/StyleGridPosition.h
@@ -100,7 +100,7 @@ struct GridPosition {
 
     WEBCORE_EXPORT int NODELETE explicitPosition() const;
     WEBCORE_EXPORT int NODELETE spanPosition() const;
-    String NODELETE namedGridLine() const;
+    const CustomIdent& NODELETE namedGridLine() const LIFETIME_BOUND;
 
     bool shouldBeResolvedAgainstOppositePosition() const { return isAuto() || isSpan(); }
 

--- a/Source/WebCore/style/values/grid/StyleGridPositionsResolver.cpp
+++ b/Source/WebCore/style/values/grid/StyleGridPositionsResolver.cpp
@@ -412,9 +412,9 @@ static std::pair<GridPosition, GridPosition> adjustGridPositionsFromStyle(const 
         finalPosition = CSS::Keyword::Auto { };
 
     // If the grid item has an automatic position and a grid span for a named line in a given dimension, instead treat the grid span as one.
-    if (initialPosition.isAuto() && finalPosition.isSpan() && !finalPosition.namedGridLine().isNull())
+    if (initialPosition.isAuto() && finalPosition.isSpan() && !finalPosition.namedGridLine().value.isNull())
         finalPosition = GridPosition::Span { { 1 } };
-    if (finalPosition.isAuto() && initialPosition.isSpan() && !initialPosition.namedGridLine().isNull())
+    if (finalPosition.isAuto() && initialPosition.isSpan() && !initialPosition.namedGridLine().value.isNull())
         initialPosition = GridPosition::Span { { 1 } };
 
     if (isIndefiniteSpan(initialPosition, finalPosition)) {

--- a/Source/WebCore/style/values/images/kinds/StyleCanvasImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleCanvasImage.cpp
@@ -39,7 +39,7 @@ namespace WebCore::Style {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CanvasImage);
 
-CanvasImage::CanvasImage(String&& name)
+CanvasImage::CanvasImage(CustomIdent&& name)
     : GeneratedImage { Type::CanvasImage, CanvasImage::isFixedSize }
     , m_name { WTF::move(name) }
 {
@@ -62,9 +62,9 @@ bool CanvasImage::equals(const CanvasImage& other) const
     return m_name == other.m_name;
 }
 
-Ref<CSSValue> CanvasImage::computedStyleValue(const RenderStyle&) const
+Ref<CSSValue> CanvasImage::computedStyleValue(const RenderStyle& style) const
 {
-    return CSSCanvasValue::create(m_name);
+    return CSSCanvasValue::create(toCSS(m_name, style));
 }
 
 bool CanvasImage::isPending() const
@@ -146,7 +146,7 @@ void CanvasImage::canvasDestroyed(CanvasBase& canvasBase)
 HTMLCanvasElement* CanvasImage::element(Document& document) const
 {
     if (!m_element) {
-        m_element = document.getCSSCanvasElement(m_name);
+        m_element = document.getCSSCanvasElement(m_name.value);
         m_element->addObserver(const_cast<CanvasImage&>(*this));
     }
     return m_element.get();

--- a/Source/WebCore/style/values/images/kinds/StyleCanvasImage.h
+++ b/Source/WebCore/style/values/images/kinds/StyleCanvasImage.h
@@ -29,6 +29,7 @@
 
 #include "CanvasObserver.h"
 #include "HTMLCanvasElement.h"
+#include "StyleCustomIdent.h"
 #include "StyleGeneratedImage.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
@@ -45,7 +46,7 @@ class CanvasImage final : public GeneratedImage, public CanvasObserver, public C
     WTF_MAKE_TZONE_ALLOCATED(CanvasImage);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CanvasImage);
 public:
-    static Ref<CanvasImage> create(String name)
+    static Ref<CanvasImage> create(CustomIdent&& name)
     {
         return adoptRef(*new CanvasImage(WTF::move(name)));
     }
@@ -59,7 +60,7 @@ public:
     OVERRIDE_ABSTRACT_CAN_MAKE_CHECKEDPTR(CanMakeCheckedPtr);
 
 private:
-    explicit CanvasImage(String&&);
+    explicit CanvasImage(CustomIdent&&);
 
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
     bool isPending() const final;
@@ -79,7 +80,7 @@ private:
     HTMLCanvasElement* element(Document&) const;
 
     // The name of the canvas.
-    String m_name;
+    CustomIdent m_name;
     // The document supplies the element and owns it.
     mutable WeakPtr<HTMLCanvasElement, WeakPtrImplWithEventTargetData> m_element;
 };

--- a/Source/WebCore/style/values/images/kinds/StyleCursorImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleCursorImage.cpp
@@ -97,10 +97,12 @@ Ref<CSSValue> CursorImage::computedStyleValue(const RenderStyle& style) const
 
 ImageWithScale CursorImage::selectBestFitImage(const Document& document)
 {
+    using namespace CSS::Literals;
+
     if (RefPtr imageSet = dynamicDowncast<ImageSet>(m_image.get()))
         return imageSet->selectBestFitImage(document);
 
-    return { m_image.ptr(), 1, String() };
+    return { m_image.ptr(), 1_css_dppx, std::nullopt };
 }
 
 void CursorImage::setContainerContextForRenderer(const RenderElement& renderer, const FloatSize& containerSize, float containerZoom, const WTF::URL& url)

--- a/Source/WebCore/style/values/images/kinds/StyleImageSet.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleImageSet.cpp
@@ -69,7 +69,11 @@ bool ImageSet::equals(const ImageSet& other) const
 Ref<CSSValue> ImageSet::computedStyleValue(const RenderStyle& style) const
 {
     auto builder = WTF::map<CSSValueListBuilderInlineCapacity>(m_images, [&](auto& image) -> Ref<CSSValue> {
-        return CSSImageSetOptionValue::create(image.image->computedStyleValue(style), CSSPrimitiveValue::create(image.scaleFactor, CSSUnitType::CSS_DPPX), image.mimeType);
+        return CSSImageSetOptionValue::create(
+            image.image->computedStyleValue(style),
+            toCSS(image.scaleFactor, style),
+            toCSS(image.mimeType, style)
+        );
     });
     return CSSImageSetValue::create(WTF::move(builder));
 }
@@ -91,7 +95,7 @@ ImageWithScale ImageSet::bestImageForScaleFactor()
     ImageWithScale result;
     for (auto index : m_sortedIndices) {
         const auto& image = m_images[index];
-        if (!image.mimeType.isNull() && !MIMETypeRegistry::isSupportedImageMIMEType(image.mimeType))
+        if (image.mimeType && !MIMETypeRegistry::isSupportedImageMIMEType(image.mimeType->parameters.value))
             continue;
         if (!result.image->isInvalidImage() && result.scaleFactor == image.scaleFactor)
             continue;
@@ -102,8 +106,8 @@ ImageWithScale ImageSet::bestImageForScaleFactor()
     }
 
     ASSERT(result.scaleFactor >= 0);
-    if (result.image->isInvalidImage() || !result.scaleFactor)
-        result = ImageWithScale { InvalidImage::create(), 1, String() };
+    if (result.image->isInvalidImage() || !result.scaleFactor.value)
+        result = ImageWithScale { InvalidImage::create(), 1, std::nullopt };
 
     return result;
 }

--- a/Source/WebCore/style/values/images/kinds/StyleMultiImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleMultiImage.cpp
@@ -80,10 +80,10 @@ void MultiImage::load(CachedResourceLoader& loader, const ResourceLoaderOptions&
     }
 
     if (RefPtr styleCachedImage = dynamicDowncast<CachedImage>(bestFitImage.image)) {
-        if (styleCachedImage->imageScaleFactor() == bestFitImage.scaleFactor)
+        if (styleCachedImage->imageScaleFactor() == bestFitImage.scaleFactor.value)
             m_selectedImage = WTF::move(styleCachedImage);
         else
-            m_selectedImage = CachedImage::copyOverridingScaleFactor(*styleCachedImage, bestFitImage.scaleFactor);
+            m_selectedImage = CachedImage::copyOverridingScaleFactor(*styleCachedImage, bestFitImage.scaleFactor.value);
 
         if (m_selectedImage->isPending())
             m_selectedImage->load(loader, options);

--- a/Source/WebCore/style/values/images/kinds/StyleMultiImage.h
+++ b/Source/WebCore/style/values/images/kinds/StyleMultiImage.h
@@ -27,6 +27,8 @@
 
 #include "StyleImage.h"
 #include "StyleInvalidImage.h"
+#include "StylePrimitiveNumeric.h"
+#include "StyleString.h"
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -37,8 +39,8 @@ namespace Style {
 
 struct ImageWithScale {
     RefPtr<Image> image { InvalidImage::create() };
-    float scaleFactor { 1 };
-    String mimeType { String() };
+    Style::Resolution<> scaleFactor { 1 };
+    std::optional<FunctionNotation<CSSValueType, Style::String>> mimeType;
 
     bool operator==(const ImageWithScale& other) const
     {

--- a/Source/WebCore/style/values/images/kinds/StyleNamedImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleNamedImage.cpp
@@ -34,7 +34,7 @@
 namespace WebCore {
 namespace Style {
 
-NamedImage::NamedImage(String&& name)
+NamedImage::NamedImage(CustomIdent&& name)
     : GeneratedImage { Type::NamedImage, NamedImage::isFixedSize }
     , m_name { WTF::move(name) }
 {
@@ -53,9 +53,9 @@ bool NamedImage::equals(const NamedImage& other) const
     return m_name == other.m_name;
 }
 
-Ref<CSSValue> NamedImage::computedStyleValue(const RenderStyle&) const
+Ref<CSSValue> NamedImage::computedStyleValue(const RenderStyle& style) const
 {
-    return CSSNamedImageValue::create(m_name);
+    return CSSNamedImageValue::create(toCSS(m_name, style));
 }
 
 bool NamedImage::isPending() const
@@ -75,7 +75,7 @@ RefPtr<WebCore::Image> NamedImage::image(const RenderElement* renderer, const Fl
     if (size.isEmpty())
         return nullptr;
 
-    return NamedImageGeneratedImage::create(m_name, size);
+    return NamedImageGeneratedImage::create(m_name.value, size);
 }
 
 bool NamedImage::knownToBeOpaque(const RenderElement&) const

--- a/Source/WebCore/style/values/images/kinds/StyleNamedImage.h
+++ b/Source/WebCore/style/values/images/kinds/StyleNamedImage.h
@@ -27,15 +27,15 @@
 
 #pragma once
 
+#include "StyleCustomIdent.h"
 #include "StyleGeneratedImage.h"
-#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 namespace Style {
 
 class NamedImage final : public GeneratedImage {
 public:
-    static Ref<NamedImage> create(String name)
+    static Ref<NamedImage> create(CustomIdent&& name)
     {
         return adoptRef(*new NamedImage(WTF::move(name)));
     }
@@ -47,7 +47,7 @@ public:
     static constexpr bool isFixedSize = false;
 
 private:
-    explicit NamedImage(String&&);
+    explicit NamedImage(CustomIdent&&);
 
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
     bool isPending() const final;
@@ -58,7 +58,7 @@ private:
     void didAddClient(RenderElement&) final { }
     void didRemoveClient(RenderElement&) final { }
 
-    String m_name;
+    CustomIdent m_name;
 };
 
 } // namespace Style

--- a/Source/WebCore/style/values/images/kinds/StylePaintImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StylePaintImage.cpp
@@ -39,7 +39,7 @@
 namespace WebCore {
 namespace Style {
 
-PaintImage::PaintImage(String&& name, Ref<CSSVariableData>&& arguments)
+PaintImage::PaintImage(CustomIdent&& name, Ref<CSSVariableData>&& arguments)
     : GeneratedImage { Type::PaintImage, PaintImage::isFixedSize }
     , m_name { WTF::move(name) }
     , m_arguments { WTF::move(arguments) }
@@ -55,9 +55,9 @@ bool PaintImage::operator==(const Image& other) const
     return otherPaintImage && otherPaintImage->m_name == m_name;
 }
 
-Ref<CSSValue> PaintImage::computedStyleValue(const RenderStyle&) const
+Ref<CSSValue> PaintImage::computedStyleValue(const RenderStyle& style) const
 {
-    return CSSPaintImageValue::create(m_name, m_arguments);
+    return CSSPaintImageValue::create(toCSS(m_name, style), m_arguments);
 }
 
 bool PaintImage::isPending() const
@@ -77,18 +77,18 @@ RefPtr<WebCore::Image> PaintImage::image(const RenderElement* renderer, const Fl
     if (size.isEmpty())
         return nullptr;
 
-    RefPtr selectedGlobalScope = renderer->document().paintWorkletGlobalScopeForName(m_name);
+    RefPtr selectedGlobalScope = renderer->document().paintWorkletGlobalScopeForName(m_name.value);
     if (!selectedGlobalScope)
         return nullptr;
 
     Locker locker { selectedGlobalScope->paintDefinitionLock() };
-    CheckedPtr registration = selectedGlobalScope->paintDefinitionMap().get(m_name);
+    CheckedPtr registration = selectedGlobalScope->paintDefinitionMap().get(m_name.value);
 
     if (!registration)
         return nullptr;
 
     // FIXME: Check if argument list matches syntax.
-    Vector<String> arguments;
+    Vector<WTF::String> arguments;
     CSSParserTokenRange localRange(m_arguments->tokenRange());
 
     while (!localRange.atEnd()) {

--- a/Source/WebCore/style/values/images/kinds/StylePaintImage.h
+++ b/Source/WebCore/style/values/images/kinds/StylePaintImage.h
@@ -27,8 +27,8 @@
 
 #pragma once
 
+#include "StyleCustomIdent.h"
 #include "StyleGeneratedImage.h"
-#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
@@ -38,7 +38,7 @@ namespace Style {
 
 class PaintImage final : public GeneratedImage {
 public:
-    static Ref<PaintImage> create(String name, Ref<CSSVariableData> arguments)
+    static Ref<PaintImage> create(CustomIdent&& name, Ref<CSSVariableData> arguments)
     {
         return adoptRef(*new PaintImage(WTF::move(name), WTF::move(arguments)));
     }
@@ -47,7 +47,7 @@ public:
     static constexpr bool isFixedSize = false;
 
 private:
-    explicit PaintImage(String&&, Ref<CSSVariableData>&&);
+    explicit PaintImage(CustomIdent&&, Ref<CSSVariableData>&&);
 
     bool operator==(const Image&) const final;
 
@@ -60,7 +60,7 @@ private:
     void didAddClient(RenderElement&) final { }
     void didRemoveClient(RenderElement&) final { }
 
-    String m_name;
+    CustomIdent m_name;
     const Ref<CSSVariableData> m_arguments;
 };
 

--- a/Source/WebCore/style/values/lists/StyleListStyleType.cpp
+++ b/Source/WebCore/style/values/lists/StyleListStyleType.cpp
@@ -28,9 +28,9 @@
 #include "StyleListStyleType.h"
 
 #include "CSSPropertyParserConsumer+CounterStyles.h"
+#include "CSSStringValue.h"
 #include "CSSValueKeywords.h"
 #include "StyleBuilderChecking.h"
-#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 namespace Style {
@@ -115,12 +115,12 @@ auto CSSValueConversion<ListStyleType>::operator()(BuilderState& state, const CS
             return CounterStyle { CustomIdent { nameStringForSerialization(valueID) } };
         }
 
-        if (primitiveValue->isString())
-            return AtomString { primitiveValue->stringValue() };
-
         state.setCurrentPropertyInvalidAtComputedValueTime();
         return CSS::Keyword::None { };
     }
+
+    if (RefPtr stringValue = dynamicDowncast<CSSStringValue>(value))
+        return toStyleFromCSSValue<String>(state, *stringValue);
 
     return CounterStyle { toStyleFromCSSValue<CustomIdent>(state, value) };
 }
@@ -128,9 +128,9 @@ auto CSSValueConversion<ListStyleType>::operator()(BuilderState& state, const CS
 auto CSSValueCreation<ListStyleType>::operator()(CSSValuePool& pool, const RenderStyle& style, const ListStyleType& value) -> Ref<CSSValue>
 {
     return WTF::switchOn(value,
-        [&](const CSS::Keyword::None& none) { return Style::createCSSValue(pool, style, none); }, // none
-        [&](const CounterStyle& counterStyle) { return Style::createCSSValue(pool, style, counterStyle.identifier); }, // custom-ident
-        [&](const AtomString& identifier) { return Style::createCSSValue(pool, style, identifier); } // string
+        [&](const CSS::Keyword::None& none) { return Style::createCSSValue(pool, style, none); },
+        [&](const CounterStyle& counterStyle) { return Style::createCSSValue(pool, style, counterStyle); },
+        [&](const String& string) { return Style::createCSSValue(pool, style, string); }
     );
 }
 

--- a/Source/WebCore/style/values/lists/StyleListStyleType.h
+++ b/Source/WebCore/style/values/lists/StyleListStyleType.h
@@ -27,9 +27,9 @@
 #pragma once
 
 #include <WebCore/StyleCounterStyle.h>
+#include <WebCore/StyleString.h>
 #include <WebCore/StyleValueTypes.h>
 #include <wtf/Variant.h>
-#include <wtf/text/AtomString.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
@@ -43,9 +43,9 @@ struct ListStyleType {
     {
     }
 
-    ListStyleType(AtomString&& string)
+    ListStyleType(String&& string)
         : m_type { Type::String }
-        , m_identifier { WTF::move(string) }
+        , m_identifier { WTF::move(string.value) }
     {
     }
 
@@ -106,7 +106,7 @@ struct ListStyleType {
         case Type::None:
             return visitor(CSS::Keyword::None { });
         case Type::String:
-            return visitor(m_identifier);
+            return visitor(String { m_identifier });
         case Type::CounterStyle:
             return visitor(CounterStyle { { m_identifier } });
         }

--- a/Source/WebCore/style/values/non-standard/StyleWebKitLocale.cpp
+++ b/Source/WebCore/style/values/non-standard/StyleWebKitLocale.cpp
@@ -35,19 +35,17 @@ namespace Style {
 
 auto CSSValueConversion<WebkitLocale>::operator()(BuilderState& state, const CSSValue& value) -> WebkitLocale
 {
-    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
-    if (!primitiveValue)
-        return CSS::Keyword::Auto { };
-
-    switch (primitiveValue->valueID()) {
-    case CSSValueInvalid:
-        return AtomString { primitiveValue->stringValue() };
-    case CSSValueAuto:
-        return CSS::Keyword::Auto { };
-    default:
-        state.setCurrentPropertyInvalidAtComputedValueTime();
-        return CSS::Keyword::Auto { };
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        switch (primitiveValue->valueID()) {
+        case CSSValueAuto:
+            return CSS::Keyword::Auto { };
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::Auto { };
+        }
     }
+
+    return toStyleFromCSSValue<String>(state, value);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/non-standard/StyleWebKitLocale.h
+++ b/Source/WebCore/style/values/non-standard/StyleWebKitLocale.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/StyleCustomIdent.h>
+#include <WebCore/StyleString.h>
 #include <WebCore/StyleValueTypes.h>
 #include <wtf/text/AtomString.h>
 
@@ -35,12 +36,17 @@ namespace Style {
 // <'-webkit-locale'> = auto | <string>
 // NOTE: There is no standard associated with this property.
 struct WebkitLocale {
-    WebkitLocale(CSS::Keyword::Auto) : m_platform { nullAtom() } { }
-    WebkitLocale(const AtomString& value) : m_platform { value } { }
-    WebkitLocale(AtomString&& value) : m_platform { WTF::move(value) } { }
+    using Platform = AtomString;
 
-    const AtomString& platform() const LIFETIME_BOUND { return m_platform; }
-    AtomString takePlatform() { return WTF::move(m_platform); }
+    WebkitLocale(CSS::Keyword::Auto) : m_platform { nullAtom() } { }
+    WebkitLocale(const String& value) : m_platform { value.value } { }
+    WebkitLocale(String&& value) : m_platform { WTF::move(value.value) } { }
+
+    WebkitLocale(const Platform& value) : m_platform { value } { }
+    WebkitLocale(Platform&& value) : m_platform { WTF::move(value) } { }
+
+    const Platform& platform() const LIFETIME_BOUND { return m_platform; }
+    Platform takePlatform() { return WTF::move(m_platform); }
 
     bool isAuto() const { return m_platform.isNull(); }
 
@@ -58,7 +64,7 @@ struct WebkitLocale {
     bool operator==(const WebkitLocale&) const = default;
 
 private:
-    AtomString m_platform;
+    Platform m_platform;
 };
 
 // MARK: - Conversion

--- a/Source/WebCore/style/values/overflow/StyleBlockEllipsis.cpp
+++ b/Source/WebCore/style/values/overflow/StyleBlockEllipsis.cpp
@@ -36,20 +36,21 @@ namespace Style {
 
 auto CSSValueConversion<BlockEllipsis>::operator()(BuilderState& state, const CSSValue& value) -> BlockEllipsis
 {
-    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
-    if (!primitiveValue)
-        return CSS::Keyword::None { };
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        switch (primitiveValue->valueID()) {
+        case CSSValueNone:
+            return CSS::Keyword::None { };
+        case CSSValueAuto:
+            return CSS::Keyword::Auto { };
+        default:
+            break;
+        }
 
-    switch (primitiveValue->valueID()) {
-    case CSSValueNone:
+        state.setCurrentPropertyInvalidAtComputedValueTime();
         return CSS::Keyword::None { };
-    case CSSValueAuto:
-        return CSS::Keyword::Auto { };
-    default:
-        break;
     }
 
-    return AtomString { primitiveValue->stringValue() };
+    return toStyleFromCSSValue<String>(state, value);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/overflow/StyleBlockEllipsis.h
+++ b/Source/WebCore/style/values/overflow/StyleBlockEllipsis.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <WebCore/StyleString.h>
 #include <WebCore/StyleValueTypes.h>
 #include <wtf/text/AtomString.h>
 
@@ -44,9 +45,9 @@ struct BlockEllipsis {
     {
     }
 
-    BlockEllipsis(AtomString&& string)
+    BlockEllipsis(String&& string)
         : m_type { Type::String }
-        , m_string { WTF::move(string) }
+        , m_string { WTF::move(string.value) }
     {
     }
 
@@ -64,7 +65,7 @@ struct BlockEllipsis {
         case Type::Auto:
             return visitor(CSS::Keyword::Auto { });
         case Type::String:
-            return visitor(m_string);
+            return visitor(String { m_string });
         }
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/Source/WebCore/style/values/primitives/StyleCustomIdent.cpp
+++ b/Source/WebCore/style/values/primitives/StyleCustomIdent.cpp
@@ -30,7 +30,6 @@
 #include "CSSCustomIdentValue.h"
 #include "CSSMarkup.h"
 #include "StyleBuilderChecking.h"
-#include "StyleValueTypes.h"
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
@@ -48,9 +47,9 @@ auto ToStyle<CSS::CustomIdent>::operator()(const CSS::CustomIdent& value, const 
     return { .value = value.value };
 }
 
-Ref<CSSValue> CSSValueCreation<CustomIdent>::operator()(CSSValuePool&, const RenderStyle& style, const CustomIdent& value)
+Ref<CSSValue> CSSValueCreation<CustomIdent>::operator()(CSSValuePool& pool, const RenderStyle& style, const CustomIdent& value)
 {
-    return CSSCustomIdentValue::create(toCSS(value, style));
+    return CSS::createCSSValue(pool, toCSS(value, style));
 }
 
 auto CSSValueConversion<CustomIdent>::operator()(BuilderState& state, const CSSCustomIdentValue& value) -> CustomIdent

--- a/Source/WebCore/style/values/primitives/StyleCustomIdent.h
+++ b/Source/WebCore/style/values/primitives/StyleCustomIdent.h
@@ -26,10 +26,13 @@
 
 #pragma once
 
-#include <WebCore/CSSCustomIdent.h>
 #include <WebCore/StyleValueTypes.h>
 
 namespace WebCore {
+
+namespace CSS {
+struct CustomIdent;
+}
 
 class CSSCustomIdentValue;
 
@@ -47,7 +50,6 @@ struct CustomIdent {
 template<> struct ToCSS<CustomIdent> { auto operator()(const CustomIdent&, const RenderStyle&) -> CSS::CustomIdent; };
 template<> struct ToStyle<CSS::CustomIdent> { auto operator()(const CSS::CustomIdent&, const BuilderState&) -> CustomIdent; };
 
-// `CustomIdent` is special-cased to return a `CSSCustomIdentValue`.
 template<> struct CSSValueCreation<CustomIdent> {
     Ref<CSSValue> operator()(CSSValuePool&, const RenderStyle&, const CustomIdent&);
 };

--- a/Source/WebCore/style/values/primitives/StyleString.cpp
+++ b/Source/WebCore/style/values/primitives/StyleString.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleString.h"
+
+#include "CSSStringValue.h"
+#include "StyleBuilderChecking.h"
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Conversion
+
+auto ToCSS<String>::operator()(const String& value, const RenderStyle&) -> CSS::String
+{
+    return { .value = value.value };
+}
+
+auto ToStyle<CSS::String>::operator()(const CSS::String& value, const BuilderState&) -> String
+{
+    return { .value = value.value };
+}
+
+Ref<CSSValue> CSSValueCreation<String>::operator()(CSSValuePool& pool, const RenderStyle& style, const String& value)
+{
+    return CSS::createCSSValue(pool, toCSS(value, style));
+}
+
+auto CSSValueConversion<String>::operator()(BuilderState& state, const CSSStringValue& value) -> String
+{
+    return toStyle(value.string(), state);
+}
+
+auto CSSValueConversion<String>::operator()(BuilderState& state, const CSSValue& value) -> String
+{
+    RefPtr stringValue = requiredDowncast<CSSStringValue>(state, value);
+    if (!stringValue) [[unlikely]]
+        return { .value = nullString() };
+    return toStyle(stringValue->string(), state);
+}
+
+// MARK: - Serialization
+
+void Serialize<String>::operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const String& value)
+{
+    CSS::serializationForCSS(builder, context, toCSS(value, style));
+}
+
+// MARK: - Logging
+
+TextStream& operator<<(TextStream& ts, const String& value)
+{
+    return ts << value.value;
+}
+
+// MARK: - Hashing
+
+void add(Hasher& hasher, const String& value)
+{
+    add(hasher, value.value);
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StyleString.h
+++ b/Source/WebCore/style/values/primitives/StyleString.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleValueTypes.h>
+
+namespace WebCore {
+
+namespace CSS {
+struct String;
+}
+
+class CSSStringValue;
+
+namespace Style {
+
+struct String {
+    WTF::String value;
+
+    bool operator==(const String&) const = default;
+    bool operator==(const WTF::String& other) const { return value == other; }
+};
+
+// MARK: - Conversion
+
+template<> struct ToCSS<String> { auto operator()(const String&, const RenderStyle&) -> CSS::String; };
+template<> struct ToStyle<CSS::String> { auto operator()(const CSS::String&, const BuilderState&) -> String; };
+
+template<> struct CSSValueCreation<String> {
+    Ref<CSSValue> operator()(CSSValuePool&, const RenderStyle&, const String&);
+};
+template<> struct CSSValueConversion<String> {
+    auto operator()(BuilderState&, const CSSStringValue&) -> String;
+    auto operator()(BuilderState&, const CSSValue&) -> String;
+};
+
+// MARK: - Serialization
+
+template<> struct Serialize<String> { void operator()(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&, const String&); };
+
+// MARK: - Logging
+
+TextStream& operator<<(TextStream&, const String&);
+
+// MARK: - Hashing
+
+void NODELETE add(Hasher&, const String&);
+
+} // namespace Style
+} // namespace WebCore
+
+namespace WTF {
+
+template<>
+struct MarkableTraits<WebCore::Style::String> {
+    static bool isEmptyValue(const WebCore::Style::String& value) { return value.value.isNull(); }
+    static WebCore::Style::String emptyValue() { return WebCore::Style::String { nullString() }; }
+};
+
+template<>
+struct HashTraits<WebCore::Style::String> : GenericHashTraits<WebCore::Style::String> {
+    using EmptyValueType = WebCore::Style::String;
+    static constexpr bool emptyValueIsZero = true;
+    static constexpr bool hasIsEmptyValueFunction = true;
+    static bool isEmptyValue(const WebCore::Style::String& value) { return value.value.isNull(); }
+    static EmptyValueType emptyValue() { return WebCore::Style::String { nullString() }; }
+
+    static void constructDeletedValue(WebCore::Style::String& value) { new (NotNull, std::addressof(value.value)) String { HashTableDeletedValue }; }
+    static bool isDeletedValue(const WebCore::Style::String& value) { return value.value.isHashTableDeletedValue(); }
+};
+
+} // namespace WTF

--- a/Source/WebCore/style/values/primitives/StyleURL.cpp
+++ b/Source/WebCore/style/values/primitives/StyleURL.cpp
@@ -81,9 +81,14 @@ auto ToStyle<CSS::URL>::operator()(const CSS::URL& url, const BuilderState& stat
     return toStyleWithScriptExecutionContext(url, protect(state.document()));
 }
 
-Ref<CSSValue> CSSValueCreation<URL>::operator()(CSSValuePool&, const RenderStyle& style, const URL& value)
+Ref<CSSValue> CSSValueCreation<URL>::operator()(CSSValuePool& pool, const RenderStyle& style, const URL& value)
 {
-    return CSSURLValue::create(toCSS(value, style));
+    return CSS::createCSSValue(pool, toCSS(value, style));
+}
+
+auto CSSValueConversion<URL>::operator()(BuilderState& state, const CSSURLValue& value) -> URL
+{
+    return toStyle(value.url(), state);
 }
 
 auto CSSValueConversion<URL>::operator()(BuilderState& state, const CSSValue& value) -> URL

--- a/Source/WebCore/style/values/primitives/StyleURL.h
+++ b/Source/WebCore/style/values/primitives/StyleURL.h
@@ -29,6 +29,7 @@
 
 namespace WebCore {
 
+class CSSURLValue;
 class ScriptExecutionContext;
 
 namespace Style {
@@ -56,9 +57,11 @@ URL toStyleWithScriptExecutionContext(const CSS::URL&, const ScriptExecutionCont
 template<> struct ToCSS<URL> { CSS::URL NODELETE operator()(const URL&, const RenderStyle&); };
 template<> struct ToStyle<CSS::URL> { auto operator()(const CSS::URL&, const BuilderState&) -> URL; };
 
-// `URL` is special-cased to return a `CSSURLValue`.
 template<> struct CSSValueCreation<URL> { Ref<CSSValue> operator()(CSSValuePool&, const RenderStyle&, const URL&); };
-template<> struct CSSValueConversion<URL> { auto operator()(BuilderState&, const CSSValue&) -> URL; };
+template<> struct CSSValueConversion<URL> {
+    auto operator()(BuilderState&, const CSSURLValue&) -> URL;
+    auto operator()(BuilderState&, const CSSValue&) -> URL;
+};
 
 // MARK: Serialization
 

--- a/Source/WebCore/style/values/shapes/StylePathFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StylePathFunction.cpp
@@ -173,7 +173,7 @@ auto Blending<Path>::blend(const Path& a, const Path& b, const BlendingContext& 
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, const Path::Data& value)
 {
-    String pathString;
+    WTF::String pathString;
     buildStringFromByteStream(value.byteStream, pathString, UnalteredParsing);
     return ts << pathString;
 }

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
@@ -38,6 +38,7 @@
 #include "StylePathFunction.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
+#include "TransformOperationData.h"
 
 namespace WebCore {
 namespace Style {

--- a/Source/WebCore/style/values/text-decoration/StyleTextEmphasisStyle.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextEmphasisStyle.cpp
@@ -92,8 +92,8 @@ const AtomString& TextEmphasisStyle::markString() const
         [&](const Shape& shape) -> const AtomString& {
             return markStringFromShape(shape);
         },
-        [&](const AtomString& customMark) -> const AtomString& {
-            return customMark;
+        [&](const CustomMark& customMark) -> const AtomString& {
+            return customMark.value;
         }
     );
 }
@@ -124,30 +124,27 @@ auto CSSValueConversion<TextEmphasisStyle>::operator()(BuilderState& state, cons
         return TextEmphasisStyle::Shape { .fill = *fill, .mark = *mark };
     }
 
-    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
-    if (!primitiveValue)
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        switch (primitiveValue->valueID()) {
+        case CSSValueInvalid:
+            break;
+
+        case CSSValueNone:
+            return CSS::Keyword::None { };
+
+        case CSSValueFilled:
+        case CSSValueOpen:
+            return defaultTextEmphasisShape(state.style().writingMode(), fromCSSValue<TextEmphasisFill>(*primitiveValue));
+
+        default:
+            return TextEmphasisStyle::Shape { .mark = fromCSSValue<TextEmphasisMark>(*primitiveValue) };
+        }
+
+        state.setCurrentPropertyInvalidAtComputedValueTime();
         return CSS::Keyword::None { };
-
-    switch (primitiveValue->valueID()) {
-    case CSSValueInvalid:
-        break;
-
-    case CSSValueNone:
-        return CSS::Keyword::None { };
-
-    case CSSValueFilled:
-    case CSSValueOpen:
-        return defaultTextEmphasisShape(state.style().writingMode(), fromCSSValue<TextEmphasisFill>(*primitiveValue));
-
-    default:
-        return TextEmphasisStyle::Shape { .mark = fromCSSValue<TextEmphasisMark>(*primitiveValue) };
     }
 
-    if (primitiveValue->isString())
-        return AtomString { primitiveValue->stringValue() };
-
-    state.setCurrentPropertyInvalidAtComputedValueTime();
-    return CSS::Keyword::None { };
+    return TextEmphasisStyle::CustomMark { AtomString { toStyleFromCSSValue<String>(state, value).value } };
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/text-decoration/StyleTextEmphasisStyle.h
+++ b/Source/WebCore/style/values/text-decoration/StyleTextEmphasisStyle.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <WebCore/RenderStyleConstants.h>
+#include <WebCore/StyleString.h>
 #include <WebCore/StyleValueTypes.h>
 
 namespace WebCore {
@@ -48,8 +49,19 @@ struct TextEmphasisStyle {
 
         bool operator==(const Shape&) const = default;
     };
+    struct CustomMark {
+        AtomString value;
 
-    Variant<CSS::Keyword::None, Shape, AtomString> value;
+        template<typename... F> decltype(auto) switchOn(F&&... f) const
+        {
+            auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+            return visitor(String { value });
+        }
+
+        bool operator==(const CustomMark&) const = default;
+    };
+
+    Variant<CSS::Keyword::None, Shape, CustomMark> value;
 
     TextEmphasisStyle(CSS::Keyword::None keyword)
         : value { keyword }
@@ -61,12 +73,12 @@ struct TextEmphasisStyle {
     {
     }
 
-    TextEmphasisStyle(AtomString&& customMark)
+    TextEmphasisStyle(CustomMark&& customMark)
         : value { WTF::move(customMark) }
     {
     }
 
-    bool isNone() const { return holdsAlternative<CSS::Keyword::None>(value); }
+    bool isNone() const { return WTF::holdsAlternative<CSS::Keyword::None>(value); }
 
     // String representation of the mark.
     const AtomString& markString() const;
@@ -87,4 +99,5 @@ template<> struct CSSValueConversion<TextEmphasisStyle> { auto operator()(Builde
 } // namespace WebCore
 
 DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::TextEmphasisStyle::Shape);
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::TextEmphasisStyle::CustomMark);
 DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::TextEmphasisStyle);

--- a/Source/WebCore/style/values/text/StyleHyphenateCharacter.h
+++ b/Source/WebCore/style/values/text/StyleHyphenateCharacter.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/StyleString.h>
 #include <WebCore/StyleValueTypes.h>
 
 namespace WebCore {
@@ -32,7 +33,7 @@ namespace Style {
 
 // <'hyphenate-character'> = auto | <string>
 // https://drafts.csswg.org/css-text-4/#propdef-hyphenate-character
-struct HyphenateCharacter : ValueOrKeyword<AtomString, CSS::Keyword::Auto> {
+struct HyphenateCharacter : ValueOrKeyword<String, CSS::Keyword::Auto> {
     using Base::Base;
 
     bool isAuto() const { return isKeyword(); }


### PR DESCRIPTION
#### 08941fb3dbebcce7e6a35625a5272ad5d775ea2c
<pre>
Add strong CSS/Style types for CSS string values
<a href="https://bugs.webkit.org/show_bug.cgi?id=312088">https://bugs.webkit.org/show_bug.cgi?id=312088</a>

Reviewed by Darin Adler.

Splits &lt;string&gt; and &lt;font-family-name&gt; out of CSSPrimitiveValue, adding new
CSS::String/Style::String/CSSStringValue and CSS::FontFamilyName/CSSFontFamilyNameValue
types (Style::FontFamilyName already existed).

Additionally stops wrapping CSSAttrValue in CSSPrimitiveValue, which was serving no purpose.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSAttrValue.cpp:
* Source/WebCore/css/CSSAttrValue.h:
* Source/WebCore/css/CSSCanvasValue.cpp:
* Source/WebCore/css/CSSCanvasValue.h:
* Source/WebCore/css/CSSCounterStyleDescriptors.cpp:
* Source/WebCore/css/CSSCounterValue.cpp:
* Source/WebCore/css/CSSCounterValue.h:
* Source/WebCore/css/CSSCustomIdentValue.h:
* Source/WebCore/css/CSSFontFace.cpp:
* Source/WebCore/css/CSSFontFace.h:
* Source/WebCore/css/CSSFontFaceSet.cpp:
* Source/WebCore/css/CSSFontFaceSet.h:
* Source/WebCore/css/CSSFontFamilyNameValue.cpp: Added.
* Source/WebCore/css/CSSFontFamilyNameValue.h: Added.
* Source/WebCore/css/CSSFontFeatureValuesRule.cpp:
* Source/WebCore/css/CSSImageSetOptionValue.cpp:
* Source/WebCore/css/CSSImageSetOptionValue.h:
* Source/WebCore/css/CSSImageSetValue.cpp:
* Source/WebCore/css/CSSMarkup.cpp:
* Source/WebCore/css/CSSMarkup.h:
* Source/WebCore/css/CSSNamedImageValue.cpp:
* Source/WebCore/css/CSSNamedImageValue.h:
* Source/WebCore/css/CSSPaintImageValue.cpp:
* Source/WebCore/css/CSSPaintImageValue.h:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/css/CSSStringValue.cpp: Added.
* Source/WebCore/css/CSSStringValue.h: Added.
* Source/WebCore/css/CSSURLValue.h:
* Source/WebCore/css/CSSUnits.cpp:
* Source/WebCore/css/CSSUnits.h:
* Source/WebCore/css/CSSValue.cpp:
* Source/WebCore/css/CSSValue.h:
* Source/WebCore/css/CSSValuePool.cpp:
* Source/WebCore/css/CSSValuePool.h:
* Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp:
* Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp:
* Source/WebCore/css/FontFace.cpp:
* Source/WebCore/css/FontFace.h:
* Source/WebCore/css/FontFace.idl:
* Source/WebCore/css/calc/CSSCalcTree+NumericIdentity.h:
* Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
* Source/WebCore/css/calc/CSSCalcTree.cpp:
* Source/WebCore/css/calc/CSSCalcTree.h:
* Source/WebCore/css/calc/CSSCalcType.cpp:
* Source/WebCore/css/parser/CSSParser.cpp:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Attr.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Content.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumer.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+String.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+String.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.cpp:
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
* Source/WebCore/css/values/CSSSerializationContext.cpp:
* Source/WebCore/css/values/CSSSerializationContext.h:
* Source/WebCore/css/values/CSSValueTypes.cpp:
* Source/WebCore/css/values/CSSValueTypes.h:
* Source/WebCore/css/values/fonts/CSSFontFamilyName.cpp: Added.
* Source/WebCore/css/values/fonts/CSSFontFamilyName.h: Added.
* Source/WebCore/css/values/grid/CSSGridNamedAreaMap.cpp:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.cpp:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.h:
* Source/WebCore/css/values/primitives/CSSString.cpp: Added.
* Source/WebCore/css/values/primitives/CSSString.h: Added.
* Source/WebCore/css/values/primitives/CSSURL.cpp:
* Source/WebCore/css/values/primitives/CSSURL.h:
* Source/WebCore/css/values/primitives/CSSURLModifiers.cpp:
* Source/WebCore/css/values/primitives/CSSURLModifiers.h:
* Source/WebCore/css/values/shapes/CSSPathFunction.cpp:
* Source/WebCore/editing/EditingStyle.cpp:
* Source/WebCore/editing/FontAttributeChanges.cpp:
* Source/WebCore/editing/TextListParser.cpp:
* Source/WebCore/editing/cocoa/FontAttributesCocoa.mm:
* Source/WebCore/editing/cocoa/NodeHTMLConverter.mm:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp:
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp:
* Source/WebCore/rendering/RenderCounter.cpp:
* Source/WebCore/rendering/RenderListMarker.cpp:
* Source/WebCore/rendering/RenderText.cpp:
* Source/WebCore/rendering/RenderTreeAsText.cpp:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
* Source/WebCore/style/ContainerQueryEvaluator.cpp:
* Source/WebCore/style/ContainerQueryEvaluator.h:
* Source/WebCore/style/PageRuleCollector.cpp:
* Source/WebCore/style/PageRuleCollector.h:
* Source/WebCore/style/PseudoElementUtilities.cpp:
* Source/WebCore/style/PseudoElementUtilities.h:
* Source/WebCore/style/RuleSet.cpp:
* Source/WebCore/style/RuleSet.h:
* Source/WebCore/style/ScopedName.cpp:
* Source/WebCore/style/ScopedName.h:
* Source/WebCore/style/StyleBuilder.cpp:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleCustomProperty.cpp:
* Source/WebCore/style/StyleCustomProperty.h:
* Source/WebCore/style/StyleExtractor.cpp:
* Source/WebCore/style/StyleExtractor.h:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleResolver.cpp:
* Source/WebCore/style/StyleResolver.h:
* Source/WebCore/style/StyleScope.cpp:
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/UserAgentStyle.cpp:
* Source/WebCore/style/values/StyleValueTypes+CSSValueConversion.h:
* Source/WebCore/style/values/StyleValueTypes.h:
* Source/WebCore/style/values/animations/StyleSingleAnimationName.cpp:
* Source/WebCore/style/values/animations/StyleSingleAnimationRangeName.cpp:
* Source/WebCore/style/values/animations/StyleSingleAnimationRangeName.h:
* Source/WebCore/style/values/color/StyleColor.cpp:
* Source/WebCore/style/values/color/StyleColor.h:
* Source/WebCore/style/values/color/StyleColorLayers.cpp:
* Source/WebCore/style/values/color/StyleColorLayers.h:
* Source/WebCore/style/values/color/StyleColorMix.cpp:
* Source/WebCore/style/values/color/StyleColorMix.h:
* Source/WebCore/style/values/color/StyleContrastColor.cpp:
* Source/WebCore/style/values/color/StyleContrastColor.h:
* Source/WebCore/style/values/color/StyleCurrentColor.cpp:
* Source/WebCore/style/values/color/StyleCurrentColor.h:
* Source/WebCore/style/values/color/StyleRelativeColor.h:
* Source/WebCore/style/values/color/StyleResolvedColor.cpp:
* Source/WebCore/style/values/color/StyleResolvedColor.h:
* Source/WebCore/style/values/content/StyleContent.cpp:
* Source/WebCore/style/values/content/StyleContent.h:
* Source/WebCore/style/values/content/StyleQuotes.cpp:
* Source/WebCore/style/values/content/StyleQuotes.h:
* Source/WebCore/style/values/fonts/StyleFontFamily.cpp:
* Source/WebCore/style/values/fonts/StyleFontFamilyName.cpp:
* Source/WebCore/style/values/fonts/StyleFontFamilyName.h:
* Source/WebCore/style/values/fonts/StyleFontVariantAlternates.cpp:
* Source/WebCore/style/values/grid/StyleGridPosition.cpp:
* Source/WebCore/style/values/grid/StyleGridPosition.h:
* Source/WebCore/style/values/grid/StyleGridPositionsResolver.cpp:
* Source/WebCore/style/values/images/kinds/StyleCanvasImage.cpp:
* Source/WebCore/style/values/images/kinds/StyleCanvasImage.h:
* Source/WebCore/style/values/images/kinds/StyleCursorImage.cpp:
* Source/WebCore/style/values/images/kinds/StyleImageSet.cpp:
* Source/WebCore/style/values/images/kinds/StyleMultiImage.cpp:
* Source/WebCore/style/values/images/kinds/StyleMultiImage.h:
* Source/WebCore/style/values/images/kinds/StyleNamedImage.cpp:
* Source/WebCore/style/values/images/kinds/StyleNamedImage.h:
* Source/WebCore/style/values/images/kinds/StylePaintImage.cpp:
* Source/WebCore/style/values/images/kinds/StylePaintImage.h:
* Source/WebCore/style/values/lists/StyleListStyleType.cpp:
* Source/WebCore/style/values/lists/StyleListStyleType.h:
* Source/WebCore/style/values/non-standard/StyleWebKitLocale.cpp:
* Source/WebCore/style/values/non-standard/StyleWebKitLocale.h:
* Source/WebCore/style/values/overflow/StyleBlockEllipsis.cpp:
* Source/WebCore/style/values/overflow/StyleBlockEllipsis.h:
* Source/WebCore/style/values/primitives/StyleCustomIdent.cpp:
* Source/WebCore/style/values/primitives/StyleCustomIdent.h:
* Source/WebCore/style/values/primitives/StyleString.cpp: Added.
* Source/WebCore/style/values/primitives/StyleString.h: Added.
* Source/WebCore/style/values/primitives/StyleURL.cpp:
* Source/WebCore/style/values/primitives/StyleURL.h:
* Source/WebCore/style/values/shapes/StylePathFunction.cpp:
* Source/WebCore/style/values/text-decoration/StyleTextEmphasisStyle.cpp:
* Source/WebCore/style/values/text-decoration/StyleTextEmphasisStyle.h:
* Source/WebCore/style/values/text/StyleHyphenateCharacter.h:

Canonical link: <a href="https://commits.webkit.org/311272@main">https://commits.webkit.org/311272@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9f2f63064a7078a6ea4eb0883303be281aeb4db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156542 "17 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165365 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158413 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29881 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/121248 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23478 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140579 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101915 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13136 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/18410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167847 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11968 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/20027 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129367 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29478 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24794 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129477 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35060 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29402 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140204 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87204 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24298 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17006 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29110 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93075 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28636 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28865 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28761 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->