### PR TITLE
document.styleSheets should be accessible on DOMParser-created documents

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-stylesheets-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-stylesheets-expected.txt
@@ -1,0 +1,8 @@
+
+PASS DOMParser-created document should have accessible styleSheets collection with one style element
+PASS DOMParser-created document styleSheets should contain CSSStyleSheet objects
+PASS DOMParser-created document styleSheets should have accessible cssRules
+PASS DOMParser-created document should expose multiple style elements in styleSheets
+PASS DOMParser-created document with full HTML structure should have accessible styleSheets
+PASS DOMParser-created document without style elements should have empty styleSheets collection
+

--- a/LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-stylesheets.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-stylesheets.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>DOMParser: parseFromString() with stylesheets</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring">
+<link rel="help" href="https://drafts.csswg.org/cssom/#dom-document-stylesheets">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+"use strict";
+
+test(() => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString("<style>div { color: green; }</style>", "text/html");
+
+  assert_equals(doc.styleSheets.length, 1, "Document should have one stylesheet");
+}, "DOMParser-created document should have accessible styleSheets collection with one style element");
+
+test(() => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString("<style>div { color: green; }</style>", "text/html");
+
+  assert_equals(doc.styleSheets.length, 1, "Document should have one stylesheet");
+  const sheet = doc.styleSheets[0];
+  assert_true(sheet instanceof CSSStyleSheet, "styleSheets[0] should be a CSSStyleSheet");
+}, "DOMParser-created document styleSheets should contain CSSStyleSheet objects");
+
+test(() => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString("<style>div { color: green; } p { color: red; }</style>", "text/html");
+
+  assert_equals(doc.styleSheets.length, 1, "Document should have one stylesheet");
+  const sheet = doc.styleSheets[0];
+  assert_equals(sheet.cssRules.length, 2, "Stylesheet should have two CSS rules");
+}, "DOMParser-created document styleSheets should have accessible cssRules");
+
+test(() => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(
+    "<style>div { color: green; }</style><style>p { color: red; }</style>",
+    "text/html"
+  );
+
+  assert_equals(doc.styleSheets.length, 2, "Document should have two stylesheets");
+}, "DOMParser-created document should expose multiple style elements in styleSheets");
+
+test(() => {
+  const parser = new DOMParser();
+  const html = `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <style>
+          .test { color: blue; }
+        </style>
+      </head>
+      <body>
+        <div class="test">Hello</div>
+      </body>
+    </html>
+  `;
+  const doc = parser.parseFromString(html, "text/html");
+
+  assert_equals(doc.styleSheets.length, 1, "Document should have one stylesheet");
+  const sheet = doc.styleSheets[0];
+  assert_equals(sheet.cssRules.length, 1, "Stylesheet should have one CSS rule");
+  assert_equals(sheet.cssRules[0].selectorText, ".test", "CSS rule should have correct selector");
+}, "DOMParser-created document with full HTML structure should have accessible styleSheets");
+
+test(() => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString("<div>No styles</div>", "text/html");
+
+  assert_equals(doc.styleSheets.length, 0, "Document without style elements should have empty styleSheets");
+}, "DOMParser-created document without style elements should have empty styleSheets collection");
+
+</script>

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -935,7 +935,14 @@ void Scope::pendingUpdateTimerFired()
 const Vector<Ref<StyleSheet>>& Scope::styleSheetsForStyleSheetList()
 {
     // FIXME: StyleSheetList content should be updated separately from style resolver updates.
-    flushPendingUpdate();
+    if (m_document->hasLivingRenderTree())
+        flushPendingUpdate();
+    else if (m_pendingUpdate) {
+        // Documents without a living render tree (e.g. created by DOMParser) can't do full
+        // style updates but should still have an accessible styleSheets collection per spec.
+        m_pendingUpdate = { };
+        m_styleSheetsForStyleSheetList = collectActiveStyleSheets().styleSheetsForStyleSheetList;
+    }
     return m_styleSheetsForStyleSheetList;
 }
 


### PR DESCRIPTION
#### 9f58e494e0bb4c28f2580783a89f683e5521bf49
<pre>
document.styleSheets should be accessible on DOMParser-created documents
<a href="https://bugs.webkit.org/show_bug.cgi?id=312089">https://bugs.webkit.org/show_bug.cgi?id=312089</a>

Reviewed by Darin Adler and Anne van Kesteren.

Style::Scope::updateActiveStyleSheets() bails out early when the document
has no living render tree. Since DOMParser-created documents have no
frame or view, flushPendingSelfUpdate() would clear m_pendingUpdate and
then call updateActiveStyleSheets() which returned immediately, leaving
the styleSheets collection empty.

Fix this by checking hasLivingRenderTree() before attempting the flush.
When there is no render tree, collect the style sheets for the list
directly via collectActiveStyleSheets(), bypassing the full style
resolver update that requires one.

Test: imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-stylesheets.html

* LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-stylesheets-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-stylesheets.html: Added.
Import WPT test coverage from upstream. This test is failing in shipping
Safari but passing in both Chrome and Firefox.

* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::styleSheetsForStyleSheetList):

Canonical link: <a href="https://commits.webkit.org/311043@main">https://commits.webkit.org/311043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9118487d455d41acae8c301e9b52c49fcacee90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164698 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157807 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29272 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120716 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158894 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140035 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101405 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21998 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20135 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12528 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131664 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17867 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167178 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11352 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19478 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128837 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28872 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24179 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128969 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34921 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28794 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139661 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86537 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23792 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16459 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28503 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92459 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28030 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28258 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28154 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->